### PR TITLE
MBS-5813: In the release editor, show the 'artist editable' checkbox

### DIFF
--- a/root/static/scripts/release-editor/MB/Control/ReleaseTracklist.js
+++ b/root/static/scripts/release-editor/MB/Control/ReleaseTracklist.js
@@ -951,6 +951,8 @@ MB.Control.ReleaseDisc = function (parent, $disc) {
 MB.Control.ReleaseTracklist = function () {
     var self = MB.Object ();
 
+    $('#release-editor table.tbl th input[type="checkbox"]').show();
+
     self.bubble_collection = MB.Control.BubbleCollection ();
     self.bubble_collection.setType (MB.Control.BubbleRow);
 


### PR DESCRIPTION
c2848355 (MBS-5740) made this checkbox only appear conditionally, if
the table contained <input> elements with type="checkbox", at the
time of initialization. However, the release editor dynamically creates
checkboxes, and so the select all checkbox would not be shown. This
commit simply re-shows the checkbox in the release editor.
