### PR TITLE
MBS-9031: Replace all usages of memcached with redis

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ Prerequisites
 
         sudo apt-get install git-core
 
-6.  Redis
+5.  Redis
 
     Sessions and cached entities are stored in Redis, so a running Redis server
     is required. Redis can be installed with the following command and will not
@@ -61,7 +61,7 @@ Prerequisites
     in lib/DBDefs.pm.  The defaults should be fine if you don't use
     your redis install for anything else.
 
-7.  Node.js
+6.  Node.js
 
     Node.js is required to build (and optionally minify) our JavaScript and CSS.
     If you plan on accessing musicbrainz-server inside a web browser, you should
@@ -76,7 +76,7 @@ Prerequisites
     This is only needed where it exists, so a warning about the package not being
     found is not a problem.
 
-8.  Standard Development Tools
+7.  Standard Development Tools
 
     In order to install some of the required Perl and Postgresql modules, you'll
     need a C compiler and make. You can install a basic set of development tools

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,21 +49,11 @@ Prerequisites
 
         sudo apt-get install git-core
 
-5.  Memcached
-
-    By default the MusicBrainz server requires a Memcached server running on the
-    same server with default settings. To install Memcached, run the following:
-
-        sudo apt-get install memcached
-
-    You can change the memcached server name and port, or configure other datastores
-    in lib/DBDefs.pm.
-
 6.  Redis
 
-    Sessions are stored in Redis, so a running Redis server is
-    required.  Redis can be installed with the
-    following command and will not need any further configuration:
+    Sessions and cached entities are stored in Redis, so a running Redis server
+    is required. Redis can be installed with the following command and will not
+    need any further configuration:
 
         sudo apt-get install redis-server
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,6 @@ version_from 'lib/MusicBrainz/Server.pm';
 # Mandatory modules
 requires 'Algorithm::Diff'                            => '1.1902';
 requires 'Authen::Passphrase'                         => '0.007';
-requires 'Cache::Memcached'                           => '1.29';
 requires 'Captcha::reCAPTCHA'                         => '0.93';
 requires 'Catalyst::Action::RenderView'               => '0.16';
 requires 'Catalyst::Plugin::Authentication'           => '0.10017';
@@ -117,7 +116,6 @@ feature 'ETag Caching' =>
 feature 'Default caching setup' =>
     -default                 => 1,
     'Cache::Memory'          => '2.04',
-    'Cache::Memcached::Fast' => '0.19'
     ;
 
 feature 'Default session store/state management' =>
@@ -138,7 +136,6 @@ feature 'Production server' =>
     'Digest::MD5::File' => '0.07',
     'Catalyst::Plugin::AutoRestart' => '0.96',
     'Catalyst::Plugin::ErrorCatcher' => '0.0.8.13',
-    'Catalyst::Plugin::Session::Store::Memcached' => '0.05',
     'FCGI' => '0.74',
     'FCGI::ProcManager' => '0.24',
     ;

--- a/admin/SetLanguageFrequencies
+++ b/admin/SetLanguageFrequencies
@@ -123,7 +123,7 @@ catch
 };
 
 #
-# Invalidate memcached entries to use the new values sooner.
+# Invalidate Redis entries to use the new values sooner.
 #
 
 $c->model('Language')->_delete_all_from_cache;

--- a/admin/replication/hooks/post-process.sample
+++ b/admin/replication/hooks/post-process.sample
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a sample post-process hook file. If moved to 'post-process' it
 # will run after every packet and clear recently-updated entities from
-# memcached. It might be useful to add calls to other scripts you'd like run,
+# Redis. It might be useful to add calls to other scripts you'd like run,
 # perhaps to update derived information of some sort.
 
 cd "$(dirname $0)/../../../"

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -233,39 +233,36 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # Cache Settings
 ################################################################################
 
-# MEMCACHED_SERVERS allows configuration of global memcached servers, if more
-# close configuration is not required
-# sub MEMCACHED_SERVERS { return ['127.0.0.1:11211']; };
+# REDIS_SERVER allows configuration of a global Redis server, if more close
+# configuration is not required.
+# sub REDIS_SERVER { '127.0.0.1:6379' }
 
-# MEMCACHED_NAMESPACE allows configuration of a global memcached namespace, if
-# more close configuration is not required
-# sub MEMCACHED_NAMESPACE { return 'MB:'; };
+# REDIS_NAMESPACE allows configuration of a global Redis namespace, if more
+# close configuration is not required.
+# sub REDIS_NAMESPACE { 'MB:' }
 
 # PLUGIN_CACHE_OPTIONS are the options configured for Plugin::Cache.  $c->cache
 # is provided by Plugin::Cache, and is required for HTTP Digest authentication
 # in the webservice (Catalyst::Authentication::Credential::HTTP).
 #
 # Using Cache::Memory is good for a development environment, but is likely not
