### PR TITLE
MBS-9042: Fix misaligned rows in user profile for translated UI

### DIFF
--- a/root/static/styles/extra/user.less
+++ b/root/static/styles/extra/user.less
@@ -1,25 +1,25 @@
-dl.profileinfo {
-    display: block;
+table.profileinfo {
+    margin: 1em 1em 0;
 }
 
-dl.profileinfo dt {
-    clear: left;
-    display: block;
-    font-weight: bold;
-    float: left;
-    width: 125px;
+table.profileinfo th,
+table.profileinfo td {
+    padding: 5px;
+    vertical-align: top;
+}
+
+table.profileinfo th {
     text-align: right;
-    padding: 5px;
+    padding-right: 0;
 }
 
-dl.profileinfo dd {
-    clear: right;
-    display: block;
-    padding: 5px;
-    margin-left: 130px;
+table.profileinfo td {
+    padding-left: .25em;
 }
 
-dd.biography p { margin-top: 0px }
+table.profileinfo tr.biography td p {
+    margin-top: 0;
+}
 
 table.statistics {
     float: left;

--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -6,17 +6,19 @@
 
 [%- WRAPPER "user/profile/layout.tt" page="index" %]
     [% BLOCK property %]
-        <dt[% IF class %] class="[% class %]"[% END %]>
-            [% name %]
-        </dt>
-        <dd[% IF class %] class="[% class %]"[% END %]>
-            [% content %]
-        </dd>
+        <tr[% IF class %] class="[% class %]"[% END %]>
+            <th>
+                [% name %]
+            </th>
+            <td>
+                [% content %]
+            </td>
+        </tr>
     [% END %]
 
     <h2>[% l('General Information') %]</h2>
 
-    <dl class="profileinfo">
+    <table class="profileinfo" role="presentation">
         [% WRAPPER property name=l("Email:") %]
             [% IF user.email %]
                 [% IF viewing_own_profile %]
@@ -140,7 +142,7 @@
             </ul>
           [% END %]
         [% END %]
-    </dl>
+    </table>
 
     [% BLOCK statistics %]
         <tr>


### PR DESCRIPTION
Each row of the _General Information_ block is now grouped into a `dl`
element, so to avoid misalignment when the translated header is large.
(It uses almost the same approach than `/relationships` pages.)

Update the stylesheet accordingly.