### PR TITLE
MBS-3457: Improve release->find_by_recordings to not exclude some releases

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -348,7 +348,7 @@ sub find_by_recordings
     return () unless @ids;
 
     my $query =
-        "SELECT DISTINCT ON (release.id) " . $self->_columns . ",
+        "SELECT DISTINCT ON (release.id, track.recording) " . $self->_columns . ",
                 track.recording, track.position
            FROM release
            JOIN release_name name ON name.id = release.name


### PR DESCRIPTION
- it was selecting DISTINCT ON (release.id), meaning that if multiple
  recordings being searched appeared on the same release only one would
  actually get marked as such
  - now is DISTINCT ON (release.id, track.recording) instead

http://tickets.musicbrainz.org/browse/MBS-3457
