### PR TITLE
Support static resource domains (staticbrainz)

### DIFF
--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -136,6 +136,9 @@ sub CANONICAL_SERVER          { "https://musicbrainz.org" }
 # The server used to link to CritiqueBrainz users and reviews.
 sub CRITIQUEBRAINZ_SERVER     { "https://critiquebrainz.org" }
 
+# The URL where static resources are located, excluding the trailing slash.
+sub STATIC_RESOURCES_LOCATION { 'http://localhost:5000/static' }
+
 ################################################################################
 # Mail Settings
 ################################################################################

--- a/lib/MusicBrainz/Server/Data/FileCache.pm
+++ b/lib/MusicBrainz/Server/Data/FileCache.pm
@@ -75,6 +75,13 @@ sub template_signature {
     return $instance->file_signatures->{$signature_key};
 }
 
+sub path_to {
+    my ($self, $manifest) = @_;
+
+    my $signature = $self->manifest_signature($manifest);
+    return DBDefs->STATIC_RESOURCES_LOCATION . '/' . $signature;
+}
+
 sub _expand {
     my ($path, $type) = @_;
     if (-d $path) {

--- a/root/account/edit.tt
+++ b/root/account/edit.tt
@@ -23,7 +23,7 @@
         [% area_field = form.field('area.name') %]
         <label for="id-profile.area.name">[% l('Location:') %]</label>
         <span class="area autocomplete">
-          <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+          <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
           [% r.hidden(form.field('area').field('gid'), class => 'gid') %]
           [% r.hidden('area_id', class => 'id') %]
           [% r.text(area_field, class => 'name') %]

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -20,7 +20,7 @@
           [% area_field = form.field('area.name') %]
           <label for="id-edit-artist.area.name">[% l('Area:') %]</label>
           <span id="area" class="area autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
 
             [% r.hidden(form.field('area').field('gid'), { class => 'gid' }) %]
             [% r.hidden('area_id', class => 'id') %]
@@ -42,7 +42,7 @@
           [% begin_area_field = form.field('begin_area.name') %]
           <label id="label-id-edit-artist.begin_area.name" for="id-edit-artist.begin_area.name">[% l('Begin Area:') %]</label>
           <span id="begin_area" class="area autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             [% r.hidden(form.field('begin_area').field('gid'), { class => 'gid' }) %]
             [% r.hidden('begin_area_id', class => 'id') %]
             [% r.text(begin_area_field, class => 'name') %]
@@ -55,7 +55,7 @@
           [% end_area_field = form.field('end_area.name') %]
           <label id="label-id-edit-artist.end_area.name" for="id-edit-artist.end_area.name">[% l('End Area:') %]</label>
           <span id="end_area" class="area autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             [% r.hidden(form.field('end_area').field('gid'), { class => 'gid' }) %]
             [% r.hidden('end_area_id', class => 'id') %]
             [% r.text(end_area_field, class => 'name') %]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -539,12 +539,12 @@ END -%]
         [% USE date %]
         <a href="http://127.0.0.1:[% c.session.tport %]/openalbum?id=[% entity.gid %]&t=[% date.now %]"
             class="tagger-icon" title="[% l('Open in tagger') %]">
-            <img src="[% c.uri_for('/static/images/icons/mblookup-tagger.png') %]" alt="[% l('Tagger') %]">
+            <img src="[% c.model('FileCache').path_to('/images/icons/mblookup-tagger.png') %]" alt="[% l('Tagger') %]">
         </a>
     [%- ELSIF entity.isa('MusicBrainz::Server::Entity::Recording') -%]
         <a href="http://127.0.0.1:[% c.session.tport %]/opennat?id=[% entity.gid %]"
             class="tagger-icon" title="[% l('Open in tagger') %]">
-            <img src="[% c.uri_for('/static/images/icons/mblookup-tagger.png') %]" alt="[% l('Tagger') %]">
+            <img src="[% c.model('FileCache').path_to('/images/icons/mblookup-tagger.png') %]" alt="[% l('Tagger') %]">
         </a>
     [%- END -%]
 [%- END -%]
@@ -785,7 +785,7 @@ END -%]
     END -%]
 
 [%~ MACRO warning_icon BLOCK -%]
