### PR TITLE
MBS-7009: Improve error message for missing replication info

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -346,7 +346,9 @@ sub begin : Private
     }
 
     if (DBDefs->REPLICATION_TYPE == RT_SLAVE) {
-        $c->stash( last_replication_date => $c->model('Replication')->last_replication_date );
+        my $last_replication_date = $c->model('Replication')->last_replication_date;
+        defined $last_replication_date or die 'Replication info missing on a slave server';
+        $c->stash( last_replication_date => $last_replication_date );
     }
 }
 


### PR DESCRIPTION
When a server is of type `RT_SLAVE`, but there is no information in the `replication_control` table, it used to crash deep inside Catalyst with a difficult-to-understand error message (because `$c->stash` was called with only one parameter). Catch this situation and die explicitly with a clearer explanation.