### PR TITLE
MBS-8648: Show source entity for old relationship edits

### DIFF
--- a/root/edit/details/historic/add_relationship.tt
+++ b/root/edit/details/historic/add_relationship.tt
@@ -7,6 +7,7 @@
       <ul>
         [% FOR relationship=edit.display_data.relationships %]
         <li>
+           [% link_entity(relationship.source); %]
            [% display_relationship(relationship); %]
         </li>
         [% END %]


### PR DESCRIPTION
Historic _Add relationship_ edits no longer displayed the source entity for the relationship. Re-add the corresponding `link_entity` macro call that was removed in commit 8639da7917a3ba1fcbf4d15bd9de6de9e70c8c86, apparently because it was no longer needed in the template for current _Add relationship_ edits (which have access to the verbose link phrase).