### PR TITLE
Output track artist aliases in /ws/2/release (MBS-7914)

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -116,10 +116,16 @@ sub release_toplevel
         }
 
         $c->model('Track')->load_for_mediums(@mediums);
-        $c->model('ArtistCredit')->load(map { $_->all_tracks } @mediums)
-            if ($c->stash->{inc}->artist_credits);
+        my @tracks = map { $_->all_tracks } @mediums;
 
-        my @recordings = $c->model('Recording')->load(map { $_->all_tracks } @mediums);
+        if ($c->stash->{inc}->artist_credits) {
+            $c->model('ArtistCredit')->load(@tracks);
+            my @acns = map { $_->artist_credit->all_names } @tracks;
+            $c->model('Artist')->load(@acns);
+            $self->_aliases($c, 'Artist', [uniq_by { $_->id } map { $_->artist } @acns], $stash);
+        }
+
+        my @recordings = $c->model('Recording')->load(@tracks);
         $c->model('Recording')->load_meta(@recordings);
 
         if ($c->stash->{inc}->recording_level_rels)

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -659,7 +659,7 @@ sub _serialize_track
         if $track->length;
 
     do {
-        local $show_aliases = 0;
+        local $show_aliases = 1;
         $self->_serialize_artist_credit(\@track, $gen, $track->artist_credit, $inc, $stash)
             if $inc->artist_credits &&
                 (

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
@@ -1200,4 +1200,98 @@ test 'release lookup, pregap track' => sub {
     };
 };
 
+
+test 'MBS-7914' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-7914');
+
+    ws_test_json 'track aliases are included (MBS-7914)',
+    '/release/a3ea3821-5955-4cee-b44f-4f7da8a332f7?inc=artists+media+recordings+artist-credits+aliases' => {
+        aliases => [],
+        'artist-credit' => [{
+            artist => {
+                aliases => [{
+                    locale => JSON::null,
+                    name => "グスタフ・マーラー",
+                    primary => JSON::null,
+                    'sort-name' => "グスタフ・マーラー",
+                    type => JSON::null
+                }],
+                disambiguation => '',
+                id => '8d610e51-64b4-4654-b8df-064b0fb7a9d9',
+                name => 'Gustav Mahler',
+                'sort-name' => 'Mahler, Gustav'
+            },
+            joinphrase => '',
+            name => 'Gustav Mahler'
+        }],
+        asin => JSON::null,
+        barcode => JSON::null,
+        'cover-art-archive' => {
+            artwork => JSON::false,
+            back => JSON::false,
+            count => 0,
+            darkened => JSON::false,
+            front => JSON::false
+        },
+        disambiguation => '',
+        id => 'a3ea3821-5955-4cee-b44f-4f7da8a332f7',
+        media => [{
+            format => JSON::null,
+            position => 1,
+            title => '',
+            'track-count' => 1,
+            'track-offset' => 0,
+            tracks => [{
+                'artist-credit' => [{
+                    artist => {
+                        aliases => [{
+                            locale => JSON::null,
+                            name => "グスタフ・マーラー",
+                            primary => JSON::null,
+                            'sort-name' => "グスタフ・マーラー",
+                            type => JSON::null
+                        }],
+                        disambiguation => '',
+                        id => '8d610e51-64b4-4654-b8df-064b0fb7a9d9',
+                        name => 'Gustav Mahler',
+                        'sort-name' => 'Mahler, Gustav'
+                    },
+                    joinphrase => '',
+                    name => 'Gustav Mahler'
+                }],
+                id => '8ac89142-1318-490a-bed2-5b0c89b251b2',
+                length => JSON::null,
+                number => '1',
+                recording => {
+                    aliases => [],
+                    'artist-credit' => [{
+                        artist => {
+                            disambiguation => '',
+                            id => '509c772e-1164-4457-8d09-0553cfa77d64',
+                            name => 'Chicago Symphony Orchestra',
+                            'sort-name' => 'Chicago Symphony Orchestra'
+                        },
+                        joinphrase => '',
+                        name => 'Chicago Symphony Orchestra'
+                    }],
+                    disambiguation => '',
+                    id => '36d398e2-85bf-40d5-8686-4f0b78c80ca8',
+                    length => JSON::null,
+                    title => 'Symphony no. 2 in C minor: I. Allegro maestoso',
+                    video => JSON::false
+                },
+                title => 'Symphony no. 2 in C minor: I. Allegro maestoso'
+            }]
+        }],
+        packaging => JSON::null,
+        quality => 'normal',
+        status => JSON::null,
+        'text-representation' => { language => JSON::null, script => JSON::null },
+        title => 'Symphony no. 2'
+    };
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -1553,4 +1553,74 @@ ws_test 'release lookup, pregap track',
 
 };
 
