### PR TITLE
MBS-8797: make tabs fit the current style a bit more

### DIFF
--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -3,9 +3,8 @@
  */
 
 div.tabs {
-    border-bottom: solid 1px @dark-border;
+    border-bottom: solid 1px @light-border;
     padding-top: 1em;
-    font-size: @small-text;
 
     ul {
         overflow: hidden;
@@ -23,23 +22,28 @@ div.tabs {
             a {
                 display: block;
                 padding: 0.1em 0.5em;
-                margin-left: 4px;
+                margin-right: 2px;
                 text-decoration: none;
-                background: @very-light-bg;
                 color: @text-black;
-                border: solid 1px @dark-border;
-                border-bottom: solid 1px @dark-border;
+                border: solid 1px @light-border;
+                border-radius: 4px 4px 0 0;
+                &:hover {
+                    border-color: @musicbrainz-purple;
+                }
             }
-
-            &.sel a, a:hover {
-                background: #fff;
-                color: @text-black;
-            }
-
             &.sel a {
-                font-weight: bold;
-                border-bottom: solid 1px #fff;
+                &,
+                &:hover,
+                &:focus {
+                    color: @text-white;
+                    font-weight: bold;
+                    background-color: @musicbrainz-orange;
+                    border: 1px solid @light-border;
+                    border-bottom-color: transparent;
+                    cursor: default;
+                }
             }
+
         }
     }
 }


### PR DESCRIPTION
This changes the old tabs to fit a bit more - orange + white text on selected to match the header, white background elsewhere, rounded corners, lighter borders, a purple border on hover because purple and all. It makes the font a bit bigger (or well, no longer @small-text) because it felt a bit too small to me but happy to change that if needed.

Available to check at my sandbox, e.g. http://reosarevok.mbsandbox.org/artist/ebe3e32c-99f5-46a3-8c15-bac2ab5b8e4d