### PR TITLE
Fix auto-generated URL validation rules, part of PR#354

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1187,7 +1187,7 @@ _.each(LINK_TYPES, function (linkType) {
         var cleanup = _.find(CLEANUPS, function (cleanup) {
           return testAll(cleanup.match, url);
         });
-        if (cleanup && cleanup.type) {
+        if (cleanup && cleanup.type && cleanup.type[entityType]) {
           return cleanup.type[entityType] === id
             && (!cleanup.validate || cleanup.validate(url, id));
         } else {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -220,6 +220,14 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                input_relationship_type: 'bandcamp',
                only_valid_entity_types: []
         },
+        {
+                             input_url: 'http://fieldtriptothemoon.bandcamp.com/album/something-owed',
+                     input_entity_type: 'release',
+            expected_relationship_type: undefined,
+                    expected_clean_url: 'http://fieldtriptothemoon.bandcamp.com/album/something-owed',
+               input_relationship_type: 'downloadpurchase',
+               only_valid_entity_types: ['recording', 'release']
+        },
         // BBC Music
         {
                              input_url: 'http://www.bbc.co.uk/music/artists/b52dd210-909c-461a-a75d-19e85a522042',


### PR DESCRIPTION
Fix auto-generated URL validation rules added by commit 8514695c21c1c8acdd0d42ccb5a20ece44b3ae65. The bug was to block URLs for some link types when there is no auto-selected link type for this entity type in the corresponding `CLEANUPS` entry.