### PR TITLE
MBS-8639: Instrument merge gives ERROR: duplicate key value violates unique constraint "link_attribute_pkey"

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Edit/Instrument/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Instrument/Merge.pm
@@ -1,0 +1,87 @@
+package t::MusicBrainz::Server::Edit::Instrument::Merge;
+
+use Test::Routine;
+use Test::More;
+use Test::Deep;
+
+with 't::Context';
+
+use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Constants qw( $EDIT_INSTRUMENT_MERGE :edit_status );
+use MusicBrainz::Server::Test qw( accept_edit );
+
+test 'MBS-8639' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-8639');
+
+    my $edit = $c->model('Edit')->create(
+        edit_type => $EDIT_INSTRUMENT_MERGE,
+        editor_id => 1,
+        old_entities => [{ id => 588, name => 'other drums' }],
+        new_entity => { id => 100, name => 'drums' },
+    );
+
+    accept_edit($c, $edit);
+    is($edit->status, $STATUS_APPLIED);
+
+    # Both instrument credits are kept, as separate relationships.
+    my $relationships = $c->sql->select_list_of_hashes('SELECT * FROM l_artist_recording ORDER BY id');
+    cmp_deeply($relationships, [
+        {
+            edits_pending => 0,
+            entity0 => 1,
+            entity0_credit => '',
+            entity1 => 1,
+            entity1_credit => '',
+            id => 1,
+            last_updated => ignore(),
+            link => 3,
+            link_order => 0,
+        },
+        {
+            edits_pending => 0,
+            entity0 => 2,
+            entity0_credit => '',
+            entity1 => 1,
+            entity1_credit => '',
+            id => 2,
+            last_updated => ignore(),
+            link => 5,
+            link_order => 0,
+        },
+        {
+            edits_pending => 0,
+            entity0 => 1,
+            entity0_credit => '',
+            entity1 => 1,
+            entity1_credit => '',
+            id => 3,
+            last_updated => ignore(),
+            link => 4,
+            link_order => 0,
+        },
+    ]);
+
+    my $credits = $c->sql->select_list_of_hashes('SELECT * FROM link_attribute_credit ORDER BY link');
+    cmp_deeply($credits, [
+        {
+            attribute_type => 125,
+            credited_as => 'drumz',
+            link => 3,
+        },
+        {
+            attribute_type => 125,
+            credited_as => 'crazy drums',
+            link => 4,
+        },
+        {
+            attribute_type => 125,
+            credited_as => 'kool drums',
+            link => 5,
+        },
+    ]);
+};
+
+1;

