### PR TITLE
Fix banner overlap with right floating top menu.

### DIFF
--- a/root/static/styles/extra/banner.less
+++ b/root/static/styles/extra/banner.less
@@ -7,6 +7,7 @@
     background: @effectively-white-bg;
     padding: @form-margin;
     position: relative;
+    clear: both;
 
     @media @wide {
         border-radius: 6px;


### PR DESCRIPTION
Server banners overlap and hide the top menu’s second row.
Especially when the window is narrow enough to reproduce this.
Confirmed in old browsers: **Internet Explorer 8** and **Opera 12.18**.
“Unwelcome” with un‐dismiss‐able banners.
Top (horizontal) menu is `float: right;` so I have added `clear: both;` to the banner so it goes below the horizontal menu bar.
`clear: right;` would have been enough, but…