### PR TITLE
MBS-8690: Rejecting add-entity edits with subscriptions

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -245,6 +245,7 @@ sub delete
     $self->isni->delete_entities(@artist_ids);
     $self->tags->delete(@artist_ids);
     $self->rating->delete(@artist_ids);
+    $self->subscription->delete(@artist_ids);
     $self->remove_gid_redirects(@artist_ids);
     $self->delete_returning_gids('artist', @artist_ids);
 

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -173,6 +173,7 @@ sub delete
     $self->isni->delete_entities(@label_ids);
     $self->tags->delete(@label_ids);
     $self->rating->delete(@label_ids);
+    $self->subscription->delete(@label_ids);
     $self->remove_gid_redirects(@label_ids);
     $self->delete_returning_gids('label', @label_ids);
     return 1;

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -172,6 +172,7 @@ sub delete
     $self->annotation->delete(@ids);
     $self->alias->delete_entities(@ids);
     $self->tags->delete(@ids);
+    $self->subscription->delete(@ids);
     $self->remove_gid_redirects(@ids);
     $self->delete_returning_gids('series', @ids);
     return 1;

--- a/t/lib/t/MusicBrainz/Server/Edit/Series/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Series/Create.pm
@@ -1,0 +1,38 @@
+package t::MusicBrainz::Server::Edit::Series::Create;
+
+use Test::Routine;
+use Test::More;
+
+with 't::Edit';
+with 't::Context';
+
+use MusicBrainz::Server::Constants qw(
+    $EDIT_SERIES_CREATE
+    $STATUS_FAILEDVOTE
+    $STATUS_OPEN
+    $UNTRUSTED_FLAG
+);
+use MusicBrainz::Server::Test qw( reject_edit );
+
+test 'Rejecting an "Add series" edit where the series has subscriptions (MBS-8690)' => sub {
+    my ($test) = @_;
+
+    my $c = $test->c;
+
+    my $edit = $c->model('Edit')->create(
+        edit_type => $EDIT_SERIES_CREATE,
+        editor_id => 1,
+        name => 'Series',
+        comment => '',
+        type_id => 1,
+        ordering_type_id => 1,
+        privileges => $UNTRUSTED_FLAG,
+    );
+
+    is($edit->status, $STATUS_OPEN);
+    $c->model('Series')->subscription->subscribe(1, $edit->series_id);
+    reject_edit($c, $edit);
+    is($edit->status, $STATUS_FAILEDVOTE);
+};
+
+1;


### PR DESCRIPTION
The ticket was about artists, but the same issue exists for labels and series, so I fixed those too.