### PR TITLE
Error message improvements

### DIFF
--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -49,6 +49,7 @@ sub _build_conn
         },
         RaiseError        => 0,
         PrintError        => 0,
+        ShowErrorStatement => 1,
     });
 
     # Make sure we notice the DB going down and attempt to reconnect

--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -98,10 +98,7 @@ sub _insert_edit {
         } elsif (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::DuplicateViolation') {
             $c->stash(duplicate_violation => 1);
         } else {
-            use Data::Dumper;
-            croak "The edit could not be created.\n" .
-                "POST: " . Dumper($c->req->params) . "\n" .
-                "Exception:" . Dumper($_);
+            croak 'The edit could not be created. Exception (' . (ref ne '' ? ref : 'string') . '): ' . $_;
         }
     };
 


### PR DESCRIPTION
1. Show the failed statement in case of a database error. I’ve found this quite useful in debugging.
2. Simplify debugging output for when inserting an edit fails
    
  When inserting an edit failed with an exception, a new exception was thrown containing the body (`POST`) parameters of the request and a dump of the original exception. However, the request parameters are shown anyway both on the ISE page and in the error email, and the dump of a complex exception object is far too verbose.
    
  Don’t include the request parameters in the new exception, and just show the stringified original exception together with its class name.
