### PR TITLE
MBS-9130: Update ReCAPTCHA to version 2

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'perl' => '5.18.2';
 # Mandatory modules
 requires 'Algorithm::Diff'                            => '1.1902';
 requires 'Authen::Passphrase'                         => '0.008';
-requires 'Captcha::reCAPTCHA'                         => '0.97';
+requires 'Captcha::reCAPTCHA'                         => '0.99';
 requires 'Catalyst::Action::RenderView'               => '0.16';
 requires 'Catalyst::Authentication::Credential::HTTP' => '1.016';
 requires 'Catalyst::Plugin::Authentication'           => '0.10023';

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -254,7 +254,7 @@ ul.tag-cloud li.tag7 { font-size: 2.5em; font-weight: bold; }
 ** Misc
 */
 
-#recaptcha_widget_div {
+div.g-recaptcha {
     display: inline-block;
 }
 


### PR DESCRIPTION
The first version of ReCAPTCHA, as used to protect account creation, is no longer considered sufficient to protect from modern spam bots. Hence, use version 2 (“NoCAPTCHA”, because in many cases users aren’t shown a traditional CAPTCHA anymore).