### PR TITLE
Various collection fixes for the web service

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -33,6 +33,7 @@
         "removal": {
             "manual": true
         },
+        "singular_with_article": "an area",
         "tags": true,
         "type": {
             "simple": true
@@ -94,6 +95,7 @@
             }
         },
         "report_filter": true,
+        "singular_with_article": "an artist",
         "sitemaps_lastmod_table": true,
         "sort_name": true,
         "subscriptions": {
@@ -198,6 +200,7 @@
         "removal": {
             "automatic": {}
         },
+        "singular_with_article": "an event",
         "tags": true,
         "type": {
             "simple": true
@@ -260,6 +263,7 @@
         "removal": {
             "manual": true
         },
+        "singular_with_article": "an instrument",
         "tags": true,
         "type": {
             "simple": true
@@ -327,6 +331,7 @@
             "manual": true
         },
         "report_filter": true,
+        "singular_with_article": "a label",
         "sitemaps_lastmod_table": true,
         "subscriptions": {
             "deleted": true,
@@ -422,6 +427,7 @@
         "removal": {
             "automatic": {}
         },
+        "singular_with_article": "a place",
         "sitemaps_lastmod_table": true,
         "tags": true,
         "type": {
@@ -477,6 +483,7 @@
             "manual": true
         },
         "report_filter": true,
+        "singular_with_article": "a recording",
         "sitemaps_lastmod_table": true,
         "tags": true,
         "url": "recording"
@@ -522,6 +529,7 @@
             "manual": true
         },
         "report_filter": true,
+        "singular_with_article": "a release",
         "sitemaps_lastmod_table": true,
         "tags": true,
         "url": "release"
@@ -571,6 +579,7 @@
             }
         },
         "report_filter": true,
+        "singular_with_article": "a release group",
         "sitemaps_lastmod_table": true,
         "tags": true,
         "type": {
@@ -652,6 +661,7 @@
             "automatic": {}
         },
         "report_filter": true,
+        "singular_with_article": "a series",
         "subscriptions": {
             "deleted": true,
             "entity": true
@@ -747,6 +757,7 @@
             "automatic": {}
         },
         "report_filter": true,
+        "singular_with_article": "a work",
         "sitemaps_lastmod_table": true,
         "tags": true,
         "type": {

--- a/lib/MusicBrainz/Server/Authentication/User.pm
+++ b/lib/MusicBrainz/Server/Authentication/User.pm
@@ -33,6 +33,8 @@ sub new_from_editor
     return Class::MOP::Class->initialize($class)->rebless_instance($editor);
 }
 
+sub is_authorized { 1 }
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Authentication/WS/Credential.pm
+++ b/lib/MusicBrainz/Server/Authentication/WS/Credential.pm
@@ -22,6 +22,7 @@ sub authenticate
         decode('utf-8', $c->req->header('Authorization'), Encode::FB_CROAK)
     }
     catch {
+        $c->stash->{bad_auth_encoding} = 1;
         $c->response->status(HTTP_BAD_REQUEST);
         $c->detach;
     };

--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -42,19 +42,21 @@ role
 
         my @collections;
         my %containment;
+        my $entity_collections = $self->_all_collections($c);
+        my %entity_collections_map = map { $_->id => 1 } @$entity_collections;
+
         if ($c->user_exists) {
             # Make a list of collections and whether this entity is contained in them
             @collections = $c->model('Collection')->find_all_by_editor($c->user->id, 1, $entity_type);
             foreach my $collection (@collections) {
-                $containment{$collection->id} = 1
-                  if ($c->model('Collection')->contains_entity($entity_type, $collection->id, $c->stash->{$entity_name}->id));
+                $containment{$collection->id} = 1 if $entity_collections_map{$collection->id};
             }
         }
 
         $c->stash
           (collections => \@collections,
            containment => \%containment,
-           all_collections => $self->_all_collections($c),
+           all_collections => $entity_collections,
           );
     };
 

--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -33,10 +33,10 @@ role
 
     method _all_collections => sub {
         my ($self, $c) = @_;
-        my ($collections) = $c->model('Collection')->find_by_entity(
-            $entity_type,
-            $c->stash->{$entity_name}->id,
-        );
+        my ($collections) = $c->model('Collection')->find_by({
+            entity_id => $c->stash->{$entity_name}->id,
+            entity_type => $entity_type,
+        });
         $collections;
     };
 
