### PR TITLE
Improve root/server.js for running inside docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /admin/apache/startup.pl
 /admin/replication/hooks/post-process
 /root/robots.txt
+/root/static/scripts/common/DBDefs.js
 /blib
 /lib/DBDefs.pm
 /Makefile

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2293,6 +2293,11 @@
       "from": "replace-ext@0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
+    "require-reload": {
+      "version": "0.2.2",
+      "from": "require-reload@0.2.2",
+      "resolved": "https://registry.npmjs.org/require-reload/-/require-reload-0.2.2.tgz"
+    },
     "resolve": {
       "version": "1.1.7",
       "from": "resolve@>=1.1.7 <2.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -900,11 +900,6 @@
       "from": "clone-stats@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
-    "code-point-at": {
-      "version": "1.0.1",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz"
-    },
     "combine-source-map": {
       "version": "0.7.2",
       "from": "combine-source-map@>=0.7.1 <0.8.0",
@@ -1475,11 +1470,6 @@
       "from": "invariant@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-    },
     "is-absolute": {
       "version": "0.2.6",
       "from": "is-absolute@>=0.2.3 <0.3.0",
@@ -1524,11 +1514,6 @@
       "version": "1.0.2",
       "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
@@ -1693,11 +1678,6 @@
       "version": "1.0.4",
       "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "less": {
       "version": "2.7.1",
@@ -2040,11 +2020,6 @@
       "version": "1.0.2",
       "from": "os-homedir@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -2455,11 +2430,6 @@
       "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
-    "string-width": {
-      "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
@@ -2545,19 +2515,7 @@
     "uglify-js": {
       "version": "2.7.3",
       "from": "uglify-js@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz"
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -2757,11 +2715,6 @@
       "from": "wordwrap@0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
     },
-    "wrap-ansi": {
-      "version": "2.0.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-    },
     "wrappy": {
       "version": "1.0.2",
       "from": "wrappy@>=1.0.0 <2.0.0",
@@ -2772,35 +2725,20 @@
       "from": "xtend@>=4.0.0 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
-    "y18n": {
-      "version": "3.2.1",
-      "from": "y18n@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-    },
     "yarb": {
       "version": "0.8.0",
       "from": "yarb@0.8.0",
       "resolved": "https://registry.npmjs.org/yarb/-/yarb-0.8.0.tgz"
     },
     "yargs": {
-      "version": "3.30.0",
-      "from": "yargs@3.30.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.30.0.tgz",
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.2.1 <2.0.0",
+          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "from": "cliui@>=3.0.3 <4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "from": "window-size@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",
     "react-dom": "https://github.com/mwiencek/react-packages/raw/master/react-dom.tgz",
     "redis": "2.6.0-0",
+    "require-reload": "0.2.2",
     "shell-quote": "1.4.3",
     "shelljs": "0.5.3",
     "sliced": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "uglifyify": "3.0.1",
     "vinyl": "1.1.0",
     "vinyl-source-stream": "1.1.0",
-    "yarb": "0.8.0",
-    "yargs": "3.30.0"
+    "yarb": "0.8.0"
   },
   "devDependencies": {
     "eslint": "1.10.2",

--- a/root/server.js
+++ b/root/server.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const http = require('http');
 const _ = require('lodash');
 const redis = require('redis');
+const reload = require('require-reload')(require);
 const path = require('path');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
@@ -18,21 +19,27 @@ const sliced = require('sliced');
 const URL = require('url');
 
 const gettext = require('./server/gettext');
-const DBDefs = require('./static/scripts/common/DBDefs');
+// Reloaded on HUP.
+let DBDefs = reload('./static/scripts/common/DBDefs');
 const i18n = require('./static/scripts/common/i18n');
 const getCookie = require('./static/scripts/common/utility/getCookie');
 
-const REDIS_ARGS = DBDefs.DATASTORE_REDIS_ARGS;
-const redisClient = redis.createClient({
-  url: 'redis://' + REDIS_ARGS.server,
-  prefix: REDIS_ARGS.namespace,
-  retry_strategy: function (options) {
-    const oneMinute = 60 * 1000; // ms
-    if (options.total_retry_time < oneMinute) {
-      return 1;
-    }
-  },
-});
+function createRedisClient() {
+  const REDIS_ARGS = DBDefs.DATASTORE_REDIS_ARGS;
+  return redis.createClient({
+    url: 'redis://' + REDIS_ARGS.server,
+    prefix: REDIS_ARGS.namespace,
+    retry_strategy: function (options) {
+      const oneMinute = 60 * 1000; // ms
+      if (options.total_retry_time < oneMinute) {
+        return 1;
+      }
+    },
+  });
+}
+
+// Reloaded on HUP.
+let redisClient = createRedisClient();
 
 function pathFromRoot(fpath) {
   return path.resolve(__dirname, '../', fpath);
@@ -161,6 +168,9 @@ http.createServer(function (req, res) {
   function reload() {
     clearRequireCache();
     gettext.clearHandles();
+    DBDefs = reload('./static/scripts/common/DBDefs');
+    redisClient.quit();
+    redisClient = createRedisClient();
   }
 
   process.on('SIGINT', cleanup);

--- a/root/server.js
+++ b/root/server.js
@@ -7,12 +7,6 @@
 
 require('babel-core/register');
 
-const argv = require('yargs')
-  .demand('port')
-  .describe('port', 'port to listen on')
-  .describe('development', 'disables module cache if set to 1')
-  .argv;
-
 const fs = require('fs');
 const http = require('http');
 const _ = require('lodash');
@@ -24,10 +18,11 @@ const sliced = require('sliced');
 const URL = require('url');
 
 const gettext = require('./server/gettext');
+const DBDefs = require('./static/scripts/common/DBDefs');
 const i18n = require('./static/scripts/common/i18n');
 const getCookie = require('./static/scripts/common/utility/getCookie');
 
-const REDIS_ARGS = JSON.parse(process.env.DATASTORE_REDIS_ARGS);
+const REDIS_ARGS = DBDefs.DATASTORE_REDIS_ARGS;
 const redisClient = redis.createClient({
   url: 'redis://' + REDIS_ARGS.server,
   prefix: REDIS_ARGS.namespace,
@@ -101,7 +96,7 @@ function getResponse(req, requestBody) {
   // to be used for this request based on the given 'lang' cookie.
   i18n.setGettextHandle(gettext.getHandle(getCookie('lang')));
 
-  if (String(argv.development) === '1') {
+  if (DBDefs.DEVELOPMENT_SERVER) {
     clearRequireCache();
   }
 
@@ -153,7 +148,7 @@ http.createServer(function (req, res) {
     res.end(resInfo.body, 'utf8');
   });
 })
-.listen(argv.port, '127.0.0.1', function (err) {
+.listen(DBDefs.RENDERER_PORT, '127.0.0.1', function (err) {
   if (err) {
     throw err;
   }
@@ -172,5 +167,5 @@ http.createServer(function (req, res) {
   process.on('SIGTERM', cleanup);
   process.on('SIGHUP', reload);
 
-  console.log('server.js listening on 127.0.0.1:' + argv.port + ' (pid ' + process.pid + ')');
+  console.log('server.js listening on 127.0.0.1:' + DBDefs.RENDERER_PORT + ' (pid ' + process.pid + ')');
 });

--- a/root/server.js
+++ b/root/server.js
@@ -155,7 +155,7 @@ http.createServer(function (req, res) {
     res.end(resInfo.body, 'utf8');
   });
 })
-.listen(DBDefs.RENDERER_PORT, '127.0.0.1', function (err) {
+.listen(DBDefs.RENDERER_PORT, '0.0.0.0', function (err) {
   if (err) {
     throw err;
   }
@@ -177,5 +177,5 @@ http.createServer(function (req, res) {
   process.on('SIGTERM', cleanup);
   process.on('SIGHUP', reload);
 
-  console.log('server.js listening on 127.0.0.1:' + DBDefs.RENDERER_PORT + ' (pid ' + process.pid + ')');
+  console.log('server.js listening on 0.0.0.0:' + DBDefs.RENDERER_PORT + ' (pid ' + process.pid + ')');
 });

--- a/script/compile_resources.sh
+++ b/script/compile_resources.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 cd "$(dirname $0)/../"
-eval "$(admin/ShowDBDefs)" && node_modules/.bin/gulp $@
+./script/dbdefs_to_js.pl
+node_modules/.bin/gulp $@

--- a/script/dbdefs_to_js.pl
+++ b/script/dbdefs_to_js.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use DBDefs;
+use JSON;
+use Readonly;
+
+Readonly our @BOOLEAN_DEFS => qw(
+    DEVELOPMENT_SERVER
+);
+
+Readonly our @HASH_DEFS => qw(
+    DATASTORE_REDIS_ARGS
+);
+
+Readonly our @NUMBER_DEFS => qw(
+    RENDERER_PORT
+);
+
+Readonly our @STRING_DEFS => qw(
+    MB_LANGUAGES
+);
+
+my $code = '';
+
+for my $def (@BOOLEAN_DEFS) {
+    my $value = DBDefs->$def;
+
+    if (defined $value && $value eq '1') {
+        $value = 'true';
+    } else {
+        $value = 'false';
+    }
+
+    $code .= "exports.$def = $value;\n";
+}
+
+my $json = JSON->new->allow_nonref->ascii;
+
+for my $def (@HASH_DEFS, @NUMBER_DEFS, @STRING_DEFS) {
+    my $value = DBDefs->$def;
+    $value = $json->encode($value);
+    $code .= "exports.$def = $value;\n";
+}
+
+my $js_path = "$FindBin::Bin/../root/static/scripts/common/DBDefs.js";
+open(my $fh, '>', $js_path);
+print $fh $code;

--- a/script/start_renderer.pl
+++ b/script/start_renderer.pl
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
-use DBDefs;
 use POSIX qw( setsid );
 use Getopt::Long;
 
@@ -12,11 +11,6 @@ my $daemonize = 0;
 GetOptions(
     'daemonize' => \$daemonize,
 ) or exit 2;
-
-my $new_env = DBDefs->get_environment_hash;
-
-local %ENV = (%ENV, %{$new_env});
-local $ENV{NODE_ENV} = DBDefs->DEVELOPMENT_SERVER ? 'development' : 'production';
 
 chomp (my $node_version = `node --version`);
 my $server_js_file = 'server.js';
@@ -48,9 +42,5 @@ if ($child) {
     };
     wait;
 } else {
-    my $server_js_path = File::Spec->catfile(DBDefs->MB_SERVER_ROOT, 'root', $server_js_file);
-
-    exec 'node'         => $server_js_path,
-        '--port'        => DBDefs->RENDERER_PORT,
-        '--development' => DBDefs->DEVELOPMENT_SERVER;
+    exec 'node' => "$FindBin::Bin/../root/$server_js_file";
 }


### PR DESCRIPTION
The gist is that we're now relying on a DBDefs.js file for our JavaScript instead of environment variables. This can be generated by ./script/dbdefs_to_js.pl in the case of client or server-side JS, or it can be generated by consul-template in the case of server-side JS, and reloaded by root/server.js on HUP.