### PR TITLE
MBS-8591: up items per page to 100

### DIFF
--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -12,7 +12,7 @@ use Try::Tiny;
 
 __PACKAGE__->config(
     form_namespace => 'MusicBrainz::Server::Form',
-    paging_limit => 50,
+    paging_limit => 100,
 );
 
 sub not_found : Private

--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -284,8 +284,8 @@ sub construct_url_lists($$$@) {
         push @base_urls, $self->create_url_opts($c, $entity_type, $url, \%suffix_info, $id_info);
 
         if ($suffix_info{paginated}) {
-            # 50 items per page, and the first page is covered by the base.
-            my $paginated_count = ceil($id_info->{$suffix_info{paginated}} / 50) - 1;
+            # 100 items per page, and the first page is covered by the base.
+            my $paginated_count = ceil($id_info->{$suffix_info{paginated}} / 100) - 1;
 
             # Since we exclude page 1 above, this is for anything above 0.
             if ($paginated_count > 0) {


### PR DESCRIPTION
Double the number of items per page as per	MBS-8591 - the idea would be to put it on beta and see if it makes it noticeably slower (it doesn't seem to affect my sandbox much, but that's so horribly slow the difference is likely to be hard to notice there in the first place).

