### PR TITLE
Correctly validate Cover Art Archive IDs

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -63,7 +63,7 @@ our @EXPORT_OK = (
         $SERIES_ORDERING_TYPE_AUTOMATIC $SERIES_ORDERING_TYPE_MANUAL
         $SERIES_ORDERING_ATTRIBUTE
         $MAX_INITIAL_MEDIUMS
-        $MAX_POSTGRES_INT
+        $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
         @FULL_TABLE_LIST
         $CONTACT_URL
         %ENTITIES entities_with
@@ -356,6 +356,7 @@ Readonly our $PART_OF_AREA_LINK_TYPE => 'de7cc874-8b1b-3a05-8272-f3834c968fb7';
 Readonly our $MAX_INITIAL_MEDIUMS => 10;
 
 Readonly our $MAX_POSTGRES_INT => 2147483647;
+Readonly our $MAX_POSTGRES_BIGINT => 9223372036854775807;
 
 Readonly our $CONTACT_URL => 'https://metabrainz.org/contact';
 

--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::Data::Utils qw(
     object_to_ids
     placeholders
 );
+use MusicBrainz::Server::Validation qw( is_database_bigint_id );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Editable' => {
@@ -33,6 +34,11 @@ sub _columns
 sub _id_column
 {
     return 'cover_art_archive.cover_art.id';
+}
+
+sub is_valid_id {
+    (undef, my $id) = @_;
+    is_database_bigint_id($id)
 }
 
 sub _column_mapping

--- a/lib/MusicBrainz/Server/Data/Entity.pm
+++ b/lib/MusicBrainz/Server/Data/Entity.pm
@@ -67,10 +67,15 @@ sub _id_column
     return 'id';
 }
 
+sub is_valid_id {
+    (undef, my $id) = @_;
+    is_database_row_id($id)
+}
+
 sub get_by_ids {
     my ($self, @ids) = @_;
 
-    @ids = grep { is_database_row_id($_) } @ids;
+    @ids = grep { $self->is_valid_id($_) } @ids;
     return {} unless @ids;
 
     my %result = map { $_->id => $_ } $self->_get_by_keys($self->_id_column, uniq(@ids));
@@ -86,7 +91,7 @@ sub _warn_about_invalid_ids {
 sub get_by_any_id {
     my ($self, $any_id) = @_;
 
-    return $self->get_by_id($any_id) if is_database_row_id($any_id);
+    return $self->get_by_id($any_id) if $self->is_valid_id($any_id);
     return $self->get_by_gid($any_id) if is_guid($any_id);
     $self->_warn_about_invalid_ids([$any_id]);
     return;
@@ -96,7 +101,7 @@ sub get_by_any_ids {
     my ($self, @any_ids) = @_;
 
     my ($ids, $gids, $invalid) = part {
-        is_database_row_id($_) ? 0 : (is_guid($_) ? 1 : 2)
+        $self->is_valid_id($_) ? 0 : (is_guid($_) ? 1 : 2)
     } @any_ids;
 
     my %result;

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -33,6 +33,7 @@ require Exporter;
         is_integer
         is_positive_integer
         is_database_row_id
+        is_database_bigint_id
         is_guid
         trim_in_place
         is_valid_iswc
@@ -67,7 +68,7 @@ use List::AllUtils qw( any );
 use Encode qw( decode encode );
 use Scalar::Util qw( looks_like_number );
 use Text::Unaccent qw( unac_string_utf16 );
-use MusicBrainz::Server::Constants qw( $MAX_POSTGRES_INT );
+use MusicBrainz::Server::Constants qw( $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT );
 use utf8;
 
 sub unaccent_utf16 ($)
@@ -96,6 +97,12 @@ sub is_database_row_id {
     my $t = shift;
 
     is_positive_integer($t) and $t <= $MAX_POSTGRES_INT;
+}
+
+sub is_database_bigint_id {
+    my $t = shift;
+
+    is_positive_integer($t) and $t <= $MAX_POSTGRES_BIGINT;
 }
 
 sub is_guid

--- a/t/lib/t/MusicBrainz/Server/Data/Artwork.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artwork.pm
@@ -31,13 +31,15 @@ INSERT INTO cover_art_archive.image_type (mime_type, suffix)
 VALUES ('image/png', 'png');
 INSERT INTO cover_art_archive.cover_art
   (id, release, edit, ordering, mime_type)
-VALUES (1, 1, 1, 1, 'image/png'), (2, 2, 2, 1, 'image/png');
-INSERT INTO cover_art_archive.cover_art_type (id, type_id) VALUES (1, 1), (2, 1);
+VALUES (9876543210, 1, 1, 1, 'image/png'), (2, 2, 2, 1, 'image/png');
+INSERT INTO cover_art_archive.cover_art_type (id, type_id) VALUES (9876543210, 1), (2, 1);
 EOSQL
 
     my $release_group = $c->model('ReleaseGroup')->get_by_id(1);
     $c->model('Artwork')->load_for_release_groups($release_group);
-    is($release_group->cover_art->id, 1);
+    is($release_group->cover_art->id, 9876543210);
+
+    ok($c->model('Artwork')->is_valid_id($release_group->cover_art->id), 'CAA ID larger than INT_MAX is considered valid');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -25,6 +25,7 @@ use MusicBrainz::Server::Validation qw(
     is_valid_ean
     is_valid_partial_date
     is_database_row_id
+    is_database_bigint_id
 );
 
 test 'Test trim_in_place' => sub {
@@ -65,6 +66,16 @@ test 'Test is_database_row_id' => sub {
     ok(!is_database_row_id(undef), 'undef is not a row id');
     ok(!is_database_row_id([1, 2, 3, 4]), 'arrayref is not a row id');
     ok(!is_database_row_id({blah => 'foo', bar => 3}), 'hashref is not a row id');
+};
+
+test 'Test is_database_bigint_id' => sub {
+    ok(is_database_bigint_id(1), "1 is a bigint");
+    ok(is_database_bigint_id(2147483647), 'max postgres int is a bigint ID');
+    ok(is_database_bigint_id(2147483648), '(max postgres int + 1) is a bigint ID');
+    ok(is_database_bigint_id(9223372036854775807), 'max postgres bigint is a bigint ID');
+    ok(!is_database_bigint_id(9223372036854775808), '(max postgres bigint + 1) is not a bigint ID');
+    ok(!is_database_bigint_id(0), 'zero is not a bigint ID');
+    ok(!is_database_bigint_id(-1), 'negative integer is not a bigint ID');
 };
 
 test 'Test is_guid' => sub {


### PR DESCRIPTION
IDs in the Cover Art Archive are `BIGINT`s, but they were only accepted as valid if they were in the range of an `INT`. This caused cover art not to be loaded in the normal way for edits, and also caused spurious warnings by `get_by_any_id(s)`.

Add a new `is_valid_id` method to `Data::Entity` and override it for `Data::Artwork` to allow `BIGINT` values.