### PR TITLE
MBS-8359: Add 'Guess Case' function for Event names

### DIFF
--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -10,7 +10,7 @@
 
       <fieldset>
         <legend>[% l('Event Details') %]</legend>
-        [%- form_row_text_long(r, 'name', l('Name:')) -%]
+        [%- form_row_name_with_guesscase(r) -%]
         [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [% form_row_checkbox(r, 'cancelled', l('This event was cancelled.')) %]
@@ -53,6 +53,8 @@
   </div>
 
 </form>
+
+[%- guesscase_options() -%]
 
 <script type="text/javascript">//<![CDATA[
   (function () {

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -119,9 +119,10 @@ const flags = require('../../flags');
         sortname: guess("Work", "guessSortName")
     };
 
-    // Series doesn't have it's own handler, and just uses the work handler
-    // because additional behavior isn't needed.
+    // Series and Event don't have their own handler, and they use the
+    // work handler because additional behavior isn't needed.
     MB.GuessCase.series = MB.GuessCase.work;
+    MB.GuessCase.event = MB.GuessCase.work;
 
     // lol
     MB.GuessCase.instrument = {


### PR DESCRIPTION
Adding the "Guess case" feature to event names while editing .

Issue Link : https://tickets.metabrainz.org/browse/MBS-8359 