### PR TITLE
MBS-8961: Relationship table mixes "guest"/"additional" and instrument attributes.

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -53,8 +53,6 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_ARTIST_EDITCREDIT
     $EDIT_RELATIONSHIP_DELETE
     $ARTIST_ARTIST_COLLABORATION
-    $INSTRUMENT_ROOT_ID
-    $VOCAL_ROOT_ID
 );
 use MusicBrainz::Server::Form::Artist;
 use MusicBrainz::Server::Form::Confirm;
@@ -269,15 +267,7 @@ sub show : PathPart('') Chained('load')
               identities => \@identities);
 }
 
-sub relationships : Chained('load') PathPart('relationships')
-{
-  my ($self, $c) = @_;
-  $c->stash(server_constants =>
-            {
-             INSTRUMENT_ROOT_ID => $INSTRUMENT_ROOT_ID,
-             VOCAL_ROOT_ID      => $VOCAL_ROOT_ID,
-            });
-}
+sub relationships : Chained('load') PathPart('relationships') {}
 
 =head2 works
 

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -53,6 +53,8 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_ARTIST_EDITCREDIT
     $EDIT_RELATIONSHIP_DELETE
     $ARTIST_ARTIST_COLLABORATION
+    $INSTRUMENT_ROOT_ID
+    $VOCAL_ROOT_ID
 );
 use MusicBrainz::Server::Form::Artist;
 use MusicBrainz::Server::Form::Confirm;
@@ -267,7 +269,15 @@ sub show : PathPart('') Chained('load')
               identities => \@identities);
 }
 
-sub relationships : Chained('load') PathPart('relationships') {}
+sub relationships : Chained('load') PathPart('relationships')
+{
+  my ($self, $c) = @_;
+  $c->stash(server_constants =>
+            {
+             INSTRUMENT_ROOT_ID => $INSTRUMENT_ROOT_ID,
+             VOCAL_ROOT_ID      => $VOCAL_ROOT_ID,
+            });
+}
 
 =head2 works
 

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -31,11 +31,24 @@
                     [%~ END ~%]
                     <td>
                       [%~ IF rel.link.attributes.size ~%]
-                      [%~ attr_list = [];
+                      [%~ attr_list1 = []; attr_list2 = [];
+                          instrument_root = '0abd7f04-5e28-425b-956f-94789d9bcbe2';
+                          vocals_root     = 'd92884b7-ee0c-46d5-96f3-918196ba8c5b';
                           FOR attr=rel.link.attributes;
-                            attr_list.push(attr.html);
+                            IF attr.type.root.gid == instrument_root OR attr.type.root.gid == vocals_root;
+                              attr_list2.push(attr.html);
+                            ELSE;
+                              attr_list1.push(attr.html);
+                            END;
                           END;
-                          comma_list(attr_list);
+                          IF attr_list1.size AND attr_list2.size;
+                            FOR text = attr_list1; text; ' '; END;
+                            comma_list(attr_list2);
+                          ELSIF attr_list1.size;
+                            comma_list(attr_list1);
+                          ELSIF attr_list2.size;
+                            comma_list(attr_list2);
+                          END;
                        ~%]
                       [%~ END ~%]
                     </td>

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -33,8 +33,7 @@
                       [%~ IF rel.link.attributes.size ~%]
                       [%~ attr_list1 = []; attr_list2 = [];
                           FOR attr=rel.link.attributes;
-                            IF attr.type.root.id == server_constants.INSTRUMENT_ROOT_ID
-                            OR attr.type.root.id == server_constants.VOCAL_ROOT_ID;
+                            IF attr.type.root.id == 14 OR attr.type.root.id == 3;
                               attr_list2.push(attr.html);
                             ELSE;
                               attr_list1.push(attr.html);

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -41,14 +41,8 @@
                               attr_list1.push(attr.html);
                             END;
                           END;
-                          IF attr_list1.size AND attr_list2.size;
-                            FOR text = attr_list1; text; ' '; END;
-                            comma_list(attr_list2);
-                          ELSIF attr_list1.size;
-                            comma_list(attr_list1);
-                          ELSIF attr_list2.size;
-                            comma_list(attr_list2);
-                          END;
+                          attr_list = attr_list1.merge(attr_list2);
+                          comma_list(attr_list);
                        ~%]
                       [%~ END ~%]
                     </td>

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -32,10 +32,9 @@
                     <td>
                       [%~ IF rel.link.attributes.size ~%]
                       [%~ attr_list1 = []; attr_list2 = [];
-                          instrument_root = '0abd7f04-5e28-425b-956f-94789d9bcbe2';
-                          vocals_root     = 'd92884b7-ee0c-46d5-96f3-918196ba8c5b';
                           FOR attr=rel.link.attributes;
-                            IF attr.type.root.gid == instrument_root OR attr.type.root.gid == vocals_root;
+                            IF attr.type.root.id == server_constants.INSTRUMENT_ROOT_ID
+                            OR attr.type.root.id == server_constants.VOCAL_ROOT_ID;
                               attr_list2.push(attr.html);
                             ELSE;
                               attr_list1.push(attr.html);

--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -41,8 +41,17 @@
                               attr_list1.push(attr.html);
                             END;
                           END;
-                          attr_list = attr_list1.merge(attr_list2);
-                          comma_list(attr_list);
+                          IF attr_list1.size;
+                            IF attr_list2.size;
+                              l('{attributes}: {instruments_and_vocals}',
+                                { 'attributes'             => comma_list(attr_list1),
+                                  'instruments_and_vocals' => comma_list(attr_list2) });
+                            ELSE;
+                              comma_list(attr_list1);
+                            END;
+                          ELSE;
+                            comma_list(attr_list2);
+                          END;
                        ~%]
                       [%~ END ~%]
                     </td>


### PR DESCRIPTION
The relationship overview for an artist now avoids rendering attributes as "additional, drums, guest and percussion".
Instrument and vocal attributes are now grouped separately in a comma-separated list at the end, with other attributes space-separated in front of that list; so the case above becomes "additional guest drums and percussion".
If only non-instrument/vocal attributes are present, they still get placed in a comma-separated list (so a producer credit would have "additional, co and executive").
