### PR TITLE
MBS-7903: Only show a matching, not any primary alias

### DIFF
--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -250,7 +250,10 @@ sub _with_primary_alias {
                     $_->primary_for_locale
                 } @{ $result->{aliases} };
 
-            $out->{primaryAlias} = $primary_alias && $primary_alias->name;
+            $out->{primaryAlias} = undef;
+            if ($primary_alias && $alias_preference{$munge_lang->($primary_alias->locale)} > 0) {
+                $out->{primaryAlias} = $primary_alias->name;
+            }
             push @output, $out;
         }
     }

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -570,7 +570,7 @@ MB.Control.autocomplete_formatters = {
             comment.push(item.primaryAlias);
         }
 
-        if (item.sortName && !isLatin(item.name) && item.sortName != item.name)
+        if (item.sortName && !isLatin(item.name) && item.sortName != item.name && !item.primaryAlias)
         {
             comment.push(item.sortName);
         }


### PR DESCRIPTION
When considering primary aliases for display in the inline search, aliases in the interface language or in English are preferred. However, if none of these exist, any random language was chosen. (E.g., a German user might have been presented with the Japanese or Arabic alias, which they are unlikely to be able to read.) Stop using such random fallback aliases.

In cases where a (matching) alias exists, it is no longer necessary to display the sort name, whose only purpose is to provide a rudimental Latin-script version (cf. MBS-7404).