### PR TITLE
Remove the in-memory cache

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -116,7 +116,6 @@ feature 'ETag Caching' =>
 
 feature 'Default caching setup' =>
     -default                 => 1,
-    'Cache::Memory'          => '2.04',
     'Cache::Memcached::Fast' => '0.19'
     ;
 

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -245,9 +245,6 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # is provided by Plugin::Cache, and is required for HTTP Digest authentication
 # in the webservice (Catalyst::Authentication::Credential::HTTP).
 #
-# Using Cache::Memory is good for a development environment, but is likely not
-# suited for production.  Use something like memcached in a production setup.
-#
 # If you want to use something such as Memcached, the settings here should be
 # the same as the settings you use for the session store.
 #
@@ -260,24 +257,13 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 #     };
 # };
 
-# Use memcached and a small in-memory cache, see below if you
-# want to disable caching
-#
-# The caching options here relate to object caching - such as caching artists,
-# releases, etc in order to speed up queries. If you are using Memcached
-# to store sessions as well this should be a *different* memcached server.
+# The caching options here relate to object caching in memcached - such as for
+# artists, releases, etc. in order to speed up queries. See below if you want
+# to disable caching.
 # sub CACHE_MANAGER_OPTIONS {
 #     my $self = shift;
 #     my %CACHE_MANAGER_OPTIONS = (
 #         profiles => {
-#             memory => {
-#                 class => 'Cache::Memory',
-#                 wrapped => 1,
-#                 keys => [qw( area_type artist_type g c lng label_type mf place_type release_group_type release_group_secondary_type rs rp scr work_type )],
-#                 options => {
-#                     default_expires => '1 hour',
-#                 },
-#             },
 #             external => {
 #                 class => 'Cache::Memcached::Fast',
 #                 options => {

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -227,9 +227,6 @@ sub MEMCACHED_NAMESPACE { return 'MB:'; };
 # is provided by Plugin::Cache, and is required for HTTP Digest authentication
 # in the webservice (Catalyst::Authentication::Credential::HTTP).
 #
-# Using Cache::Memory is good for a development environment, but is likely not
-# suited for production.  Use something like memcached in a production setup.
-#
 # If you want to use something such as Memcached, the settings here should be
 # the same as the settings you use for the session store.
 #
@@ -242,24 +239,13 @@ sub PLUGIN_CACHE_OPTIONS {
     };
 };
 
-# Use memcached and a small in-memory cache, see below if you
-# want to disable caching
-#
-# The caching options here relate to object caching - such as caching artists,
-# releases, etc in order to speed up queries. If you are using Memcached
-# to store sessions as well this should be a *different* memcached server.
+# The caching options here relate to object caching in memcached - such as for
+# artists, releases, etc. in order to speed up queries. See below if you want
+# to disable caching.
 sub CACHE_MANAGER_OPTIONS {
     my $self = shift;
     my %CACHE_MANAGER_OPTIONS = (
         profiles => {
-            memory => {
-                class => 'Cache::Memory',
-                wrapped => 1,
-                keys => [qw( area_type artist_type g c lng label_type mf place_type release_group_type release_group_secondary_type rs rp scr work_type )],
-                options => {
-                    default_expires => '1 hour',
-                },
-            },
             external => {
                 class => 'Cache::Memcached::Fast',
                 options => {

--- a/t/lib/t/Context.pm
+++ b/t/lib/t/Context.pm
@@ -26,20 +26,12 @@ sub _build_context {
 sub _build_cache_aware_context {
     my $test = shift;
 
+    my $opts = DBDefs->CACHE_MANAGER_OPTIONS;
+    $opts->{profiles}{external}{options}{namespace} = 'mbtest:';
+
     return $test->c->meta->clone_object(
         $test->c,
-        cache_manager => MusicBrainz::Server::CacheManager->new(
-            profiles => {
-                memory => {
-                    class => 'Cache::Memory',
-                    wrapped => 1,
-                    options => {
-                        default_expires => '1 hour',
-                    },
-                },
-            },
-            default_profile => 'memory'
-        ),
+        cache_manager => MusicBrainz::Server::CacheManager->new(%$opts),
         models => {} # Need to reload models to use this new $c
     );
 }

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -121,19 +121,19 @@ test 'Merging updates the complete name' => sub {
 test 'Merging clears the cache' => sub {
     my $test = shift;
     my $c = $test->cache_aware_c;
-    my $cache = $c->cache_manager->_get_cache('memory');
+    my $cache = $c->cache_manager->_get_cache('external');
     my $artist_credit_data = $c->model('ArtistCredit');
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+artistcredit');
 
     $artist_credit_data->get_by_ids(1);
-    ok($cache->exists('ac:1'), 'cache contains artist credit #1');
+    ok($cache->get('ac:1'), 'cache contains artist credit #1');
 
     $c->sql->begin;
     $artist_credit_data->merge_artists(3, [ 2 ]);
     $c->sql->commit;
 
-    ok(!$cache->exists('ac:1'), 'cache no longer contains artist credit #1');
+    ok(!$cache->get('ac:1'), 'cache no longer contains artist credit #1');
 };
 
 test 'Replace artist credit' => sub {


### PR DESCRIPTION
This probably isn't critical for performance, and it only causes an issue for us: the cache is per-server (not shared), so we must wait for every cache to expire (within 1 hour) after new entities are added.