### PR TITLE
MBS-6381: Fetch images for entities from Wikidata

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -14,6 +14,7 @@ with 'MusicBrainz::Server::Controller::Role::Details';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
+with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
     endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -17,6 +17,7 @@ with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Rating';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
+with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type     => 'event',

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -25,6 +25,7 @@ with 'MusicBrainz::Server::Controller::Role::Rating';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::Subscribe';
 with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
+with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
     endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}]},

--- a/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
@@ -2,8 +2,13 @@ package MusicBrainz::Server::Controller::Role::CommonsImage;
 use Moose::Role -traits => 'MooseX::MethodAttributes::Role::Meta::Role';
 use List::UtilsBy qw( sort_by );
 use namespace::autoclean;
+use Readonly;
 
 requires 'load';
+
+Readonly my $WIKIDATA_PROP_IMAGE => "P18";
+Readonly my $WIKIDATA_PROP_LOGO_IMAGE => "P154";
+Readonly my $WIKIDATA_PROP_LOCATOR_MAP_IMAGE => "P242";
 
 after load => sub {
     my ($self, $c) = @_;
@@ -11,8 +16,7 @@ after load => sub {
     $self->_get_commons_image($c, 1);
 };
 
-sub commons_image : Chained('load') PathPart('commons-image')
-{
+sub commons_image : Chained('load') PathPart('commons-image') {
     my ($self, $c) = @_;
 
     $self->_get_commons_image($c, 0);
@@ -21,24 +25,53 @@ sub commons_image : Chained('load') PathPart('commons-image')
     $c->stash->{template} = 'components/commons-image.tt';
 }
 
-sub _get_commons_image
-{
+sub _get_commons_image {
     my ($self, $c, $cache_only) = @_;
 
     my $entity = $c->stash->{entity};
+    my $title;
+
+    # Check if there's a Wikimedia Commons relationship
     my ($commons_link) = map {
             $_->target;
         } grep {
             $_->target->isa('MusicBrainz::Server::Entity::URL::Commons')
         } @{ $entity->relationships_by_link_type_names('image') };
-
     if ($commons_link) {
-        my $page_name = $commons_link->page_name;
-        my $commons_image = $c->model('CommonsImage')->get_commons_image($page_name, cache_only => $cache_only);
-        if ($commons_image) {
-            $c->stash->{image} = $commons_image;
-        } else {
-            $c->stash->{image_url} = $c->uri_for_action($self->action_for('commons_image'), [ $entity->gid ]);
+        $title = $commons_link->page_name;
+    }
+
+    # and if not, check Wikidata entity
+    $title = _get_wikidata_image($c) if !$title;
+
+    my $commons_image = $c->model('CommonsImage')->get_commons_image($title, cache_only => $cache_only);
+    if ($commons_image) {
+        $c->stash->{image} = $commons_image;
+    } else {
+        $c->stash->{image_url} = $c->uri_for_action($self->action_for('commons_image'), [ $entity->gid ]);
+    }
+}
+
+sub _get_wikidata_image {
+    my ($c) = @_;
+    my $entity = $c->stash->{entity};
+
+    my ($wikidata_link) = map {
+            $_->target;
+        } grep {
+            $_->target->isa('MusicBrainz::Server::Entity::URL::Wikidata')
+        } @{ $entity->relationships_by_link_type_names('wikidata') };
+
+    if ($wikidata_link) {
+        my $properties = $c->model('WikidataProperties')->get_wikidata_properties($wikidata_link->pretty_name);
+        if ($entity->isa('MusicBrainz::Server::Entity::Area') &&
+            exists $properties->{$WIKIDATA_PROP_LOCATOR_MAP_IMAGE}) {
+            return "File:$properties->{$WIKIDATA_PROP_LOCATOR_MAP_IMAGE}[0]{mainsnak}{datavalue}{value}";
+        }
+        if (exists $properties->{$WIKIDATA_PROP_IMAGE}) {
+            return "File:$properties->{$WIKIDATA_PROP_IMAGE}[0]{mainsnak}{datavalue}{value}";
+        } elsif (exists $properties->{$WIKIDATA_PROP_LOGO_IMAGE}) {
+            return "File:$properties->{$WIKIDATA_PROP_LOGO_IMAGE}[0]{mainsnak}{datavalue}{value}";
         }
     }
 }

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -30,6 +30,7 @@ with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Subscribe';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
+with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'series'
 };

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -26,6 +26,7 @@ with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Cleanup';
 with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
+with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
     endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}

--- a/lib/MusicBrainz/Server/Data/Role/MediaWikiAPI.pm
+++ b/lib/MusicBrainz/Server/Data/Role/MediaWikiAPI.pm
@@ -52,10 +52,10 @@ sub _get_and_process_json
         return undef;
     }
 
-    # decode JSON
+    # decode JSON depending on the action
     my $content = decode_json(encode("utf-8", $response->content));
     if ($content->{query}) {
-        # Wikipedia
+        # Wikipedia (action: query)
         $content = $content->{query};
         # save title as passed in
         my $noncanonical = $title;
@@ -78,8 +78,11 @@ sub _get_and_process_json
 
         return {content => $ret->{$property}, title => $noncanonical, canonical => $title};
     } elsif ($content->{entities} && $content->{entities}{$title}) {
-        # Wikidata
+        # Wikidata (action: wbgetentities)
         return {content => $content->{entities}{$title}};
+    } elsif ($content->{claims}) {
+        # Wikidata (action: wbgetclaims)
+        return {content => $content->{claims}};
     } else {
         return undef;
     };

--- a/lib/MusicBrainz/Server/Data/WikidataProperties.pm
+++ b/lib/MusicBrainz/Server/Data/WikidataProperties.pm
@@ -1,0 +1,51 @@
+package MusicBrainz::Server::Data::WikidataProperties;
+use Moose;
+use namespace::autoclean;
+
+use Readonly;
+
+with 'MusicBrainz::Server::Data::Role::MediaWikiAPI';
+
+Readonly my $WIKIDATA_CACHE_TIMEOUT => 60 * 60 * 24 * 3; # 3 days
+
+sub get_wikidata_properties {
+    my ($self, $entity, $property) = @_;
+
+    my $url_pattern = "https://www.wikidata.org/w/api.php?action=wbgetclaims&format=json&entity=%s%s";
+    return $self->_fetch_cache_or_url($url_pattern,
+                                      "wikidata_property",
+                                      $WIKIDATA_CACHE_TIMEOUT,
+                                      $entity,
+                                      undef,
+                                      \&_wikidata_properties_callback);
+}
+
+sub _wikidata_properties_callback {
+    my (%opts) = @_;
+    return $opts{fetched}{content} if $opts{fetched}{content};
+}
+
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 MetaBrainz Foundation
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+=cut

--- a/root/area/layout.tt
+++ b/root/area/layout.tt
@@ -6,6 +6,8 @@
 
     [%~ IF !full_width ~%]
         [%~ WRAPPER 'layout/sidebar/shared-entity-sidebar.tt' entity=area ~%]
+            [%~ show_image() ~%]
+            
             <h2 class="area-information">[%~ l('Area information') ~%]</h2>
             [%~ WRAPPER 'layout/sidebar/properties.tt' ~%]
                 [%~ INCLUDE 'layout/sidebar/property.tt' label=l('Type:')

--- a/root/event/layout.tt
+++ b/root/event/layout.tt
@@ -6,6 +6,8 @@
 
     [%~ IF !full_width ~%]
         [%~ WRAPPER 'layout/sidebar/shared-entity-sidebar.tt' entity=event ~%]
+            [%~ show_image() ~%]
+
             <h2 class="event-information">[%~ l('Event information') ~%]</h2>
             [%~ WRAPPER 'layout/sidebar/properties.tt' ~%]
                 [%~ INCLUDE 'layout/sidebar/property.tt' label=l('Type:')

--- a/root/label/layout.tt
+++ b/root/label/layout.tt
@@ -9,6 +9,8 @@
         [%~ edit_links_add_entity.push({ url => c.uri_for_action('/release_editor/add', { label = label.gid }), text => l('Add release') }) ~%]
 
         [%~ WRAPPER 'layout/sidebar/shared-entity-sidebar.tt' entity=label edit_links_add_entity=edit_links_add_entity ~%]
+            [%~ show_image() ~%]
+            
             <h2 class="label-information">[%~ l('Label information') ~%]</h2>
             [%~ WRAPPER 'layout/sidebar/properties.tt' ~%]
                 [%~ INCLUDE 'layout/sidebar/property.tt' label=l('Type:')

--- a/root/series/layout.tt
+++ b/root/series/layout.tt
@@ -6,6 +6,8 @@
 
     [%~ IF !full_width ~%]
         [%~ WRAPPER 'layout/sidebar/shared-entity-sidebar.tt' entity=series ~%]
+            [%~ show_image() ~%]
+
             <h2 class="series-information">[%~ l('Series information') ~%]</h2>
             [%~ WRAPPER 'layout/sidebar/properties.tt' ~%]
                 [%~ INCLUDE 'layout/sidebar/property.tt' label=l('Type:')

--- a/root/work/layout.tt
+++ b/root/work/layout.tt
@@ -10,6 +10,8 @@
 
     [%~ IF !full_width ~%]
         [%~ WRAPPER 'layout/sidebar/shared-entity-sidebar.tt' entity=work ~%]
+            [%~ show_image() ~%]
+
             [%~ IF work.type || work.iswcs.size || work.language || work.attributes.size ~%]
                 <h2 class="work-information">[%~ l('Work information') ~%]</h2>
                 [%~ WRAPPER 'layout/sidebar/properties.tt' ~%]


### PR DESCRIPTION
For example, to get image for label [bf519cd2-4e1e-46bf-948b-615f75424606](https://beta.musicbrainz.org/label/bf519cd2-4e1e-46bf-948b-615f75424606) we can use https://www.wikidata.org/w/api.php?action=wbgetclaims&format=json&entity=Q330629&property=P154.

*http://tickets.musicbrainz.org/browse/MBS-6381*