### PR TITLE
Replace deprecated Postgres keyword

### DIFF
--- a/admin/InitDb.pl
+++ b/admin/InitDb.pl
@@ -206,7 +206,7 @@ sub Create
 
             $system_sql->auto_commit;
             $system_sql->do(
-                "CREATE USER $username $passwordclause NOCREATEDB NOCREATEUSER",
+                "CREATE USER $username $passwordclause NOCREATEDB NOSUPERUSER",
             );
         }
     }


### PR DESCRIPTION
The `NOCREATEUSER` option to the `CREATE USER` command was renamed to `NOSUPERUSER` in Postgres 8.1, and support for the old keyword has been removed in 9.6. It therefore needs to be replaced in `InitDb.pl`.