### PR TITLE
MBS-5761: Can't use keyboard shortcuts to create a new work in the releditor

### DIFF
--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -90,7 +90,11 @@
         <!-- ko if: showCreateWorkLink -->
         <tr>
           <td></td>
-          <td><a href="#" data-bind="click: createWork">[% l('Create a new work') %]</a></td>
+          <td>
+            <button id="create-work-btn" data-bind="click: createWork, clickBubble: false">
+              [% l('Create a new work') %]
+            </button>
+          </td>
         </tr>
         <!-- /ko -->
         <!-- ko template: {"if": mode() == "batch.create.works", afterRender: batchWorksMode} -->


### PR DESCRIPTION
Turns the "Create a new work" link into a button, so that you can tab to it, and press enter/space to click it.

Allows closing any dialog using the esc key. Some general browser workarounds were necessary to avoid quirks with the autocomplete plugin.

Manually tested in Firefox, Chrome, Opera 12.12 and Opera 10.00. Can be tested on http://bitmap.mbsandbox.org/
