### PR TITLE
MBS-8941: ACs don't change with release artist

### DIFF
--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -181,8 +181,17 @@ class ArtistCreditEditor extends React.Component {
     this.createBubble();
 
     const $bubble = $('#artist-credit-bubble');
-    const props = this.props;
+    const bubbleWasVisible = $bubble.is(':visible');
 
+    if (!show && !bubbleWasVisible) {
+      return;
+    }
+
+    if (bubbleWasVisible && $bubble.data('target') !== this.props.entity) {
+      return;
+    }
+
+    const props = this.props;
     if (show && props.beforeShow) {
       props.beforeShow(props, this.state);
     }
@@ -201,9 +210,6 @@ class ArtistCreditEditor extends React.Component {
       />,
       $bubble[0],
       show ? (() => {
-        const $button = $(this.refs.button);
-        const bubbleWasVisible = $bubble.is(':visible');
-
         this.positionBubble();
 
         if (!bubbleWasVisible) {


### PR DESCRIPTION
When all of the ArtistCreditEditor components mount, they each try to take over the (one) AC bubble on the screen. This can become a problem if you open the release AC bubble before mediums have loaded. If that happens, you'll likely end up editing the last track AC instead.