### PR TITLE
MBS-8848: Own private collections ignored on entity pages

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -36,6 +36,7 @@ role
         my ($collections) = $c->model('Collection')->find_by({
             entity_id => $c->stash->{$entity_name}->id,
             entity_type => $entity_type,
+            show_private => $c->user->id,
         });
         $collections;
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/New.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/New.pm
@@ -34,6 +34,8 @@ test 'Create collection from release page adds the new release' => sub {
     $tx->is('count(//table[@class="tbl"]/tbody/tr)',
             "1", "one item in the table");
 
+    $mech->get_ok('/release/f34c079d-374e-4436-9448-da92dedef3ce');
+    $mech->content_contains('Remove from Super collection');
 };
 
 test 'Create collection with no release set does not add release' => sub {


### PR DESCRIPTION
Missed an arg to load private collections for the current user, when I refactored the `find_by` stuff.