### PR TITLE
MBS-7111: Improve URL matching of Musik-Sammler.de

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -737,6 +737,8 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/work\/([^\/?#]+)(?:.*)?$/, "http://trove.nla.gov.au/work/$1");
       url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/people\/([^\/?#]+)(?:.*)?$/, "http://nla.gov.au/nla.party-$1");
       url = url.replace(/^(?:https?:\/\/)?nla\.gov\.au\/(nla\.party-|anbd\.bib-an)([^\/?#]+)(?:.*)?$/, "http://nla.gov.au/$1$2");
+      // Standardising Musik-Sammler.de
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/(album|artist|media)\/([0-9a-z-]+)(?:[\/?#].*)?$/, "https://www.musik-sammler.de/$1/$2/");
       // Standardising Rockens Danmarkskort
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockensdanmarkskort\.dk\/steder\/(.*)+$/, "http://www.rockensdanmarkskort.dk/steder/$1");
       // Standardising RIC

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -110,6 +110,24 @@ test('Guess type', function (t) {
                 'release', 'http://musicmoz.org/Bands_and_Artists/S/Soundgarden/Discography/Superunknown/',
                 LINK_TYPES.otherdatabases.release
             ],
+            // Musik-Sammler.de
+            [
+                'artist', 'http://www.musik-sammler.de/artist/100743',
+                LINK_TYPES.otherdatabases.artist
+            ],
+            [
+                'artist', 'https://www.musik-sammler.de/artist/end-of-a-year/',
+                LINK_TYPES.otherdatabases.artist
+            ],
+            [
+                'release', 'http://www.musik-sammler.de/media/594158',
+                LINK_TYPES.otherdatabases.release
+            ],
+            [
+                'release_group', 'http://www.musik-sammler.de/album/364515',
+                LINK_TYPES.otherdatabases.release_group
+            ],
+            // Rock in China
             [
                 'artist', 'http://www.rockinchina.com/w/Beyond_Cure_(TW)',
                 LINK_TYPES.otherdatabases.artist
@@ -1389,6 +1407,27 @@ test('Cleanup', function (t) {
             [
                 'http://mora.jp/package/43000021/SQEX-20016_F/#',
                 'http://mora.jp/package/43000021/SQEX-20016_F/',
+            ],
+            // Musik-Sammler.de
+            [
+                'https://musik-sammler.de/artist/100743?test',
+                'https://www.musik-sammler.de/artist/100743/',
+                'artist'
+            ],
+            [
+                'http://www.musik-sammler.de/artist/end-of-a-year/#',
+                'https://www.musik-sammler.de/artist/end-of-a-year/',
+                'artist'
+            ],
+            [
+                'musik-sammler.de/media/594158',
+                'https://www.musik-sammler.de/media/594158/',
+                'release'
+            ],
+            [
+                'https://www.musik-sammler.de/album/804508/review/rain/',
+                'https://www.musik-sammler.de/album/804508/',
+                'release_group'
             ],
             // Soundtrack Collector
             [


### PR DESCRIPTION
- Normalize to `https://www.musik-sammler.de/(album|artist|media)/(id|clean-name)/`
- Add corresponding tests