### PR TITLE
MBS-2677: Add a way to filter search by edit count of the editor

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
@@ -23,9 +23,9 @@ sub combine_with_query {
     my $sql = "EXISTS (
         SELECT 1
         FROM edit edit_inner
-        WHERE edit_inner.editor = edit.editor AND edit_inner.status = " . $STATUS_APPLIED .
-        "HAVING " . $having .
-        ")";
+        WHERE edit_inner.editor = edit.editor AND edit_inner.status = $STATUS_APPLIED
+        HAVING $having
+    )";
     $query->add_where([ $sql, $self->sql_arguments ]);
 }
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/AppliedEdits.pm
@@ -1,0 +1,33 @@
+package MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
+use Moose;
+use namespace::autoclean;
+use feature 'switch';
+
+use MusicBrainz::Server::Constants qw( :edit_status ); 
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::ID';
+
+sub combine_with_query {
+    my ($self, $query) = @_;
+
+    my $having;
+    given ($self->operator) {
+        when ('BETWEEN') {
+            $having = 'count(*) BETWEEN SYMMETRIC ? AND ?';
+        }
+        default {
+            $having = join(' ', 'count(*)', $self->operator, '?');
+        }
+    }
+
+    my $sql = "EXISTS (
+        SELECT 1
+        FROM edit edit_inner
+        WHERE edit_inner.editor = edit.editor AND edit_inner.status = " . $STATUS_APPLIED .
+        "HAVING " . $having .
+        ")";
+    $query->add_where([ $sql, $self->sql_arguments ]);
+}
+
+
+1;

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -12,6 +12,7 @@ use MusicBrainz::Server::EditSearch::Predicate::Set;
 use MusicBrainz::Server::EditSearch::Predicate::Entity;
 use MusicBrainz::Server::EditSearch::Predicate::Editor;
 use MusicBrainz::Server::EditSearch::Predicate::EditorFlag;
+use MusicBrainz::Server::EditSearch::Predicate::AppliedEdits;
 use MusicBrainz::Server::EditSearch::Predicate::Vote;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseLanguage;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality;
@@ -41,6 +42,7 @@ my %field_map = (
     release_country => 'MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry',
     link_type => 'MusicBrainz::Server::EditSearch::Predicate::RelationshipType',
     editor_flag => 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag',
+    applied_edits => 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits',
 
     map {
         $_ => 'MusicBrainz::Server::EditSearch::Predicate::' . camelize($_)

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -81,6 +81,8 @@
                predicate_link_type(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
                predicate_editor_flag(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits';
+               predicate_applied_edits(field.field_name, field);
            END %]
         [% IF field.does('MusicBrainz::Server::EditSearch::Predicate::SubscribedEntity');
              predicate_subscription(field.field_name, field);
@@ -299,6 +301,23 @@
   </select>
 [% END %]
 
+[% MACRO predicate_applied_edits(field, field_contents) WRAPPER wfield predicate='id' %]
+  [% operators([ [ '=', l('equal to') ],
+                 [ '!=', l('not equal to') ],
+                 [ '>', l('more than') ],
+                 [ '<', l('less than') ],
+                 ['BETWEEN', l('is between') ] ], field_contents) %]
+
+  <span style="display:none" class="arg">
+    <input type="number" name="args.0" size="10" value="[% html_escape(field_contents.argument(0)) %]" />
+  </span>
+
+  <span style="display:none" class="arg">
+    &#x2013;
+    <input type="number" name="args.1" size="10" value="[% html_escape(field_contents.argument(1)) %]" />
+  </span>
+[% END %]
+
 [% MACRO select_field(field_contents) BLOCK %]
   <select name="field" class="field">
     [% UNLESS field_contents %]
@@ -331,6 +350,7 @@
                    [ 'release_country', l('Release Country') ]
                    [ 'link_type', l('Relationship Type') ],
                    [ 'editor_flag', l('Editor Flag') ],
+                   [ 'applied_edits', l('Applied Edit Count of Editor') ],
                    ] -%]
     <option
        [%~ ' selected="selected"' IF field_contents.field_name == field.0 =%]

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -82,7 +82,7 @@
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag';
                predicate_editor_flag(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits';
-               predicate_applied_edits(field.field_name, field);
+               predicate_int(field.field_name, field);
            END %]
         [% IF field.does('MusicBrainz::Server::EditSearch::Predicate::SubscribedEntity');
              predicate_subscription(field.field_name, field);
@@ -299,23 +299,6 @@
             >[% html_escape(item.1) %]</option>
     [% END %]
   </select>
-[% END %]
-
-[% MACRO predicate_applied_edits(field, field_contents) WRAPPER wfield predicate='id' %]
-  [% operators([ [ '=', l('equal to') ],
-                 [ '!=', l('not equal to') ],
-                 [ '>', l('more than') ],
-                 [ '<', l('less than') ],
-                 ['BETWEEN', l('is between') ] ], field_contents) %]
-
-  <span style="display:none" class="arg">
-    <input type="number" name="args.0" size="10" value="[% html_escape(field_contents.argument(0)) %]" />
-  </span>
-
-  <span style="display:none" class="arg">
-    &#x2013;
-    <input type="number" name="args.1" size="10" value="[% html_escape(field_contents.argument(1)) %]" />
-  </span>
 [% END %]
 
 [% MACRO select_field(field_contents) BLOCK %]


### PR DESCRIPTION
This adds a new condition into [edit search](https://beta.musicbrainz.org/search/edits): "Applied Edit Count of Editor". It allows to filter search by number of applied edits associated with the user (editor). :mag_right: 