### PR TITLE
 MBS-8645: Enable searching for edits by an event

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -5,7 +5,7 @@ use MusicBrainz::Server::CGI::Expand qw( expand_hash );
 use MooseX::Types::Moose qw( Any ArrayRef Bool Int Maybe Str );
 use MooseX::Types::Structured qw( Map Tuple );
 use Moose::Util::TypeConstraints qw( enum role_type );
-use MusicBrainz::Server::Constants qw( $LIMIT_FOR_EDIT_LISTING );
+use MusicBrainz::Server::Constants qw( $LIMIT_FOR_EDIT_LISTING entities_with );
 use MusicBrainz::Server::EditSearch::Predicate::Date;
 use MusicBrainz::Server::EditSearch::Predicate::ID;
 use MusicBrainz::Server::EditSearch::Predicate::Set;
@@ -21,7 +21,6 @@ use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry;
 use MusicBrainz::Server::EditSearch::Predicate::RelationshipType;
 use MusicBrainz::Server::Log 'log_warning';
-use String::CamelCase qw( camelize );
 use Try::Tiny;
 
 my %field_map = (
@@ -44,9 +43,12 @@ my %field_map = (
     editor_flag => 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag',
     applied_edits => 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits',
 
-    map {
-        $_ => 'MusicBrainz::Server::EditSearch::Predicate::' . camelize($_)
-    } qw( area artist instrument label place recording release release_group series work )
+    entities_with(['mbid', 'relatable'],
+        take => sub {
+            my ($type, $info) = @_;
+            ($type => 'MusicBrainz::Server::EditSearch::Predicate::' . $info->{model})
+        },
+    ),
 );
 
 has negate => (

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Relationship.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Relationship.pm
@@ -2,7 +2,6 @@ package MusicBrainz::Server::WebService::Serializer::JSON::2::Relationship;
 use Moose;
 use Hash::Merge qw( merge );
 use List::AllUtils qw( any );
-use String::CamelCase qw( camelize );
 use MusicBrainz::Server::Data::Utils qw( non_empty );
 use MusicBrainz::Server::WebService::Serializer::JSON::2::Utils qw( date_period serialize_entity );
 

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -316,6 +316,7 @@
                    [ 'yes_votes', l('Yes vote count') ],
                    [ 'area', l('Area') ],
                    [ 'artist', l('Artist') ],
+                   [ 'event', l('Event') ],
                    [ 'instrument', l('Instrument') ],
                    [ 'label', l('Label') ],
                    [ 'place', l('Place') ],
@@ -356,7 +357,7 @@
          predicate_subscription(linked_type);
        END %]
 
-    [% FOR linked_type=[ 'area', 'instrument', 'place', 'recording', 'release_group', 'release', 'work', 'editor' ];
+    [% FOR linked_type=[ 'area', 'event', 'instrument', 'place', 'recording', 'release_group', 'release', 'work', 'editor' ];
          predicate_link(linked_type);
        END %]
 


### PR DESCRIPTION
Events were missing from edit search due to hard-coded entity lists. Add them to the templates and make the query parser use `entities_with`.