### PR TITLE
Fixes for /doc error pages

### DIFF
--- a/root/doc/bare_error.tt
+++ b/root/doc/bare_error.tt
@@ -3,7 +3,7 @@
 <p>
     <strong>
         [%- l('Sorry, “{id}” is not a valid documentation page.',
-             { id => replace(id,'_',' ') }) -%]
+             { id => html_escape(replace(id,'_',' ')) }) -%]
     </strong>
 </p>
 

--- a/root/doc/error.tt
+++ b/root/doc/error.tt
@@ -4,24 +4,7 @@
           [%- wikidoc_search_box -%]
         [%- END -%]
 
-        <h1>[%- l('Page Not Found') -%]</h1>
+        [% PROCESS 'doc/bare_error.tt' %]
 
-        <p>
-            <strong>
-                [%- l('Sorry, “{id}” is not a valid documentation page.',
-                     { id => replace(id,'_',' ') }) -%]
-            </strong>
-        </p>
-
-        <p>
-            [%- l('Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',
-                 { doc => doc_link('MusicBrainz_Documentation'),
-                   faq => doc_link('Frequently_Asked_Questions') }) -%]
-        </p>
-
-        <p>
-            [%- l('Found a broken link on our site? Please let us know by {report|reporting a bug}.',
-                 { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1&description=Broken+link:" _ url_escape(c.req.uri) _ "+Referer:" _ url_escape(c.req.referer)) })-%]
-        </p>
     </div>
 [%- END -%]


### PR DESCRIPTION
Removes redundant code from the `doc/error` template (`doc/bare_error` is identical to the removed code, except for indentation) and fixes an encoding issue in the common code. The pull request is against beta (with the intention of continuing to production immediately at today’s release); [see here for justification](https://beta.musicbrainz.org/doc/%3Cscript%20type=%22text/javascript%22%3Ealert%28%22It%20is%20a%20XSS%20vulnerability.%20All%20your%20MB%20cookies%20are%20belong%20to%20us!%22%29;%3C/script%3E).