### PR TITLE
MBS-8798: invert paginator colours, make hover text white

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -716,11 +716,12 @@ nav .pagination {
         color: @text-black;
 
         &:hover {
-            background-color: @musicbrainz-orange;
+            background-color: @musicbrainz-purple;
+            color: @text-white;
         }
 
         &.sel {
-            background-color: @musicbrainz-purple;
+            background-color: @musicbrainz-orange;
             color: @text-white;
             font-weight: bold;
         }


### PR DESCRIPTION
I feel this is more consistent. Also, white on hover makes the number more visible.