### PR TITLE
More XSS fixes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -4,9 +4,8 @@ BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use namespace::autoclean;
 use Digest::SHA qw(sha1_base64);
-use HTML::Entities qw( encode_entities );
 use MusicBrainz::Server::Translation qw(l ln );
-use MusicBrainz::Server::Validation qw( is_positive_integer );
+use MusicBrainz::Server::Validation qw( encode_entities is_positive_integer );
 use Try::Tiny;
 use Captcha::reCAPTCHA;
 

--- a/lib/MusicBrainz/Server/Plugin/Diff.pm
+++ b/lib/MusicBrainz/Server/Plugin/Diff.pm
@@ -14,21 +14,9 @@ use HTML::Tiny;
 use HTML::TreeBuilder;
 use Scalar::Util qw( blessed );
 use MusicBrainz::Server::Translation qw( l );
-use MusicBrainz::Server::Validation qw( trim_in_place );
+use MusicBrainz::Server::Validation qw( encode_entities trim_in_place );
 
 no if $] >= 5.018, warnings => "experimental::smartmatch";
-
-sub html_filter {
-    my $text = shift;
-    return unless defined $text;
-    for ($text) {
-        s/&/&amp;/g;
-        s/</&lt;/g;
-        s/>/&gt;/g;
-        s/"/&quot;/g;
-    }
-    return $text;
-}
 
 sub new {
     my ($class, $context) = @_;
@@ -142,19 +130,19 @@ sub _link_artist_credit_name {
         return $h->a({
             href => $self->uri_for_action('/artist/show', [ $acn->artist->gid ]),
             title => $acn->artist->sort_name . $comment
-        }, $name || html_filter($acn->name));
+        }, $name || encode_entities($acn->name));
     }
     else {
         return $h->span({
             class => 'deleted tooltip',
             title => l('This entity has been removed, and cannot be displayed correctly.')
-        }, $name || html_filter($acn->name));
+        }, $name || encode_entities($acn->name));
     }
 }
 
 sub _link_joined {
     my ($self, $acn) = @_;
-    return $self->_link_artist_credit_name($acn) . (html_filter($acn->join_phrase) || '');
+    return $self->_link_artist_credit_name($acn) . (encode_entities($acn->join_phrase) || '');
 }
 
 sub diff_artist_credits {

--- a/lib/MusicBrainz/Server/View/Node.pm
+++ b/lib/MusicBrainz/Server/View/Node.pm
@@ -5,10 +5,11 @@ use warnings;
 use base 'MusicBrainz::Server::View::Base';
 use DBDefs;
 use Encode;
-use HTML::Entities qw( encode_entities decode_entities );
+use HTML::Entities qw( decode_entities );
 use HTTP::Request;
 use JSON -convert_blessed_universally;
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
+use MusicBrainz::Server::Validation qw( encode_entities );
 use URI;
 
 # INFORMATION SEPARATOR ONE

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -209,7 +209,7 @@ END -%]
         SET show_list = 0;
         FOR name=ac.names;
           IF name.artist.name != name.name;
-            artist_list.push(l('{artist} as {name}', { artist => descriptive_link(name.artist), name => name.name}));
+            artist_list.push(l('{artist} as {name}', { artist => descriptive_link(name.artist), name => html_escape(name.name)}));
             SET show_list = 1;
           ELSE;
             artist_list.push(descriptive_link(name.artist));

--- a/root/doc/page.tt
+++ b/root/doc/page.tt
@@ -12,7 +12,7 @@
                     [% doc = doc _ "/" _ link %]
                 [% END %]
 
-                <a href="[%- doc_link(doc.replace(' ', '_')) -%]" [% ' style="font-weight:bold;"' IF loop.last %]>[%- link -%]</a>
+                <a href="[%- doc_link(doc.replace(' ', '_')) | html -%]" [% ' style="font-weight:bold;"' IF loop.last %]>[%- link | html -%]</a>
                 [% ' / ' IF !loop.last %]
             [% END %]
         </h1>
@@ -31,8 +31,8 @@
                 [%- l('This page is {doc|transcluded} from revision {version} of {title}.',
                     {
                         doc => doc_link('WikiDocs'),
-                        version => '<a href="' _ wiki_history_link(wiki_server, id, page.version) _ '" class="internal">#' _ page.version _ '</a>',
-                        title => '<a href="' _ wiki_link(wiki_server, id) _ '" class="internal">' _ page.title _ '</a>',
+                        version => '<a href="' _ html_escape(wiki_history_link(wiki_server, id, page.version)) _ '" class="internal">#' _ page.version _ '</a>',
+                        title => '<a href="' _ html_escape(wiki_link(wiki_server, id)) _ '" class="internal">' _ html_escape(page.title) _ '</a>',
                     }
                 ) -%]
             </div>
