### PR TITLE
MBS-5762

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -7,6 +7,7 @@ use Data::OptList;
 use DateTime;
 use Try::Tiny;
 use List::MoreUtils qw( uniq zip );
+use List::AllUtils qw( any );
 use MusicBrainz::Server::Constants qw( $QUALITY_UNKNOWN_MAPPED $EDITOR_MODBOT );
 use MusicBrainz::Server::Data::Editor;
 use MusicBrainz::Server::EditRegistry;
@@ -459,8 +460,16 @@ sub load_all
             $ids = Data::OptList::mkopt_hash($ids);
             while (my ($object_id, $extra_models) = each %$ids) {
                 push @{ $objects_to_load->{$model} }, $object_id;
-                $post_load_models->{$model}->{$object_id} = $extra_models
-                    if $extra_models && @$extra_models;
+                if ($extra_models && @$extra_models) {
+                    if (!exists $post_load_models->{$model}->{$object_id}) {
+                        $post_load_models->{$model}->{$object_id} = $extra_models;
+                    } else {
+                        for my $extra_model (@$extra_models) {
+                            push @{ $post_load_models->{$model}->{$object_id} }, $extra_model
+                              unless (any { $_ eq $extra_model } @{ $post_load_models->{$model}->{$object_id} });
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Ensure that in a listing of edits, edits processed later in the queue cannot clobber loading of foreign keys required by earlier edits. Formerly, it could happen such:

edit 444 wants artist credits, work types, and language for work number 4567, adds them to the list

edit 446 wants artist credits (but nothing else) for work number 4567, and adds them to the list (but it does this by clobbering the set of things to load added by edit 444).

This patch makes sure it'll simply _add_ things, not remove things added by other edits.

http://tickets.musicbrainz.org/browse/MBS-5762
