### PR TITLE
Silence overall sitemaps cron

### DIFF
--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -218,7 +218,10 @@ sub drop_temporary_tables {
                        artist_works
                        instrument_recordings
                        instrument_releases )) {
-        $sql->do("DROP TABLE IF EXISTS tmp_sitemaps_$table");
+        $sql->do(<<EOSQL);
+          SET client_min_messages TO WARNING;
+          DROP TABLE IF EXISTS tmp_sitemaps_$table;
+EOSQL
     }
     $sql->commit;
 }

--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -35,8 +35,7 @@ sub create_temporary_tables {
 
     $sql->begin;
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_direct_rgs
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_direct_rgs
              (artist INTEGER,
               rg     INTEGER,
               is_official BOOLEAN NOT NULL,
@@ -44,8 +43,7 @@ sub create_temporary_tables {
               PRIMARY KEY (artist, rg))
          ON COMMIT DELETE ROWS");
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_va_rgs
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_va_rgs
              (artist INTEGER,
               rg     INTEGER,
               is_official BOOLEAN NOT NULL,
@@ -53,24 +51,21 @@ sub create_temporary_tables {
               PRIMARY KEY (artist, rg))
          ON COMMIT DELETE ROWS");
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_direct_releases
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_direct_releases
              (artist  INTEGER,
               release INTEGER,
 
               PRIMARY KEY (artist, release))
          ON COMMIT DELETE ROWS");
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_va_releases
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_va_releases
              (artist  INTEGER,
               release INTEGER,
 
               PRIMARY KEY (artist, release))
          ON COMMIT DELETE ROWS");
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_recordings
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_recordings
              (artist        INTEGER,
               recording     INTEGER,
               is_video      BOOLEAN NOT NULL,
@@ -79,8 +74,7 @@ sub create_temporary_tables {
               PRIMARY KEY (artist, recording))
          ON COMMIT DELETE ROWS");
     $sql->do(
-        "SET client_min_messages TO WARNING;
-         CREATE TEMPORARY TABLE tmp_sitemaps_artist_works
+        "CREATE TEMPORARY TABLE tmp_sitemaps_artist_works
              (artist   INTEGER,
               work     INTEGER,
 
@@ -88,16 +82,14 @@ sub create_temporary_tables {
          ON COMMIT DELETE ROWS");
 
     $sql->do(
-         "SET client_min_messages TO WARNING;
-          CREATE TEMPORARY TABLE tmp_sitemaps_instrument_recordings
+         "CREATE TEMPORARY TABLE tmp_sitemaps_instrument_recordings
              (instrument INTEGER,
               recording  INTEGER,
 
               PRIMARY KEY (instrument, recording))
           ON COMMIT DELETE ROWS");
     $sql->do(
-         "SET client_min_messages TO WARNING;
-          CREATE TEMPORARY TABLE tmp_sitemaps_instrument_releases
+         "CREATE TEMPORARY TABLE tmp_sitemaps_instrument_releases
              (instrument INTEGER,
               release  INTEGER,
 


### PR DESCRIPTION
I hope this silences the cron emails we get every day where the entire message is just:
```
NOTICE:  table "tmp_sitemaps_artist_direct_rgs" does not exist, skipping
NOTICE:  table "tmp_sitemaps_artist_va_rgs" does not exist, skipping
NOTICE:  table "tmp_sitemaps_artist_direct_releases" does not exist, skipping
NOTICE:  table "tmp_sitemaps_artist_va_releases" does not exist, skipping
NOTICE:  table "tmp_sitemaps_artist_recordings" does not exist, skipping
NOTICE:  table "tmp_sitemaps_artist_works" does not exist, skipping
NOTICE:  table "tmp_sitemaps_instrument_recordings" does not exist, skipping
NOTICE:  table "tmp_sitemaps_instrument_releases" does not exist, skipping
```

Attempted this earlier in 6df8378, which is now reverted here because I apparently thought these messages were from the `CREATE TEMPORARY TABLE` statements. No idea what I was thinking.