### PR TITLE
MBS-8660: Fix removing an editor’s location

### DIFF
--- a/lib/MusicBrainz/Server/Form/User/EditProfile.pm
+++ b/lib/MusicBrainz/Server/Form/User/EditProfile.pm
@@ -32,9 +32,9 @@ has_field 'gender_id' => (
 );
 
 has_field 'area_id'   => ( type => 'Hidden' );
-
-has_field 'area'      => ( type => 'Compound' );
-has_field 'area.name' => ( type => 'Text' );
+has_field 'area'      => (
+    type => '+MusicBrainz::Server::Form::Field::Area'
+);
 
 has_field 'birth_date' => (
     type => '+MusicBrainz::Server::Form::Field::PartialDate'

--- a/root/account/edit.tt
+++ b/root/account/edit.tt
@@ -24,7 +24,7 @@
         <label for="id-profile.area.name">[% l('Location:') %]</label>
         <span class="area autocomplete">
           <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
-          <input type="hidden" class="gid" />
+          [% r.hidden(form.field('area').field('gid'), class => 'gid') %]
           [% r.hidden('area_id', class => 'id') %]
           [% r.text(area_field, class => 'name') %]
         </span>


### PR DESCRIPTION
It was impossible to remove a location from an editor’s profile. The problem and fix was exactly the same as MBS-7437 (removing the area from places); see commit bc8d2635731f2541d9523dc4cf8c480f643c7876 for a detailed explanation.