### PR TITLE
MBS-9079: Wikidata URL cleanup improvements

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -662,6 +662,9 @@ const CLEANUPS = {
     type: LINK_TYPES.wikidata,
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/(?:wiki|entity)\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
+    },
+    validate: function (url, id) {
+      return /^https:\/\/www\.wikidata\.org\/wiki\/Q[1-9][0-9]*$/.test(url);
     }
   },
   bandcamp: {
@@ -1089,15 +1092,6 @@ validationRules[LINK_TYPES.secondhandsongs.release] = function (url) {
 validationRules[LINK_TYPES.secondhandsongs.work] = function (url) {
   return /secondhandsongs\.com\/work\//.test(url);
 };
-
-// allow only Wikidata pages with the Wikidata rel
-function validateWikidata(url) {
-  return /wikidata\.org\//.test(url);
-}
-
-_.each(LINK_TYPES.wikidata, function (id) {
-  validationRules[id] = validateWikidata;
-});
 
 // allow only top-level Bandcamp pages as artist/label URLs
 validationRules[LINK_TYPES.bandcamp.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -661,7 +661,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?([^/]+\\.)?wikidata\\.org","i")],
     type: LINK_TYPES.wikidata,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/wiki\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/(?:wiki|entity)\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
     }
   },
   bandcamp: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1717,6 +1717,12 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.wikidata.org/wiki/Q14005#sitelinks-wikipedia',
                     expected_clean_url: 'https://www.wikidata.org/wiki/Q14005',
         },
+        {
+                             input_url: 'http://www.wikidata.org/entity/Q4655955',
+                     input_entity_type: 'artist',
+                    expected_clean_url: 'https://www.wikidata.org/wiki/Q4655955',
+            expected_relationship_type: 'wikidata',
+        },
         // Wikimedia Commons
         {
                              input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1723,6 +1723,11 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                     expected_clean_url: 'https://www.wikidata.org/wiki/Q4655955',
             expected_relationship_type: 'wikidata',
         },
+        {
+                             input_url: 'http://www.example.org/not/wikidata.org',
+               input_relationship_type: 'wikidata',
+               only_valid_entity_types: [],
+        },
         // Wikimedia Commons
         {
                              input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',


### PR DESCRIPTION
For Wikidata URLs, clean up those that have `/entity` instead of `/wiki`, and use stricter validation.