### PR TITLE
MBS-8694 (beta): Re-allow 0 for edit search “ID” fields, for now

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/ID.pm
@@ -37,7 +37,7 @@ sub valid {
     my $cardinality = $self->operator_cardinality($self->operator) or return 1;
     for my $arg_index (1..$cardinality) {
         my $arg = $self->argument($arg_index - 1);
-        is_database_row_id($arg) or return;
+        is_database_row_id($arg) || $arg == 0 or return;
     }
 
     return 1;


### PR DESCRIPTION
Because the “ID” edit search predicate class is used not only for IDs, but also other numbers such as the Yes/No vote counts, the recently improved validation for database row IDs broke those other criteria.

Re-allow 0 (which does not cause problems when used in a database query; it will simply never find anything) as a temporary solution until the predicate class hierarchy is improved.