-   <img class="warning" src="[% c.uri_for('/static/images/icons/warning.png') %]" />
+   <img class="warning" src="[% c.model('FileCache').path_to('/images/icons/warning.png') %]" />
 [%- END -%]
 
 [%~ MACRO error(message, class) BLOCK -%]
@@ -818,11 +818,11 @@ END -%]
         attr_string = "$attr_string ${attr.key}=\"" _ html_escape(attr.value) _ '"';
       END
   ~%]
-  <script src="[% c.uri_for("/static/build/") %][% c.model('FileCache').manifest_signature(manifest) %]"[% attr_string %]></script>
+  <script src="[% c.model('FileCache').path_to('/build/' _ manifest) %]"[% attr_string %]></script>
 [%~ END ~%]
 
 [%~ MACRO css_manifest(manifest) BLOCK ~%]
-  <link rel="stylesheet" type="text/css" href="[% c.uri_for('/static/build/') %][% c.model('FileCache').manifest_signature(manifest) %]" />
+  <link rel="stylesheet" type="text/css" href="[% c.model('FileCache').path_to('/build/' _ manifest) %]" />
 [%~ END ~%]
 
 [%~ MACRO format_length(n) BLOCK; n | format_length; END -%]
@@ -864,7 +864,7 @@ END ~%]
 [%- END -%]
 
 [%~ MACRO filter_button BLOCK -%]
-  <div style="float:right;margin-top:1.5em;"><a class="filter-button"><img src="[% c.uri_for('/static/images/icons/filter.png') %]" alt="" /></a> <a class="filter-button" href="#">[% l("Filter") %]</a></div>
+  <div style="float:right;margin-top:1.5em;"><a class="filter-button"><img src="[% c.model('FileCache').path_to('/images/icons/filter.png') %]" alt="" /></a> <a class="filter-button" href="#">[% l("Filter") %]</a></div>
 [%- END -%]
 
 [%~ MACRO wikidoc_search_box BLOCK -%]

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -221,7 +221,7 @@
   <fieldset class="guesscase">
     <legend>[% lp('Guess case', 'header') %]</legend>
     [% IF show_icon %]
-      <img src="[% c.uri_for("/static/images/icons/guesscase.32x32.png") %]" style="float: left; margin: 1em;" alt="" />
+      <img src="[% c.model('FileCache').path_to('/images/icons/guesscase.32x32.png') %]" style="float: left; margin: 1em;" alt="" />
     [% END %]
     <div style="float: right; margin: 10px;" class="buttons">
       <button type="button" data-bind="click: guessCase">[% lp('Guess case', 'button/menu') %]</button>

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -62,7 +62,7 @@
     </td>
     <td>
       <span class="autocomplete">
-        <img class="search" src="../../../static/images/icons/search.png" alt="[% l('Search') %]"/>
+        <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]"/>
         <input class="name" type="text" data-bind="relationshipEditorAutocomplete: $data" />
       </span>
       <div class="error" data-bind="text: targetEntityError()"></div>
@@ -179,7 +179,7 @@
           <div class="instrument-selection-credit">
             <span class="autocomplete">
               <input data-bind="autocomplete: { entity: 'instrument', currentSelection: $rawData }" />
-              <img class="search" src="/static/images/icons/search.png" alt="[% l('Search') %]" />
+              <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             </span>
             <!-- ko with: $rawData.linkAttribute -->
               <input type="text" class="attribute-credit" placeholder="[% l('credited as') %]" data-bind="value: creditedAs" />

--- a/root/edit/details/edit_medium.tt
+++ b/root/edit/details/edit_medium.tt
@@ -1,5 +1,5 @@
 [%- MACRO changed_mbid_icon BLOCK -%]
-<img title="[% l("This track's MBID will change when this edit is applied.") %]" src="[% c.uri_for('/static/images/icons/information.png') %]" />
+<img title="[% l("This track's MBID will change when this edit is applied.") %]" src="[% c.model('FileCache').path_to('/images/icons/information.png') %]" />
 [%- END -%]
 [%- PROCESS 'edit/details/macros.tt' -%]
 <table class="details edit-medium">

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -228,7 +228,7 @@
                  [ '!=', l('is not') ] ], field_contents) %]
 
   <span class="autocomplete [% autocomplete_name %]">
