### PR TITLE
URL fixes, part 1 (includes MBS-8413)

### DIFF
--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -224,6 +224,7 @@ sub format_editnote
          [<a href="//$server/edit/$1">edit #$1</a>]gi;
 
     # links to wikidocs
+    # (only safe because \w doesn't match any of the HTML reserved characters)
     $html =~ s/doc:(\w[\/\w]*)(``)*/<a href="\/doc\/$1">$1<\/a>/gi;
     $html =~ s/\[(\p{IsUpper}[\/\w]*)\]/<a href="\/doc\/$1">$1<\/a>/g;
 

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -10,12 +10,6 @@
 [%~ MACRO bracketed(text) BLOCK; text != '' ? l(' ({text})', { text => text }) : ''; END -%]
 [%~ MACRO js_escape(text) BLOCK; text | js; END ~%]
 [%~ MACRO closing_tag_escape(text) BLOCK; text.replace('</', '<\\/'); END ~%]
-[%~ MACRO display_url(url) BLOCK; PROCESS _unescaped_display_url | html; END -%]
-[%~ BLOCK _unescaped_display_url;
-    IF url.pretty_name; url.pretty_name;
-    ELSE; url | uri_decode;
-    END;
-END -%]
 [%- USE UserDate(c.user.preferences, current_language) -%]
 [%- USE Countdown -%]
 [%~ MACRO doc_link(to) BLOCK -%][% c.uri_for('/doc', to) %][%- END -%]
@@ -361,7 +355,7 @@ END -%]
     END;
 
     IF type == 'url' AND content == '';
-        mod_content = INCLUDE _unescaped_display_url url=entity;
+        mod_content = entity.pretty_name;
         options.unshift('info_link');
         infolink = link;
         link = entity.href_url;

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -5,7 +5,7 @@
 [%~ MACRO add_commas(n) GET n.chunk(-3).join(',') -%]
 [%~ MACRO replace(text, search, replace) BLOCK; text | replace(search, replace); END -%]
 [%~ MACRO url_escape(url) BLOCK; url | url; END -%]
-[%~ MACRO html_escape(url) BLOCK; url | html; END -%]
+[%~ MACRO html_escape(text) BLOCK; text | html; END ~%]
 [%~ MACRO html_unescape(text) BLOCK; text.replace('&quot;', '"').replace('&lt;', '<').replace('&gt;', '>').replace('&#39;', "'").replace('&amp;', '&'); END -%]
 [%~ MACRO bracketed(text) BLOCK; text != '' ? l(' ({text})', { text => text }) : ''; END -%]
 [%~ MACRO js_escape(text) BLOCK; text | js; END ~%]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -249,7 +249,7 @@ END -%]
       ELSIF entity.isa('MusicBrainz::Server::Entity::URL'); link_url(entity, action, text);
       END;
     ELSIF entity.isa('MusicBrainz::Server::Entity::URL');
-      simple_link(url_escape(entity.url), display_url(entity.url));
+      simple_link(html_escape(entity.url), display_url(entity.url));
       ' ';
       link_deleted(undef, '[' _ l('info') _ ']');
     ELSIF entity.isa('MusicBrainz::Server::Entity::Editor');

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -249,7 +249,7 @@ END -%]
       ELSIF entity.isa('MusicBrainz::Server::Entity::URL'); link_url(entity, action, text);
       END;
     ELSIF entity.isa('MusicBrainz::Server::Entity::URL');
-      simple_link(html_escape(entity.url), display_url(entity.url));
+      simple_link(entity.href_url, entity.pretty_name);
       ' ';
       link_deleted(undef, '[' _ l('info') _ ']');
     ELSIF entity.isa('MusicBrainz::Server::Entity::Editor');
@@ -307,8 +307,8 @@ END -%]
             CASE 'escape';
                 html_escape(content);
             CASE 'link';  # add. parameter: link, hover
-                SET hover = ' title="' _ hover _ '"' IF hover != '';
-                '<a href="' _ link _ '"' _ hover _ '>' _ content _ '</a>';
+                SET hover = ' title="' _ html_escape(hover) _ '"' IF hover != '';
+                '<a href="' _ html_escape(link) _ '"' _ hover _ '>' _ content _ '</a>';
             CASE 'code';
                 '<code>' _ content _ '</code>';
             CASE 'edits_pending';
