### PR TITLE
[WIP] One macro to link them all

### DIFF
--- a/lib/MusicBrainz/Server/Plugin/Diff.pm
+++ b/lib/MusicBrainz/Server/Plugin/Diff.pm
@@ -139,7 +139,7 @@ sub _link_artist_credit_name {
     $name //= encode_entities($acn->name);
 
     # defer to the template macro
-    return $self->{c}->stash->get([ 'link_entity', [ $acn->artist, 'show', $name, undef, 1 ] ]);
+    return $self->{c}->stash->get([ 'link_entity', [ $acn->artist, 'show', $name, { already_html => 1 } ] ]);
 }
 
 sub _link_joined {

--- a/root/collection/delete.tt
+++ b/root/collection/delete.tt
@@ -1,7 +1,7 @@
 [%- WRAPPER 'collection/layout.tt' title=l('Remove') page='delete' full_width=1 -%]
     <h2>[% l('Remove collection') %]</h2>
     <p>
-            [%- l('Are you sure you want to remove the collection {collection}?', { collection => link_collection(collection) }) -%]
+            [%- l('Are you sure you want to remove the collection {collection}?', { collection => link_entity(collection) }) -%]
     </p>
     <form action="[% c.req.uri %]" method="post">
         [% form_submit(l('Remove collection')) %]

--- a/root/collection/header.tt
+++ b/root/collection/header.tt
@@ -1,14 +1,14 @@
 [%- info_links = [
-    ['index', link_collection(collection, 'show', l('Overview'))]
+    ['index', link_entity(collection, 'show', l('Overview'))]
 ] -%]
 
 [%- IF c.user_exists && collection.editor.id == c.user.id -%]
-    [%- info_links.push(['edit', link_collection(collection, 'edit', l('Edit'))]) -%]
-    [%- info_links.push(['delete', link_collection(collection, 'delete', l('Remove'))]) -%]
+    [%- info_links.push(['edit', link_entity(collection, 'edit', l('Edit'))]) -%]
+    [%- info_links.push(['delete', link_entity(collection, 'delete', l('Remove'))]) -%]
 [%- END -%]
 
 <div class="collectionheader">
-    <h1>[% link_collection(collection) %]</h1>
+    <h1>[% link_entity(collection) %]</h1>
     <p class="subheader">
         <span class="prefix">~</span>
         [% collection.public ? l('Public collection by {owner}', { owner => link_editor(collection.editor) })

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -234,25 +234,19 @@ END -%]
     # - show_disambiguation (omit for default behaviour)
     # - already_html: the text argument is HTML; no entity encoding
     #   will be done.
-    #   already_html is only available for artists and recordings.
     show_disambiguation = text == '';
     SET show_disambiguation = opts.show_disambiguation
       IF opts.show_disambiguation.exists;
     IF entity.gid;
-      IF    entity.isa('MusicBrainz::Server::Entity::Artist'); link_artist(entity, action, text, opts.already_html);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Area'); link_area(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Collection'); link_collection(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Work'); link_work(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Event'); link_event(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Instrument'); link_instrument(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Label'); link_label(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Place'); link_place(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Release'); link_release(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::ReleaseGroup'); link_release_group(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Recording'); link_recording(entity, action, text, opts.already_html);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Series'); link_series(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::URL'); link_url(entity, action, text);
-      END;
+      ent_type = get_entity_type(entity);
+      INCLUDE _link_mbid_entity entity=entity
+          type=ent_type action=action content=text
+          noescape=opts.already_html
+          hover=ent_type == 'artist' ?
+              artist.sort_name _ bracketed(artist.comment) : ''
+          default_content=(ent_type == 'area' OR ent_type == 'instrument') ?
+              entity.l_name : ''
+          namevar=(ent_type == 'artist' OR ent_type == 'recording');
     ELSIF entity.isa('MusicBrainz::Server::Entity::URL');
       simple_link(entity.href_url, entity.pretty_name);
       ' ';
@@ -403,27 +397,6 @@ END -%]
     INCLUDE _wrap_text options=options content=mod_content link=link avatar=avatar image_size=image_size;
 END -%]
 
