### PR TITLE
Wikimedia Commons URL cleanup improvements (includes MBS-9053)

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -491,6 +491,7 @@ const CLEANUPS = {
       url = url.replace(/\/wiki\/[^#]+#mediaviewer\/(.*)/, "\/wiki\/$1");
       url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, "https://commons.wikimedia.org/wiki/File:$2");
       url = url.replace(/\?uselang=[a-z-]+$/, "");
+      url = url.replace(/#.*$/, "");
       return url.replace(/^https?:\/\/commons\.(?:m\.)?wikimedia\.org\/wiki\/(?:File|Image):/, "https://commons.wikimedia.org/wiki/File:");
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -485,13 +485,13 @@ const CLEANUPS = {
     type: LINK_TYPES.bbcmusic
   },
   wikimediacommons: {
-    match: [new RegExp("^(https?://)?(commons\\.wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],
+    match: [new RegExp("^(https?://)?(commons\\.(?:m\\.)?wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],
     type: _.defaults({}, LINK_TYPES.image, LINK_TYPES.score),
     clean: function (url) {
       url = url.replace(/\/wiki\/[^#]+#mediaviewer\/(.*)/, "\/wiki\/$1");
       url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, "https://commons.wikimedia.org/wiki/File:$2");
       url = url.replace(/\?uselang=[a-z-]+$/, "");
-      return url.replace(/^https?:\/\/commons\.wikimedia\.org\/wiki\/(File|Image):/, "https://commons.wikimedia.org/wiki/File:");
+      return url.replace(/^https?:\/\/commons\.(?:m\.)?wikimedia\.org\/wiki\/(?:File|Image):/, "https://commons.wikimedia.org/wiki/File:");
     }
   },
   discographyentry: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1688,7 +1688,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.wikidata.org/wiki/Q14005#sitelinks-wikipedia',
                     expected_clean_url: 'https://www.wikidata.org/wiki/Q14005',
         },
-        // Wikimedia
+        // Wikimedia Commons
         {
                              input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',
                      input_entity_type: 'artist',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1709,6 +1709,10 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://commons.wikimedia.org/wiki/Main_Page#mediaviewer/File:Origanum_vulgare_-_harilik_pune.jpg',
                     expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Origanum_vulgare_-_harilik_pune.jpg',
         },
+        {
+                             input_url: 'https://commons.m.wikimedia.org/wiki/File:Karel-R%C5%AF%C5%BEi%C4%8Dka-star%C5%A1%C3%AD.jpg#mw-jump-to-license',
+                    expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Karel-R%C5%AF%C5%BEi%C4%8Dka-star%C5%A1%C3%AD.jpg',
+        },
         // Wikipedia
         {
                              input_url: 'http://en.wikipedia.org/wiki/Source_Direct_%28band%29',


### PR DESCRIPTION
Some improvements related to Wikimedia Commons:

- Recognize `commons.m.wikimedia.org` URLs and remove the `m.` on cleanup. (MBS-9053)
- Remove `#fragment` from Wikimedia Commons URLs.
- Add a test for both.
- Fix a comment. (Wikimedia is the organization that, among other projects like Wiktionary and Wikipedia, runs Wikimedia Commons.)

This builds on pull request #354, which should be merged first.