-      <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+      <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
       <input type="text" class="name" name="name" value="[% html_escape(field_contents.name) %]" style="width: 170px;" />
       <input type="hidden" class="gid" />
       <input type="hidden" class="id" name="args.0" value="[% html_escape(field_contents.argument(0)) %]" />
@@ -260,7 +260,7 @@
                ], field_contents) %]
 
   <span class="arg autocomplete [% field | replace('_', '-') %]">
-      <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+      <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
       <input type="text" class="name" name="name" value="[% html_escape(field_contents.name) %]" style="width: 170px;" />
       <input type="hidden" class="gid" />
       <input type="hidden" class="id" name="args.0" value="[% html_escape(field_contents.argument(0)) %]"  />

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -18,7 +18,7 @@
           [% area_field = form.field('area.name') %]
           <label for="id-edit-label.area.name">[% l('Area:') %]</label>
           <span class="area autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             [% r.hidden(form.field('area').field('gid'), { class => 'gid' }) %]
             [% r.hidden('area_id', class => 'id') %]
             [% r.text(area_field, class => 'name') %]

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -5,7 +5,7 @@
         [%- IF c.debug -%][%- INCLUDE 'debug/stats.tt' -%][%- END ~%]
 
         <div class="header">
-            <a href="/" title="MusicBrainz"><img src="/static/images/layout/header-logo.svg" class="logo" /></a>
+            <a href="/" title="MusicBrainz"><img src="[% c.model('FileCache').path_to('/images/layout/header-logo.svg') %]" class="logo" /></a>
             <div class="right">
                 <div class="top">
                     [%- INCLUDE "layout/header/top.tt" -%]

--- a/root/layout/components/Header.js
+++ b/root/layout/components/Header.js
@@ -5,13 +5,14 @@
 
 const React = require('react');
 
+const manifest = require('../../static/manifest');
 const TopMenu = require('./TopMenu');
 const BottomMenu = require('./BottomMenu');
 
 const Header = (props) => (
   <div className="header">
     <a href="/" className="logo" title="MusicBrainz">
-      <img src="/static/images/layout/header-logo.svg" className="logo" />
+      <img src={manifest.pathTo('/images/layout/header-logo.svg')} className="logo" />
     </a>
     <div className="right">
       <TopMenu {...props} />

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -5,6 +5,7 @@
 
 const React = require('react');
 
+const manifest = require('../../static/manifest');
 const {l, lp} = require('../../static/scripts/common/i18n');
 
 let TYPE_OPTIONS = {
@@ -44,7 +45,7 @@ const Search = () => (
     {' '}{searchOptions}{' '}
     <input type="hidden" id="headerid-method" name="method" value="indexed" />
     <button type="submit">
-      <img src="/static/images/icons/search.svg" />
+      <img src={manifest.pathTo('/images/icons/search.svg')} />
     </button>
   </form>
 );

--- a/root/layout/header/top.tt
+++ b/root/layout/header/top.tt
@@ -96,7 +96,7 @@
         [% sidebar.select('type') %]
         [% sidebar.hidden('method', { value => 'indexed' }) %]
         <button type="submit">
-            <img src="/static/images/icons/search.svg" />
+            <img src="[% c.model('FileCache').path_to('/images/icons/search.svg') %]" />
         </button>
     </form>
 </div>

--- a/root/layout/sidebar/sidebar-licenses.tt
+++ b/root/layout/sidebar/sidebar-licenses.tt
@@ -1,6 +1,6 @@
 [%- MACRO display_license(url) BLOCK -%]
        <li class="[% license_class(url) %]">
-          <a href="[% url.href_url %]"><img src="[% '/static/images/licenses/' _ license_class(url) _ '.png' %]" /></a>
+          <a href="[% url.href_url %]"><img src="[% c.model('FileCache').path_to('/images/licenses/' _ license_class(url) _ '.png') %]" /></a>
         </li>
 [%- END -%]
 

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -19,7 +19,7 @@
           [% area_field = form.field('area.name') %]
           <label for="id-edit-place.area.name">[% l('Area:') %]</label>
           <span class="area autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             [% r.hidden(form.field('area').field('gid'), class => 'gid') %]
             [% r.hidden('area_id', class => 'id') %]
             [% r.text(area_field, class => 'name') %]

--- a/root/relationship/linktype/form.tt
+++ b/root/relationship/linktype/form.tt
@@ -115,7 +115,7 @@
                          optionsText: 'text', optionsValue: 'value'">
           </select>
           <span class="autocomplete">
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
             <input type="text" class="name" value="" style="width: 170px;" />
             <input type="hidden" class="id" value=""  />
             <input type="hidden" class="gid" value=""

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -42,7 +42,7 @@
                 },
                 controlsBubble: $root.releaseGroupBubble"
             />
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
           </span>
         </td>
       </tr>
@@ -179,7 +179,7 @@
                 },
                 controlsBubble: $root.labelBubble"
             />
