### PR TITLE
MBS-5742: require JS on ISWCs/IPIs only for interactive use

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -129,7 +129,7 @@
           </div>
       </div>
       <script>
-         MB.Form.TextList ("[%- r.form.field(field_name).html_name -%]").init([% r.form.field(field_name).value.size - 1 %]);
+         MB.Form.TextList ("[%- r.form.field(field_name).html_name -%]").init([% r.form.field(field_name).value.size %]);
       </script>
 
       [% field_errors(r.form, field_name) %]

--- a/root/static/scripts/edit/MB/TextList.js
+++ b/root/static/scripts/edit/MB/TextList.js
@@ -26,7 +26,7 @@ MB.Form.TextList = function (input) {
     var $template = $('.' + template.replace (/\./g, '\\.'));
     var counter = 0;
 
-    var last_item = null;
+    var last_item = input;
 
     self.removeEvent = function (event) {
         $(this).closest ('div.text-list-row').remove();
@@ -35,9 +35,7 @@ MB.Form.TextList = function (input) {
     };
 
     self.init = function(max_index) {
-        last_item = input;
-
-        counter = max_index + 1;
+        counter = max_index;
         $template.parent()
             .find('div.text-list-row input.value')
             .siblings('button.remove')
@@ -47,8 +45,6 @@ MB.Form.TextList = function (input) {
     };
 
     self.add = function (init_value) {
-        last_item = input;
-
         $template.clone ()
             .removeClass (template)
             .insertAfter ($template.parent ().find ('div.text-list-row').last ())


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-5742

This makes it so the page renders correctly without JS; it's still used for the interactive bits (adding more fields, removing ISWCs, etc.), but not for setting up the initial page to have the appropriate form fields for the ISWCs/IPIs already attached to the entity. This means that without JS on people (or bots) won't do damage to the data already in the DB. (For bots, this makes it possible for them to edit entities with ISWCs or IPIs at all).
