### PR TITLE
MBS-8928: Properly display not-logged-in error

### DIFF
--- a/root/release/edit/editnote.tt
+++ b/root/release/edit/editnote.tt
@@ -41,7 +41,7 @@
     </div>
 
     <!-- ko if: submissionError -->
-      <p class="error" data-bind="text: submissionError"></p>
+      <p class="error" data-bind="html: submissionError"></p>
     <!-- /ko -->
   </div>
 </div>

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -526,11 +526,18 @@ const ERROR_NO_CHANGES = 3;
         try {
             error = JSON.parse(data.responseText).error;
 
-            if (_.isObject(error) && error.errorCode === ERROR_NO_CHANGES) {
-                return false;
+            if (_.isObject(error)) {
+                if (error.errorCode === ERROR_NO_CHANGES) {
+                    return false;
+                }
+                if (error.message) {
+                    error = error.message;
+                } else {
+                    error = _.escape(data.statusText + ": " + data.status);
+                }
             }
         } catch (e) {
-            error = data.statusText + ": " + data.status;
+            error = _.escape(data.statusText + ": " + data.status);
         }
 
         releaseEditor.submissionError(error);


### PR DESCRIPTION
If the response contains an object with a "message" property, that should be what's displayed, not the object itself.