### PR TITLE
MBS-7654: Remove “Infer track length from recording” option

### DIFF
--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -118,12 +118,6 @@
       <legend>[% l('Options') %]</legend>
       <p>
         <label>
-          <input type="checkbox" data-bind="checked: $root.inferTrackDurationsFromRecordings" />
-          [% l('Infer track durations from associated recordings') %]
-        </label>
-      </p>
-      <p>
-        <label>
           <input type="checkbox" data-bind="checked: $root.copyTrackTitlesToRecordings" />
           [% l('Copy all track titles to associated recordings.') %]
         </label>

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -299,8 +299,6 @@ const guessFeat = require('../edit/utility/guessFeat');
             });
         },
 
-        inferTrackDurationsFromRecordings: ko.observable(false),
-
         copyTrackTitlesToRecordings: ko.observable(false),
         copyTrackArtistsToRecordings: ko.observable(false)
     });

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -135,7 +135,6 @@ const ERROR_NO_CHANGES = 3;
 
         medium: function (release) {
             var edits = [];
-            var inferTrackDurations = releaseEditor.inferTrackDurationsFromRecordings();
 
             // oldPositions are the original positions for all the original
             // mediums (as they exist in the database). newPositions are all
@@ -160,10 +159,6 @@ const ERROR_NO_CHANGES = 3;
 
                     if (track.hasExistingRecording()) {
                         var newRecording = MB.edit.fields.recording(track.recording());
-
-                        if (inferTrackDurations) {
-                            trackData.length = newRecording.length || trackData.length;
-                        }
 
                         var oldRecording = track.recording.savedEditData;
 


### PR DESCRIPTION
The release editor used to have an option to infer missing track lengths from the length of the associated recording. Now, however, this means a circular reasoning because recording lengths are in turn computed from the lengths of the tracks they appear on. This option is therefore removed.