### PR TITLE
MBS-3962: Really exclude artists/labels/etc. when "!=" is used

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/LinkedEntity.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/LinkedEntity.pm
@@ -44,7 +44,7 @@ role {
 
             when ('!=') {
                 $query->add_where([
-                    "NOT EXISTS (SELECT TRUE from $table edit_entity WHERE edit_entity.$column = ?)",
+                    "NOT EXISTS (SELECT TRUE from $table edit_entity WHERE edit_entity.edit = edit.id AND edit_entity.$column = ?)",
                     $self->sql_arguments
                 ]);
             }


### PR DESCRIPTION
Using a join (as before) doesn't work because an edit can be linked to multiple artists/labels/whatever, so it's easy to find _some_ row of edit_$entity that doesn't mention the provided artist. Using WHERE NOT EXISTS (SELECT) instead.
