### PR TITLE
Remove user tabs from edit listings

### DIFF
--- a/root/user/edits.tt
+++ b/root/user/edits.tt
@@ -1,4 +1,4 @@
-[%- param = { name => user.name };
+[%- param = { name => link_editor(user) };
     SWITCH c.action.name;
         CASE 'votes';
             page_title = l('Votes');
@@ -26,7 +26,7 @@
             page_heading = l('Edits by {name}', param);
     END ~%]
 
-[% WRAPPER 'user/profile/layout.tt' title=page_title %]
-   <h2>[% page_heading | html %]</h2>
+[% WRAPPER 'layout.tt' title=page_title %]
+   <h2>[% page_heading %]</h2>
    [% INCLUDE 'edit/list.tt' guess_search=1 %]
 [% END %]


### PR DESCRIPTION
cc @reosarevok 

9e2e988 made it so that "open edits"/"all edits" are no longer tabs on the user's profile, and I think it's kind of strange/confusing to show the tabs if the current page isn't part of the tab group. So this removes them and links to the user in the heading instead.