### PR TITLE
Make menu work without JavaScript

### DIFF
--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -14,7 +14,7 @@ function userLink(userName, path) {
 }
 
 const AccountMenu = () => (
-  <li className="account">
+  <li className="account" tabindex="-1">
     <span className="menu-header">{$c.user.name}{'\xA0\u25BE'}</span>
     <ul>
       <li>
@@ -39,7 +39,7 @@ const DataMenu = () => {
   let userName = $c.user.name;
 
   return (
-    <li className="data">
+    <li className="data" tabindex="-1">
       <span className="menu-header">{l('My Data')}{'\xA0\u25BE'}</span>
       <ul>
         <li>
@@ -72,7 +72,7 @@ const DataMenu = () => {
 };
 
 const AdminMenu = () => (
-  <li className="admin">
+  <li className="admin" tabindex="-1">
     <span className="menu-header">{l('Admin')}{'\xA0\u25BE'}</span>
     <ul>
       {$c.user.is_location_editor &&
@@ -107,7 +107,7 @@ const AdminMenu = () => (
 );
 
 const UserMenu = (props) => (
-  <ul className="menu">
+  <ul className="menu" tabindex="-1">
     {$c.user && [
       <AccountMenu key={1} />,
       <DataMenu key={2} />,

--- a/root/layout/head.tt
+++ b/root/layout/head.tt
@@ -19,7 +19,9 @@
     <link rel="search" type="application/opensearchdescription+xml" title="[%- l("MusicBrainz: Track") -%]" href="[% c.uri_for('/static/search_plugins/opensearch/musicbrainz_track.xml') %]" />
     <noscript>
         <style type="text/css">
-          .menu li:focus ul { left: auto; }
+          .header > .right > .bottom > .menu > li:focus > ul {
+            left: auto;
+          }
         </style>
     </noscript>
     [%~ script_manifest('jed-' _ current_language _ '.js') ~%]

--- a/root/layout/head.tt
+++ b/root/layout/head.tt
@@ -19,7 +19,7 @@
     <link rel="search" type="application/opensearchdescription+xml" title="[%- l("MusicBrainz: Track") -%]" href="[% c.uri_for('/static/search_plugins/opensearch/musicbrainz_track.xml') %]" />
     <noscript>
         <style type="text/css">
-          #header-menu li:hover ul { left: auto; }
+          #header-menu li:hover ul, .menu li:hover ul { left: auto; }
         </style>
     </noscript>
     [%~ script_manifest('jed-' _ current_language _ '.js') ~%]

--- a/root/layout/head.tt
+++ b/root/layout/head.tt
@@ -19,7 +19,7 @@
     <link rel="search" type="application/opensearchdescription+xml" title="[%- l("MusicBrainz: Track") -%]" href="[% c.uri_for('/static/search_plugins/opensearch/musicbrainz_track.xml') %]" />
     <noscript>
         <style type="text/css">
-          #header-menu li:hover ul, .menu li:hover ul { left: auto; }
+          .menu li:focus ul { left: auto; }
         </style>
     </noscript>
     [%~ script_manifest('jed-' _ current_language _ '.js') ~%]

--- a/root/layout/header/bottom.tt
+++ b/root/layout/header/bottom.tt
@@ -12,7 +12,7 @@
 [%- END -%]
 
 <ul class="menu">
-    <li class="about">
+    <li class="about" tabindex="-1">
         <span class="menu-header">[% l('About Us') %]&#xA0;&#x25BE;</span>
         <ul>
             <li>
@@ -53,7 +53,7 @@
             </li>
         </ul>
     </li>
-    <li class="products">
+    <li class="products" tabindex="-1">
         <span class="menu-header">[% l('Products') %]&#xA0;&#x25BE;</span>
         <ul>
             <li>
@@ -88,7 +88,7 @@
             </li>
         </ul>
     </li>
-    <li class="search">
+    <li class="search" tabindex="-1">
         <span class="menu-header">[% l('Search') %]&#xA0;&#x25BE;</span>
         <ul>
             <li>
@@ -108,7 +108,7 @@
         </ul>
     </li>
     [%- IF c.user_exists -%]
-        <li class="editing">
+        <li class="editing" tabindex="-1">
             <span class="menu-header">[% l('Editing') %]&#xA0;&#x25BE;</span>
             <ul>
                 <li>
@@ -150,7 +150,7 @@
             </ul>
         </li>
     [%- END -%]
-    <li class="documentation">
+    <li class="documentation" tabindex="-1">
         <span class="menu-header">[% l('Documentation') %]&#xA0;&#x25BE;</span>
         <ul>
             <li>
@@ -184,7 +184,7 @@
     </li>
 
     [% IF server_languages.size > 1 -%]
-    <li class="language-selector">
+    <li class="language-selector" tabindex="-1">
         [% FOREACH language = server_languages; IF language.0 == current_language -%]
             <span class="menu-header">
                 [%- print_language_name(language, 1) -%]

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -104,7 +104,8 @@ const Layout = (props) => {
 
         <noscript>
           <style type="text/css">
-            {'#header-menu li:hover ul { left: auto; }'}
+            {'.header > .right > .bottom > .menu > li:focus > ul {
+            left: auto; }'}
           </style>
         </noscript>
 


### PR DESCRIPTION
This hopefully will make it only open the menu when it is clicked. That
is by using the CSS focus attribute, instead of the hover attribute
that was previously used. I guess I wasn’t paying attention then….