### PR TITLE
MBS-5815: Use "Dead" in edit artist page like on sidebar

### DIFF
--- a/root/scripts/text_strings.tt
+++ b/root/scripts/text_strings.tt
@@ -70,7 +70,7 @@
         },
         ArtistDate: {
             Unknown: [ '[% l('Began:') | js %]', '[% l('Ended:') | js %]', '[% l('This artist has ended.') | js %]'  ],
-            Person: [ '[% l('Born:') | js %]', '[% l('Dead:') | js %]', '[% l('This person is deceased.') | js %]' ],
+            Person: [ '[% l('Born:') | js %]', '[% l('Died:') | js %]', '[% l('This person is deceased.') | js %]' ],
             Founded: [ '[% l('Founded:') | js %]', '[% l('Dissolved:') | js %]', '[% l('This group has dissolved.') | js %]' ]
         },
         Pager: '[% l('page #{page} of #{total}') | js %]',


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-5815

Just to use the same word in both places (we use the same "Born:" string for birth). I've left "This artist is deceased" because it sounds better there, but if you want me to change it too shout at me :)
