### PR TITLE
Only allow admins to search for untrusted users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -206,7 +206,7 @@ sub search : Path('/search/edits') RequireAuth
     );
     return unless %{ $c->req->query_params };
 
-    my $query = MusicBrainz::Server::EditSearch::Query->new_from_user_input($c->req->query_params, $c->user->id);
+    my $query = MusicBrainz::Server::EditSearch::Query->new_from_user_input($c->req->query_params, $c->user);
     $c->stash( query => $query );
 
     if ($query->valid && !$c->req->query_params->{'form_only'}) {

--- a/lib/MusicBrainz/Server/EditSearch/Predicate.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate.pm
@@ -61,7 +61,7 @@ sub transform_user_input {
 sub cross_validate { }
 
 sub new_from_input {
-    my ($class, $field_name, $input, $user_id) = @_;
+    my ($class, $field_name, $input, $user) = @_;
 
     my $op = $input->{operator};
     MusicBrainz::Server::EditSearch::Exceptions::UnsupportOperator->throw(
@@ -74,7 +74,7 @@ sub new_from_input {
         if defined $cardinality;
 
     if (defined $input->{user_id}) {
-        $input->{user_id} == $user_id or croak "User tried to feign a different identity";
+        $input->{user_id} == $user->id or croak "User tried to feign a different identity";
     }
 
     return $class->new(
@@ -82,6 +82,7 @@ sub new_from_input {
         field_name => $field_name,
         operator => $op,
         arguments => [ @args ],
+        user => $user,
     );
 }
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditorFlag.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditorFlag.pm
@@ -1,19 +1,44 @@
 package MusicBrainz::Server::EditSearch::Predicate::EditorFlag;
 use Moose;
+use MusicBrainz::Server::Constants qw( $UNTRUSTED_FLAG );
 use namespace::autoclean;
 
 extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
 
+has user => (
+    isa => 'Editor',
+    is => 'ro',
+    required => 1,
+);
+
+sub valid_flags {
+    my ($self) = @_;
+
+    my @flags = @{ $self->sql_arguments->[0] };
+    unless ($self->user->is_admin) {
+        # This flag is only intended to be visible to admins.
+        @flags = grep { $_ != $UNTRUSTED_FLAG } @flags;
+    }
+    return @flags;
+}
+
+sub valid {
+    my ($self) = @_;
+    return $self->valid_flags > 0;
+}
+
 sub combine_with_query {
     my ($self, $query) = @_;
-    return unless $self->arguments;
+
+    my @flags = $self->valid_flags;
+    return unless @flags;
 
     $query->add_where([
-        "EXISTS (SELECT 1 FROM editor WHERE id = edit.editor AND privs & (" . join(" | ", map { "?::integer" } @{ $self->sql_arguments->[0] }) . ") " .
+        "EXISTS (SELECT 1 FROM editor WHERE id = edit.editor AND privs & (" . join(" | ", map { "?::integer" } @flags) . ") " .
              ($self->operator eq '='  ? '!=' :
              $self->operator eq '!=' ? '=' : die 'Shouldnt get here')
          . " 0)",
-        @{ $self->sql_arguments }
+        \@flags,
     ]);
 }
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditorFlag.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditorFlag.pm
@@ -15,7 +15,7 @@ sub valid_flags {
     my ($self) = @_;
 
     my @flags = @{ $self->sql_arguments->[0] };
-    unless ($self->user->is_admin) {
+    unless ($self->user->is_account_admin) {
         # This flag is only intended to be visible to admins.
         @flags = grep { $_ != $UNTRUSTED_FLAG } @flags;
     }

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -102,7 +102,7 @@ has fields => (
 );
 
 sub new_from_user_input {
-    my ($class, $user_input, $user_id) = @_;
+    my ($class, $user_input, $user) = @_;
     my $input = expand_hash($user_input);
     my $ae = $input->{auto_edit_filter};
     $ae = undef if $ae =~ /^\s*$/;
@@ -113,20 +113,20 @@ sub new_from_user_input {
         auto_edit_filter => $ae,
         fields => [
             map {
-                $class->_construct_predicate($_, $user_id)
+                $class->_construct_predicate($_, $user)
             } grep { defined } @{ $input->{conditions} }
         ]
     );
 }
 
 sub _construct_predicate {
-    my ($class, $input, $user_id) = @_;
+    my ($class, $input, $user) = @_;
     return try {
         my $predicate_class = $field_map{$input->{field}} or die 'No predicate for field ' . $input->{field};
         $predicate_class->new_from_input(
             $input->{field},
             $input,
-            $user_id,
+            $user,
         )
     } catch {
         my $err = $_;

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -157,8 +157,13 @@ sub is_newbie
 sub is_admin
 {
     my $self = shift;
-    return $self->is_relationship_editor || $self->is_wiki_transcluder ||
-           $self->is_location_editor || $self->is_banner_editor;
+    return (
+        $self->is_account_admin ||
+        $self->is_banner_editor ||
+        $self->is_location_editor ||
+        $self->is_relationship_editor ||
+        $self->is_wiki_transcluder
+    );
 }
 
 has 'preferences' => (

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -285,7 +285,7 @@
                  [ '!=', l('is not') ] ], field_contents) %]
   <select name="args" multiple="multiple">
     [%~ editor_flags = [[1, l('Auto-Editor')], [2, l('Bot')]];
-        IF c.user.is_admin; editor_flags.push([4, l('Untrusted')]); END;
+        IF c.user.is_account_admin; editor_flags.push([4, l('Untrusted')]); END;
         editor_flags.push(
           [8, l('Relationship Editor')],
           [32, l('Wiki Transcluder')],

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -284,13 +284,15 @@
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
   <select name="args" multiple="multiple">
-    [% FOR item=[ [   1,   l('Auto-Editor') ]
-                , [   2,   l('Bot') ]
-                , [   4,   l('Untrusted') ]
-                , [   8,   l('Relationship Editor') ]
-                , [  32,   l('Wiki Transcluder') ]
-                , [ 256,   l('Location Editor') ]
-                ] %]
+    [%~ editor_flags = [[1, l('Auto-Editor')], [2, l('Bot')]];
+        IF c.user.is_admin; editor_flags.push([4, l('Untrusted')]); END;
+        editor_flags.push(
+          [8, l('Relationship Editor')],
+          [32, l('Wiki Transcluder')],
+          [256, l('Location Editor')]
+        )
+    ~%]
+    [% FOR item=editor_flags %]
     <option value="[% html_escape(item.0) %]"
             [% 'selected="selected"' IF field_contents.find_argument(item.0).defined %]
             >[% html_escape(item.1) %]</option>


### PR DESCRIPTION
This flag is only supposed to be set by and visible to account admins, so this can be considered a privacy breach. cc @Freso who alerted this to me.