### PR TITLE
Don't populate edit_note_recipient for own notes (related: MBS-8963)

### DIFF
--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1160,6 +1160,7 @@ BEGIN
         SELECT edit.editor, NEW.id
           FROM edit
          WHERE edit.id = NEW.edit
+           AND edit.editor != NEW.editor
     );
     RETURN NULL;
 END;

--- a/admin/sql/updates/20160602-mbs-8963.sql
+++ b/admin/sql/updates/20160602-mbs-8963.sql
@@ -1,0 +1,23 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+CREATE OR REPLACE FUNCTION a_ins_edit_note() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO edit_note_recipient (recipient, edit_note) (
+        SELECT edit.editor, NEW.id
+          FROM edit
+         WHERE edit.id = NEW.edit
+           AND edit.editor != NEW.editor
+    );
+    RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DELETE FROM edit_note_recipient
+    USING edit_note, edit
+    WHERE edit_note_recipient.edit_note = edit_note.id
+      AND edit_note.edit = edit.id
+      AND edit_note.editor = edit.editor
+      AND edit.editor = edit_note_recipient.recipient;
+
+COMMIT;

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -122,8 +122,7 @@ sub find_by_recipient {
         SELECT ${\($self->_columns)}
           FROM edit_note_recipient
           JOIN ${\($self->_table)} ON ${\($self->_table)}.id = edit_note_recipient.edit_note
-         WHERE editor != \$1
-           AND recipient = \$1
+         WHERE recipient = \$1
          ORDER BY post_time DESC, edit DESC
          LIMIT $LIMIT_FOR_EDIT_LISTING
 EOSQL


### PR DESCRIPTION
Stop storing rows in `edit_note_recipient` for edit notes left by the author of the edit. Makes the table a lot smaller and removes the need for a filter in `Data::EditNote::find_by_recipient`.

This means the table no longer maps any arbitrary edit note to the edit author. But we don't need to use it like that.