### PR TITLE
MBS-6166 once more: Don’t restore deleted users that still have a Catalyst session

### DIFF
--- a/lib/MusicBrainz/Server/Authentication/Store.pm
+++ b/lib/MusicBrainz/Server/Authentication/Store.pm
@@ -43,7 +43,9 @@ sub for_session
 sub from_session
 {
     my ($self, $c, $frozen) = @_;
-    return _rebless_editor($c->model('Editor')->get_by_id($frozen->{id}));
+    my $editor = $c->model('Editor')->get_by_id($frozen->{id});
+    return unless ($editor && !$editor->deleted);
+    return _rebless_editor($editor);
 }
 
 sub _rebless_editor {

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -199,7 +199,7 @@ sub begin : Private
     $c->stats->enable(1) if DBDefs->DEVELOPMENT_SERVER;
 
     # Can we automatically login?
-    if (!$c->user_exists) {
+    if (!$c->user) {
         $c->forward('/user/cookie_login');
     }
 

--- a/t/lib/t/Mechanize.pm
+++ b/t/lib/t/Mechanize.pm
@@ -8,14 +8,16 @@ has mech => (
     is => 'ro',
     required => 1,
     lazy => 1,
-    default => sub {
-        MusicBrainz::WWW::Mechanize->new( catalyst_app => 'MusicBrainz::Server', quiet => 1 );
-    },
+    builder => 'make_mech',
     clearer => '_clear_mech'
 );
 
 before run_test => sub {
     shift->_clear_mech;
 };
+
+sub make_mech {
+    MusicBrainz::WWW::Mechanize->new( catalyst_app => 'MusicBrainz::Server', quiet => 1 )
+}
 
 1;


### PR DESCRIPTION
Deleted users that still had a Catalyst session, possibly on another computer or in a different browser, could be active on the site until that session expired. (They could not log in again, even if they had set a new password during that time.) When trying to restore a user from a session, check for the deleted flag and deny restoration when indicated.