### PR TITLE
MBS-4222: Show a generic error message when merging

### DIFF
--- a/lib/MusicBrainz/Server/Form/Merge.pm
+++ b/lib/MusicBrainz/Server/Form/Merge.pm
@@ -13,7 +13,7 @@ has '+name' => ( default => 'merge' );
 has_field 'target' => (
     type => '+MusicBrainz::Server::Form::Field::Integer',
     required => 1,
-    required_message => l('Please pick which work you want the others merged into.')
+    required_message => l('Please pick the entity you want the others merged into.')
 );
 
 has_field 'merging' => (


### PR DESCRIPTION
I was the one that added that error message in. I forgot that works aren't the only entities that can be merged. Oops!
