### PR TITLE
MBS-8451: Turn WP/WD URLs into https on cleanup

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CommonsImage.pm
+++ b/lib/MusicBrainz/Server/Entity/CommonsImage.pm
@@ -20,7 +20,7 @@ has 'thumb_url' => (
 sub page_url
 {
     my $self = shift;
-    return sprintf "//commons.wikimedia.org/wiki/%s", $self->title;
+    return sprintf "https://commons.wikimedia.org/wiki/%s", $self->title;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/static/images/attribution.txt
+++ b/root/static/images/attribution.txt
@@ -47,7 +47,7 @@ Images:
 Image set:   famfamfam flag icons
 Author:      Mark James (original set), various (additional images)
 License:     Public Domain (original set, see: famfamfam_flag_icons/readme.txt), Public Domain, CC0 (additional images)
-Download:    http://www.famfamfam.com/lab/icons/flags/ and http://commons.wikimedia.org/wiki/Category:Famfamfam_flag_icons
+Download:    http://www.famfamfam.com/lab/icons/flags/ and https://commons.wikimedia.org/wiki/Category:Famfamfam_flag_icons
 Images:
 
     flags/*

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -223,8 +223,8 @@ const CLEANUPS = {
       url = url.replace(/^https:\/\/secure\.wikimedia\.org\/wikipedia\/([a-z-]+)\/wiki\/(.*)/, "https://$1.wikipedia.org/wiki/$2");
       url = url.replace(/^http:\/\/wikipedia\.org\/(.+)$/, "https://en.wikipedia.org/$1");
       url = url.replace(/\.wikipedia\.org\/w\/index\.php\?title=([^&]+).*/, ".wikipedia.org/wiki/$1");
-      url = url.replace(/(?:\.m)?\.wikipedia\.org\/[a-z-]+\/([^?]+)$/, ".wikipedia.org/wiki/$1");
       url = url.replace(/\?oldformat=true$/, '');
+      url = url.replace(/^(?:https?:\/\/)?([a-z-]+)(?:\.m)?\.wikipedia\.org\/[a-z-]+\/([^?]+)$/, "https://$1.wikipedia.org/wiki/$2");
       var m = url.match(/^(.*\.wikipedia\.org\/wiki\/)([^?#]+)(.*)$/);
       if (m) {
         url = m[1] + encodeURIComponent(decodeURIComponent(m[2])).replace(/%20/g, "_").replace(/%24/g, "$").replace(/%2C/g, ",").replace(/%2F/g, "/").replace(/%3A/g, ":").replace(/%3B/g, ";").replace(/%40/g, "@") + m[3];
@@ -623,7 +623,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?([^/]+\\.)?wikidata\\.org","i")],
     type: LINK_TYPES.wikidata,
     clean: function (url) {
-      return url.replace(/^(https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/wiki\/(Q([0-9]+)).*$/, "$1www.wikidata.org/wiki/$2");
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/wiki\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
     }
   },
   bandcamp: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1608,7 +1608,7 @@ test('Cleanup', function (t) {
             // MBS-8457: Remove "?oldformat=true" from Wikipedia URLs
             [
                 'http://en.wikipedia.org/wiki/Ramesh_Vinayakam?oldformat=true',
-                'http://en.wikipedia.org/wiki/Ramesh_Vinayakam'
+                'https://en.wikipedia.org/wiki/Ramesh_Vinayakam'
             ],
             // BookBrainz
             [

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1345,6 +1345,10 @@ test('Cleanup', function (t) {
                 'http://wikipedia.org/wiki/Oberhofer',
                 'https://en.wikipedia.org/wiki/Oberhofer',
             ],
+            [
+                'it.wikipedia.org/wiki/Foo',
+                'https://it.wikipedia.org/wiki/Foo',
+            ],
             // Open Library
             [
                 'http://openlibrary.org/books/OL8993487M/Harry_Potter_and_the_Philosopher\'s_Stone',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1349,6 +1349,15 @@ test('Cleanup', function (t) {
                 'it.wikipedia.org/wiki/Foo',
                 'https://it.wikipedia.org/wiki/Foo',
             ],
+            // Wikidata
+            [
+                'https://www.wikidata.org/wiki/Q638',
+                'https://www.wikidata.org/wiki/Q638',
+            ],
+            [
+                'http://www.wikidata.org/wiki/Q14005#sitelinks-wikipedia',
+                'https://www.wikidata.org/wiki/Q14005',
+            ],
             // Open Library
             [
                 'http://openlibrary.org/books/OL8993487M/Harry_Potter_and_the_Philosopher\'s_Stone',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -28,7 +28,7 @@ test('Guess type', function (t) {
                 LINK_TYPES.wikipedia.artist
             ],
             [
-                'release_group', 'http://en.wikipedia.org/wiki/Exorcise_the_Demons',
+                'release_group', 'https://en.wikipedia.org/wiki/Exorcise_the_Demons',
                 LINK_TYPES.wikipedia.release_group
             ],
             [
@@ -164,15 +164,15 @@ test('Guess type', function (t) {
             ],
             // Wikimedia Commons
             [
-                'artist', 'http://commons.wikimedia.org/wiki/File:NIN2008.jpg',
+                'artist', 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',
                 LINK_TYPES.image.artist
             ],
             [
-                'label', 'http://commons.wikimedia.org/wiki/File:EMI_Records.svg',
+                'label', 'https://commons.wikimedia.org/wiki/File:EMI_Records.svg',
                 LINK_TYPES.image.label
             ],
             [
-                'work', 'http://commons.wikimedia.org/wiki/File:Kimigayo.score.png',
+                'work', 'https://commons.wikimedia.org/wiki/File:Kimigayo.score.png',
                 LINK_TYPES.image.work
             ],
             // CPDL
@@ -619,19 +619,19 @@ test('Guess type', function (t) {
             ],
             // Wikidata
             [
-                'artist', 'http://www.wikidata.org/wiki/Q42',
+                'artist', 'https://www.wikidata.org/wiki/Q42',
                 LINK_TYPES.wikidata.artist
             ],
             [
-                'label', 'http://www.wikidata.org/wiki/Q42',
+                'label', 'https://www.wikidata.org/wiki/Q42',
                 LINK_TYPES.wikidata.label
             ],
             [
-                'release_group', 'http://www.wikidata.org/wiki/Q42',
+                'release_group', 'https://www.wikidata.org/wiki/Q42',
                 LINK_TYPES.wikidata.release_group
             ],
             [
-                'work', 'http://www.wikidata.org/wiki/Q42',
+                'work', 'https://www.wikidata.org/wiki/Q42',
                 LINK_TYPES.wikidata.work
             ],
             // Rockipedia
@@ -1327,17 +1327,19 @@ test('Cleanup', function (t) {
                 'label'
             ],
             [
-                'http://en.wikipedia.org/wiki/$&+,/:;=@[]%20%23%24%25%2B%2C%2F%3A%3B%3F%40',
-                'http://en.wikipedia.org/wiki/$%26%2B,/:;%3D@%5B%5D_%23$%25%2B,/:;%3F@',
+                'https://en.wikipedia.org/wiki/$&+,/:;=@[]%20%23%24%25%2B%2C%2F%3A%3B%3F%40',
+                'https://en.wikipedia.org/wiki/$%26%2B,/:;%3D@%5B%5D_%23$%25%2B,/:;%3F@',
                 'label'
             ],
             [
                 'http://userserve-ak.last.fm/serve/_/13629495/Lab+Beat+Lab_Beat_Logo_500.gif',
                 'http://userserve-ak.last.fm/serve/_/13629495/Lab+Beat+Lab_Beat_Logo_500.gif'
             ],
+
+            // Wikipedia
             [
-                'http://sv.m.wikipedia.org/wiki/Bullet',
-                'http://sv.wikipedia.org/wiki/Bullet',
+                'https://sv.m.wikipedia.org/wiki/Bullet',
+                'https://sv.wikipedia.org/wiki/Bullet',
             ],
             [
                 'http://wikipedia.org/wiki/Oberhofer',

--- a/root/static/scripts/tests/externalLinks.js
+++ b/root/static/scripts/tests/externalLinks.js
@@ -44,7 +44,7 @@ function not_contains(t, $mountPoint, selector, description) {
 externalLinksTest("automatic link type detection for URL", function (t, $mountPoint, component, addURL) {
     t.plan(2);
 
-    addURL("http://en.wikipedia.org/wiki/No_Age");
+    addURL("https://en.wikipedia.org/wiki/No_Age");
 
     contains(t, $mountPoint, '.wikipedia-favicon', 'wikipedia favicon is used');
     contains(t, $mountPoint, ':contains(Wikipedia)', 'wikipedia label is used');
@@ -58,7 +58,7 @@ externalLinksTest("invalid URL detection", function (t, $mountPoint, component, 
 
     triggerChange(
         ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'input')[0],
-        'http://en.wikipedia.org/wiki/No_Age'
+        'https://en.wikipedia.org/wiki/No_Age'
     );
 
     not_contains(t, $mountPoint, ':contains(Enter a valid url)', 'error is removed after valid URL is entered');
@@ -124,21 +124,21 @@ externalLinksTest("hidden input data for form submission", function (t, $mountPo
 
     MB.relationshipEditor.prepareSubmission('edit-artist');
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.relationship_id]").val(), "1");
-    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "http://en.wikipedia.org/wiki/Deerhunter");
+    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "https://en.wikipedia.org/wiki/Deerhunter");
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.link_type_id]").val(), "179");
     t.equal($re.find("input[name=edit-artist\\.url\\.1\\.text]").val(), "http://rateyourmusic.com/artist/deerhunter");
     t.equal($re.find("input[name=edit-artist\\.url\\.1\\.link_type_id]").val(), "188");
 
     triggerChange(
         $mountPoint.find('input[type=url]:eq(0)')[0],
-        'http://en.wikipedia.org/wiki/dEErHuNtER'
+        'https://en.wikipedia.org/wiki/dEErHuNtER'
     );
 
     triggerClick($mountPoint.find('button:eq(1)')[0]);
 
     MB.relationshipEditor.prepareSubmission('edit-artist');
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.relationship_id]").val(), "1");
-    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "http://en.wikipedia.org/wiki/dEErHuNtER");
+    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "https://en.wikipedia.org/wiki/dEErHuNtER");
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.link_type_id]").val(), "179");
 
     triggerClick($mountPoint.find('button:eq(0)')[0]);
@@ -146,7 +146,7 @@ externalLinksTest("hidden input data for form submission", function (t, $mountPo
     MB.relationshipEditor.prepareSubmission('edit-artist');
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.relationship_id]").val(), "1");
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.removed]").val(), "1");
-    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "http://en.wikipedia.org/wiki/Deerhunter");
+    t.equal($re.find("input[name=edit-artist\\.url\\.0\\.text]").val(), "https://en.wikipedia.org/wiki/Deerhunter");
     t.equal($re.find("input[name=edit-artist\\.url\\.0\\.link_type_id]").val(), "179");
 
     $re.remove();
@@ -155,7 +155,7 @@ externalLinksTest("hidden input data for form submission", function (t, $mountPo
 [
     {
         id: 1,
-        target: MB.entity.URL({ name: "http://en.wikipedia.org/wiki/Deerhunter" }),
+        target: MB.entity.URL({ name: "https://en.wikipedia.org/wiki/Deerhunter" }),
         linkTypeID: 179
     }
 ]);


### PR DESCRIPTION
All Wikimedia projects are https-only now; http requests will be redirected. In light of this and the fact that the external links editor will no longer run cleanup on unchanged pre-existing URLs (MBS-8987), make the URL cleanup code change Wikipedia and Wikidata URLs to https. Also link to Wikimedia Commons using https.

Includes some related updates in tests and documentation.