### PR TITLE
MBS-5727: Disc [medium] title missing from edit relationships page

### DIFF
--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -379,7 +379,9 @@
             <td></td>
             <td colspan="2">
               <input type="checkbox" class="medium-recordings">
-              <!-- ko text: format --><!-- /ko -->
+              <!-- ko text: format --><!-- /ko --><!-- ko if: name -->:
+                <!-- ko text: name --><!-- /ko -->
+              <!-- /ko -->
             </td>
             <td><input type="checkbox" class="medium-works"></td>
           </tr>


### PR DESCRIPTION
Adds medium titles to the template (CD 2: Electric Boogaloo)

Manual testing, ran QUnit.