@@ -318,7 +318,7 @@ END -%]
             CASE 'flagclass';  # add. parameter: flag
                 '<span class="flag flag-' _ flag _ '">' _ content _ '</span>';
             CASE 'info_link';  # add. parameter: infolink
-                content _ ' [<a href="' _ infolink _ '">' _ l('info') _ '</a>]';
+                content _ ' [<a href="' _ html_escape(infolink) _ '">' _ l('info') _ '</a>]';
             CASE 'show_dates';
                 content _ bracketed(dates);
             CASE 'avatar'; # add. parameter: avatar
@@ -344,8 +344,8 @@ END -%]
     IF namevar AND action == 'show' AND content != ''
             AND (noescape ? html_unescape(content.remove('</?span\b[^>]*>')) : content) != entity.name;
         options.unshift('name_variation');
-        hover = hover != '' ? l('{name} – {additional_info}', { name => html_escape(entity.name), additional_info => hover })
-                            : html_escape(entity.name);
+        hover = hover != '' ? l('{name} – {additional_info}', { name => entity.name, additional_info => hover })
+                            : entity.name;
     END;
 
     options.unshift('edits_pending') IF entity.edits_pending AND action == 'show';
@@ -401,7 +401,7 @@ END -%]
 END -%]
 
 [%~ MACRO link_artist(artist, action, text, no_escape) BLOCK;
-    hover = html_escape(artist.sort_name) _ bracketed(html_escape(artist.comment));
+    hover = artist.sort_name _ bracketed(artist.comment);
     INCLUDE _link_mbid_entity entity=artist type='artist' action=action content=text hover=hover namevar=1 noescape=no_escape;
 END -%]
 
@@ -520,8 +520,8 @@ END -%]
     c.uri_for_action('/account/register', { uri => c.req.query_params.uri || redirect || c.relative_uri });
 END -%]
 
