### PR TITLE
MBS-8790: put parens around ended

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -746,7 +746,7 @@ END -%]
         l('until {date}', { date => relationship.link.end_date.format });
     ELSIF relationship.link.ended;
         ' ';
-        l('ended');
+        l('(ended)');
     END;
     IF relationship.${extra_attributes_field};
         ' (' _ relationship.${extra_attributes_field} _ ')';

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -746,7 +746,7 @@ END -%]
         l('until {date}', { date => relationship.link.end_date.format });
     ELSIF relationship.link.ended;
         ' ';
-        l('(ended)');
+        bracketed(l('ended'));
     END;
     IF relationship.${extra_attributes_field};
         ' (' _ relationship.${extra_attributes_field} _ ')';

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -156,7 +156,7 @@
       (<!-- ko text: $data --><!-- /ko -->)
     <!-- /ko -->
     <!-- ko if: relationship.period.ended() && !relationship.formatDatePeriod() -->
-      ([% l('ended') %])
+      [% bracketed(l('ended')) %]
     <!-- /ko -->
   <!-- /ko -->
   <!-- ko with: relationship.phraseAndExtraAttributes()[2] -->

--- a/root/edit/details/macros.tt
+++ b/root/edit/details/macros.tt
@@ -58,7 +58,7 @@
      ELSIF !relationship.link.end_date.is_empty;
        l('until {date}', { date => relationship.link.end_date.format });
      ELSIF relationship.link.ended;
-       l('(ended)');
+       bracketed(l('ended'));
      END;
    END; -%]
 


### PR DESCRIPTION
This should mean both add and edit rel edits show "(ended)" instead of the former showing "ended". This is also apparently used somewhere in series but I can't see any reason why we'd want a bare "ended" when linking to a rel anyway.