### PR TITLE
Providing links to accounts in emails to admins. http://tickets.musicbrainz.org/browse/MBS-8663

### DIFF
--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -490,9 +490,9 @@ $subject for the following reason:
 
 “$reason”
 
-Links to related accounts :
-	Reporter’s account: https://musicbrainz.org/user/$reporter_tolink
-	Reported user’s account: https://musicbrainz.org/user/$reported_user_tolink
+Reporter’s account: https://musicbrainz.org/user/$reporter_tolink
+Reported user’s account: https://musicbrainz.org/user/$reported_user_tolink
+
 EOF
 
     if ($opts{reveal_address}) {

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -483,7 +483,7 @@ sub send_editor_report {
     my $reported_user = $opts{reported_user};
     my $subject = 'Editor ' . $reported_user->name . ' has been reported by ' . $reporter->name;
     my $reason = $MusicBrainz::Server::Form::User::Report::REASONS{$opts{reason}};
-    my $reporter_tolink = uri_escape_utf8($reporter)
+    my $reporter_tolink = uri_escape_utf8($reporter);
     my $reported_user_tolink = uri_escape_utf8($reported_user);
     my $body .= <<EOF;
 $subject for the following reason:

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -483,15 +483,16 @@ sub send_editor_report {
     my $reported_user = $opts{reported_user};
     my $subject = 'Editor ' . $reported_user->name . ' has been reported by ' . $reporter->name;
     my $reason = $MusicBrainz::Server::Form::User::Report::REASONS{$opts{reason}};
-
+    my $reporter_tolink = uri_escape_utf8($reporter)
+    my $reported_user_tolink = uri_escape_utf8($reported_user);
     my $body .= <<EOF;
 $subject for the following reason:
 
 “$reason”
 
-Reported User's account : https://musicbrainz.org/user/$reported_user
-Reporter's account      : https://musicbrainz.org/user/$reporter 
-
+Links to related accounts :
+	Reporter’s account: https://musicbrainz.org/user/$reporter_tolink
+	Reported user’s account: https://musicbrainz.org/user/$reporter_user_tolink
 EOF
 
     if ($opts{reveal_address}) {

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -492,7 +492,7 @@ $subject for the following reason:
 
 Links to related accounts :
 	Reporter’s account: https://musicbrainz.org/user/$reporter_tolink
-	Reported user’s account: https://musicbrainz.org/user/$reporter_user_tolink
+	Reported user’s account: https://musicbrainz.org/user/$reported_user_tolink
 EOF
 
     if ($opts{reveal_address}) {

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -489,6 +489,9 @@ $subject for the following reason:
 
 “$reason”
 
+Reported User's account : https://musicbrainz.org/user/$reported_user
+Reporter's account      : https://musicbrainz.org/user/$reporter 
+
 EOF
 
     if ($opts{reveal_address}) {


### PR DESCRIPTION
We have an option to report a user that's misbehaving or needs to be looked into for whatever reason. This sends a mail to the admins that includes the user's username, but it would be much nicer if it also included a link to their MusicBrainz profile. So the code that sends the emails is modified now to do that.

GCI task, connected to this pull request.
https://codein.withgoogle.com/dashboard/task-instances/5804155620818944/