### PR TITLE
More HTTPS fixes

### DIFF
--- a/lib/MusicBrainz/Server/CoverArt/Provider/WebService/Amazon.pm
+++ b/lib/MusicBrainz/Server/CoverArt/Provider/WebService/Amazon.pm
@@ -64,7 +64,7 @@ sub handles
 
 sub parse_asin {
     my $uri = shift;
-    my ($store, $asin) = $uri =~ m{^http://(?:www.)?(.*?)(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}i;
+    my ($store, $asin) = $uri =~ m{^https?://(?:www.)?(.*?)(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}i;
     return ($store, $asin);
 }
 

--- a/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleArtists.pm
+++ b/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleArtists.pm
@@ -20,7 +20,7 @@ sub query {
                 FROM
                     url JOIN l_artist_url lau ON lau.entity1 = url.id
                 WHERE
-                    url ~ E'^http://www\\\\.discogs\\\\.com/'
+                    url ~ E'^https?://www\\\\.discogs\\\\.com/'
                 GROUP BY
                     url.id, url.gid, url HAVING COUNT(url) > 1
             ) AS q

--- a/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleLabels.pm
+++ b/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleLabels.pm
@@ -20,7 +20,7 @@ sub query {
                 FROM
                     url JOIN l_label_url llu ON llu.entity1 = url.id
                 WHERE
-                    url ~ E'^http://www\\\\.discogs\\\\.com/'
+                    url ~ E'^https?://www\\\\.discogs\\\\.com/'
                 GROUP BY
                     url.id, url.gid, url HAVING COUNT(url) > 1
             ) AS q

--- a/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleReleaseGroups.pm
@@ -17,7 +17,7 @@ sub query {
                 FROM
                     url JOIN l_release_group_url lru ON lru.entity1 = url.id
                 WHERE
-                    url ~ E'^http://www\\\\.discogs\\\\.com/'
+                    url ~ E'^https?://www\\\\.discogs\\\\.com/'
                 GROUP BY
                     url.id, url.gid, url HAVING COUNT(url) > 1
             ) AS q

--- a/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleReleases.pm
+++ b/lib/MusicBrainz/Server/Report/DiscogsLinksWithMultipleReleases.pm
@@ -17,7 +17,7 @@ sub query {
                 FROM
                     url JOIN l_release_url lru ON lru.entity1 = url.id
                 WHERE
-                    url ~ E'^http://www\\\\.discogs\\\\.com/'
+                    url ~ E'^https?://www\\\\.discogs\\\\.com/'
                 GROUP BY
                     url.id, url.gid, url HAVING COUNT(url) > 1
             ) AS q

--- a/lib/MusicBrainz/Server/WebService/Serializer/XML/1/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/XML/1/Release.pm
@@ -56,7 +56,7 @@ sub serialize
         # FIXME: use aCiD2's coverart/amazon stuff to get the ASIN.
         push @body, ( $self->gen->asin("".$2) )
             if ($_->target->url =~
-                m{^http://(?:www.)?(.*?)(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}i);
+                m{^https?://(?:www.)?(.*?)(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)}i);
         last;
     }
 

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -459,7 +459,6 @@ const CLEANUPS = {
       new RegExp("^(https?://)?([^/]+\\.)?directlyrics\\.com", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?decoda\\.com", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?kasi-time\\.com", "i"),
-      new RegExp("^(https?://)?([^/]+\\.)?wikisource\\.org", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?lieder\\.net", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?utamap\\.com", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?j-lyric\\.net", "i"),
@@ -470,7 +469,6 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.lyrics,
     clean: function (url) {
-      url = url.replace(/^https:\/\/([a-z-]+\.)?wikisource\.org/, "http://$1wikisource.org");
       url = url.replace(/^https?:\/\/(.+\.)?genius\.com/, "http://$1genius.com");
       return url;
     }
@@ -478,6 +476,18 @@ const CLEANUPS = {
   bbcmusic: {
     match: [new RegExp("^(https?://)?(www\\.)?bbc\\.co\\.uk/music/artists/", "i")],
     type: LINK_TYPES.bbcmusic
+  },
+  wikisource: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?wikisource\\.org", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      url = url.replace(/^https:\/\/([a-z-]+\.)?wikisource\.org/, "http://$1wikisource.org");
+      url = reencode_mediawiki_localpart(url);
+      return url;
+    },
+    validate: function (url, id) {
+      return /^http:\/\/(?:[a-z-]+\.)?wikisource\.org\/wiki\//.test(url);
+    }
   },
   wikimediacommons: {
     match: [new RegExp("^(https?://)?(commons\\.(?:m\\.)?wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -481,12 +481,12 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?([^/]+\\.)?wikisource\\.org", "i")],
     type: LINK_TYPES.lyrics,
     clean: function (url) {
-      url = url.replace(/^https:\/\/([a-z-]+\.)?wikisource\.org/, "http://$1wikisource.org");
+      url = url.replace(/^http:\/\/([a-z-]+\.)?wikisource\.org/, "https://$1wikisource.org");
       url = reencode_mediawiki_localpart(url);
       return url;
     },
     validate: function (url, id) {
-      return /^http:\/\/(?:[a-z-]+\.)?wikisource\.org\/wiki\//.test(url);
+      return /^https:\/\/(?:[a-z-]+\.)?wikisource\.org\/wiki\//.test(url);
     }
   },
   wikimediacommons: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1786,7 +1786,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'https://pt.wikisource.org/wiki/A_Portuguesa',
                      input_entity_type: 'work',
             expected_relationship_type: 'lyrics',
-                    expected_clean_url: 'http://pt.wikisource.org/wiki/A_Portuguesa',
+                    expected_clean_url: 'https://pt.wikisource.org/wiki/A_Portuguesa',
         },
         // Warner Music
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1788,6 +1788,14 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             expected_relationship_type: 'lyrics',
                     expected_clean_url: 'https://pt.wikisource.org/wiki/A_Portuguesa',
         },
+        {
+                             input_url: 'http://wikisource.org/wiki/Reise,_Reise',
+                                        // rare languages are on wikisource.org directly
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://wikisource.org/wiki/Reise,_Reise',
+               only_valid_entity_types: ['artist', 'release_group', 'work'],
+        },
         // Warner Music
         {
                              input_url: 'http://wmg.jp/artist/ayaka/WPCL000010415.html',


### PR DESCRIPTION
- Fix some regexes parsing Amazon URLs to also understand HTTPS.
- Fix some Discogs reports to also consider HTTPS URLs.
- Clean up Wikisource URLs to HTTPS, and make some general improvements to cleanup (reencode the local part, using the function that does that for Wikipedia and Wikimedia Commons already) and validation.