### PR TITLE
Two string improvements

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/DatePeriod.pm
+++ b/lib/MusicBrainz/Server/Form/Field/DatePeriod.pm
@@ -37,7 +37,7 @@ after 'validate' => sub {
     return 1 unless $begin->{year} && $end->{year};
 
     unless (is_date_range_valid($begin, $end)) {
-        return $self->field('end_date')->add_error(l('The end date must occur on or after the begin date'));
+        return $self->field('end_date')->add_error(l('The end date cannot precede the begin date.'));
     }
 
     return 1;

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -490,7 +490,7 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
 
             if (!this.dateError(a) && !this.dateError(b)) {
                 if (!dates.isDatePeriodValid(ko.toJS(a), ko.toJS(b))) {
-                    return i18n.l("The end date cannot preceed the begin date.");
+                    return i18n.l("The end date cannot precede the begin date.");
                 }
             }
 


### PR DESCRIPTION
I fixed a spelling mistake in one string (it’s _proceed_, but _precede_), then used the corrected string in another place where the same thing was explained in less clear words.