### PR TITLE
Small fixes to the “report user” feature

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -504,7 +504,8 @@ sub report : Chained('load') RequireAuth HiddenOnSlaves {
 
     if ($reporter->id == $reported_user->id) {
         # A user can't report themselves
-        $c->detach('/user/profile', [$reported_user->name]);
+        $c->response->redirect($c->uri_for_action('/user/profile', [ $reported_user->name ]));
+        $c->detach;
     }
 
     _check_for_confirmed_email($c);

--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -246,7 +246,7 @@
         </tfoot>
     </table>
 
-    [%- IF c.user.id != user.id -%]
+    [%- IF c.user_exists AND !viewing_own_profile -%]
         <h2 style="clear: both;">
             <a href="[% c.uri_for_action('/user/report', [user.name]) %]">
                 [% l('Report this user for bad behavior') %]


### PR DESCRIPTION
1. Only show user-reporting link when logged in

    The link to the form for reporting misbehaving users was shown even to anonymous users. This was inconsistent with related functionality such as contacting users. Only show the link when a user is logged in.

2. Redirect to profile instead of forwarding silently

    When a user tried to report themselves, this was ignored, and the profile page shown under the `/report` URL. Instead, explicitly redirect to the profile page.