### PR TITLE
MBS-8542: Block Jaikoz from submitting barcodes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -321,6 +321,8 @@ sub release_submit : Private
     if (@submit) {
         $self->forbidden($c)
             unless $c->user->is_authorized($ACCESS_SCOPE_SUBMIT_BARCODE);
+        $self->_error($c, 'Your client may not submit release barcodes')
+            if $client eq '' || $client =~ /jaikoz/i; # MBS-8542
 
         try {
             $c->model('MB')->with_transaction(sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitRelease.pm
@@ -43,6 +43,13 @@ EOSQL
 
     $mech->credentials('localhost:80', 'musicbrainz.org', 'new_editor', 'password');
 
+    subtest 'Submissions from Jaikoz are rejected (MBS-8542)' => sub {
+        $req = xml_post('/ws/2/release?client=Jaikoz-1.23', $content);
+        $mech->request($req);
+        is($mech->status, HTTP_BAD_REQUEST);
+    };
+
+    $req = xml_post('/ws/2/release?client=test-1.0', $content);
     $mech->request($req);
     is($mech->status, HTTP_OK);
     xml_ok($mech->content);


### PR DESCRIPTION
Barcode submissions from Jaikoz users are notoriously bad, probably due to interface issues in the client. Block submissions from it, at least until these issues are fixed.