-[%~ MACRO link_work(work, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=work type='work' action=action content=text;
-END -%]
-
-[%~ MACRO link_instrument(instrument, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=instrument type='instrument' action=action content=text default_content=instrument.l_name;
-END -%]
-
-[%~ MACRO link_label(label, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=label type='label' action=action content=text;
-END -%]
-
-[%~ MACRO link_artist(artist, action, text, no_escape) BLOCK;
-    hover = artist.sort_name _ bracketed(artist.comment);
-    INCLUDE _link_mbid_entity entity=artist type='artist' action=action content=text hover=hover namevar=1 noescape=no_escape;
-END -%]
-
-[%~ MACRO link_area(area, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=area type='area' action=action content=text default_content=area.l_name;
-END -%]
-
 [%~ MACRO link_area_containment(area) BLOCK;
     areas = [];
     IF area.parent_city; areas.push({link => link_area(area.parent_city), depth => area.parent_city_depth}); END;
@@ -441,38 +414,6 @@ END -%]
     link_entity(area, action, text, opts);
     containment_link = link_area_containment(area);
     IF containment_link; ', ' _ containment_link; END;
-END -%]
-
-[%~ MACRO link_place(place, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=place type='place' action=action content=text;
-END -%]
-
-[%~ MACRO link_collection(collection, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=collection type='collection' action=action content=text;
-END -%]
-
-[%~ MACRO link_event(event, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=event type='event' action=action content=text;
-END -%]
-
-[%~ MACRO link_release(release, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=release type='release' action=action content=text;
-END -%]
-
-[%~ MACRO link_release_group(rg, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=rg type='release_group' action=action content=text;
-END -%]
-
-[%~ MACRO link_recording(recording, action, text, no_escape) BLOCK;
-    INCLUDE _link_mbid_entity entity=recording type='recording' action=action content=text namevar=1 noescape=no_escape;
-END -%]
-
-[%~ MACRO link_series(series, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=series type='series' action=action content=text;
-END -%]
-
-[%~ MACRO link_url(url, action, text) BLOCK;
-    INCLUDE _link_mbid_entity entity=url type='url' action=action content=text;
 END -%]
 
 [%~ MACRO link_tag(tag, action, text) BLOCK;

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -229,14 +229,17 @@ END -%]
 
 [%~ MACRO entity_exists(entity) BLOCK; entity.gid.defined; END -%]
 
-[%~ MACRO link_entity(entity, action, text, credited_as, no_escape) BLOCK;
-    # no_escape is only available for artists and recordings
+[%~ MACRO link_entity(entity, action, text, opts) BLOCK;
+    # opts is an optional hash reference; possible keys:
+    # - show_disambiguation (omit for default behaviour)
+    # - already_html: the text argument is HTML; no entity encoding
+    #   will be done.
+    #   already_html is only available for artists and recordings.
     show_disambiguation = text == '';
-    IF (NOT text.defined OR text == '');
-        text = credited_as;
-    END;
+    SET show_disambiguation = opts.show_disambiguation
+      IF opts.show_disambiguation.exists;
     IF entity.gid;
-      IF    entity.isa('MusicBrainz::Server::Entity::Artist'); link_artist(entity, action, text, no_escape);
+      IF    entity.isa('MusicBrainz::Server::Entity::Artist'); link_artist(entity, action, text, opts.already_html);
       ELSIF entity.isa('MusicBrainz::Server::Entity::Area'); link_area(entity, action, text);
       ELSIF entity.isa('MusicBrainz::Server::Entity::Collection'); link_collection(entity, action, text);
       ELSIF entity.isa('MusicBrainz::Server::Entity::Work'); link_work(entity, action, text);
@@ -246,7 +249,7 @@ END -%]
       ELSIF entity.isa('MusicBrainz::Server::Entity::Place'); link_place(entity, action, text);
       ELSIF entity.isa('MusicBrainz::Server::Entity::Release'); link_release(entity, action, text);
       ELSIF entity.isa('MusicBrainz::Server::Entity::ReleaseGroup'); link_release_group(entity, action, text);
-      ELSIF entity.isa('MusicBrainz::Server::Entity::Recording'); link_recording(entity, action, text, no_escape);
+      ELSIF entity.isa('MusicBrainz::Server::Entity::Recording'); link_recording(entity, action, text, opts.already_html);
       ELSIF entity.isa('MusicBrainz::Server::Entity::Series'); link_series(entity, action, text);
       ELSIF entity.isa('MusicBrainz::Server::Entity::URL'); link_url(entity, action, text);
       END;
@@ -275,18 +278,24 @@ END -%]
       '</span>';
     END; -%]
 
-[%~ MACRO descriptive_link(entity, credited_as)
+[%~ MACRO descriptive_link(entity, credited_as) BLOCK;
+    with_disamb = { show_disambiguation => 1 };
     IF entity.artist_credit.defined;
-        l('{entity} by {artist}', { entity => link_entity(entity, 'show', '', credited_as),
-                                    artist => artist_credit(entity.artist_credit) });
+        l('{entity} by {artist}', {
+            entity => link_entity(entity, 'show', credited_as, with_disamb),
+            artist => artist_credit(entity.artist_credit)
+        });
     ELSIF get_entity_type(entity) == 'place' && entity.area.defined;
-        l('{place} in {area}', { place => link_entity(entity, 'show', '', credited_as),
-                                 area => link_area_with_containment(entity.area) });
+        l('{place} in {area}', {
+            place => link_entity(entity, 'show', credited_as, with_disamb),
+            area => link_area_with_containment(entity.area)
+        });
     ELSIF get_entity_type(entity) == 'area' && entity.gid;
-        link_area_with_containment(entity, 'show', '', credited_as);
+        link_area_with_containment(entity, 'show', credited_as, with_disamb);
     ELSE;
-        link_entity(entity, 'show', '', credited_as);
-    END; -%]
+        link_entity(entity, 'show', credited_as, with_disamb);
+    END;
+END ~%]
 
 [%~ MACRO get_entity_type(entity) BLOCK;
     IF entity.isa('MusicBrainz::Server::Entity::Artist'); "artist";
@@ -428,8 +437,8 @@ END -%]
     comma_only_list(link_areas);
 END -%]
 
-[%~ MACRO link_area_with_containment(area, action, text, credited_as) BLOCK;
-    link_entity(area, action, text, credited_as);
+[%~ MACRO link_area_with_containment(area, action, text, opts) BLOCK;
+    link_entity(area, action, text, opts);
     containment_link = link_area_containment(area);
     IF containment_link; ', ' _ containment_link; END;
 END -%]
@@ -950,7 +959,7 @@ END ~%]
 [%~ MACRO relationship_target_links(rel) BLOCK;
     '<span class="mp mp-rel">' IF rel.edits_pending;
     IF rel.target.artist_credit AND rel.target.artist_credit.name == hide_ac;
-        link_entity(rel.target, 'show', '', rel.target_credit);
+        link_entity(rel.target, 'show', rel.target_credit, { show_disambiguation => 1 });
     ELSE;
         descriptive_link(rel.target, rel.target_credit);
     END;

--- a/root/components/medium.tt
+++ b/root/components/medium.tt
@@ -8,7 +8,7 @@
             [%- work = relationship.target %]
             <dt>[% add_colon(link_type_group.key) %]</dt>
             <dd>
-              [%- link_work(work, 'show', work.name) %]
+              [%- link_entity(work, 'show', work.name) %]
               [%- grouped_relationships(work) %]
             </dd>
           [%- END %]
@@ -38,7 +38,7 @@
       [% END %]
     [% END %]
     <td>
-      [%- link_recording(track.recording, 'show', track.name) -%]
+      [%- link_entity(track.recording, 'show', track.name) -%]
       <br/>
       <div class="ars" style="display: none;">
         [% grouped_relationships(track.recording) %]

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -21,7 +21,8 @@
                     <td>[% rel.link.formatted_date %]</td>
                     <td>
                         [%~ '<span class="mp mp-rel">' IF rel.edits_pending ~%]
-                        [% link_entity(rel.target, 'show', '', rel.target_credit) %]
+                        [% link_entity(rel.target, 'show', rel.target_credit,
+                               { show_disambiguation => 1 }) %]
                         [%~ '</span>' IF rel.edits_pending ~%]
                     </td>
                     [%~ IF show_credits ~%]

--- a/root/edit/details/edit_medium.tt
+++ b/root/edit/details/edit_medium.tt
@@ -85,7 +85,7 @@
               [%~ data_track_icon IF old_track.is_data_track %]
               [%= link_entity(
                      old_track.recording, 'show',
-                     old_name_diff, undef, 1
+                     old_name_diff, { already_html => 1 }
                    ) ~%]
             </td>
             <td>
@@ -101,7 +101,7 @@
               [%~ data_track_icon IF new_track.is_data_track %]
               [%= link_entity(
                      new_track.recording, 'show',
-                     new_name_diff, undef, 1
+                     new_name_diff, { already_html => 1 }
                    ) ~%]
             </td>
             <td>

--- a/root/entity/collections.tt
+++ b/root/entity/collections.tt
@@ -7,7 +7,7 @@
                  { entity => html_escape($entity_type.name), num => public_collections.size + private_collections }) %]</p>
         <ul>
             [% FOR col=public_collections %]
-                <li>[% l('{collection} by {owner}', { collection => link_collection(col),
+                <li>[% l('{collection} by {owner}', { collection => link_entity(col),
                                                       owner => link_editor(col.editor) } ) %]</li>
             [% END %]
 

--- a/root/recording/index.tt
+++ b/root/recording/index.tt
@@ -30,7 +30,7 @@
                                           track.medium.position _ '.' _ track.position) -%]</td>
                       <td>[%- isolate_text(track.name) -%]</td>
                       <td>[%- format_length(track.length) -%]</td>
-                      <td>[%- link_release(release) -%]</td>
+                      <td>[%- link_entity(release, 'show', '', { show_disambiguation => 0 }) -%]</td>
                       <td>[%- artist_credit(release.artist_credit) -%]</td>
                       <td>[% release_dates(release.events) %]</td>
                       <td>[% release_countries(release.events) %]</td>

--- a/root/release/layout.tt
+++ b/root/release/layout.tt
@@ -74,7 +74,7 @@
                 <ul class="links">
                     [%~ FOR label=release.labels ~%]
                         <li>
-                            [%~ link_label(label.label) _ '<br />' ~%]
+                            [%~ link_entity(label.label, 'show', '', { show_disambiguation => 0 }) _ '<br />' ~%]
                             <span class="catalog-number">[%~ html_escape(label.catalog_number) ~%]</span>
                         </li>
                     [%~ END ~%]

--- a/root/user/collections.tt
+++ b/root/user/collections.tt
@@ -54,15 +54,15 @@
         <tbody>
             [%- FOR collection = colentity.value -%]
                 <tr class="[% loop.parity %]">
-                    <td>[% link_collection(collection) %]</td>
+                    <td>[% link_entity(collection) %]</td>
                     <td>[% collection.type.l_name %]</td>
                     <td>[% collection.entity_count %]</td>
                     [% IF viewing_own_profile %]
                         <td>[% yesno(collection.subscribed) %]</td>
                         <td>[% collection.public ? l('Public') : l('Private') %]</td>
                         <td>
-                            [% link_collection(collection, 'edit', l('Edit')) %] |
-                            [% link_collection(collection, 'delete', l('Remove')) %]
+                            [% link_entity(collection, 'edit', l('Edit')) %] |
+                            [% link_entity(collection, 'delete', l('Remove')) %]
                         </td>
                     [% END %]
                 </tr>


### PR DESCRIPTION
_NB. This can’t be merged yet or things will break; there are still `link_area` and `link_artist` calls that need to be replaced. I put it up so that @mwiencek can consider the changed `link_entity` syntax for the JavaScript version._

Up to now, we had a generic `link_entity` macro that can link the core entities, but also individual `link_artist`, `link_label`, `link_recording` etc. macros. The only difference left was that `link_artist` etc. would never show a disambiguation comment; `link_entity` would if it also displayed the entity name (instead of some random text provided as the third argument) **or** if it displayed some random text provided as the _fourth_ argument. To make this syntax clearer, I did the following:
- Have only one “random text to replace the entity name”, as the third argument.
- Make the macro accept a hash with options as the fourth parameter, with a `show_disambiguation` option explicitly controlling whether the disambiguation is shown or not. (No option in the hash = default behaviour, as before.)
- Turn the `no_escape` flag, up to now the fifth parameter, into another option (under the name `already_html`).

I then proceeded to adapt the (few) `link_entity` calls that made use of the fourth/fifth parameters to the new syntax, and to replace the remaining direct calls to `link_label` etc. with `link_entity` calls; if necessary, with `show_disambiguation => 0`. _(Not complete yet.)_ Lastly, I removed all the `link_foo` macros; this saved a considerable amount of duplication  and one level of indirection, which might or might not result in a perceivable performance improvement (macro calls in TT are relatively slow).
