### PR TITLE
MBS-5016: Buttons misaligned in Firefox

### DIFF
--- a/root/static/styles/widgets.css
+++ b/root/static/styles/widgets.css
@@ -11,7 +11,6 @@
 .buttons button,
 .buttons input[type=submit],
 .buttons input[type=button] {
-    display:block;
     float:left;
     margin:0 7px 0 0;
     background-color:#F0F0F0;


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-5016

Removed display:block as suggested in the comment there. That makes it work fine in Firefox, and doesn't seem to cause any problems in Chrome, IE and Opera (the other three browsers I tried it on, all in Win 7)
