### PR TITLE
MBS-8987: Don't run URL cleanup on existing URLs

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -429,7 +429,11 @@ MB.createExternalLinksEditor = function (options) {
     }
 
     _.each(urls, function (data) {
-      initialLinks.push(new LinkState({url: data.text || "", type: data.link_type_id, relationship: _.uniqueId('new-')}));
+      initialLinks.push(new LinkState({
+        url: URLCleanup.cleanURL(data.text) || data.text || '',
+        type: data.link_type_id,
+        relationship: _.uniqueId('new-'),
+      }));
     });
   }
 
@@ -442,11 +446,10 @@ MB.createExternalLinksEditor = function (options) {
   });
 
   initialLinks = initialLinks.map(function (link) {
-    var newData = {url: URLCleanup.cleanURL(link.url) || link.url};
     if (!_.isNumber(link.relationship)) {
-      newData.relationship = _.uniqueId('new-');
+      return link.set('relationship', _.uniqueId('new-'));
     }
-    return link.merge(newData);
+    return link;
   });
 
   var typeOptions = (


### PR DESCRIPTION
This makes it so that the URL cleanup is only run on seeded URLs, not ones that already exist. If you actually modify an existing URL, it'll trigger a cleanup, but as long as you don't touch it, no mysterious edits will be submitted anymore.