### PR TITLE
MBS-5591: Pressing Enter in AR editor Work combo box submits work instead of selecting element from list

### DIFF
--- a/root/static/scripts/relationship-editor/Dialog.js
+++ b/root/static/scripts/relationship-editor/Dialog.js
@@ -287,14 +287,16 @@ ko.bindingHandlers.autocomplete = (function() {
 
 
 var BaseDialog = (function() {
-    var inputRegex = /^input|button|select$/, selectChanged = {};
+    var inputRegex = /^input|button|select$/;
+    var selectChanged = {};
 
     function dialogKeydown(event) {
         if (event.isDefaultPrevented())
             return;
 
-        var self = this, target = event.target,
-            nodeName = target.nodeName.toLowerCase();
+        var self = this;
+        var target = event.target;
+        var nodeName = target.nodeName.toLowerCase();
 
         if (nodeName == "select" && target.id)
             selectChanged[target.id] = false;


### PR DESCRIPTION
Fixes another sensitive browser-keyboard issue in the relationship editor.

Tested in Chrome/Firefox/Opera 10.
