### PR TITLE
Make _get_by_keys return a list instead of a hash reference

### DIFF
--- a/lib/MusicBrainz/Server/Data/Application.pm
+++ b/lib/MusicBrainz/Server/Data/Application.pm
@@ -48,7 +48,7 @@ sub load
 sub get_by_oauth_id
 {
     my ($self, $oauth_id) = @_;
-    my @result = values %{$self->_get_by_keys('oauth_id', $oauth_id)};
+    my @result = $self->_get_by_keys('oauth_id', $oauth_id);
     return $result[0];
 }
 

--- a/lib/MusicBrainz/Server/Data/CDStubTOC.pm
+++ b/lib/MusicBrainz/Server/Data/CDStubTOC.pm
@@ -44,7 +44,7 @@ sub load
 sub get_by_discid
 {
     my ($self, $discid) = @_;
-    my @result = values %{$self->_get_by_keys("discid", $discid)};
+    my @result = $self->_get_by_keys("discid", $discid);
     return $result[0];
 }
 

--- a/lib/MusicBrainz/Server/Data/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Data/CDTOC.pm
@@ -39,7 +39,7 @@ sub _entity_class
 sub get_by_discid
 {
     my ($self, $discid) = @_;
-    my @result = values %{$self->_get_by_keys("discid", $discid)};
+    my @result = $self->_get_by_keys("discid", $discid);
     return $result[0];
 }
 

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -153,16 +153,16 @@ around '_get_by_keys' => sub {
     my $orig = shift;
     my $self = shift;
 
-    my $ret = $self->$orig(@_);
-    $self->load_preferences(values %$ret);
+    my @ret = $self->$orig(@_);
+    $self->load_preferences(@ret);
 
-    return $ret;
+    return @ret;
 };
 
 sub find_by_email
 {
     my ($self, $email) = @_;
-    return values %{$self->_get_by_keys('email', $email)};
+    return $self->_get_by_keys('email', $email);
 }
 
 sub find_by_privileges

--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -45,21 +45,21 @@ sub _entity_class
 sub get_by_authorization_code
 {
     my ($self, $token) = @_;
-    my @result = values %{$self->_get_by_keys('authorization_code', $token)};
+    my @result = $self->_get_by_keys('authorization_code', $token);
     return $result[0];
 }
 
 sub get_by_access_token
 {
     my ($self, $token) = @_;
-    my @result = values %{$self->_get_by_keys('access_token', $token)};
+    my @result = $self->_get_by_keys('access_token', $token);
     return $result[0];
 }
 
 sub get_by_refresh_token
 {
     my ($self, $token) = @_;
-    my @result = values %{$self->_get_by_keys('refresh_token', $token)};
+    my @result = $self->_get_by_keys('refresh_token', $token);
     return $result[0];
 }
 

--- a/lib/MusicBrainz/Server/Data/Entity.pm
+++ b/lib/MusicBrainz/Server/Data/Entity.pm
@@ -6,7 +6,6 @@ use Class::MOP;
 use Data::Dumper;
 use Devel::StackTrace;
 use List::MoreUtils qw( part uniq );
-use MusicBrainz::Server::Data::Utils qw( placeholders );
 use MusicBrainz::Server::Validation qw( is_guid is_database_row_id );
 use Carp qw( confess );
 
@@ -29,28 +28,17 @@ sub _column_mapping
     return {};
 }
 
-sub _get_by_keys
-{
+sub _get_by_keys {
     my ($self, $key, @ids) = @_;
-    return $self->_get_by_keys_append_sql($key, '', @ids);
-}
 
-sub _get_by_keys_append_sql
-{
-    my ($self, $key, $extra_sql, @ids) = @_;
     @ids = grep { defined && $_ } @ids;
     return {} unless @ids;
+
     my $query = "SELECT " . $self->_columns .
                 " FROM " . $self->_table .
-                " WHERE $key IN (" . placeholders(@ids) . ") " .
-                $extra_sql;
+                " WHERE $key = any(?)";
 
-    my %result;
-    for my $row (@{ $self->sql->select_list_of_hashes($query, @ids) }) {
-        my $obj = $self->_new_from_row($row);
-        $result{$obj->id} = $obj;
-    }
-    return \%result;
+    $self->query_to_list($query, [\@ids]);
 }
 
 sub get_by_id
@@ -60,11 +48,18 @@ sub get_by_id
     return $result[0];
 }
 
-sub get_by_id_locked
-{
+sub get_by_id_locked {
     my ($self, $id) = @_;
-    my @result = values %{$self->_get_by_keys_append_sql($self->_id_column, 'FOR UPDATE', $id)};
-    return $result[0];
+
+    return unless $id;
+
+    my $key = $self->_id_column;
+    my $query = "SELECT " . $self->_columns .
+                " FROM " . $self->_table .
+                " WHERE $key = ? FOR UPDATE";
+
+    my $rows = $self->c->sql->select_list_of_hashes($query, $id);
+    $self->_new_from_row($rows->[0]);
 }
 
 sub _id_column
@@ -72,14 +67,14 @@ sub _id_column
     return 'id';
 }
 
-sub get_by_ids
-{
+sub get_by_ids {
     my ($self, @ids) = @_;
 
     @ids = grep { is_database_row_id($_) } @ids;
     return {} unless @ids;
 
-    return $self->_get_by_keys($self->_id_column, uniq(@ids));
+    my %result = map { $_->id => $_ } $self->_get_by_keys($self->_id_column, uniq(@ids));
+    \%result;
 }
 
 sub _warn_about_invalid_ids {

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -146,7 +146,7 @@ sub _hash_to_row
 sub get_by_gid
 {
     my ($self, $gid) = @_;
-    my @result = values %{$self->_get_by_keys("gid", $gid)};
+    my @result = $self->_get_by_keys('gid', $gid);
     if (scalar(@result)) {
         return $result[0];
     }

--- a/lib/MusicBrainz/Server/Data/Role/GetByGID.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GetByGID.pm
@@ -8,7 +8,7 @@ requires '_get_by_keys';
 sub get_by_gid {
     my ($self, $gid) = @_;
     return unless is_guid($gid);
-    my @result = values %{$self->_get_by_keys("gid", $gid)};
+    my @result = $self->_get_by_keys("gid", $gid);
     if (scalar(@result)) {
         return $result[0];
     }
@@ -19,8 +19,8 @@ sub get_by_gid {
 
 sub get_by_gids {
     my ($self, @gids) = @_;
-    my $result = $self->_get_by_keys('gid', grep { is_guid($_) } @gids);
-    return { map { $_->gid => $_ } values %$result };
+    my @result = $self->_get_by_keys('gid', grep { is_guid($_) } @gids);
+    return { map { $_->gid => $_ } @result };
 }
 
 1;

--- a/lib/MusicBrainz/Server/Data/Tag.pm
+++ b/lib/MusicBrainz/Server/Data/Tag.pm
@@ -34,7 +34,7 @@ sub _entity_class
 sub get_by_name
 {
     my ($self, $name) = @_;
-    my @result = values %{$self->_get_by_keys('name', $name)};
+    my @result = $self->_get_by_keys('name', $name);
     return $result[0];
 }
 


### PR DESCRIPTION
The majority of places that use `_get_by_keys` wrap the result in `values %{}`, so it makes more sense to just return a list.

This was part of my MBS-7241 branch, but since it's taking me a while to finish that, I'm submitting this for review now.