### PR TITLE
Skip unnecessary update of a recently created edit

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -583,13 +583,6 @@ sub create {
     $edit->id($edit_id);
 
     $edit->post_insert;
-    my $post_insert_update = {
-        data => JSON->new->encode($edit->to_hash),
-        status => $edit->status,
-        type => $edit->edit_type,
-    };
-
-    $self->c->sql->update_row('edit', $post_insert_update, { id => $edit_id });
 
     $edit->adjust_edit_pending(+1) unless $edit->auto_edit;
 


### PR DESCRIPTION
After inserting a new edit, the `post_insert` hook is called, then the edit updated in case the hook changed the status, type, or data of the edit. However, no `post_insert` method actually does this, so remove the unnecessary update.