### PR TITLE
Vertically center the search box

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -169,7 +169,7 @@ pre code {
                 float: right;
                 form {
                     width: 302px;
-                    margin-top: 3px;
+                    margin-top: -1px;
                     position: relative;
                     input#headerid-query {
                         width: 150px;


### PR DESCRIPTION
Vertically center the search box between the top of the page and the horizontal line, as suggested by @MonkeyDo.