### PR TITLE
MBS-5779: Remove useless nbsp on common-macros.tt

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -55,22 +55,22 @@ END; -%]
         l('aged {num}', { num => age.0 });
       ELSE;
         IF age.0;
-          ln('{num} year', '{num}&#xa0;years', age.0, { num => age.0 });
+          ln('{num} year', '{num} years', age.0, { num => age.0 });
         ELSIF age.1;
-          ln('{num} month', '{num}&#xa0;months', age.1, { num => age.1 });
+          ln('{num} month', '{num} months', age.1, { num => age.1 });
         ELSE;
-          ln('{num} day', '{num}&#xa0;days', age.2, { num => age.2 });
+          ln('{num} day', '{num} days', age.2, { num => age.2 });
         END;
       END;
     END -%]
 
 [%- MACRO display_age_ago(age) BLOCK;
         IF age.0;
-          ln('{num} year ago', '{num}&#xa0;years ago', age.0, { num => age.0 });
+          ln('{num} year ago', '{num} years ago', age.0, { num => age.0 });
         ELSIF age.1;
-          ln('{num} month ago', '{num}&#xa0;months ago', age.1, { num => age.1 });
+          ln('{num} month ago', '{num} months ago', age.1, { num => age.1 });
         ELSE;
-          ln('{num} day ago', '{num}&#xa0;days ago', age.2, { num => age.2 });
+          ln('{num} day ago', '{num} days ago', age.2, { num => age.2 });
         END;
     END -%]
 


### PR DESCRIPTION
This might well be the most minor ticket ever, but there's just no reason for those non-breaking spaces to be there. Especially since they're not there for singular.
