### PR TITLE
MBS-1352: Different icon for different artist types on Artist pages

### DIFF
--- a/root/artist/header.tt
+++ b/root/artist/header.tt
@@ -1,4 +1,4 @@
-<div class="artistheader">
+<div class="artistheader[% ' ' _ artist.type.name.lower _ '-icon' IF artist.type %]">
     <h1>[% link_entity(artist) %]</h1>
     <p class="subheader">
         <span class="prefix">~</span> [% html_escape(artist.l_type_name) or l('Artist') %]

--- a/root/static/styles/entity-icons.less
+++ b/root/static/styles/entity-icons.less
@@ -8,7 +8,13 @@
 }
 
 .blankheader      { background-image: data-uri('../images/entity/blank.svg') }
-.artistheader     { background-image: data-uri('../images/entity/artist.svg') }
+.artistheader     { background-image: data-uri('../images/entity/artist.svg');
+                    &.choir-icon      { background-image: data-uri('../images/entity/choir.svg') }
+                    &.group-icon      { background-image: data-uri('../images/entity/group.svg') }
+                    &.orchestra-icon  { background-image: data-uri('../images/entity/orchestra.svg') }
+                    &.person-icon     { background-image: data-uri('../images/entity/person.svg') }
+                    &.character-icon  { background-image: data-uri('../images/entity/character.svg') }
+                  }
 .releaseheader    { background-image: data-uri('../images/entity/release.svg') }
 .rgheader         { background-image: data-uri('../images/entity/release_group.svg') }
 .recordingheader  { background-image: data-uri('../images/entity/recording.svg') }


### PR DESCRIPTION
Display different icons for different artist types on the top of the artist page. Earlier on all artist pages only artist icon was displayed.
Issue Link : https://tickets.metabrainz.org/browse/MBS-1352