### PR TITLE
Replace Algorithm::Merge with Text::Diff3 (MBS-7475, MBS-8752, ...)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,6 @@ version_from 'lib/MusicBrainz/Server.pm';
 
 # Mandatory modules
 requires 'Algorithm::Diff'                            => '1.1902';
-requires 'Algorithm::Merge'                           => '0.08';
 requires 'Authen::Passphrase'                         => '0.007';
 requires 'Cache::Memcached'                           => '1.29';
 requires 'Captcha::reCAPTCHA'                         => '0.93';
@@ -97,6 +96,7 @@ requires 'Sys::Hostname';
 requires 'Template::Plugin::Class'                    => '0.13';
 requires 'Template::Plugin::JavaScript'               => '0.02';
 requires 'Template::Plugin::JSON::Escape'             => '0.02';
+requires 'Text::Diff3'                                => '0.10';
 requires 'Text::Markdown'                             => '1.000026';
 requires 'Text::WikiFormat'                           => '0.81';
 requires 'Text::Unaccent'                             => '1.08';

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -24,7 +24,7 @@ use MusicBrainz::Server::Edit::Types qw(
     NullableOnPreview
 );
 use MusicBrainz::Server::Edit::Medium::Util qw( check_track_hash );
-use MusicBrainz::Server::Edit::Utils qw( verify_artist_credits hash_artist_credit hash_artist_credit_without_join_phrases );
+use MusicBrainz::Server::Edit::Utils qw( verify_artist_credits hash_artist_credit );
 use MusicBrainz::Server::Log qw( log_assertion log_debug );
 use MusicBrainz::Server::Validation 'normalise_strings';
 use MusicBrainz::Server::Translation qw( N_l );
@@ -300,15 +300,6 @@ sub build_display_data
         if (scalar(@changes_with_track_ids) && any { $_->[2] && !$_->[2]->id } @$tracklist_changes) {
             $data->{changed_mbids} = 1;
         }
-
-        $data->{artist_credit_changes} = [
-            grep {
-                ($_->[1] && hash_artist_credit_without_join_phrases($_->[1]->artist_credit))
-                    ne
-                ($_->[2] && hash_artist_credit_without_join_phrases($_->[2]->artist_credit))
-            }
-            grep { $_->[0] ne '-' }
-            @$tracklist_changes ];
 
         # Generate a map of track id => old recording id, for edits that store
         # track ids, to detect if recordings have changed.

