### PR TITLE
MBS-9072: Validate the tagger port URL parameter

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -313,9 +313,10 @@ sub begin : Private
     }
 
     # Update the tagger port
-    if (exists $c->req->query_params->{tport})
-    {
-        $c->session->{tport} = $c->req->query_params->{tport};
+    if (defined $c->req->query_params->{tport}) {
+        my ($tport) = $c->req->query_params->{tport} =~ /^([0-9]{1,5})$/
+            or $c->forward('/error_400');
+        $c->session->{tport} = $tport;
     }
 
     # Merging


### PR DESCRIPTION
The contents of the tagger port URL parameter are stored in the user session and later included in various generated pages. Since there used to be no validation, arbitrary text could be injected (a XSS
vulnerability).

Make sure that the tport value is a number (of at most five digits); report an invalid request otherwise.