### PR TITLE
MBS-6314, MBS-7164, MBS-8802 & MBS-9044: Update iTunes URLs’ display, clean-up and validation

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/iTunes.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/iTunes.pm
@@ -8,7 +8,12 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    return "iTunes";
+    if (my ($country) = $self->url->path =~ m{^/([a-z]{2})/}i) {
+        $country =~ tr/a-z/A-Z/;
+        return "iTunes $country";
+    } else {
+        return "iTunes US";
+    }
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1180,6 +1180,27 @@ validationRules[LINK_TYPES.image.artist] = validateImage;
 validationRules[LINK_TYPES.image.label] = validateImage;
 validationRules[LINK_TYPES.image.place] = validateImage;
 
+// allow iTunes pages only for the correct entities with the downloadpurchase rel
+// block links to linkmaker.itunes.apple.com
+validationRules[LINK_TYPES.downloadpurchase.artist] = function (url) {
+  if (/itunes\.apple\.com/.test(url)) {
+    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?artist\/id[0-9]+$/.test(url);
+  }
+  return true;
+}
+validationRules[LINK_TYPES.downloadpurchase.recording] = function (url) {
+  if (/itunes\.apple\.com/.test(url)) {
+    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?music-video\/id[0-9]+$/.test(url);
+  }
+  return true;
+}
+validationRules[LINK_TYPES.downloadpurchase.release] = function (url) {
+  if (/itunes\.apple\.com/.test(url)) {
+    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?(album|audiobook|podcast|preorder)\/id[0-9]+$/.test(url);
+  }
+  return true;
+}
+
 _.each(LINK_TYPES, function (linkType) {
   _.each(linkType, function (id, entityType) {
     if (!validationRules[id]) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -418,7 +418,7 @@ const CLEANUPS = {
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
       url = url.replace(/^https?:\/\/play\.google\.com\/store\/music\/(artist|album)(?:\/[^?]*)?\?id=([^&#]+)(?:[&#].*)?$/, "https://play.google.com/store/music/$1?id=$2");
-      url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|music-video|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
+      url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
       url = url.replace(/^https?:\/\/loudr\.fm\/(artist|release)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]{5}).*$/, "https://loudr.fm/$1/$2/$3");
       return url;
     }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -418,7 +418,7 @@ const CLEANUPS = {
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
       url = url.replace(/^https?:\/\/play\.google\.com\/store\/music\/(artist|album)(?:\/[^?]*)?\?id=([^&#]+)(?:[&#].*)?$/, "https://play.google.com/store/music/$1?id=$2");
-      url = url.replace(/^https?:\/\/itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|music-video|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
+      url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|music-video|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
       url = url.replace(/^https?:\/\/loudr\.fm\/(artist|release)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]{5}).*$/, "https://loudr.fm/$1/$2/$3");
       return url;
     }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -412,15 +412,31 @@ const CLEANUPS = {
       new RegExp("^(https?://)?([^/]+\\.)?ototoy\\.jp", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?hd-music\\.info", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?(7digital\\.com|zdigital\\.com\\.au)", "i"),
-      new RegExp("^(https?://)?([^/]+\\.)?itunes\\.apple\\.com/", "i"),
       new RegExp("^(https?://)?loudr\.fm/", "i"),
     ],
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
       url = url.replace(/^https?:\/\/play\.google\.com\/store\/music\/(artist|album)(?:\/[^?]*)?\?id=([^&#]+)(?:[&#].*)?$/, "https://play.google.com/store/music/$1?id=$2");
-      url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
       url = url.replace(/^https?:\/\/loudr\.fm\/(artist|release)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]{5}).*$/, "https://loudr.fm/$1/$2/$3");
       return url;
+    }
+  },
+  itunes: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?itunes\\.apple\\.com/", "i")],
+    type: LINK_TYPES.downloadpurchase,
+    clean: function (url) {
+      return url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
+    },
+    validate: function (url, id) {
+      if (id === LINK_TYPES.downloadpurchase.artist) {
+        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?artist\/id[0-9]+$/.test(url);
+      } else if (id === LINK_TYPES.downloadpurchase.recording) {
+        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?music-video\/id[0-9]+$/.test(url);
+      } else if (id === LINK_TYPES.downloadpurchase.release) {
+        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?(album|audiobook|podcast|preorder)\/id[0-9]+$/.test(url);
+      } else {
+        return false;
+      }
     }
   },
   jamendo: {
@@ -1179,27 +1195,6 @@ function validateImage(url) {
 validationRules[LINK_TYPES.image.artist] = validateImage;
 validationRules[LINK_TYPES.image.label] = validateImage;
 validationRules[LINK_TYPES.image.place] = validateImage;
-
-// allow iTunes pages only for the correct entities with the downloadpurchase rel
-// block links to linkmaker.itunes.apple.com
-validationRules[LINK_TYPES.downloadpurchase.artist] = function (url) {
-  if (/itunes\.apple\.com/.test(url)) {
-    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?artist\/id[0-9]+$/.test(url);
-  }
-  return true;
-}
-validationRules[LINK_TYPES.downloadpurchase.recording] = function (url) {
-  if (/itunes\.apple\.com/.test(url)) {
-    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?music-video\/id[0-9]+$/.test(url);
-  }
-  return true;
-}
-validationRules[LINK_TYPES.downloadpurchase.release] = function (url) {
-  if (/itunes\.apple\.com/.test(url)) {
-    return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?(album|audiobook|podcast|preorder)\/id[0-9]+$/.test(url);
-  }
-  return true;
-}
 
 _.each(LINK_TYPES, function (linkType) {
   _.each(linkType, function (id, entityType) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -768,18 +768,21 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/artist/id444923726',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://itunes.apple.com/music-video/gangnam-style/id564322420?v0=WWW-NAUS-ITSTOP100-MUSICVIDEOS&ign-mpt=uo%3D2',
                      input_entity_type: 'recording',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/music-video/id564322420',
+               only_valid_entity_types: ['recording']
         },
         {
                              input_url: 'http://itunes.apple.com/au/preorder/the-last-of-the-tourists/id499465357',
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/au/preorder/id499465357',
+               only_valid_entity_types: ['release']
         },
         {
                              input_url: 'http://itunes.apple.com/gb/album/now-thats-what-i-call-music!-82/id543575947?v0=WWW-EUUK-STAPG-MUSIC-PROMO',
@@ -810,18 +813,28 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/us/album/id547068224',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'https://linkmaker.itunes.apple.com/en-us/details/547068224?q=lonerism&country=us&media=music&genre=all',
+                     input_entity_type: 'release',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'downloadpurchase',
+               only_valid_entity_types: []
         },
         {
                              input_url: 'https://itunes.apple.com/de/audiobook/der-marsianer/id923371856?mt=3&ign-mpt=uo%3D4',
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/de/audiobook/id923371856',
+               only_valid_entity_types: ['release']
         },
         {
                              input_url: 'https://itunes.apple.com/ir/podcast/bia2.com-masouds-podcast/id469326376',
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/ir/podcast/id469326376',
+               only_valid_entity_types: ['release']
         },
         // Jamendo Music
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -805,6 +805,12 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/us/album/id721686178',
         },
+        {
+                             input_url: 'https://geo.itunes.apple.com/us/album/lonerism/id547068224?app=itunes',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://itunes.apple.com/us/album/id547068224',
+        },
         // Jamendo Music
         {
                              input_url: 'http://www.jamendo.com/en/track/725574/giraffe',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -811,6 +811,18 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://itunes.apple.com/us/album/id547068224',
         },
+        {
+                             input_url: 'https://itunes.apple.com/de/audiobook/der-marsianer/id923371856?mt=3&ign-mpt=uo%3D4',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://itunes.apple.com/de/audiobook/id923371856',
+        },
+        {
+                             input_url: 'https://itunes.apple.com/ir/podcast/bia2.com-masouds-podcast/id469326376',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://itunes.apple.com/ir/podcast/id469326376',
+        },
         // Jamendo Music
         {
                              input_url: 'http://www.jamendo.com/en/track/725574/giraffe',


### PR DESCRIPTION
For iTunes *purchase for download* URL relationship
* `geo.itunes.apple.com` URLs (that already matched) are now cleaned up (like other matched URLs). **Standardisation is forced to remove the `geo` prefix from iTunes URLs.** ([MBS-9044](http://tickets.musicbrainz.org/browse/MBS-9044))
* `/audiobook/` and `/podcast/` URLs (that already matched) are now cleaned up (like other matched URLs) ([MBS-8802](http://tickets.musicbrainz.org/browse/MBS-8802)).
* Validation rules are now added so that:
  * iTunes URLs are allowed for the correct entities only ([MBS-7164](http://tickets.musicbrainz.org/browse/MBS-7164)),
  * `linkmaker.itunes.apple.com` URLs are no more accepted ([MBS-9044](http://tickets.musicbrainz.org/browse/MBS-9044)).
* iTunes sidebar links’ titles now feature country code ([MBS-6314](http://tickets.musicbrainz.org/browse/MBS-6314)), default is "iTunes US" per [iTunes doc](http://images.apple.com/itunesaffiliates/US/2009/Document/LinktoiTune.pdf).
* Move the code into a single `itunes` entry of `CLEANUPS`, making use of PR #354 changes.