### PR TITLE
Remove CalculateRelatedTags.sh from daily.sh

### DIFF
--- a/admin/CalculateRelatedTags.sh
+++ b/admin/CalculateRelatedTags.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+# This script is currently broken. Presumably it needs updating for all
+# the entities added in MBS-7551. Once it's fixed, it can be re-added to
+# daily.sh.
+
 DIR=`dirname $0`
 $DIR/psql READWRITE <$DIR/sql/CalculateRelatedTags.sql

--- a/admin/cron/daily.sh
+++ b/admin/cron/daily.sh
@@ -88,9 +88,6 @@ fi
 # `date`" : Updating language frequencies"
 ./admin/SetLanguageFrequencies
 
-# Recalculate related tags
-./admin/CalculateRelatedTags.sh
-
 echo `date`" : Nightly jobs complete!"
 
 # eof


### PR DESCRIPTION
Judging by the last_updated timestamps, this script has been broken since 2014-11-17. We can enable it again once it works, and once we have an actual use for it, perhaps when we do something with genres.

I think this is partially responsible for the daily script always emailing us, since it always results in a division by zero error.