### PR TITLE
MBS-8837: rare ISE editing event time

### DIFF
--- a/lib/MusicBrainz/Server/Edit/CheckForConflicts.pm
+++ b/lib/MusicBrainz/Server/Edit/CheckForConflicts.pm
@@ -123,7 +123,7 @@ sub merge_changes {
                 );
 
             # Stores a mapping of the JSON serialization to the object value
-            my %hashed = map { @$_ } ($new, $ancestor, $current);
+            my %hashed = map { @$_ } ($ancestor, $current, $new);
 
             # Attempt to merge all JSON values together
             my $merged_json = merge(map +[ $_->[0] ], ($new, $ancestor, $current));

--- a/lib/MusicBrainz/Server/Edit/Utils.pm
+++ b/lib/MusicBrainz/Server/Edit/Utils.pm
@@ -390,10 +390,11 @@ sub merge_barcode {
 sub merge_time {
     my ($name, $ancestor, $current, $new) = @_;
 
+    $current = $current->$name ? $current->$name->strftime('%H:%M') : undef;
     return (
-        [ defined $ancestor->{$name} ? $ancestor->{$name} : undef, $ancestor->{$name} ],
-        [ defined $current->$name ? $current->$name->strftime('%H:%M') : undef, $current->$name ],
-        [ defined $new->{$name} ? $new->{$name} : undef, $new->{$name} ],
+        [$ancestor->{$name}, $ancestor->{$name}],
+        [$current, $current],
+        [$new->{$name}, $new->{$name}],
     );
 }
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -1,0 +1,36 @@
+package t::MusicBrainz::Server::Edit::Event::Edit;
+
+use Test::Routine;
+use Test::More;
+use Test::Fatal;
+
+with 't::Edit';
+with 't::Context';
+
+use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Constants qw( $EDIT_EVENT_EDIT $UNTRUSTED_FLAG );
+
+test 'MBS-8837' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    $c->sql->do(<<'EOSQL');
+        INSERT INTO event (id, name, gid, time)
+        VALUES (1, 'test', '5140d04f-a0f9-4846-8b23-b53a36b5c5ff', '19:30:00');
+EOSQL
+
+    my $edit = $c->model('Edit')->create(
+        edit_type => $EDIT_EVENT_EDIT,
+        editor_id => 1,
+        to_edit => $c->model('Event')->get_by_id(1),
+        time => '19:00',
+        privileges => $UNTRUSTED_FLAG,
+    );
+
+    $c->sql->do('UPDATE event SET time = ? WHERE id = 1', '19:00:00');
+    ok !exception { $edit->accept };
+    my $time = $c->sql->select_single_value('SELECT time FROM event WHERE id = 1');
+    is($time, '19:00:00');
+};
+
+1;


### PR DESCRIPTION
Broken in 6a8e2e6127cbdec3e23590368e78c2490c200768

This ISE can occur if the time being set is already the current value.

The source of the bug is due to the change in parameter order associated with Text::Diff3's merge subroutine.

Before the referenced commit, CheckForConflicts hashed the results of merge_time in the order (ancestor, current, new), which would be something like [['19:30', '19:30'], ['19:00', (DateTime object)], ['19:00', '19:00]], where the first value in each array ref is the key. Since the last two array refs have the same key, the second would override the first.

After 6a8e2e6, those array refs are hashed in the order new, ancestor, current, which means the DateTime object is the result.

The fix here is to revert the change in the order they're hashed (new should be last), and always return a formatted string for the current value, not a DateTime object, since the object isn't stringified to the same format that ancestor and new are in.