### PR TITLE
MBS-5698: Display historic 'move disc ID' edits correctly

### DIFF
--- a/root/edit/details/historic/move_disc_id.tt
+++ b/root/edit/details/historic/move_disc_id.tt
@@ -7,22 +7,31 @@
   <tr>
     <th>[% l('From:') %]</th>
     <td>
-      <ul>
-        [% FOR release=edit.display_data.old_releases %]
-          <li>[% descriptive_link(release) %]</li>
-        [% END %]
-      </ul>
+      [% IF edit.display_data.old_releases.size %]
+        <ul>
+          [% FOR release=edit.display_data.old_releases %]
+            <li>[% release %]</li>
+            <li>[% descriptive_link(release) %]</li>
+          [% END %]
+        </ul>
+      [% ELSE %]
+        [% link_deleted(undef, undef) %]
+      [% END %]
     </td>
   </tr>
 
   <tr>
     <th>[% l('To:') %]</th>
     <td>
-      <ul>
-        [% FOR release=edit.display_data.new_releases %]
-          <li>[% descriptive_link(release) %]</li>
-        [% END %]
-      </ul>
+      [% IF edit.display_data.new_releases.size %]
+        <ul>
+          [% FOR release=edit.display_data.new_releases %]
+            <li>[% descriptive_link(release) %]</li>
+          [% END %]
+        </ul>
+      [% ELSE %]
+        [% link_deleted(undef, undef) %]
+      [% END %]
     </td>
   </tr>
 </table>


### PR DESCRIPTION
When the migration script ran, it attempt to resolve a release ID into the set
of release IDs that the release was migrated to in NES (as multiple release
events produced a new release ID). However, if this resolution couldn't be done
because the release was deleted since the edit, the result was the empty set.

When displaying the from/to release set in the edit display, we now check for
whether or not the release set is the empty set and if so display
'[removed]'. Otherwsie, we show all the releases.
