### PR TITLE
CAA types i18n (re-do)

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -466,16 +466,15 @@ sub reorder_cover_art : Chained('load') PathPart('reorder-cover-art') RequireAut
         $c->detach;
     }
 
-    my @artwork = @{
-        $c->model ('CoverArtArchive')->find_available_artwork($entity->gid)
-    } or $c->detach('/error_404');
+    my $artwork = $c->model ('Artwork')->find_by_release ($entity);
+    $c->model ('CoverArtType')->load_for (@$artwork);
 
-    $c->stash( images => \@artwork );
+    $c->stash( images => $artwork );
 
     my $count = 1;
     my @positions = map {
         { id => $_->id, position => $count++ }
-    } @artwork;
+    } @$artwork;
 
     my $form = $c->form(
         form => 'Release::ReorderCoverArt',

--- a/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
@@ -10,6 +10,7 @@ use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Translation qw ( N_l );
 
 use aliased 'MusicBrainz::Server::Entity::Release';
+use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Release';
@@ -100,20 +101,14 @@ sub build_display_data {
     my $release = $loaded->{Release}{ $self->data->{entity}{id} } ||
         Release->new( name => $self->data->{entity}{name} );
 
-    # FIXME: replace this with a proper MusicBrainz::Server::Entity::Artwork object
-    my $prefix = DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . "/release/" . $release->gid . "/";
-    my $artwork = {
-        image => $prefix.$self->data->{cover_art_id}.'.jpg',
-        large_thumbnail => $prefix.$self->data->{cover_art_id}.'-500.jpg',
-        small_thumbnail => $prefix.$self->data->{cover_art_id}.'-250.jpg',
-    };
+    my $artwork = Artwork->new(release => $release,
+                               id => $self->data->{cover_art_id},
+                               comment => $self->data->{cover_art_comment},
+                               cover_art_types => [map {$loaded->{CoverArtType}{$_}} @{ $self->data->{cover_art_types} }]);
 
     return {
         release => $release,
         artwork => $artwork,
-        types => [ map { $loaded->{CoverArtType}{$_} }
-                       @{ $self->data->{cover_art_types} } ],
-        comment => $self->data->{cover_art_comment},
         position => $self->data->{cover_art_position}
     };
 }

--- a/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
@@ -11,6 +11,7 @@ use MusicBrainz::Server::Edit::Utils qw( changed_display_data );
 use MusicBrainz::Server::Translation qw ( N_l );
 
 use aliased 'MusicBrainz::Server::Entity::Release';
+use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Release';
@@ -123,13 +124,10 @@ sub build_display_data {
     $data{release} = $loaded->{Release}{ $self->data->{entity}{id} } ||
         Release->new( name => $self->data->{entity}{name} );
 
-    # FIXME: replace this with a proper MusicBrainz::Server::Entity::Artwork object
-    my $prefix = DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . "/release/" . $data{release}->gid . "/";
-    $data{artwork} = {
-        image => $prefix.$self->data->{id}.'.jpg',
-        large_thumbnail => $prefix.$self->data->{id}.'-500.jpg',
-        small_thumbnail => $prefix.$self->data->{id}.'-250.jpg',
-    };
+    $data{artwork} = Artwork->new(release => $data{release},
+                               id => $self->data->{id},
+                               comment => $self->data->{new}{comment} // '',
+                               cover_art_types => [map {$loaded->{CoverArtType}{$_}} @{ $self->data->{new}{types} }]);
 
     if ($self->data->{old}->{types})
     {

--- a/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
@@ -9,6 +9,7 @@ use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Translation qw ( N_l );
 
 use aliased 'MusicBrainz::Server::Entity::Release';
+use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Release';
@@ -87,21 +88,13 @@ sub build_display_data {
     my $release = $loaded->{Release}{ $self->data->{entity}{id} } ||
         Release->new( name => $self->data->{entity}{name} );
 
-    # FIXME: replace this with a proper MusicBrainz::Server::Entity::Artwork object
-    my $prefix = DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . "/release/" . $release->gid . "/";
-    my $artwork = {
-        image => $prefix.$self->data->{cover_art_id}.'.jpg',
-        large_thumbnail => $prefix.$self->data->{cover_art_id}.'-500.jpg',
-        small_thumbnail => $prefix.$self->data->{cover_art_id}.'-250.jpg',
-    };
-
+    my $artwork = Artwork->new(release => $release,
+                               id => $self->data->{cover_art_id},
+                               comment => $self->data->{cover_art_comment},
+                               cover_art_types => [map {$loaded->{CoverArtType}{$_}} @{ $self->data->{cover_art_types} }]);
     return {
         release => $release,
-        types => [
-            map { $loaded->{CoverArtType}{ $_ } } @{ $self->data->{cover_art_types} }
-        ],
         artwork => $artwork,
-        comment => $self->data->{cover_art_comment}
     };
 }
 

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
@@ -101,7 +101,8 @@ sub build_display_data {
     $data{release} = $loaded->{Release}{ $self->data->{entity}{id} } ||
         Release->new( name => $self->data->{entity}{name} );
 
-    my $artwork = $self->c->model('CoverArtArchive')->find_available_artwork ($data{release}->gid);
+    my $artwork = $self->c->model('Artwork')->find_by_release($data{release});
+    $self->c->model ('CoverArtType')->load_for(@$artwork);
 
     my %artwork_by_id = map { $_->id => $_ } @$artwork;
 

--- a/lib/MusicBrainz/Server/Entity/Artwork.pm
+++ b/lib/MusicBrainz/Server/Entity/Artwork.pm
@@ -23,6 +23,12 @@ sub types {
     return [ map { $_->name } @{ $self->cover_art_types } ];
 }
 
+sub l_types {
+    my $self = shift;
+    return [] unless $self->cover_art_types;
+    return [ map { $_->l_name } @{ $self->cover_art_types } ];
+}
+
 has is_front => (
     is => 'rw',
     isa => 'Bool',

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -75,7 +75,7 @@ END; -%]
     END -%]
 
 [%- MACRO artwork_hover(artwork) BLOCK -%]
-    [%- IF artwork.types; comma_only_list(artwork.types) | html; END %][% IF artwork.comment %] ([% artwork.comment | html%])[% END -%]
+    [%- IF artwork.l_types; comma_only_list(artwork.l_types) | html; END %][% IF artwork.comment %] ([% artwork.comment | html%])[% END -%]
 [%- END -%]
 
 [%- USE JavaScript -%]

--- a/root/edit/details/add_cover_art.tt
+++ b/root/edit/details/add_cover_art.tt
@@ -6,19 +6,18 @@
     <td>[% descriptive_link(edit.display_data.release) %]</td>
   </tr>
 
-  [% IF edit.display_data.comment %]
+  [% IF edit.display_data.artwork.comment %]
   <tr>
     <th>[% l('Comment:') %]</th>
-    <td>[% edit.display_data.comment | html %]</td>
+    <td>[% edit.display_data.artwork.comment | html %]</td>
   </tr>
   [% END %]
 
-  [% IF edit.display_data.types.size %]
+  [% IF edit.display_data.artwork.types.size %]
   <tr>
     <th>[% l('Types:') %]</th>
     <td>
-        [% USE Map %]
-        [% comma_only_list(edit.display_data.types.map('l_name')) | html %]
+        [% comma_only_list(edit.display_data.artwork.l_types) | html %]
     </td>
   </tr>
   [% END %]

--- a/root/edit/details/remove_cover_art.tt
+++ b/root/edit/details/remove_cover_art.tt
@@ -9,9 +9,8 @@
   <tr>
     <th>[% l('Types:') %]</th>
     <td>
-      [% IF edit.display_data.types.size %]
-        [% USE Map %]
-        [% comma_only_list(edit.display_data.types.map('l_name')) | html %]
+      [% IF edit.display_data.artwork.types.size %]
+        [% comma_only_list(edit.display_data.artwork.l_types) | html %]
       [% ELSE %]
         [% l('(none)') %]
       [% END %]
@@ -25,7 +24,7 @@
 
   <tr>
     <th>[% l('Comment:') %]</th>
-    <td>[% html_escape(edit.display_data.comment) || l('(none)') %]</td>
+    <td>[% html_escape(edit.display_data.artwork.comment) || l('(none)') %]</td>
   </tr>
 
   [%- display_edit_artwork(edit.display_data.artwork, edit.display_data.release) -%]

--- a/root/release/cover_art.tt
+++ b/root/release/cover_art.tt
@@ -11,7 +11,7 @@
         </div>
         <p>
           [%- l('Types:') -%]
-          [% comma_only_list(artwork.types) || '-' %]
+          [% comma_only_list(artwork.l_types) || '-' %]
         </p>
         [%- IF artwork.comment -%]
         <p>


### PR DESCRIPTION
Related to a bunch of cover-art/i18n-related bugs, and I'm sure I've missed some, but: http://tickets.musicbrainz.org/browse/MBS-5776 http://tickets.musicbrainz.org/browse/MBS-5432, probably http://tickets.musicbrainz.org/browse/MBS-5567 as well.

Reworks a lot of our cover art stuff to support i18n. Specifically: gets rid of a lot of the "FIXME: Replace with a real Entity::Artwork object" by replacing them with Entity::Artwork objects, as well as using Artwork->find_by_release (and a subsequent CoverArtType load) rather than CoverArtArchive->find_available_artwork (i.e., using Entity::Artwork).

I haven't done this here, but we may want to consider moving cover art types to the in-memory cache (along with artist types, languages, countries, etc.).

(reopened against beta)
