### PR TITLE
MBS-8145: Treat timeouts differently from ISEs

### DIFF
--- a/lib/MusicBrainz/ErrorCatcherEmailWrapper.pm
+++ b/lib/MusicBrainz/ErrorCatcherEmailWrapper.pm
@@ -1,0 +1,49 @@
+package MusicBrainz::ErrorCatcherEmailWrapper;
+
+use strict;
+use warnings;
+
+use Catalyst::Plugin::ErrorCatcher::Email;
+
+our $suppress = 0;
+
+sub emit {
+    my ($class, $c, $output) = @_;
+
+    if ($suppress) {
+        return; # will cause ErrorCatcher to log the error instead
+    } else {
+        Catalyst::Plugin::ErrorCatcher::Email->emit($c, $output);
+        return 1;
+    }
+}
+
+1;
+
+=head1 DESCRIPTION
+
+Wrapper around C<Catalyst::Plugin::ErrorCatcher::Email> that allows
+deactivating the emitter on a case-by-case basis. When you do not want
+for an email to be sent, use C<local> to temporarily give C<$suppress>
+a true value.
+
+=head1 COPYRIGHT
+
+Copyright (C) 2015 Ulrich Klauer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+=cut

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -93,7 +93,7 @@ if ($ENV{'MUSICBRAINZ_USE_PROXY'})
 if (DBDefs->EMAIL_BUGS) {
     __PACKAGE__->config->{'Plugin::ErrorCatcher'} = {
         enable => 1,
-        emit_module => 'Catalyst::Plugin::ErrorCatcher::Email',
+        emit_module => 'MusicBrainz::ErrorCatcherEmailWrapper',
         user_identified_by => 'identity_string'
     };
 

--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -39,7 +39,14 @@ sub _build_conn
     my $conn = DBIx::Connector->new($dsn, $db->username, $db->password, {
         pg_enable_utf8    => 1,
         pg_server_prepare => 0, # XXX Still necessary?
-        HandleError       => sub { my ($msg, $h) = @_; die $h->state . ' ' . $msg },
+        HandleError       => sub {
+            my ($msg, $h) = @_;
+            my $state = $h->state;
+            my $exception = 'MusicBrainz::Server::Exceptions::DatabaseError';
+            $exception .= '::StatementTimedOut'
+                if $state eq '57014';
+            $exception->throw( sqlstate => $state, message => $msg );
+        },
         RaiseError        => 0,
         PrintError        => 0,
     });

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -217,8 +217,11 @@ sub search : Path('/search/edits') RequireAuth
                 return $c->model('Edit')->run_query($query, shift, shift);
             });
         } catch {
-            if ($c->model('MB')->context->sql->is_timeout($_)) { $timed_out = 1; }
-            else { die $_; }
+            unless (blessed $_
+                    && $_->does('MusicBrainz::Server::Exceptions::Role::Timeout')) {
+                die $_; # rethrow
+            }
+            $timed_out = 1;
         };
         if ($timed_out) {
             $c->stash( timed_out => 1 );

--- a/lib/MusicBrainz/Server/Exceptions.pm
+++ b/lib/MusicBrainz/Server/Exceptions.pm
@@ -22,4 +22,20 @@ with 'Throwable';
 
 has 'conflict' => ( is => 'ro', required => 1 );
 
+package MusicBrainz::Server::Exceptions::DatabaseError;
+use Moose;
+extends 'Throwable::Error';
+
+use overload q{""} => 'as_string', fallback => 1;
+
+has sqlstate => ( is => 'ro', isa => 'Str', required => 1 );
+has message => ( is => 'ro', isa => 'Str', required => 1 );
+
+sub as_string { my $self = shift; $self->sqlstate . ' ' . $self->message }
+
+package MusicBrainz::Server::Exceptions::DatabaseError::StatementTimedOut;
+use Moose;
+extends 'MusicBrainz::Server::Exceptions::DatabaseError';
+with 'MusicBrainz::Server::Exceptions::Role::Timeout';
+
 1;

--- a/lib/MusicBrainz/Server/Exceptions.pm
+++ b/lib/MusicBrainz/Server/Exceptions.pm
@@ -22,6 +22,11 @@ with 'Throwable';
 
 has 'conflict' => ( is => 'ro', required => 1 );
 
+package MusicBrainz::Server::Exceptions::GenericTimeout;
+use Moose;
+extends 'Throwable::Error';
+with 'MusicBrainz::Server::Exceptions::Role::Timeout';
+
 package MusicBrainz::Server::Exceptions::DatabaseError;
 use Moose;
 extends 'Throwable::Error';

--- a/lib/MusicBrainz/Server/Exceptions/Role/Timeout.pm
+++ b/lib/MusicBrainz/Server/Exceptions/Role/Timeout.pm
@@ -1,0 +1,4 @@
+package MusicBrainz::Server::Exceptions::Role::Timeout;
+use Moose::Role;
+
+1;

--- a/lib/Sql.pm
+++ b/lib/Sql.pm
@@ -356,13 +356,6 @@ sub run_in_transaction
     }
 }
 
