### PR TITLE
MBS-8656: Bring edit table indexes back into sync

### DIFF
--- a/admin/sql/updates/20151223-edit-note-index.sql
+++ b/admin/sql/updates/20151223-edit-note-index.sql
@@ -1,6 +1,9 @@
 \set ON_ERROR_STOP 1
 BEGIN;
 
+-- Broken index exists on totoro, drop it first.
+DROP INDEX IF EXISTS edit_note_idx_post_time_edit;
+
 -- For Data::EditNote::find_by_recipient
 CREATE INDEX CONCURRENTLY edit_note_idx_post_time_edit ON edit_note (post_time DESC, edit DESC);
 

--- a/admin/sql/updates/20160429-mbs-8656.sql
+++ b/admin/sql/updates/20160429-mbs-8656.sql
@@ -1,0 +1,14 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+-- MBS-8656: Bring edit table indexes back into sync
+DROP INDEX IF EXISTS edit_close_time_idx;
+DROP INDEX IF EXISTS edit_date_trunc_idx;
+DROP INDEX IF EXISTS edit_date_trunc_idx1;
+DROP INDEX IF EXISTS edit_date_trunc_idx2;
+DROP INDEX IF EXISTS edit_id_idx;
+DROP INDEX IF EXISTS edit_open_time_idx1;
+DROP INDEX IF EXISTS edit_status_idx;
+ALTER INDEX IF EXISTS edit_open_time_idx RENAME TO edit_idx_open_time;
+
+COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -26,7 +26,8 @@
   "23": {
     "slave": ["20160516-mbs-8838.sql",
               "20160516-mbs-8720.sql",
-              "20141226-geodesic-index.sql"],
+              "20141226-geodesic-index.sql",
+              "20160429-mbs-8656.sql"],
     "standalone": []
   }
 }

--- a/upgrade.json
+++ b/upgrade.json
@@ -27,7 +27,8 @@
     "slave": ["20160516-mbs-8838.sql",
               "20160516-mbs-8720.sql",
               "20141226-geodesic-index.sql",
-              "20160429-mbs-8656.sql"],
+              "20160429-mbs-8656.sql",
+              "20151223-edit-note-index.sql"],
     "standalone": []
   }
 }


### PR DESCRIPTION
I included `edit_note_idx_post_time_edit` in here too, as mentioned in https://github.com/metabrainz/musicbrainz-server/pull/271#issuecomment-208104239