### PR TITLE
MBS-5788, MBS-5791: Fix creation of move disc ID/remove ISRC edits (and more)

### DIFF
--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -146,6 +146,15 @@ sub edit_action
             $opts{on_creation}->($edit, $form) if $edit && exists $opts{on_creation};
         });
 
+        # `post_creation` and `on_creation` often perform a redirection.
+        # If they have called $c->res->redirect, $c->res->location will be a
+        # true value, and we can detach early. `post_creation` and `on_creation`
+        # can't do this, as $c->detach is implemented by throwing an exception,
+        # which causes the above transaction to rollback.
+        if ($c->res->location) {
+            $c->detach;
+        }
+
         return $edit;
     }
     elsif (!$c->form_posted && %{ $c->req->query_params }) {

--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -95,7 +95,6 @@ sub remove : Local RequireAuth
         },
         on_creation => sub {
             $c->response->redirect($c->uri_for_action('/release/discids', [ $release->gid ]));
-            $c->detach;
         }
     )
 }
@@ -129,7 +128,6 @@ sub set_durations : Chained('load') PathPart('set-durations') Edit RequireAuth
         },
         on_creation => sub {
             $c->response->redirect($c->uri_for_action($self->action_for('show'), [ $cdtoc->discid ]));
-            $c->detach;
         }
     );
 }
@@ -192,7 +190,6 @@ sub attach : Local
                 $c->response->redirect(
                     $c->uri_for_action(
                         '/release/discids' => [ $medium->release->gid ]));
-                $c->detach;
             }
         )
     }
@@ -359,7 +356,6 @@ sub move : Local RequireAuth Edit
                 $c->response->redirect(
                     $c->uri_for_action(
                         '/release/discids' => [ $medium->release->gid ]));
-                $c->detach;
             }
         )
     }

--- a/lib/MusicBrainz/Server/Controller/ISRC.pm
+++ b/lib/MusicBrainz/Server/Controller/ISRC.pm
@@ -64,7 +64,6 @@ sub delete : Local RequireAuth
         type        => $EDIT_RECORDING_REMOVE_ISRC,
         on_creation => sub {
             $c->response->redirect($c->uri_for_action('/isrc/show', [ $isrc->isrc ]));
-            $c->detach;
         }
     );
 }

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -711,7 +711,6 @@ sub remove_cover_art : Chained('load') PathPart('remove-cover-art') Args(1) Edit
         },
         on_creation => sub {
             $c->response->redirect($c->uri_for_action('/release/cover_art', [ $release->gid ]));
-            $c->detach;
         }
     )
 }


### PR DESCRIPTION
These edits called $c->detach inside their on_creation hooks, which causes an
exception to be thrown. MBS-5586 (26eee) moved these hooks to be inside the
transaction, and so when the detach exception is thrown the transaction is
first rolled back.

This commit stops calling $c->detach inside these handlers, and instead performs
this outside the transaction.
