### PR TITLE
Serialize front cover in release index JSON-LD

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -16,7 +16,11 @@ with 'MusicBrainz::Server::Controller::Role::Details';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {}, aliases => {copy_stash => ['aliases']}, cover_art => {copy_stash => ['cover_art']}}
+    endpoints => {
+        show => {copy_stash => ['release_artwork']},
+        aliases => {copy_stash => ['aliases']},
+        cover_art => {copy_stash => ['cover_art']},
+    },
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'release'

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
@@ -43,6 +43,8 @@ around serialize => sub {
 
         if ($stash->store($entity)->{cover_art}) {
             $ret->{image} = list_or_single(map { artwork($_) } @{ $stash->store($entity)->{cover_art} });
+        } elsif ($stash->store($entity)->{release_artwork}) {
+            $ret->{image} = artwork($stash->store($entity)->{release_artwork});
         }
 
         if ($entity->all_mediums) {


### PR DESCRIPTION
This may fix the image previews Facebook generates when you link to a release page there. Thanks to @zas for reporting and helping test this.