### PR TITLE
MBS-5733: Allow to validate `otherdatabases` URL relationships

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -812,15 +812,12 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
-      if (id !== LINK_TYPES.otherdatabases.artist) {
-        return !/^(https?:\/\/)?(www\.)?soundtrackcollector\.com\/title\//.test(url);
-      } else if (id !== LINK_TYPES.otherdatabases.release) {
-        return !/^(https?:\/\/)?(www\.)?soundtrackcollector\.com\/title\//.test(url)
-          && !/^(https?:\/\/)?(www\.)?soundtrackcollector\.com\/composer\//.test(url);
-      } else if (id !== LINK_TYPES.otherdatabases.release_group) {
-        return !/^(https?:\/\/)?(www\.)?soundtrackcollector\.com\/composer\//.test(url);
+      if (id === LINK_TYPES.otherdatabases.artist) {
+        return /^http:\/\/soundtrackcollector\.com\/composer\/[0-9]+\/$/.test(url);
+      } else if (id === LINK_TYPES.otherdatabases.release_group) {
+        return /^http:\/\/soundtrackcollector\.com\/title\/[0-9]+\/$/.test(url);
       } else {
-        return true; // FIXME return false once all cases have been checked
+        return false;
       }
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -732,7 +732,6 @@ const CLEANUPS = {
       new RegExp("^(https?://)?(www\\.)?rockensdanmarkskort\\.dk", "i"),
       new RegExp("^(https?://)?((www|wiki)\\.)?rockinchina\\.com", "i"),
       new RegExp("^(https?://)?(www\\.)?dhhu\\.dk", "i"),
-      new RegExp("^(https?://)?(www\\.)?thesession\\.org", "i"),
       new RegExp("^(https?://)?(www\\.)?openlibrary\\.org", "i"),
       new RegExp("^(https?://)?(www\\.)?animenewsnetwork\\.com", "i"),
       new RegExp("^(https?://)?(www\\.)?generasia\\.com/wiki/", "i"),
@@ -791,8 +790,6 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockipedia\.no\/(utgivelser|artister|plateselskap)\/(.+)\/.*$/, "http://www.rockipedia.no/$1/$2/");
       // Standardising DHHU
       url = url.replace(/^(?:https?:\/\/)?(www\.)?dhhu\.dk\/w\/(.*)+$/, "http://www.dhhu.dk/w/$2");
-      // Standardising The Session
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?)(?:\/.*)?\/([0-9]+)(?:.*)?$/, "http://thesession.org/$1/$2");
       // Standardising Open Library
       url = url.replace(/^(?:https?:\/\/)?(www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, "http://openlibrary.org/$2/$3");
       // Standardising Anime News Network
@@ -816,6 +813,26 @@ const CLEANUPS = {
         return /^http:\/\/soundtrackcollector\.com\/composer\/[0-9]+\/$/.test(url);
       } else if (id === LINK_TYPES.otherdatabases.release_group) {
         return /^http:\/\/soundtrackcollector\.com\/title\/[0-9]+\/$/.test(url);
+      } else {
+        return false;
+      }
+    }
+  },
+  thesession: {
+    match: [new RegExp("^(https?://)?(www\\.)?thesession\\.org", "i")],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?)(?:\/.*)?\/([0-9]+)(?:.*)?$/, "http://thesession.org/$1/$2");
+    },
+    validate: function (url, id) {
+      if (id === LINK_TYPES.otherdatabases.artist) {
+        return /^http:\/\/thesession\.org\/recordings\/artists\/[0-9]+$/.test(url);
+      } else if (id === LINK_TYPES.otherdatabases.event) {
+        return /^http:\/\/thesession\.org\/events\/[0-9]+$/.test(url);
+      } else if (id === LINK_TYPES.otherdatabases.release_group) {
+        return /^http:\/\/thesession\.org\/recordings\/[0-9]+$/.test(url);
+      } else if (id === LINK_TYPES.otherdatabases.work) {
+        return /^http:\/\/thesession\.org\/tunes\/[0-9]+$/.test(url);
       } else {
         return false;
       }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -79,8 +79,6 @@ const LINK_TYPES = {
     artist: "221132e9-e30e-43f2-a741-15afc4c5fa7c",
     label: "b35f7822-bf3c-4148-b306-fb723c63ee8b",
     place: "68a4537c-f2a6-49b8-81c5-82a62b0976b7",
-    // This is the "score" type, which is here because of Wikipedia Commons URLs
-    work: "0cc8527e-ea40-40dd-b144-3b7588e759bf",
     instrument: "f64eacbd-1ea1-381e-9886-2cfb552b7d90"
   },
   discographyentry: {
@@ -137,11 +135,8 @@ const LINK_TYPES = {
     release: "08445ccf-7b99-4438-9f9a-fb9ac18099ee"
   },
   vimeo: {
-    // Video channel for artist/label, streaming music for release/recording
     artist: "d86c9450-b6d0-4760-a275-e7547495b48b",
     label: "20ad367c-cba0-4c02-bd61-2df3ae8cc799",
-    recording: "7e41ef12-a124-4324-afdb-fdbae687a89c",
-    release: "08445ccf-7b99-4438-9f9a-fb9ac18099ee"
   },
   vgmdb: {
     artist: "0af15ab3-c615-46d6-b95b-a5fcd2a92ed9",
@@ -152,7 +147,6 @@ const LINK_TYPES = {
   youtube: {
     artist: "6a540e5b-58c6-4192-b6ba-dbc71ec8fcf0",
     label: "d9c71059-ba9d-4135-b909-481d12cf84e3",
-    recording: "7e41ef12-a124-4324-afdb-fdbae687a89c",
     place: "22ec436d-bb65-4c83-a268-0fdb0dbd8834",
     series: "f23802a4-36be-3751-8e4d-93422e08b3e8",
     event: "fea46163-dc45-3af9-917e-1798f325d21a"
@@ -459,9 +453,9 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?(www\\.)?bbc\\.co\\.uk/music/artists/", "i")],
     type: LINK_TYPES.bbcmusic
   },
-  image: {
+  wikimediacommons: {
     match: [new RegExp("^(https?://)?(commons\\.wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],
-    type: LINK_TYPES.image,
+    type: _.defaults({}, LINK_TYPES.image, LINK_TYPES.score),
     clean: function (url) {
       url = url.replace(/\/wiki\/[^#]+#mediaviewer\/(.*)/, "\/wiki\/$1");
       url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, "https://commons.wikimedia.org/wiki/File:$2");
@@ -506,7 +500,6 @@ const CLEANUPS = {
     match: [
       new RegExp("^(https?://)?(www\\.)?imslp\\.org/", "i"),
       new RegExp("^(https?://)?(www\\.)?neyzen\\.com", "i"),
-      new RegExp("^(https?://)?commons\\.wikimedia\\.org", "i"),
       new RegExp("^(https?://)?(www[0-9]?\\.)?cpdl\\.org", "i")
     ],
     type: LINK_TYPES.score,
@@ -607,7 +600,7 @@ const CLEANUPS = {
   },
   vimeo: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?(vimeo\\.com/)", "i")],
-    type: LINK_TYPES.vimeo,
+    type: _.defaults({}, LINK_TYPES.vimeo, LINK_TYPES.streamingmusic),
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?vimeo\.com/, "http://vimeo.com");
       // Remove query string, just the video id should be enough.
@@ -617,7 +610,7 @@ const CLEANUPS = {
   },
   youtube: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?(youtube\\.com/|youtu\\.be/)", "i")],
-    type: LINK_TYPES.youtube,
+    type: _.defaults({}, LINK_TYPES.youtube, LINK_TYPES.streamingmusic),
     clean: function (url) {
       url = url.replace(/^(https?:\/\/)?([^\/]+\.)?youtube\.com(?:\/#)?/, "http://www.youtube.com");
       // YouTube URL shortener

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1418,12 +1418,21 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://thesession.org/recordings/artists/793',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://thesession.org/members/01234',
+                     input_entity_type: 'artist',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'otherdatabases',
+               only_valid_entity_types: []
         },
         {
                              input_url: 'thesession.org/events/3811#comment748363',
                      input_entity_type: 'event',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://thesession.org/events/3811',
+               only_valid_entity_types: ['event']
         },
         {
                              input_url: 'https://www.thesession.org/recordings/display/1488',
@@ -1436,12 +1445,14 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'release_group',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://thesession.org/recordings/4740',
+               only_valid_entity_types: ['release_group']
         },
         {
                              input_url: 'http://www.thesession.org/tunes/display/2305',
                      input_entity_type: 'work',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://thesession.org/tunes/2305',
+               only_valid_entity_types: ['work']
         },
         // Tipeee
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1367,6 +1367,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://soundtrackcollector.com/composer/94/',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://soundtrackcollector.com/title/5751/Jurassic+Park',
@@ -1384,6 +1385,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'release_group',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://soundtrackcollector.com/title/99711/',
+               only_valid_entity_types: ['release_group']
         },
         // Spirit of Rock
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -354,7 +354,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         {
                              input_url: 'www2.cpdl.org/wiki/index.php/Weave_Me_A_Poem_(Tim_Blickhan)',
                      input_entity_type: 'work',
-            expected_relationship_type: 'image',
+            expected_relationship_type: 'score',
                     expected_clean_url: 'http://cpdl.org/wiki/index.php/Weave_Me_A_Poem_(Tim_Blickhan)',
         },
         // Creative Commons
@@ -1689,7 +1689,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         {
                              input_url: 'http://commons.wikimedia.org/wiki/File:Kimigayo.score.png?uselang=de',
                      input_entity_type: 'work',
-            expected_relationship_type: 'image',
+            expected_relationship_type: 'score',
                     expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Kimigayo.score.png',
         },
         {


### PR DESCRIPTION
Previously, it was not handy to define validation rules for `otherdatabases` URLs, because validation rules had to be defined separately for each entity type whereas there were much more other databases.

Changes caused by this improvement:
- `LINK_TYPES` no longer contain fictive duplicate IDs
- `CLEANUPS` are website `match`-related before relationship `type`-related
- New validation rules can be defined in `CLEANUPS.*.validate` and are stricter than old ones:
  - Matched URLs could be blocked for other relationship types if `type` does not match
  - Matched URLs could be blocked for other entity types if `type` does not match
  - Matched URLs could be blocked if unclean

Old validation rules are still supported. Ultimately, all of them should be converted.

Additionally, other restricted URL relationships (`lyrics`, `score`, `youtube`) can be validated the same way.

Two examples are provided: Soundtrack Collector (converted rules) and The Session (created rules).