### PR TITLE
MBS-5786: translate release group secondary-type tag-labels on artist overview page

### DIFF
--- a/root/artist/index.tt
+++ b/root/artist/index.tt
@@ -84,7 +84,7 @@
                       [% rdfa_made_rg_link(rg) %]
                       [% disambiguation(rg) %]
                       [% FOR t=rg.secondary_types %]
-                        <span class="release-group-type">[% t.name %]</span>
+                        <span class="release-group-type">[% t.l_name %]</span>
                       [% END %]
                     </td>
                     [% IF show_artists %]


### PR DESCRIPTION
I'll just ship this when freeze is over, as it's a tiny change. But I've put this review here to remind myself :)