@@ -40,7 +40,7 @@
             <div class="wikidocs-footer">
             [%- l('This page is {doc|transcluded} from {title}.',
                  { doc => doc_link('WikiDocs'),
-                   title => '<a href="//' _ wiki_server _ '/' _ id _ '" class="internal">' _ page.title _ '</a>' }) -%]
+                   title => '<a href="//' _ wiki_server _ '/' _ html_escape(id) _ '" class="internal">' _ html_escape(page.title) _ '</a>' }) -%]
             </div>
         [%- END -%]
     </div>

--- a/root/edit/data.tt
+++ b/root/edit/data.tt
@@ -36,7 +36,12 @@
         $('#edit-raw-data').each(function () {
             var $this = $(this);
             var json = JSON.parse($this.text());
-            if (json) { $this.html('<pre>'+JSON.stringify(json,null,2)+'</pre>') }
+            if (json) {
+                var $pre = $('<pre />');
+                $pre.text(JSON.stringify(json,null,2)); // .text() encodes HTML reserved characters
+                $this.parent().after($pre);
+                $this.remove();
+            }
         });
     </script>
 [%- END -%]

--- a/root/layout/head.tt
+++ b/root/layout/head.tt
@@ -3,7 +3,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>[% title %][% IF !homepage; " - " IF title; l('Page {n}', { n => pager.current_page }) _ " - " IF (pager.current_page && pager.current_page > 1); "MusicBrainz"; END %]</title>
+    <title>[% title | html %][% IF !homepage; " - " IF title; l('Page {n}', { n => pager.current_page }) _ " - " IF (pager.current_page && pager.current_page > 1); "MusicBrainz"; END %]</title>
     [%~ USE Canonicalize ~%]
     [%~ IF Canonicalize.canonicalize(canonical_url || c.req.uri) != c.req.uri ~%]
         <link rel="canonical" href="[% Canonicalize.canonicalize(canonical_url || c.req.uri) | html %]" />

--- a/root/layout/sidebar/shared-entity-sidebar.tt
+++ b/root/layout/sidebar/shared-entity-sidebar.tt
@@ -77,11 +77,11 @@
                     <li>
                     [%~ IF containment.${collection.id} ~%]
                         <a href="[%~ c.uri_for_action("/collection/remove", [collection.gid], { event => event.id }) ~%]">
-                            [%~ l('Remove from {collection}', { collection => collection.name }) ~%]
+                            [%~ l('Remove from {collection}', { collection => html_escape(collection.name) }) ~%]
                         </a>
                     [%~ ELSE ~%]
                         <a href="[%~ c.uri_for_action("/collection/add", [collection.gid], { event => event.id }) ~%]">
-                        [%~ l('Add to {collection}', {collection => collection.name }) ~%]
+                        [%~ l('Add to {collection}', {collection => html_escape(collection.name) }) ~%]
                         </a>
                     [%~ END ~%]
                     </li>
@@ -101,11 +101,11 @@
                     <li>
                     [%~ IF containment.${collection.id} ~%]
                         <a href="[%~ c.uri_for_action("/collection/remove", [collection.gid], { $entity_type => entity.id }) ~%]">
-                            [%~ l('Remove from {collection}', { collection => collection.name }) ~%]
+                            [%~ l('Remove from {collection}', { collection => html_escape(collection.name) }) ~%]
                         </a>
                     [%~ ELSE ~%]
                         <a href="[%~ c.uri_for_action("/collection/add", [collection.gid], { $entity_type => entity.id }) ~%]">
-                            [%~ l('Add to {collection}', {collection => collection.name }) ~%]
+                            [%~ l('Add to {collection}', {collection => html_escape(collection.name) }) ~%]
                         </a>
                     [%~ END ~%]
                     </li>


### PR DESCRIPTION
This fixes more encoding issues that allow to inject HTML into pages; not via query parameters this time, but via entity names etc. from the database, so the Chrome XSS Auditor wouldn’t notice, I believe. On the other hand, an editor account is required to make an exploit.

- Various places in the templates where strings controlled by other editors weren’t encoded (collection names, Wiki pages, ).
- Our `Diff` plugin for TT deals with both encoded and unencoded strings in a complicated way and got it wrong in some places. This affected "Edit medium" edits in particular, for their two types of artist credit diffs. An example that broke horribly before is at http://chirlu.mbsandbox.org/edit/33191778
- One interesting case was the raw edit data page (e.g. http://chirlu.mbsandbox.org/edit/33191778/data). The template did encode the JSON string correctly, but there is a client-side script to pretty-print it (indentation etc.). When the pretty version was put back into the DOM, re-encoding was not done.

One more thing I’m doing here is to use `MB::S::Validation::encode_entities` eve
rywhere (on the Perl side), replacing both `HTML::Entities::encode_entities` and
 a private reimplementation in the `Diff` plugin called `html_filter`.