### PR TITLE
Always show the collection name to add/remove even if there is only one

### DIFF
--- a/root/layout/sidebar/shared-entity-sidebar.tt
+++ b/root/layout/sidebar/shared-entity-sidebar.tt
@@ -101,19 +101,11 @@
                     <li>
                     [%~ IF containment.${collection.id} ~%]
                         <a href="[%~ c.uri_for_action("/collection/remove", [collection.gid], { $entity_type => entity.id }) ~%]">
-                            [%~ IF collections.size == 1 ~%]
-                                [%~ l('Remove from my collection') ~%]
-                            [%~ ELSE ~%]
-                                [%~ l('Remove from {collection}', { collection => collection.name }) ~%]
-                            [%~ END ~%]
+                            [%~ l('Remove from {collection}', { collection => collection.name }) ~%]
                         </a>
                     [%~ ELSE ~%]
                         <a href="[%~ c.uri_for_action("/collection/add", [collection.gid], { $entity_type => entity.id }) ~%]">
-                        [%~ IF collections.size == 1 ~%]
-                            [%~ l('Add to my collection') ~%]
-                        [%~ ELSE ~%]
                             [%~ l('Add to {collection}', {collection => collection.name }) ~%]
-                        [%~ END ~%]
                         </a>
                     [%~ END ~%]
                     </li>


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/MBS-8460

It doesn't make sense to show 'your collection' when there is only one
collection, but then show collection names when there is more than one.
Instead, always show collection names in the text 'add to {collection}'