### PR TITLE
MBS-8681: Let edits again expire after 7, not 0 days

### DIFF
--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -189,7 +189,7 @@ sub editor_may_edit {
 sub edit_conditions
 {
     return {
-        duration      => $OPEN_EDIT_DURATION->days,
+        duration      => $OPEN_EDIT_DURATION->in_units('days'),
         votes         => $REQUIRED_VOTES,
         expire_action => $EXPIRE_ACCEPT,
         auto_edit     => 1


### PR DESCRIPTION
The changes in commit 909831ea267c19d7355db8a36a0d6f7ceba81e89 changed the default number of days an edit was to stay open to zero, because the `days` method on a `Duration` doesn't count days that are already included for `weeks`. Use `in_units` instead, which allows control over which units are to be considered.