### PR TITLE
Postgres version fixes

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -75,7 +75,7 @@ sub RequireMinimumPostgreSQLVersion
     $version =~ s/PostgreSQL ([0-9\.]*)(?:beta[0-9]*)? .*/$1/;
 
     if (version->parse("v".$version) < version->parse('v9.5')) {
-        die 'MusicBrainz requires PostgreSQL 9.5 on later';
+        die 'MusicBrainz requires PostgreSQL 9.5 or later';
     }
 }
 

--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -30,7 +30,6 @@ use warnings;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use version;
 
 use DBDefs;
 use MusicBrainz::Server::Replication ':replication_type';
@@ -71,10 +70,9 @@ sub RequireMinimumPostgreSQLVersion
     my $mb = Databases->get_connection('SYSTEM');
     my $sql = Sql->new( $mb->conn );
 
-    my $version = $sql->select_single_value("SELECT version();");
-    $version =~ s/PostgreSQL ([0-9\.]*)(?:beta[0-9]*)? .*/$1/;
+    my $version = $sql->select_single_value("SELECT current_setting('server_version_num')");
 
-    if (version->parse("v".$version) < version->parse('v9.5')) {
+    if ($version < 90500) {
         die 'MusicBrainz requires PostgreSQL 9.5 or later';
     }
 }

--- a/admin/functions.sh
+++ b/admin/functions.sh
@@ -20,14 +20,3 @@ make_temp_dir()
     # accumulating temporary directories over time.
     trap 'rmdir "$TEMP_DIR"' 0 1 2 3 15
 }
-
-compare_postgres_version ()
-{
-    PG_VERSION=$( echo "SELECT version()" | ./admin/psql READWRITE | grep 'PostgreSQL' | sed 's/^.*PostgreSQL \([0-9\.]*\).*/\1/' );
-
-    SCRIPT="print version->parse('v$PG_VERSION') >= version->parse('v$1') ? 'newer' : 'older';";
-    RESULT=`perl -Mversion -e "$SCRIPT"`;
-
-    echo "$RESULT";
-}
-


### PR DESCRIPTION
As it happens, I had recently also stumbled over the outdated Postgres version check now fixed in #334. Here are some related improvements: A typo in the error message, using the machine-readable Pg version instead of parsing the human-readable version (which is guaranteed to keep its format, see https://www.postgresql.org/message-id/4422.1465937807%40sss.pgh.pa.us), and removing an unused version comparison function.