### PR TITLE
MBS-8999: Track lengths are in the wrong table column in the release editor

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -348,7 +348,7 @@
             <th class="reorder"></th>
             <th class="position">[% l('#') %]</th>
             <th class="title">[% l('Title') %]</th>
-            <th class="artist" colspan="2">[% l('Artist') %]</th>
+            <th class="artist">[% l('Artist') %]</th>
             <th class="length">[% l('Length') %]</th>
             <th class="icons"></th>
           </tr>


### PR DESCRIPTION
This broke when we released the new AC editor stuff, because now that's all in its own table (and the table is embedded in a single cell). Previously, the release editor had the open-ac button in a separate column.