### PR TITLE
Added metabrainz_user_id field containing $c->user->id to /userinfo endpoint response

### DIFF
--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -345,6 +345,7 @@ sub userinfo : Local
     my $data = {
         sub => $c->user->name,
         profile => $c->uri_for_action('/user/profile', [ $c->user->name ])->as_string,
+        metabrainz_user_id => $c->user->id,
     };
 
     if ($c->user->website) {

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -516,6 +516,7 @@ test 'User info' => sub {
         zoneinfo => 'Europe/Bratislava',
         email => 'me@mysite.com',
         email_verified => JSON::true,
+        metabrainz_user_id => 1,
     });
 
     # Valid token without email
@@ -529,6 +530,7 @@ test 'User info' => sub {
         website => 'http://www.mysite.com/',
         gender => 'male',
         zoneinfo => 'Europe/Bratislava',
+        metabrainz_user_id => 1,
     });
 };
 


### PR DESCRIPTION
The /userinfo endpoint currently provides no invariant data about the user - the name and email can change. 3rd party applications that store additional information about users need invariant data to reliably match their own information to the user information from MusicBrainz.

This PR introduces an ID field into the /userinfo response, which contains the internal database ID of the user. As this is the user's PK, this is unlikely to change.