### PR TITLE
MBS-8861: adding text if last login is empty

### DIFF
--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -92,9 +92,13 @@
         [% END %]
 
         [% IF c.user_exists AND (viewing_own_profile OR c.user.is_account_admin);
-             WRAPPER property name=l('Last login:');
-               UserDate.format(user.last_login_date);
-             END;
+            WRAPPER property name=l('Last login:');
+                IF user.last_login_date;
+                    UserDate.format(user.last_login_date);
+                ELSE;
+                    l("Hasn't logged in yet");
+                END;
+            END;
            END %]
 
         [% IF user.website && (user.has_confirmed_email_address || c.user.is_account_admin) %]


### PR DESCRIPTION
I *think* this should work just fine, although I couldn't test it because every user seems to have a last login date in my sandbox.