### PR TITLE
Add inc=user-collections to /ws/2/release (MBS-6152)

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -79,7 +79,7 @@ sub serialize
     };
 
     $body{collections} = list_of($entity, $inc, $stash, "collections")
-        if $inc && $inc->collections;
+        if $inc && ($inc->collections || $inc->user_collections);
 
     $body{"release-group"} = serialize_entity($entity->release_group, $inc, $stash)
         if $inc && $inc->release_groups;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
@@ -141,51 +141,54 @@ test 'basic release with tags' => sub {
 };
 
 test 'basic release with collections' => sub {
-
     my $c = shift->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
-    MusicBrainz::Server::Test->prepare_test_database(
-        $c,
-        "INSERT INTO release_tag (count, release, tag) VALUES (1, 123054, 114); " .
-        "INSERT INTO editor (id, name, password, ha1) VALUES (15412, 'editor', '{CLEARTEXT}mb', 'be88da857f697a78656b1307f89f90ab'); " .
-        "INSERT INTO editor_collection (id, gid, editor, name, public, type) VALUES (14933, 'f34c079d-374e-4436-9448-da92dedef3cd', 15412, 'My Collection', TRUE, 1); " .
-        "INSERT INTO editor_collection_release (collection, release) VALUES (14933, 123054); ");
+    MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
+        INSERT INTO release_tag (count, release, tag) VALUES (1, 123054, 114);
+        INSERT INTO editor (id, name, password, ha1, email, email_confirm_date) VALUES (15412, 'editor', '{CLEARTEXT}mb', 'be88da857f697a78656b1307f89f90ab', 'foo@example.com', now());
+        INSERT INTO editor_collection (id, gid, editor, name, public, type) VALUES (14933, 'f34c079d-374e-4436-9448-da92dedef3cd', 15412, 'My Collection', TRUE, 1);
+        INSERT INTO editor_collection (id, gid, editor, name, public, type) VALUES (14934, '5e8dd65f-7d52-4d6e-93f6-f84651e137ca', 15412, 'My Private Collection', FALSE, 1);
+        INSERT INTO editor_collection_release (collection, release) VALUES (14933, 123054), (14934, 123054);
+EOSQL
+
+    my $common_release_json = {
+        id => "b3b7e934-445b-4c68-a097-730c6a6d47e6",
+        title => "Summer Reggae! Rainbow",
+        status => "Pseudo-Release",
+        quality => "normal",
+        "text-representation" => {
+            language => "jpn",
+            script => "Latn",
+        },
+        "cover-art-archive" => {
+            artwork => JSON::false,
+            count => 0,
+            front => JSON::false,
+            back => JSON::false,
+            darkened => JSON::false,
+        },
+        date => "2001-07-04",
+        country => "JP",
+        "release-events" => [{
+            date => "2001-07-04",
+            "area" => {
+                disambiguation => '',
+                "id" => "2db42837-c832-3c27-b4a3-08198f75693c",
+                "name" => "Japan",
+                "sort-name" => "Japan",
+                "iso-3166-1-codes" => ["JP"],
+            },
+        }],
+        barcode => "4942463511227",
+        asin => "B00005LA6G",
+        disambiguation => "",
+        packaging => JSON::null,
+    };
 
     ws_test_json 'basic release with collections',
-    '/release/b3b7e934-445b-4c68-a097-730c6a6d47e6?inc=collections' =>
-        {
-            id => "b3b7e934-445b-4c68-a097-730c6a6d47e6",
-            title => "Summer Reggae! Rainbow",
-            status => "Pseudo-Release",
-            quality => "normal",
-            "text-representation" => {
-                language => "jpn",
-                script => "Latn",
-            },
-            "cover-art-archive" => {
-                artwork => JSON::false,
-                count => 0,
-                front => JSON::false,
-                back => JSON::false,
-                darkened => JSON::false,
-            },
-            date => "2001-07-04",
-            country => "JP",
-            "release-events" => [{
-                date => "2001-07-04",
-                "area" => {
-                    disambiguation => '',
-                    "id" => "2db42837-c832-3c27-b4a3-08198f75693c",
-                    "name" => "Japan",
-                    "sort-name" => "Japan",
-                    "iso-3166-1-codes" => ["JP"],
-                },
-            }],
-            barcode => "4942463511227",
-            asin => "B00005LA6G",
-            disambiguation => "",
-            packaging => JSON::null,
+        '/release/b3b7e934-445b-4c68-a097-730c6a6d47e6?inc=collections' => {
+            %$common_release_json,
             collections => [
                 {
                     id => "f34c079d-374e-4436-9448-da92dedef3cd",
@@ -194,8 +197,32 @@ test 'basic release with collections' => sub {
                     type => "Release",
                     "entity-type" => "release",
                     "release-count" => 1
-                }]
+                },
+            ],
         };
+
+    ws_test_json 'basic release with private collections',
+        '/release/b3b7e934-445b-4c68-a097-730c6a6d47e6?inc=user-collections' => {
+            %$common_release_json,
+            collections => [
+                {
+                    id => "5e8dd65f-7d52-4d6e-93f6-f84651e137ca",
+                    name => "My Private Collection",
+                    editor => "editor",
+                    type => "Release",
+                    "entity-type" => "release",
+                    "release-count" => 1
+                },
+                {
+                    id => "f34c079d-374e-4436-9448-da92dedef3cd",
+                    name => "My Collection",
+                    editor => "editor",
+                    type => "Release",
+                    "entity-type" => "release",
+                    "release-count" => 1
+                },
+            ],
+        }, { username => 'editor', password => 'mb' };
 };
 
 test 'release lookup with artists + aliases' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -25,7 +25,8 @@ MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
 INSERT INTO release_tag (count, release, tag) VALUES (1, 123054, 114);
 INSERT INTO editor (id, name, password, ha1, email, email_confirm_date) VALUES (15412, 'editor', '{CLEARTEXT}mb', 'be88da857f697a78656b1307f89f90ab', 'foo@example.com', now());
 INSERT INTO editor_collection (id, gid, editor, name, public, type) VALUES (14933, 'f34c079d-374e-4436-9448-da92dedef3cd', 15412, 'My Collection', TRUE, 1);
