### PR TITLE
Update IRC and mailing list references.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -407,8 +407,8 @@ If you intend to run a server with translations, there are a few steps to follow
 Troubleshooting
 ---------------
 
-If you have any difficulties, feel free to ask in #musicbrainz-devel on
-irc.freenode.net, or email the [developer mailing list](http://lists.musicbrainz.org/mailman/listinfo/musicbrainz-devel).
+If you have any difficulties, feel free to ask in #metabrainz on irc.freenode.net,
+or ask on [our forums](https://community.metabrainz.org/c/musicbrainz).
 
 Please report any issues on our [bug tracker](http://tickets.musicbrainz.org/).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MusicBrainz is a user-maintained open community that collects music metadata
 and makes it available to the public in the form of a relational database.
 For more information, [visit our website](http://musicbrainz.org/doc/About).
 
-To get help, please join #musicbrainz-devel on irc.freenode.net
+To get help, please join #metabrainz on irc.freenode.net
 
 Installation
 ------------


### PR DESCRIPTION
We currently use #metabrainz for MusicBrainz server development discussion and https://community.metabrainz.org/ has replaced the mailing lists.