### PR TITLE
Update team link to the MeB Team page

### DIFF
--- a/admin/nginx/mbserver-rewrites.conf
+++ b/admin/nginx/mbserver-rewrites.conf
@@ -54,6 +54,7 @@ rewrite ^/doc/MusicBrainz_Picard/Tags$                     http://picard.musicbr
 rewrite ^/doc/MusicBrainz_Picard/Tags/Mapping$             http://picard.musicbrainz.org/docs/mappings/            permanent;
 rewrite ^/doc/MusicBrainz_Picard/Troubleshooting$          http://picard.musicbrainz.org/docs/troubleshooting/     permanent;
 rewrite ^/doc/Contact_Us$                                  https://metabrainz.org/contact                          permanent;
+rewrite ^/bio\.html$                                       https://metabrainz.org/team                             permanent;
 
 # Wikidocs pages
 rewrite ^/wd/(.*)$                               $mb_server/doc/$1                           ;
@@ -62,7 +63,6 @@ rewrite ^/about/helpwanted\.html$                $mb_server/doc/Help_Wanted     
 rewrite ^/about/logos\.html$                     $mb_server/doc/About/Logos                  permanent;
 rewrite ^/about/licenses\.html$                  $mb_server/doc/About/Data_License           permanent;
 rewrite ^/about/stats\.html$                     $mb_server/doc/Server_Statistics            permanent;
-rewrite ^/bio\.html$                             $mb_server/doc/About/Team                   permanent;
 rewrite ^/cd_submission\.html$                   $mb_server/doc/How_to_Add_Disc_IDs          permanent;
 rewrite ^/contract\.html$                        $mb_server/doc/Social_Contract              permanent;
 rewrite ^/db_structure\.html$                    $mb_server/doc/MusicBrainz_Database/Schema  permanent;

--- a/root/layout/components/Menu.js
+++ b/root/layout/components/Menu.js
@@ -164,10 +164,10 @@ const AboutMenu = () => (
     <a href="/doc/About">{l('About')}</a>
     <ul>
       <li>
-        <a href="//metabrainz.org/doc/Sponsors">{l('Sponsors')}</a>
+        <a href="https://metabrainz.org/sponsors">{l('Sponsors')}</a>
       </li>
       <li>
-        <a href="//metabrainz.org/team">{l('Team')}</a>
+        <a href="https://metabrainz.org/team">{l('Team')}</a>
       </li>
       <li className="separator">
         <a href="/doc/About/Data_License">{l('Data Licenses')}</a>

--- a/root/layout/components/Menu.js
+++ b/root/layout/components/Menu.js
@@ -167,7 +167,7 @@ const AboutMenu = () => (
         <a href="//metabrainz.org/doc/Sponsors">{l('Sponsors')}</a>
       </li>
       <li>
-        <a href="/doc/About/Team">{l('Team')}</a>
+        <a href="//metabrainz.org/team">{l('Team')}</a>
       </li>
       <li className="separator">
         <a href="/doc/About/Data_License">{l('Data Licenses')}</a>

--- a/root/layout/menu.tt
+++ b/root/layout/menu.tt
@@ -133,7 +133,7 @@
                 <a href="https://metabrainz.org/sponsors">[% l('Sponsors') %]</a>
             </li>
             <li>
-                <a href="[% doc_link('About/Team') %]">[% l('Team') %]</a>
+                <a href="https://metabrainz.org/team">[% l('Team') %]</a>
             </li>
             <li class="separator">
                 <a href="[% doc_link('About/Data_License') %]">[% l('Data Licenses') %]</a>


### PR DESCRIPTION
Much less uses than the contact us page so probably not worthy of a constant? 

As before, there's an entry in admin/nginx/mbserver-rewrites.conf that I decided not to touch. Let me know if I should. 