### PR TITLE
MBS-8983: Fix report subscription filtering

### DIFF
--- a/lib/MusicBrainz/Server/Report.pm
+++ b/lib/MusicBrainz/Server/Report.pm
@@ -38,8 +38,8 @@ sub _load {
     my $ordering = $self->ordering;
 
     my ($rows, $hits) = $self->query_to_list_limited(
-        "SELECT DISTINCT report.* FROM $qualified_table report ORDER BY $ordering",
-        [],
+        "SELECT DISTINCT report.* FROM $qualified_table report $join_sql ORDER BY $ordering",
+        \@params,
         $limit,
         $offset,
         sub { $_[1] },


### PR DESCRIPTION
Adds back the `$join_sql` bit which was accidentally removed in 2d64080751192bb234ee1327ebc41df6db3530d2