### PR TITLE
MBS-8661: Fix adding and editing non-ended areas

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Area/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Create.pm
@@ -15,6 +15,7 @@ extends 'MusicBrainz::Server::Edit::Generic::Create';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Area';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Add area') }
 sub edit_type { $EDIT_AREA_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -28,6 +28,7 @@ extends 'MusicBrainz::Server::Edit::Generic::Edit';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Area';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Edit area') }
 sub edit_type { $EDIT_AREA_EDIT }


### PR DESCRIPTION
The edit types for adding and editing areas did not have the new `DatePeriod` role added when the default value for the `ended` field was removed in commit 1616482a0e6681a810dcb7994601d81230dc87bd. With the code to set the `ended` value correctly missing, edits affecting non-ended areas tried to set the `ended` flag in the database to `NULL`, causing a constraint violation and an ISE. Fix this by adding the missing role.