### PR TITLE
MBS-7963: Prevent >255-char release comments

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -202,7 +202,13 @@ sub process_entity {
     my ($c, $loader, $data) = @_;
 
     trim_string($data, 'name');
-    trim_string($data, 'comment');
+
+    if ($data->{comment}) {
+        trim_string($data, 'comment');
+        # MBS-7963
+        $data->{comment} = substr($data->{comment}, 0, 255);
+    }
+
     process_artist_credit($c, $loader, $data);
 }
 

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -248,7 +248,7 @@
       <tr>
         <td><label for="comment">[% l('Disambiguation:') %]</label></td>
         <td>
-          <input id="comment" type="text" data-bind="value: comment, controlsBubble: $root.commentBubble" />
+          <input id="comment" type="text" maxlength="255" data-bind="value: comment, controlsBubble: $root.commentBubble" />
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Add a maxlength attribute to the `<input />`, and if something somehow gets through, silently truncate it.