### PR TITLE
MBS-8647: "Edits for subscribed entites" doesn't show auto-edits

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -48,6 +48,7 @@
         "date_period": true,
         "disambiguation": true,
         "edit_table": true,
+        "materialized_edit_status": true,
         "mbid": {
             "indexable": true,
             "multiple": true,
@@ -187,6 +188,7 @@
         "date_period": true,
         "disambiguation": true,
         "edit_table": true,
+        "materialized_edit_status": true,
         "mbid": {
             "indexable": true,
             "multiple": true,

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -8,7 +8,7 @@ use Data::Page;
 use DBDefs;
 use MusicBrainz::Server::EditRegistry;
 use MusicBrainz::Server::Edit::Utils qw( status_names );
-use MusicBrainz::Server::Constants qw( $STATUS_OPEN :quality $REQUIRED_VOTES $OPEN_EDIT_DURATION );
+use MusicBrainz::Server::Constants qw( :quality $REQUIRED_VOTES $OPEN_EDIT_DURATION );
 use MusicBrainz::Server::Validation qw( is_positive_integer );
 use MusicBrainz::Server::EditSearch::Query;
 use MusicBrainz::Server::Data::Utils qw( type_to_model load_everything_for_edits );
@@ -238,13 +238,13 @@ sub search : Path('/search/edits') RequireAuth
 sub subscribed : Local RequireAuth {
     my ($self, $c) = @_;
 
-    my $status;
+    my $only_open = 0;
     if ($c->req->query_params->{open} eq '1') {
-        $status = $STATUS_OPEN;
+        $only_open = 1;
     }
 
     my $edits = $self->_load_paged($c, sub {
-        $c->model('Edit')->subscribed_entity_edits($c->user->id, $status, shift, shift);
+        $c->model('Edit')->subscribed_entity_edits($c->user->id, $only_open, shift, shift);
     });
 
     $c->stash(
@@ -258,13 +258,13 @@ sub subscribed : Local RequireAuth {
 sub subscribed_editors : Local RequireAuth {
     my ($self, $c) = @_;
 
-    my $status;
+    my $only_open = 0;
     if ($c->req->query_params->{open} eq '1') {
-        $status = $STATUS_OPEN;
+        $only_open = 1;
     }
 
     my $edits = $self->_load_paged($c, sub {
-        $c->model('Edit')->subscribed_editor_edits($c->user->id, $status, shift, shift);
+        $c->model('Edit')->subscribed_editor_edits($c->user->id, $only_open, shift, shift);
     });
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -235,11 +235,16 @@ sub search : Path('/search/edits') RequireAuth
     }
 }
 
-sub subscribed : Local RequireAuth
-{
+sub subscribed : Local RequireAuth {
     my ($self, $c) = @_;
+
+    my $status;
+    if ($c->req->query_params->{open} eq '1') {
+        $status = $STATUS_OPEN;
+    }
+
     my $edits = $self->_load_paged($c, sub {
-        $c->model('Edit')->subscribed_entity_edits($c->user->id, shift, shift);
+        $c->model('Edit')->subscribed_entity_edits($c->user->id, $status, shift, shift);
     });
 
     $c->stash(
@@ -250,11 +255,16 @@ sub subscribed : Local RequireAuth
     load_everything_for_edits($c, $edits);
 }
 
-sub subscribed_editors : Local RequireAuth
-{
+sub subscribed_editors : Local RequireAuth {
     my ($self, $c) = @_;
+
+    my $status;
+    if ($c->req->query_params->{open} eq '1') {
+        $status = $STATUS_OPEN;
+    }
+
     my $edits = $self->_load_paged($c, sub {
-        $c->model('Edit')->subscribed_editor_edits($c->user->id, shift, shift);
+        $c->model('Edit')->subscribed_editor_edits($c->user->id, $status, shift, shift);
     });
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -22,9 +22,11 @@ use MusicBrainz::Server::Constants qw(
     $VOTE_APPROVE
     $MINIMUM_RESPONSE_PERIOD
     $LIMIT_FOR_EDIT_LISTING
+    $OPEN_EDIT_DURATION
     $QUALITY_UNKNOWN_MAPPED
     $EDITOR_MODBOT
-    entities_with );
+    entities_with
+    %ENTITIES );
 use MusicBrainz::Server::Data::Utils qw( placeholders );
 use JSON::Any;
 
@@ -316,31 +318,62 @@ sub find_creation_edit {
 }
 
 sub subscribed_entity_edits {
-    my ($self, $editor_id, $status, $limit, $offset) = @_;
+    my ($self, $editor_id, $only_open, $limit, $offset) = @_;
 
     my $columns = $self->_columns;
     my $table = $self->_table;
-    my $order = 'DESC';
-    my @args;
+    my @args = (
+        $STATUS_OPEN, # $1
+        $editor_id,   # $2
+    );
 
-    if ($status) {
-        $order = 'ASC';
+    unless ($only_open) {
+        # $3
+        push @args, DateTime::Format::Pg->format_interval(
+            DateTime::Duration->new(days => $OPEN_EDIT_DURATION)
+        );
     }
 
-    my $filter = sub {
-        my ($edit_table, $editor_subscribe_table) = @_;
+    my $edit_filter = sub {
+        my ($status_table, $editor_table, $editor_op) = @_;
 
-        my $result = '';
+        my $result;
 
-        if ($status) {
-            $result .= "$edit_table.status = ? AND ";
-            push @args, $status;
+        if ($only_open) {
+            $result = "$status_table.status = \$1\n";
+        } else {
+            $result = "($status_table.status = \$1 OR (now() - edit.open_time) < interval \$3)\n";
         }
 
-        $result .= "$editor_subscribe_table.editor = ?";
-        push @args, $editor_id;
+        $editor_op //= '=';
+        $result .= "AND $editor_table.editor $editor_op \$2\n";
         $result;
     };
+
+    my $entity_sql = join(' UNION ', map {
+        my $edit_entity_table = 'edit_' . $_;
+        my $edit_status_table = $edit_entity_table;
+        my $editor_subscribe_table = 'editor_subscribe_' . $_;
+        my $result = <<EOSQL;
+SELECT edit FROM $edit_entity_table
+JOIN $editor_subscribe_table ON $editor_subscribe_table.$_ = $edit_entity_table.$_
+EOSQL
+
+        # Join with the edit table if
+        # (1) this entity doesn't have a materialized edit status (e.g. series), or
+        # (2) we're showing recent closed edits too (needs edit.open_time).
+        unless ($ENTITIES{$_}{materialized_edit_status} && $only_open) {
+            $result .= "JOIN edit ON $edit_entity_table.edit = edit.id\n";
+        }
+
+        unless ($ENTITIES{$_}{materialized_edit_status}) {
+            $edit_status_table = 'edit';
+        }
+
+        $result .= 'WHERE ';
+        $result .= $edit_filter->($edit_status_table, $editor_subscribe_table);
+        $result;
+    } entities_with([['mbid', 'relatable'], ['subscriptions', 'entity']]));
 
     my $subscriptions_sql = join(' UNION ', map {
         my $type = $_;
@@ -355,61 +388,39 @@ sub subscribed_entity_edits {
 
     my $query = <<EOSQL;
 SELECT * FROM edit, (
-    SELECT edit FROM edit_artist ea
-    JOIN editor_subscribe_artist esa ON esa.artist = ea.artist
-    WHERE ${\($filter->('ea', 'esa'))}
-    UNION
-    SELECT edit FROM edit_label el
-    JOIN editor_subscribe_label esl ON esl.label = el.label
-    WHERE ${\($filter->('el', 'esl'))}
+    $entity_sql
     UNION
     SELECT edit FROM ($subscriptions_sql) ce
       JOIN edit ON ce.edit = edit.id
-    WHERE ${\($filter->('edit', 'ce'))}
-    UNION
-    SELECT edit FROM edit_series es
-    JOIN editor_subscribe_series ess ON ess.series = es.series
-    JOIN edit ON es.edit = edit.id
-    WHERE ${\($filter->('edit', 'ess'))}
+     WHERE ${\($edit_filter->('edit', 'ce'))}
 ) edits
 WHERE edit.id = edits.edit
-EOSQL
-
-    if ($status) {
-        $query .= 'AND edit.status = ?';
-        push @args, $status;
-    }
-
-    $query .= <<EOSQL;
-AND edit.editor != ?
+AND ${\($edit_filter->('edit', 'edit', '!='))}
 AND NOT EXISTS (
     SELECT TRUE FROM vote
     WHERE vote.edit = edit.id
-    AND vote.editor = ?
+    AND vote.editor = \$2
 )
-ORDER BY id $order
+ORDER BY id ASC
 LIMIT $LIMIT_FOR_EDIT_LISTING
 EOSQL
 
-    push @args, (
-        $editor_id, # Editor (not current one)
-        $editor_id, # Editor (has not voted)
-    );
-
-    $self->query_to_list_limited($query, \@args, $limit, $offset);
+    $self->query_to_list_limited($query, \@args, $limit, $offset, undef, 1);
 }
 
 sub subscribed_editor_edits {
-    my ($self, $editor_id, $status, $limit, $offset) = @_;
+    my ($self, $editor_id, $only_open, $limit, $offset) = @_;
 
-    my @args = ($editor_id, $editor_id);
-    my $status_sql = '';
-    my $order = 'DESC';
+    my @args = ($editor_id, $editor_id, $STATUS_OPEN);
+    my $status_sql;
 
-    if ($status) {
+    if ($only_open) {
         $status_sql = 'AND status = ?';
-        $order = 'ASC';
-        push @args, $status;
+    } else {
+        $status_sql = 'AND (status = ? OR (now() - open_time) < interval ?)';
+        push @args, DateTime::Format::Pg->format_interval(
+            DateTime::Duration->new(days => $OPEN_EDIT_DURATION)
+        );
     }
 
     my $query =
@@ -422,7 +433,7 @@ sub subscribed_editor_edits {
                    AND vote.superseded = FALSE
                 )
             $status_sql
-       ORDER BY id $order
+       ORDER BY id ASC
           LIMIT " . $LIMIT_FOR_EDIT_LISTING;
 
     $self->query_to_list_limited($query, \@args, $limit, $offset);

--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -16,13 +16,19 @@ sub query_to_list {
 }
 
 sub query_to_list_limited {
-    my ($self, $query, $args, $limit, $offset, $builder) = @_;
+    my ($self, $query, $args, $limit, $offset, $builder, $dollar_placeholders) = @_;
 
     $builder //= $self->can('_new_from_row');
 
     my @args = @$args;
+    my $count = @args;
+
     if (defined $offset) {
-        $query .= " OFFSET ?";
+        if ($dollar_placeholders) {
+            $query .= ' OFFSET $' . (++$count);
+        } else {
+            $query .= ' OFFSET ?';
+        }
         push @args, $offset;
     }
 
@@ -33,7 +39,11 @@ sub query_to_list_limited {
     };
 
     if (defined $limit) {
-        $wrapping_query .= " LIMIT ?";
+        if ($dollar_placeholders) {
+            $wrapping_query .= ' LIMIT $' . (++$count);
+        } else {
+            $wrapping_query .= ' LIMIT ?';
+        }
         push @args, $limit;
     }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -175,9 +175,9 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.2.1.tgz"
     },
     "babel-generator": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "from": "babel-generator@>=6.2.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.3.1.tgz"
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.1.18",
@@ -791,27 +791,22 @@
           "version": "1.1.3",
           "from": "domelementtype@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-        },
-        "entities": {
-          "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "from": "domelementtype@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
+      "from": "domhandler@>=2.3.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
+      "from": "domutils@>=1.5.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "duplexer2": {
@@ -842,9 +837,9 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
     },
     "entities": {
-      "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+      "version": "1.1.1",
+      "from": "entities@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "envify": {
       "version": "3.4.0",
@@ -872,9 +867,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.0.0.tgz"
     },
     "es5-ext": {
-      "version": "0.10.8",
+      "version": "0.10.9",
       "from": "es5-ext@>=0.10.8 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.9.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
@@ -1794,9 +1789,9 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "globals": {
-      "version": "8.13.0",
+      "version": "8.14.0",
       "from": "globals@>=8.3.0 <9.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-8.13.0.tgz"
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.14.0.tgz"
     },
     "globby": {
       "version": "3.0.1",
@@ -1967,16 +1962,9 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "htmlparser2": {
-      "version": "3.8.3",
+      "version": "3.9.0",
       "from": "htmlparser2@>=3.7.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz"
     },
     "http-signature": {
       "version": "1.1.0",
@@ -2649,14 +2637,14 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
-      "version": "1.19.0",
-      "from": "mime-db@>=1.19.0 <1.20.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+      "version": "1.20.0",
+      "from": "mime-db@>=1.20.0 <1.21.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "from": "mime-types@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
     },
     "minimatch": {
       "version": "2.0.10",
@@ -2952,9 +2940,9 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
     },
     "process-nextick-args": {
-      "version": "1.0.3",
+      "version": "1.0.5",
       "from": "process-nextick-args@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.5.tgz"
     },
     "promise": {
       "version": "6.1.0",
@@ -2975,6 +2963,11 @@
       "version": "5.2.0",
       "from": "qs@>=5.2.0 <5.3.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "randomatic": {
       "version": "1.1.3",
@@ -3274,9 +3267,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.7.0",
+      "version": "1.7.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "parse-stack": "0.1.3",
     "po2json": "0.4.1",
     "q": "1.4.1",
+    "querystring": "0.2.0",
     "rcss": "0.1.5",
     "react": "0.14.3",
     "react-dom": "0.14.3",

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -14,6 +14,15 @@
     [%~ END ~%]
 [%~ END ~%]
 
+[% IF show_open_filter %]
+    <p>
+        <label>
+            <input type="checkbox" id="only-open-edits"[% ' checked' IF c.req.query_params.open == 1 %] />
+            [% l('Only show open edits (oldest first).') %]
+        </label>
+    </p>
+[% END %]
+
 [% INCLUDE 'edit/list_header.tt' %]
 
 <div class="search-toggle c">
@@ -90,11 +99,9 @@
     [% END %]
 [% END %]
 
-<script type="text/javascript">//<![CDATA[
-  $(".edit-list").each(function () {
-      MB.Control.EditSummary(this);
-  });
+[% script_manifest('voting.js') %]
 
+<script type="text/javascript">//<![CDATA[
   [% IF c.user.is_auto_editor %]
     MB.Control.EditList("#edits");
   [% END %]

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -18,7 +18,7 @@
     <p>
         <label>
             <input type="checkbox" id="only-open-edits"[% ' checked' IF c.req.query_params.open == 1 %] />
-            [% l('Only show open edits (oldest first).') %]
+            [% l('Only show open edits') %]
         </label>
     </p>
 [% END %]

--- a/root/edit/subscribed-editors.tt
+++ b/root/edit/subscribed-editors.tt
@@ -1,6 +1,6 @@
-[% WRAPPER 'layout.tt' title=l('Open Edits by Your Subscribed Editors') full_width=1 %]
+[% WRAPPER 'layout.tt' title=l('Edits by Your Subscribed Editors') full_width=1 %]
     <div id="content">
-        <h1>[% l('Open Edits by Your Subscribed Editors') %]</h1>
-        [% INCLUDE 'edit/list.tt' guess_search=1 %]
+        <h1>[% l('Edits by Your Subscribed Editors') %]</h1>
+        [% INCLUDE 'edit/list.tt' guess_search=1 show_open_filter=1 %]
     </div>
 [% END %]

--- a/root/edit/subscribed.tt
+++ b/root/edit/subscribed.tt
@@ -1,6 +1,6 @@
-[% WRAPPER 'layout.tt' title=l('Open Edits for Your Subscribed Entities') full_width=1 %]
+[% WRAPPER 'layout.tt' title=l('Edits for Your Subscribed Entities') full_width=1 %]
     <div id="content">
-        <h1>[% l('Open Edits for Your Subscribed Entities') %]</h1>
-        [% INCLUDE 'edit/list.tt' guess_search=1 %]
+        <h1>[% l('Edits for Your Subscribed Entities') %]</h1>
+        [% INCLUDE 'edit/list.tt' guess_search=1 show_open_filter=1 %]
     </div>
 [% END %]

--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -195,6 +195,10 @@ function buildScripts() {
     b.external(editBundle);
   });
 
+  var votingBundle = runYarb('voting.js', function (b) {
+    b.external(commonBundle);
+  });
+
   var workBundle = runYarb('work.js', function (b) {
     b.external(editBundle).external(guessCaseBundle);
   });
@@ -209,6 +213,7 @@ function buildScripts() {
     writeScript(statisticsBundle, 'statistics.js'),
     writeScript(timelineBundle, 'timeline.js'),
     writeScript(urlBundle, 'url.js'),
+    writeScript(votingBundle, 'voting.js'),
     writeScript(workBundle, 'work.js'),
     writeScript(runYarb('debug.js', function (b) {
       b.external(commonBundle);

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -16,8 +16,6 @@ require("./common/artworkViewer.js");
 require("./common/dialogs.js");
 require("./common/entity.js");
 require("./common/MB/Control/Autocomplete.js");
-require("./common/MB/Control/EditList.js");
-require("./common/MB/Control/EditSummary.js");
 require("./common/MB/Control/Filter.js");
 require("./common/MB/Control/Menu.js");
 require("./common/MB/Control/SelectAll.js");

--- a/root/static/scripts/voting.js
+++ b/root/static/scripts/voting.js
@@ -1,0 +1,27 @@
+// This file is part of MusicBrainz, the open internet music database.
+// Copyright (C) 2015 MetaBrainz Foundation
+// Licensed under the GPL version 2, or (at your option) any later version:
+// http://www.gnu.org/licenses/gpl-2.0.txt
+
+import querystring from 'querystring';
+
+require("./common/MB/Control/EditList.js");
+require("./common/MB/Control/EditSummary.js");
+
+$('.edit-list').each(function () {
+  MB.Control.EditSummary(this);
+});
+
+$('#only-open-edits').on('change', function () {
+  let search = window.location.search.replace(/^\?/, '');
+  let args = querystring.parse(search);
+
+  if (this.checked) {
+    args.open = 1;
+  } else {
+    delete args.open;
+  }
+
+  this.disabled = true;
+  window.location.search = '?' + querystring.stringify(args);
+});


### PR DESCRIPTION
cc @reosarevok

This'll show all edits by default, and it reverses the sorting so that newer edits are shown first.

But if you check "Only show open edits (oldest first)." it'll sort them oldest-first, like before.

We'll see what people think about that. See comments on http://tickets.musicbrainz.org/browse/MBS-8647