### PR TITLE
Validate Generasia URLs (solves MBS-8744)

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -734,7 +734,6 @@ const CLEANUPS = {
       new RegExp("^(https?://)?(www\\.)?dhhu\\.dk", "i"),
       new RegExp("^(https?://)?(www\\.)?openlibrary\\.org", "i"),
       new RegExp("^(https?://)?(www\\.)?animenewsnetwork\\.com", "i"),
-      new RegExp("^(https?://)?(www\\.)?generasia\\.com/wiki/", "i"),
       new RegExp("^(https?://)?(www\\.)?rockipedia\\.no", "i"),
       new RegExp("^(https?://)?(www\\.)?whosampled\\.com", "i"),
       new RegExp("^(https?://)?(www\\.)?maniadb\\.com", "i"),
@@ -794,9 +793,20 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, "http://openlibrary.org/$2/$3");
       // Standardising Anime News Network
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?animenewsnetwork\.com\/encyclopedia\/(people|company).php\?id=([0-9]+).*$/, "http://www.animenewsnetwork.com/encyclopedia/$1.php?id=$2");
-      // Standardising Generasia
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?generasia\.com\/wiki\/(.*)$/, "http://www.generasia.com/wiki/$1");
       return url;
+    }
+  },
+  generasia: {
+    match: [new RegExp("^(https?://)?(www\\.)?generasia\\.com/wiki/", "i")],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?generasia\.com\/wiki\/(.*)$/, "http://www.generasia.com/wiki/$1");
+    },
+    validate: function (url, id) {
+      return id === LINK_TYPES.otherdatabases.artist
+          || id === LINK_TYPES.otherdatabases.label
+          || id === LINK_TYPES.otherdatabases.release_group
+          || id === LINK_TYPES.otherdatabases.work;
     }
   },
   soundtrackcollector: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -620,6 +620,12 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://www.generasia.com/wiki/Wink',
+               only_valid_entity_types: ['artist', 'label', 'release_group', 'work']
+        },
+        {
+                             input_url: 'http://www.generasia.com/wiki/Nippon_Crown',
+                     input_entity_type: 'label',
+            expected_relationship_type: 'otherdatabases',
         },
         {
                              input_url: 'http://www.generasia.com/wiki/Ai_ga_Tomaranai_~Turn_It_into_Love~',


### PR DESCRIPTION
Like most of other databases, Generasia URLs were allowed for all entity types.

This makes use of PR #354 to allow it for Artists, Release Groups, and Works only.

It prevents linking to Generasia from Releases (MBS-8744).