-INSERT INTO editor_collection_release (collection, release) VALUES (14933, 123054);
+INSERT INTO editor_collection (id, gid, editor, name, public, type) VALUES (14934, '5e8dd65f-7d52-4d6e-93f6-f84651e137ca', 15412, 'My Private Collection', FALSE, 1);
+INSERT INTO editor_collection_release (collection, release) VALUES (14933, 123054), (14934, 123054);
 EOSQL
 
 ws_test 'basic release lookup',
@@ -220,6 +221,55 @@ ws_test 'basic release with collections',
         </cover-art-archive>
     </release>
 </metadata>';
+
+ws_test 'basic release with private collections',
+    '/release/b3b7e934-445b-4c68-a097-730c6a6d47e6?inc=user-collections' =>
+    '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <release id="b3b7e934-445b-4c68-a097-730c6a6d47e6">
+        <title>Summer Reggae! Rainbow</title>
+        <status>Pseudo-Release</status>
+        <quality>normal</quality>
+        <text-representation>
+            <language>jpn</language>
+            <script>Latn</script>
+        </text-representation>
+        <date>2001-07-04</date>
+        <country>JP</country>
+        <release-event-list count="1">
+            <release-event>
+                <date>2001-07-04</date>
+                <area id="2db42837-c832-3c27-b4a3-08198f75693c">
+                    <name>Japan</name>
+                    <sort-name>Japan</sort-name>
+                    <iso-3166-1-code-list>
+                        <iso-3166-1-code>JP</iso-3166-1-code>
+                    </iso-3166-1-code-list>
+                </area>
+            </release-event>
+        </release-event-list>
+        <barcode>4942463511227</barcode>
+        <asin>B00005LA6G</asin>
+        <collection-list count="2">
+            <collection type="Release" entity-type="release" id="f34c079d-374e-4436-9448-da92dedef3cd">
+                <name>My Collection</name>
+                <editor>editor</editor>
+                <release-list count="1"/>
+            </collection>
+            <collection type="Release" entity-type="release" id="5e8dd65f-7d52-4d6e-93f6-f84651e137ca">
+                <name>My Private Collection</name>
+                <editor>editor</editor>
+                <release-list count="1"/>
+            </collection>
+        </collection-list>
+        <cover-art-archive>
+            <artwork>false</artwork>
+            <count>0</count>
+            <front>false</front>
+            <back>false</back>
+        </cover-art-archive>
+    </release>
+</metadata>', { username => 'editor', password => 'mb' };
 
 ws_test 'release lookup with artists + aliases',
     '/release/aff4a693-5970-4e2e-bd46-e2ee49c22de7?inc=artists+aliases' =>


### PR DESCRIPTION
`inc=user-collections` will return private (and public) collections for the authenticated user. It does not imply `inc=collections` (which returns all public collections).

Was probably wrong to not do this in the previous PR. Should help fix one or two Picard tickets.