### PR TITLE
MBS-5797: Don't crash on non-Wikipedia Wikipedia relationships

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
@@ -31,6 +31,8 @@ sub _get_extract
             $_->target;
         } reverse sort_by {
             $_->target->language eq $wanted_lang
+        } grep {
+            $_->target->isa('MusicBrainz::Server::Entity::URL::Wikipedia')
         } @{ $entity->relationships_by_link_type_names('wikipedia') };
 
     if ($wp_link) {


### PR DESCRIPTION
Controller::Role::WikipediaExtract is used to add Wikipedia summaries on an
entity, based on Wikipedia URL relationships. However, if a Wikipedia URL
relationship is present, but the URL is not actually to Wikipedia, an exception
would be thrown.

This commit addresses that by filtering the list of relationships considered to
only be those relationships that truly do point to Wikipedia.
