### PR TITLE
MBS-9078: Cleanup and validation improvements for Wikimedia Commons URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -257,6 +257,14 @@ const RESTRICTED_LINK_TYPES = _.reduce([
   LINK_TYPES.youtube,
 ], function (result, linkType) {return result.concat(_.values(linkType));}, []);
 
+function reencode_mediawiki_localpart(url) {
+  var m = url.match(/^(https?:\/\/[^\/]+\/wiki\/)([^?#]+)(.*)$/);
+  if (m) {
+    url = m[1] + encodeURIComponent(decodeURIComponent(m[2])).replace(/%20/g, "_").replace(/%24/g, "$").replace(/%2C/g, ",").replace(/%2F/g, "/").replace(/%3A/g, ":").replace(/%3B/g, ";").replace(/%40/g, "@") + m[3];
+  }
+  return url;
+}
+
 const CLEANUPS = {
   wikipedia: {
     match: [new RegExp("^(https?://)?(([^/]+\\.)?wikipedia|secure\\.wikimedia)\\.","i")],
@@ -267,10 +275,7 @@ const CLEANUPS = {
       url = url.replace(/\.wikipedia\.org\/w\/index\.php\?title=([^&]+).*/, ".wikipedia.org/wiki/$1");
       url = url.replace(/\?oldformat=true$/, '');
       url = url.replace(/^(?:https?:\/\/)?([a-z-]+)(?:\.m)?\.wikipedia\.org\/[a-z-]+\/([^?]+)$/, "https://$1.wikipedia.org/wiki/$2");
-      var m = url.match(/^(.*\.wikipedia\.org\/wiki\/)([^?#]+)(.*)$/);
-      if (m) {
-        url = m[1] + encodeURIComponent(decodeURIComponent(m[2])).replace(/%20/g, "_").replace(/%24/g, "$").replace(/%2C/g, ",").replace(/%2F/g, "/").replace(/%3A/g, ":").replace(/%3B/g, ";").replace(/%40/g, "@") + m[3];
-      }
+      url = reencode_mediawiki_localpart(url);
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -497,6 +497,7 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, "https://commons.wikimedia.org/wiki/File:$2");
       url = url.replace(/\?uselang=[a-z-]+$/, "");
       url = url.replace(/#.*$/, "");
+      url = reencode_mediawiki_localpart(url);
       return url.replace(/^https?:\/\/commons\.(?:m\.)?wikimedia\.org\/wiki\/(?:File|Image):/, "https://commons.wikimedia.org/wiki/File:");
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -488,7 +488,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?(commons\\.(?:m\\.)?wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],
     type: _.defaults({}, LINK_TYPES.image, LINK_TYPES.score),
     clean: function (url) {
-      url = url.replace(/\/wiki\/[^#]+#mediaviewer\/(.*)/, "\/wiki\/$1");
+      url = url.replace(/\/wiki\/[^#]+#(?:mediaviewer|\/media)\/(.*)/, "\/wiki\/$1");
       url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, "https://commons.wikimedia.org/wiki/File:$2");
       url = url.replace(/\?uselang=[a-z-]+$/, "");
       url = url.replace(/#.*$/, "");

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -508,7 +508,7 @@ const CLEANUPS = {
   unwelcomeimages: { // Block images from sites that don't allow deeplinking
     match: [
       new RegExp("^(https?://)?s\\.pixogs\\.com\/", "i"),
-      new RegExp("^(https?://)?s\\.discogss\\.com\/", "i"),
+      new RegExp("^(https?://)?(s|img)\\.discogss?\\.com\/", "i"),
     ],
     type: LINK_TYPES.image,
     validate: disallow,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -503,6 +503,9 @@ const CLEANUPS = {
       url = url.replace(/#.*$/, "");
       url = reencode_mediawiki_localpart(url);
       return url.replace(/^https?:\/\/commons\.(?:m\.)?wikimedia\.org\/wiki\/(?:File|Image):/, "https://commons.wikimedia.org/wiki/File:");
+    },
+    validate: function (url, id) {
+      return /^https:\/\/commons\.wikimedia\.org\/wiki\/File:[^?#]+$/.test(url);
     }
   },
   unwelcomeimages: { // Block images from sites that don't allow deeplinking

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -265,6 +265,10 @@ function reencode_mediawiki_localpart(url) {
   return url;
 }
 
+function disallow(url, id) {
+  return false;
+}
+
 const CLEANUPS = {
   wikipedia: {
     match: [new RegExp("^(https?://)?(([^/]+\\.)?wikipedia|secure\\.wikimedia)\\.","i")],
@@ -500,6 +504,14 @@ const CLEANUPS = {
       url = reencode_mediawiki_localpart(url);
       return url.replace(/^https?:\/\/commons\.(?:m\.)?wikimedia\.org\/wiki\/(?:File|Image):/, "https://commons.wikimedia.org/wiki/File:");
     }
+  },
+  unwelcomeimages: { // Block images from sites that don't allow deeplinking
+    match: [
+      new RegExp("^(https?://)?s\\.pixogs\\.com\/", "i"),
+      new RegExp("^(https?://)?s\\.discogss\\.com\/", "i"),
+    ],
+    type: LINK_TYPES.image,
+    validate: disallow,
   },
   discographyentry: {
     match: [
@@ -1165,21 +1177,6 @@ function validateFacebook(url) {
 
 validationRules[LINK_TYPES.socialnetwork.artist] = validateFacebook;
 validationRules[LINK_TYPES.socialnetwork.label] = validateFacebook;
-
-// Block images from sites that don't allow deeplinking
-function validateImage(url) {
-  if (url.match(/\/\/s\.pixogs\.com\//)) {
-    return false;
-  }
-  if (url.match(/\/\/s\.discogss\.com\//)) {
-    return false;
-  }
-  return true;
-}
-
-validationRules[LINK_TYPES.image.artist] = validateImage;
-validationRules[LINK_TYPES.image.label] = validateImage;
-validationRules[LINK_TYPES.image.place] = validateImage;
 
 _.each(LINK_TYPES, function (linkType) {
   _.each(linkType, function (id, entityType) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1735,6 +1735,25 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             expected_relationship_type: 'score',
                     expected_clean_url: 'https://commons.wikimedia.org/wiki/File:$%26%2B,/:;%3D@%5B%5D_%23$%25%2B,/:;%3F@',
         },
+        {
+                             input_url: 'https://commons.wikimedia.org/wiki/Within_Temptation',
+                                        // gallery page
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'image',
+               only_valid_entity_types: [],
+        },
+        {
+                             input_url: 'https://commons.wikimedia.org/wiki/Category:Ewa_Demarczyk',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'image',
+               only_valid_entity_types: [],
+        },
+        {
+                             input_url: 'https://commons.wikimedia.org/w/index.php?search=umberto+alongi&title=Special%3ASearch&go=Go',
+                     input_entity_type: 'label',
+            expected_relationship_type: 'image',
+               only_valid_entity_types: [],
+        },
         // Wikipedia
         {
                              input_url: 'http://en.wikipedia.org/wiki/Source_Direct_%28band%29',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1713,6 +1713,28 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'https://commons.m.wikimedia.org/wiki/File:Karel-R%C5%AF%C5%BEi%C4%8Dka-star%C5%A1%C3%AD.jpg#mw-jump-to-license',
                     expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Karel-R%C5%AF%C5%BEi%C4%8Dka-star%C5%A1%C3%AD.jpg',
         },
+        {
+                             input_url: 'https://commons.wikimedia.org/wiki/Category:Opeth#/media/File:Opeth_-_Kavarna_Rock_Fest_2011.jpg',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'image',
+                    expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Opeth_-_Kavarna_Rock_Fest_2011.jpg',
+        },
+        {
+                             input_url: 'http://commons.wikimedia.org/wiki/Category:Michl_M%C3%BCller?uselang=de#/media/File:Michl_M%C3%BCller_Garitz_2013.JPG',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'image',
+                    expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Michl_M%C3%BCller_Garitz_2013.JPG',
+        },
+        {
+                             input_url: 'https://commons.wikimedia.org/wiki/File%3APolygram_Gold_Disc_Award_Wet_Wet_Wet_Ralph_Ruppert_1987.jpg',
+                    expected_clean_url: 'https://commons.wikimedia.org/wiki/File:Polygram_Gold_Disc_Award_Wet_Wet_Wet_Ralph_Ruppert_1987.jpg',
+        },
+        {
+                             input_url: 'https://commons.wikimedia.org/wiki/File%3A$&+,/:;=@[]%20%23%24%25%2B%2C%2F%3A%3B%3F%40',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'score',
+                    expected_clean_url: 'https://commons.wikimedia.org/wiki/File:$%26%2B,/:;%3D@%5B%5D_%23$%25%2B,/:;%3F@',
+        },
         // Wikipedia
         {
                              input_url: 'http://en.wikipedia.org/wiki/Source_Direct_%28band%29',


### PR DESCRIPTION
See the individual commits. The tests are taken from original URLs found in the database (except for the artificial “special characters” test, for which I copied the corresponding Wikipedia test).