### PR TITLE
MBS-5748: Only require an edit note during approval if other editors voted no

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -94,7 +94,8 @@ sub approve : Chained('load') RequireAuth(auto_editor)
         $c->detach;
     }
 
-    if($edit->no_votes > 0) {
+    $c->model('Vote')->load_for_edits($edit);
+    if($edit->approval_requires_comment($c->user)) {
         $c->model('EditNote')->load_for_edits($edit);
         my $left_note;
         for my $note (@{ $edit->edit_notes }) {

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -231,6 +231,16 @@ sub was_approved
     return scalar $self->_grep_votes(sub { $_->vote == $VOTE_APPROVE })
 }
 
+sub approval_requires_comment {
+    my ($self, $editor) = @_;
+
+    return $self->_grep_votes(sub {
+        $_->vote == $VOTE_NO &&
+            !$_->superseded &&
+                $_->editor_id != $editor->id
+    }) > 0;
+}
+
 =head2 related_entities
 
 A list of all entities that this edit relates to. For each entity, a row in the edit_*


### PR DESCRIPTION
We currently check that the no vote counter for an edit is >0. However, if the
no vote is your own vote, then you shouldn't have to justify changing your vote
to approval.