-# suited for production.  Use something like memcached in a production setup.
+# suited for production.  Use something like Redis in a production setup.
 #
-# If you want to use something such as Memcached, the settings here should be
+# If you want to use something such as Redis, the settings here should be
 # the same as the settings you use for the session store.
 #
 # sub PLUGIN_CACHE_OPTIONS {
 #     my $self = shift;
 #     return {
-#         class => "Cache::Memcached::Fast",
-#         servers => $self->MEMCACHED_SERVERS(),
-#         namespace => $self->MEMCACHED_NAMESPACE(),
+#         class => 'MusicBrainz::Server::CacheWrapper::Redis',
+#         server => $self->REDIS_SERVER,
+#         namespace => $self->REDIS_NAMESPACE,
 #     };
 # };
 
-# Use memcached and a small in-memory cache, see below if you
-# want to disable caching
-#
 # The caching options here relate to object caching - such as caching artists,
-# releases, etc in order to speed up queries. If you are using Memcached
-# to store sessions as well this should be a *different* memcached server.
+# releases, etc in order to speed up queries. We use Redis and a small
+# in-memory cache; see below if you want to disable caching.
 # sub CACHE_MANAGER_OPTIONS {
 #     my $self = shift;
 #     my %CACHE_MANAGER_OPTIONS = (
@@ -279,10 +276,10 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 #                 },
 #             },
 #             external => {
-#                 class => 'Cache::Memcached::Fast',
+#                 class => 'MusicBrainz::Server::CacheWrapper::Redis',
 #                 options => {
-#                     servers => $self->MEMCACHED_SERVERS(),
-#                     namespace => $self->MEMCACHED_NAMESPACE()
+#                     server => $self->REDIS_SERVER,
+#                     namespace => $self->REDIS_NAMESPACE,
 #                 },
 #             },
 #         },
@@ -292,7 +289,7 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 #     return \%CACHE_MANAGER_OPTIONS
 # }
 
-# Sets the TTL for entities stored in memcached, in seconds. A value of 0
+# Sets the TTL for entities stored in Redis, in seconds. A value of 0
 # indicates that no expiration is set.
 # sub ENTITY_CACHE_TTL { 0 }
 
@@ -303,7 +300,7 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # The "host:port" of the ratelimit server ($MB_SERVER/bin/ratelimit-server).
 # If undef, the rate-limit code always returns undef (as it does if there is
 # an error).
-# Just like the memcached server settings, there is NO SECURITY built into the
+# Just like the Redis server settings, there is NO SECURITY built into the
 # ratelimit protocol, so be careful about enabling it.
 # sub RATELIMIT_SERVER { undef }
 
@@ -326,16 +323,16 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # sub DATASTORE_REDIS_ARGS {
 #     my $self = shift;
 #     return {
-#         prefix => 'MB:',
+#         prefix => $self->REDIS_NAMESPACE,
 #         database => 0,
 #         test_database => 1,
 #         redis_new_args => {
-#             server => '127.0.0.1:6379',
+#             server => $self->REDIS_SERVER,
 #             reconnect => 60,
 #             encoding => undef,
 #         }
 #     };
-# };
+# }
 
 ################################################################################
 # Session cookies

--- a/lib/MusicBrainz/Script/PruneCache.pm
+++ b/lib/MusicBrainz/Script/PruneCache.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Script::PruneCache;
 =head1 DESCRIPTION
 
 This script can be used to clear entities last updated within `interval`
-seconds from memcached. It's suitable for running after replication.
+seconds from Redis. It's suitable for running after replication.
 
 =cut
 
