### PR TITLE
MBS-8793: Improve Twitter URLs’ clean-up

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -554,7 +554,7 @@ const CLEANUPS = {
         url = url.replace(/\/event\.php\?eid=/, "/events/");
       }
       url = url.replace(/^(?:https?:\/\/)?plus\.google\.com\/(?:u\/[0-9]\/)?([0-9]+)(\/.*)?$/, "https://plus.google.com/$1");
-      url = url.replace(/^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\/@?([^\/]+)\/?$/, "https://twitter.com/$1");
+      url = url.replace(/^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\/@?([^\/?#]+)(?:[\/?#].*)?$/, "https://twitter.com/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:(?:www|m)\.)?reverbnation\.com(?:\/#!)?\//, "http://www.reverbnation.com/");
       url = url.replace(/^(https?:\/\/)?((www|cn|m)\.)?(last\.fm|lastfm\.(com\.br|com\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/, "http://www.last.fm");
       url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?weibo\.com\/([^\/?#]+)(?:.*)$/, "http://www.weibo.com/$1");

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -970,6 +970,21 @@ test('Cleanup', function (t) {
                 'https://twitter.com/ACEHOOD',
                 'artist'
             ],
+            [
+                'http://twitter.com/miguelgrimaldo/media',
+                'https://twitter.com/miguelgrimaldo',
+                'artist'
+            ],
+            [
+                'https://mobile.twitter.com/cirrhaniva?lang=en-gb',
+                'https://twitter.com/cirrhaniva',
+                'artist'
+            ],
+            [
+                'https://twitter.com/@UNIVERSAL_D#content-main-heading',
+                'https://twitter.com/UNIVERSAL_D',
+                'artist'
+            ],
             // SoundCloud
             [
                 'http://soundcloud.com/alec_empire',


### PR DESCRIPTION
Removes query strings (such as `?lang=en-gb` or `?ref_src=example.com`), possible anchors (`#content-main-heading`), and sub-paths (such as `/media` or `/status/47830`) from Twitter URLs.