-[%~ MACRO simple_link(url, text) BLOCK;
-    INCLUDE _wrap_text options=['link'] content=text link=url;
+[%~ MACRO simple_link(url, text) BLOCK; # url may be a string or a URI object
+    INCLUDE _wrap_text options=['link', 'escape'] content=text link=url;
 END -%]
 
 [%~ MACRO request_login(text) BLOCK;

--- a/root/entity/details.tt
+++ b/root/entity/details.tt
@@ -33,7 +33,7 @@
                 [%~ xml_inc.push('releases') IF entity_type == 'recording' || entity_type == 'release_group' ~%]
                 [%~ xml_inc.push('labels', 'discids', 'recordings') IF entity_type == 'release' ~%]
                 [%~ link = c.uri_for("/ws/2/$entity_type_for_url", entity.gid, { 'inc' => xml_inc.sort.join('+') }) ~%]
-                <a href="[%~ link ~%]">[%~ display_url(link) ~%]</a>
+                [%~ simple_link(link, link) ~%]
             </td>
         </tr>
     </table>

--- a/root/entity/edits.tt
+++ b/root/entity/edits.tt
@@ -4,7 +4,7 @@
 
     SET name_for_title = entity.name;
     SET name_for_title = entity.l_name IF ent_type == 'instrument';
-    SET name_for_title = display_url(entity) IF ent_type == 'url';
+    SET name_for_title = entity.pretty_name IF ent_type == 'url';
 
     SET link_for_heading = link_entity(entity);
     SET link_for_heading = link_entity(entity, 'show', entity.url) IF ent_type == 'url';

--- a/root/relationship/header.tt
+++ b/root/relationship/header.tt
@@ -1,7 +1,6 @@
-[% MACRO generic_link(url, text) BLOCK %]<a href="[% url %]">[% text %]</a>[% END %]
 [%- info_links = [
-    ['index', generic_link(c.uri_for_action('/relationship/linktype/index'), l('Relationship Types'))],
-    ['attributes', generic_link(c.uri_for_action('/relationship/linkattributetype/index'), l('Relationship Attributes'))],
+    ['index', simple_link(c.uri_for_action('/relationship/linktype/index'), l('Relationship Types'))],
+    ['attributes', simple_link(c.uri_for_action('/relationship/linkattributetype/index'), l('Relationship Attributes'))],
 ] -%]
 
 <h1>[% l('Relationships') %]</h1>

--- a/root/url/index.tt
+++ b/root/url/index.tt
@@ -3,7 +3,7 @@
     <table class="details">
         <tr>
             <th>[% l('URL:') %]</th>
-            <td><a href="[% html_escape(url.url) %]">[% display_url(url.url) %]</a></td>
+            <td>[% simple_link(url.href_url, url.pretty_name) %]</a></td>
         </tr>
     </table>
     [%- INCLUDE "components/relationships.tt" source=url -%]

--- a/root/user/profile/layout.tt
+++ b/root/user/profile/layout.tt
@@ -7,37 +7,35 @@
 
     <h1>[% l("{user}", { user => link_editor(user, undef, '', 54) }) %]</h1>
 
-[% MACRO generic_link(url, text) BLOCK %]<a href="[% url %]">[% text %]</a>[% END %]
-
 [%- info_links = [
-    ['index', generic_link(c.uri_for_action("/user/profile", [ user.name ]), l('Profile'))],
-    ['subscriptions', generic_link(c.uri_for_action("/user/subscriptions/artist", [ user.name ]), l('Subscriptions'))],
-    ['subscribers', generic_link(c.uri_for_action("/user/subscribers", [ user.name ]), l('Subscribers'))],
-    ['collections', generic_link(c.uri_for_action("/user/collections", [ user.name ]), l('Collections'))],
+    ['index', simple_link(c.uri_for_action("/user/profile", [ user.name ]), l('Profile'))],
+    ['subscriptions', simple_link(c.uri_for_action("/user/subscriptions/artist", [ user.name ]), l('Subscriptions'))],
+    ['subscribers', simple_link(c.uri_for_action("/user/subscribers", [ user.name ]), l('Subscribers'))],
+    ['collections', simple_link(c.uri_for_action("/user/collections", [ user.name ]), l('Collections'))],
 ] -%]
 
 [%- info_links.push(
-    ['tags', generic_link(c.uri_for_action("/user/tags", [ user.name ]), l('Tags'))],
-    ['ratings', generic_link(c.uri_for_action("/user/ratings", [ user.name ]), l('Ratings'))],
-    ['open_edits', generic_link(c.uri_for_action("/user/edits/open", [ user.name ]), l('Open Edits'))],
-    ['all_edits', generic_link(c.uri_for_action("/user/edits/all", [ user.name ]), l('All Edits'))],
+    ['tags', simple_link(c.uri_for_action("/user/tags", [ user.name ]), l('Tags'))],
+    ['ratings', simple_link(c.uri_for_action("/user/ratings", [ user.name ]), l('Ratings'))],
+    ['open_edits', simple_link(c.uri_for_action("/user/edits/open", [ user.name ]), l('Open Edits'))],
+    ['all_edits', simple_link(c.uri_for_action("/user/edits/all", [ user.name ]), l('All Edits'))],
 ) -%]
 
 [%- IF c.user.is_account_admin || (server_details.testing_features && c.user_exists)-%]
 [%- info_links.push(
-    ['edit_user', generic_link(c.uri_for_action("/admin/edit_user", user.name), l('Edit User'))],
+    ['edit_user', simple_link(c.uri_for_action("/admin/edit_user", user.name), l('Edit User'))],
 ) -%]
 [%- END -%]
 
 [%- IF viewing_own_profile -%]
 [%- info_links.push(
-    ['donation', generic_link(c.uri_for_action("/account/donation"), l('Donation Check'))],
+    ['donation', simple_link(c.uri_for_action("/account/donation"), l('Donation Check'))],
 ) -%]
 [%- END -%]
 
 [%- IF (c.user.is_account_admin || c.user.id == user.id) && !user.deleted -%]
 [%- info_links.push(
-    ['delete', generic_link(c.uri_for_action("/admin/delete_user", user.name), l('Delete Account'))],
+    ['delete', simple_link(c.uri_for_action("/admin/delete_user", user.name), l('Delete Account'))],
 ) -%]
 [%- END -%]
 


### PR DESCRIPTION
This is the first part of a number of loosely URL-related improvements. Having only one pull request would make it difficult to review.

The main change here is to give all the link macros the responsability to entity-encode their parameters, instead of the callers having to do that (who will forget it). This affects the hover text (`title` attribute) and the `href` attribute itself.

Other changes are the removal of the `display_url` macro, because it didn’t serve any useful purpose, and of the `generic_link` macro, which two templates had locally to do the same as `simple_link`.

Finally, this has a fix for MBS-8413, where deleted URL entities (in the edit history) were doubly percent-encoded, breaking the link.