### PR TITLE
Added work relationship to batch add relationships.

### DIFF
--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -74,7 +74,7 @@
         <tr>
           <td class="section">
             <select id="target-type" data-bind="targetType: $data,
-              disable: mode() == 'edit' || relationship().type == 'recording-work'"></select>
+              disable: mode() == 'edit'"></select>
           </td>
           <td>
             <span id="autocomplete" class="autocomplete" data-bind="autocomplete: relationship">

--- a/root/static/scripts/relationship-editor/Dialog.js
+++ b/root/static/scripts/relationship-editor/Dialog.js
@@ -22,7 +22,7 @@ MB.RelationshipEditor = (function(RE) {
 var UI = RE.UI = RE.UI || {}, Util = RE.Util = RE.Util || {}, $w = $(window);
 
 var allowedRelations = {
-    recording:     ["artist", "label", "recording", "release"],
+    recording:     ["artist", "label", "recording", "release", "work"],
     work:          ["artist", "label", "work"],
     release:       ["artist", "label", "recording", "release"],
     release_group: ["artist", "release_group"]


### PR DESCRIPTION
This is going to be important for linking to books, as required by the new audiobook style guideline. The original ticket also gave linking recordings on a "single" release as a use case.

Enabled linking of work relationships using the "Batch-add a relationship to recordings" button, in addition to the "Add related work" button. This has the side effect of enabling the type selection box on the "Add related work" dialog - when clicked - this has a single value - work.
