### PR TITLE
URL fixes, part 2

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL.pm
+++ b/lib/MusicBrainz/Server/Entity/URL.pm
@@ -73,13 +73,14 @@ sub url_is_scheme_independent { 0 }
 
 sub href_url {
     my $self = shift;
-    my $url = $self->affiliate_url();
+    my $url = $self->affiliate_url;
 
-    if ($self->url_is_scheme_independent()) {
+    if ($self->url_is_scheme_independent) {
+        $url = $url->clone;
         $url->scheme("");
     }
 
-    return $url;
+    return $url->as_string;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/ASIN.pm
@@ -27,14 +27,16 @@ sub sidebar_name { shift->pretty_name }
 override affiliate_url => sub {
     my $self = shift;
 
-    my $url = super()->clone;
+    my $url = super();
     if ($url =~ m{^(?:https?:)?//(?:.*?\.)(amazon\.([a-z\.]+))(?:\:[0-9]+)?/[^?]+$}i) {
         my $ass_id = DBDefs->AWS_ASSOCIATE_ID($1);
         return $url unless $ass_id;
-        return URI->new("$url?tag=$ass_id");
-    } else {
+
+        $url = $url->clone;
+        $url->query_form(tag => $ass_id);
         return $url;
     }
+    return $url;
 };
 
 sub url_is_scheme_independent { 1 }

--- a/lib/MusicBrainz/Server/Entity/URL/Ozon.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Ozon.pm
@@ -8,7 +8,7 @@ sub pretty_name { 'OZON.ru' }
 
 override affiliate_url => sub {
     my $self = shift;
-    my $url = super();
+    my $url = super()->clone;
     $url->query_form(partner => 'musicbrainz');
     return $url;
 };

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -5,6 +5,13 @@
 [%~ MACRO add_commas(n) GET n.chunk(-3).join(',') -%]
 [%~ MACRO replace(text, search, replace) BLOCK; text | replace(search, replace); END -%]
 [%~ MACRO url_escape(url) BLOCK; url | url; END -%]
+[%~# Use uri_escape for percent-encoding random text to be used as a parameter
+   # in an external URL (use c.uri_for(_action) for making internal URLs).
+   # A URL passed in from somewhere, on the other hand, should already be
+   # percent-encoded and not be run through uri_escape; just use html_escape
+   # for entity-encoding reserved characters (the ampersand, in particular).
+   # ~%]
+[%~ MACRO uri_escape(text) BLOCK; text | uri; END ~%]
 [%~ MACRO html_escape(text) BLOCK; text | html; END ~%]
 [%~ MACRO html_unescape(text) BLOCK; text.replace('&quot;', '"').replace('&lt;', '<').replace('&gt;', '>').replace('&#39;', "'").replace('&amp;', '&'); END -%]
 [%~ MACRO bracketed(text) BLOCK; text != '' ? l(' ({text})', { text => text }) : ''; END -%]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -4,7 +4,6 @@
 [%-# This next could use localization for alternating comma/period use per locale -%]
 [%~ MACRO add_commas(n) GET n.chunk(-3).join(',') -%]
 [%~ MACRO replace(text, search, replace) BLOCK; text | replace(search, replace); END -%]
-[%~ MACRO url_escape(url) BLOCK; url | url; END -%]
 [%~# Use uri_escape for percent-encoding random text to be used as a parameter
    # in an external URL (use c.uri_for(_action) for making internal URLs).
    # A URL passed in from somewhere, on the other hand, should already be

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -1104,3 +1104,9 @@ note-[%- edit.id -%]-[%- loop.count() -%]
     </div>
   </div>
 [%~ END ~%]
+
+[%~ MACRO bugtracker_url(description) BLOCK;
+    'http://tickets.musicbrainz.org/secure/CreateIssueDetails!init.jspa?' _
+    'pid=10000&issuetype=1' _
+    (description == '' ? '' : '&description=' _ uri_escape(description));
+END ~%]

--- a/root/doc/bare_error.tt
+++ b/root/doc/bare_error.tt
@@ -15,5 +15,6 @@
 
 <p>
     [%- l('Found a broken link on our site? Please let us know by {report|reporting a bug}.',
-         { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1&description=Broken+link:" _ url_escape(c.req.uri) _ "+Referer:" _ url_escape(c.req.referer)) })-%]
+         { report => bugtracker_url('Broken link: ' _ c.req.uri _ "\n" _
+                                    'Referrer: ' _ c.req.referer) })-%]
 </p>

--- a/root/entity/details.tt
+++ b/root/entity/details.tt
@@ -21,7 +21,7 @@
             <td>
                 [%~ USE Canonicalize ~%]
                 [%~ perma = Canonicalize.canonicalize(c.uri_for_action(c.controller.action_for('show'), [ entity.gid ])) ~%]
-                <a href="[%~ perma | url ~%]">[%~ perma | html ~%]</a>
+                [%~ simple_link(perma, perma) ~%]
             </td>
         </tr>
         <tr>

--- a/root/main/400.tt
+++ b/root/main/400.tt
@@ -14,7 +14,7 @@
 
         <p>
             [%- l('Found a problem on our site? Please {report|report a bug} and include any error message that is shown above.',
-                 { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1") }) -%]
+                 { report => bugtracker_url() }) -%]
         </p>
 
         <h2>[% l('Technical Information') %]</h2>

--- a/root/main/403.tt
+++ b/root/main/403.tt
@@ -6,7 +6,8 @@
 
         <p>
             [%- l('If you followed a link on our site to get here, please {report|report a bug} and the URL of the page that sent you here.',
-                 { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1") }) -%]
+                 { report => bugtracker_url('Forbidden page: ' _ c.req.uri _ "\n" _
+                                            'Referrer: ' _ c.req.referer) }) -%]
         </p>
     </div>
 [% END %]

--- a/root/main/404.js
+++ b/root/main/404.js
@@ -29,10 +29,9 @@ const _404 = (props) => (
       <p>
         {l('Found a broken link on our site? Please {report|report a bug} and include any error message that is shown above.',
            {__react: true,
-            report: 'http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1&description=Broken+link:' +
-                    encodeURIComponent($c.req.url) +
-                    '+Referer:' +
-                    encodeURIComponent($c.req.headers.referer)})}
+            report: bugtracker_url('Nonexistent page: ' + $c.req.url + '\n' +
+                                   'Referrer: ' + ($c.req.headers.referer || ''))
+           })}
       </p>
     </div>
   </Layout>

--- a/root/main/500.tt
+++ b/root/main/500.tt
@@ -23,7 +23,8 @@
         </p>
         <p>
             [%- l('If the problem persists, please {report|report a bug} and include any error message that is shown above.',
-                 { report => display_url("http://tickets.musicbrainz.org/secure/CreateIssue.jspa?pid=10000&issuetype=1&description=Broken+link:" _ url_escape(c.req.uri) _ "+Referer:" _ url_escape(c.req.referer)) })-%]
+                 { report => bugtracker_url('Internal server error on ' _ c.req.uri _ "\n" _
+                                            'Referrer: ' _ c.req.referer) })-%]
         </p>
 
         [% IF stack_trace %]

--- a/root/server.js
+++ b/root/server.js
@@ -50,6 +50,11 @@ function uriForAction() {
 _.assign(global, {
   doc_link: function (to) {
     return uriFor('/doc', to);
+  },
+  bugtracker_url: function (description) {
+    return 'http://tickets.musicbrainz.org/secure/CreateIssueDetails!init.jspa?' +
+           'pid=10000&issuetype=1' +
+           (!description ? '' : '&description=' + encodeURIComponent(description));
   }
 });
 

--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -99,8 +99,8 @@
 
         [% IF user.website && (user.has_confirmed_email_address || c.user.is_account_admin) %]
             [% WRAPPER property name=l("Homepage:") %]
-                <a href="[% user.website | url %]" rel="nofollow">
-                    [%~ user.website | html_entity ~%]
+                <a href="[% user.website | html %]" rel="nofollow">
+                    [%~ user.website | html ~%]
                 </a>
             [% END %]
         [% END %]


### PR DESCRIPTION
More about URLs:
- Remove the `url_escape` macro and all uses of the `url` filter (all bugs, the `html` filter was intended).
- Fix report-a-bug links on error pages: They used the wrong JIRA base URL that doesn’t fully accept seeding, had double-encoding issues, and (due to a mistake I made when preparing this patch series) still used the `display_url` macro that was already removed in part 1.
- In some cases, URIs inside an URL entity were changed unintentionally. Use `clone` to operate on copies instead.