+test 'MBS-7914' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-7914');
+
+    ws_test 'track aliases are included (MBS-7914)',
+    '/release/a3ea3821-5955-4cee-b44f-4f7da8a332f7?inc=artists+media+recordings+artist-credits+aliases' =>
+    '<?xml version="1.0" ?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <release id="a3ea3821-5955-4cee-b44f-4f7da8a332f7">
+    <title>Symphony no. 2</title>
+    <quality>normal</quality>
+    <artist-credit>
+      <name-credit>
+        <artist id="8d610e51-64b4-4654-b8df-064b0fb7a9d9">
+          <name>Gustav Mahler</name>
+          <sort-name>Mahler, Gustav</sort-name>
+          <alias-list count="1">
+            <alias sort-name="グスタフ・マーラー">グスタフ・マーラー</alias>
+          </alias-list>
+        </artist>
+      </name-credit>
+    </artist-credit>
+    <cover-art-archive>
+      <artwork>false</artwork>
+      <count>0</count>
+      <front>false</front>
+      <back>false</back>
+    </cover-art-archive>
+    <medium-list count="1">
+      <medium>
+        <position>1</position>
+        <track-list count="1" offset="0">
+          <track id="8ac89142-1318-490a-bed2-5b0c89b251b2">
+            <position>1</position>
+            <number>1</number>
+            <artist-credit>
+              <name-credit>
+                <artist id="8d610e51-64b4-4654-b8df-064b0fb7a9d9">
+                  <name>Gustav Mahler</name>
+                  <sort-name>Mahler, Gustav</sort-name>
+                  <alias-list count="1">
+                    <alias sort-name="グスタフ・マーラー">グスタフ・マーラー</alias>
+                  </alias-list>
+                </artist>
+              </name-credit>
+            </artist-credit>
+            <recording id="36d398e2-85bf-40d5-8686-4f0b78c80ca8">
+              <title>Symphony no. 2 in C minor: I. Allegro maestoso</title>
+              <artist-credit>
+                <name-credit>
+                  <artist id="509c772e-1164-4457-8d09-0553cfa77d64">
+                    <name>Chicago Symphony Orchestra</name>
+                    <sort-name>Chicago Symphony Orchestra</sort-name>
+                    <alias-list count="1">
+                      <alias sort-name="CSO">CSO</alias>
+                    </alias-list>
+                  </artist>
+                </name-credit>
+              </artist-credit>
+            </recording>
+          </track>
+        </track-list>
+      </medium>
+    </medium-list>
+  </release>
+</metadata>';
+};
+
 1;