--- a/lib/MusicBrainz/Server/Edit/Role/EditArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/EditArtistCredit.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Edit::Utils qw(
     clean_submitted_artist_credits
-    hash_artist_credit
 );
 
 around initialize => sub {

--- a/lib/MusicBrainz/Server/Edit/Utils.pm
+++ b/lib/MusicBrainz/Server/Edit/Utils.pm
@@ -35,7 +35,6 @@ our @EXPORT_OK = qw(
     edit_status_name
     gid_or_id
     hash_artist_credit
-    hash_artist_credit_without_join_phrases
     large_spread
     merge_artist_credit
     merge_barcode
@@ -295,22 +294,13 @@ sub status_names
 }
 
 sub hash_artist_credit {
-    return _hash_artist_credit(shift)
-}
-
-sub hash_artist_credit_without_join_phrases {
-    return _hash_artist_credit(shift, 1)
-}
-
-sub _hash_artist_credit {
-    my ($artist_credit, $visible_only) = @_;
+    my ($artist_credit) = @_;
     return join(', ', map {
         '[' .
             join(',',
                  $_->{name},
-                 $_->{artist}{id} // -1)
-            . (!$visible_only ? ',' . $_->{join_phrase} || '' : '')
-            .
+                 $_->{artist}{id} // -1,
+                 $_->{join_phrase} // '') .
         ']'
     } @{ $artist_credit->{names} });
 }

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -262,8 +262,9 @@ test 'Accept/failure conditions regarding links' => sub {
         is(@{ $edit->display_data->{tracklist_changes} }, 1, '1 tracklist change');
         is($edit->display_data->{tracklist_changes}->[0][0], '+', 'tracklist change is an addition');
 
-        is(@{ $edit->display_data->{artist_credit_changes} }, 1, '1 artist credit change');
-        is($edit->display_data->{artist_credit_changes}->[0][0], '+', 'artist credit change is an addition');
+        my @artist_credit_changes = artist_credit_changes($edit->display_data);
+        is(@artist_credit_changes, 1, '1 artist credit change');
+        is($artist_credit_changes[0][0], '+', 'artist credit change is an addition');
     };
 
     subtest 'Can change the recording to another existing recording' => sub {
@@ -289,7 +290,8 @@ test 'Accept/failure conditions regarding links' => sub {
 
         $c->model('Edit')->load_all($edit);
         is(@{ $edit->display_data->{tracklist_changes} }, 0, '0 tracklist changes');
-        is(@{ $edit->display_data->{artist_credit_changes} }, 0, '0 artist credit changes');
+        my @artist_credit_changes = artist_credit_changes($edit->display_data);
+        is(@artist_credit_changes, 0, '0 artist credit changes');
         is(@{ $edit->display_data->{recording_changes} }, 1, '1 recording change');
 
         is($edit->display_data->{recording_changes}[0][1]->recording_id, 3, 'was recording 3');
@@ -375,8 +377,9 @@ test 'Accept/failure conditions regarding links' => sub {
         is((grep { $_->[0] ne 'u' } @{ $edit->display_data->{tracklist_changes} }), 1, '1 tracklist change');
         is($edit->display_data->{tracklist_changes}->[1][0], '+', 'tracklist change is an addition');
 
-        is(@{ $edit->display_data->{artist_credit_changes} }, 1, '1 artist credit change');
-        is($edit->display_data->{artist_credit_changes}->[0][0], '+', 'artist credit change is an addition');
+        my @artist_credit_changes = artist_credit_changes($edit->display_data);
+        is(@artist_credit_changes, 1, '1 artist credit change');
+        is($artist_credit_changes[0][0], '+', 'artist credit change is an addition');
     };
 
     subtest 'Changes that dont touch recording IDs can pass merges' => sub {
@@ -409,7 +412,8 @@ test 'Accept/failure conditions regarding links' => sub {
         is($edit->display_data->{tracklist_changes}->[0][0], 'c', 'tracklist change 1 is a change');
         is($edit->display_data->{tracklist_changes}->[1][0], 'c', 'tracklist change 2 is a change');
 
-        is(@{ $edit->display_data->{artist_credit_changes} }, 0, '0 artist credit changes');
+        my @artist_credit_changes = artist_credit_changes($edit->display_data);
+        is(@artist_credit_changes, 0, '0 artist credit changes');
     };
 };
 
@@ -641,6 +645,14 @@ sub is_unchanged {
     is($medium->format_id, undef);
     is($medium->release_id, 1);
     is($medium->position, 1);
+}
+
+sub artist_credit_changes {
+    my $tracklist_changes = shift->{tracklist_changes};
+
+    grep { $_->[1] ? $_->[1]->artist_credit != $_->[2]->artist_credit : 1 }
+    grep { $_->[0] ne '-' }
+    @$tracklist_changes;
 }
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -606,6 +606,98 @@ test 'Tracks can be reordered' => sub {
     })
 };
 
+test 'Tracklist merging (MBS-8752 / MBS-7475)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-8752');
+
+    my $artist_credit = ArtistCredit->new(
+        names => [
+            ArtistCreditName->new(
+                artist => Artist->new( id => 9113, name => 'Meat Loaf' ),
+                join_phrase => '',
+                name => 'Meat Loaf',
+            ),
+        ],
+    );
+
+    my $medium = $c->model('Medium')->get_by_id(1819308);
+    $c->model('Track')->load_for_mediums($medium);
+    $c->model('ArtistCredit')->load($medium->all_tracks);
+
+    my $expected_tracklist = [
+        Track->new(
+            artist_credit => $artist_credit,
+            is_data_track => '0',
+            length => 481000,
+            name => 'Life Is a Lemon and I Want My Money Back (live)',
+            number => '1',
+            position => 1,
+            recording_id => 9724192,
+        ),
+        Track->new(
+            artist_credit => $artist_credit,
+            id => 20036049,
+            is_data_track => '0',
+            length => 507000,
+            name => 'Rock and Roll Dreams Come Through (live)',
+            number => '2',
+            position => 2,
+            recording_id => 9724193,
+        ),
+        Track->new(
+            artist_credit => $artist_credit,
+            id => 20036047,
+            is_data_track => '0',
+            length => 522000,
+            name => 'Out of the Frying Pan (And Into the Fire) (live)',
+            number => '3',
+            position => 3,
+            recording_id => 9724194,
+        ),
+        Track->new(
+            artist_credit => $artist_credit,
+            is_data_track => '0',
+            length => 583000,
+            name => 'Everything Louder Than Everything Else (live)',
+            number => '4',
+            position => 4,
+            recording_id => 9724195,
+        ),
+        Track->new(
+            artist_credit => $artist_credit,
+            id => 20036050,
+            is_data_track => '0',
+            length => 356000,
+            name => 'Objects in the Rear View Mirror May Appear Closer Than They Are (edit)',
+            number => '5',
+            position => 5,
+            recording_id => 9724196,
+        ),
+    ];
+
+    my $expected_tracklist_hash = tracks_to_hash($expected_tracklist);
+
+    my $edit = $c->model('Edit')->create(
+        editor_id => 1,
+        edit_type => $EDIT_MEDIUM_EDIT,
+        to_edit => $medium,
+        tracklist => $expected_tracklist,
+    );
+
+    accept_edit($c, $edit);
+
+    $medium = $c->model('Medium')->get_by_id(1819308);
+    $c->model('Track')->load_for_mediums($medium);
+    $c->model('ArtistCredit')->load($medium->all_tracks);
+
+    my $got_tracklist_hash = tracks_to_hash($medium->tracks);
+    $expected_tracklist_hash->[0]{id} = 20036051;
+    $expected_tracklist_hash->[3]{id} = 20036052;
+    cmp_deeply($got_tracklist_hash, $expected_tracklist_hash);
+};
+
 sub create_edit {
     my ($c, $medium, $tracklist) = @_;
 

--- a/t/sql/mbs-8752.sql
+++ b/t/sql/mbs-8752.sql
@@ -1,0 +1,36 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO artist (area, begin_area, begin_date_day, begin_date_month, begin_date_year, comment, edits_pending, end_area, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type) VALUES
+    (NULL, NULL, 27, 9, 1947, '', 0, NULL, NULL, NULL, NULL, '0', 1, 'b134d1bf-c7c7-4427-93ac-9fdbc2b59ef1', 9113, '2015-06-21 09:12:12.187989+00', 'Meat Loaf', 'Meat Loaf', 1);
+
+INSERT INTO artist_credit (artist_count, created, id, name, ref_count) VALUES
+    (1, '2011-05-16 16:32:11.963929+00', 9113, 'Meat Loaf', 4332);
+
+INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES
+    (9113, 9113, '', 'Meat Loaf', 0);
+
+INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES
+    (9113, '', 0, '758d7dc5-4aa2-3731-b970-549251a98232', 17814, '2010-03-19 18:03:48.279801+00', 'Bat Out of Hell II: Back Into Hell', 1);
+
+INSERT INTO release (artist_credit, barcode, comment, edits_pending, gid, id, language, last_updated, name, packaging, quality, release_group, script, status) VALUES
+    (9113, '094637912355', '', 2, '3a1a6bd7-dbe1-4004-813b-11debf0b61e8', 1718385, 120, '2016-01-22 10:53:51.139298+00', 'Bat Out of Hell II: Back Into Hell', NULL, -1, 17814, NULL, 1);
+
+INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES
+    (0, NULL, 1819308, '2016-01-22 10:13:55.59614+00', '', 3, 1718385, 5);
+
+INSERT INTO recording (artist_credit, comment, edits_pending, gid, id, last_updated, length, name, video) VALUES
+    (9113, '', 0, '7cb020c5-c7c4-495e-bbdb-774c0ac438b3', 14428606, '2013-01-10 18:11:06.367649+00', 562000, 'Back Into Hell: Meat Loaf and Jim Steinman Interview', '0'),
+    (9113, '', 0, '23aec39a-896c-4a16-a1f5-d3ef9811cd5f', 14428607, '2016-01-22 10:13:55.59614+00', 460000, 'I’ll Do Anything for Love (But I Won’t Do That)', '0'),
+    (9113, '', 0, 'c3a91791-1c5a-477e-8440-d74ac1ce5bf2', 14428608, '2013-01-10 18:11:06.367649+00', 347000, 'Rock and Roll Dreams Come Through', '0'),
+    (9113, '', 0, '6e505245-98c3-47d6-8ee2-269cffeb97dc', 14428609, '2015-01-18 12:04:18.111683+00', 463000, 'Objects in the Rear View Mirror May Appear Closer Than They Are', '0'),
+    (9113, '', 0, '69c38d37-901b-45d6-b469-0708d6d4a289', 9724192, NULL, 481000, 'Life Is a Lemon and I Want My Money Back (live)', '0'),
+    (9113, '', 0, 'bff3edaf-c019-4cb5-8ede-78872ff472a9', 9724194, '2016-01-22 10:30:11.549976+00', 522000, 'Out of the Frying Pan (And Into the Fire) (live)', '0'),
+    (9113, '', 0, '6a4ad015-a7b0-4687-be4c-1183858868c9', 9724195, '2016-01-22 10:27:51.598498+00', 583000, 'Everything Louder Than Everything Else (live)', '0'),
+    (9113, '', 0, 'f531199f-db87-451b-ad3c-bea08435e9b3', 9724196, NULL, 356000, 'Objects in the Rear View Mirror May Appear Closer Than They Are (edit)', '0'),
+    (9113, '', 0, '25a9c7a1-f9a0-4929-87ba-eef3d3661cee', 9724193, NULL, 507000, 'Rock and Roll Dreams Come Through (live)', '0');
+
+INSERT INTO track (artist_credit, edits_pending, gid, id, is_data_track, last_updated, length, medium, name, number, position, recording) VALUES
+    (9113, 0, '420e76c4-5d0e-493d-9af1-b113d45eec1f', 20036047, '0', '2016-01-22 10:30:11.549976+00', 562000, 1819308, 'Back Into Hell: Meat Loaf and Jim Steinman Interview', '1', 1, 14428606),
+    (9113, 0, 'fb9b72a5-b8a1-4e66-9b8c-b7b2b712a364', 20036048, '0', '2016-01-22 10:30:11.549976+00', 460000, 1819308, 'I’ll Do Anything for Love (But I Won’t Do That)', '2', 2, 14428607),
+    (9113, 0, 'b2237b04-eb5f-411e-901c-024cc430cf0a', 20036049, '0', '2016-01-22 10:30:11.549976+00', 347000, 1819308, 'Rock and Roll Dreams Come Through', '3', 4, 14428608),
+    (9113, 0, '683d5ae0-fd1a-405b-be66-541d60d8d6d4', 20036050, '0', '2016-01-22 10:30:11.549976+00', 463000, 1819308, 'Objects in the Rear View Mirror May Appear Closer Than They Are', '4', 5, 14428609);


### PR DESCRIPTION
Looks like we finally found a reproducible case where Algorithm::Merge is the culprit for buggy behavior (see rationale in MBS-7475). Using Text::Diff3 instead causes it to not drop tracks in the test I added, and the rest of our Edit:: tests still pass. I haven't done extensive testing outside of that—I'm not sure how many of our Edit:: tests go through CheckForConflicts, actually.