@@ -51,7 +51,11 @@ role
 
         if ($c->user_exists) {
             # Make a list of collections and whether this entity is contained in them
-            ($collections) = $c->model('Collection')->find_by_editor($c->user->id, 1, $entity_type);
+            ($collections) = $c->model('Collection')->find_by({
+                editor_id => $c->user->id,
+                entity_type => $entity_type,
+                show_private => $c->user->id,
+            });
             foreach my $collection (@$collections) {
                 $containment{$collection->id} = 1 if $entity_collections_map{$collection->id};
             }

--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -33,28 +33,32 @@ role
 
     method _all_collections => sub {
         my ($self, $c) = @_;
-        return [ $c->model('Collection')->find_all_by_entity($entity_type, $c->stash->{$entity_name}->id) ];
+        my ($collections) = $c->model('Collection')->find_by_entity(
+            $entity_type,
+            $c->stash->{$entity_name}->id,
+        );
+        $collections;
     };
 
     # Stuff that has the side bar and thus needs to display collection information
     method _stash_collections => sub {
         my ($self, $c) = @_;
 
-        my @collections;
+        my $collections;
         my %containment;
         my $entity_collections = $self->_all_collections($c);
         my %entity_collections_map = map { $_->id => 1 } @$entity_collections;
 
         if ($c->user_exists) {
             # Make a list of collections and whether this entity is contained in them
-            @collections = $c->model('Collection')->find_all_by_editor($c->user->id, 1, $entity_type);
-            foreach my $collection (@collections) {
+            ($collections) = $c->model('Collection')->find_by_editor($c->user->id, 1, $entity_type);
+            foreach my $collection (@$collections) {
                 $containment{$collection->id} = 1 if $entity_collections_map{$collection->id};
             }
         }
 
         $c->stash
-          (collections => \@collections,
+          (collections => $collections,
            containment => \%containment,
            all_collections => $entity_collections,
           );

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -311,13 +311,13 @@ sub collections : Chained('load') PathPart('collections')
     my $show_private = $c->stash->{viewing_own_profile};
     my $no_collections = 1;
 
-    my @collections = $c->model('Collection')->find_all_by_editor($user->id, $show_private);
-    $c->model('Collection')->load_entity_count(@collections);
-    $c->model('CollectionType')->load(@collections);
+    my ($collections) = $c->model('Collection')->find_by_editor($user->id, $show_private);
+    $c->model('Collection')->load_entity_count(@$collections);
+    $c->model('CollectionType')->load(@$collections);
 
-    $no_collections = 0 if ($no_collections && @collections);
+    $no_collections = 0 if ($no_collections && @$collections);
 
-    for my $collection (@collections) {
+    for my $collection (@$collections) {
         if ($c->user_exists) {
             $collection->{'subscribed'} =
                 $c->model('Collection')->subscription->check_subscription($c->user->id, $collection->id);

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -308,24 +308,23 @@ sub collections : Chained('load') PathPart('collections')
     my ($self, $c) = @_;
 
     my $user = $c->stash->{user};
-
     my $show_private = $c->stash->{viewing_own_profile};
     my $no_collections = 1;
 
-    for my $entity_type (entities_with('collections')) {
-        my @collections = $c->model('Collection')->find_all_by_editor($user->id, $show_private, $entity_type);
-        $no_collections = 0 if ($no_collections && @collections);
+    my @collections = $c->model('Collection')->find_all_by_editor($user->id, $show_private);
+    $c->model('Collection')->load_entity_count(@collections);
+    $c->model('CollectionType')->load(@collections);
 
-        $c->model('Collection')->load_entity_count(@collections);
-        $c->model('CollectionType')->load(@collections);
+    $no_collections = 0 if ($no_collections && @collections);
 
+    for my $collection (@collections) {
         if ($c->user_exists) {
-            for my $collection (@collections) {
-                $collection->{'subscribed'} = $c->model('Collection')->subscription->check_subscription($c->user->id, $collection->id);
-            }
+            $collection->{'subscribed'} =
+                $c->model('Collection')->subscription->check_subscription($c->user->id, $collection->id);
         }
-        $c->stash->{collections}{$entity_type} = \@collections;
+        push @{ $c->stash->{collections}{$collection->type->entity_type} }, $collection;
     }
+
     $c->stash(user => $user, no_collections => $no_collections);
 }
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -308,10 +308,13 @@ sub collections : Chained('load') PathPart('collections')
     my ($self, $c) = @_;
 
     my $user = $c->stash->{user};
-    my $show_private = $c->stash->{viewing_own_profile};
+    my $viewing_own_profile = $c->stash->{viewing_own_profile};
     my $no_collections = 1;
 
-    my ($collections) = $c->model('Collection')->find_by_editor($user->id, $show_private);
+    my ($collections) = $c->model('Collection')->find_by({
+        editor_id => $user->id,
+        show_private => $viewing_own_profile ? $user->id : undef,
+    });
     $c->model('Collection')->load_entity_count(@$collections);
     $c->model('CollectionType')->load(@$collections);
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
@@ -14,6 +14,13 @@ my $ws_defs = Data::OptList::mkopt([
      },
      area => {
                          method   => 'GET',
+                         linked   => [ qw(collection) ],
+                         inc      => [ qw(aliases annotation
+                                          _relations tags user-tags ratings user-ratings) ],
+                         optional => [ qw(fmt limit offset) ],
+     },
+     area => {
+                         method   => 'GET',
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
@@ -34,6 +41,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Area'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -86,7 +95,9 @@ sub area_browse : Private
     }
 
     my $areas;
-    my $total;
+    if ($resource eq 'collection') {
+        $areas = $self->browse_by_collection($c, 'area', $id, $limit, $offset);
+    }
 
     my $stash = WebServiceStash->new;
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
      },
      artist => {
                          method   => 'GET',
-                         linked   => [ qw(area recording release release-group work) ],
+                         linked   => [ qw(area recording release release-group work collection) ],
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
@@ -36,6 +36,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Artist'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -143,6 +145,8 @@ sub artist_browse : Private
 
         my @tmp = $c->model('Artist')->find_by_area($area->id, $limit, $offset);
         $artists = $self->make_list(@tmp, $offset);
+    } elsif ($resource eq 'collection') {
+        $artists = $self->browse_by_collection($c, 'artist', $id, $limit, $offset);
     } elsif ($resource eq 'recording') {
         my $recording = $c->model('Recording')->get_by_gid($id);
         $c->detach('not_found') unless ($recording);

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -118,7 +118,9 @@ map {
 sub releases : Chained('load') PathPart('releases') Args(1) {
     my ($self, $c, $releases) = @_;
 
-    my $collection = $self->get_collection_from_stash($c);
+    $self->authenticate($c, $ACCESS_SCOPE_COLLECTION);
+
+    my $collection = $c->stash->{entity} // $c->detach('not_found');
     $c->model('CollectionType')->load($collection);
 
     $self->_error($c, 'You do not have permission to modify this collection')

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -166,8 +166,8 @@ sub list_list : Chained('base') PathPart('') {
     $self->authenticate($c, $ACCESS_SCOPE_COLLECTION);
 
     my $stash = WebServiceStash->new;
-
-    my @collections = $c->model('Collection')->find_all_by_editor($c->user->id, 1);
+    my @result = $c->model('Collection')->find_by_editor($c->user->id, 1);
+    my @collections = @{ $result[0] };
     $c->model('Editor')->load(@collections);
     $c->model('Collection')->load_entity_count(@collections);
     $c->model('CollectionType')->load(@collections);

--- a/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
@@ -17,7 +17,7 @@ my $ws_defs = Data::OptList::mkopt([
                          inc      => [ qw(aliases annotation _relations
                                           tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
-                         linked   => [ qw( area artist place ) ]
+                         linked   => [ qw( area artist place collection ) ]
      },
      event => {
                          method   => 'GET',
@@ -34,6 +34,8 @@ with 'MusicBrainz::Server::WebService::Validator' => {
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Event'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 sub base : Chained('root') PathPart('event') CaptureArgs(0) { }
 
@@ -84,7 +86,6 @@ sub event_browse : Private {
     }
 
     my $events;
-    my $total;
 
     if ($resource eq 'area') {
         my $area = $c->model('Area')->get_by_gid($id);
@@ -100,6 +101,10 @@ sub event_browse : Private {
 
         my @tmp = $c->model('Event')->find_by_artist($artist->id, $limit, $offset);
         $events = $self->make_list(@tmp, $offset);
+    }
+
+    if ($resource eq 'collection') {
+        $events = $self->browse_by_collection($c, 'event', $id, $limit, $offset);
     }
 
     if ($resource eq 'place') {

--- a/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
@@ -1,5 +1,7 @@
 package MusicBrainz::Server::Controller::WS::2::Instrument;
 use Moose;
+use MusicBrainz::Server::Validation qw( is_guid );
+
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
@@ -10,6 +12,12 @@ my $ws_defs = Data::OptList::mkopt([
         required => [ qw(query) ],
         optional => [ qw(fmt limit offset) ],
     },
+    instrument => {
+        method   => 'GET',
+        linked   => [ qw(collection) ],
+        inc      => [ qw(aliases annotation _relations tags user-tags) ],
+        optional => [ qw(fmt limit offset) ],
+     },
     instrument => {
         method   => 'GET',
         inc      => [ qw(aliases annotation _relations tags user-tags) ],
@@ -29,6 +37,8 @@ with 'MusicBrainz::Server::WebService::Validator' => {
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Instrument'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 sub base : Chained('root') PathPart('instrument') CaptureArgs(0) { }
 
@@ -62,9 +72,38 @@ sub instrument : Chained('load') PathPart('') {
     $c->res->body($c->stash->{serializer}->serialize('instrument', $instrument, $c->stash->{inc}, $stash));
 }
 
+
+sub instrument_browse : Private {
+    my ($self, $c) = @_;
+
+    my ($resource, $id) = @{ $c->stash->{linked} };
+    my ($limit, $offset) = $self->_limit_and_offset($c);
+
+    if (!is_guid($id)) {
+        $c->stash->{error} = "Invalid mbid.";
+        $c->detach('bad_req');
+    }
+
+    my $instruments;
+
+    if ($resource eq 'collection') {
+        $instruments = $self->browse_by_collection($c, 'instrument', $id, $limit, $offset);
+    }
+
+    my $stash = WebServiceStash->new;
+
+    for (@{ $instruments->{items} }) {
+        $self->instrument_toplevel($c, $stash, $_);
+    }
+
+    $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
+    $c->res->body($c->stash->{serializer}->serialize('instrument-list', $instruments, $c->stash->{inc}, $stash));
+}
+
 sub instrument_search : Chained('root') PathPart('instrument') Args(0) {
     my ($self, $c) = @_;
 
+    $c->detach('instrument_browse') if $c->stash->{linked};
     $self->_search($c, 'instrument');
 }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
      },
      label => {
                          method   => 'GET',
-                         linked   => [ qw(area release) ],
+                         linked   => [ qw(area release collection) ],
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
@@ -35,6 +35,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Label'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -105,6 +107,8 @@ sub label_browse : Private
 
         my @tmp = $c->model('Label')->find_by_area($area->id, $limit, $offset);
         $labels = $self->make_list(@tmp, $offset);
+    } elsif ($resource eq 'collection') {
+        $labels = $self->browse_by_collection($c, 'label', $id, $limit, $offset);
     } elsif ($resource eq 'release') {
         my $release = $c->model('Release')->get_by_gid($id);
         $c->detach('not_found') unless ($release);

--- a/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
      },
      place => {
                          method   => 'GET',
-                         linked   => [ qw(area) ],
+                         linked   => [ qw(area collection) ],
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags) ],
                          optional => [ qw(fmt limit offset) ],
@@ -35,6 +35,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Place'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -87,7 +89,6 @@ sub place_browse : Private
     }
 
     my $places;
-    my $total;
 
     if ($resource eq 'area') {
         my $area = $c->model('Area')->get_by_gid($id);
@@ -95,6 +96,8 @@ sub place_browse : Private
 
         my @tmp = $c->model('Place')->find_by_area($area->id, $limit, $offset);
         $places = $self->make_list(@tmp, $offset);
+    } elsif ($resource eq 'collection') {
+        $places = $self->browse_by_collection($c, 'place', $id, $limit, $offset);
     }
 
     my $stash = WebServiceStash->new;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
@@ -22,7 +22,7 @@ my $ws_defs = Data::OptList::mkopt([
      },
      recording => {
                          method   => 'GET',
-                         linked   => [ qw(artist release) ],
+                         linked   => [ qw(artist release collection) ],
                          inc      => [ qw(aliases artist-credits puids isrcs annotation
                                           _relations tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
@@ -47,6 +47,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Recording'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -148,6 +150,9 @@ sub recording_browse : Private
 
         my @tmp = $c->model('Recording')->find_by_artist($artist->id, $limit, $offset);
         $recordings = $self->make_list(@tmp, $offset);
+    }
+    elsif ($resource eq 'collection') {
+        $recordings = $self->browse_by_collection($c, 'recording', $id, $limit, $offset);
     }
     elsif ($resource eq 'release')
     {

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -128,11 +128,11 @@ sub release_toplevel
 
     $self->load_relationships($c, $stash, @rels_entities);
 
-    if ($c->stash->{inc}->collections)
-    {
+    if ($c->stash->{inc}->collections) {
+        my ($collections) = $c->model('Collection')->find_by_entity('release', $release->id);
         my @collections =
             grep { $_->public || ($c->user_exists && $c->user->id == $_->editor_id) }
-            $c->model('Collection')->find_all_by_entity('release', $release->id);
+            @$collections;
 
         $c->model('Editor')->load(@collections);
         $c->model('Collection')->load_entity_count(@collections);

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -133,7 +133,8 @@ sub release_toplevel
     $self->load_relationships($c, $stash, @rels_entities);
 
     if ($c->stash->{inc}->collections) {
-        my ($collections) = $c->model('Collection')->find_by_entity('release', $release->id);
+        my ($collections, $total) =
+            $c->model('Collection')->find_by_entity('release', $release->id);
         my @collections =
             grep { $_->public || ($c->user_exists && $c->user->id == $_->editor_id) }
             @$collections;
@@ -142,7 +143,8 @@ sub release_toplevel
         $c->model('Collection')->load_entity_count(@collections);
         $c->model('CollectionType')->load(@collections);
 
-        $stash->store($release)->{collections} = \@collections;
+        $stash->store($release)->{collections} =
+            $self->make_list(\@collections, scalar @collections);
     }
 }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -133,18 +133,18 @@ sub release_toplevel
     $self->load_relationships($c, $stash, @rels_entities);
 
     if ($c->stash->{inc}->collections) {
-        my ($collections, $total) =
-            $c->model('Collection')->find_by_entity('release', $release->id);
-        my @collections =
-            grep { $_->public || ($c->user_exists && $c->user->id == $_->editor_id) }
-            @$collections;
+        my ($collections, $total) = $c->model('Collection')->find_by({
+            entity_type => 'release',
+            entity_id => $release->id,
+            show_private => $c->user_exists ? $c->user->id : undef,
+        });
 
-        $c->model('Editor')->load(@collections);
-        $c->model('Collection')->load_entity_count(@collections);
-        $c->model('CollectionType')->load(@collections);
+        $c->model('Editor')->load(@$collections);
+        $c->model('Collection')->load_entity_count(@$collections);
+        $c->model('CollectionType')->load(@$collections);
 
         $stash->store($release)->{collections} =
-            $self->make_list(\@collections, scalar @collections);
+            $self->make_list($collections, $total);
     }
 }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -21,7 +21,9 @@ my $ws_defs = Data::OptList::mkopt([
      },
      release => {
                          method   => 'GET',
-                         linked   => [ qw(area track_artist artist label recording release-group track) ],
+                         linked   => [ qw(area track_artist artist label
+                                          recording release-group track
+                                          collection) ],
                          inc      => [ qw(aliases artist-credits labels recordings discids
                                           release-groups media _relations annotation) ],
                          optional => [ qw(fmt limit offset) ],
@@ -48,6 +50,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Release',
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -193,6 +197,8 @@ sub release_browse : Private
         my @tmp = $c->model('Release')->find_by_artist(
             $artist->id, $limit, $offset, filter => { status => $c->stash->{status}, type => $c->stash->{type} });
         $releases = $self->make_list(@tmp, $offset);
+    } elsif ($resource eq 'collection') {
+        $releases = $self->browse_by_collection($c, 'release', $id, $limit, $offset);
     } elsif ($resource eq 'track_artist') {
         my $artist = $c->model('Artist')->get_by_gid($id);
         $c->detach('not_found') unless ($artist);

--- a/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
@@ -14,7 +14,7 @@ my $ws_defs = Data::OptList::mkopt([
      },
      "release-group" => {
                          method   => 'GET',
-                         linked   => [ qw(artist release) ],
+                         linked   => [ qw(artist release collection) ],
                          inc      => [ qw(aliases artist-credits annotation
                                           _relations tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
@@ -35,6 +35,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'ReleaseGroup'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -114,6 +116,9 @@ sub release_group_browse : Private
         my @tmp = $c->model('ReleaseGroup')->find_by_artist(
             $artist->id, $show_all, $limit, $offset, filter => { type => $c->stash->{type} });
         $rgs = $self->make_list(@tmp, $offset);
+    }
+    elsif ($resource eq 'collection') {
+        $rgs = $self->browse_by_collection($c, 'release_group', $id, $limit, $offset);
     }
     elsif ($resource eq 'release')
     {

--- a/lib/MusicBrainz/Server/Controller/WS/2/Role/BrowseByCollection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Role/BrowseByCollection.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection;
+
+use Moose::Role;
+use MusicBrainz::Server::Constants qw( $ACCESS_SCOPE_COLLECTION );
+use MusicBrainz::Server::Data::Utils qw( type_to_model );
+
+requires qw(
+    authenticate
+    make_list
+    unauthorized
+);
+
+sub browse_by_collection {
+    my ($self, $c, $entity_type, $collection_gid, $limit, $offset) = @_;
+
+    my $collection = $c->model('Collection')->get_by_gid($collection_gid);
+    $c->detach('not_found') unless $collection;
+    $c->model('Editor')->load($collection);
+
+    if (!$collection->public) {
+        $self->authenticate($c, $ACCESS_SCOPE_COLLECTION);
+        $self->unauthorized($c)
+            unless $c->user->id == $collection->editor->id;
+    }
+
+    my $model = $c->model(type_to_model($entity_type));
+    my ($entities, $hits) = $model->find_by_collection(
+        $collection->id,
+        $limit,
+        $offset,
+    );
+    $self->make_list($entities, $hits, $offset);
+}
+
+1;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Series;
 use Moose;
+use MusicBrainz::Server::Validation qw( is_guid );
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
@@ -9,6 +10,12 @@ my $ws_defs = Data::OptList::mkopt([
      series => {
                          method   => 'GET',
                          required => [ qw(query) ],
+                         optional => [ qw(fmt limit offset) ],
+     },
+     series => {
+                         method   => 'GET',
+                         linked   => [ qw(collection) ],
+                         inc      => [ qw(aliases annotation _relations tags user-tags) ],
                          optional => [ qw(fmt limit offset) ],
      },
      series => {
@@ -25,6 +32,8 @@ with 'MusicBrainz::Server::WebService::Validator' => {
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Series'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 Readonly our $MAX_ITEMS => 25;
 
@@ -61,9 +70,36 @@ sub series : Chained('load') PathPart('') {
     $c->res->body($c->stash->{serializer}->serialize('series', $series, $c->stash->{inc}, $stash));
 }
 
+sub series_browse : Private
+{
+    my ($self, $c) = @_;
+
+    my ($resource, $id) = @{ $c->stash->{linked} };
+    my ($limit, $offset) = $self->_limit_and_offset($c);
+
+    if (!is_guid($id)) {
+        $c->stash->{error} = "Invalid mbid.";
+        $c->detach('bad_req');
+    }
+
+    my $series;
+    if ($resource eq 'collection') {
+        $series = $self->browse_by_collection($c, 'series', $id, $limit, $offset);
+    }
+
+    my $stash = WebServiceStash->new;
+    for (@{ $series->{items} }) {
+        $self->series_toplevel($c, $stash, $_);
+    }
+
+    $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
+    $c->res->body($c->stash->{serializer}->serialize('series-list', $series, $c->stash->{inc}, $stash));
+}
+
 sub series_search : Chained('root') PathPart('series') Args(0) {
     my ($self, $c) = @_;
 
+    $c->detach('series_browse') if $c->stash->{linked};
     $self->_search($c, 'series');
 }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
@@ -17,7 +17,7 @@ my $ws_defs = Data::OptList::mkopt([
                          inc      => [ qw(aliases annotation _relations
                                           tags user-tags ratings user-ratings) ],
                          optional => [ qw(fmt limit offset) ],
-                         linked   => [ qw( artist ) ]
+                         linked   => [ qw( artist collection ) ]
      },
      work => {
                          method   => 'GET',
@@ -35,6 +35,8 @@ with 'MusicBrainz::Server::WebService::Validator' =>
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Work'
 };
+
+with 'MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection';
 
 sub work_toplevel
 {
@@ -94,6 +96,8 @@ sub work_browse : Private
 
         my @tmp = $c->model('Work')->find_by_artist($artist->id, $limit, $offset);
         $works = $self->make_list(@tmp, $offset);
+    } elsif ($resource eq 'collection') {
+        $works = $self->browse_by_collection($c, 'work', $id, $limit, $offset);
     }
 
     my $stash = WebServiceStash->new;

--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -152,6 +152,16 @@ sub invalid_mbid : Private
     $c->detach('bad_req');
 }
 
+sub method_not_allowed : Private {
+    my ($self, $c) = @_;
+
+    $c->res->status(405);
+    $c->res->content_type($c->stash->{serializer}->mime_type . '; charset=utf-8');
+    $c->res->body($c->stash->{serializer}->output_error(
+        $c->req->method . ' is not allowed on this endpoint.'
+    ));
+}
+
 sub begin : Private { }
 sub end : Private { }
 

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -147,8 +147,9 @@ sub find_by {
     }
 
     if (my $entity_type = $opts->{entity_type}) {
-        push @joins, 'JOIN editor_collection_type ct ON editor_collection.type = ct.id';
-        push @conditions, 'ct.entity_type = ?';
+        push @conditions,
+            'EXISTS (SELECT 1 FROM editor_collection_type ct' .
+                    ' WHERE ct.id = editor_collection.type AND ct.entity_type = ?)';
         push @args, $entity_type;
 
         if (my $entity_id = $opts->{entity_id}) {

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -407,7 +407,8 @@ ORDER BY id ASC
 LIMIT $LIMIT_FOR_EDIT_LISTING
 EOSQL
 
-    $self->query_to_list_limited($query, \@args, $limit, $offset, undef, 1);
+    $self->query_to_list_limited($query, \@args, $limit, $offset, undef,
+                                 dollar_placeholders => 1);
 }
 
 sub subscribed_editor_edits {

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -128,7 +128,8 @@ sub find_by_recipient {
          LIMIT $LIMIT_FOR_EDIT_LISTING
 EOSQL
     $self->query_to_list_limited(
-        $query, [$recipient_id], $limit, $offset, undef, 1
+        $query, [$recipient_id], $limit, $offset, undef,
+        dollar_placeholders => 1,
     );
 }
 

--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -16,7 +16,7 @@ sub query_to_list {
 }
 
 sub query_to_list_limited {
-    my ($self, $query, $args, $limit, $offset, $builder, $dollar_placeholders) = @_;
+    my ($self, $query, $args, $limit, $offset, $builder, %opts) = @_;
 
     $builder //= $self->can('_new_from_row');
 
@@ -24,7 +24,7 @@ sub query_to_list_limited {
     my $count = @args;
 
     if (defined $offset) {
-        if ($dollar_placeholders) {
+        if ($opts{dollar_placeholders}) {
             $query .= ' OFFSET $' . (++$count);
         } else {
             $query .= ' OFFSET ?';
@@ -39,7 +39,7 @@ sub query_to_list_limited {
     };
 
     if (defined $limit) {
-        if ($dollar_placeholders) {
+        if ($opts{dollar_placeholders}) {
             $wrapping_query .= ' LIMIT $' . (++$count);
         } else {
             $wrapping_query .= ' LIMIT ?';

--- a/lib/MusicBrainz/Server/Entity/Collection.pm
+++ b/lib/MusicBrainz/Server/Entity/Collection.pm
@@ -8,7 +8,7 @@ extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'CollectionType' };
 
 has 'editor' => (
-    is => 'ro',
+    is => 'rw',
     isa => 'Editor',
 );
 

--- a/lib/MusicBrainz/Server/Test.pm
+++ b/lib/MusicBrainz/Server/Test.pm
@@ -327,6 +327,8 @@ sub _build_ws_test_xml {
     my $validator = schema_validator($args->{version});
 
     return sub {
+        use Test::More;
+
         my ($msg, $url, $expected, $opts) = @_;
         $opts ||= {};
 
@@ -337,10 +339,16 @@ sub _build_ws_test_xml {
                 $mech->credentials('localhost:80', 'musicbrainz.org', $opts->{username}, $opts->{password});
             }
 
-            $Test->plan(tests => 4);
-
-            $mech->get_ok($end_point . $url, 'fetching');
-            $validator->($mech->content, 'validating');
+            $mech->get($end_point . $url, 'fetching');
+            if ($opts->{response_code}) {
+                $Test->plan(tests => 2);
+                is($mech->res->code, $opts->{response_code});
+            } else {
+                $Test->plan(tests => 4);
+                ok($mech->success);
+                # only do this on success, there's no schema for error messages
+                $validator->($mech->content, 'validating');
+            }
 
             is_xml_same($expected, $mech->content);
             $Test->note($mech->content);

--- a/lib/MusicBrainz/Server/Test/WS.pm
+++ b/lib/MusicBrainz/Server/Test/WS.pm
@@ -1,0 +1,48 @@
+package MusicBrainz::Server::Test::WS;
+
+use strict;
+use warnings;
+
+use base 'Exporter';
+use Readonly;
+use MusicBrainz::Server::Test ws_test => { version => 2 };
+
+our @EXPORT_OK = qw(
+    ws2_test_xml
+    ws2_test_xml_forbidden
+    ws2_test_xml_unauthorized
+);
+
+Readonly our $FORBIDDEN_XML_RESPONSE => <<'EOXML';
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <text>You are not authorized to access this resource.</text>
+  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+</error>
+EOXML
+
+Readonly our $UNAUTHORIZED_XML_RESPONSE => <<'EOXML';
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <text>Your credentials could not be verified. Either you supplied the wrong credentials (e.g., bad password), or your client doesn't understand how to supply the credentials required.</text>
+  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+</error>
+EOXML
+
+sub ws2_test_xml { ws_test(@_) }
+
+sub ws2_test_xml_forbidden {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 401;
+    ws_test($msg, $url, $FORBIDDEN_XML_RESPONSE, $opts);
+}
+
+sub ws2_test_xml_unauthorized {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 401;
+    ws_test($msg, $url, $UNAUTHORIZED_XML_RESPONSE, $opts);
+}

--- a/lib/MusicBrainz/Server/Test/WS.pm
+++ b/lib/MusicBrainz/Server/Test/WS.pm
@@ -14,6 +14,8 @@ our @EXPORT_OK = qw(
     ws2_test_json_unauthorized
     ws2_test_xml
     ws2_test_xml_forbidden
+    ws2_test_xml_invalid_mbid
+    ws2_test_xml_not_found
     ws2_test_xml_unauthorized
 );
 
@@ -37,6 +39,22 @@ Readonly our $UNAUTHORIZED_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>Your credentials could not be verified. Either you supplied the wrong credentials (e.g., bad password), or your client doesn't understand how to supply the credentials required.</text>
+  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+</error>
+EOXML
+
+Readonly our $NOT_FOUND_XML_RESPONSE => <<'EOXML';
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <text>Not Found</text>
+  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+</error>
+EOXML
+
+Readonly our $INVALID_MBID_XML_RESPONSE => <<'EOXML';
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <text>Invalid mbid.</text>
   <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
@@ -75,4 +93,20 @@ sub ws2_test_xml_unauthorized {
     $opts //= {};
     $opts->{response_code} = 401;
     ws_test($msg, $url, $UNAUTHORIZED_XML_RESPONSE, $opts);
+}
+
+sub ws2_test_xml_not_found {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 404;
+    ws_test($msg, $url, $NOT_FOUND_XML_RESPONSE, $opts);
+}
+
+sub ws2_test_xml_invalid_mbid {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 400;
+    ws_test($msg, $url, $INVALID_MBID_XML_RESPONSE, $opts);
 }

--- a/lib/MusicBrainz/Server/Test/WS.pm
+++ b/lib/MusicBrainz/Server/Test/WS.pm
@@ -6,12 +6,24 @@ use warnings;
 use base 'Exporter';
 use Readonly;
 use MusicBrainz::Server::Test ws_test => { version => 2 };
+use MusicBrainz::Server::Test ws_test_json => { version => 2 };
 
 our @EXPORT_OK = qw(
+    ws2_test_json
+    ws2_test_json_forbidden
+    ws2_test_json_unauthorized
     ws2_test_xml
     ws2_test_xml_forbidden
     ws2_test_xml_unauthorized
 );
+
+Readonly our $FORBIDDEN_JSON_RESPONSE => {
+    error => 'You are not authorized to access this resource.',
+};
+
+Readonly our $UNAUTHORIZED_JSON_RESPONSE => {
+    error => 'Your credentials could not be verified. Either you supplied the wrong credentials (e.g., bad password), or your client doesn\'t understand how to supply the credentials required.',
+};
 
 Readonly our $FORBIDDEN_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
@@ -28,6 +40,24 @@ Readonly our $UNAUTHORIZED_XML_RESPONSE => <<'EOXML';
   <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
+
+sub ws2_test_json { ws_test_json(@_) }
+
+sub ws2_test_json_forbidden {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 401;
+    ws_test_json($msg, $url, $FORBIDDEN_JSON_RESPONSE, $opts);
+}
+
+sub ws2_test_json_unauthorized {
+    my ($msg, $url, $opts) = @_;
+
+    $opts //= {};
+    $opts->{response_code} = 401;
+    ws_test_json($msg, $url, $UNAUTHORIZED_JSON_RESPONSE, $opts);
+}
 
 sub ws2_test_xml { ws_test(@_) }
 

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -58,7 +58,7 @@ sub event_list         { shift->entity_list(@_, "event", "events") };
 sub collection_list    {
     my ($self, $list, $inc, $opts) = @_;
 
-    $self->entity_list({ items => $list }, $inc, $opts, 'collection', 'collections');
+    $self->entity_list($list, $inc, $opts, 'collection', 'collections');
 }
 
 sub serialize_internal {

--- a/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
+++ b/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
@@ -12,7 +12,7 @@ has $_ => (
 ) for (qw(
           aliases discids isrcs media puids various_artists artist_credits
           artists labels recordings releases release_groups works
-          tags ratings user_tags user_ratings collections
+          tags ratings user_tags user_ratings collections user_collections
           recording_level_rels work_level_rels rels annotation release_events
 ), map { $_ . '_rels' } entities_with(['mbid', 'relatable']));
 

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -774,15 +774,12 @@ sub _serialize_label_list
 {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} })
+    my @list;
+    foreach my $label (sort_by { $_->gid } @{ $list->{items} })
     {
-        my @list;
-        foreach my $label (sort_by { $_->gid } @{ $list->{items} })
-        {
-            $self->_serialize_label(\@list, $gen, $label, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->label_list($self->_list_attributes($list), @list);
+        $self->_serialize_label(\@list, $gen, $label, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->label_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_label
@@ -836,15 +833,12 @@ sub _serialize_area_list
 {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} })
+    my @list;
+    foreach my $area (sort_by { $_->gid } @{ $list->{items} })
     {
-        my @list;
-        foreach my $area (sort_by { $_->gid } @{ $list->{items} })
-        {
-            $self->_serialize_area(\@list, $gen, $area, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->area_list($self->_list_attributes($list), @list);
+        $self->_serialize_area(\@list, $gen, $area, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->area_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_area_inner
@@ -922,15 +916,12 @@ sub _serialize_place_list
 {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} })
+    my @list;
+    foreach my $place (sort_by { $_->gid } @{ $list->{items} })
     {
-        my @list;
-        foreach my $place (sort_by { $_->gid } @{ $list->{items} })
-        {
-            $self->_serialize_place(\@list, $gen, $place, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->place_list($self->_list_attributes($list), @list);
+        $self->_serialize_place(\@list, $gen, $place, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->place_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_place
@@ -968,13 +959,11 @@ sub _serialize_place
 sub _serialize_instrument_list {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} }) {
-        my @list;
-        foreach my $instrument (sort_by { $_->gid } @{ $list->{items} }) {
-            $self->_serialize_instrument(\@list, $gen, $instrument, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->instrument_list($self->_list_attributes($list), @list);
+    my @list;
+    foreach my $instrument (sort_by { $_->gid } @{ $list->{items} }) {
+        $self->_serialize_instrument(\@list, $gen, $instrument, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->instrument_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_instrument {
@@ -1078,15 +1067,12 @@ sub _serialize_series_list
 {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} })
+    my @list;
+    foreach my $series (sort_by { $_->gid } @{ $list->{items} })
     {
-        my @list;
-        foreach my $series (sort_by { $_->gid } @{ $list->{items} })
-        {
-            $self->_serialize_series(\@list, $gen, $series, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->series_list($self->_list_attributes($list), @list);
+        $self->_serialize_series(\@list, $gen, $series, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->series_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_series
@@ -1120,15 +1106,12 @@ sub _serialize_event_list
 {
     my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
-    if (@{ $list->{items} })
+    my @list;
+    foreach my $event (sort_by { $_->gid } @{ $list->{items} })
     {
-        my @list;
-        foreach my $event (sort_by { $_->gid } @{ $list->{items} })
-        {
-            $self->_serialize_event(\@list, $gen, $event, $inc, $stash, $toplevel);
-        }
-        push @$data, $gen->event_list($self->_list_attributes ($list), @list);
+        $self->_serialize_event(\@list, $gen, $event, $inc, $stash, $toplevel);
     }
+    push @$data, $gen->event_list($self->_list_attributes ($list), @list);
 }
 
 sub _serialize_event

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -228,9 +228,10 @@ sub _serialize_collection
 
     my $ser = "_serialize_${entity_type}_list";
     my $gen_list = "${entity_type}_list";
+    my $list = $opts->{$plural};
 
-    if ($toplevel) {
-        $self->$ser(\@collection, $gen, $opts->{$plural}, $inc, $stash);
+    if ($toplevel && defined($list->{items}) && @{ $list->{items} }) {
+        $self->$ser(\@collection, $gen, $list, $inc, $stash);
     } elsif ($collection->loaded_entity_count) {
         push @collection, $gen->$gen_list({ count => $collection->entity_count });
     }

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -241,13 +241,13 @@ sub _serialize_collection
 
 sub _serialize_collection_list
 {
-    my ($self, $data, $gen, $collections, $inc, $stash, $toplevel) = @_;
+    my ($self, $data, $gen, $list, $inc, $stash, $toplevel) = @_;
 
     my @list;
-    map { $self->_serialize_collection(\@list, $gen, $_, $inc, $stash, 0) }
-        @$collections;
-
-    push @$data, $gen->collection_list(@list);
+    foreach my $collection (@{ $list->{items} }) {
+        $self->_serialize_collection(\@list, $gen, $collection, $inc, $stash, $toplevel);
+    }
+    push @$data, $gen->collection_list($self->_list_attributes($list), @list);
 }
 
 sub _serialize_release_group_list
@@ -441,7 +441,7 @@ sub _serialize_release
     $self->_serialize_relation_lists($release, \@list, $gen, $release->relationships, $inc, $stash) if ($inc->has_rels);
     $self->_serialize_tags_and_ratings(\@list, $gen, $inc, $opts);
     $self->_serialize_collection_list(\@list, $gen, $opts->{collections}, $inc, $stash, 0)
-        if ($opts->{collections} && @{ $opts->{collections} });
+        if $opts->{collections};
 
     push @$data, $gen->release({ id => $release->gid }, @list);
 }

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -245,7 +245,7 @@ sub _serialize_collection_list
 
     my @list;
     map { $self->_serialize_collection(\@list, $gen, $_, $inc, $stash, 0) }
-        sort_by { $_->gid } @$collections;
+        @$collections;
 
     push @$data, $gen->collection_list(@list);
 }

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/1/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/1/Collection.pm
@@ -18,18 +18,13 @@ my $c = $test->c;
 my $mech = $test->mech;
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
-MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
-INSERT INTO editor (id, name, password, ha1) VALUES (1, 'editor', '{CLEARTEXT}password', '3a115bc4f05ea9856bd4611b75c80bca');
-INSERT INTO editor_collection (id, gid, editor, name, type)
-    VALUES (1, 'b33f3e54-caab-4ad4-94a6-a598e0e52eec', 1, 'My Collection', 1);
-EOSQL
 
 subtest 'Add a release to a collection' => sub {
     my $request = POST '/ws/1/collection/?type=xml', [
         add => '4ccb3e54-caab-4ad4-94a6-a598e0e52eec,980e0f65-930e-4743-95d3-602665c25c15',
     ];
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'editor', 'password');
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
     my $response = $mech->request($request);
     ok($mech->success);
@@ -41,7 +36,7 @@ subtest 'Add a release to a collection' => sub {
            <release id="4ccb3e54-caab-4ad4-94a6-a598e0e52eec" />
            <release id="980e0f65-930e-4743-95d3-602665c25c15" />
         </release-list></metadata>',
-        { username => 'editor', password => 'password' };
+        { username => 'the-anti-kuno', password => 'notreally' };
 
     done_testing;
 };
@@ -51,7 +46,7 @@ subtest 'Remove releases from collections' => sub {
         remove => '980e0f65-930e-4743-95d3-602665c25c15',
     ];
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'editor', 'password');
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
     my $response = $mech->request($request);
     ok($mech->success);
@@ -62,7 +57,7 @@ subtest 'Remove releases from collections' => sub {
          <release-list count="1">
           <release id="4ccb3e54-caab-4ad4-94a6-a598e0e52eec" />
         </release-list></metadata>',
-        { username => 'editor', password => 'password' };
+        { username => 'the-anti-kuno', password => 'notreally' };
 
     done_testing;
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Authenticated.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Authenticated.pm
@@ -55,7 +55,7 @@ my $content = '<?xml version="1.0" encoding="UTF-8"?>
 
 $mech->request(xml_post('/ws/2/tag?client=post.t-0.0.2', $content));
 is ($mech->status, 401, 'Tags rejected without authentication');
-$mech->content_contains('Authorization required');
+$mech->content_contains('You are not authorized');
 
 $mech->credentials('localhost:80', 'musicbrainz.org', 'new_editor', 'password');
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/BrowseArtists.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/BrowseArtists.pm
@@ -9,9 +9,11 @@ with 't::Mechanize', 't::Context';
 use utf8;
 use XML::SemanticDiff;
 use MusicBrainz::Server::Test qw( xml_ok schema_validator );
-use MusicBrainz::Server::Test ws_test => {
-    version => 2
-};
+use MusicBrainz::Server::Test::WS qw(
+    ws2_test_xml
+    ws2_test_xml_forbidden
+    ws2_test_xml_unauthorized
+);
 
 test all => sub {
 
@@ -22,7 +24,7 @@ my $diff = XML::SemanticDiff->new;
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
 
-ws_test 'browse artists via release group',
+ws2_test_xml 'browse artists via release group',
     '/artist?release-group=22b54315-6e51-350b-bb34-e6e16f7688bd' =>
     '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -33,7 +35,7 @@ ws_test 'browse artists via release group',
     </artist-list>
 </metadata>';
 
-ws_test 'browse artists via recording',
+ws2_test_xml 'browse artists via recording',
     '/artist?inc=aliases&recording=0cf3008f-e246-428f-abc1-35f87d584d60' =>
     '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -68,7 +70,7 @@ ws_test 'browse artists via recording',
     </artist-list>
 </metadata>';
 
-ws_test 'browse artists via release, inc=tags+ratings',
+ws2_test_xml 'browse artists via release, inc=tags+ratings',
     '/artist?release=aff4a693-5970-4e2e-bd46-e2ee49c22de7&inc=tags+ratings' =>
     '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -103,7 +105,7 @@ ws_test 'browse artists via release, inc=tags+ratings',
     </artist-list>
 </metadata>';
 
-ws_test 'browse artists via work',
+ws2_test_xml 'browse artists via work',
     '/artist?work=3c37b9fa-a6c1-37d2-9e90-657a116d337c' =>
     '<?xml version="1.0"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -113,6 +115,44 @@ ws_test 'browse artists via work',
         </artist>
     </artist-list>
 </metadata>';
+
+ws2_test_xml 'browse artists via public collection',
+    '/artist?collection=9c782444-f9f4-4a4f-93cb-92d132c79887' =>
+    '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <artist-list count="1">
+        <artist type="Person" id="a16d1433-ba89-4f72-a47b-a370add0bb55">
+            <name>BoA</name>
+            <sort-name>BoA</sort-name>
+            <life-span>
+              <begin>1986-11-05</begin>
+            </life-span>
+        </artist>
+    </artist-list>
+</metadata>';
+
+ws2_test_xml 'browse artists via private collection',
+    '/artist?collection=5f0831af-c84c-44a3-849d-abdf0a18cdd9' =>
+    '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <artist-list count="1">
+        <artist type="Group" id="22dd2db3-88ea-4428-a7a8-5cd3acf23175">
+            <name>m-flo</name>
+            <sort-name>m-flo</sort-name>
+            <life-span>
+              <begin>1998</begin>
+            </life-span>
+        </artist>
+    </artist-list>
+</metadata>',
+    { username => 'the-anti-kuno', password => 'notreally' };
+
+ws2_test_xml_forbidden 'browse artists via private collection, no credentials',
+    '/artist?collection=5f0831af-c84c-44a3-849d-abdf0a18cdd9';
+
+ws2_test_xml_unauthorized 'browse artists via private collection, bad credentials',
+    '/artist?collection=5f0831af-c84c-44a3-849d-abdf0a18cdd9',
+    { username => 'the-anti-kuno', password => 'idk' };
 
 my $res = $test->mech->get('/ws/2/artist?work=3c37b9fa-a6c1-37d2-9e90-657a116d337c&limit=-1');
 is($res->code, HTTP_BAD_REQUEST);

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -2,15 +2,17 @@ package t::MusicBrainz::Server::Controller::WS::2::Collection;
 use Test::Routine;
 use Test::More;
 use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test::WS qw(
+    ws2_test_xml
+    ws2_test_xml_forbidden
+    ws2_test_xml_unauthorized
+);
 
 with 't::Mechanize', 't::Context';
 
 use utf8;
 use XML::SemanticDiff;
 use MusicBrainz::Server::Test qw( xml_ok schema_validator );
-use MusicBrainz::Server::Test ws_test => {
-    version => 2
-};
 
 test "collection lookup" => sub {
     my $test = shift;
@@ -20,11 +22,38 @@ test "collection lookup" => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
 INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
 INSERT INTO editor_collection (id, gid, editor, name, public, type)
-    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 1, 'my collection', FALSE, 1);
-INSERT INTO editor_collection_release (collection, release) VALUES (1, 123054);
+    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 1, 'my collection', FALSE, 1),
+           (2, '32bb90e3-aa68-4e3c-9f7a-338096a20ae3', 1, 'my public collection', TRUE, 1);
+INSERT INTO editor_collection_release (collection, release)
+    VALUES (1, 123054), (2, 123054);
 EOSQL
 
-    ws_test 'collection lookup',
+    ws2_test_xml 'all collections',
+        '/collection/' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list>
+    <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
+      <name>my collection</name>
+      <editor>new_editor</editor>
+      <release-list count="1" />
+    </collection>
+    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
+      <name>my public collection</name>
+      <editor>new_editor</editor>
+      <release-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>', { username => 'new_editor', password => 'password' };
+
+    ws2_test_xml_forbidden 'all collections, no credentials',
+        '/collection/';
+
+    ws2_test_xml_unauthorized 'all collections, bad credentials',
+        '/collection/',
+        { username => 'new_editor', password => 'wrong_password' };
+
+    ws2_test_xml 'private collection lookup',
         '/collection/f34c079d-374e-4436-9448-da92dedef3ce' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -35,7 +64,14 @@ EOSQL
   </collection>
 </metadata>', { username => 'new_editor', password => 'password' };
 
-    ws_test 'collection releases lookup',
+    ws2_test_xml_forbidden 'private collection lookup, no credentials',
+        '/collection/f34c079d-374e-4436-9448-da92dedef3ce';
+
+    ws2_test_xml_unauthorized 'private collection lookup, bad credentials',
+        '/collection/f34c079d-374e-4436-9448-da92dedef3ce',
+        { username => 'new_editor', password => 'wrong_password' };
+
+    ws2_test_xml 'private collection releases lookup',
         '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
@@ -71,6 +107,23 @@ EOSQL
   </collection>
 </metadata>', { username => 'new_editor', password => 'password' };
 
+    ws2_test_xml_forbidden 'private collection releases lookup, no credentials',
+        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/';
+
+    ws2_test_xml_unauthorized 'private collection releases lookup, bad credentials',
+        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/',
+        { username => 'new_editor', password => 'wrong_password' };
+
+    ws2_test_xml 'public collection lookup',
+        '/collection/32bb90e3-aa68-4e3c-9f7a-338096a20ae3' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
+    <name>my public collection</name>
+    <editor>new_editor</editor>
+    <release-list count="1" />
+  </collection>
+</metadata>';
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -24,7 +24,7 @@ test "collection lookup" => sub {
         '/collection/' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection-list>
+  <collection-list count="22">
     <collection type="Area" id="9ece2fbd-3f4e-431d-9424-da8af38374e0" entity-type="area">
       <name>private area collection</name>
       <editor>the-anti-kuno</editor>
@@ -221,7 +221,7 @@ test "collection lookup" => sub {
         '/collection/?editor=the-anti-kuno' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection-list>
+  <collection-list count="11">
     <collection id="cc8cd8ee-6477-47d5-a16d-adac11ed9f30" type="Area" entity-type="area">
       <name>public area collection</name>
       <editor>the-anti-kuno</editor>
@@ -284,7 +284,7 @@ test "collection lookup" => sub {
         '/collection/?editor=the-anti-kuno&inc=user-collections&limit=3' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection-list>
+  <collection-list count="22">
     <collection type="Area" id="9ece2fbd-3f4e-431d-9424-da8af38374e0" entity-type="area">
       <name>private area collection</name>
       <editor>the-anti-kuno</editor>

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -311,4 +311,145 @@ test "collection lookup" => sub {
         { username => 'the-anti-kuno', password => 'wrong_password' };
 };
 
+test "browsing by area" => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+
+    ws2_test_xml 'browse by area',
+        '/collection/?area=106e0bec-b638-3b37-b731-f53d507dc00e' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="area" type="Area" id="cc8cd8ee-6477-47d5-a16d-adac11ed9f30">
+      <name>public area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>';
+
+    ws2_test_xml 'browse by area, no public collections',
+        '/collection/?area=85752fda-13c4-31a3-bee5-0e5cb1f51dad' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="0" />
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml 'browse by area, inc=user-collections',
+        '/collection/?area=85752fda-13c4-31a3-bee5-0e5cb1f51dad&inc=user-collections' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="area" type="Area" id="9ece2fbd-3f4e-431d-9424-da8af38374e0">
+      <name>private area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml_forbidden 'browse by area, inc=user-collections, no credentials',
+        '/collection/?area=85752fda-13c4-31a3-bee5-0e5cb1f51dad&inc=user-collections';
+
+    ws2_test_xml_unauthorized 'browse by area, inc=user-collections, bad credentials',
+        '/collection/?area=85752fda-13c4-31a3-bee5-0e5cb1f51dad&inc=user-collections',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
+};
+
+test "browsing by release" => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+
+    ws2_test_xml 'browse by release',
+        '/collection/?release=0385f276-5f4f-4c81-a7a4-6bd7b8d85a7e' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="release" type="Release" id="dd07ea8b-0ec3-4b2d-85cf-80e523de4902">
+      <name>public release collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>';
+
+    ws2_test_xml 'browse by release, no public collections',
+        '/collection/?release=b3b7e934-445b-4c68-a097-730c6a6d47e6' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="0" />
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml 'browse by release, inc=user-collections',
+        '/collection/?release=b3b7e934-445b-4c68-a097-730c6a6d47e6&inc=user-collections' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="release" type="Release" id="1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5">
+      <name>private release collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml_forbidden 'browse by release, inc=user-collections, no credentials',
+        '/collection/?release=b3b7e934-445b-4c68-a097-730c6a6d47e6&inc=user-collections';
+
+    ws2_test_xml_unauthorized 'browse by release, inc=user-collections, bad credentials',
+        '/collection/?release=b3b7e934-445b-4c68-a097-730c6a6d47e6&inc=user-collections',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
+};
+
+test "browsing by release group" => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+
+    ws2_test_xml 'browse by release group',
+        '/collection/?release-group=b84625af-6229-305f-9f1b-59c0185df016' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="release_group" type="Release group" id="dadae81b-ff9e-464e-8c38-51156557bc36">
+      <name>public release group collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-group-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>';
+
+    ws2_test_xml 'browse by release group, no public collections',
+        '/collection/?release-group=202cad78-a2e1-3fa7-b8bc-77c1f737e3da' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="0" />
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml 'browse by release group, inc=user-collections',
+        '/collection/?release-group=202cad78-a2e1-3fa7-b8bc-77c1f737e3da&inc=user-collections' =>
+        '<?xml version="1.0"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list count="1">
+    <collection entity-type="release_group" type="Release group" id="b0f09ccf-a777-4c17-a917-28e01b0e66a3">
+      <name>private release group collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-group-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
+
+    ws2_test_xml_forbidden 'browse by releasegroup, inc=user-collections, no credentials',
+        '/collection/?release-group=202cad78-a2e1-3fa7-b8bc-77c1f737e3da&inc=user-collections';
+
+    ws2_test_xml_unauthorized 'browse by release group, inc=user-collections, bad credentials',
+        '/collection/?release-group=202cad78-a2e1-3fa7-b8bc-77c1f737e3da&inc=user-collections',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -25,6 +25,17 @@ INSERT INTO editor_collection_release (collection, release) VALUES (1, 123054);
 EOSQL
 
     ws_test 'collection lookup',
+        '/collection/f34c079d-374e-4436-9448-da92dedef3ce' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
+    <name>my collection</name>
+    <editor>new_editor</editor>
+    <release-list count="1" />
+  </collection>
+</metadata>', { username => 'new_editor', password => 'password' };
+
+    ws_test 'collection releases lookup',
         '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -124,6 +124,44 @@ EOSQL
     <release-list count="1" />
   </collection>
 </metadata>';
+
+    ws2_test_xml 'browse by editor name, no credentials',
+        '/collection/?editor=new_editor' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list>
+    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
+      <name>my public collection</name>
+      <editor>new_editor</editor>
+      <release-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>';
+
+    ws2_test_xml 'browse by editor name, inc=user-collections',
+        '/collection/?editor=new_editor&inc=user-collections' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <collection-list>
+    <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
+      <name>my collection</name>
+      <editor>new_editor</editor>
+      <release-list count="1" />
+    </collection>
+    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
+      <name>my public collection</name>
+      <editor>new_editor</editor>
+      <release-list count="1" />
+    </collection>
+  </collection-list>
+</metadata>', { username => 'new_editor', password => 'password' };
+
+    ws2_test_xml_forbidden 'browse by editor name, inc=user-collections, no credentials',
+        '/collection/?editor=new_editor&inc=user-collections';
+
+    ws2_test_xml_unauthorized 'browse by editor name, inc=user-collections, bad credentials',
+        '/collection/?editor=new_editor&inc=user-collections',
+        { username => 'new_editor', password => 'wrong_password' };
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -19,65 +19,157 @@ test "collection lookup" => sub {
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
-    MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
-INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
-INSERT INTO editor_collection (id, gid, editor, name, public, type)
-    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 1, 'my collection', FALSE, 1),
-           (2, '32bb90e3-aa68-4e3c-9f7a-338096a20ae3', 1, 'my public collection', TRUE, 1);
-INSERT INTO editor_collection_release (collection, release)
-    VALUES (1, 123054), (2, 123054);
-EOSQL
 
     ws2_test_xml 'all collections',
         '/collection/' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
   <collection-list>
-    <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
-      <name>my collection</name>
-      <editor>new_editor</editor>
+    <collection type="Area" id="9ece2fbd-3f4e-431d-9424-da8af38374e0" entity-type="area">
+      <name>private area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
+    </collection>
+    <collection id="5f0831af-c84c-44a3-849d-abdf0a18cdd9" type="Artist" entity-type="artist">
+      <name>private artist collection</name>
+      <editor>the-anti-kuno</editor>
+      <artist-list count="1" />
+    </collection>
+    <collection entity-type="event" type="Event" id="13b1d199-a79e-40fe-bd7c-0ecc3ca52d73">
+      <name>private event collection</name>
+      <editor>the-anti-kuno</editor>
+      <event-list count="1" />
+    </collection>
+    <collection entity-type="instrument" type="Instrument" id="cdef54c4-2798-4d39-a0c9-5074191f9b6e">
+      <name>private instrument collection</name>
+      <editor>the-anti-kuno</editor>
+      <instrument-list count="1" />
+    </collection>
+    <collection id="b0f57375-7009-47ab-a631-469aaba34885" type="Label" entity-type="label">
+      <name>private label collection</name>
+      <editor>the-anti-kuno</editor>
+      <label-list count="1" />
+    </collection>
+    <collection entity-type="place" id="65e18c7a-0958-4066-9c3e-7c1474c623d1" type="Place">
+      <name>private place collection</name>
+      <editor>the-anti-kuno</editor>
+      <place-list count="1" />
+    </collection>
+    <collection entity-type="recording" type="Recording" id="b5486110-906e-4c0c-a6e6-e16baf4e18e2">
+      <name>private recording collection</name>
+      <editor>the-anti-kuno</editor>
+      <recording-list count="1" />
+    </collection>
+    <collection type="Release" id="1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5" entity-type="release">
+      <name>private release collection</name>
+      <editor>the-anti-kuno</editor>
       <release-list count="1" />
     </collection>
-    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
-      <name>my public collection</name>
-      <editor>new_editor</editor>
+    <collection id="b0f09ccf-a777-4c17-a917-28e01b0e66a3" type="Release group" entity-type="release_group">
+      <name>private release group collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-group-list count="1" />
+    </collection>
+    <collection entity-type="series" id="870dbdcf-e047-4da5-9c80-c39e964da96f" type="Series">
+      <name>private series collection</name>
+      <editor>the-anti-kuno</editor>
+      <series-list count="1" />
+    </collection>
+    <collection entity-type="work" type="Work" id="b69030b0-911e-4f7d-aa59-c488b2c8fe8e">
+      <name>private work collection</name>
+      <editor>the-anti-kuno</editor>
+      <work-list count="1" />
+    </collection>
+    <collection id="cc8cd8ee-6477-47d5-a16d-adac11ed9f30" type="Area" entity-type="area">
+      <name>public area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
+    </collection>
+    <collection type="Artist" id="9c782444-f9f4-4a4f-93cb-92d132c79887" entity-type="artist">
+      <name>public artist collection</name>
+      <editor>the-anti-kuno</editor>
+      <artist-list count="1" />
+    </collection>
+    <collection type="Event" id="05febe0a-a9df-414a-a2c9-7dc366b0de9b" entity-type="event">
+      <name>public event collection</name>
+      <editor>the-anti-kuno</editor>
+      <event-list count="1" />
+    </collection>
+    <collection id="7749c811-d77c-4ea5-9a9e-e2a4e7ae0d1f" type="Instrument" entity-type="instrument">
+      <name>public instrument collection</name>
+      <editor>the-anti-kuno</editor>
+      <instrument-list count="1" />
+    </collection>
+    <collection type="Label" id="d8c9f799-9255-45ca-93fa-88f7c438d0d8" entity-type="label">
+      <name>public label collection</name>
+      <editor>the-anti-kuno</editor>
+      <label-list count="1" />
+    </collection>
+    <collection entity-type="place" id="e6fac30e-28c9-46ed-9cbc-5aabce8170e8" type="Place">
+      <name>public place collection</name>
+      <editor>the-anti-kuno</editor>
+      <place-list count="1" />
+    </collection>
+    <collection type="Recording" id="38a6a0ec-f4a9-4424-80fd-bd4f9eb2e880" entity-type="recording">
+      <name>public recording collection</name>
+      <editor>the-anti-kuno</editor>
+      <recording-list count="1" />
+    </collection>
+    <collection entity-type="release" type="Release" id="dd07ea8b-0ec3-4b2d-85cf-80e523de4902">
+      <name>public release collection</name>
+      <editor>the-anti-kuno</editor>
       <release-list count="1" />
+    </collection>
+    <collection entity-type="release_group" id="dadae81b-ff9e-464e-8c38-51156557bc36" type="Release group">
+      <name>public release group collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-group-list count="1" />
+    </collection>
+    <collection id="5adf966d-d82f-4ae9-a9a3-e5e187ed2c34" type="Series" entity-type="series">
+      <name>public series collection</name>
+      <editor>the-anti-kuno</editor>
+      <series-list count="1" />
+    </collection>
+    <collection entity-type="work" id="3529acda-c0c1-4b13-9761-a4a8dedb64be" type="Work">
+      <name>public work collection</name>
+      <editor>the-anti-kuno</editor>
+      <work-list count="1" />
     </collection>
   </collection-list>
-</metadata>', { username => 'new_editor', password => 'password' };
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
 
     ws2_test_xml_forbidden 'all collections, no credentials',
         '/collection/';
 
     ws2_test_xml_unauthorized 'all collections, bad credentials',
         '/collection/',
-        { username => 'new_editor', password => 'wrong_password' };
+        { username => 'the-anti-kuno', password => 'wrong_password' };
 
     ws2_test_xml 'private collection lookup',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce' =>
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
-    <name>my collection</name>
-    <editor>new_editor</editor>
+  <collection entity-type="release" type="Release" id="1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5">
+    <name>private release collection</name>
+    <editor>the-anti-kuno</editor>
     <release-list count="1" />
   </collection>
-</metadata>', { username => 'new_editor', password => 'password' };
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
 
     ws2_test_xml_forbidden 'private collection lookup, no credentials',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce';
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5';
 
     ws2_test_xml_unauthorized 'private collection lookup, bad credentials',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce',
-        { username => 'new_editor', password => 'wrong_password' };
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
 
     ws2_test_xml 'private collection releases lookup',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/' =>
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
-    <name>my collection</name>
-    <editor>new_editor</editor>
+  <collection entity-type="release" type="Release" id="1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5">
+    <name>private release collection</name>
+    <editor>the-anti-kuno</editor>
     <release-list count="1">
       <release id="b3b7e934-445b-4c68-a097-730c6a6d47e6">
         <title>Summer Reggae! Rainbow</title>
@@ -105,63 +197,118 @@ EOSQL
       </release>
     </release-list>
   </collection>
-</metadata>', { username => 'new_editor', password => 'password' };
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
 
     ws2_test_xml_forbidden 'private collection releases lookup, no credentials',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/';
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/';
 
     ws2_test_xml_unauthorized 'private collection releases lookup, bad credentials',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/',
-        { username => 'new_editor', password => 'wrong_password' };
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
 
     ws2_test_xml 'public collection lookup',
-        '/collection/32bb90e3-aa68-4e3c-9f7a-338096a20ae3' =>
+        '/collection/dd07ea8b-0ec3-4b2d-85cf-80e523de4902' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
-  <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
-    <name>my public collection</name>
-    <editor>new_editor</editor>
+  <collection entity-type="release" type="Release" id="dd07ea8b-0ec3-4b2d-85cf-80e523de4902">
+    <name>public release collection</name>
+    <editor>the-anti-kuno</editor>
     <release-list count="1" />
   </collection>
 </metadata>';
 
     ws2_test_xml 'browse by editor name, no credentials',
-        '/collection/?editor=new_editor' =>
+        '/collection/?editor=the-anti-kuno' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
   <collection-list>
-    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
-      <name>my public collection</name>
-      <editor>new_editor</editor>
+    <collection id="cc8cd8ee-6477-47d5-a16d-adac11ed9f30" type="Area" entity-type="area">
+      <name>public area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
+    </collection>
+    <collection type="Artist" id="9c782444-f9f4-4a4f-93cb-92d132c79887" entity-type="artist">
+      <name>public artist collection</name>
+      <editor>the-anti-kuno</editor>
+      <artist-list count="1" />
+    </collection>
+    <collection type="Event" id="05febe0a-a9df-414a-a2c9-7dc366b0de9b" entity-type="event">
+      <name>public event collection</name>
+      <editor>the-anti-kuno</editor>
+      <event-list count="1" />
+    </collection>
+    <collection id="7749c811-d77c-4ea5-9a9e-e2a4e7ae0d1f" type="Instrument" entity-type="instrument">
+      <name>public instrument collection</name>
+      <editor>the-anti-kuno</editor>
+      <instrument-list count="1" />
+    </collection>
+    <collection type="Label" id="d8c9f799-9255-45ca-93fa-88f7c438d0d8" entity-type="label">
+      <name>public label collection</name>
+      <editor>the-anti-kuno</editor>
+      <label-list count="1" />
+    </collection>
+    <collection entity-type="place" id="e6fac30e-28c9-46ed-9cbc-5aabce8170e8" type="Place">
+      <name>public place collection</name>
+      <editor>the-anti-kuno</editor>
+      <place-list count="1" />
+    </collection>
+    <collection type="Recording" id="38a6a0ec-f4a9-4424-80fd-bd4f9eb2e880" entity-type="recording">
+      <name>public recording collection</name>
+      <editor>the-anti-kuno</editor>
+      <recording-list count="1" />
+    </collection>
+    <collection entity-type="release" type="Release" id="dd07ea8b-0ec3-4b2d-85cf-80e523de4902">
+      <name>public release collection</name>
+      <editor>the-anti-kuno</editor>
       <release-list count="1" />
+    </collection>
+    <collection entity-type="release_group" id="dadae81b-ff9e-464e-8c38-51156557bc36" type="Release group">
+      <name>public release group collection</name>
+      <editor>the-anti-kuno</editor>
+      <release-group-list count="1" />
+    </collection>
+    <collection id="5adf966d-d82f-4ae9-a9a3-e5e187ed2c34" type="Series" entity-type="series">
+      <name>public series collection</name>
+      <editor>the-anti-kuno</editor>
+      <series-list count="1" />
+    </collection>
+    <collection entity-type="work" id="3529acda-c0c1-4b13-9761-a4a8dedb64be" type="Work">
+      <name>public work collection</name>
+      <editor>the-anti-kuno</editor>
+      <work-list count="1" />
     </collection>
   </collection-list>
 </metadata>';
 
     ws2_test_xml 'browse by editor name, inc=user-collections',
-        '/collection/?editor=new_editor&inc=user-collections' =>
+        '/collection/?editor=the-anti-kuno&inc=user-collections&limit=3' =>
         '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
   <collection-list>
-    <collection entity-type="release" type="Release" id="f34c079d-374e-4436-9448-da92dedef3ce">
-      <name>my collection</name>
-      <editor>new_editor</editor>
-      <release-list count="1" />
+    <collection type="Area" id="9ece2fbd-3f4e-431d-9424-da8af38374e0" entity-type="area">
+      <name>private area collection</name>
+      <editor>the-anti-kuno</editor>
+      <area-list count="1" />
     </collection>
-    <collection entity-type="release" type="Release" id="32bb90e3-aa68-4e3c-9f7a-338096a20ae3">
-      <name>my public collection</name>
-      <editor>new_editor</editor>
-      <release-list count="1" />
+    <collection id="5f0831af-c84c-44a3-849d-abdf0a18cdd9" type="Artist" entity-type="artist">
+      <name>private artist collection</name>
+      <editor>the-anti-kuno</editor>
+      <artist-list count="1" />
+    </collection>
+    <collection entity-type="event" type="Event" id="13b1d199-a79e-40fe-bd7c-0ecc3ca52d73">
+      <name>private event collection</name>
+      <editor>the-anti-kuno</editor>
+      <event-list count="1" />
     </collection>
   </collection-list>
-</metadata>', { username => 'new_editor', password => 'password' };
+</metadata>', { username => 'the-anti-kuno', password => 'notreally' };
 
     ws2_test_xml_forbidden 'browse by editor name, inc=user-collections, no credentials',
-        '/collection/?editor=new_editor&inc=user-collections';
+        '/collection/?editor=the-anti-kuno&inc=user-collections';
 
     ws2_test_xml_unauthorized 'browse by editor name, inc=user-collections, bad credentials',
-        '/collection/?editor=new_editor&inc=user-collections',
-        { username => 'new_editor', password => 'wrong_password' };
+        '/collection/?editor=the-anti-kuno&inc=user-collections',
+        { username => 'the-anti-kuno', password => 'wrong_password' };
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
@@ -15,43 +15,205 @@ test "collection lookup" => sub {
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
-    MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
-INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
-INSERT INTO editor_collection (id, gid, editor, name, public, type)
-    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 1, 'my collection', FALSE, 1);
-INSERT INTO editor_collection_release (collection, release) VALUES (1, 123054);
-EOSQL
 
     ws_test_json 'collection lookup',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce' => {
-            id => "f34c079d-374e-4436-9448-da92dedef3ce",
-            name => "my collection",
-            editor => "new_editor",
-            type => "Release",
-            "entity-type" => "release",
-            "release-count" => 1,
+        '/collection/05febe0a-a9df-414a-a2c9-7dc366b0de9b' => {
+            "event-count" => 1,
+            "id" => "05febe0a-a9df-414a-a2c9-7dc366b0de9b",
+            "type" => "Event",
+            "editor" => "the-anti-kuno",
+            "name" => "public event collection",
+            "entity-type" => "event"
         }, { username => 'new_editor', password => 'password' };
 
     ws_test_json 'collections lookup',
         '/collection/' => {
-            collections => [
+            "collections" => [
                 {
-                    id => "f34c079d-374e-4436-9448-da92dedef3ce",
-                    name => "my collection",
-                    editor => "new_editor",
-                    type => "Release",
+                    "event-count" => 1,
+                    "id" => "05febe0a-a9df-414a-a2c9-7dc366b0de9b",
+                    "type" => "Event",
+                    "editor" => "the-anti-kuno",
+                    "name" => "public event collection",
+                    "entity-type" => "event"
+                },
+                {
+                    "entity-type" => "event",
+                    "name" => "private event collection",
+                    "type" => "Event",
+                    "editor" => "the-anti-kuno",
+                    "id" => "13b1d199-a79e-40fe-bd7c-0ecc3ca52d73",
+                    "event-count" => 1
+                },
+                {
+                    "editor" => "the-anti-kuno",
+                    "type" => "Release",
                     "entity-type" => "release",
+                    "name" => "private release collection",
+                    "id" => "1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5",
+                    "release-count" => 1
+                },
+                {
+                    "entity-type" => "work",
+                    "name" => "public work collection",
+                    "type" => "Work",
+                    "editor" => "the-anti-kuno",
+                    "id" => "3529acda-c0c1-4b13-9761-a4a8dedb64be",
+                    "work-count" => 1
+                },
+                {
+                    "type" => "Recording",
+                    "editor" => "the-anti-kuno",
+                    "entity-type" => "recording",
+                    "recording-count" => 1,
+                    "name" => "public recording collection",
+                    "id" => "38a6a0ec-f4a9-4424-80fd-bd4f9eb2e880"
+                },
+                {
+                    "id" => "5adf966d-d82f-4ae9-a9a3-e5e187ed2c34",
+                    "series-count" => 1,
+                    "entity-type" => "series",
+                    "name" => "public series collection",
+                    "editor" => "the-anti-kuno",
+                    "type" => "Series"
+                },
+                {
+                    "name" => "private artist collection",
+                    "entity-type" => "artist",
+                    "type" => "Artist",
+                    "artist-count" => 1,
+                    "editor" => "the-anti-kuno",
+                    "id" => "5f0831af-c84c-44a3-849d-abdf0a18cdd9"
+                },
+                {
+                    "editor" => "the-anti-kuno",
+                    "type" => "Place",
+                    "place-count" => 1,
+                    "entity-type" => "place",
+                    "name" => "private place collection",
+                    "id" => "65e18c7a-0958-4066-9c3e-7c1474c623d1"
+                },
+                {
+                    "id" => "7749c811-d77c-4ea5-9a9e-e2a4e7ae0d1f",
+                    "entity-type" => "instrument",
+                    "name" => "public instrument collection",
+                    "type" => "Instrument",
+                    "editor" => "the-anti-kuno",
+                    "instrument-count" => 1
+                },
+                {
+                    "id" => "870dbdcf-e047-4da5-9c80-c39e964da96f",
+                    "series-count" => 1,
+                    "entity-type" => "series",
+                    "name" => "private series collection",
+                    "editor" => "the-anti-kuno",
+                    "type" => "Series"
+                },
+                {
+                    "entity-type" => "artist",
+                    "name" => "public artist collection",
+                    "editor" => "the-anti-kuno",
+                    "artist-count" => 1,
+                    "type" => "Artist",
+                    "id" => "9c782444-f9f4-4a4f-93cb-92d132c79887"
+                },
+                {
+                    "id" => "9ece2fbd-3f4e-431d-9424-da8af38374e0",
+                    "name" => "private area collection",
+                    "entity-type" => "area",
+                    "editor" => "the-anti-kuno",
+                    "type" => "Area",
+                    "area-count" => 1
+                },
+                {
+                    "type" => "Release group",
+                    "editor" => "the-anti-kuno",
+                    "name" => "private release group collection",
+                    "entity-type" => "release_group",
+                    "release-group-count" => 1,
+                    "id" => "b0f09ccf-a777-4c17-a917-28e01b0e66a3"
+                },
+                {
+                    "type" => "Label",
+                    "editor" => "the-anti-kuno",
+                    "entity-type" => "label",
+                    "name" => "private label collection",
+                    "id" => "b0f57375-7009-47ab-a631-469aaba34885",
+                    "label-count" => 1
+                },
+                {
+                    "editor" => "the-anti-kuno",
+                    "type" => "Recording",
+                    "recording-count" => 1,
+                    "name" => "private recording collection",
+                    "entity-type" => "recording",
+                    "id" => "b5486110-906e-4c0c-a6e6-e16baf4e18e2"
+                },
+                {
+                    "id" => "b69030b0-911e-4f7d-aa59-c488b2c8fe8e",
+                    "work-count" => 1,
+                    "name" => "private work collection",
+                    "entity-type" => "work",
+                    "type" => "Work",
+                    "editor" => "the-anti-kuno"
+                },
+                {
+                    "id" => "cc8cd8ee-6477-47d5-a16d-adac11ed9f30",
+                    "type" => "Area",
+                    "area-count" => 1,
+                    "editor" => "the-anti-kuno",
+                    "entity-type" => "area",
+                    "name" => "public area collection"
+                },
+                {
+                    "id" => "cdef54c4-2798-4d39-a0c9-5074191f9b6e",
+                    "type" => "Instrument",
+                    "instrument-count" => 1,
+                    "editor" => "the-anti-kuno",
+                    "name" => "private instrument collection",
+                    "entity-type" => "instrument"
+                },
+                {
+                    "id" => "d8c9f799-9255-45ca-93fa-88f7c438d0d8",
+                    "label-count" => 1,
+                    "type" => "Label",
+                    "editor" => "the-anti-kuno",
+                    "entity-type" => "label",
+                    "name" => "public label collection"
+                },
+                {
+                    "release-group-count" => 1,
+                    "id" => "dadae81b-ff9e-464e-8c38-51156557bc36",
+                    "editor" => "the-anti-kuno",
+                    "type" => "Release group",
+                    "entity-type" => "release_group",
+                    "name" => "public release group collection"
+                },
+                {
+                    "id" => "dd07ea8b-0ec3-4b2d-85cf-80e523de4902",
                     "release-count" => 1,
+                    "editor" => "the-anti-kuno",
+                    "type" => "Release",
+                    "entity-type" => "release",
+                    "name" => "public release collection"
+                },
+                {
+                    "id" => "e6fac30e-28c9-46ed-9cbc-5aabce8170e8",
+                    "type" => "Place",
+                    "place-count" => 1,
+                    "editor" => "the-anti-kuno",
+                    "entity-type" => "place",
+                    "name" => "public place collection"
                 }
             ]
-        }, { username => 'new_editor', password => 'password' };
+        }, { username => 'the-anti-kuno', password => 'notreally' };
 
     ws_test_json 'collection releases lookup',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/' =>
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/' =>
             {
-                id => "f34c079d-374e-4436-9448-da92dedef3ce",
-                name => "my collection",
-                editor => "new_editor",
+                id => "1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5",
+                name => "private release collection",
+                editor => "the-anti-kuno",
                 type => "Release",
                 "entity-type" => "release",
                 "release-count" => 1,
@@ -81,18 +243,18 @@ EOSQL
                         disambiguation => "",
                         packaging => JSON::null,
                     }]
-            }, { username => 'new_editor', password => 'password' };
+            }, { username => 'the-anti-kuno', password => 'notreally' };
 
     ws_test_json 'collection release-count (MBS-8776)',
-        '/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/?limit=1&offset=1' =>
+        '/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/?limit=1&offset=1' =>
             {
-                id => "f34c079d-374e-4436-9448-da92dedef3ce",
-                name => "my collection",
-                editor => "new_editor",
+                id => "1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5",
+                name => "private release collection",
+                editor => "the-anti-kuno",
                 type => "Release",
                 "entity-type" => "release",
                 "release-count" => 1,
-            }, { username => 'new_editor', password => 'password' };
+            }, { username => 'the-anti-kuno', password => 'notreally' };
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
@@ -22,8 +22,18 @@ INSERT INTO editor_collection (id, gid, editor, name, public, type)
 INSERT INTO editor_collection_release (collection, release) VALUES (1, 123054);
 EOSQL
 
-    ws_test_json 'collections lookup',
+    ws_test_json 'collection lookup',
         '/collection/f34c079d-374e-4436-9448-da92dedef3ce' => {
+            id => "f34c079d-374e-4436-9448-da92dedef3ce",
+            name => "my collection",
+            editor => "new_editor",
+            type => "Release",
+            "entity-type" => "release",
+            "release-count" => 1,
+        }, { username => 'new_editor', password => 'password' };
+
+    ws_test_json 'collections lookup',
+        '/collection/' => {
             collections => [
                 {
                     id => "f34c079d-374e-4436-9448-da92dedef3ce",

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Collection.pm
@@ -28,6 +28,8 @@ test "collection lookup" => sub {
 
     ws_test_json 'collections lookup',
         '/collection/' => {
+            "collection-count" => 22,
+            "collection-offset" => 0,
             "collections" => [
                 {
                     "event-count" => 1,

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -169,7 +169,7 @@ ws_test 'basic release with collections',
         </release-event-list>
         <barcode>4942463511227</barcode>
         <asin>B00005LA6G</asin>
-        <collection-list>
+        <collection-list count="1">
             <collection type="Release" entity-type="release" id="f34c079d-374e-4436-9448-da92dedef3cd">
                 <name>My Collection</name>
                 <editor>editor</editor>

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
@@ -25,29 +25,24 @@ my $mech = $test->mech;
 $mech->default_header("Accept" => "application/xml");
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
-MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
-INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
-INSERT INTO editor_collection (id, gid, editor, name, public, type)
-    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3ce', 1, 'my collection', FALSE, 1);
-EOSQL
 
-my $collection = $c->model('Collection')->get_first_collection(1);
-my $release = $c->model('Release')->get_by_gid('0385f276-5f4f-4c81-a7a4-6bd7b8d85a7e');
+my $collection = $c->model('Collection')->get_by_gid('1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5');
+my $release = $c->model('Release')->get_by_gid('a84b9fea-aee9-4e1f-b5a2-a5a23c673688');
 
-my $uri = '/ws/2/collection/f34c079d-374e-4436-9448-da92dedef3ce/releases/'.
+my $uri = '/ws/2/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/'.
     $release->gid . '?client=test-1.0';
 
 subtest 'Add releases to collection' => sub {
     $mech->put($uri);
     is($mech->status, HTTP_UNAUTHORIZED, 'cant PUT without authentication');
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'new_editor', 'password');
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
     $mech->put_ok($uri);
     note($mech->content);
     xml_ok($mech->content);
 
-    ok($c->model('Collection')->contains_entity('release', $collection, $release->id));
+    ok($c->model('Collection')->contains_entity('release', $collection->id, $release->id));
 };
 
 $test->_clear_mech;
@@ -58,13 +53,13 @@ subtest 'Remove releases from collection' => sub {
     $mech->request($req);
     is($mech->status, HTTP_UNAUTHORIZED, 'cant POST without authentication');
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'new_editor', 'password');
+    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
     $mech->request($req);
     is($mech->status, HTTP_OK);
     xml_ok($mech->content);
 
-    ok(!$c->model('Collection')->contains_entity('release', $collection, $release->id));
+    ok(!$c->model('Collection')->contains_entity('release', $collection->id, $release->id));
 };
 
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
@@ -11,57 +11,121 @@ use HTTP::Request::Common qw( DELETE );
 use XML::SemanticDiff;
 use XML::XPath;
 
-use MusicBrainz::Server::Test qw( xml_ok schema_validator xml_post );
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+use MusicBrainz::Server::Test qw( xml_ok xml_post );
 use MusicBrainz::Server::Test ws_test => {
     version => 2
 };
 
 test all => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
 
-my $test = shift;
-my $c = $test->c;
-my $v2 = schema_validator;
-my $mech = $test->mech;
-$mech->default_header("Accept" => "application/xml");
+    $mech->default_header("Accept" => "application/xml");
 
-MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
 
-my $collection = $c->model('Collection')->get_by_gid('1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5');
-my $release = $c->model('Release')->get_by_gid('a84b9fea-aee9-4e1f-b5a2-a5a23c673688');
+    my @tests = (
+        {
+            collection => 'cc8cd8ee-6477-47d5-a16d-adac11ed9f30',
+            entity => '89a675c2-3e37-3518-b83c-418bad59a85a',
+            entity_type => 'area',
+        },
+        {
+            collection => '5f0831af-c84c-44a3-849d-abdf0a18cdd9',
+            entity => '97fa3f6e-557c-4227-bc0e-95a7f9f3285d',
+            entity_type => 'artist',
+        },
+        {
+            collection => '05febe0a-a9df-414a-a2c9-7dc366b0de9b',
+            entity => 'eb668bdc-a928-49a1-beb7-8e37db2a5b65',
+            entity_type => 'event',
+        },
+        {
+            collection => 'cdef54c4-2798-4d39-a0c9-5074191f9b6e',
+            entity => '3590521b-8c97-4f4b-b1bb-5f68d3663d8a',
+            entity_type => 'instrument',
+        },
+        {
+            collection => 'd8c9f799-9255-45ca-93fa-88f7c438d0d8',
+            entity => 'b4edce40-090f-4956-b82a-5d9d285da40b',
+            entity_type => 'label',
+        },
+        {
+            collection => '65e18c7a-0958-4066-9c3e-7c1474c623d1',
+            entity => 'df9269dd-0470-4ea2-97e8-c11e46080edd',
+            entity_type => 'place',
+        },
+        {
+            collection => '38a6a0ec-f4a9-4424-80fd-bd4f9eb2e880',
+            entity => '4f3321a6-7277-4c0e-808f-423b81e083e0',
+            entity_type => 'recording',
+        },
+        {
+            collection => '1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5',
+            entity => 'a84b9fea-aee9-4e1f-b5a2-a5a23c673688',
+            entity_type => 'release',
+        },
+        {
+            collection => 'dadae81b-ff9e-464e-8c38-51156557bc36',
+            entity => '9b5006e5-b276-3a05-bcdd-8d986842320b',
+            entity_type => 'release_group',
+        },
+        {
+            collection => '870dbdcf-e047-4da5-9c80-c39e964da96f',
+            entity => 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582',
+            entity_type => 'series',
+        },
+        {
+            collection => '3529acda-c0c1-4b13-9761-a4a8dedb64be',
+            entity => 'fa97639c-ea29-47d6-9461-16b411322bac',
+            entity_type => 'work',
+        },
+    );
 
-my $uri = '/ws/2/collection/1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5/releases/'.
-    $release->gid . '?client=test-1.0';
+    for my $t (@tests) {
+        my $entity_type = $t->{entity_type};
+        my $collection = $c->model('Collection')->get_by_gid($t->{collection});
+        my $entity = $c->model($ENTITIES{$entity_type}{model})->get_by_gid($t->{entity});
 
-subtest 'Add releases to collection' => sub {
-    $mech->put($uri);
-    is($mech->status, HTTP_UNAUTHORIZED, 'cant PUT without authentication');
+        my $uri = '/ws/2/collection/' . $collection->gid . '/' .
+                $ENTITIES{$entity_type}{plural_url} . '/' .  $entity->gid .
+                '?client=test-1.0';
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
+        $test->_clear_mech;
+        $mech = $test->mech;
 
-    $mech->put_ok($uri);
-    note($mech->content);
-    xml_ok($mech->content);
+        subtest "Add $entity_type to collection" => sub {
+            $mech->put($uri);
+            is($mech->status, HTTP_UNAUTHORIZED, "can’t PUT $entity_type without authentication");
 
-    ok($c->model('Collection')->contains_entity('release', $collection->id, $release->id));
-};
+            $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
-$test->_clear_mech;
-$mech = $test->mech;
+            $mech->put_ok($uri);
+            note($mech->content);
+            xml_ok($mech->content);
 
-subtest 'Remove releases from collection' => sub {
-    my $req = DELETE $uri;
-    $mech->request($req);
-    is($mech->status, HTTP_UNAUTHORIZED, 'cant POST without authentication');
+            ok($c->model('Collection')->contains_entity($entity_type, $collection->id, $entity->id));
+        };
 
-    $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
+        $test->_clear_mech;
+        $mech = $test->mech;
 
-    $mech->request($req);
-    is($mech->status, HTTP_OK);
-    xml_ok($mech->content);
+        subtest "Remove $entity_type from collection" => sub {
+            my $req = DELETE $uri;
+            $mech->request($req);
+            is($mech->status, HTTP_UNAUTHORIZED, "can’t POST $entity_type without authentication");
 
-    ok(!$c->model('Collection')->contains_entity('release', $collection->id, $release->id));
-};
+            $mech->credentials('localhost:80', 'musicbrainz.org', 'the-anti-kuno', 'notreally');
 
+            $mech->request($req);
+            is($mech->status, HTTP_OK);
+            xml_ok($mech->content);
+
+            ok(!$c->model('Collection')->contains_entity($entity_type, $collection->id, $entity->id));
+        };
+    }
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Collection.pm
@@ -84,7 +84,7 @@ $coll_data->add_entities_to_collection('release', 1, 3);
 ok($coll_data->contains_entity('release', 1, 3), 'No exception occured when re-adding release #3');
 
 
-my ($releases) = $coll_data->find_by_entity('release', 3);
+my ($releases) = $coll_data->find_by({ entity_type => 'release', entity_id => 3, show_private => 1 });
 is(scalar(@$releases), 1, 'One collection contains release #3');
 ok((grep { $_->id == 1 } @$releases), 'found collection by release');
 
@@ -100,7 +100,7 @@ ok(!$coll_data->contains_entity('event', 4, 3), 'Event #3 has been merged and is
 ok($coll_data->contains_entity('event', 3, 2), 'Event #2 is still in collection #3');
 ok($coll_data->contains_entity('event', 4, 2), 'Event #2 is now in collection #4');
 
-my ($events) = $coll_data->find_by_entity('event', 2);
+my ($events) = $coll_data->find_by({ entity_type => 'event', entity_id => 2, show_private => 1 });
 is(scalar(@$events), 2, 'Two collections contain event #2');
 ok((grep { $_->id == 4 } @$events), 'Collection #4 is one of the ones containing event #2');
 ok((grep { $_->id == 3 } @$events), 'Collection #3 is one of the ones containing event #2');

--- a/t/lib/t/MusicBrainz/Server/Data/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Collection.pm
@@ -84,9 +84,9 @@ $coll_data->add_entities_to_collection('release', 1, 3);
 ok($coll_data->contains_entity('release', 1, 3), 'No exception occured when re-adding release #3');
 
 
-my @releases = $coll_data->find_all_by_entity('release', 3);
-is(scalar(@releases), 1, 'One collection contains release #3');
-ok((grep { $_->id == 1 } @releases), 'found collection by release');
+my ($releases) = $coll_data->find_by_entity('release', 3);
+is(scalar(@$releases), 1, 'One collection contains release #3');
+ok((grep { $_->id == 1 } @$releases), 'found collection by release');
 
 ok(!$coll_data->contains_entity('event', 3, 1), 'Event #1 is not in collection #3');
 $coll_data->add_entities_to_collection('event', 3, 1);
@@ -100,10 +100,10 @@ ok(!$coll_data->contains_entity('event', 4, 3), 'Event #3 has been merged and is
 ok($coll_data->contains_entity('event', 3, 2), 'Event #2 is still in collection #3');
 ok($coll_data->contains_entity('event', 4, 2), 'Event #2 is now in collection #4');
 
-my @events = $coll_data->find_all_by_entity('event', 2);
-is(scalar(@events), 2, 'Two collections contain event #2');
-ok((grep { $_->id == 4 } @events), 'Collection #4 is one of the ones containing event #2');
-ok((grep { $_->id == 3 } @events), 'Collection #3 is one of the ones containing event #2');
+my ($events) = $coll_data->find_by_entity('event', 2);
+is(scalar(@$events), 2, 'Two collections contain event #2');
+ok((grep { $_->id == 4 } @$events), 'Collection #4 is one of the ones containing event #2');
+ok((grep { $_->id == 3 } @$events), 'Collection #3 is one of the ones containing event #2');
 
 $coll_data->remove_entities_from_collection('event', 3, (1,2));
 ok(!$coll_data->contains_entity('event', 3, 1), 'Event #1 is out of collection #3 again');

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -2988,6 +2988,52 @@ INSERT INTO l_label_url (edits_pending, entity0, entity1, id, last_updated, link
 INSERT INTO l_label_url (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 2988, 195251, 21646, '2011-01-18 16:23:37.789736+00', 23776);
 INSERT INTO l_label_url (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 2988, 195250, 17124, '2011-01-18 16:23:37.789736+00', 23778);
 
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (1, 'cc8cd8ee-6477-47d5-a16d-adac11ed9f30', 95821, 'public area collection', TRUE, '', 7);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (2, '9ece2fbd-3f4e-431d-9424-da8af38374e0', 95821, 'private area collection', FALSE, '', 7);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (3, '9c782444-f9f4-4a4f-93cb-92d132c79887', 95821, 'public artist collection', TRUE, '', 8);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (4, '5f0831af-c84c-44a3-849d-abdf0a18cdd9', 95821, 'private artist collection', FALSE, '', 8);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (5, '05febe0a-a9df-414a-a2c9-7dc366b0de9b', 95821, 'public event collection', TRUE, '', 4);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (6, '13b1d199-a79e-40fe-bd7c-0ecc3ca52d73', 95821, 'private event collection', FALSE, '', 4);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (7, '7749c811-d77c-4ea5-9a9e-e2a4e7ae0d1f', 95821, 'public instrument collection', TRUE, '', 9);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (8, 'cdef54c4-2798-4d39-a0c9-5074191f9b6e', 95821, 'private instrument collection', FALSE, '', 9);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (9, 'd8c9f799-9255-45ca-93fa-88f7c438d0d8', 95821, 'public label collection', TRUE, '', 10);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (10, 'b0f57375-7009-47ab-a631-469aaba34885', 95821, 'private label collection', FALSE, '', 10);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (11, 'e6fac30e-28c9-46ed-9cbc-5aabce8170e8', 95821, 'public place collection', TRUE, '', 11);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (12, '65e18c7a-0958-4066-9c3e-7c1474c623d1', 95821, 'private place collection', FALSE, '', 11);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (13, '38a6a0ec-f4a9-4424-80fd-bd4f9eb2e880', 95821, 'public recording collection', TRUE, '', 12);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (14, 'b5486110-906e-4c0c-a6e6-e16baf4e18e2', 95821, 'private recording collection', FALSE, '', 12);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (15, 'dd07ea8b-0ec3-4b2d-85cf-80e523de4902', 95821, 'public release collection', TRUE, '', 1);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (16, '1d1e41eb-20a2-4545-b4a7-d76e53d6f2f5', 95821, 'private release collection', FALSE, '', 1);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (17, 'dadae81b-ff9e-464e-8c38-51156557bc36', 95821, 'public release group collection', TRUE, '', 13);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (18, 'b0f09ccf-a777-4c17-a917-28e01b0e66a3', 95821, 'private release group collection', FALSE, '', 13);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (19, '5adf966d-d82f-4ae9-a9a3-e5e187ed2c34', 95821, 'public series collection', TRUE, '', 14);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (20, '870dbdcf-e047-4da5-9c80-c39e964da96f', 95821, 'private series collection', FALSE, '', 14);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (21, '3529acda-c0c1-4b13-9761-a4a8dedb64be', 95821, 'public work collection', TRUE, '', 15);
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type) VALUES (22, 'b69030b0-911e-4f7d-aa59-c488b2c8fe8e', 95821, 'private work collection', FALSE, '', 15);
+
+INSERT INTO editor_collection_area (collection, area) VALUES (1, 13);
+INSERT INTO editor_collection_area (collection, area) VALUES (2, 81);
+INSERT INTO editor_collection_artist (collection, artist) VALUES (3, 9496);
+INSERT INTO editor_collection_artist (collection, artist) VALUES (4, 135345);
+INSERT INTO editor_collection_event (collection, event) VALUES (5, 7);
+INSERT INTO editor_collection_event (collection, event) VALUES (6, 8);
+INSERT INTO editor_collection_instrument (collection, instrument) VALUES (7, 7);
+INSERT INTO editor_collection_instrument (collection, instrument) VALUES (8, 7);
+INSERT INTO editor_collection_label (collection, label) VALUES (9, 8092);
+INSERT INTO editor_collection_label (collection, label) VALUES (10, 395);
+INSERT INTO editor_collection_place (collection, place) VALUES (11, 1);
+INSERT INTO editor_collection_place (collection, place) VALUES (12, 1);
+INSERT INTO editor_collection_recording (collection, recording) VALUES (13, 1542682);
+INSERT INTO editor_collection_recording (collection, recording) VALUES (14, 1542683);
+INSERT INTO editor_collection_release (collection, release) VALUES (15, 49161);
+INSERT INTO editor_collection_release (collection, release) VALUES (16, 123054);
+INSERT INTO editor_collection_release_group (collection, release_group) VALUES (17, 377462);
+INSERT INTO editor_collection_release_group (collection, release_group) VALUES (18, 155364);
+INSERT INTO editor_collection_series (collection, series) VALUES (19, 25);
+INSERT INTO editor_collection_series (collection, series) VALUES (20, 25);
+INSERT INTO editor_collection_work (collection, work) VALUES (21, 12488154);
+INSERT INTO editor_collection_work (collection, work) VALUES (22, 12488155);
+
 UPDATE medium
 SET track_count = tc.count
 FROM (SELECT count(id),medium FROM track GROUP BY medium) tc


### PR DESCRIPTION
Basically finishes implementing collections for all the new entity types in the WS, and fixes some other issues people have reported regarding them.

Main API changes:
 * Makes /ws/2/collection/mbid behave like other lookups. Previously it behaved like `GET /ws/2/collection` which returns all collections. This is a breaking change, but the existing behavior was not documented in the API, and generally makes no sense.
 * Adds browsing entities by `collection`
 * Adds browsing collections by `editor` (with inc=user-collections added to include private collections).
 * Adds browsing collections by entity (also with inc=user-collections)
 * Adds PUT/DELETE support for all entity types

Should resolve these tickets:
http://tickets.musicbrainz.org/browse/MBS-3125
http://tickets.musicbrainz.org/browse/MBS-5323
http://tickets.musicbrainz.org/browse/MBS-6120
http://tickets.musicbrainz.org/browse/MBS-6152
http://tickets.musicbrainz.org/browse/MBS-8459
http://tickets.musicbrainz.org/browse/MBS-8651
