### PR TITLE
Mandate JSON::XS and kill JSON::Any

### DIFF
--- a/admin/CompileSchemaScripts.pl
+++ b/admin/CompileSchemaScripts.pl
@@ -5,7 +5,7 @@ use strict;
 
 use FindBin;
 
-use JSON;
+use JSON::XS;
 use File::Slurp;
 
 my $schema_version = shift() or die('schema version required');

--- a/admin/EditEdit.pl
+++ b/admin/EditEdit.pl
@@ -4,7 +4,7 @@ use warnings;
 
 use Encode;
 use FindBin;
-use JSON::Any;
+use JSON::XS;
 use lib "$FindBin::Bin/../lib";
 use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Validation qw( is_positive_integer );
@@ -23,7 +23,7 @@ my $new_data = <STDIN>;
 chomp($new_data);
 
 # will die if JSON is invalid
-JSON::Any->new(utf8 => 1)->jsonToObj($new_data);
+JSON::XS->new->decode($new_data);
 $new_data = decode('UTF-8', $new_data, Encode::FB_CROAK);
 
 $c->sql->auto_commit;

--- a/app.psgi
+++ b/app.psgi
@@ -7,6 +7,18 @@ use Moose::Util qw( ensure_all_roles );
 use Plack::Builder;
 
 BEGIN {
+    # We've hit some pathological cases where different JSON backends are
+    # used on different systems (e.g. JSON::PP instead of JSON::XS, due to the
+    # latter not being installed despite existing in the Makefile), which
+    # then breaks the code in some opaque way (e.g. JSON::PP doesn't assign a
+    # ($) prototype to decode_json).
+    #
+    # The effect of the environment variable here is to force the use of
+    # JSON::XS as the JSON backend, and die if it's not available.
+    $ENV{PERL_JSON_BACKEND} = 2;
+}
+
+BEGIN {
     if (DBDefs->CATALYST_DEBUG) {
         require Plack::Middleware::Debug::DAOLogger;
         require Plack::Middleware::Debug::ExclusiveTime;

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -282,7 +282,6 @@ sub cover_art_uploader : Chained('load') PathPart('cover-art-uploader') Edit {
 sub add_cover_art : Chained('load') PathPart('add-cover-art') Edit {
     my ($self, $c) = @_;
     my $entity = $c->stash->{$self->{entity_name}};
-    my $json = JSON::Any->new( utf8 => 1 );
 
     $c->model('Release')->load_meta($entity);
 
@@ -307,7 +306,7 @@ sub add_cover_art : Chained('load') PathPart('add-cover-art') Edit {
         images => \@artwork,
         mime_types => \@mime_types,
         access_key => DBDefs->COVER_ART_ARCHIVE_ACCESS_KEY // '',
-        cover_art_types_json => $json->encode(
+        cover_art_types_json => $c->json->encode(
             [ map {
                 { name => $_->name, l_name => $_->l_name, id => $_->id }
             } $c->model('CoverArtType')->get_all() ]),
@@ -653,16 +652,15 @@ sub edit_relationships : Chained('load') PathPart('edit-relationships') Edit {
     $c->model('ReleaseGroup')->load_meta($release->release_group);
     $c->model('Relationship')->load_cardinal($release->release_group);
 
-    my $json = JSON->new->convert_blessed;
     my @link_type_tree = $c->model('LinkType')->get_full_tree;
     my $attr_tree = $c->model('LinkAttributeType')->get_tree;
 
     $c->stash(
         work_types      => select_options($c, 'WorkType'),
         work_languages  => build_grouped_options($c, language_options($c, 'work')),
-        source_entity   => $json->encode($release),
-        attr_info       => $json->encode(build_attr_info($attr_tree)),
-        type_info       => $json->encode(build_type_info($c, qr/(recording|work|release)/, @link_type_tree)),
+        source_entity   => $c->json->encode($release),
+        attr_info       => $c->json->encode(build_attr_info($attr_tree)),
+        type_info       => $c->json->encode(build_type_info($c, qr/(recording|work|release)/, @link_type_tree)),
     );
 }
 

--- a/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
@@ -8,7 +8,6 @@ __PACKAGE__->config(
     namespace => 'release_editor'
 );
 
-use JSON::Any;
 use List::UtilsBy qw( partition_by );
 use Try::Tiny;
 use Scalar::Util qw( looks_like_number );
@@ -33,14 +32,12 @@ sub _init_release_editor
 {
     my ($self, $c, %options) = @_;
 
-    my $json = JSON::Any->new( utf8 => 1, convert_blessed => 1 );
-
     $options{redirect_uri} = (
         $c->req->query_params->{redirect_uri} //
         $c->req->body_params->{redirect_uri}
     );
 
-    $options{seeded_data} = $json->encode($self->_seeded_data($c) // {});
+    $options{seeded_data} = $c->json->encode($self->_seeded_data($c) // {});
 
     my $url_link_types = $c->model('LinkType')->get_tree('release', 'url');
     my $attr_tree = $c->model('LinkAttributeType')->get_tree;
@@ -59,9 +56,9 @@ sub _init_release_editor
         packagings      => select_options_tree($c, 'ReleasePackaging'),
         countries       => select_options($c, 'CountryArea'),
         formats         => select_options_tree($c, 'MediumFormat'),
-        type_info       => $json->encode(build_type_info($c, qr/release-url/, $url_link_types)),
-        attr_info       => $json->encode(build_attr_info($attr_tree)),
-        discid_formats  => $json->encode($discid_formats),
+        type_info       => $c->json->encode(build_type_info($c, qr/release-url/, $url_link_types)),
+        attr_info       => $c->json->encode(build_attr_info($attr_tree)),
+        discid_formats  => $c->json->encode($discid_formats),
         %options
     );
 }

--- a/lib/MusicBrainz/Server/Controller/Role/Create.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Create.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Controller::Role::Create;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
-use JSON::Any;
 use aliased 'MusicBrainz::Server::WebService::JSONSerializer';
 
 parameter 'form' => (
@@ -69,8 +68,7 @@ role {
 
                 return unless $args{within_dialog};
 
-                my $json = JSON::Any->new( utf8 => 1 );
-                $c->stash( dialog_result => $json->encode(JSONSerializer->serialize_internal($c, $entity)) );
+                $c->stash( dialog_result => $c->json->encode(JSONSerializer->serialize_internal($c, $entity)) );
 
                 # XXX Delete the "Thank you, your edit has been..." message
                 # so it doesn't weirdly show up on the next page.

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -4,7 +4,6 @@ use Moose;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 
-use JSON;
 use MusicBrainz::Server::Constants qw(
     $EDIT_WORK_CREATE
     $EDIT_WORK_EDIT
@@ -112,7 +111,6 @@ before 'edit' => sub
 
 sub stash_work_attribute_json {
     my ($c) = @_;
-    state $json = JSON::Any->new( utf8 => 1 );
 
     my $build_json;
     my $coll = $c->get_collator();
@@ -130,10 +128,10 @@ sub stash_work_attribute_json {
     };
 
     $c->stash(
-        workAttributeTypesJson => $json->encode(
+        workAttributeTypesJson => $c->json->encode(
             $build_json->($c->model('WorkAttributeType')->get_tree)
         ),
-        workAttributeValuesJson => $json->encode(
+        workAttributeValuesJson => $c->json->encode(
             $build_json->($c->model('WorkAttributeTypeAllowedValue')->get_tree)
         )
     );

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -28,7 +28,7 @@ use MusicBrainz::Server::Constants qw(
     entities_with
     %ENTITIES );
 use MusicBrainz::Server::Data::Utils qw( placeholders );
-use JSON::Any;
+use JSON;
 
 use aliased 'MusicBrainz::Server::Entity::Subscription::Active' => 'ActiveSubscription';
 use aliased 'MusicBrainz::Server::Entity::CollectionSubscription';
@@ -67,7 +67,7 @@ sub _new_from_row
     # Readd the class marker
     my $class = MusicBrainz::Server::EditRegistry->class_from_type($row->{type})
         or confess"Could not look up class for type ".$row->{type};
-    my $data = JSON::Any->new(utf8 => 1)->jsonToObj($row->{data});
+    my $data = JSON->new->decode($row->{data});
 
     my $edit = $class->new({
         c => $self->c,
@@ -564,7 +564,7 @@ sub create {
 
     my $row = {
         editor => $edit->editor_id,
-        data => JSON::Any->new( utf8 => 1 )->objToJson($edit->to_hash),
+        data => JSON->new->encode($edit->to_hash),
         status => $edit->status,
         type => $edit->edit_type,
         open_time => \"now()",
@@ -579,7 +579,7 @@ sub create {
 
     $edit->post_insert;
     my $post_insert_update = {
-        data => JSON::Any->new( utf8 => 1 )->objToJson($edit->to_hash),
+        data => JSON->new->encode($edit->to_hash),
         status => $edit->status,
         type => $edit->edit_type,
     };

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -14,8 +14,6 @@ use MusicBrainz::Server::Edit::Utils qw(
 use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 
-use JSON::Any;
-
 use MooseX::Types::Moose qw( ArrayRef Bool Int Maybe Str );
 use MooseX::Types::Structured qw( Dict Optional );
 

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -14,8 +14,6 @@ use MusicBrainz::Server::Edit::Utils qw(
 use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 
-use JSON::Any;
-
 use MooseX::Types::Moose qw( ArrayRef Bool Int Maybe Str );
 use MooseX::Types::Structured qw( Dict Optional );
 

--- a/lib/MusicBrainz/Server/Edit/CheckForConflicts.pm
+++ b/lib/MusicBrainz/Server/Edit/CheckForConflicts.pm
@@ -4,7 +4,6 @@ use Moose::Role;
 use namespace::autoclean;
 
 use Algorithm::Merge qw( merge );
-use JSON::Any;
 use MusicBrainz::Server::Edit::Utils qw( merge_value );
 use Try::Tiny;
 

--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -17,8 +17,6 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 use MusicBrainz::Server::Validation qw( normalise_strings );
 
-use JSON::Any;
-
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 

--- a/lib/MusicBrainz/Server/Edit/Historic/Fast.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Fast.pm
@@ -5,7 +5,6 @@ use Moose;
 extends 'Class::Accessor::Fast::XS';
 
 use Class::Load qw( load_class );
-use JSON::Any qw( XS JSON );
 use Memoize;
 use MusicBrainz::Server::Data::Utils qw( copy_escape );
 use URI::Escape qw( uri_escape uri_unescape );
@@ -66,35 +65,5 @@ sub decode_value
 }
 
 sub extra_parameters { () }
-
-sub for_copy {
-    my $edit = shift;
-    my $type = $edit->edit_type;
-    if ($edit->can('ngs_class')) {
-        load_class($edit->ngs_class);
-        $type = $edit->ngs_class->edit_type;
-    }
-
-    return join("\t",
-        $edit->id,
-        $edit->editor_id,
-        $type,
-        $edit->status,
-        copy_escape(
-            JSON::Any->new(utf8 => 1)->encode({
-                %{ $edit->data },
-                $edit->extra_parameters
-            })
-        ),
-        $edit->yes_votes,
-        $edit->no_votes,
-        $edit->auto_edit,
-        $edit->created_time,
-        $edit->close_time,
-        $edit->expires_time,
-        '\N',
-        1
-    );
-}
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
@@ -13,8 +13,6 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 use MusicBrainz::Server::Validation qw( normalise_strings );
 
-use JSON::Any;
-
 use MooseX::Types::Moose qw( ArrayRef Bool Int Maybe Str );
 use MooseX::Types::Structured qw( Dict Optional );
 

--- a/lib/MusicBrainz/Server/Edit/Place/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Edit.pm
@@ -17,8 +17,6 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 use MusicBrainz::Server::Validation qw( normalise_strings );
 
-use JSON::Any;
-
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 

--- a/lib/MusicBrainz/Server/Edit/Utils.pm
+++ b/lib/MusicBrainz/Server/Edit/Utils.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use 5.10.0;
 
+use JSON;
 use List::MoreUtils qw( minmax uniq );
 use MusicBrainz::Server::Constants qw( :edit_status :vote $AUTO_EDITOR_FLAG );
 use MusicBrainz::Server::Data::Utils qw( artist_credit_to_ref coordinates_to_hash sanitize trim partial_date_to_hash );
@@ -398,8 +399,8 @@ sub merge_time {
 
 sub merge_value {
     my $v = shift;
-    state $json = JSON::Any->new( utf8 => 1, allow_blessed => 1, canonical => 1 );
-    return [ ref($v) ? $json->objToJson($v) : defined($v) ? "'$v'" : 'undef', $v ];
+    state $json = JSON->new->allow_blessed->canonical;
+    return [ ref($v) ? $json->encode($v) : defined($v) ? "'$v'" : 'undef', $v ];
 }
 
 sub merge_set {

--- a/lib/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -28,15 +28,13 @@ with 'MusicBrainz::Server::Edit::Role::ValueSet' => {
     extract_value => \&_work_attribute_to_edit,
     hash => sub {
         my $input = shift;
-        state $json = JSON::Any->new(
-            utf8 => 1, allow_blessed => 1, canonical => 1
-        );
+        state $json = JSON->new->allow_blessed->canonical;
 
         # The various string append and 0 additions here are to create a
         # canonical form for hashing, as we will later be doing a string
         # comparison on the JavaScript. Thus "foo":0 and "foo":"0" will be
         # different, so we need to make sure all keys are normalised.
-        return $json->objToJson({
+        return $json->encode({
             attribute_text => '' . ($input->{attribute_text} // ''),
             attribute_type_id => 0 + $input->{attribute_type_id},
             attribute_value_id => 0 + ($input->{attribute_value_id} // 0),

--- a/lib/MusicBrainz/Server/Test.pm
+++ b/lib/MusicBrainz/Server/Test.pm
@@ -133,6 +133,7 @@ sub prepare_test_server
     {
         no warnings 'redefine';
         $ENV{MUSICBRAINZ_RUNNING_TESTS} = 1;
+        $ENV{PERL_JSON_BACKEND} = 2;
         *DBDefs::REPLICATION_TYPE = sub { RT_STANDALONE };
     };
 

--- a/script/qunit_test_data.pl
+++ b/script/qunit_test_data.pl
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use JSON;
+use JSON::XS;
 use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Form::Utils qw( build_attr_info build_type_info );
 use Text::Trim qw( trim );
@@ -13,7 +13,7 @@ my $c = MusicBrainz::Server::Context->create_script_context(database => 'READWRI
 my @link_types = $c->model('LinkType')->get_full_tree;
 my $attr_tree = $c->model('LinkAttributeType')->get_tree;
 
-my $json = JSON->new->utf8->pretty;
+my $json = JSON::XS->new->utf8->pretty;
 my $type_info = trim $json->encode(build_type_info($c, qr/.*/, @link_types));
 my $attr_info = trim $json->encode(build_attr_info($attr_tree));
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Work.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Work.pm
@@ -11,7 +11,7 @@ test all => sub {
 
     my $test = shift;
     my $c = $test->c;
-    my $json = JSON::Any->new( utf8 => 1 );
+    my $json = JSON->new;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
     $c->sql->do(<<'EOSQL');


### PR DESCRIPTION
This simplifies our JSON story somewhat, and avoids cases like the one described in the comment in app.psgi. (See: http://chatlogs.metabrainz.org/brainzbot/metabrainz/2015-12-03/?msg=3422352&page=5)

The reason I set an environment variable instead of just importing `JSON::XS` everywhere is, `JSON::XS` doesn't export things like `null`, `true`, `false`, etc., and it's also a huge amount of work to update everything, for questionable gain.

I did however use `JSON::XS` directly in various admin scripts, rather than making sure the environment variable is set everywhere.

In the process of fixing things, I converted the deprecated `jsonToObj` and `objToJson` methods to `decode` and `encode`, respectively.

Bizarrely, the `JSON::Any` `utf8` flag has the exact opposite meaning that `JSON` uses. You can see where it's flipped in the `JSON::Any` source code, and it became obvious once I started getting mojibake in certain places while testing. So, everywhere that `utf8 => 1` was passed to `JSON::Any->new`, we now do *not* pass the `utf8` flag, which is to say it should have the exact same behavior as before.