### PR TITLE
MBS-8676: Add a page to see all notes left on your own edits

### DIFF
--- a/lib/MusicBrainz/DataStore/Redis.pm
+++ b/lib/MusicBrainz/DataStore/Redis.pm
@@ -48,6 +48,14 @@ sub get {
     return defined $value ? $self->_json->decode($value) : undef;
 }
 
+sub mget {
+    my ($self, @keys) = @_;
+
+    map {
+        defined $_ ? $self->_json->decode($_) : undef
+    } $self->_connection->mget(map { encode('utf-8', $self->prefix . $_) } @keys);
+}
+
 sub set {
     my ($self, $key, $value) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -278,6 +278,23 @@ sub subscribed_editors : Local RequireAuth {
     load_everything_for_edits($c, $edits);
 }
 
+sub notes_received : Path('/edit/notes-received') RequireAuth {
+    my ($self, $c) = @_;
+
+    my $edit_notes = $self->_load_paged($c, sub {
+        $c->model('EditNote')->find_by_recipient($c->user->id, shift, shift);
+    });
+
+    $c->model('Editor')->load(@$edit_notes);
+    $c->model('Edit')->load_for_edit_notes(@$edit_notes);
+    $c->model('Vote')->load_for_edits(map { $_->edit } @$edit_notes);
+
+    $c->stash(
+        edit_notes => $edit_notes,
+        template => 'edit/notes-received.tt',
+    );
+}
+
 =head2 conditions
 
 Display a table of all edit types, and their relative conditions

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -692,6 +692,23 @@ sub load_all
     }
 }
 
+sub load_for_edit_notes {
+    my ($self, @edit_notes) = @_;
+
+    my $edits_by_id = $self->get_by_ids(map { $_->edit_id } @edit_notes);
+
+    for my $note (@edit_notes) {
+        $note->edit($edits_by_id->{$note->edit_id});
+
+        # XXX Workaround weak_ref in Entity::EditNote.
+        my $tmp = $note->{edit};
+        undef $note->{edit};
+        $note->{edit} = $tmp;
+    }
+
+    return;
+}
+
 sub default_includes {
     # Additional models that should automatically be included with a model.
     # NB: A list, not a hash, because order may be important.

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -85,6 +85,13 @@ sub add_note
         (map { $_->editor_id } @{ $edit->edit_notes }));
     $self->c->model('Editor')->load_preferences(values %$editors);
 
+    # Inform the edit's author that a note was left.
+    my $edit_author = $editors->{$edit->editor_id}->name;
+    my $notes_updated_key = "edit_notes_received_last_updated:$edit_author";
+    $self->c->redis->set($notes_updated_key, time);
+    # Expire the notification in 30 days.
+    $self->c->redis->expire($notes_updated_key, 60 * 60 * 24 * 30);
+
     my @to_email = grep { $_ != $note_hash->{editor_id} }
         map { $_->id } grep { $_->preferences->email_on_notes }
         map { $editors->{$_->editor_id} }

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -106,6 +106,21 @@ sub add_note
     }
 }
 
+sub find_by_recipient {
+    my ($self, $recipient_id, $limit, $offset) = @_;
+
+    my $query = <<EOSQL;
+        SELECT ${\($self->_columns)}
+          FROM ${\($self->_table)}
+         WHERE editor != \$1
+           AND edit IN (SELECT id FROM edit WHERE editor = \$1)
+         ORDER BY post_time DESC, edit DESC
+EOSQL
+    $self->query_to_list_limited(
+        $query, [$recipient_id], $limit, $offset, undef, 1
+    );
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -650,6 +650,22 @@ END -%]
         CASE 9; l('This edit was cancelled.');
 END -%]
 
