### PR TITLE
MBS-5525: Correctly display parent changes in 'edit relationship type' edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
@@ -66,7 +66,11 @@ sub foreign_keys {
             map { $_->{type} }
                 @{ $self->data->{old}{attributes} },
                 @{ $self->data->{new}{attributes} }
-            ]
+            ],
+        LinkType => [
+            map { $self->data->{$_}{parent_id} }
+                qw( old new )
+            ],
     }
 }
 
@@ -92,12 +96,18 @@ sub build_display_data {
         $self->data->{old}{attributes},
         $self->data->{new}{attributes}
     );
-    return if Compare($old, $new);
+    return if Compare($old, $new) &&
+        $self->data->{old}{parent_id} == $self->data->{new}{parent_id};
 
     return {
         attributes => {
             old => $self->_build_attributes($old, $loaded),
             new => $self->_build_attributes($new, $loaded),
+        },
+        parent => {
+            map {
+                $_ => $loaded->{LinkType}{ $self->data->{$_}{parent_id} }
+            } qw( old new )
         }
     }
 }

--- a/root/edit/details/edit_relationship_type.tt
+++ b/root/edit/details/edit_relationship_type.tt
@@ -45,11 +45,11 @@
   </tr>
   [% END %]
 
-  [% IF edit.data.old.parent %]
+  [% IF edit.data.old.parent_id != edit.data.new.parent_id %]
   <tr>
     <th>[% l('Parent') %]</th>
-    <td class="old">[% edit.data.old.parent %]</td>
-    <td class="new">[% edit.data.new.parent %]</td>
+    <td class="old">[% edit.display_data.parent.old.name %]</td>
+    <td class="new">[% edit.display_data.parent.new.name %]</td>
   </tr>
   [% END %]
 </table>


### PR DESCRIPTION
Previously, we didn't load the actual LinkType objects (pointed to via
parent_id). Furthermore, the test for display and the display itself was wrong,
so that's also been fixed up.
