### PR TITLE
Instructions to install bzip2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -298,8 +298,12 @@ Creating the database
 
             gpg --recv-keys C777580F
             gpg --verify-files /tmp/dumps/*.asc
+            
+		Before you can actually import the dumps, make sure that bzip2 is installed:
 
-        If this is OK and you wish to continue, you can import them with:
+			apt-get install bzip2
+
+        If the GPG signing key is OK and you wish to continue, you can import them with:
 
             ./admin/InitDb.pl --createdb --import /tmp/dumps/mbdump*.tar.bz2 --echo
 
@@ -326,7 +330,7 @@ Creating the database
     database level:
 
         ALTER DATABASE musicbrainz_db SET statement_timeout TO 60000;
-
+    
 
 Starting the server
 -------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -330,7 +330,7 @@ Creating the database
     database level:
 
         ALTER DATABASE musicbrainz_db SET statement_timeout TO 60000;
-    
+
 
 Starting the server
 -------------------


### PR DESCRIPTION
bzip2 is not default installed on CentOS systems, so provide general instructions to do this always, even for other systems.