-            <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+            <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
           </span>
         </td>
         <td><label>[% l('Cat. No:') %]</label></td>

--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -147,7 +147,7 @@
       <p data-bind="with: target">
         [% l('Search:') %]
         <span class="autocomplete">
-          <img class="search" src="[% c.uri_for("/static/images/icons/search.png") %]" alt="[% l('Search') %]" />
+          <img class="search" src="[% c.model('FileCache').path_to('/images/icons/search.png') %]" alt="[% l('Search') %]" />
           <input type="text" class="name" data-bind="autocomplete: { entity: 'recording', currentSelection: recording, lookupHook: $root.recordingAssociation.autocompleteHook($data) }" />
         </span>
       </p>

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -23,19 +23,19 @@
         <tr>
           <td>
             <a id="batch-recording" class="btn" data-bind="css: {disabled: recordingCount() == 0}" data-click="openBatchRecordingsDialog">
-              <img src="/static/images/icons/add.png" class="bottom" />
+              <img src="[% c.model('FileCache').path_to('/images/icons/add.png') %]" class="bottom" />
               [% l('Batch-add a relationship to recordings') %]
             </a>
           </td>
           <td>
             <a id="batch-create-works" class="btn" data-bind="css: {disabled: recordingCount() == 0}" data-click="openBatchCreateWorksDialog">
-              <img src="/static/images/icons/add.png" class="bottom" />
+              <img src="[% c.model('FileCache').path_to('/images/icons/add.png') %]" class="bottom" />
               [% l('Batch-create new works') %]
             </a>
           </td>
           <td>
             <a id="batch-work" class="btn" data-bind="css: {disabled: workCount() == 0}" data-click="openBatchWorksDialog">
-              <img src="/static/images/icons/add.png" class="bottom" />
+              <img src="[% c.model('FileCache').path_to('/images/icons/add.png') %]" class="bottom" />
               [% l('Batch-add a relationship to works') %]
             </a>
           </td>
@@ -195,7 +195,7 @@
         </div>
       </div>
       <span class="add-rel btn" data-click="openAddDialog">
-        <img src="/static/images/icons/add.png" class="bottom" /> [% l('Add relationship') %]
+        <img src="[% c.model('FileCache').path_to('/images/icons/add.png') %]" class="bottom" /> [% l('Add relationship') %]
       </span>
     </script>
 
@@ -213,7 +213,7 @@
         </td>
         <td class="midcol">
           <span class="relate-work btn" data-click="openRelateToWorkDialog">
-            &#8592; <img src="/static/images/icons/add.png" class="bottom"> [% l('Add related work') %] &#8594;
+            &#8592; <img src="[% c.model('FileCache').path_to('/images/icons/add.png') %]" class="bottom"> [% l('Add related work') %] &#8594;
           </span>
         </td>
         <!-- ko with: recording -->

--- a/root/static/manifest.js
+++ b/root/static/manifest.js
@@ -7,6 +7,8 @@ const fs = require('fs');
 const path = require('path');
 const React = require('react');
 
+const DBDefs = require('./scripts/common/DBDefs');
+
 let MANIFEST_MTIME = 0;
 let MANIFEST_LAST_CHECKED = 0;
 let MANIFEST_SIGNAUTRES = {};
@@ -29,15 +31,15 @@ function pathTo(manifest) {
     throw new Error('no such manifest: ' + manifest);
   }
 
