### PR TITLE
Name-variation fixes (includes MBS-7844, MBS-8330)

### DIFF
--- a/lib/MusicBrainz/Server/Plugin/Diff.pm
+++ b/lib/MusicBrainz/Server/Plugin/Diff.pm
@@ -124,26 +124,11 @@ sub _render_side_diff {
 
 sub _link_artist_credit_name {
     my ($self, $acn, $name) = @_;
-    my $comment;
-    if ($acn->artist->comment) {
-        $comment = ' (' . $acn->artist->comment . ')';
-    }
-    else {
-        $comment = '';
-    }
 
-    if ($acn->artist->gid) {
-        return $h->a({
-            href => $self->uri_for_action('/artist/show', [ $acn->artist->gid ]),
-            title => encode_entities($acn->artist->sort_name . $comment),
-        }, $name || encode_entities($acn->name));
-    }
-    else {
-        return $h->span({
-            class => 'deleted tooltip',
-            title => l('This entity has been removed, and cannot be displayed correctly.')
-        }, $name || encode_entities($acn->name));
-    }
+    $name //= encode_entities($acn->name);
+
+    # defer to the template macro
+    return $self->{c}->stash->get('link_artist', [ $acn->artist, 'show', $name, 1 ]);
 }
 
 sub _link_joined {

--- a/lib/MusicBrainz/Server/Plugin/Diff.pm
+++ b/lib/MusicBrainz/Server/Plugin/Diff.pm
@@ -201,7 +201,6 @@ sub diff_artist_credits {
 
 sub diff {
     my ($self, $old, $new) = @_;
-    my $h = HTML::Tiny->new;
 
     my @spans;
 

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -399,9 +399,9 @@ END -%]
     INCLUDE _link_mbid_entity entity=label type='label' action=action content=text;
 END -%]
 
-[%~ MACRO link_artist(artist, action, text) BLOCK;
+[%~ MACRO link_artist(artist, action, text, no_escape) BLOCK;
     hover = html_escape(artist.sort_name) _ bracketed(html_escape(artist.comment));
-    INCLUDE _link_mbid_entity entity=artist type='artist' action=action content=text hover=hover namevar=1;
+    INCLUDE _link_mbid_entity entity=artist type='artist' action=action content=text hover=hover namevar=1 noescape=no_escape;
 END -%]
 
 [%~ MACRO link_area(area, action, text) BLOCK;

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -6,6 +6,7 @@
 [%~ MACRO replace(text, search, replace) BLOCK; text | replace(search, replace); END -%]
 [%~ MACRO url_escape(url) BLOCK; url | url; END -%]
 [%~ MACRO html_escape(url) BLOCK; url | html; END -%]
+[%~ MACRO html_unescape(text) BLOCK; text.replace('&quot;', '"').replace('&lt;', '<').replace('&gt;', '>').replace('&#39;', "'").replace('&amp;', '&'); END -%]
 [%~ MACRO bracketed(text) BLOCK; text != '' ? l(' ({text})', { text => text }) : ''; END -%]
 [%~ MACRO js_escape(text) BLOCK; text | js; END ~%]
 [%~ MACRO display_url(url) BLOCK; PROCESS _unescaped_display_url | html; END -%]
@@ -340,7 +341,7 @@ END -%]
     END;
 
     IF namevar AND action == 'show' AND content != ''
-            AND (noescape ? content.remove('</?span\b[^>]*>') : content) != entity.name;
+            AND (noescape ? html_unescape(content.remove('</?span\b[^>]*>')) : content) != entity.name;
         options.unshift('name_variation');
         hover = hover != '' ? l('{name} – {additional_info}', { name => html_escape(entity.name), additional_info => hover })
                             : html_escape(entity.name);


### PR DESCRIPTION
We wrap entites in `<span class="name-variation">` if the displayed name is not identical to the true entity name so that client-side CSS can highlight them. However, there were some cases where this was done or omitted erroneously:

- If the display name is from a diff and already in HTML form, it is necessary not only to remove any `<span>` tags (for diff highlighting) before the comparison – we already did that – but also to undo the conversion of HTML reserved characters into entities. Otherwise, names containing one of the reserved characters were treated as a variation even when they were, in fact, identical to the entity name. (MBS-8330)
- Artist names in artist credit diffs from the `Diff` plugin were linked inside the plugin, using what was essentially a Perl reimplementation of the `link_artist` template macro. However, this knock-off did not even attempt to create the name-variation marker. (MBS-7844) It has even more bugs for which no separate tickets exist; see the comments on MBS-7844. Instead of trying to fix it, I just made the plugin call the TT macro directly, removing the duplication and ensuring feature parity. For this, I needed to extend `link_artist` slightly so that it can take HTML (like `link_recording` already did).