### PR TITLE
Add link to explanation of the various db dump files.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -280,7 +280,8 @@ Creating the database
 
         To get going, you need at least the mbdump.tar.bz2,
         mbdump-editor.tar.bz2 and mbdump-derived.tar.bz2 archives, but you can
-        grab whichever dumps suit your needs.
+        grab whichever dumps suit your needs. The online documentation has a
+        [description of the various data dump files](https://musicbrainz.org/doc/MusicBrainz_Database/Download#File_Descriptions).
 
         Assuming the dumps have been downloaded to /tmp/dumps/ you can verify
         that the data is correct by running:


### PR DESCRIPTION
`INSTALL.md` currently says to "grab whichever dumps suit your needs", but doesn't at all explain what the various dumps do, making that statement lead to confusion rather than clarification. It might also be good stating whether more dumps can be imported in later or if whomever is setting is up need to decide what they will need right then and there… but that's for another commit/PR.

See https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/3703747/ for my motivation for doing the PR.