--- a/t/sql/initial.sql
+++ b/t/sql/initial.sql
@@ -126,6 +126,7 @@ INSERT INTO link_attribute_type VALUES (582, NULL, 582, 0, '112054d5-e706-4dd8-9
 INSERT INTO link_attribute_type VALUES (596, NULL, 596, 0, '63daa0d3-9b63-4434-acff-4977c07808ca', 'solo', 'This should be used when an artist is credited in liner notes or a similar source as performing a solo part.', '2011-12-11 19:32:02.707134+00');
 INSERT INTO link_attribute_type VALUES (617, NULL, 617, 0, '65969e82-5ee5-4035-a211-00e6bf8a0f75', 'emeritus', 'This title indicates that a conductor has at least partially retired, and no longer plays an active role with the group.', '2012-05-10 11:55:43.372982+00');
 INSERT INTO link_attribute_type VALUES (618, NULL, 618, 0, 'd3362ce5-ea76-4cb4-854b-9540fc716078', 'principal', 'This indicates that the group had multiple conductors who were led by this conductor. This may be indicated by either the title of "principal conductor" or "first conductor".', '2012-05-10 11:56:58.200781+00');
+INSERT INTO link_attribute_type VALUES (700, 14, 14, 0, '1da1ca18-9d70-4217-9e3c-9e67c93b834a', 'other drums', 'variously sized drums', '2015-11-06 23:07:56.985481+00');
 INSERT INTO link_attribute_type VALUES (750, NULL, 750, 0, '37da3398-5d1b-4acb-be25-df95e33e423c', 'medley', 'This indicates that the recording is of a medley, of which the work is one part.', '2014-01-01 10:32:01.979531+00');
 INSERT INTO link_attribute_type VALUES (788, NULL, 788, 0, 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a', 'number', 'This attribute indicates the number of a work in a series.', '2014-05-14 16:39:54.654562+00');
 INSERT INTO link_attribute_type VALUES (830, NULL, 830, 0, 'ebd303c3-7f57-452a-aa3b-d780ebad868d', 'time', 'Local time a band''s performance is scheduled to start, formatted HH:MM.', '2014-11-18 14:34:00.964336+00');
@@ -133,8 +134,10 @@ INSERT INTO link_attribute_type VALUES (830, NULL, 830, 0, 'ebd303c3-7f57-452a-a
 INSERT INTO link_creditable_attribute_type VALUES (3);
 INSERT INTO link_creditable_attribute_type VALUES (14);
 INSERT INTO link_creditable_attribute_type VALUES (46);
+INSERT INTO link_creditable_attribute_type VALUES (125);
 INSERT INTO link_creditable_attribute_type VALUES (229);
 INSERT INTO link_creditable_attribute_type VALUES (302);
+INSERT INTO link_creditable_attribute_type VALUES (700);
 
 INSERT INTO link_text_attribute_type VALUES (788);
 INSERT INTO link_text_attribute_type VALUES (830);

--- a/t/sql/mbs-8639.sql
+++ b/t/sql/mbs-8639.sql
@@ -1,0 +1,37 @@
+DROP TRIGGER a_ins_instrument ON instrument;
+
+INSERT INTO editor (id, name, password, ha1, email, email_confirm_date, privs)
+    VALUES (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'editor@example.com', now(), 8);
+
+INSERT INTO instrument (id, gid, name, type)
+    VALUES (100, '3bccb7eb-cbca-42cd-b0ac-a5e959df7221', 'drums', 3),
+           (588, '1da1ca18-9d70-4217-9e3c-9e67c93b834a', 'other drums', 3);
+
+INSERT INTO link (id, link_type, attribute_count)
+    VALUES (1, 148, 2), (2, 148, 2);
+
+INSERT INTO link_attribute (link, attribute_type)
+    VALUES (1, 125), (1, 700), (2, 125), (2, 700);
+
+INSERT INTO link_attribute_credit (link, attribute_type, credited_as)
+    VALUES (1, 125, 'drumz'),
+           (1, 700, 'crazy drums'), -- link 1 should be split into two separate links, since credits differ
+           (2, 700, 'kool drums');  -- link 2 should remain as a single link
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, '52bf0d89-9668-4cd4-95f3-3d9d87a54c5c', 'A1', 'A1'),
+           (2, 'd5359fdc-2601-4071-b6df-59394e353244', 'A2', 'A2');
+
+INSERT INTO artist_credit (id, name, artist_count) VALUES (1, 'A1', 1);
+
+INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phrase)
+    VALUES (1, 0, 1, 'A1', '');
+
+INSERT INTO recording (id, gid, name, artist_credit, length)
+    VALUES (1, '86368c22-3794-454f-8763-ba1d6279dae6', 'R1', 1, NULL);
+
+INSERT INTO l_artist_recording (id, link, entity0, entity1)
+    VALUES (1, 1, 1, 1), (2, 2, 2, 1);
+
+CREATE TRIGGER a_ins_instrument AFTER INSERT ON instrument
+    FOR EACH ROW EXECUTE PROCEDURE a_ins_instrument();


### PR DESCRIPTION
This was really annoying to fix. http://musicbrainz.org/edit/35820353 is stuck because http://musicbrainz.org/release/d769b4ac-cd35-39ab-833c-8933f2f128e5 contains this relationship: "drums, musical saw, other drums [stringdrum], percussion and tambourine: Björn Tollin (1994)."

So, that relationship contains a link attribute to "drums" (the merge target) and "other drums" (the merge source) with a `credited_as` value of "stringdrum." Since the credit makes the attributes differentiable, it tries to keep both post-merge, but you can only have one (link, attribute_type) pair in the `link_attribute` table, so it fails.

The solution here is, if there's only one conflicting attribute (like in this case), to just move the credit into the target's link attribute if it's empty. Otherwise, it creates separate links/relationships to keep the conflicting credits in.