### PR TITLE
Fix a latent bug in MB::S::Data::WikipediaExtract

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -75,8 +75,8 @@ sub get_extract_by_language
 sub get_available_languages
 {
     my ($self, $links, %opts) = @_;
-    my ($url_pattern, $key, $callback, $language, $ret);
     for my $link (@$links) {
+        my ($url_pattern, $key, $callback, $language, $ret);
         if ($link->isa('MusicBrainz::Server::Entity::URL::Wikidata')) {
             $url_pattern = "https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&props=sitelinks&ids=%s%s";
             $key = 'sitelinks';


### PR DESCRIPTION
The `get_available_languages` method in `MB::S::Data::WikipediaExtract` loops over a list of (Wikipedia and/or Wikidata) URLs. On each iteration, `$key` is set to the page name (e.g. `"Queen (band)"` or `"Q15862"`); only for Wikipedia URLs, `$language` is set to the language code for the Wikipedia edition (e.g. `"en"`). If a Wikidata URLs follows after a Wikipedia one, the value of `$language` was not reset, leading to the construction of a broken API URL.

Move the variable declarations into the loop so that `$language` goes out of scope after each iteration and is recreated with an undefined value.

(It doesn’t appear as if that bug could currently actually be triggered in the current server, though, because the URLs are sorted in a particular order before being passed in. Still, it is better not to rely on that behaviour.)