### PR TITLE
Added a notice showing when an edit changes only relationship credits

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -1054,3 +1054,5 @@ END -%]
     </div>
   [%- END -%]
 [%~ END ~%]
+
+[%~ MACRO non_empty(text) GET (text != '' && text.defined) ~%]

--- a/root/edit/details/edit_relationship.tt
+++ b/root/edit/details/edit_relationship.tt
@@ -7,6 +7,18 @@
 <table class="details edit-relationship">
   [%- display_relationship_differences(l('Relationship:'), old_rel, new_rel) -%]
 
+  [%- IF (edit.data.new.size == 1 && 
+    (non_empty(edit.data.new.entity0_credit) ||
+    non_empty(edit.data.new.entity1_credit))) ||
+    (edit.data.new.size == 2 && 
+    non_empty(edit.data.new.entity0_credit) && non_empty(edit.data.new.entity1_credit)) -%]
+  <tr>
+    <th></th>
+    <td colspan="2">
+      [% l('This edit only changes the credited names.') %]
+    </td>
+  </tr>
+  [%- END -%]
   [% IF edit.display_data.unknown_attributes %]
   <tr>
     <th></th>


### PR DESCRIPTION
User might change only relationship credits and not the actual relationship and it would have looked the same. I've added a notice, which shows only if relationship credits were changed and everything else remains the same.
[Link to the ticket](http://tickets.musicbrainz.org/browse/MBS-8662)
[Link to the GCI task](https://codein.withgoogle.com/dashboard/task-instances/5300055393173504/?sp-page=1)