### PR TITLE
Remove memcached from Perl dependencies section because it's realdy inst...

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,7 +150,7 @@ Below outlines how to setup MusicBrainz server with local::lib.
     There are also a few development headers that will be needed when installing
     dependencies. Run the following steps as a normal user on your system.
 
-        sudo apt-get install libxml2-dev libpq-dev libexpat1-dev libdb-dev liblocal-lib-perl cpanminus
+        sudo apt-get install libxml2-dev libpq-dev libexpat1-dev libdb-dev libicu-dev liblocal-lib-perl cpanminus
 
 3.  Enable local::lib
 


### PR DESCRIPTION
Remove memcached from Perl dependencies section because it's realdy installed in the Prerequisites section

Also libicu-dev is required for Perl dependencies section.