-# Given an error possibly thrown by DBI, does it represent a query timeout?
-sub is_timeout
-{
-    my ($self, $error) = @_;
-    return $error =~ /^57014 /;
-}
-
 # The "Select*" methods.  All these methods accept ($query, @args) parameters,
 # run the given SELECT query using prepare_cached, retrieve the required data,
 # and then "finish" the statement handle.

--- a/root/main/400.tt
+++ b/root/main/400.tt
@@ -16,5 +16,9 @@
             [%- l('Found a problem on our site? Please {report|report a bug} and include any error message that is shown above.',
                  { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1") }) -%]
         </p>
+
+        <h2>[% l('Technical Information') %]</h2>
+
+        [% INCLUDE 'main/info/environment.tt' %]
     </div>
 [% END %]

--- a/root/main/400.tt
+++ b/root/main/400.tt
@@ -4,15 +4,7 @@
 
         <p><strong>[%- l("Sorry, there was a problem with your request.") -%]</strong></p>
 
-        <p>
-            <strong>[%- l('Error message: ') -%]</strong>
-            [% IF message %]
-                <code>[%- message | html -%]</code>
-            [% ELSE %]
-                <code>[%- l('(No details about this error are available)') -%]</code>
-            [% END %]
-        </p>
-
+        [% INCLUDE 'main/info/error.tt' %]
 
         <p>
             [%- l('Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',

--- a/root/main/500.tt
+++ b/root/main/500.tt
@@ -4,44 +4,7 @@
 
         <p><strong>[%- l('Oops, something went wrong!') -%]</strong></p>
 
-        [% IF stack_trace %]
-        <p>
-          <strong>[% ln('Error:', 'Errors:', errors.size) %]</strong>
-          [% IF errors.size > 1 %]
-          <ul>
-            [% FOR error=errors %]<li><code>[% error %]</code></li>[% END %]
-          </ul>
-          [% ELSE %]
-            <p><pre>[% errors.0 %]</pre></p>
-          [% END %]
-        </p>
-        <p>
-            <strong>[%- l('Stack trace:') -%]</strong><br />
-            <ul>
-            [% FOR frame=stack_trace %]
-              <li><code>line [% frame.line %]&#10;[% frame.pkg %]</code></li>
-            [% END %]
-            </ul>
-        </p>
-        <p>
-            <strong>[% l('Request data:') %]</strong>
-            <pre>
-              [%- USE Dumper; Dumper.dump({
-                  query_parameters => c.req.query_params,
-                  body_parameters => c.req.body_params
-              }) -%]
-            </pre>
-        </p>
-        [% ELSE %]
-        <p>
-            <strong>[%- l('Error message: ') -%]</strong>
-            [% IF message %]
-                <code>[%- message | html -%]</code>
-            [% ELSE %]
-                <code>[%- l('(No details about this error are available)') -%]</code>
-            [% END %]
-        </p>
-        [% END %]
+        [% INCLUDE 'main/info/error.tt' %]
 
         [% IF edit.defined; edits = [ edit ]; END %]
         [% IF edits.size %]
@@ -53,25 +16,7 @@
         </ul>
         [% END %]
 
-        <p>
-            <strong>[% l('Time:') %]</strong> [% USE date; date.format(date.now, format => '%Y-%m-%d %H:%M:%S', gmt => 1) %] UTC
-        </p>
-
-        [% IF hostname %]
-        <p>
-            <strong>[% l('Host:') %]</strong> [% hostname %]
-        </p>
-        [% END %]
-        [% IF use_languages %]
-        <p>
-            <strong>[% l('Interface language:') %]</strong> [% current_language %]
-        </p>
-        [% END %]
-
-        <p>
-          <strong>[% l("URL:") %]</strong>
-          <code>[% c.req.uri %]</code>
-        </p>
+        [% INCLUDE 'main/info/environment.tt' %]
 
         <p>
             [%- l("We're terribly sorry for this problem. Please wait a few minutes and repeat your request &#x2014; the problem may go away.") %]

--- a/root/main/info/environment.tt
+++ b/root/main/info/environment.tt
@@ -1,0 +1,20 @@
+<p>
+    <strong>[% l('Time:') %]</strong> [% USE date; date.format(date.now, format => '%Y-%m-%d %H:%M:%S', gmt => 1) %] UTC
+</p>
+
+[% IF hostname %]
+<p>
+    <strong>[% l('Host:') %]</strong> [% hostname %]
+</p>
+[% END %]
+
+[% IF use_languages %]
+<p>
+    <strong>[% l('Interface language:') %]</strong> [% current_language %]
+</p>
+[% END %]
+
+<p>
+  <strong>[% l("URL:") %]</strong>
+  <code>[% c.req.uri %]</code>
+</p>

--- a/root/main/info/environment.tt
+++ b/root/main/info/environment.tt
@@ -18,3 +18,13 @@
   <strong>[% l("URL:") %]</strong>
   <code>[% c.req.uri %]</code>
 </p>
+
+<p>
+    <strong>[% l('Request data:') %]</strong>
+    <pre>
+      [%- USE Dumper; Dumper.dump({
+          query_parameters => c.req.query_params,
+          body_parameters => c.req.body_params
+      }) -%]
+    </pre>
+</p>

--- a/root/main/info/error.tt
+++ b/root/main/info/error.tt
@@ -1,0 +1,38 @@
+[% IF stack_trace %]
+<p>
+  <strong>[% ln('Error:', 'Errors:', errors.size) %]</strong>
+  [% IF errors.size > 1 %]
+  <ul>
+    [% FOR error=errors %]<li><code>[% error %]</code></li>[% END %]
+  </ul>
+  [% ELSE %]
+    <p><pre>[% errors.0 %]</pre></p>
+  [% END %]
+</p>
+<p>
+    <strong>[%- l('Stack trace:') -%]</strong><br />
+    <ul>
+    [% FOR frame=stack_trace %]
+      <li><code>line [% frame.line %]&#10;[% frame.pkg %]</code></li>
+    [% END %]
+    </ul>
+</p>
+<p>
+    <strong>[% l('Request data:') %]</strong>
+    <pre>
+      [%- USE Dumper; Dumper.dump({
+          query_parameters => c.req.query_params,
+          body_parameters => c.req.body_params
+      }) -%]
+    </pre>
+</p>
+[% ELSE %]
+<p>
+    <strong>[%- l('Error message: ') -%]</strong>
+    [% IF message %]
+        <code>[%- message | html -%]</code>
+    [% ELSE %]
+        <code>[%- l('(No details about this error are available)') -%]</code>
+    [% END %]
+</p>
+[% END %]

--- a/root/main/info/error.tt
+++ b/root/main/info/error.tt
@@ -17,15 +17,6 @@
     [% END %]
     </ul>
 </p>
-<p>
-    <strong>[% l('Request data:') %]</strong>
-    <pre>
-      [%- USE Dumper; Dumper.dump({
-          query_parameters => c.req.query_params,
-          body_parameters => c.req.body_params
-      }) -%]
-    </pre>
-</p>
 [% ELSE %]
 <p>
     <strong>[%- l('Error message: ') -%]</strong>

--- a/root/main/timeout.tt
+++ b/root/main/timeout.tt
@@ -1,0 +1,15 @@
+[% WRAPPER "layout.tt" title=l('Request Timed Out') full_width=1 %]
+    <div id="content">
+        <h1>[% l('Request Timed Out') %]</h1>
+
+        <p><strong>[% l('Processing your request took too long and timed out.') %]</strong></p>
+        <p>[% l('It may help to try again by reloading the page.') %]</p>
+
+        <div style="display: none">
+            <h2>[% l('Technical Information') %]</h2>
+
+            [% INCLUDE 'main/info/error.tt' %]
+            [% INCLUDE 'main/info/environment.tt' %]
+        </div>
+    </div>
+[%- END -%]


### PR DESCRIPTION
Database timeouts used to be treated as an internal server error, i.e. an email was sent to MetaBrainz employees about each timeout, and a rather technical error page with a stack trace shown to
the user. When, on the other hand, a request exceeded the allowable time, the server process was
immediately killed with a notice in the logs. The user was shown a plain nginx error page.

This, instead, suppresses error emails for both kinds of timeouts (but logs them) and shows a dedicated error page suggesting to reload the page, with a 503 status code (service unavailable). Instead of killing the process, an exception is thrown, allowing the normal error processing and cleanup to happen. This also makes the return-to-search-form feature of the edit search less fragile (it only worked when the query timed out before the request did, MBS-8382).