### PR TITLE
MBS-9138: Avoid redundant requests for image-less entities

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
@@ -44,6 +44,9 @@ sub _get_commons_image {
     # and if not, check Wikidata entity
     $title = _get_wikidata_image($c) if !$title;
 
+    # Return early if no image exists.
+    return unless defined $title;
+
     my $commons_image = $c->model('CommonsImage')->get_commons_image($title, cache_only => $cache_only);
     if ($commons_image) {
         $c->stash->{image} = $commons_image;


### PR DESCRIPTION
For entities supporting images, when there is no image to display (based on any Wikimedia Commons or Wikidata URLs), JavaScript code was still generated for the client to retrieve an image from the `.../commons-image` endpoint. That endpoint then had to load and check the same URLs, only to find again that no image exists; it even did an unnecessary call to the Wikimedia API for an image with an empty title. This may have caused considerable additional and useless load.

When no image is to be found, return early without querying Wikimedia and without prompting the client to access the `commons-image` endpoint.