### PR TITLE
MBS-9000: Escape and bidi-isolate entity aliases

### DIFF
--- a/root/components/aliases.tt
+++ b/root/components/aliases.tt
@@ -27,13 +27,13 @@
                     [%- show_sort_name = alias.name != alias.sort_name -%]
                     <td [% 'colspan="2"' IF !show_sort_name %]>
                       [% '<span class="mp">' IF alias.edits_pending %]
-                      [% alias.name %]
+                      [%~ isolate_text(alias.name) ~%]
                       [% '</span>' IF alias.edits_pending %]
                     </td>
 
                     [%- IF show_sort_name -%]
                     <td>
-                      [%- alias.sort_name | html -%]
+                      [%~ isolate_text(alias.sort_name) ~%]
                     </td>
                     [%- END -%]
 


### PR DESCRIPTION
An alias was put verbatim into the aliases page, even when it contained special characters. It was a bit better for the sort name, which was escaped, but `<bdi>` tags were missing on both.