### PR TITLE
MBS-8414/MBS-7572: Discrepancies between edit data and database

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Alias.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias.pm
@@ -1,0 +1,49 @@
+package MusicBrainz::Server::Edit::Alias;
+use Moose::Role;
+
+use MusicBrainz::Server::Data::Utils qw( partial_date_to_hash non_empty );
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+
+use aliased 'MusicBrainz::Server::Entity::PartialDate';
+
+sub enforce_dependencies {
+    my ($self, $opts) = @_;
+
+    unless (non_empty($opts->{locale})) {
+        # Alias without locale can't be primary
+        $opts->{primary_for_locale} = 0;
+    }
+
+    my $search_hint_type = $ENTITIES{$self->_alias_model->type}->{aliases}{search_hint_type};
+    my $type = $opts->{type_id};
+    if (defined $type && $type == $search_hint_type) {
+        # Search hints can't have any other data
+        $opts->{sort_name} = $opts->{name};
+        $opts->{locale} = undef;
+        @$opts{qw( begin_date end_date )} = (partial_date_to_hash(PartialDate->new)) x 2;
+        @$opts{qw( ended primary_for_locale )} = (0) x 2;
+    }
+}
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2015 Ulrich Klauer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+=cut

--- a/lib/MusicBrainz/Server/Edit/Alias.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias.pm
@@ -14,6 +14,11 @@ sub enforce_dependencies {
         $opts->{primary_for_locale} = 0;
     }
 
+    unless (non_empty($opts->{sort_name})) {
+        # Sortname defaults to the name
+        $opts->{sort_name} = $opts->{name};
+    }
+
     my $search_hint_type = $ENTITIES{$self->_alias_model->type}->{aliases}{search_hint_type};
     my $type = $opts->{type_id};
     if (defined $type && $type == $search_hint_type) {

--- a/lib/MusicBrainz/Server/Edit/Alias/Add.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Add.pm
@@ -101,7 +101,6 @@ role {
             name => $entity->name
         };
 
-        $opts{sort_name} = $opts{name} unless non_empty($opts{sort_name});
         $self->enforce_dependencies(\%opts);
 
         $self->data(\%opts);

--- a/lib/MusicBrainz/Server/Edit/Alias/Add.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Add.pm
@@ -17,6 +17,7 @@ role {
     my $entity_type = model_to_type($model);
     my $entity_id = "${entity_type}_id";
 
+    with 'MusicBrainz::Server::Edit::Alias';
     with "MusicBrainz::Server::Edit::$model";
     with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
     with 'MusicBrainz::Server::Edit::Role::DatePeriod';
@@ -99,7 +100,10 @@ role {
             id => $entity->id,
             name => $entity->name
         };
+
         $opts{sort_name} = $opts{name} unless non_empty($opts{sort_name});
+        $self->enforce_dependencies(\%opts);
+
         $self->data(\%opts);
     };
 

--- a/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Data::Utils qw( partial_date_to_hash );
 use MusicBrainz::Server::Edit::Types qw( Nullable PartialDateHash );
 
 extends 'MusicBrainz::Server::Edit';
-
+with 'MusicBrainz::Server::Edit::Alias';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub _alias_model { die 'Not implemented' }

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -169,11 +169,6 @@ sub initialize
     die "You must specify the alias object to edit" unless defined $alias;
     my $entity = delete $opts{entity} or die 'Missing "entity" argument';
 
-    unless (non_empty($opts{sort_name})) {
-        delete $opts{sort_name};
-        $opts{sort_name} = $opts{name} if non_empty($opts{name});
-    }
-
     $self->enforce_dependencies(\%opts);
 
     $self->data({

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -11,13 +11,14 @@ use MusicBrainz::Server::Data::Utils qw(
     type_to_model
     non_empty
 );
-use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Edit::Types qw( Nullable PartialDateHash );
 use MusicBrainz::Server::Edit::Utils qw(
     date_closure
     merge_partial_date
 );
+
+use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 no if $] >= 5.018, warnings => "experimental::smartmatch";
 
@@ -104,12 +105,12 @@ sub build_display_data
             old => $self->_alias_model->parent->alias_type->get_by_id($self->data->{old}{type_id}),
         },
         begin_date => {
-            new => MusicBrainz::Server::Entity::PartialDate->new_from_row($self->data->{new}{begin_date}),
-            old => MusicBrainz::Server::Entity::PartialDate->new_from_row($self->data->{old}{begin_date}),
+            new => PartialDate->new_from_row($self->data->{new}{begin_date}),
+            old => PartialDate->new_from_row($self->data->{old}{begin_date}),
         },
         end_date => {
-            new => MusicBrainz::Server::Entity::PartialDate->new_from_row($self->data->{new}{end_date}),
-            old => MusicBrainz::Server::Entity::PartialDate->new_from_row($self->data->{old}{end_date}),
+            new => PartialDate->new_from_row($self->data->{new}{end_date}),
+            old => PartialDate->new_from_row($self->data->{old}{end_date}),
         },
         primary_for_locale => {
             new => $self->data->{new}{primary_for_locale},

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -23,6 +23,7 @@ use aliased 'MusicBrainz::Server::Entity::PartialDate';
 no if $] >= 5.018, warnings => "experimental::smartmatch";
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
+with 'MusicBrainz::Server::Edit::Alias';
 with 'MusicBrainz::Server::Edit::CheckForConflicts';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 with 'MusicBrainz::Server::Edit::Role::DatePeriod';
@@ -172,6 +173,8 @@ sub initialize
         delete $opts{sort_name};
         $opts{sort_name} = $opts{name} if non_empty($opts{name});
     }
