### PR TITLE
MBS-9142: Return unmatched variable in link phrase

### DIFF
--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -26,7 +26,7 @@ exports.clean = _.memoize(function (linkType, backward) {
     return clean(phrase.replace(attributeRegex, function (match, name, alt) {
         var id = idsByName[name];
 
-        if (typeInfo.attributes[id].min < 1) {
+        if (id !== undefined && typeInfo.attributes[id].min < 1) {
             return (alt ? alt.split('|')[1] : '') || '';
         }
 


### PR DESCRIPTION
Previously, translated (or not) link phrase that contains a variable
which is not an attribute of its relationship/link type would break
the relationship editing dialog in entity editor.

This patch returns the link phrase with the variable name untouched,
rather than crashing the JavaScript interpreter on the next condition.