### PR TITLE
URL fixes, part 3 (mostly internationalized domain names/MBS-8683)

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -59,7 +59,6 @@ __PACKAGE__->config(
             'format_wikitext' => \&MusicBrainz::Server::Filters::format_wikitext,
             'format_editnote' => \&MusicBrainz::Server::Filters::format_editnote,
             'format_setlist' => \&MusicBrainz::Server::Filters::format_setlist,
-            'uri_decode' => \&MusicBrainz::Server::Filters::uri_decode,
             'language' => \&MusicBrainz::Server::Filters::language,
             'locale' => \&MusicBrainz::Server::Filters::locale,
             'gravatar' => \&MusicBrainz::Server::Filters::gravatar,

--- a/lib/MusicBrainz/Server/Entity/URL/Commons.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Commons.pm
@@ -11,7 +11,7 @@ sub url_is_scheme_independent { 1 }
 
 sub page_name {
     my $self = shift;
-    return undef unless defined($self->utf8_decoded);
+    return undef if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/wiki/}{};

--- a/lib/MusicBrainz/Server/Entity/URL/Commons.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Commons.pm
@@ -1,24 +1,13 @@
 package MusicBrainz::Server::Entity::URL::Commons;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
+with 'MusicBrainz::Server::Entity::URL::MediaWiki';
 
 sub show_in_sidebar { 0 }
 
 sub url_is_scheme_independent { 1 }
-
-sub page_name {
-    my $self = shift;
-    return undef if $self->uses_legacy_encoding;
-
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-    $name =~ s{_}{ }g;
-
-    return $name;
-}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/URL/Facebook.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Facebook.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Entity::URL::Facebook;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
@@ -9,8 +8,9 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    if ($self->url =~ m{^https?://(?:www.)?facebook.com/(?:pages/)?([^/]+)(?:/[^/]+)?/?$}i) {
-        return MusicBrainz::Server::Filters::uri_decode($1);
+    if (!$self->uses_legacy_encoding &&
+        $self->decoded_local_part =~ m{^/(?:pages/)?([^/]+)(?:/[^/]+)?/?$}i) {
+        return $1;
     } else {
         return "Facebook";
     }

--- a/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
@@ -1,10 +1,10 @@
 package MusicBrainz::Server::Entity::URL::IMSLP;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Entity::URL';
+with 'MusicBrainz::Server::Entity::URL::MediaWiki';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
 =method pretty_name
@@ -19,13 +19,7 @@ sub pretty_name
     my $self = shift;
     return $self->name if $self->uses_legacy_encoding;
 
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-    $name =~ s{_}{ }g;
-
-    $name = "imslp: $name";
-
-    return $name;
+    return 'imslp: ' . $self->page_name;
 }
 
 sub sidebar_name {

--- a/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
@@ -17,7 +17,7 @@ happen if the URL can be decoded from utf-8. If not, the entire URL is used.
 sub pretty_name
 {
     my $self = shift;
-    return $self->url->as_string unless defined($self->utf8_decoded);
+    return $self->name if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/wiki/}{};
@@ -44,7 +44,7 @@ IMSLP URLs are only show in the sidebar if the URL can be decoded from utf-8
 
 =cut
 
-sub show_in_sidebar { defined(shift->utf8_decoded) }
+sub show_in_sidebar { !shift->uses_legacy_encoding }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/URL/LastFM.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/LastFM.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Entity::URL::LastFM;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
@@ -9,11 +8,11 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    my $name = $self->url->path;
+    my $name = $self->decoded_local_part;
     $name =~ s{^/music/}{};
-    $name =~ s{\+}{ }g;
+    $name =~ tr/+/ /;
 
-    return MusicBrainz::Server::Filters::uri_decode($name);
+    return $name;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
@@ -7,9 +7,9 @@ sub page_name {
     my $self = shift;
     return undef if $self->uses_legacy_encoding;
 
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-    $name =~ s{_}{ }g;
+    my ($name) = $self->decoded_local_part =~ m{^/wiki/(.*)$}
+        or return undef;
+    $name =~ tr/_/ /;
 
     return $name;
 }

--- a/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
@@ -1,0 +1,39 @@
+package MusicBrainz::Server::Entity::URL::MediaWiki;
+use Moose::Role;
+
+use MusicBrainz::Server::Filters;
+
+sub page_name {
+    my $self = shift;
+    return undef if $self->uses_legacy_encoding;
+
+    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
+    $name =~ s{^/wiki/}{};
+    $name =~ s{_}{ }g;
+
+    return $name;
+}
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2016 Ulrich Klauer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+=cut

--- a/lib/MusicBrainz/Server/Entity/URL/SoundCloud.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/SoundCloud.pm
@@ -3,7 +3,6 @@ package MusicBrainz::Server::Entity::URL::SoundCloud;
 use utf8;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
@@ -11,14 +10,14 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    my $name = $self->url->path;
+    my $name = $self->decoded_local_part;
     # e.g. "/someartist/somesong" -> "someartist/somesong"
     $name =~ s{^/}{};
     # only show "SoundCloud" for URI parts containing slashes (e.g. songs),
     # since they are too long for the sidebar
     return "SoundCloud" if $name =~ /\//;
 
-    return MusicBrainz::Server::Filters::uri_decode($name);
+    return $name;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
@@ -9,7 +9,7 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub pretty_name
 {
     my $self = shift;
-    return $self->url->as_string unless defined($self->utf8_decoded);
+    return $self->name if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/viaf/}{};

--- a/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Entity::URL::VIAF;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
@@ -9,9 +8,9 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub pretty_name
 {
     my $self = shift;
-    return $self->name if $self->uses_legacy_encoding;
+    return 'VIAF' if $self->uses_legacy_encoding;
 
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
+    my $name = $self->decoded_local_part;
     $name =~ s{^/viaf/}{};
 
     $name = "VIAF: $name";

--- a/lib/MusicBrainz/Server/Entity/URL/VK.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/VK.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Entity::URL::VK;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
@@ -9,8 +8,8 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    if ($self->url =~ m{^https?://(?:www.)?vk.com/([^/]+)$}i) {
-        return MusicBrainz::Server::Filters::uri_decode($1);
+    if ($self->decoded =~ m{^https?://(?:www.)?vk.com/([^/]+)$}) {
+        return $1;
     } else {
         return "VK";
     }

--- a/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
@@ -16,7 +16,7 @@ happen if the URL can be decoded from utf-8. If not, the entire URL is used.
 sub pretty_name
 {
     my $self = shift;
-    return $self->url->as_string unless defined($self->utf8_decoded);
+    return $self->name if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/wiki/}{};
@@ -29,7 +29,7 @@ sub sidebar_name { shift->pretty_name }
 sub page_name
 {
     my $self = shift;
-    return undef unless defined($self->utf8_decoded);
+    return undef if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/wiki/}{};

--- a/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
@@ -1,9 +1,9 @@
 package MusicBrainz::Server::Entity::URL::Wikidata;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
+with 'MusicBrainz::Server::Entity::URL::MediaWiki';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
 =method pretty_name
@@ -18,25 +18,10 @@ sub pretty_name
     my $self = shift;
     return $self->name if $self->uses_legacy_encoding;
 
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-
-    return $name;
+    return $self->page_name;
 }
 
 sub sidebar_name { shift->pretty_name }
-
-sub page_name
-{
-    my $self = shift;
-    return undef if $self->uses_legacy_encoding;
-
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-    $name =~ s{_}{ }g;
-
-    return $name;
-}
 
 sub url_is_scheme_independent { 1 }
 

--- a/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
@@ -1,9 +1,9 @@
 package MusicBrainz::Server::Entity::URL::Wikipedia;
 
 use Moose;
-use MusicBrainz::Server::Filters;
 
 extends 'MusicBrainz::Server::Entity::URL';
+with 'MusicBrainz::Server::Entity::URL::MediaWiki';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
 =method pretty_name
@@ -28,18 +28,6 @@ sub pretty_name
 }
 
 sub sidebar_name { shift->pretty_name }
-
-sub page_name
-{
-    my $self = shift;
-    return undef if $self->uses_legacy_encoding;
-
-    my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
-    $name =~ s{^/wiki/}{};
-    $name =~ s{_}{ }g;
-
-    return $name;
-}
 
 sub language
 {

--- a/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
@@ -16,7 +16,7 @@ happen if the URL can be decoded from utf-8. If not, the entire URL is used.
 sub pretty_name
 {
     my $self = shift;
-    return $self->url->as_string unless defined($self->utf8_decoded);
+    return $self->name if $self->uses_legacy_encoding;
 
     my $name = $self->page_name;
 
@@ -32,7 +32,7 @@ sub sidebar_name { shift->pretty_name }
 sub page_name
 {
     my $self = shift;
-    return undef unless defined($self->utf8_decoded);
+    return undef if $self->uses_legacy_encoding;
 
     my $name = MusicBrainz::Server::Filters::uri_decode($self->url->path);
     $name =~ s{^/wiki/}{};
@@ -44,7 +44,7 @@ sub page_name
 sub language
 {
     my $self = shift;
-    return undef unless defined($self->utf8_decoded);
+    return undef if $self->uses_legacy_encoding;
 
     if (my ($language) = $self->url->host =~ /(.*)\.wikipedia/) {
         return $language
@@ -59,7 +59,7 @@ Wikipedia URLs are only show in the sidebar if the URL can be decoded from utf-8
 
 =cut
 
-sub show_in_sidebar { defined(shift->utf8_decoded) }
+sub show_in_sidebar { !shift->uses_legacy_encoding }
 
 sub url_is_scheme_independent { 1 }
 

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -237,25 +237,6 @@ sub format_editnote
     return $html;
 }
 
-=func uri_decode
-
-Attempt to decode a URL and unescape characters, assuming it's in UTF-8
-encoding. If this is not the case, the function behaves as the identity
-function.
-
-=cut
-
-sub uri_decode
-{
-    my $uri = shift;
-    try {
-        decode('utf-8', uri_unescape($uri), Encode::FB_CROAK);
-    }
-    catch {
-        $uri;
-    }
-}
-
 sub language
 {
     return code2language(shift);

--- a/root/entity/edits.tt
+++ b/root/entity/edits.tt
@@ -6,8 +6,8 @@
     SET name_for_title = entity.l_name IF ent_type == 'instrument';
     SET name_for_title = entity.pretty_name IF ent_type == 'url';
 
-    SET link_for_heading = link_entity(entity);
-    SET link_for_heading = link_entity(entity, 'show', entity.url) IF ent_type == 'url';
+    SET link_for_heading = ent_type == 'url' ?
+        link_entity(entity, 'show', entity.decoded) : link_entity(entity);
 
     SET layout_title = all_edits ? l('Edits for {name}', { name => name_for_title }) : l('Open Edits for {name}', { name => name_for_title });
     SET heading = all_edits ? l('Edits for {name}', { name => link_for_heading }) : l('Open Edits for {name}', { name => link_for_heading });

--- a/root/url/header.tt
+++ b/root/url/header.tt
@@ -1,7 +1,7 @@
 <div class="urlheader">
 <h1>
   [% '<span class="mp">' IF url.edits_pending %]
-  [% link_entity(url, 'show', url.url) %]
+  [% link_entity(url, 'show', url.decoded) %]
   [% '</span>' IF url.edits_pending %]
 </h1>
 <p class="subheader">

--- a/root/url/index.tt
+++ b/root/url/index.tt
@@ -3,7 +3,7 @@
     <table class="details">
         <tr>
             <th>[% l('URL:') %]</th>
-            <td>[% simple_link(url.href_url, url.pretty_name) %]</a></td>
+            <td>[% simple_link(url.href_url, url.pretty_name) %]</td>
         </tr>
     </table>
     [%- INCLUDE "components/relationships.tt" source=url -%]

--- a/t/lib/t/MusicBrainz/Server/Controller/URL/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/URL/Show.pm
@@ -15,7 +15,7 @@ my $c    = $test->c;
 MusicBrainz::Server::Test->prepare_test_database($c, '+url');
 
 $mech->get_ok('/url/25d6b63a-12dc-41c9-858a-2f42ae610a7d');
-$mech->content_contains('http://zh-yue.wikipedia.org/wiki/%E7%8E%8B%E8%8F%B2');
+$mech->content_contains('http://zh-yue.wikipedia.org/wiki/王菲');
 $mech->content_contains('zh-yue: 王菲');
 
 };


### PR DESCRIPTION
Percent-encoded UTF-8 in the local part of URLs has long been decoded for display, but punycoded internationalized domain names were shown as raw ASCII.
    
This uses the existing IRI support of the `URI` module to decode all parts of URLs at the same time. Some new attributes (so that the decoding only has to be done once) are added to the URL base class for access to the decoded URL or just the decoded local part and for checking whether the local part was in some non-UTF-8 legacy encoding.
    
Finally, the `pretty_name` method of the base class and overridden display names in the subclasses make use ofthe decoded form, as do two templates that don’t use `pretty_name` but always show the actual URL.

Additional changes:
- One of my previous related pull requests left a spurious `</a>` that is now removed.
- Added an `MB::S::Entity::URL::MediaWiki` role to hold some code that the classes for MediaWiki sites duplicated.
- Ozon.ru was marked as scheme independent, i.e. links from HTTPS MusicBrainz led to their HTTPS site. However, their certificate is broken (only valid for ozone.ru), so let’s stick with HTTP for now.