### PR TITLE
Discogs URL cleanup/validation improvements (includes MBS-9012)

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -254,9 +254,8 @@ const CLEANUPS = {
     type: LINK_TYPES.discogs,
     clean: function (url) {
       url = url.replace(/\/viewimages\?release=([0-9]*)/, "/release/$1");
-      url = url.replace(/^https?:\/\/([^.]+\.)?discogs\.com\/(.*\/(artist|release|master|label))?([^#?]*).*$/, "http://www.discogs.com/$3$4");
+      url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "http://www.discogs.com/$1");
       url = url.replace(/^(http:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
-      url = url.replace(/^(http:\/\/www\.discogs\.com\/(?:artist|label))\/([0-9]+)-[^+]*$/, "$1/$2"); // URLs containing Discogs IDs
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -840,26 +840,26 @@ validationRules[LINK_TYPES.lyrics.work] = function (url) {
 
 // allow Discogs page only for the correct entities
 validationRules[LINK_TYPES.discogs.artist] = function (url) {
-  return /discogs\.com\/(artist|user)\//.test(url);
+  return /^https:\/\/www\.discogs\.com\/(?:artist\/[0-9]+|user\/.+)$/.test(url);
 };
 
 function validateDiscogsLabel(url) {
-  return /discogs\.com\/label\//.test(url);
+  return /^https:\/\/www\.discogs\.com\/label\/[0-9]+$/.test(url);
 }
 
 validationRules[LINK_TYPES.discogs.label] = validateDiscogsLabel;
 validationRules[LINK_TYPES.discogs.series] = validateDiscogsLabel;
 
 validationRules[LINK_TYPES.discogs.place] = function (url) {
-  return /discogs\.com\/(artist|label)\//.test(url);
+  return /^https:\/\/www\.discogs\.com\/(?:artist|label)\/[0-9]+$/.test(url);
 };
 
 validationRules[LINK_TYPES.discogs.release_group] = function (url) {
-  return /discogs\.com\/master\//.test(url);
+  return /^https:\/\/www\.discogs\.com\/master\/[0-9]+$/.test(url);
 };
 
 validationRules[LINK_TYPES.discogs.release] = function (url) {
-  return /discogs\.com\/(release|mp3)\//.test(url);
+  return /^https:\/\/www\.discogs\.com\/release\/[0-9]+$/.test(url);
 };
 
 // allow Allmusic page only for the correct entities

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -254,8 +254,8 @@ const CLEANUPS = {
     type: LINK_TYPES.discogs,
     clean: function (url) {
       url = url.replace(/\/viewimages\?release=([0-9]*)/, "/release/$1");
-      url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "http://www.discogs.com/$1");
-      url = url.replace(/^(http:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
+      url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "https://www.discogs.com/$1");
+      url = url.replace(/^(https:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -257,10 +257,6 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/([^.]+\.)?discogs\.com\/(.*\/(artist|release|master|label))?([^#?]*).*$/, "http://www.discogs.com/$3$4");
       url = url.replace(/^(http:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
       url = url.replace(/^(http:\/\/www\.discogs\.com\/(?:artist|label))\/([0-9]+)-[^+]*$/, "$1/$2"); // URLs containing Discogs IDs
-      var m = url.match(/^(http:\/\/www\.discogs\.com\/(?:artist|label))\/(.+)/);
-      if (m) {
-        url = m[1] + "/" + encodeURIComponent(decodeURIComponent(m[2].replace(/\+/g, "%20"))).replace(/%20/g, "+");
-      }
       return url;
     }
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -462,6 +462,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.discogs.com/artist/301-Source-Direct',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
+                    expected_clean_url: 'https://www.discogs.com/artist/301',
         },
         {
                              input_url: 'http://www.discogs.com/artist/Source+Direct',
@@ -474,31 +475,32 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.discogs.com/artist/1944002-',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/1944002',
+                    expected_clean_url: 'https://www.discogs.com/artist/1944002',
         },
         {
                              input_url: 'http://www.discogs.com/artist/3080207-Maybebop',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/3080207',
+                    expected_clean_url: 'https://www.discogs.com/artist/3080207',
         },
         {
                              input_url: 'https://www.discogs.com/artist/997299-Guy-Balbaert?filter_anv=0&subtype=Writing-Arrangement&type=Credits',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/997299',
+                    expected_clean_url: 'https://www.discogs.com/artist/997299',
         },
         {
                              input_url: 'https://www.discogs.com/artist/535943-Teresa-Teng?filter_anv=1&anv=%E9%84%A7%E9%BA%97%E5%90%9B',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/535943',
+                    expected_clean_url: 'https://www.discogs.com/artist/535943',
                only_valid_entity_types: ['artist', 'place']
         },
         {
                              input_url: 'http://www.discogs.com/label/2262-Demonic',
                      input_entity_type: 'label',
             expected_relationship_type: 'discogs',
+                    expected_clean_url: 'https://www.discogs.com/label/2262',
         },
         {
                              input_url: 'http://www.discogs.com/label/Demonic',
@@ -511,39 +513,41 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.discogs.com/release/12130',
                      input_entity_type: 'release',
             expected_relationship_type: 'discogs',
+                    expected_clean_url: 'https://www.discogs.com/release/12130',
                only_valid_entity_types: ['release']
         },
         {
                              input_url: 'https://www.discogs.com/release/7086846-Rocks/images',
                      input_entity_type: 'release',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/release/7086846',
+                    expected_clean_url: 'https://www.discogs.com/release/7086846',
                only_valid_entity_types: ['release'],
         },
         {
                              input_url: 'http://www.discogs.com/Source-Direct-Exorcise-The-Demons/master/126685',
                      input_entity_type: 'release_group',
             expected_relationship_type: 'discogs',
+                    expected_clean_url: 'https://www.discogs.com/master/126685',
         },
         {
                              input_url: 'http://www.discogs.com/master/view/267989',
                      input_entity_type: 'release_group',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/master/267989',
+                    expected_clean_url: 'https://www.discogs.com/master/267989',
                only_valid_entity_types: ['release_group']
         },
         {
                              input_url: 'http://www.discogs.com/master/681937-80s-Mixtape/history',
                      input_entity_type: 'release_group',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/master/681937',
+                    expected_clean_url: 'https://www.discogs.com/master/681937',
                only_valid_entity_types: ['release_group']
         },
         {
                              input_url: 'http://www.discogs.com/Various-Out-Patients-2/release/5578',
                      input_entity_type: 'release',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/release/5578',
+                    expected_clean_url: 'https://www.discogs.com/release/5578',
         },
         // e-onkyo music
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -465,8 +465,10 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         },
         {
                              input_url: 'http://www.discogs.com/artist/Source+Direct',
+                                        // old-style URL without numerical ID
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
+               only_valid_entity_types: [],
         },
         {
                              input_url: 'http://www.discogs.com/artist/1944002-',
@@ -500,8 +502,10 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         },
         {
                              input_url: 'http://www.discogs.com/label/Demonic',
+                                        // old-style URL without numerical ID
                      input_entity_type: 'label',
             expected_relationship_type: 'discogs',
+               only_valid_entity_types: [],
         },
         {
                              input_url: 'http://www.discogs.com/release/12130',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -481,16 +481,16 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                     expected_clean_url: 'http://www.discogs.com/artist/3080207',
         },
         {
-                             input_url: 'http://www.discogs.com/artist/Guy+Balbaert#t=Credits_Writing-Arrangement&q=&p=1',
+                             input_url: 'https://www.discogs.com/artist/997299-Guy-Balbaert?filter_anv=0&subtype=Writing-Arrangement&type=Credits',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/Guy+Balbaert',
+                    expected_clean_url: 'http://www.discogs.com/artist/997299',
         },
         {
-                             input_url: 'http://www.discogs.com/artist/Teresa+Teng?anv=%E9%84%A7%E9%BA%97%E5%90%9B',
+                             input_url: 'https://www.discogs.com/artist/535943-Teresa-Teng?filter_anv=1&anv=%E9%84%A7%E9%BA%97%E5%90%9B',
                      input_entity_type: 'artist',
             expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/artist/Teresa+Teng',
+                    expected_clean_url: 'http://www.discogs.com/artist/535943',
                only_valid_entity_types: ['artist', 'place']
         },
         {
@@ -502,13 +502,6 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.discogs.com/label/Demonic',
                      input_entity_type: 'label',
             expected_relationship_type: 'discogs',
-        },
-        {
-                             input_url: 'http://www.discogs.com/label/$&+,/:;=@[]%20%23%24%25%2B%2C%2F%3A%3B%3F%40',
-                     input_entity_type: 'label',
-            expected_relationship_type: 'discogs',
-                    expected_clean_url: 'http://www.discogs.com/label/%24%26+%2C%2F%3A%3B%3D%40%5B%5D+%23%24%25%2B%2C%2F%3A%3B%3F%40',
-               only_valid_entity_types: ['label', 'place', 'series']
         },
         {
                              input_url: 'http://www.discogs.com/release/12130',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -514,6 +514,13 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                only_valid_entity_types: ['release']
         },
         {
+                             input_url: 'https://www.discogs.com/release/7086846-Rocks/images',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'discogs',
+                    expected_clean_url: 'http://www.discogs.com/release/7086846',
+               only_valid_entity_types: ['release'],
+        },
+        {
                              input_url: 'http://www.discogs.com/Source-Direct-Exorcise-The-Demons/master/126685',
                      input_entity_type: 'release_group',
             expected_relationship_type: 'discogs',
@@ -523,6 +530,13 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'release_group',
             expected_relationship_type: 'discogs',
                     expected_clean_url: 'http://www.discogs.com/master/267989',
+               only_valid_entity_types: ['release_group']
+        },
+        {
+                             input_url: 'http://www.discogs.com/master/681937-80s-Mixtape/history',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: 'discogs',
+                    expected_clean_url: 'http://www.discogs.com/master/681937',
                only_valid_entity_types: ['release_group']
         },
         {

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -478,7 +478,7 @@ editReleaseTest("mediumDelete edit is generated for existing release", function 
 var testURLRelationship = {
     target: {
         entityType: "url",
-        name: "http://www.discogs.com/release/1369894"
+        name: "https://www.discogs.com/release/1369894"
     },
     linkTypeID: 76,
     id: 123
@@ -492,7 +492,7 @@ editReleaseTest("relationshipCreate edit for external link is generated for exis
         document.createElement('div')
     );
 
-    addURL(component, 'http://www.discogs.com/release/1369894');
+    addURL(component, 'https://www.discogs.com/release/1369894');
 
     t.deepEqual(releaseEditor.edits.externalLinks(release), [
       {
@@ -506,10 +506,10 @@ editReleaseTest("relationshipCreate edit for external link is generated for exis
           },
           {
             "entityType": "url",
-            "name": "http://www.discogs.com/release/1369894"
+            "name": "https://www.discogs.com/release/1369894"
           }
         ],
-        "hash": "05d4c2a59527d50caf84db74df7814f125f41728",
+        "hash": "4436c776fd02c161b235368c5da2ae0c8d52c450",
         "linkTypeID": 76
       }
     ]);
@@ -576,10 +576,10 @@ editReleaseTest("relationshipDelete edit for external link is generated for exis
           },
           {
             "entityType": "url",
-            "name": "http://www.discogs.com/release/1369894"
+            "name": "https://www.discogs.com/release/1369894"
           }
         ],
-        "hash": "06b3b80df94eb75cdb26b98afda49431b0d42db8",
+        "hash": "54bd2a4f4c79e7d4a4bb1d93a368dc7cd56cd822",
         "id": 123,
         "linkTypeID": 76
       }
@@ -589,7 +589,7 @@ editReleaseTest("relationshipDelete edit for external link is generated for exis
 editReleaseTest("edits are not generated for external links that duplicate existing removed ones", function (t, release) {
     t.plan(6);
 
-    var newURL = { name: "http://www.discogs.com/release/13698944", entityType: "url" };
+    var newURL = { name: "https://www.discogs.com/release/13698944", entityType: "url" };
 
     var component = releaseEditor.createExternalLinksEditor(
         _.assign(
@@ -611,7 +611,7 @@ editReleaseTest("edits are not generated for external links that duplicate exist
     triggerClick($mountPoint.find('button:eq(0)')[0]);
 
     // Add a duplicate of the first URL
-    addURL(component, 'http://www.discogs.com/release/1369894');
+    addURL(component, 'https://www.discogs.com/release/1369894');
 
     // No edits are generated, because there are errors.
     t.equal(releaseEditor.edits.externalLinks(release).length, 0);
@@ -633,10 +633,10 @@ editReleaseTest("edits are not generated for external links that duplicate exist
           },
           {
             "entityType": "url",
-            "name": "http://www.discogs.com/release/1369894"
+            "name": "https://www.discogs.com/release/1369894"
           }
         ],
-        "hash": "06b3b80df94eb75cdb26b98afda49431b0d42db8",
+        "hash": "54bd2a4f4c79e7d4a4bb1d93a368dc7cd56cd822",
         "id": 123,
         "linkTypeID": 76
       }
@@ -647,7 +647,7 @@ editReleaseTest("edits are not generated for external links that duplicate exist
     // Duplicate the first URL again by editing the other existing URL
     triggerChange(
         $mountPoint.find('input:eq(0)')[0],
-        'http://www.discogs.com/release/1369894'
+        'https://www.discogs.com/release/1369894'
     );
 
     t.equal(releaseEditor.edits.externalLinks(release).length, 0);


### PR DESCRIPTION
Some improvements for Discogs URLs:

- Better validation – disallow anything that doesn’t have the proper format.
- Drop everything after the ID (fixes MBS-9012 in particular).
- Harmonize to HTTPS URLs.

This also removes the remaining support for old URLs that didn’t contain a numerical ID.