### PR TITLE
MBS-5757: reduce open time for all edits to 7 days

### DIFF
--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -169,7 +169,7 @@ sub edit_conditions
 {
     return {
         map { $_ =>
-               { duration      => 14,
+               { duration      => 7,
                  votes         => $REQUIRED_VOTES,
                  expire_action => $EXPIRE_ACCEPT,
                  auto_edit     => 1 }


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-5757

We decided in the meeting to change everything for now, and pull back or amend to only non-destructive edits if we decide this is a problem.

I don't mind this, but if we merge this now it means that edits entered on beta get the 7-day expiration and edits entered on production get 14-day expiration. If we want to avoid this, we'll have to merge it right at the next release instead.
