### PR TITLE
Restore IMSLP URLs validation for Artist entities

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -572,7 +572,6 @@ const CLEANUPS = {
   },
   score: {
     match: [
-      new RegExp("^(https?://)?(www\\.)?imslp\\.org/", "i"),
       new RegExp("^(https?://)?(www\\.)?neyzen\\.com", "i"),
       new RegExp("^(https?://)?(www[0-9]?\\.)?cpdl\\.org", "i")
     ],
@@ -734,7 +733,7 @@ const CLEANUPS = {
   },
   imslp: {
     match: [new RegExp("^(https?://)?(www\\.)?imslp\\.org/", "i")],
-    type: LINK_TYPES.imslp
+    type: _.defaults({}, LINK_TYPES.imslp, LINK_TYPES.score)
   },
   lastfm: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/(music|label|venue|event|festival)/", "i")],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -746,11 +746,13 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://imslp.org/wiki/Category:Buxtehude%2C_Dietrich',
                      input_entity_type: 'artist',
             expected_relationship_type: 'imslp',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://imslp.org/wiki/Die_Zauberfl%C3%B6te,_K.620_(Mozart,_Wolfgang_Amadeus)',
                      input_entity_type: 'work',
             expected_relationship_type: 'score',
+               only_valid_entity_types: ['work']
         },
         // Indiegogo
         {


### PR DESCRIPTION
Newly generated validation rules failed to validate IMSLP artist pages using `CLEANUPS.score` which preceded `CLEANUPS.imslp`. This gets fixed by matching both relationships into `CLEANUPS.imslp`.