### PR TITLE
MBS-8636: Adding duplicate entities to a series causes an internal server error

### DIFF
--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -315,6 +315,7 @@ sub automatically_reorder {
             unless ($conflicting_relationship) {
                 push @from_values, "(?, ?)";
                 push @from_args, $relationship->id, $link_order;
+                push @{$relationships_by_link_order{$link_order}}, $relationship;
             }
 
             $prev_relationship = $relationship;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
@@ -1,7 +1,7 @@
 package t::MusicBrainz::Server::Controller::Work::Edit;
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
+use Test::Deep qw( cmp_deeply ignore re );
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
 use HTTP::Request::Common;
 use List::UtilsBy qw( sort_by );
@@ -144,6 +144,81 @@ EOSQL
             }
         ]
     );
+};
+
+test 'MBS-8636: Adding a relationship to a series which contains duplicate items' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-8636');
+
+    $c->sql->do(<<'EOSQL');
+INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
+VALUES (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo@example.com', now());
+EOSQL
+
+    $mech->get_ok('/login');
+    $mech->submit_form(with_fields => { username => 'editor', password => 'pass' });
+
+    my @edits = capture_edits {
+        $mech->post("/work/02bfb89e-8877-47c0-a19d-b574bae78198/edit", {
+            'edit-work.comment' => '',
+            'edit-work.edit_note' => '',
+            'edit-work.iswcs.0' => '',
+            'edit-work.language_id' => '486',
+            'edit-work.name' => 'Concerto and Fugue in C minor, BWV 909',
+            'edit-work.rel.0.attributes.0.text_value' => 'BWV 909',
+            'edit-work.rel.0.attributes.0.type.gid' => 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a',
+            'edit-work.rel.0.backward' => '1',
+            'edit-work.rel.0.entity0_credit' => '',
+            'edit-work.rel.0.entity1_credit' => '',
+            'edit-work.rel.0.link_order' => '0',
+            'edit-work.rel.0.link_type_id' => '743',
+            'edit-work.rel.0.target' => 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582',
+            'edit-work.type_id' => '',
+        });
+    } $c;
+
+    is(scalar @edits, 1);
+    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Relationship::Create');
+
+    my $relationships = $c->sql->select_list_of_hashes('SELECT * FROM l_series_work ORDER BY id');
+    cmp_deeply($relationships, [
+          {
+            edits_pending => 1,
+            entity0 => 25,
+            entity0_credit => '',
+            entity1 => 10465539,
+            entity1_credit => '',
+            id => 2025,
+            last_updated => ignore(),
+            link => 170801,
+            link_order => 749,
+          },
+          {
+            edits_pending => 0,
+            entity0 => 25,
+            entity0_credit => '',
+            entity1 => 10465539,
+            entity1_credit => '',
+            id => 15120,
+            last_updated => ignore(),
+            link => 170801,
+            link_order => 2,
+          },
+          {
+            edits_pending => 0,
+            entity0 => 25,
+            entity0_credit => '',
+            entity1 => 12894254,
+            entity1_credit => '',
+            id => 15121,
+            last_updated => ignore(),
+            link => 170802,
+            link_order => 1,
+          },
+    ]);
 };
 
 1;

--- a/t/sql/initial.sql
+++ b/t/sql/initial.sql
@@ -84,6 +84,8 @@ INSERT INTO label_type VALUES (7, 'Publisher', NULL, 0, NULL);
 INSERT INTO label_type VALUES (8, 'Rights Society', NULL, 0, NULL);
 INSERT INTO label_type VALUES (9, 'Imprint', NULL, 0, NULL);
 
+INSERT INTO language VALUES (486, 'zxx', 'zxx', NULL, 'No linguistic content', 1, 'zxx');
+
 INSERT INTO link_attribute_type VALUES (1, NULL, 1, 0, '0a5341f8-3b1d-4f99-a0c6-26b7f4e42c7f', 'additional', 'This attribute describes if a particular role was considered normal or additional.', '2014-03-30 09:53:32.715353+00');
 INSERT INTO link_attribute_type VALUES (2, NULL, 2, 0, '5b66c85d-6963-4d4b-86e5-18d2caccb349', 'minor', 'This attribute describes if a particular collaboration was considered equal or minor.', '2011-09-28 20:29:34.86135+00');
 INSERT INTO link_attribute_type VALUES (3, NULL, 3, 2, 'd92884b7-ee0c-46d5-96f3-918196ba8c5b', 'vocal', 'This attribute describes a type of vocal performance.', '2011-09-21 18:29:05.11911+00');

--- a/t/sql/mbs-8636.sql
+++ b/t/sql/mbs-8636.sql
@@ -1,0 +1,16 @@
+INSERT INTO series (id, gid, name, comment, type, ordering_attribute, ordering_type, edits_pending, last_updated)
+    VALUES (25, 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582', 'Bach-Werke-Verzeichnis', '', 5, 788, 1, 0, '2014-05-14 18:28:59.030601+00');
+
+INSERT INTO work (id, gid, name, type, comment, edits_pending, last_updated, language)
+    VALUES (10465539, '9deecf21-8d3f-3bbd-8f36-6331c9fd6d35', '9 kleine Präludien: Präludium D-Dur, BWV 925', NULL, '', 0, '2014-01-08 21:17:20.377241+00', 486),
+           (12894254, '02bfb89e-8877-47c0-a19d-b574bae78198', 'Concerto and Fugue in C minor, BWV 909', NULL, '', 0, '2015-11-20 10:27:40.150479+00', 486);
+
+INSERT INTO link (id, link_type, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, attribute_count, created, ended)
+    VALUES (170801, 743, NULL, NULL, NULL, NULL, NULL, NULL, 1, '2014-05-21 06:35:59.318332+00', 'f');
+
+INSERT INTO link_attribute_text_value (link, attribute_type, text_value)
+    VALUES (170801, 788, 'BWV 925');
+
+INSERT INTO l_series_work (id, link, entity0, entity1, edits_pending, last_updated, link_order, entity0_credit, entity1_credit)
+    VALUES (15120, 170801, 25, 10465539, 0, '2015-11-11 16:23:07.850893+00', 0, '', ''),
+           (2025, 170801, 25, 10465539, 1, '2014-05-21 06:35:59.318332+00', 749, '', '');


### PR DESCRIPTION
Ensure that `%relationships_by_link_order` is kept up-to-date based on where we plan to move things, not just based on what's currently in the database, to avoid all conflicts.