### PR TITLE
MBS-8770: Load banner message correctly

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -219,7 +219,8 @@ sub begin : Private
             );
         }
 
-        my ($alert, $alert_mtime, $notes_viewed, $notes_updated) = $redis->mget(@cache_keys);
+        my ($notes_viewed, $notes_updated);
+        ($alert, $alert_mtime, $notes_viewed, $notes_updated) = $redis->mget(@cache_keys);
 
         if ($notes_updated && (!defined($notes_viewed) || $notes_updated > $notes_viewed)) {
             $new_edit_notes = 1;


### PR DESCRIPTION
The banner message (if any) was assigned to a local variable that was shadowing the variable that it should have been assigned to. Consequently, when the inner variable went out of scope, the banner message text was gone and could no longer be shown.