### PR TITLE
#MBS-8482 Renamed "Add Disc" button in release editor to "Add Medium"

### DIFF
--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -61,7 +61,7 @@
       <button type="button" data-bind="visible: activeTabIndex() < tabCount - 1" data-click="nextTab">[% l('Next »') | html_entity %]</button>
 
       <!-- ko template: { if: activeTabID() === "#tracklist", data: addDiscDialog } -->
-        <button type="button" data-click="open">[% l('Add Disc') %]</button>
+        <button type="button" data-click="open">[% l('Add Medium') %]</button>
       <!-- /ko -->
 
       <button type="button" class="positive" data-click="submitEdits" data-bind="visible: activeTabID() === '#edit-note', enable: allowsSubmission()">[% l('Enter edit') %]</button>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -90,7 +90,7 @@
   </table>
 
   <!-- ko if: searchResults() && searchResults().length > 0 -->
-  <p>[% l('Select a disc from the search results below and then click "Add Disc".') %]</p>
+  <p>[% l('Select a disc from the search results below and then click "Add Medium".') %]</p>
   <!-- /ko -->
 
   <!-- ko if: totalPages() > 1 -->
@@ -260,13 +260,13 @@
 
   <div class="buttons">
     <button type="button" class="negative" data-click="close">[% l('Close') %]</button>
-    <button type="button" style="float: right" class="positive" data-click="addDisc" data-bind="enable: currentTab().result()">[% l('Add Disc') %]</button>
+    <button type="button" style="float: right" class="positive" data-click="addDisc" data-bind="enable: currentTab().result()">[% l('Add Medium') %]</button>
   </div>
 </div>
 
 <div data-bind="with: rootField.release, affectsBubble: trackArtistBubble">
   <p class="error field-error" data-bind="showErrorRightAway: needsMediums">
-    [%~ l('Add a medium by clicking “Add Disc” below, or tick the box confirming the tracklist is unknown.') ~%]
+    [%~ l('Add a medium by clicking “Add Medium” below, or tick the box confirming the tracklist is unknown.') ~%]
   </p>
 
   <!-- ko if: !mediums().length -->

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -90,7 +90,7 @@
   </table>
 
   <!-- ko if: searchResults() && searchResults().length > 0 -->
-  <p>[% l('Select a disc from the search results below and then click "Add Medium".') %]</p>
+  <p>[% l('Select a medium from the search results below and then click "Add Medium".') %]</p>
   <!-- /ko -->
 
   <!-- ko if: totalPages() > 1 -->

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -230,11 +230,11 @@
 </div>
 
 <div id="add-disc-dialog" style="display: none;" data-bind="with: $root.addDiscDialog, delegatedHandler: ['click', 'keydown']">
-  <p>[% l('To create a new tracklist, use an existing tracklist or import a disc from a CD stub or FreeDB, select the appropriate tab.') %]</p>
+  <p>[% l('To create a new tracklist, use an existing medium or import a disc from a CD stub or FreeDB, select the appropriate tab.') %]</p>
 
   <ul>
     <li><a href="#add-disc-parser">[% l('Manual entry') %]</a></li>
-    <li><a href="#add-disc-medium">[% l('Existing tracklist') %]</a></li>
+    <li><a href="#add-disc-medium">[% l('Existing medium') %]</a></li>
     <li><a href="#add-disc-cdstub">[% l('CD stub import') %]</a></li>
     <li><a href="#add-disc-freedb">[% l('FreeDB import') %]</a></li>
   </ul>
@@ -244,7 +244,7 @@
   </div>
 
   <div id="add-disc-medium">
-    <p>[% l('Use the following fields to search for an existing tracklist.') %]</p>
+    <p>[% l('Use the following fields to search for an existing medium.') %]</p>
     <!-- ko template: { name: "template.medium-search", data: mediumSearch } --><!-- /ko -->
   </div>
 

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -250,7 +250,7 @@ var formatTrackLength = require('../common/utility/formatTrackLength');
 
     var addDiscDialog = releaseEditor.addDiscDialog = Dialog().extend({
         element: "#add-disc-dialog",
-        title: i18n.l("Add Disc"),
+        title: i18n.l("Add Medium"),
 
         trackParser: releaseEditor.trackParserDialog,
         mediumSearch: mediumSearchTab,


### PR DESCRIPTION
MB's button to add another medium to a release is labeled "Add disc", but a lot of our releases don't have discs (they have cassettes, or USBs, or just folders in a download). So i renamed that to "Add medium", which is the more MusicBrainz-y term.

While i was at it  i changed the mentions of "tracklist" to say "medium" too, where it says "search for an existing tracklist", "Existing tracklist" and "To create a new tracklist, use an existing tracklist or".

[Link to the ticket](http://tickets.musicbrainz.org/browse/MBS-8482)
[Link to the GCI task](https://codein.withgoogle.com/dashboard/task-instances/6181327283945472/)

Sorry for this previous request, i didn't understand what is the role of "po" directory.
I think it should be ok now. :+1: 