+[%~ MACRO edit_status_class(edit) BLOCK ~%]
+    [%~ IF edit.status == 1 ~%]
+        [%- " open" -%]
+    [%~ ELSIF edit.status == 2 ~%]
+        [%- " applied" -%]
+    [%~ ELSIF edit.status == 3 ~%]
+        [%- " failed" -%]
+    [%~ ELSIF edit.status == 8 %]
+        [%- " cancelling" -%]
+    [%~ ELSIF edit.status == 9 ~%]
+        [%- " cancelled" -%]
+    [%~ ELSE ~%]
+        [%- " edit-error" -%]
+    [%~ END ~%]
+[%~ END ~%]
+
 [%~ MACRO expiration_time(datetime) BLOCK -%]
     [%- IF Countdown.in_the_future(datetime) # Make sure datetime is a "countdownable" date -%]
         [%- IF Countdown.days(datetime) > 0 # If the date is far away, only display days -%]
@@ -1053,4 +1069,35 @@ END -%]
       [%~ l('An entity with that name and disambiguation already exists. You must enter a unique disambiguation comment.') IF duplicate_violation ~%]
     </div>
   [%- END -%]
+[%~ END ~%]
+
+[%- MACRO note_anchor(edit, loop) BLOCK -%]
+note-[%- edit.id -%]-[%- loop.count() -%]
+[%- END -%]
+
+[% MACRO votename(note) BLOCK %]
+  [% edit = note.edit %]
+  [%- FOR vote=edit.votes -%]
+    [%- vote.vote_name IF (vote.editor_id == note.editor_id) && !vote.superseded -%]
+  [%- END -%]
+  [%- 'owner' IF edit.editor_id == note.editor_id -%]
+[% END %]
+
+[%~ MACRO edit_note_display(edit_note) BLOCK ~%]
+  <div class="edit-note" id="[% note_anchor(note.edit, loop) %]">
+    <h3 class="[%- votename(note) -%]">
+      [%- link_entity(note.editor) -%]
+      [%- FOR vote=note.edit.votes;
+        IF (vote.editor_id == note.editor_id) &&
+           !vote.superseded &&
+           (vote.vote_name == 'No' || vote.vote_name == 'Yes');
+        '<div class="voting-icon"></div>'; LAST;
+      END; END; -%]
+      <a href="#[% note_anchor(note.edit, loop) %]" class="date">[%- UserDate.format(note.post_time) -%]</a>
+      [%- editor_type_info(note.editor) -%]
+    </h3>
+    <div class="edit-note-text [% 'modbot' IF note.editor_id == 4 %]">
+      [%- note.text | format_editnote -%]
+    </div>
+  </div>
 [%~ END ~%]

--- a/root/edit/edit_header.tt
+++ b/root/edit/edit_header.tt
@@ -1,20 +1,4 @@
-[%~ BLOCK edit_status ~%]
-    [%~ IF edit.status == 1 ~%]
-        [%- " open" -%]
-    [%~ ELSIF edit.status == 2 ~%]
-        [%- " applied" -%]
-    [%~ ELSIF edit.status == 3 ~%]
-        [%- " failed" -%]
-    [%~ ELSIF edit.status == 8 %]
-        [%- " cancelling" -%]
-    [%~ ELSIF edit.status == 9 ~%]
-        [%- " cancelled" -%]
-    [%~ ELSE ~%]
-        [%- " edit-error" -%]
-    [%~ END ~%]
-[%~ END ~%]
-
-<div class="edit-header[%- PROCESS edit_status -%] edit-[%~ edit.edit_kind =%]
+<div class="edit-header[%- edit_status_class(edit) -%] edit-[%~ edit.edit_kind =%]
             [%= css_class_name(edit.edit_name) ~%]">
     [%~ IF summary ~%]
         <div class="edit-description">

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -1,19 +1,3 @@
-[%~ BLOCK edit_status ~%]
-    [%~ IF edit.status == 1 ~%]
-        [%- " open" -%]
-    [%~ ELSIF edit.status == 2 ~%]
-        [%- " applied" -%]
-    [%~ ELSIF edit.status == 3 ~%]
-        [%- " failed" -%]
-    [%~ ELSIF edit.status == 8 %]
-        [%- " cancelling" -%]
-    [%~ ELSIF edit.status == 9 ~%]
-        [%- " cancelled" -%]
-    [%~ ELSE ~%]
-        [%- " edit-error" -%]
-    [%~ END ~%]
-[%~ END ~%]
-
 [% IF show_open_filter %]
     <p>
         <label>
@@ -66,7 +50,7 @@
 
                     <input type="hidden" value="[% edit.id %]" name="enter-vote.vote.[% loop.index %].edit_id" />
 
-                    <div class="edit-actions c[%- PROCESS edit_status -%]">
+                    <div class="edit-actions c[%- edit_status_class(edit) -%]">
                         [%- INCLUDE 'edit/info.tt' summary=1 -%]
                     </div>
 

--- a/root/edit/notes-received.tt
+++ b/root/edit/notes-received.tt
@@ -1,0 +1,26 @@
+[% WRAPPER 'layout.tt' title=l('Notes Left on Your Edits') full_width=1 %]
+  <div id="content">
+    <h1>[% l('Notes Left on Your Edits') %]</h1>
+
+    [% IF edit_notes.size %]
+      <div class="edit-notes">
+        [% WRAPPER 'components/with-pager.tt' search=0 %]
+          [% FOR note = edit_notes %]
+            [% edit = note.edit %]
+            <div class="edit-list">
+              <div class="edit-header[%- edit_status_class(edit) -%] edit-[%~ edit.edit_kind =%]
+                          [%= css_class_name(edit.edit_name) ~%]">
+                <h2>
+                  [%~ link_edit(edit, show, l('Edit #{id} - {name}', { id => edit.id, name => edit.l_edit_name})) ~%]
+                </h2>
+              </div>
+              [% edit_note_display(note) %]
+            </div>
+          [% END %]
+        [% END %]
+      </div>
+    [% ELSE %]
+      <p>[% l('Nobody has left notes on any of your edits.') %]</p>
+    [% END %]
+  </div>
+[% END %]

--- a/root/edit/notes-received.tt
+++ b/root/edit/notes-received.tt
@@ -2,6 +2,16 @@
   <div id="content">
     <h1>[% l('Notes Left on Your Edits') %]</h1>
 
+    [% IF !user.is_limited %]
+      <p>
+        <label>
+          <input type="checkbox" id="alert-new-edit-notes"
+                 [%= ' checked' IF (c.req.cookies.alert_new_edit_notes.value || 'true') != 'false' %] />
+          [% l('Show me an alert whenever I receive a new edit note.') %]
+        </label>
+      </p>
+    [% END %]
+
     [% IF edit_notes.size %]
       <div class="edit-notes">
         [% WRAPPER 'components/with-pager.tt' search=0 %]
@@ -23,4 +33,6 @@
       <p>[% l('Nobody has left notes on any of your edits.') %]</p>
     [% END %]
   </div>
+
+  [% script_manifest('edit-notes-received.js') %]
 [% END %]

--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -1,15 +1,3 @@
-[%- MACRO note_anchor(edit, loop) BLOCK -%]
-note-[%- edit.id -%]-[%- loop.count() -%]
-[%- END -%]
-
-[% BLOCK votename %]
-    [%- FOR vote=edit.votes -%]
-        [%- vote.vote_name IF (vote.editor_id == note.editor_id) && !vote.superseded -%]
-    [%- END -%]
-
-    [%- 'owner' IF edit.editor_id == note.editor_id -%]
-[% END %]
-
 [% DEFAULT verbose = 'verbose',
            hide = 0,
            rows = 5,
@@ -18,22 +6,7 @@ note-[%- edit.id -%]-[%- loop.count() -%]
 <div class="edit-notes">
     [% IF edit.edit_notes.size %]
         [% FOR note=edit.edit_notes %]
-            <div class="edit-note" id="[% note_anchor(edit, loop) %]">
-                <h3 class="[%- PROCESS votename -%]">
-                    [%- link_entity(note.editor) -%]
-                    [%- FOR vote=edit.votes;
-                        IF (vote.editor_id == note.editor_id) &&
-                           !vote.superseded &&
-                           (vote.vote_name == 'No' || vote.vote_name == 'Yes');
-                        '<div class="voting-icon"></div>'; LAST;
-                    END; END; -%]
-                    <a href="#[% note_anchor(edit, loop) %]" class="date">[%- UserDate.format(note.post_time) -%]</a>
-                    [%- editor_type_info(note.editor) -%]
-                </h3>
-                <div class="edit-note-text [% 'modbot' IF note.editor_id == 4 %]">
-                    [%- note.text | format_editnote -%]
-                </div>
-            </div>
+            [% edit_note_display(note) %]
         [% END %]
     [% ELSIF verbose == 'verbose' %]
         <div class="edit-note">

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -71,6 +71,18 @@
             </div>
         [%- END -%]
 
+        [%- IF new_edit_notes &&
+               new_edit_notes_mtime > (c.req.cookies.new_edit_notes_dismissed_mtime.value || 0) &&
+               (c.user.is_limited || (c.req.cookies.alert_new_edit_notes.value || 'true') != 'false') -%]
+            <div class="banner new-edit-notes">
+                <p>
+                    [% l('{link|New notes} have been left on some of your edits. Please make sure to read them and respond if necessary.',
+                         {link => c.uri_for_action('/edit/notes_received')}) %]
+                </p>
+                [% dismiss_banner_button('new_edit_notes') %]
+            </div>
+        [%- END -%]
+
         [% IF makes_no_changes %]
         <div class="banner warning-header">
             <p>[% l('The data you have submitted does not make any changes to the data already present.') %]</p>

--- a/root/layout/components/Menu.js
+++ b/root/layout/components/Menu.js
@@ -107,6 +107,9 @@ const DataMenu = () => {
         <li>
           <a href={$c.uri_for_action('/edit/subscribed_editors')}>{l('Edits by Subscribed Editors')}</a>
         </li>
+        <li>
+          <a href={$c.uri_for_action('/edit/notes_received')}>{l('Notes Left on My Edits')}</a>
+        </li>
       </ul>
     </li>
   );

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -9,6 +9,7 @@ import Header from './components/Header';
 import MergeHelper from './components/MergeHelper';
 import * as manifest from '../static/manifest';
 import {l} from '../static/scripts/common/i18n';
+import getCookie from '../static/scripts/common/utility/getCookie';
 
 let canonRegexp = new RegExp('^(https?:)?//' + process.env.WEB_SERVER);
 function canonicalize(url) {
@@ -28,6 +29,42 @@ const openSearchTags = [
   <link key={3} rel="search" type="application/opensearchdescription+xml" title={l("MusicBrainz: Release")} href="/static/search_plugins/opensearch/musicbrainz_release.xml" />,
   <link key={4} rel="search" type="application/opensearchdescription+xml" title={l("MusicBrainz: Track")} href="/static/search_plugins/opensearch/musicbrainz_track.xml" />,
 ];
+
+const DismissBannerButton = ({bannerName}) => (
+  <button className="dismiss-banner remove-item icon"
+          data-banner-name={bannerName}
+          type="button">
+  </button>
+);
+
+const serverDetailsBanner = (server) => {
+  if (server.staging_server) {
+    return (
+      <div className="banner server-details">
+        <p>
+          {server.staging_server_description || l('This is a MusicBrainz development server.')}
+          {' '}
+          {l('{uri|Return to musicbrainz.org}.',
+             {__react: true,
+              uri: '//musicbrainz.org' + (server.beta_redirect === 'musicbrainz.org' ? '?unset_beta=1' : '' )})}
+        </p>
+        <DismissBannerButton bannerName="server_details" />
+      </div>
+    );
+  }
+
+  if (server.is_slave_db) {
+    return (
+      <div className="banner server-details">
+        <p>
+          {l('This is a Musicbrainz mirror server. To edit or make changes to the data please ' +
+             '{uri|return to musicbrainz.org}.', {uri: '//musicbrainz.org'})}
+        </p>
+        <DismissBannerButton bannerName="server_details" />
+      </div>
+    );
+  }
+};
 
 const Layout = (props) => {
   let {title, pager} = props;
@@ -91,28 +128,12 @@ const Layout = (props) => {
       <body>
         <Header {...props} />
 
-        {!!server.staging_server &&
-          <div className="banner server-details">
-            <p>
-              {server.staging_server_description || l('This is a MusicBrainz development server.')}
-              {' '}
-              {l('{uri|Return to musicbrainz.org}.',
-                 {__react: true,
-                  uri: '//musicbrainz.org' + (server.beta_redirect === 'musicbrainz.org' ? '?unset_beta=1' : '' )})}
-            </p>
-          </div>}
+        {!getCookie('server_details_dismissed_mtime') && serverDetailsBanner(server)}
 
-        {!!server.is_slave_db &&
-          <div className="banner server-details">
-            <p>
-              {l('This is a Musicbrainz mirror server. To edit or make changes to the data please ' +
-                 '{uri|return to musicbrainz.org}.', {uri: '//musicbrainz.org'})}
-            </p>
-          </div>}
-
-        {!!server.alert &&
+        {!!(server.alert && server_details.alert_mtime > getCookie('alert_dismissed_mtime', 0)) &&
           <div className="banner warning-header">
             <p dangerouslySetInnerHTML={{__html: server.alert}}></p>
+            <DismissBannerButton bannerName="alert" />
           </div>}
 
         {!!server.read_only &&

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -143,6 +143,17 @@ const Layout = (props) => {
             </p>
           </div>}
 
+        {!!($c.stash.new_edit_notes &&
+            $c.stash.new_edit_notes_mtime > getCookie('new_edit_notes_dismissed_mtime', 0) &&
+            ($c.user.is_limited || getCookie('alert_new_edit_notes', 'true') !== 'false')) &&
+          <div className="banner new-edit-notes">
+            <p>
+              {l('{link|New notes} have been left on some of your edits. Please make sure to read them and respond if necessary.',
+                 {__react: true, link: '/edit/notes-received'})}
+            </p>
+            <DismissBannerButton bannerName="new_edit_notes" />
+          </div>}
+
         {!!$c.stash.makes_no_changes &&
           <div className="banner warning-header">
             <p>{l('The data you have submitted does not make any changes to the data already present.')}</p>

--- a/root/layout/menu.tt
+++ b/root/layout/menu.tt
@@ -79,6 +79,9 @@
                 <li>
                     <a href="[% c.uri_for_action('/edit/subscribed_editors') %]">[% l('Edits by Subscribed Editors') %]</a>
                 </li>
+                <li>
+                    <a href="[% c.uri_for_action('/edit/notes_received') %]">[% l('Notes Left on My Edits') %]</a>
+                </li>
             </ul>
         </li>
         [% IF c.user_exists && c.user.is_admin %]

--- a/root/server.js
+++ b/root/server.js
@@ -23,7 +23,7 @@ let ReactDOMServer = require('react-dom/server');
 let sliced = require('sliced');
 let URL = require('url');
 let gettext = require('./server/gettext');
-let getCookie = require('./static/scripts/common/utility/getCookie');
+let getCookie = require('./static/scripts/common/utility/getCookie').default;
 let i18n = require('./static/scripts/common/i18n');
 
 const DOCTYPE = '<!DOCTYPE html>';
@@ -90,16 +90,16 @@ function getResponse(req, requestBodyBuf) {
   // Emulate perl context/request API.
   req.query_params = url.query;
 
-  // We use a separate gettext handle for each language. Set the current handle
-  // to be used for this request based on the given 'lang' cookie.
-  i18n.setGettextHandle(gettext.getHandle(getCookie('lang', req.headers.cookie)));
-
   global.$c = _.assign(context, {
     req: req,
     relative_uri: url.path,
     uri_for: uriFor,
     uri_for_action: uriForAction
   });
+
+  // We use a separate gettext handle for each language. Set the current handle
+  // to be used for this request based on the given 'lang' cookie.
+  i18n.setGettextHandle(gettext.getHandle(getCookie('lang')));
 
   if (String(argv.development) === '1') {
     clearRequireCache();

--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -167,6 +167,10 @@ function buildScripts() {
     b.external(commonBundle);
   });
 
+  var editNotesReceivedBundle = runYarb('edit/notes-received.js', function (b) {
+    b.external(commonBundle);
+  });
+
   var guessCaseBundle = runYarb('guess-case.js', function (b) {
     b.external(commonBundle);
   });
@@ -206,6 +210,7 @@ function buildScripts() {
   return Q.all([
     writeScript(commonBundle, 'common.js'),
     writeScript(editBundle, 'edit.js'),
+    writeScript(editNotesReceivedBundle, 'edit-notes-received.js'),
     writeScript(guessCaseBundle, 'guess-case.js'),
     writeScript(placeBundle, 'place.js'),
     writeScript(releaseEditorBundle, 'release-editor.js'),

--- a/root/static/scripts/common/utility/getCookie.js
+++ b/root/static/scripts/common/utility/getCookie.js
@@ -1,7 +1,15 @@
-var cookie = require('cookie');
+import {parse as parseCookie} from 'cookie';
 
-module.exports = function (name, string) {
-    if (string || typeof document !== 'undefined') {
-        return cookie.parse(string || document.cookie)[name];
-    }
-};
+export default function getCookie(name, defaultValue = undefined) {
+  let cookie;
+  if (typeof $c !== 'undefined') {
+    cookie = $c.req.headers.cookie;
+  } else {
+    cookie = document.cookie;
+  }
+  let values = parseCookie(cookie);
+  if (values.hasOwnProperty(name)) {
+    return values[name];
+  }
+  return defaultValue;
+}

--- a/root/static/scripts/edit/notes-received.js
+++ b/root/static/scripts/edit/notes-received.js
@@ -1,0 +1,11 @@
+// This file is part of MusicBrainz, the open internet music database.
+// Copyright (C) 2015 MetaBrainz Foundation
+// Licensed under the GPL version 2, or (at your option) any later version:
+// http://www.gnu.org/licenses/gpl-2.0.txt
+
+import setCookie from '../common/utility/setCookie';
+
+$('#alert-new-edit-notes')
+  .on('change', function () {
+    setCookie('alert_new_edit_notes', String(this.checked));
+  });

--- a/root/static/styles/extra/banner.less
+++ b/root/static/styles/extra/banner.less
@@ -25,7 +25,8 @@
 .warning-header,
 .server-details,
 .alert,
-.editing-disabled {
+.editing-disabled,
+.new-edit-notes {
     font-weight: bold;
 }
 


### PR DESCRIPTION
I hacked in a basic notification banner for when this page changes, using redis. It stores two keys per user; when they last viewed the page, and when it was last updated. (These expire in a month, so we don't store unused data indefinitely.) The latter is bumped in `Data::EditNote::add_note` (so now we have two problems, besides emails :)).

There's also a new option cookie on the page to disable the banner permanently. It can't be toggled by limited users.

One problem is that if someone were to load all the individual edits they received notes on, the banner still wouldn't go away until they loaded `/edit/notes-received`, which is strange, and I'm unsure of a good solution. (Perhaps there isn't one, except to wait for a proper notification system.)