### PR TITLE
MBS-5750: When filtering reports by subscriptions, also account for label subscriptions

### DIFF
--- a/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseID.pm
@@ -9,9 +9,11 @@ sub filter_sql {
     return (
         "JOIN release ON release.id = release_id
          JOIN artist_credit_name ON release.artist_credit = artist_credit_name.artist_credit
-         JOIN editor_subscribe_artist esa ON esa.artist = artist_credit_name.artist
-         WHERE esa.editor = ?",
-        $editor_id
+         JOIN release_label ON release_label.release = release.id
+         LEFT JOIN editor_subscribe_artist esa ON esa.artist = artist_credit_name.artist
+         LEFT JOIN editor_subscribe_label esl ON esl.label = release_label.label
+         WHERE (esa.editor IS NOT DISTINCT FROM ?) OR (esl.editor IS NOT DISTINCT FROM ?)",
+        $editor_id, $editor_id
     );
 }
 


### PR DESCRIPTION
Extends the FilterForEditor::ReleaseID filter to also join release labels
against editor_subscribe_label.