--- a/t/sql/mbs-7914.sql
+++ b/t/sql/mbs-7914.sql
@@ -1,0 +1,31 @@
+-- Automatically generated, do not edit.
+-- release a3ea3821-5955-4cee-b44f-4f7da8a332f7
+
+SET client_min_messages TO 'warning';
+
+INSERT INTO artist (area, begin_area, begin_date_day, begin_date_month, begin_date_year, comment, edits_pending, end_area, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type) VALUES
+	(NULL, NULL, 7, 7, 1860, '', 0, NULL, 18, 5, 1911, '1', 1, '8d610e51-64b4-4654-b8df-064b0fb7a9d9', 10293, '2014-08-13 10:00:45.722409-05', 'Gustav Mahler', 'Mahler, Gustav', 1);
+INSERT INTO artist_alias (artist, begin_date_day, begin_date_month, begin_date_year, edits_pending, end_date_day, end_date_month, end_date_year, ended, id, last_updated, locale, name, primary_for_locale, sort_name, type) VALUES
+	(10293, NULL, NULL, NULL, 0, NULL, NULL, NULL, '0', 69060, '2012-05-15 13:57:13.252186-05', NULL, 'グスタフ・マーラー', '0', 'グスタフ・マーラー', NULL);
+INSERT INTO artist_credit (artist_count, created, id, name, ref_count) VALUES
+	(1, '2011-05-16 11:32:11.963929-05', 10293, 'Gustav Mahler', 12630);
+INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES
+	(10293, 10293, '', 'Gustav Mahler', 0);
+INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES
+	(10293, '', 0, '9d693063-3b22-4834-bb97-701d37a4ed37', 1481234, '2016-03-10 11:58:56.073617-06', 'Symphony no. 2', NULL);
+INSERT INTO release (artist_credit, barcode, comment, edits_pending, gid, id, language, last_updated, name, packaging, quality, release_group, script, status) VALUES
+	(10293, NULL, '', 0, 'a3ea3821-5955-4cee-b44f-4f7da8a332f7', 1550385, NULL, '2016-03-10 11:58:59.048362-06', 'Symphony no. 2', NULL, -1, 1481234, NULL, NULL);
+INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES
+	(0, NULL, 1624904, '2016-03-10 11:59:01.045484-06', '', 1, 1550385, 1);
+INSERT INTO artist (area, begin_area, begin_date_day, begin_date_month, begin_date_year, comment, edits_pending, end_area, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type) VALUES
+	(NULL, NULL, NULL, NULL, 1891, '', 0, NULL, NULL, NULL, NULL, '0', NULL, '509c772e-1164-4457-8d09-0553cfa77d64', 9739, '2014-11-30 14:01:29.548519-06', 'Chicago Symphony Orchestra', 'Chicago Symphony Orchestra', 5);
+INSERT INTO artist_alias (artist, begin_date_day, begin_date_month, begin_date_year, edits_pending, end_date_day, end_date_month, end_date_year, ended, id, last_updated, locale, name, primary_for_locale, sort_name, type) VALUES
+	(9739, NULL, NULL, NULL, 0, NULL, NULL, NULL, '0', 58023, '2012-05-15 13:57:13.252186-05', NULL, 'CSO', '0', 'CSO', NULL);
+INSERT INTO artist_credit (artist_count, created, id, name, ref_count) VALUES
+	(1, '2011-05-16 11:32:11.963929-05', 9739, 'Chicago Symphony Orchestra', 59);
+INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES
+	(9739, 9739, '', 'Chicago Symphony Orchestra', 0);
+INSERT INTO recording (artist_credit, comment, edits_pending, gid, id, last_updated, length, name, video) VALUES
+	(9739, '', 0, '36d398e2-85bf-40d5-8686-4f0b78c80ca8', 17296700, '2016-03-10 12:02:23.150916-06', NULL, 'Symphony no. 2 in C minor: I. Allegro maestoso', '0');
+INSERT INTO track (artist_credit, edits_pending, gid, id, is_data_track, last_updated, length, medium, name, number, position, recording) VALUES
+	(10293, 0, '8ac89142-1318-490a-bed2-5b0c89b251b2', 17990346, '0', '2016-03-10 11:59:37.6962-06', NULL, 1624904, 'Symphony no. 2 in C minor: I. Allegro maestoso', '1', 1, 17296700);


### PR DESCRIPTION
Doesn't make sense to output aliases for recording artists but not track artists. Note that we already don't output the track AC at all if it's the same as the recording AC.

This will output duplicate data if the track and recording ACs share any artists. But I'd rather do that than have some weird rule that makes parsing the data like a puzzle (e.g., outputting track artist aliases where the artist doesn't appear in the recording AC, or something).