### PR TITLE
Correct a translated string

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -219,9 +219,7 @@
   </select>
 
   <br />
-  <p>[% l('Note: only searches edits that: add or edit relationships, created after 2011-05-16; ' _
-          'or which remove relationships, created after 2013-07-08; ' _
-          'or which reorder relationships.') %]</p>
+  <p>[% l('Note: only searches edits that: add or edit relationships, created after 2011-05-16; or which remove relationships, created after 2013-07-08; or which reorder relationships.') %]</p>
 [% END %]
 
 [% MACRO predicate_link(field, field_contents, autocomplete_name) WRAPPER wfield predicate="set" %]


### PR DESCRIPTION
Unfortunately, the string extractor for templates is not sophisticated enough to detect strings that are split into multiple parts and combined with the concatenation operator (`_`). It only finds the first part, which is then used as the ID in the translation files, breaking gettext.

Undo a split made in commit c4c1d1ae74b05528de6b73a1294524dc5402bd01.