### PR TITLE
MBS-8942: Keep cursor position in artist field

### DIFF
--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -48,7 +48,7 @@ class Autocomplete extends React.Component {
     }
 
     autocomplete.element.prop('disabled', !!nextProps.disabled);
-    if (next) {
+    if (next && autocomplete.element.val() !== next.name) {
       autocomplete.element.val(next.name);
     }
 


### PR DESCRIPTION
Setting the value also resets the cursor position, so don't set it unless the value actually changed.