### PR TITLE
MBS-8801: Fix spurious group-with-gender error

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -214,8 +214,10 @@ around merge_changes => sub {
 
     my $merged = $self->$orig(@args);
     my $artist = $self->current_instance;
-    my $gender_id = $merged->{gender_id} // $artist->gender_id;
-    my $type_id = $merged->{type_id} // $artist->type_id;
+    my $gender_id = exists $merged->{gender_id} ?
+            $merged->{gender_id} : $artist->gender_id;
+    my $type_id = exists $merged->{type_id} ?
+            $merged->{type_id} : $artist->type_id;
 
     if (defined $gender_id && defined $type_id) {
         MusicBrainz::Server::Edit::Exceptions::GeneralError->throw(

--- a/t/lib/t/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -398,6 +398,29 @@ EOSQL
     is $exception->message, 'A group of artists cannot have a gender.';
 };
 
+test 'Type can be set to group when gender is removed (MBS-8801)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    $c->sql->do(<<'EOSQL');
+INSERT INTO artist (id, gid, name, sort_name, gender)
+VALUES (2, 'cdf5588d-cca8-4e0c-bae1-d53bc73b012a', 'Foo Baz', 'Foo Baz', 2);
+EOSQL
+
+    my $edit = $c->model('Edit')->create(
+        edit_type => $EDIT_ARTIST_EDIT,
+        editor_id => 1,
+        to_edit => $c->model('Artist')->get_by_id(2),
+        gender_id => undef,
+        type_id => 2,
+        ipi_codes => [],
+        isni_codes => [],
+    );
+    accept_edit($c, $edit);
+
+    is($c->model('Artist')->get_by_id(2)->type_id, 2);
+};
+
 sub _create_full_edit {
     my ($c, $artist) = @_;
     return $c->model('Edit')->create(


### PR DESCRIPTION
An artist edit can remove the artist’s type or gender by setting it to `NULL` (represented by `undef` in Perl). On the other hand, it can leave fields unchanged (represented in Perl by the absence of a hash entry). Because of a test for definedness instead of existence of a key before falling back to the current state of the artist, it could happen that an edit was rejected for resulting in a group artist with a gender when that was not actually the case.

Includes a test.