### PR TITLE
MBS-5719: Track number sometimes missing in rel editor

### DIFF
--- a/root/static/scripts/relationship-editor/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/RelationshipEditor.js
@@ -216,15 +216,17 @@ parseTrack = function(track, release) {
     var recording = track.recording;
     recording.type = "recording";
     recording.name = track.name;
-    recording.position = track.position;
-    recording.number = track.number;
     delete recording.artist_credit;
-    recording.artistCredit = "";
+
+    var entity = RE.Entity(recording);
+    entity.position = track.position;
+    entity.number = track.number;
+    entity.artistCredit = "";
 
     if (!Util.compareArtistCredits(release.artist_credit, track.artist_credit))
-        recording.artistCredit = UI.renderArtistCredit(track.artist_credit);
+        entity.artistCredit = UI.renderArtistCredit(track.artist_credit);
 
-    return RE.Entity(recording);
+    return entity;
 };
 
 


### PR DESCRIPTION
If a relationship whose target is a recording that's also part of the
tracklist is parsed before the recording node for the actual tracklist
is parsed, then the recording Entity will be missing its number
attribute, among other things.

http://tickets.musicbrainz.org/browse/MBS-5719

Manual testing, QUnit tests still pass.
