### PR TITLE
MBS-8698: Be more flexible in identifying JSON-LD requests

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/JSONLD.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/JSONLD.pm
@@ -38,7 +38,7 @@ role
             my $jsonld_data = serialize_entity($entity, undef, $stash, 1);
 
             my $accept = $c->req->header('Accept');
-            if (defined $accept && $accept eq 'application/ld+json') {
+            if (defined $accept && $accept =~ m(\b application/ld+json \b)x) {
                 $c->res->content_type('application/ld+json; charset=utf-8');
                 $c->res->body(encode_json($jsonld_data));
                 $c->detach;


### PR DESCRIPTION
A request for the JSON-LD of an entity was only honoured if its HTTP `Accept` header consisted of the exact string `application/ld+json`. Even adding a `q` value or a second acceptable MIME type caused the server to fall back to the standard HTML page.

This commit makes the server look for any occurrence of the JSON-LD type in the `Accept` header, which will fix the common scenarios mentioned above. However, it might cause new problems if clients use valid but unusual `Accept` headers (e.g. containing both `text/html` and `application/ld+json`, with the former being preferred).