### PR TITLE
MBS-8241: Highlight mediums with pending edits

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -491,6 +491,7 @@ div.warning img.warning {
 .tooltip { border-bottom: 1px dotted; } /* Useful when adding title attributes to elements */
 
 table.tbl tr.mp td,
+table.tbl tr.mp th, /* Medium headers in release view */
 span.mp,
 div.mp,
 tr.diff-changes {


### PR DESCRIPTION
The medium header still had the `class="mp"`, but the CSS to turn it orange was missing.

This doesn’t completely match the style of the regular header, which has a bit of 3D. I leave fixing that to someone who cares. ;-) At least this fixes the functionality.