### PR TITLE
MBS-5395: remove fixed width for 'Actions' headers so longer languages don't break it

### DIFF
--- a/root/artist/aliases.tt
+++ b/root/artist/aliases.tt
@@ -19,7 +19,7 @@
                         [% l('Name') %]
                     </th>
                     [% IF c.user_exists %]
-                    <th style="width: 5em">
+                    <th class="actions-header">
                         [% l('Actions') %]
                     </th>
                     [% END %]

--- a/root/artist/relationships.tt
+++ b/root/artist/relationships.tt
@@ -15,7 +15,7 @@
                 <th>[% l('Attributes') %]</th>
                 <th>[% l('Artist') %]</th>
                 [% IF c.user_exists %]
-                <th style="width: 10em">[% l('Edit') %]</th>
+                <th class="actions-header">[% l('Edit') %]</th>
                 [% END %]
             </tr>
         </thead>

--- a/root/components/aliases.tt
+++ b/root/components/aliases.tt
@@ -15,7 +15,7 @@
                     <th>[% l('Type') %]</th>
                     <th>[% l('Locale') %]</th>
                     [% IF c.user_exists %]
-                        <th style="width: 10em">
+                        <th class="actions-header">
                             [% l('Actions') %]
                         </th>
                     [% END %]

--- a/root/components/tags.tt
+++ b/root/components/tags.tt
@@ -10,7 +10,7 @@
       <thead>
         <tr>
           <th>[% lp('Tag', 'noun') %]</th>
-          <th style="width: 10em">[% l('Usage Count') %]</th>
+          <th class="actions-header">[% l('Usage Count') %]</th>
         </tr>
       </thead>
       <tbody>

--- a/root/recording/fingerprints.tt
+++ b/root/recording/fingerprints.tt
@@ -10,7 +10,7 @@
                 <tr>
                     <th>[% l('PUID') %]</th>
                     [% IF c.user_exists %]
-                        <th style="width: 5em">
+                        <th class="actions-header">
                             [% l('Actions') %]
                         </th>
                     [% END %]

--- a/root/static/styles/layout.css
+++ b/root/static/styles/layout.css
@@ -998,3 +998,7 @@ span.release-group-type {
     border-radius: 3px;
     padding: 0 3px;
 }
+
+.actions-header {
+    min-width: 10em;
+}

--- a/root/user/collections.tt
+++ b/root/user/collections.tt
@@ -7,10 +7,10 @@
     <thead>
         <tr>
             <th>[% l('Collection') %]</th>
-            <th style="width: 10em">[% l('Releases') %]</th>
+            <th>[% l('Releases') %]</th>
             [% IF viewing_own_profile %]
-            <th style="width: 10em">[% l('Privacy') %]</th>
-            <th style="width: 10em">[% l('Actions') %]</th>
+            <th>[% l('Privacy') %]</th>
+            <th class="actions-header">[% l('Actions') %]</th>
             [% END %]
         </tr>
     </thead>


### PR DESCRIPTION
Like it says. Changes width to min-width and standardizes somewhat on an actions-header class.
