### PR TITLE
MBS-8208 and MBS-8271

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -298,6 +298,7 @@ Readonly our $MBID_SUBMITTER_FLAG      => 64;
 Readonly our $ACCOUNT_ADMIN_FLAG       => 128;
 Readonly our $LOCATION_EDITOR_FLAG     => 256;
 Readonly our $BANNER_EDITOR_FLAG       => 512;
+Readonly our $EDITING_DISABLED_FLAG    => 1024;
 
 Readonly our $ELECTION_VOTE_NO      => -1;
 Readonly our $ELECTION_VOTE_ABSTAIN => 0;

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -24,16 +24,17 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves
     my $form = $c->form(
         form => 'User::AdjustFlags',
         item => {
-            auto_editor     => $user->is_auto_editor,
-            bot             => $user->is_bot,
-            untrusted       => $user->is_untrusted,
-            link_editor     => $user->is_relationship_editor,
-            location_editor => $user->is_location_editor,
-            no_nag          => $user->is_nag_free,
-            wiki_transcluder=> $user->is_wiki_transcluder,
-            banner_editor   => $user->is_banner_editor,
-            mbid_submitter  => $user->is_mbid_submitter,
-            account_admin   => $user->is_account_admin,
+            auto_editor         => $user->is_auto_editor,
+            bot                 => $user->is_bot,
+            untrusted           => $user->is_untrusted,
+            link_editor         => $user->is_relationship_editor,
+            location_editor     => $user->is_location_editor,
+            no_nag              => $user->is_nag_free,
+            wiki_transcluder    => $user->is_wiki_transcluder,
+            banner_editor       => $user->is_banner_editor,
+            mbid_submitter      => $user->is_mbid_submitter,
+            account_admin       => $user->is_account_admin,
+            editing_disabled    => $user->is_editing_disabled,
         },
     );
 

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -80,7 +80,7 @@ sub data : Chained('load') RequireAuth
                template => 'edit/data.tt' );
 }
 
-sub enter_votes : Local RequireAuth DenyWhenReadonly
+sub enter_votes : Local RequireAuth(editing_enabled) DenyWhenReadonly
 {
     my ($self, $c) = @_;
 
@@ -99,7 +99,7 @@ sub enter_votes : Local RequireAuth DenyWhenReadonly
     $c->detach;
 }
 
-sub approve : Chained('load') RequireAuth(auto_editor) DenyWhenReadonly
+sub approve : Chained('load') RequireAuth(auto_editor) RequireAuth(editing_enabled) DenyWhenReadonly
 {
     my ($self, $c) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -272,7 +272,7 @@ sub begin : Private
     }
 
     if (exists $c->action->attributes->{Edit} && $c->user_exists &&
-        !$c->user->has_confirmed_email_address)
+        (!$c->user->has_confirmed_email_address || $c->user->is_editing_disabled))
     {
         $c->forward('/error_401');
     }

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -283,8 +283,7 @@ sub update_profile
     }, $self->sql);
 }
 
