### PR TITLE
MBS-5777: Users' work ratings page has no title

### DIFF
--- a/root/user/ratings.tt
+++ b/root/user/ratings.tt
@@ -2,8 +2,8 @@
   titles = { 'artist' => l('Artist ratings'),
              'label' => l('Label ratings'),
              'recording' => l('Recording ratings'),
-             'release' => l('Release ratings'),
              'release_group' => l('Release group ratings')
+             'work' => l('Work ratings')
            };
   title = titles.${ type };
 -%]


### PR DESCRIPTION
Added the "Work ratings" h2 to a user's rated works page, removed the line for releases in the same file since releases have no ratings.
