### PR TITLE
MBS-8167: Use HTML diffs for relationship attributes

### DIFF
--- a/root/edit/details/macros.tt
+++ b/root/edit/details/macros.tt
@@ -89,7 +89,7 @@
             entity1 => differences_span(old_rel, new_rel, 'target', 'old', 'diff-only-a')
         }) %]
       [% Diff.diff_side(relationship_date_text(old_rel), relationship_date_text(new_rel), '-') %]
-      [% Diff.diff_side(relationship_extra_attributes(old_rel), relationship_extra_attributes(new_rel), '-') %]
+      [% Diff.diff_html_side(relationship_extra_attributes(old_rel), relationship_extra_attributes(new_rel), '-') %]
     </td>
   </tr>
   <tr>
@@ -100,7 +100,7 @@
             entity1 => differences_span(old_rel, new_rel, 'target', 'new', 'diff-only-b')
         }) %]
       [% Diff.diff_side(relationship_date_text(old_rel), relationship_date_text(new_rel), '+') %]
-      [% Diff.diff_side(relationship_extra_attributes(old_rel), relationship_extra_attributes(new_rel), '+') %]
+      [% Diff.diff_html_side(relationship_extra_attributes(old_rel), relationship_extra_attributes(new_rel), '+') %]
     </td>
   </tr>
 [%- END -%]


### PR DESCRIPTION
Relationship attributes can now contain HTML (instrument links); diffing them as regular text for edit display may lead to broken tags. Use HTML diffs instead.