-sub update_privileges
-{
+sub update_privileges {
     my ($self, $editor, $values) = @_;
 
     my $privs =   ($values->{auto_editor}      // 0) * $AUTO_EDITOR_FLAG
@@ -296,11 +295,11 @@ sub update_privileges
                 + ($values->{wiki_transcluder} // 0) * $WIKI_TRANSCLUSION_FLAG
                 + ($values->{banner_editor}    // 0) * $BANNER_EDITOR_FLAG
                 + ($values->{mbid_submitter}   // 0) * $MBID_SUBMITTER_FLAG
-                + ($values->{account_admin}    // 0) * $ACCOUNT_ADMIN_FLAG;
+                + ($values->{account_admin}    // 0) * $ACCOUNT_ADMIN_FLAG
+                + ($values->{editing_disabled} // 0) * $EDITING_DISABLED_FLAG;
 
     Sql::run_in_transaction(sub {
-        $self->sql->do('UPDATE editor SET privs=? WHERE id=?',
-                 $privs, $editor->id);
+        $self->sql->do('UPDATE editor SET privs = ? WHERE id = ?', $privs, $editor->id);
     }, $self->sql);
 }
 

--- a/lib/MusicBrainz/Server/Edit/Area.pm
+++ b/lib/MusicBrainz/Server/Edit/Area.pm
@@ -6,9 +6,9 @@ use MusicBrainz::Server::Translation 'l';
 
 sub edit_category { l('Area') }
 
-sub editor_may_edit {
-    my ($self) = @_;
-    return $self->editor->is_location_editor;
-}
+around editor_may_edit => sub {
+    my ($orig, $self) = @_;
+    return $self->$orig && $self->editor->is_location_editor;
+};
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Instrument.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument.pm
@@ -6,9 +6,9 @@ use MusicBrainz::Server::Translation 'l';
 
 sub edit_category { l('Instrument') }
 
-sub editor_may_edit {
-    my ($self) = @_;
-    return $self->editor->is_relationship_editor;
-}
+around editor_may_edit => sub {
+    my ($orig, $self) = @_;
+    return $self->$orig && $self->editor->is_relationship_editor;
+};
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -296,12 +296,12 @@ before restore => sub {
     $self->restore_int_attributes($data) unless defined $data->{edit_version};
 };
 
-sub editor_may_edit {
-    my ($self, $opts) = @_;
+around editor_may_edit => sub {
+    my ($orig, $self, $opts) = @_;
 
     my $lt = $opts->{link_type};
-    return $self->editor_may_edit_types($lt->entity0_type, $lt->entity1_type);
-}
+    return $self->$orig && $self->editor_may_edit_types($lt->entity0_type, $lt->entity1_type);
+};
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -272,12 +272,12 @@ before restore => sub {
     }
 };
 
-sub editor_may_edit {
-    my ($self, $opts) = @_;
+around editor_may_edit => sub {
+    my ($orig, $self, $opts) = @_;
 
     my $lt = $opts->{relationship}->link->type;
-    return $self->editor_may_edit_types($lt->entity0_type, $lt->entity1_type);
-}
+    return $self->$orig && $self->editor_may_edit_types($lt->entity0_type, $lt->entity1_type);
+};
 
 around edit_conditions => sub {
     my ($orig, $self, @args) = @_;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -554,17 +554,18 @@ before restore => sub {
     }
 };
 
-sub editor_may_edit {
-    my ($self, $opts) = @_;
+around editor_may_edit => sub {
+    my ($orig, $self, $opts) = @_;
 
     my $old_lt = $opts->{relationship}->link->type;
     my $new_lt = $opts->{link_type} // $old_lt;
 
     return (
+        $self->$orig &&
         $self->editor_may_edit_types($old_lt->entity0_type, $old_lt->entity1_type) &&
         $self->editor_may_edit_types($new_lt->entity0_type, $new_lt->entity1_type)
     );
-}
+};
 
 sub allow_auto_edit {
     my ($self) = @_;

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -91,6 +91,14 @@ sub is_banner_editor
     return (shift->privileges & $mask) > 0;
 }
 
+sub is_editing_disabled {
+    (shift->privileges & $EDITING_DISABLED_FLAG) > 0;
+}
+
+sub is_editing_enabled {
+    (shift->privileges & $EDITING_DISABLED_FLAG) == 0;
+}
+
 has 'email' => (
     is        => 'rw',
     isa       => 'Str',
@@ -259,6 +267,7 @@ around TO_JSON => sub {
         is_account_admin => boolean_to_json($self->is_account_admin),
         is_admin => boolean_to_json($self->is_admin),
         is_banner_editor => boolean_to_json($self->is_banner_editor),
+        is_editing_disabled => boolean_to_json($self->is_editing_disabled),
         is_location_editor => boolean_to_json($self->is_location_editor),
         is_relationship_editor => boolean_to_json($self->is_relationship_editor),
         is_wiki_transcluder => boolean_to_json($self->is_wiki_transcluder),

--- a/lib/MusicBrainz/Server/Form/User/AdjustFlags.pm
+++ b/lib/MusicBrainz/Server/Form/User/AdjustFlags.pm
@@ -50,6 +50,10 @@ has_field 'account_admin' => (
     type => 'Boolean',
 );
 
+has_field 'editing_disabled' => (
+    type => 'Boolean',
+);
+
 1;
 
 =head1 COPYRIGHT

--- a/lib/MusicBrainz/Server/Form/User/Report.pm
+++ b/lib/MusicBrainz/Server/Form/User/Report.pm
@@ -1,0 +1,56 @@
+package MusicBrainz::Server::Form::User::Report;
+
+use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( l );
+use Readonly;
+
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => (
+    default => 'report',
+);
+
+has_field 'reason' => (
+    type => 'Select',
+    required => 1,
+);
+
+has_field 'message' => (
+    type => 'Text',
+    required => 1,
+);
+
+has_field 'reveal_address' => (
+    type => 'Boolean',
+);
+
+Readonly our %REASONS => (
+    'spam' => l('Editor is spamming'),
+    'unresponsiveness' => l('Editor is unresponsive to edit notes'),
+    'ignoring_guidelines' => l('Editor intentionally ignores accepted guidelines'),
+    'enforcing_guidelines' => l('Editor is overzealous in enforcing guidelines as rules'),
+    'voting' => l('Editor engages in overzealous or abusive yes/no voting'),
+    'other' => l('Editor has violated some other part of our Code of Conduct'),
+);
+
+sub options_reason {
+    [map { $_ => $REASONS{$_} } qw(
+        spam
+        unresponsiveness
+        ignoring_guidelines
+        enforcing_guidelines
+        voting
+        other
+    )];
+}
+
+1;
+
+=head1 COPYRIGHT
+
+This file is part of MusicBrainz, the open internet music database.
+Copyright (C) 2015 MetaBrainz Foundation
+Licensed under the GPL version 2, or (at your option) any later version:
+http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/admin/edit_user.tt
+++ b/root/admin/edit_user.tt
@@ -9,6 +9,7 @@
         [% form_row_checkbox(r, 'link_editor', l('Relationship editor')) %]
         [% form_row_checkbox(r, 'location_editor', l('Location editor')) %]
         [% form_row_checkbox(r, 'banner_editor', l('Banner message editor')) %]
+        [% form_row_checkbox(r, 'editing_disabled', l('Editing/voting disabled')) %]
 
         <h2>[%- l('Technical flags') -%]</h2>
         [% form_row_checkbox(r, 'bot', l('Bot')) %]

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -24,6 +24,16 @@
             </div>
         </div>
 
+        [%- IF c.user.is_editing_disabled -%]
+            <div class="banner editing-disabled">
+                <p>
+                    [% l('You’re currently not allowed to edit or vote because an admin has revoked your privileges.
+                          If you haven’t already been contacted about why, please {uri|send us a message}.',
+                        { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
+                </p>
+            </div>
+        [%- END -%]
+
         [%- IF !c.req.cookies.server_details_dismissed_mtime.value -%]
             [% IF server_details.staging_server %]
                 <div class="banner server-details">

--- a/root/static/styles/extra/banner.less
+++ b/root/static/styles/extra/banner.less
@@ -24,10 +24,21 @@
 
 .warning-header,
 .server-details,
-.alert {
+.alert,
+.editing-disabled {
     font-weight: bold;
 }
 
 .server-details {
     color: @text-orange;
+}
+
+.editing-disabled {
+    background: @error-header;
+    color: @text-white;
+    font-size: @large-text;
+
+    a {
+        color: @text-orange;
+    }
 }

--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -246,4 +246,13 @@
         </tfoot>
     </table>
 
+    [%- IF c.user.id != user.id -%]
+        <p style="clear: both;">
+            <h2>
+                <a href="[% c.uri_for_action('/user/report', [user.name]) %]">
+                    [% l('Report this user for bad behavior') %]
+                </a>
+            </h2>
+        </p>
+    [%- END -%]
 [% END %]

--- a/root/user/report.tt
+++ b/root/user/report.tt
@@ -1,0 +1,29 @@
+[%- WRAPPER 'user/profile/layout.tt' title=l("Report User") full_width=1 -%]
+    <h2>[% l('Report User') %]</h2>
+
+    <p>[%- l('Please review our {uri|Code of Conduct} before sending a report.',
+            { uri => { href => doc_link('Code_of_Conduct'), target => '_blank' } }) -%]</p>
+
+    <p>[%- l('Your report will be sent to our {uri|account administrators}, who will decide what action to take.',
+            { uri => { href => c.uri_for_action('/user/privileged'), target => '_blank' } }) -%]</p>
+
+    <p>[%- l('If you’d like us to be able to easily respond to your report, please check “Reveal my email address” below.') -%]</p>
+
+    [%- USE r = FormRenderer(form) -%]
+
+    <form action="[% c.req.uri %]" method="post" class="report-form">
+        [% form_row_select(r, 'reason', l('Reason:')) %]
+
+        [% WRAPPER form_row %]
+            [% r.label('message', l('Message:')) %]
+            [% r.textarea('message', { cols => 50, rows => 10 }) %]
+            [% field_errors(form, 'message') %]
+        [% END %]
+
+        [% form_row_checkbox(r, 'reveal_address', l('Reveal my email address')) %]
+
+        <div class="row no-label">
+            [% form_submit(l('Send')) %]
+        </div>
+    </form>
+[%- END -%]


### PR DESCRIPTION
cc @Freso @reosarevok

Adds an `$EDITING_DISABLED_FLAG` which when set disables editing/voting on an account, and displays a large banner message on every page (with the assumption that we won't ever set this flag without also contacting the user to explain why).

![MBS-8271 banner](https://i.imgur.com/oZ9YPRZ.png)

Also adds a UI for reporting editors for bad behavior, mostly copied from the UI for sending messages to editors. Except this sends a message to all the "account administrators" (since they're the ones who can toggle account flags).

Please review/comment on the list of options!

![MBS-8208 UI](https://i.imgur.com/GjT5NlO.png)