### PR TITLE
MBS-8800: Add a geodetic index on place

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,9 +35,9 @@ Prerequisites
         sudo apt-get install postgresql-9.x postgresql-server-dev-9.x postgresql-contrib-9.x postgresql-plperl-9.x
 
     Alternatively, you may compile PostgreSQL from source, but then make sure to
-    also compile the cube extension found in contrib/cube. The database import
-    script will take care of installing that extension into the database when it
-    creates the database for you.
+    also compile the cube and earthdistance extensions found in the contrib
+    directory. The database import script will take care of installing those
+    extensions into the database when it creates the database for you.
 
 4.  Git
 

--- a/admin/sql/CreateIndexes.sql
+++ b/admin/sql/CreateIndexes.sql
@@ -389,6 +389,7 @@ CREATE UNIQUE INDEX medium_format_idx_gid ON medium_format (gid);
 CREATE UNIQUE INDEX place_idx_gid ON place (gid);
 CREATE INDEX place_idx_name ON place (name);
 CREATE INDEX place_idx_area ON place (area);
+CREATE INDEX place_idx_geo ON place USING gist (ll_to_earth(coordinates[0], coordinates[1])) WHERE coordinates IS NOT NULL;
 
 CREATE INDEX place_alias_idx_place ON place_alias (place);
 CREATE UNIQUE INDEX place_alias_idx_primary ON place_alias (place, locale) WHERE primary_for_locale = TRUE AND locale IS NOT NULL;

--- a/admin/sql/DropIndexes.sql
+++ b/admin/sql/DropIndexes.sql
@@ -303,6 +303,7 @@ DROP INDEX place_alias_idx_place;
 DROP INDEX place_alias_idx_primary;
 DROP INDEX place_alias_type_idx_gid;
 DROP INDEX place_idx_area;
+DROP INDEX place_idx_geo;
 DROP INDEX place_idx_gid;
 DROP INDEX place_idx_name;
 DROP INDEX place_tag_idx_tag;

--- a/admin/sql/Extensions.sql
+++ b/admin/sql/Extensions.sql
@@ -2,6 +2,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS musicbrainz_unaccent WITH SCHEMA musicbrainz;
 CREATE EXTENSION IF NOT EXISTS musicbrainz_collate WITH SCHEMA musicbrainz;
 

--- a/admin/sql/sitemaps/CreateFKConstraints.sql
+++ b/admin/sql/sitemaps/CreateFKConstraints.sql
@@ -1,7 +1,7 @@
 -- Automatically generated, do not edit.
 \set ON_ERROR_STOP 1
 
-SET search_path = 'sitemaps';
+SET search_path = 'sitemaps', 'musicbrainz', 'public';
 
 ALTER TABLE artist_lastmod
    ADD CONSTRAINT artist_lastmod_fk_id

--- a/admin/sql/updates/20141226-geodesic-index.sql
+++ b/admin/sql/updates/20141226-geodesic-index.sql
@@ -1,0 +1,5 @@
+\set ON_ERROR_STOP 1
+
+CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;
+
+CREATE INDEX IF NOT EXISTS place_idx_geo ON place USING gist (ll_to_earth(coordinates[0], coordinates[1])) WHERE coordinates IS NOT NULL;

--- a/upgrade.json
+++ b/upgrade.json
@@ -25,8 +25,10 @@
 
   "23": {
     "slave": ["20160516-mbs-8838.sql",
-              "20160516-mbs-8720.sql"],
+              "20160516-mbs-8720.sql",
+              "20141226-geodesic-index.sql"],
     "standalone": ["20160516-mbs-8838.sql",
-                   "20160516-mbs-8720.sql"]
+                   "20160516-mbs-8720.sql",
+                   "20141226-geodesic-index.sql"]
   }
 }


### PR DESCRIPTION
Create the `earthdistance` extension and use it for a geodetic index on the `place` table, enabling fast queries for places near a given point or within a given region.