### PR TITLE
MBS-8148: Identify ResidentAdvisor reviews as such

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -480,7 +480,8 @@ const CLEANUPS = {
   review: {
     match: [
       new RegExp("^(https?://)?(www\\.)?bbc\\.co\\.uk/music/reviews/", "i"),
-      new RegExp("^(https?://)?(www\\.)?metal-archives\\.com/reviews/", "i")
+      new RegExp("^(https?://)?(www\\.)?metal-archives\\.com/reviews/", "i"),
+      new RegExp("^(https?://)?(www\\.)?residentadvisor\\.net/review", "i")
     ],
     type: LINK_TYPES.review
   },
@@ -699,7 +700,7 @@ const CLEANUPS = {
       new RegExp("^(https?://)?(www\\.)?whosampled\\.com", "i"),
       new RegExp("^(https?://)?(www\\.)?maniadb\\.com", "i"),
       new RegExp("^(https?://)?(www\\.)?imvdb\\.com", "i"),
-      new RegExp("^(https?://)?(www\\.)?residentadvisor\\.net", "i"),
+      new RegExp("^(https?://)?(www\\.)?residentadvisor\\.net/(?!review)", "i"),
       new RegExp("^(https?://)?(www\\.)?vkdb\\.jp", "i"),
       new RegExp("^(https?://)?(www\\.)?ci\\.nii\\.ac\\.jp", "i"),
       new RegExp("^(https?://)?(www\\.)?iss\\.ndl\\.go\\.jp/", "i"),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -238,6 +238,27 @@ test('Guess type', function (t) {
                 'recording', 'http://recochoku.jp/song/S21893898/',
                 LINK_TYPES.downloadpurchase.recording
             ],
+            // Resident Advisor
+            [
+                'artist', 'https://www.residentadvisor.net/dj/adamx',
+                LINK_TYPES.otherdatabases.artist
+            ],
+            [
+                'event', 'https://www.residentadvisor.net/event.aspx?860109',
+                LINK_TYPES.otherdatabases.event
+            ],
+            [
+                'label', 'https://www.residentadvisor.net/record-label.aspx?id=2795',
+                LINK_TYPES.otherdatabases.label
+            ],
+            [
+                'recording', 'https://www.residentadvisor.net/track.aspx?544258',
+                LINK_TYPES.otherdatabases.recording
+            ],
+            [
+                'release_group', 'https://www.residentadvisor.net/reviews/7636',
+                LINK_TYPES.review.release_group
+            ],
             // Rockens Danmarkskort
             [
                 'place', 'http://www.rockensdanmarkskort.dk/steder/den-gr%C3%A5-hal',


### PR DESCRIPTION
Guess type of RA links, either `otherdatabases` or `review`, rather than `otherdatabases` only.