### PR TITLE
MBS-5765: Correctly render a duration in seconds as hours, minutes, seconds

### DIFF
--- a/lib/MusicBrainz/Server/Track.pm
+++ b/lib/MusicBrainz/Server/Track.pm
@@ -30,7 +30,7 @@ sub FormatTrackLength
     my ($hours, $minutes, $seconds);
     ($hours, $ms) = (floor($ms / $one_hour), $ms % $one_hour);
     ($minutes, $ms) = (floor($ms / $one_minute), $ms % $one_minute);
-    $seconds = floor($ms / $one_second);
+    $seconds = round($ms / $one_second);
 
     return $hours > 0 ?
         sprintf ("%d:%02d:%02d", $hours, $minutes, $seconds) :

--- a/root/static/scripts/common/MB/utility.js
+++ b/root/static/scripts/common/MB/utility.js
@@ -197,29 +197,29 @@ MB.utility.formatTrackLength = function (duration)
         return duration + ' ms';
     }
 
-    var seconds = 1000;
-    var minutes = 60 * seconds;
-    var hours = 60 * minutes;
+    var one_second = 1000.0;
+    var one_minute = 60 * one_second;
+    var one_hour = 60 * one_minute;
 
-    var hours_str = '';
-    duration = duration + 500;
+    var hours = Math.floor(duration / one_hour);
+    duration = duration % one_hour;
 
-    if (duration > 1 * hours)
-    {
-        hours_str = Math.floor (duration / hours) + ':';
-        duration = Math.floor (duration % hours);
+    var minutes = Math.floor(duration / one_minute);
+    duration = duration % one_minute;
+
+    var seconds = Math.round(duration / one_second);
+
+    var ret = '';
+    ret = ('00' + seconds).slice(-2);
+
+    if (hours > 0) {
+        ret = hours + ':' + ('00' + minutes).slice(-2) + ':' + ret;
+    }
+    else {
+        ret = minutes + ':' + ret;
     }
 
-    /* pad minutes with zeroes of the hours string is non-empty. */
-    var minutes_str = hours_str === '' ?
-        Math.floor (duration / minutes) + ':' :
-        ('00' + Math.floor (duration / minutes)).slice (-2) + ':';
-
-    duration = Math.floor (duration % minutes);
-
-    var seconds_str = ('00' + Math.floor (duration / seconds)).slice (-2);
-
-    return hours_str + minutes_str + seconds_str;
+    return ret;
 };
 
 


### PR DESCRIPTION
`Time::Duration->normalize` normalizes a large duration into years, months, and
days - rather than just the needed hours, minutes, seconds. Rather than manually
re-fudging the calculation to account for that overflow, I've just implemented
partioning of seconds in hours, minutes and seconds manually.
