### PR TITLE
MBS-5434: Inconsistent terminology: primary/secondary types and type/extra types

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -40,8 +40,8 @@
 
       [%# FIXME: should only be editable on Add Release. %]
       [% IF !release_group %]
-        [% form_row_select (r, 'primary_type_id', l('Type:')) %]
-        [% form_row_select (r, 'secondary_type_ids', l('Extra Types:')) %]
+        [% form_row_select (r, 'primary_type_id', l('Primary Type:')) %]
+        [% form_row_select (r, 'secondary_type_ids', l('Secondary Types:')) %]
       [% ELSE %]
         <div class="row">
           <div class="label">[% l('Type:') %]</div>


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-5434

Choosing Primary / Secondary since that's what we call them internally and also in documentation: http://wiki.musicbrainz.org/Release_Group/Type
