### PR TITLE
MBS-8806: Don’t cache non-existent ACs as empty

### DIFF
--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -33,15 +33,14 @@ sub get_by_ids
         $counts{$id} = 0;
     }
     for my $row (@{ $self->sql->select_list_of_hashes($query, @ids) }) {
-        my %info = (
-            artist_id => $row->{artist},
-            name => $row->{ac_name}
-        );
-        $info{join_phrase} = $row->{join_phrase} // '';
-        my $obj = MusicBrainz::Server::Entity::ArtistCreditName->new(%info);
-        $obj->artist($self->c->model('Artist')->_new_from_row($row));
         my $id = $row->{artist_credit};
-        $result{$id}->add_name($obj);
+        my $acn = MusicBrainz::Server::Entity::ArtistCreditName->new(
+                      artist_id => $row->{artist},
+                      artist => $self->c->model('Artist')->_new_from_row($row),
+                      name => $row->{ac_name},
+                      join_phrase => $row->{join_phrase} // '',
+                  );
+        $result{$id}->add_name($acn);
         $counts{$id} += 1;
     }
     foreach my $id (@ids) {

--- a/t/sql/series.sql
+++ b/t/sql/series.sql
@@ -25,7 +25,13 @@ INSERT INTO link_attribute_text_value (link, attribute_type, text_value)
            (7, 788, 'WTF 99'),
            (8, 788, 'WTF 12');
 
+INSERT INTO artist (id, gid, name, sort_name) VALUES
+    (77, 'ac3a3195-ba87-4154-a937-bbc06aac4038', 'Some Artist', 'Some Artist');
+
 INSERT INTO artist_credit (id, name, artist_count) VALUES (1, 'Shared Name', 1);
+
+INSERT INTO artist_credit_name (artist_credit, position, artist, name) VALUES
+    (1, 0, 77, 'Shared Name');
 
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
     (1, '123c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 1, 123456),


### PR DESCRIPTION
When `Data::ArtistCredit::get_by_ids` was called with IDs that didn’t actually exist, it returned empty `ArtistCredit` entities for them. Those were then automatically put into the cache and persisted there. When an artist credit with the relevant ID later actually was created, the empty artist credit was displayed in its place until the old cache entry expired (MBS-8806). It is unclear how `get_by_ids` could be called with a not-yet-existing ID.

Only create and return an `ArtistCredit` entity for IDs actually found in the database. Also emit a stack trace when a non-existent ID is encountered in order to aid further debugging.