### PR TITLE
Add some missing calls to localization wrappers

### DIFF
--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -84,6 +84,12 @@ sub status_name
     return edit_status_name($self->status);
 }
 
+sub l_status_name
+{
+    my $self = shift;
+    return l(edit_status_name($self->status));
+}
+
 has 'data' => (
     isa       => 'HashRef',
     is        => 'rw',

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -73,7 +73,7 @@
 
 <script type="text/html" id="template.dialog-link-type">
   <tr>
-    <td class="section">[% l('Type') %]:</td>
+    <td class="section">[% add_colon(l('Type')) %]</td>
     <td>
       <select class="link-type"
         data-bind="options: linkTypeOptions(relationship().entityTypes),

--- a/root/components/relationships.tt
+++ b/root/components/relationships.tt
@@ -9,7 +9,7 @@
       <table class="details" style="width: 100%">
       [%- FOREACH relationship IN group.value.pairs -%]
           <tr>
-              <th>[% relationship.key %]:</th>
+              <th>[% add_colon(relationship.key) %]</th>
               <td>
                   [% FOR rel IN relationship.value %]
                       [% IF relationship.value.size > 1 && rel.link_order && rel.entity_is_orderable(rel.target) %]

--- a/root/edit/data.tt
+++ b/root/edit/data.tt
@@ -16,7 +16,7 @@
         <ul>
             [% FOREACH type IN related_entities.pairs %]
                 <li>
-                    [% get_plural_type(type.key) %]:
+                    [% add_colon(get_plural_type(type.key)) %]
                     [% es = [];
                        FOREACH e IN type.value.pairs.nsort('key');
                            es.push(link_entity(e.value, 'show', e.key));

--- a/root/edit/data.tt
+++ b/root/edit/data.tt
@@ -4,7 +4,7 @@
 
     <p><strong>[% l('Type:') %]</strong> [% edit.l_edit_name %] ([% edit.edit_type %])</p>
 
-    <p><strong>[% l('Status:') %]</strong> [% edit.status_name %] ([% edit.status %])</p>
+    <p><strong>[% l('Status:') %]</strong> [% edit.l_status_name %] ([% edit.status %])</p>
 
     <p>
         <strong>[% l('Data:') %]</strong>

--- a/root/edit/details/add_relationship_type.tt
+++ b/root/edit/details/add_relationship_type.tt
@@ -39,7 +39,7 @@
       <ul>
         [% FOR attribute=edit.display_data.attributes %]
         <li>
-          [% attribute.type.name %]: [% attribute.min %]-[% attribute.max %]
+          [% add_colon(attribute.type.name) %] [% attribute.min %]-[% attribute.max %]
         </li>
         [% END %]
       </ul>

--- a/root/edit/details/diff_table.tt
+++ b/root/edit/details/diff_table.tt
@@ -3,7 +3,7 @@
         [% IF change.new != change.prev %]
             <tr>
                 <th>
-                    [%- change.label -%]:
+                    [%- add_colon(change.label) -%]
                 </th>
                 <td class="change">
                     [% UNLESS no_prev OR prev == '' %]

--- a/root/edit/details/edit_relationship_type.tt
+++ b/root/edit/details/edit_relationship_type.tt
@@ -70,7 +70,7 @@
       <ul>
         [% FOR attribute=edit.display_data.attributes.old %]
         <li>
-          [% attribute.type.name %]: [% attribute.min %]-[% attribute.max %]
+          [% add_colon(attribute.type.name) %] [% attribute.min %]-[% attribute.max %]
         </li>
         [% END %]
       </ul>
@@ -79,7 +79,7 @@
       <ul>
         [% FOR attribute=edit.display_data.attributes.new %]
         <li>
-          [% attribute.type.name %]: [% attribute.min %]-[% attribute.max %]
+          [% add_colon(attribute.type.name) %] [% attribute.min %]-[% attribute.max %]
         </li>
         [% END %]
       </ul>

--- a/root/edit/info.tt
+++ b/root/edit/info.tt
@@ -1,7 +1,7 @@
 [% IF summary %]
     [% IF edit.status != 1 && edit.status != 2 %]
         <div class="edit-status">
-            [%- edit.status_name -%]
+            [%- edit.l_status_name -%]
         </div>
     [% END %]
 

--- a/root/edit/info.tt
+++ b/root/edit/info.tt
@@ -31,7 +31,7 @@
 [% ELSE %]
     [%- WRAPPER 'layout/sidebar/properties.tt' class='edit-status'-%]
         [%- INCLUDE 'layout/sidebar/property.tt' label=lp('Status:', 'edit status')
-            content=l(edit.status_name) -%]
+            content=edit.l_status_name -%]
     [% END %]
 
     <p>[% edit_status_description(edit) %]</p>

--- a/root/medium/tracklist.tt
+++ b/root/medium/tracklist.tt
@@ -55,13 +55,13 @@ dl.ars dt {
           [% IF type_relationships.key == 'work' %]
             [% FOR group=type_relationships.value %]
               [% FOR rel=group.value %]
-                <dt>[% l(group.key) %]:</dt>
+                <dt>[% add_colon(l(group.key)) %]</dt>
                 <dd>
                   [% link_entity(rel.target) %]
                   [% FOR work_rel_type=rel.target.grouped_relationships('artist') %]
                     <dl class="ars">
                       [% FOR work_rel_group=work_rel_type.value %]
-                        <dt>[% l(work_rel_group.key) %]:</dt>
+                        <dt>[% add_colon(l(work_rel_group.key)) %]</dt>
                         <dd>[% group_dd(work_rel_group) %]</dd>
                       [% END %]
                     </dl>
@@ -71,7 +71,7 @@ dl.ars dt {
             [% END %]
           [% ELSE %]
             [% FOR group=type_relationships.value %]
-              <dt>[% l(group.key) %]:</dt>
+              <dt>[% add_colon(l(group.key)) %]</dt>
               <dd>[% group_dd(group) %]</dd>
             [% END %]
           [% END %]


### PR DESCRIPTION
Fix localization by adding some missing calls to:
- `add_colon` wrapper, in relationship lists for instance
- (new) `l_status_name` wrapper, in summary of failed, rejected, or cancelled edits, and in raw edit data page of all edits.
