### PR TITLE
Remove Catalyst::Plugin::AutoRestart

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -136,7 +136,6 @@ feature 'Developer features' =>
 
 feature 'Production server' =>
     'Digest::MD5::File' => '0.07',
-    'Catalyst::Plugin::AutoRestart' => '0.96',
     'Catalyst::Plugin::ErrorCatcher' => '0.0.8.13',
     'Catalyst::Plugin::Session::Store::Memcached' => '0.05',
     'FCGI' => '0.74',

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -468,16 +468,6 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # Log if a request in / (not /ws) takes more than x seconds
 # sub PROFILE_SITE { 0 }
 
-# If you want the FastCGI processes to restart, configure this
-# sub AUTO_RESTART {
-##    return {
-##        active => 1,
-##        check_each => 10,
-##        max_bits => 134217728,
-##        min_handled_requests => 100
-##    }
-# }
-
 # The maximum amount of time a process can be serving a single request. This
 # function takes a Catalyst::Request as input, and should return the amount of time
 # in seconds that it should take to respond to this request.

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -477,16 +477,6 @@ sub PROFILE_WEB_SERVICE { 0 }
 # Log if a request in / (not /ws) takes more than x seconds
 sub PROFILE_SITE { 0 }
 
-# If you want the FastCGI processes to restart, configure this
-sub AUTO_RESTART {
-#    return {
-#        active => 1,
-#        check_each => 10,
-#        max_bits => 134217728,
-#        min_handled_requests => 100
-#    }
-}
-
 # The maximum amount of time a process can be serving a single request. This
 # function takes a Catalyst::Request as input, and should return the amount of time
 # in seconds that it should take to respond to this request.

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -200,11 +200,6 @@ if (DBDefs->USE_ETAGS) {
     push @args, "Cache::HTTP";
 }
 
-if (my $config = DBDefs->AUTO_RESTART) {
-    __PACKAGE__->config->{'Plugin::AutoRestart'} = $config;
-    push @args, 'AutoRestart';
-}
-
 if ($ENV{'MUSICBRAINZ_USE_TEST_DATABASE'})
 {
     use MusicBrainz::Server::DatabaseConnectionFactory;


### PR DESCRIPTION
Remove this module for a few reasons:

 1. Starlet already kills workers for us between a configured min and max number of requests.
 2. Proc::ProcessTable can't compile against musl libc, which is used in Alpine Linux (though this isn't really an issue anymore, because we switched our docker images to use phusion/baseimage).
 3. We can finally close MBS-4071 (Proc::ProcessTable does not scale).

With the settings currently used in production, our logs confirm that workers always get killed after 60 requests (the minimum they're required to handle), because they always exceed a memory size of 350000000 at that point. We can change the Starlet settings min- and max-reqs-per-child to approximate that behavior.