+
+    $self->enforce_dependencies(\%opts);
 
     $self->data({
         alias_id => $alias->id,

--- a/lib/MusicBrainz/Server/Edit/Artist/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Create.pm
@@ -53,6 +53,14 @@ before initialize => sub {
     die "You must specify isni_codes" unless defined $opts{isni_codes};
 };
 
+around initialize => sub {
+    my ($orig, $self, %opts) = @_;
+
+    $opts{ended} = 1 if $opts{end_area_id};
+
+    $self->$orig(%opts);
+};
+
 sub foreign_keys
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -69,6 +69,14 @@ has '+data' => (
     ]
 );
 
+around initialize => sub {
+    my ($orig, $self, %opts) = @_;
+
+    $opts{ended} = 1 if $opts{end_area_id};
+
+    $self->$orig(%opts);
+};
+
 sub foreign_keys
 {
     my ($self) = @_;

--- a/root/entity/alias/edit_form.tt
+++ b/root/entity/alias/edit_form.tt
@@ -55,6 +55,7 @@
         var conditionalFields = $('#id-edit-alias\\\.sort_name')
             .add('#id-edit-alias\\\.locale')
             .add('#id-edit-alias\\\.primary_for_locale')
+            .add('#id-edit-alias\\\.period\\\.ended')
             .add('.partial-date input');
 
         conditionalFields.prop('disabled',

--- a/t/lib/t/MusicBrainz/Server/Edit/Artist/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Artist/EditAlias.pm
@@ -3,6 +3,12 @@ use Test::Routine;
 use Test::Fatal;
 use Test::More;
 
+use Hash::Merge qw( merge );
+
+use MusicBrainz::Server::Data::Utils qw( partial_date_to_hash );
+
+use aliased 'MusicBrainz::Server::Entity::PartialDate';
+
 with 't::Edit';
 with 't::Context';
 
@@ -84,13 +90,21 @@ test 'Setting an alias as primary for a locale is an auto edit' => sub {
 
 sub create_edit {
     my $c = shift;
-    return $c->model('Edit')->create(
+    my %opts = merge({ @_ }, {
         edit_type => $EDIT_ARTIST_EDIT_ALIAS,
         editor_id => 1,
         entity    => $c->model('Artist')->get_by_id(1),
         alias     => $c->model('Artist')->alias->get_by_id(3),
-        @_,
-    );
+        name      => 'Alias 2',
+        sort_name => 'Alias 2',
+        locale    => undef,,
+        primary_for_locale => 0,
+        begin_date => partial_date_to_hash(PartialDate->new),
+        end_date  => partial_date_to_hash(PartialDate->new),
+        ended     => 0,
+        type_id   => undef,
+    });
+    return $c->model('Edit')->create(%opts);
 }
 
 1;


### PR DESCRIPTION
Two variations of the same problem: We have database triggers that will enforce certain restrictions on the data; in particular, an artist with an end area must have `ended` set to true (MBS-8414) and a search hint alias can’t have locale, dates etc. (MBS-7572). However, the edit types didn’t know about this, and so it was possible that an edit stored an invalid combination (e.g. `end_area_id => 1234, ended => 0`). The edit would be displayed with the information “Ended: No”, but when it was applied, _ended_ would be set to true. I fix this by making sure that the edit data is consistent when an edit is created.

There is a minor UI thing here, too, that is somewhat related; interestingly, nobody has ever complained about it, so no ticket. In the edit form for an alias, when “search hint” is chosen as the type, the input fields that aren’t applicable to search hints are disabled. However, the checkbox for “ended” stayed active, even though search hints can’t have an ended flag.