### PR TITLE
MBS-8688: Use consistent order for entity types on tag pages

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -440,7 +440,7 @@ sub tag : Chained('load') PathPart('tag') Args(1)
     my $tag = $c->model('Tag')->get_by_name($tag_name);
     my %tags = ();
     my $tag_in_use = 0;
-    my @entities_with_tags = sort { $a <=> $b } entities_with('tags');
+    my @entities_with_tags = sort { $a cmp $b } entities_with('tags');
 
     # Determine whether this tag exists in the database
     if ($tag) {


### PR DESCRIPTION
For user tag pages, the entity types were sorted using the `<=>` operator. Since this operator treats its operands as numbers, the strings `"release"`, `"recording"` etc. were all the same to it, having the numerical value 0. As Perl’s sort is not guaranteed to be stable, the resulting order was unpredictable.

Use `cmp` instead, the operator for lexicographic comparison of strings.