### PR TITLE
MBS-8977: Edit searches with relationship type conditions cause an internal server error

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
@@ -26,7 +26,7 @@ sub combine_with_query {
                                    (data#>>'{old,link_type,id}')::int,
                                    (data#>>'{new,link_type,id}')::int,
                                    (data#>>'{relationship,link_type,id}')::int
-                               ], NULL) )",
+                               ], NULL)",
         [ $self->sql_arguments ],
     ]);
 }


### PR DESCRIPTION
Tested this locally and the search doesn't ISE anymore.