### PR TITLE
MBS-8951: Make recent notes handle NULL post_time

### DIFF
--- a/admin/sql/CreateIndexes.sql
+++ b/admin/sql/CreateIndexes.sql
@@ -127,7 +127,7 @@ CREATE INDEX edit_url_idx ON edit_url (url);
 CREATE INDEX edit_note_idx_edit ON edit_note (edit);
 CREATE INDEX edit_note_idx_editor ON edit_note (editor);
 CREATE INDEX edit_note_idx_post_time ON edit_note USING BRIN (post_time);
-CREATE INDEX edit_note_idx_post_time_edit ON edit_note (post_time DESC, edit DESC);
+CREATE INDEX edit_note_idx_post_time_edit ON edit_note (post_time DESC NULLS LAST, edit DESC);
 
 CREATE INDEX edit_note_recipient_idx_recipient ON edit_note_recipient (recipient);
 

--- a/admin/sql/updates/20160604-mbs-8951.sql
+++ b/admin/sql/updates/20160604-mbs-8951.sql
@@ -1,0 +1,4 @@
+\set ON_ERROR_STOP 1
+
+DROP INDEX CONCURRENTLY edit_note_idx_post_time_edit;
+CREATE INDEX CONCURRENTLY edit_note_idx_post_time_edit ON edit_note (post_time DESC NULLS LAST, edit DESC);

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -123,7 +123,7 @@ sub find_by_recipient {
           FROM edit_note_recipient
           JOIN ${\($self->_table)} ON ${\($self->_table)}.id = edit_note_recipient.edit_note
          WHERE recipient = \$1
-         ORDER BY post_time DESC, edit DESC
+         ORDER BY post_time DESC NULLS LAST, edit DESC
          LIMIT $LIMIT_FOR_EDIT_LISTING
 EOSQL
     $self->query_to_list_limited(


### PR DESCRIPTION
I guess old edit notes don't have a post time. Sort these last so that /edit/notes-received behaves correctly.