### PR TITLE
MBS-8504: Make adding a disambiguation comment an autoedit

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
@@ -114,7 +114,7 @@ override allow_auto_edit => sub {
     for my $field (@text_fields) {
         my ($old, $new) = normalise_strings(
             $self->data->{old}{$field}, $self->data->{new}{$field});
-        return 0 if $old ne $new;
+        return 0 if $old ne $new && $old ne '';
     }
 
     # Adding a date is automatic if there was no date yet.


### PR DESCRIPTION
Everyone was surprised it wasn’t already, and it is easy enough to undo.