### PR TITLE
MBS-8940: Make banner dismissal temporary for banner editors

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Controller::Root;
 use Moose;
 use Try::Tiny;
+use List::Util qw( max );
+
 BEGIN { extends 'Catalyst::Controller' }
 
 # Import MusicBrainz libraries
@@ -231,6 +233,10 @@ sub begin : Private
         $alert = l('Our Redis server appears to be down; some features may not work as intended or expected.');
         warn "Redis connection to get alert failed: $_";
     };
+    if ($c->user_exists && $c->user->is_banner_editor) {
+        # For banner editors, show a dismissed banner again after 20 hours (MBS-8940)
+        $alert_mtime = max($alert_mtime, time()-20*60*60);
+    }
 
     # For displaying which git branch is active as well as last commit information
     # (only shown on staging servers)


### PR DESCRIPTION
Since banner message editors tend to forget about messages that they have dismissed previously and do not remove them, limit the effect of dismissing a banner to 20 hours for them. After that time, the banner will be reshown, but can be dismissed again (for another 20 hours). For regular users, the dismissal remains permanent as before, i.e. the banner will be hidden until a new banner message is set.