### PR TITLE
MBS-9140: Language menu has ids instead of names

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -27,6 +27,7 @@ requires 'Date::Calc'                                 => '6.3';
 requires 'DateTime::Format::ISO8601'                  => '0.08';
 requires 'DateTime::Format::Natural'                  => '1.02';
 requires 'DateTime::Format::Pg'                       => '0.16009';
+requires 'DateTime::Locale'                           => '1.11';
 requires 'DateTime::TimeZone'                         => '1.63';
 requires 'DBD::Pg'                                    => '3.5.3';
 requires 'DBI'                                        => '1.63';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1364,15 +1364,15 @@ DISTRIBUTIONS
       DateTime 0
       ExtUtils::MakeMaker 6.42
       Test::More 0.61
-  DateTime-Locale-1.10
-    pathname: D/DR/DROLSKY/DateTime-Locale-1.10.tar.gz
+  DateTime-Locale-1.11
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.11.tar.gz
     provides:
-      DateTime::Locale 1.10
-      DateTime::Locale::Base 1.10
-      DateTime::Locale::Catalog 1.10
-      DateTime::Locale::Data 1.10
-      DateTime::Locale::FromData 1.10
-      DateTime::Locale::Util 1.10
+      DateTime::Locale 1.11
+      DateTime::Locale::Base 1.11
+      DateTime::Locale::Catalog 1.11
+      DateTime::Locale::Data 1.11
+      DateTime::Locale::FromData 1.11
+      DateTime::Locale::Util 1.11
     requirements:
       Carp 0
       Dist::CheckConflicts 0.02
@@ -3296,7 +3296,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       File::Basename 0
       File::Spec 0
-      Mail::Address 1.62
   MIME-Types-2.13
     pathname: M/MA/MARKOV/MIME-Types-2.13.tar.gz
     provides:

--- a/lib/MusicBrainz/Server/Translation.pm
+++ b/lib/MusicBrainz/Server/Translation.pm
@@ -181,12 +181,12 @@ sub all_languages
                            map { [ $_ => DateTime::Locale->load($_) ] }
                            grep { my $l = $_;
                                   grep { $l eq $_ } DateTime::Locale->ids() }
-                           map { s/-([a-z]{2})/_\U$1/; $_; } DBDefs->MB_LANGUAGES;
+                           map { s/-([a-z]{2})/-\U$1/; $_; } DBDefs->MB_LANGUAGES;
     my @lang_without_locale = sort_by { $_->[1]->{id} }
                               map { [ $_ => {'id' => $_, 'native_language' => ''} ] }
                               grep { my $l = $_;
                                      !(grep { $l eq $_ } DateTime::Locale->ids()) }
-                              map { s/-([a-z]{2})/_\U$1/; $_; } DBDefs->MB_LANGUAGES;
+                              map { s/-([a-z]{2})/-\U$1/; $_; } DBDefs->MB_LANGUAGES;
     my @languages = (@lang_with_locale, @lang_without_locale);
     return \@languages;
 }


### PR DESCRIPTION
Version 1.00 of DateTime::Locale had some breaking changes. One of them was that "The canonical form of the locale codes now uses dashes (-) instead of underscores (_)." See: http://cpansearch.perl.org/src/DROLSKY/DateTime-Locale-1.11/Changes

Version 1.10 is already in the cpanfile.snapshot, but I ran ./docker/generate_cpanfile_snapshot.sh again anyway.