@@ -47,7 +47,7 @@ sub prune_entity {
     my $interval = DateTime::Format::Pg->format_interval(
         DateTime::Duration->new(seconds => $self->interval)
     );
-    my $cache_prefix = DBDefs->MEMCACHED_NAMESPACE . $data->_id_cache_prefix;
+    my $cache_prefix = DBDefs->REDIS_NAMESPACE . $data->_id_cache_prefix;
 
     Sql::run_in_transaction(sub {
         if ($entity_properties->{last_updated_column}) {

--- a/lib/MusicBrainz/Server/CacheWrapper/Redis.pm
+++ b/lib/MusicBrainz/Server/CacheWrapper/Redis.pm
@@ -49,7 +49,9 @@ sub get_multi {
 sub set {
     my ($self, $key, $value, $exptime) = @_;
 
-    $self->redis->set($key, Storable::freeze(\$value), 'EX', $exptime);
+    my @args = ($key, Storable::freeze(\$value));
+    push @args, 'EX', $exptime if defined $exptime;
+    $self->redis->set(@args);
     return;
 }
 

--- a/lib/MusicBrainz/Server/CacheWrapper/Redis.pm
+++ b/lib/MusicBrainz/Server/CacheWrapper/Redis.pm
@@ -1,0 +1,113 @@
+package MusicBrainz::Server::CacheWrapper::Redis;
+
+use Moose;
+use Redis;
+use Storable;
+
+has 'redis' => (
+    is => 'rw',
+    isa => 'Redis',
+);
+
+has 'namespace' => (
+    is => 'rw',
+    isa => 'Str',
+);
+
+sub BUILD {
+    my ($self, $params) = @_;
+
+    $self->redis(Redis->new(
+        encoding => undef,
+        reconnect => 60,
+        server => $params->{server},
+    ));
+    $self->namespace($params->{namespace});
+}
+
+sub get {
+    my ($self, $key) = @_;
+
+    my $value = $self->redis->get($key);
+    return ${Storable::thaw($value)} if defined $value;
+    return;
+}
+
+sub get_multi {
+    my ($self, @keys) = @_;
+
+    my @values = $self->redis->mget(@keys);
+    my $i = 0;
+    my %result;
+    for my $key (@keys) {
+        my $value = $values[$i++];
+        $result{$key} = ${Storable::thaw($value)} if defined $value;
+    }
+    return \%result;
+}
+
+sub set {
+    my ($self, $key, $value, $exptime) = @_;
+
+    $self->redis->set($key, Storable::freeze(\$value), 'EX', $exptime);
+    return;
+}
+
+sub set_multi {
+    my ($self, @items) = @_;
+
+    for (@items) {
+        my ($key, $value, $exptime) = @$_;
+        my @args = ($key, Storable::freeze(\$value));
+        push @args, 'EX', $exptime if defined $exptime;
+        $self->redis->set(@args, sub {});
+    }
+    $self->redis->wait_all_responses;
+    return;
+}
+
+sub delete {
+    my ($self, $key) = @_;
+
+    $self->redis->del($key);
+    return;
+}
+
+sub remove {
+    my ($self, $key) = @_;
+
+    $self->delete($key);
+}
+
+sub delete_multi {
+    my ($self, @keys) = @_;
+
+    $self->redis->del(@keys);
+    return;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2016 MetaBrainz Foundation
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -96,7 +96,7 @@ sub load_containment
     my %ids_to_load = map { $_ => 1 } @all_ids;
     my @containments;
 
-    my $namespace_key = $self->c->redis->get('area_containment_memcached_key');
+    my $namespace_key = $self->c->redis->get('area_containment_key');
     unless (defined $namespace_key) {
         $namespace_key = $self->clear_containment_cache;
     }
@@ -157,7 +157,7 @@ sub load_containment
 
 sub clear_containment_cache {
     my $key = time;
-    shift->c->redis->set('area_containment_memcached_key', $key);
+    shift->c->redis->set('area_containment_key', $key);
     return $key;
 }
 

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -325,7 +325,7 @@ EOSQL
     $self->c->model('Link')->_delete_from_cache(@old_link_ids);
 }
 
-# The entries in the memcached store for 'Link' objects also have all attributes
+# The entries in the Redis store for 'Link' objects also have all attributes
 # loaded. Thus changing an attribute should clear all of these link objects.
 for my $method (qw( delete update )) {
     before $method => sub {


### PR DESCRIPTION
I didn't see any point in using `Cache::Redis`, because we'd have to write a wrapper around it anyway (it handles serialization on its own, doesn't have `delete`/`*_multi` methods, etc.), and `Cache::Redis` itself is already [a very small wrapper](http://cpansearch.perl.org/src/SONGMU/Cache-Redis-0.02/lib/Cache/Redis.pm) around the `Redis` module, so instead of writing a wrapper around a wrapper, we can just write a wrapper. But if we were to use `Cache::Redis`, we'd have to add a flag to `MusicBrainz::Server::CacheWrapper` to disable serialization, and add expiration time support to `set_multi`. However, another advantage of having a new wrapper is that we can use Redis-specific features like `mget` in `get_multi` and command pipelining in `set_multi`, which the generic wrapper can't do without breaking the in-memory cache.

Sessions and cached entities are now stored in the same server. Because sessions are in there, we can't enable any new memory limit or LRU eviction, i.e. how memcached operated. So, I've changed `ENTITY_CACHE_TTL` from its default of 0 (no expiration on keys) on standalone servers to a new default of 86400 (1 day).