### PR TITLE
MBS-8635: Untranslatable strings

### DIFF
--- a/lib/MusicBrainz/Server/Plugin/Translation.pm
+++ b/lib/MusicBrainz/Server/Plugin/Translation.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use base 'Template::Plugin';
+use Encode qw( encode );
 use MusicBrainz::Server::Translation ();
 use MusicBrainz::Server::Translation::Statistics ();
 
@@ -23,20 +24,24 @@ sub new {
 sub l {
     my ($self, $msgid, $vars) = @_;
 
+    $msgid = encode('utf-8', $msgid);
+
     if ($self->domain eq 'statistics') {
-    return MusicBrainz::Server::Translation::Statistics::l($msgid, $vars);
+        return MusicBrainz::Server::Translation::Statistics::l($msgid, $vars);
     } else {
-    return MusicBrainz::Server::Translation::l($msgid, $vars);
+        return MusicBrainz::Server::Translation::l($msgid, $vars);
     }
 }
 
 sub ln {
     my ($self, $msgid, $msgid_plural, $num, $vars) = @_;
 
+    $msgid = encode('utf-8', $msgid);
+
     if ($self->domain eq 'statistics') {
-    return MusicBrainz::Server::Translation::Statistics::ln($msgid, $msgid_plural, $num, $vars);
+        return MusicBrainz::Server::Translation::Statistics::ln($msgid, $msgid_plural, $num, $vars);
     } else {
-    return MusicBrainz::Server::Translation::ln($msgid, $msgid_plural, $num, $vars);
+        return MusicBrainz::Server::Translation::ln($msgid, $msgid_plural, $num, $vars);
     }
 }
 
@@ -45,10 +50,12 @@ sub N_ln { shift; return @_; }
 sub lp {
     my ($self, $msgid, $msgctxt, $vars) = @_;
 
+    $msgid = encode('utf-8', $msgid);
+
     if ($self->domain eq 'statistics') {
-    return MusicBrainz::Server::Translation::Statistics::lp($msgid, $msgctxt, $vars);
+        return MusicBrainz::Server::Translation::Statistics::lp($msgid, $msgctxt, $vars);
     } else {
-    return MusicBrainz::Server::Translation::lp($msgid, $msgctxt, $vars);
+        return MusicBrainz::Server::Translation::lp($msgid, $msgctxt, $vars);
     }
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -99,6 +99,21 @@
       "from": "array-differ@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "from": "array-filter@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "from": "array-map@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "from": "array-reduce@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+    },
     "array-slice": {
       "version": "0.2.3",
       "from": "array-slice@>=0.2.3 <0.3.0",
@@ -3183,6 +3198,11 @@
       "version": "1.0.0",
       "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+    },
+    "shell-quote": {
+      "version": "1.4.3",
+      "from": "shell-quote@*",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz"
     },
     "shelljs": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "rcss": "0.1.5",
     "react": "0.14.3",
     "react-dom": "0.14.3",
+    "shell-quote": "1.4.3",
     "shelljs": "0.5.3",
     "sliced": "1.0.1",
     "tablesorter": "Mottie/tablesorter#430f8c5",

--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -7,6 +7,7 @@ var path = require('path');
 var po2json = require('po2json');
 var rev = require('gulp-rev');
 var shell = require('shelljs');
+var shellQuote = require('shell-quote');
 var source = require('vinyl-source-stream');
 var streamify = require('gulp-streamify');
 var through2 = require('through2');
@@ -145,11 +146,21 @@ function buildScripts() {
     .without('en')
     .map(langToPosix)
     .transform(function (result, lang) {
-      var srcPo = findObjectFile('mb_server', lang, 'po');
-      var tmpPo = path.resolve(PO_DIR, `javascript.${lang}.po`);
+      var srcPo = shellQuote.quote([findObjectFile('mb_server', lang, 'po')]);
+      var tmpPo = shellQuote.quote([path.resolve(PO_DIR, `javascript.${lang}.po`)]);
+
+      // msggrep's -N option supports wildcards which use fnmatch internally.
+      // The '*' cannot match path separators, so we must generate a list of
+      // possible terminal paths.
+      let scriptsDir = shellQuote.quote([SCRIPTS_DIR]);
+      let nestedDirs = shell.exec(`find ${scriptsDir} -type d`, {silent: true}).output.split('\n');
+      let msgLocations = _(nestedDirs)
+        .compact()
+        .map(dir => '-N ' + shellQuote.quote(['..' + dir.replace(CHECKOUT_DIR, '') + '/*.js']))
+        .join(' ');
 
       // Create a temporary .po file containing only the strings used by root/static/scripts.
-      shell.exec(`msggrep -N '../root/static/scripts/**/*.js' ${srcPo} -o ${tmpPo}`);
+      shell.exec(`msggrep ${msgLocations} ${srcPo} -o ${tmpPo}`);
 
       result[lang] = po2json.parseFileSync(tmpPo, {format: 'jed', domain: 'mb_server'});
 

--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -162,7 +162,7 @@ function buildScripts() {
       // Create a temporary .po file containing only the strings used by root/static/scripts.
       shell.exec(`msggrep ${msgLocations} ${srcPo} -o ${tmpPo}`);
 
-      result[lang] = po2json.parseFileSync(tmpPo, {format: 'jed', domain: 'mb_server'});
+      result[lang] = po2json.parseFileSync(tmpPo, {format: 'jed1.x', domain: 'mb_server'});
 
       fs.unlinkSync(tmpPo);
     }, {})


### PR DESCRIPTION
There were three quite unrelated issues here. The commits have additional info, but the summaries are:

* Locale::Messages strictly looks up msgids via bytewise comparison
* A msggrep wildcard of ours wasn't doing what was intended
* We were using the wrong po2json `format` option

I *think* my solution to the first bullet point shouldn't cause any unintended effects (those subroutines should only be called from the templates and with raw strings), but it could certainly use some sanity checking.