### PR TITLE
MBS-9102: Don’t try to calculate an age when there is not enough data

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Role/Age.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Age.pm
@@ -44,9 +44,9 @@ sub has_age
     my @end_comp = $self->end_date->defined_run;
 
     # Shrink @begin_comp and @end_comp to the same size
-    my $shortest_run = min(scalar(@begin_comp) - 1, scalar(@end_comp) - 1);
-    @begin_comp = @begin_comp[0..$shortest_run];
-    @end_comp = @end_comp[0..$shortest_run];
+    my $shortest_run = min(scalar @begin_comp, scalar @end_comp);
+    splice @begin_comp, $shortest_run;
+    splice @end_comp, $shortest_run;
 
     # Compare all elements that are defined in both @begin_comp and
     # @end_comp to determine if @end_comp is greater than @begin_comp.

--- a/lib/MusicBrainz/Server/Entity/Role/Age.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Age.pm
@@ -38,8 +38,10 @@ sub has_age
             )
         ) == -1;
 
-    # If there is no end date, then the end date is now() (so there is an age).
-    my @end_comp = $self->end_date->defined_run or return 1;
+    # If the entity is still active, the end date is now() (so there is an age).
+    return 1 if !$self->ended;
+
+    my @end_comp = $self->end_date->defined_run;
 
     # Shrink @begin_comp and @end_comp to the same size
     my $shortest_run = min(scalar(@begin_comp) - 1, scalar(@end_comp) - 1);

--- a/lib/MusicBrainz/Server/Entity/Role/Age.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Age.pm
@@ -45,6 +45,7 @@ sub has_age
 
     # Shrink @begin_comp and @end_comp to the same size
     my $shortest_run = min(scalar @begin_comp, scalar @end_comp);
+    return 0 if $shortest_run == 0; # no age if there is not even a year
     splice @begin_comp, $shortest_run;
     splice @end_comp, $shortest_run;
 

--- a/t/lib/t/MusicBrainz/Server/Entity/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Entity/Artist.pm
@@ -95,6 +95,9 @@ $artist->begin_date->day(31);
 @got = $artist->age;
 is_deeply ( \@got, [1, 0, 1], "Artist with partial dates, age 1 day" );
 
+$artist->end_date->year(undef);
+ok(!$artist->has_age, "No age for ended artist without end year");
+
 # testing ->age with negative years
 $artist->begin_date->year  (-551);
 $artist->begin_date->month(9);

--- a/t/lib/t/MusicBrainz/Server/Entity/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Entity/Artist.pm
@@ -39,6 +39,8 @@ my $constant_now = wrap 'DateTime::now', post => sub {
     );
 };
 
+# FIXME: Split these tests and make them independent of each other
+
 # testing ->age with exact dates
 $artist->begin_date->year  (1976);
 $artist->begin_date->month(7);
@@ -46,6 +48,7 @@ $artist->begin_date->day   (23);
 $artist->end_date->year  (1976);
 $artist->end_date->month(7);
 $artist->end_date->day   (24);
+$artist->ended(1);
 my @got = $artist->age;
 is_deeply ( \@got, [0, 0, 1], "Artist age 1 day" );
 
@@ -75,6 +78,7 @@ is( ($artist->age)[0], 24, "Artist still alive, age 24 years" );
 # testing ->age with partial dates
 $artist->begin_date->year  (2010);
 $artist->end_date->year  (2012);
+$artist->ended(1);
 @got = $artist->age;
 is_deeply( \@got, [2, 0, 0], "Artist with partial dates, age 1 year" );
 
@@ -98,6 +102,7 @@ $artist->begin_date->day   (28);
 $artist->end_date->year  (-479);
 $artist->end_date->month(4);
 $artist->end_date->day   (11);
+$artist->ended(1);
 ok( !$artist->has_age, "Do not calculate age for artists with negative years");
 
 # testing ->age with future begin dates


### PR DESCRIPTION
The `Age` role didn’t correctly recognize an ended entity without an end date (just the `ended` flag) nor the case where partial begin and end dates were present, but one of them didn’t include the year. This led to it thinking the entity was still active (age calculation up to the current date) or trying to calculate with `undef` (leading to an ISE, https://beta.musicbrainz.org/artist/5cc78d71-a007-4f2d-a703-cd479fad89ac vs. http://mb.chirlu.de/artist/5cc78d71-a007-4f2d-a703-cd479fad89ac).