### PR TITLE
MBS-9087: Convert VIAF URLs for linking

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
@@ -5,6 +5,12 @@ use Moose;
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
+override href_url => sub {
+    # Turn the official permalink into what VIAF currently redirects to.
+    shift->url->as_string =~
+        s{^http://viaf\.org/viaf/([0-9]+)$}{https://viaf.org/viaf/$1/}r;
+};
+
 sub pretty_name
 {
     my $self = shift;


### PR DESCRIPTION
For linking to VIAF URLs, convert the permalinks stored in the database (e.g. `http://viaf.org/viaf/27092134`) to the form currently used by VIAF (e.g. `https://viaf.org/viaf/27092134/`, HTTPS with trailing slash).