-  return path.join('/static/build/', MANIFEST_SIGNAUTRES[manifest]);
+  return DBDefs.STATIC_RESOURCES_LOCATION + '/' + MANIFEST_SIGNAUTRES[manifest];
 }
 
 function js(manifest) {
-  return <script src={pathTo(manifest + '.js')}></script>;
+  return <script src={pathTo('/build/' + manifest + '.js')}></script>;
 }
 
 function css(manifest) {
-  return <link rel="stylesheet" type="text/css" href={pathTo(manifest + '.css')} />;
+  return <link rel="stylesheet" type="text/css" href={pathTo('/build/' + manifest + '.css')} />;
 }
 
 exports.js = js;

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -9,6 +9,7 @@ global.$ = global.jQuery = require("jquery");
 require("jquery.browser");
 require("../lib/jquery.ui/ui/jquery-ui.custom");
 
+require("./common/DBDefs");
 require("./common/MB");
 require("./common/i18n");
 require("./common/text-collapse");

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const $ = require('jquery');
 const ko = require('knockout');
 const React = require('react');
+const manifest = require('../../../manifest');
 const {l} = require('../../common/i18n');
 
 require('../MB/Control/Autocomplete');
@@ -65,7 +66,7 @@ class Autocomplete extends React.Component {
     }
     return (
       <span className={entity + ' autocomplete'}>
-        <img className="search" src="/static/images/icons/search.png" alt={l('Search')} />
+        <img className="search" src={manifest.pathTo('/images/icons/search.png')} alt={l('Search')} />
         <input
           className={className}
           disabled={disabled}

--- a/root/static/scripts/common/errors.js
+++ b/root/static/scripts/common/errors.js
@@ -6,6 +6,7 @@
 const parseStack = require('parse-stack');
 
 const request = require('./utility/request');
+const DBDefs = require('./DBDefs');
 
 // https://wiki.musicbrainz.org/Development/Supported_browsers
 var browser = $.browser;
@@ -21,8 +22,7 @@ var browserIsSupported = (
 
 if (browserIsSupported) {
   let location = window.location;
-  let origin = location.origin || (location.protocol + "//" + location.host);
-  let urlRegex = new RegExp("^" + origin + "/static/build/.*\\.js$");
+  let urlRegex = new RegExp('^' + DBDefs.STATIC_RESOURCES_LOCATION + '/.+\\.js$');
   let reported = {};
 
   window.onerror = function (message, url, line, column, error) {

--- a/root/static/styles/extra/homepage.less
+++ b/root/static/styles/extra/homepage.less
@@ -52,22 +52,21 @@
 }
 
 #taggers ul {
-    background: url(/static/images/logos/musicbrainz-picard.png) no-repeat top left;
+    background: data-uri('../../images/logos/musicbrainz-picard.png') no-repeat top left;
 }
 
 #quick-start ul {
-    background: url(/static/images/layout/quick-start.png) no-repeat top left;
+    background: data-uri('../../images/layout/quick-start.png') no-repeat top left;
 }
 
 #community ul {
-    background: url(/static/images/layout/community.png) no-repeat top left;
+    background: data-uri('../../images/layout/community.png') no-repeat top left;
 }
 
 #products p {
-    background: url(/static/images/layout/download.png) no-repeat top left;
+    background: data-uri('../../images/layout/download.png') no-repeat top left;
 }
 
 #developers p {
-    background: url(/static/images/layout/developer.png) no-repeat top left;
+    background: data-uri('../../images/layout/developer.png') no-repeat top left;
 }
-

--- a/script/dbdefs_to_js.pl
+++ b/script/dbdefs_to_js.pl
@@ -22,6 +22,7 @@ Readonly our @NUMBER_DEFS => qw(
 
 Readonly our @STRING_DEFS => qw(
     MB_LANGUAGES
+    STATIC_RESOURCES_LOCATION
 );
 
 my $code = '';


### PR DESCRIPTION
The majority of the changes are to do with images. Images are now copied to root/static/build along with JS and CSS, their filenames appended with a hash, and all references to them looked up in rev-manifest.json.

This makes it trivial to copy all assets to another server and run zopfli on them, for example.