### PR TITLE
More autoedits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -10,6 +10,7 @@ with 'MusicBrainz::Server::Edit::Relationship';
 with 'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use MooseX::Types::Moose qw( ArrayRef Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
@@ -284,16 +285,6 @@ sub reject
         $self->c->model('Relationship')->load_subset([ 'url' ], $release);
         $self->c->model('CoverArt')->cache_cover_art($release);
     }
-}
-
-sub allow_auto_edit {
-    my ($self) = @_;
-
-    if ($self->data->{type0} eq "recording" && $self->data->{type1} eq "work") {
-        return 1;
-    }
-
-    return 0;
 }
 
 before restore => sub {

--- a/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
@@ -13,6 +13,7 @@ with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
 with 'MusicBrainz::Server::Edit::Role::Insert';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add release label') }
 sub edit_kind { 'add' }

--- a/lib/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Create.pm
@@ -22,6 +22,7 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
@@ -15,6 +15,7 @@ extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Remove release label') }
 sub edit_kind { 'remove' }

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -9,7 +9,10 @@ BEGIN { use MusicBrainz::Server::Edit::Relationship::Create }
 
 use DBDefs;
 use MusicBrainz::Server::Context;
-use MusicBrainz::Server::Constants qw( $EDIT_RELATIONSHIP_CREATE );
+use MusicBrainz::Server::Constants qw(
+    $EDIT_RELATIONSHIP_CREATE
+    $UNTRUSTED_FLAG
+);
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
 test all => sub {
@@ -66,7 +69,6 @@ subtest 'creating cover art relationships should update the releases coverart' =
     );
 
     $c->sql->do('UPDATE link_type SET is_deprecated = TRUE where id = 78');
-    accept_edit($c, $edit);
 
     my $release = $c->model('Release')->get_by_id(1);
     $c->model('Release')->load_meta($release);
@@ -87,7 +89,6 @@ subtest 'creating asin relationships should update the releases coverart' => sub
             link_type => $c->model('LinkType')->get_by_id(77),
             ended => 1
         );
-        accept_edit($c, $edit);
 
         my $release = $c->model('Release')->get_by_id(2);
         $c->model('Release')->load_meta($release);
@@ -117,8 +118,6 @@ subtest 'Text attributes of value 0 are supported' => sub {
         ],
     );
 
-    accept_edit($c, $edit);
-
     my $rel = $c->model('Relationship')->get_by_id('artist', 'event', $edit->entity_id);
     $c->model('Link')->load($rel);
 
@@ -144,8 +143,6 @@ subtest 'Instrument credits can be added with a new relationship' => sub {
             }
         ],
     );
-
-    accept_edit($c, $edit);
 
     my $rel = $c->model('Relationship')->get_by_id('artist', 'artist', $edit->entity_id);
     $c->model('Link')->load($rel);
@@ -185,6 +182,7 @@ sub _create_edit {
         end_date => { year => 1995 },
         attributes => [ ],
         ended => 1,
+        privileges => $UNTRUSTED_FLAG,
         %args,
     );
 }

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
@@ -8,7 +8,10 @@ with 't::Context';
 
 BEGIN { use MusicBrainz::Server::Edit::Release::AddReleaseLabel }
 
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_ADDRELEASELABEL );
+use MusicBrainz::Server::Constants qw(
+    $EDIT_RELEASE_ADDRELEASELABEL
+    $UNTRUSTED_FLAG
+);
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
 test all => sub {
@@ -64,6 +67,7 @@ test 'Inserting just a catalog number' => sub {
             editor_id => 1,
             release => $c->model('Release')->get_by_id(1),
             catalog_number => 'AVCD-51002',
+            privileges => $UNTRUSTED_FLAG,
         );
 
         $edit = $c->model('Edit')->get_by_id_and_lock($edit->id);
@@ -82,8 +86,6 @@ test 'Inserting just a catalog number' => sub {
             release => $c->model('Release')->get_by_id(1),
             catalog_number => 'AVCD-51002',
         );
-
-        accept_edit($c, $edit);
 
         my $release = $c->model('Release')->get_by_id(1);
         $c->model('ReleaseLabel')->load($release);
@@ -166,6 +168,7 @@ sub create_edit {
         release => $c->model('Release')->get_by_id(1),
         label => $c->model('Label')->get_by_id(2),
         catalog_number => 'AVCD-51002',
+        privileges => $UNTRUSTED_FLAG,
     );
 }
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/Create.pm
@@ -8,7 +8,10 @@ with 't::Context';
 BEGIN { use MusicBrainz::Server::Edit::Release::Create }
 
 use MusicBrainz::Server::Context;
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_CREATE );
+use MusicBrainz::Server::Constants qw(
+    $EDIT_RELEASE_CREATE
+    $UNTRUSTED_FLAG
+);
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
 test all => sub {
@@ -112,6 +115,7 @@ sub create_edit
         comment => 'An empty release!',
         status_id => 1,
         release_group_id => 1,
+        privileges => $UNTRUSTED_FLAG,
     );
 }
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
@@ -7,7 +7,10 @@ with 't::Context';
 
 BEGIN { use MusicBrainz::Server::Edit::Release::DeleteReleaseLabel }
 
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_DELETERELEASELABEL );
+use MusicBrainz::Server::Constants qw(
+    $EDIT_RELEASE_DELETERELEASELABEL
+    $UNTRUSTED_FLAG
+);
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
 test all => sub {
@@ -113,6 +116,7 @@ sub create_edit {
         edit_type => $EDIT_RELEASE_DELETERELEASELABEL,
         editor_id => 1,
         release_label => $c->model('ReleaseLabel')->get_by_id($id),
+        privileges => $UNTRUSTED_FLAG,
     );
 }
 


### PR DESCRIPTION
Makes "add release," "add release label," "delete release label," and "add relationship" edits auto-edits, as decided during the summit.