### PR TITLE
MBS-1880: Allow an editor to apply edits without voting within a short timeframe after his/her 'add release'

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -511,16 +511,16 @@ sub create {
 
     $edit->insert;
 
-    my $now = DateTime->now;
     my $duration = DateTime::Duration->new( days => $conditions->{duration} );
+    my $interval = DateTime::Format::Pg->format_interval($duration);
 
     my $row = {
         editor => $edit->editor_id,
         data => JSON::Any->new( utf8 => 1 )->objToJson($edit->to_hash),
         status => $edit->status,
         type => $edit->edit_type,
-        open_time => $now,
-        expire_time => $now + $duration,
+        open_time => \"now()",
+        expire_time => \"now() + interval '$interval'",
         autoedit => $edit->auto_edit,
         quality => $edit->quality,
         close_time => $edit->close_time

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -35,6 +35,7 @@ extends 'MusicBrainz::Server::Edit::WithDifferences';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Medium';
+with 'MusicBrainz::Server::Edit::Role::AllowAmendingRelease';
 
 use aliased 'MusicBrainz::Server::Entity::Medium';
 use aliased 'MusicBrainz::Server::Entity::Release';
@@ -45,6 +46,7 @@ sub edit_kind { 'edit' }
 sub _edit_model { 'Medium' }
 sub entity_id { shift->data->{entity_id} }
 sub medium_id { shift->entity_id }
+sub release_id { shift->data->{release}{id} }
 
 has '+data' => (
     isa => Dict[

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -35,6 +35,7 @@ with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
+with 'MusicBrainz::Server::Edit::Role::AllowAmendingRelease';
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -22,6 +22,7 @@ with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit release label') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Role/AllowAmendingRelease.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/AllowAmendingRelease.pm
@@ -1,0 +1,37 @@
+package MusicBrainz::Server::Edit::Role::AllowAmendingRelease;
+
+use Moose::Role;
+use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_CREATE );
+
+requires 'release_id';
+
+around allow_auto_edit => sub {
+    my ($orig, $self) = @_;
+
+    # Allow being an auto-edit if the release-add edit was opened by the same
+    # editor less than an hour ago.
+
+    my @args = ($self->release_id, $self->editor_id, $EDIT_RELEASE_CREATE);
+    my $add_release_edit = $self->c->sql->select_single_value(<<'EOSQL', @args);
+        SELECT id FROM edit
+          JOIN edit_release ON edit.id = edit_release.edit
+         WHERE edit_release.release = ?
+           AND edit.editor = ?
+           AND edit.type = ?
+           AND (now() - edit.open_time) < interval '1 hour'
+EOSQL
+
+    return 1 if defined $add_release_edit;
+    return $self->$orig;
+};
+
+1;
+
+=head1 COPYRIGHT
+
+This file is part of MusicBrainz, the open internet music database.
+Copyright (C) 2014-2015 MetaBrainz Foundation
+Licensed under the GPL version 2, or (at your option) any later version:
+http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -469,7 +469,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     @edits = capture_edits {
         post_json($mech, '/ws/js/edit/create', encode_json({
             edits => $medium_edits,
-            makeVotable => 0,
+            makeVotable => 1,
         }));
     } $c;
 


### PR DESCRIPTION
Makes the following edits auto-edits if entered within 1 hour of the original release add, by the same editor:
Add medium
Edit medium
Edit release

"Add release label" and "Remove release label" were already made auto-edits, but "Edit release label" was not, which doesn't make sense. So I just added the `AlwaysAutoEdit` role to `EditReleaseLabel` too, instead of the new `AllowAmendingRelease` role.