### PR TITLE
MBS-8692: Set an expire time for all Catalyst session keys

### DIFF
--- a/admin/RemoveExpiredSessions.pl
+++ b/admin/RemoveExpiredSessions.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use DBDefs;
+
+use MooseX::Runnable::Run;
+run_application 'MusicBrainz::Script::RemoveExpiredSessions', @ARGV;

--- a/lib/Catalyst/Plugin/Session/Store/MusicBrainz.pm
+++ b/lib/Catalyst/Plugin/Session/Store/MusicBrainz.pm
@@ -30,15 +30,11 @@ sub get_session_data {
 sub store_session_data {
     my ($self, $key, $data) = @_;
 
-    if (my ($sid) = $key =~ /^expires:(.*)/)
-    {
-        $self->_datastore->set($key, $data);
+    unless ($key =~ /^expires:/) {
+        $data = encode_base64(nfreeze($data));
     }
-    else
-    {
-        $self->_datastore->set($key, encode_base64(nfreeze($data)));
-        $self->_datastore->expireat($key, $self->session_expires);
-    }
+    $self->_datastore->set($key, $data);
+    $self->_datastore->expireat($key, $self->session_expires);
 }
 
 sub delete_session_data {

--- a/lib/MusicBrainz/DataStore.pm
+++ b/lib/MusicBrainz/DataStore.pm
@@ -22,25 +22,6 @@ Expire the specified key at (unix) $timestamp.
 
 requires 'expireat';
 
-=method incr
-
-Increment the value for the $key.
-
-=cut
-
-requires 'incr';
-
-=method add
-
-Store the $value on the server under the $key, but only if the key
-doesn't exists on the server.
-
-=cut
-
-requires 'add';
-
-requires 'ttl';
-
 =head1 LICENSE
 
 Copyright (C) 2013 MetaBrainz Foundation

--- a/lib/MusicBrainz/DataStore.pm
+++ b/lib/MusicBrainz/DataStore.pm
@@ -12,7 +12,7 @@ Expire the specified key in $s seconds.
 
 =cut
 
-requires 'expireat';
+requires 'expire';
 
 =method expireat
 

--- a/lib/MusicBrainz/DataStore/Redis.pm
+++ b/lib/MusicBrainz/DataStore/Redis.pm
@@ -40,39 +40,48 @@ has '_json' => (
     default => sub { return JSON->new->allow_nonref->ascii; }
 );
 
+sub _prepare_key {
+    my ($self, $key) = @_;
+    return encode('utf-8', $self->prefix . $key);
+}
+
+sub _decode_value {
+    my ($self, $value) = @_;
+    return defined $value ? $self->_json->decode($value) : undef;
+}
+
 sub get {
     my ($self, $key) = @_;
 
-    my $value = $self->_connection->get(encode('utf-8', $self->prefix.$key));
+    my $value = $self->_connection->get($self->_prepare_key($key));
 
-    return defined $value ? $self->_json->decode($value) : undef;
+    return $self->_decode_value($value);
 }
 
 sub mget {
     my ($self, @keys) = @_;
 
-    map {
-        defined $_ ? $self->_json->decode($_) : undef
-    } $self->_connection->mget(map { encode('utf-8', $self->prefix . $_) } @keys);
+    map { $self->_decode_value($_) }
+    $self->_connection->mget(map { $self->_prepare_key($_) } @keys);
 }
 
 sub set {
     my ($self, $key, $value) = @_;
 
     return $self->_connection->set(
-        encode('utf-8', $self->prefix.$key), $self->_json->encode($value));
+        $self->_prepare_key($key), $self->_json->encode($value));
 }
 
 sub exists {
     my ($self, $key) = @_;
 
-    return $self->_connection->exists(encode('utf-8', $self->prefix.$key));
+    return $self->_connection->exists($self->_prepare_key($key));
 }
 
 sub del {
     my ($self, $key) = @_;
 
-    return $self->_connection->del(encode('utf-8', $self->prefix.$key));
+    return $self->_connection->del($self->_prepare_key($key));
 }
 
 =method expire
@@ -84,13 +93,13 @@ Expire the specified key in $s seconds
 sub expire {
     my ($self, $key, $s) = @_;
 
-    return $self->_connection->expire(encode('utf-8', $self->prefix.$key), $s);
+    return $self->_connection->expire($self->_prepare_key($key), $s);
 }
 
 sub expireat {
     my ($self, $key, $timestamp) = @_;
 
-    return $self->_connection->expireat(encode('utf-8', $self->prefix.$key), $timestamp);
+    return $self->_connection->expireat($self->_prepare_key($key), $timestamp);
 }
 
 sub _flushdb {

--- a/lib/MusicBrainz/DataStore/Redis.pm
+++ b/lib/MusicBrainz/DataStore/Redis.pm
@@ -93,30 +93,6 @@ sub expireat {
     return $self->_connection->expireat(encode('utf-8', $self->prefix.$key), $timestamp);
 }
 
-sub incr {
-    my ($self, $key, $increment) = @_;
-
-    return $self->_connection->incrby(encode('utf-8', $self->prefix.$key), $increment // 1);
-}
-
-=method add
-
-Store the $value on the server under the $key, but only if the key
-doesn't exists on the server.
-
-=cut
-
-sub add {
-    my ($self, $key, $value) = @_;
-
-    return $self->_connection->setnx(encode('utf-8', $self->prefix.$key), $self->_json->encode($value));
-}
-
-sub ttl {
-    my ($self, $key) = @_;
-    return $self->_connection->ttl(encode('utf-8', $self->prefix.$key));
-}
-
 sub _flushdb {
     my ($self) = @_;
 

--- a/lib/MusicBrainz/Script/RemoveExpiredSessions.pm
+++ b/lib/MusicBrainz/Script/RemoveExpiredSessions.pm
@@ -1,0 +1,102 @@
+package MusicBrainz::Script::RemoveExpiredSessions;
+
+=head1 DESCRIPTION
+
+This is a cleanup script related to MBS-8692. It removes all Catalyst
+"expires" session keys for which the expire time (stored as the value) is in
+the past. For the other session sub-keys used by Catalyst, namely "session"
+and "flash", cleanup is not necessary because they already had their Redis
+expire time set correctly.
+
+The base issue for "expires" keys is now also fixed, so it should not be
+necessary to re-run this script.
+
+=cut
+
+use Moose;
+use namespace::autoclean;
+
+with 'MooseX::Runnable';
+with 'MooseX::Getopt';
+with 'MusicBrainz::Script::Role::Context';
+
+has 'verbose' => (
+    isa => 'Bool',
+    is => 'ro',
+    default => sub { -t },
+);
+
+has 'dry_run' => (
+    isa => 'Bool',
+    is => 'ro',
+    default => 0,
+    traits => [ 'Getopt' ],
+    cmd_flag => 'dry-run',
+);
+
+sub run {
+    my ($self, @args) = @_;
+    die "Usage error ($0 takes no arguments)" if @args;
+
+    my $r = $self->c->redis;
+    my $now = time + 5; # five seconds grace period for server differences
+
+    printf "Fetching entries from database; prefix used is \"%s\".\n", $r->prefix if $self->verbose;
+    my @keys = $r->_connection->keys($r->prefix . "expires:*");
+        # KEYS is very heavy, but our current Redis doesn't have SCAN
+    my $considered = scalar @keys;
+    if ($considered == 0) {
+        print "WARNING: No sessions found.\n";
+        return 0;
+    }
+    printf 'Retrieved %d keys,', $considered if $self->verbose;
+    my @values = $r->_connection->mget(@keys);
+    printf " %d values.\n", scalar @values if $self->verbose;
+
+    scalar @values == $considered or die 'Number of values from the database does not match keys';
+
+    my @remove;
+    while (my $key = shift @keys) {
+        my $expire_time = shift @values;
+        push @remove, $key
+            if $expire_time < $now;
+    }
+    my $to_be_removed = scalar @remove;
+    printf "Found %d of the entries to be expired (%.2f %%).\n",
+            $to_be_removed, (100 * $to_be_removed / $considered)
+        if $self->verbose;
+
+    if ($to_be_removed && !$self->dry_run) {
+        print 'Deleting expired entries ...' if $self->verbose;
+        my $deleted = $r->_connection->del(@remove);
+        printf " deleted %d entries.\n", $deleted if $self->verbose;
+        $deleted == $to_be_removed
+            or printf "WARNING: Wanted to delete %d entries, but actually deleted %d!\n", $to_be_removed, $deleted;
+    }
+
+    print "Finished.\n" if $self->verbose;
+    return 0;
+}
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2015 Ulrich Klauer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -612,7 +612,7 @@ sub allocate_remember_me_token {
         my $token = generate_token();
 
         my $key = "$normalized_name|$token";
-        $self->redis->add($key, 1);
+        $self->redis->set($key, 1);
 
         # Expire tokens after 1 year.
         $self->redis->expire($key, 60 * 60 * 24 * 7 * 52);

--- a/t/lib/t/MusicBrainz/DataStore/Redis.pm
+++ b/t/lib/t/MusicBrainz/DataStore/Redis.pm
@@ -65,20 +65,11 @@ test all => sub {
     ok(! $redis->exists("does-not-exist"), "exists returns false for non-existent key");
     ok($redis->exists("string"), "exists returns true for existing key");
 
-    ok(! $redis->add("string", "Murió"), "add returns false when not adding a key");
-    is($redis->get("string"), "Esperándote", "string is unchanged");
-
     ok($redis->del("string"), "delete string");
     ok(! $redis->exists("strings"), "exists returns false for deleted key");
 
-    ok($redis->add("string", "Murió"), "add returns true when adding a key");
-    is($redis->get("string"), "Murió", "string is now changed");
-
     $redis->set("int", 23);
     is($redis->get("int"), 23, "retrieved expected integer");
-
-    $redis->incr("int", 2);
-    is($redis->get("int"), 25, "retrieved incremented integer");
 
     ok($redis->expireat("int", time() + 1), "expire int in one second");
     ok($redis->exists("int"), "int still exists");

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -59,9 +59,6 @@ test 'Remember me tokens' => sub {
     ok(!$model->consume_remember_me_token($user_name, $token),
        'Remember me tokens with improper capitalization can\'t be consumed');
 
-    ok( $test->c->redis->ttl("$normalized_name|$token") <= 5 * 60,
-        'TTL of remember me token at most 5 minutes' );
-
     ok(!exception { $model->consume_remember_me_token('Unknown User', $token) },
        'It is not an exception to attempt to consume tokens for non-existant users');
 


### PR DESCRIPTION
Of the three types of session sub-keys used by Catalyst, only two had an expire time set in order to get them auto-removed from Redis when the session was no longer valid, but `expires` had not. This was introduced in commit e7e15ef, most likely unintentionally and a side effect of `expires` being treated specially for encoding purposes. It has led to the production Redis instance accumulating over 4.8 million keys since early 2013, most of which presumably are `expires` subkeys of long-gone Catalyst sessions.

Ensure that a Redis expire time is set for all session keys equally. This also adds a script that will clean out existing expired session keys, and does some cleanup for `MB::DataStore:Redis`.