### PR TITLE
MBS-8268: Fix an issue with rating stars display

### DIFF
--- a/root/components/rating-macros.tt
+++ b/root/components/rating-macros.tt
@@ -16,7 +16,7 @@ END -%]
 
 [%- MACRO rating_stars(entity, prevent_rating) BLOCK -%]
 <span class="inline-rating">
-    <span class="star-rating">
+    <span class="star-rating" tabindex="-1">
         [%- current_star_rating = entity.user_rating ? 5 * entity.user_rating / 100 : 0 -%]
         [%- IF entity.user_rating -%]
         <span class="current-user-rating" style="width:[% entity.user_rating %]%;">[% current_star_rating %]</span>

--- a/root/static/scripts/common/ratings.js
+++ b/root/static/scripts/common/ratings.js
@@ -19,9 +19,10 @@ $(document).on("click", "span.star-rating a", function () {
 
     $.getJSON(url, function (data) {
         var currentRatingSpan = $ratingLink.siblings('span');
+        var container = $ratingLink.parent();
         if (!currentRatingSpan.length) {
             currentRatingSpan = $('<span/>');
-            $ratingLink.parent().prepend(currentRatingSpan);
+            container.prepend(currentRatingSpan);
         }
         var rating;
         if (data.rating > 0) {
@@ -46,7 +47,10 @@ $(document).on("click", "span.star-rating a", function () {
             currentRatingSpan.remove();
         }
 
-        $ratingLink.parent().children('a').each(function (i) {
+        // Take focus away from the clicked link as a visual indication
+        container.focus();
+
+        container.children('a').each(function (i) {
             var originalRating = 100 * (1 + i) / 5;
             var newRating = data.rating == originalRating ? 0 : originalRating;
             var oldRatingMatch = this.href.match(/rating=(\d+)/);

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -152,7 +152,6 @@ div.buttons, span.buttons { display: inline-block; }
         top:0;
         left:0;
         text-indent:-1000em;
-        outline:none;
         overflow:hidden;
         border: none;
     }
@@ -164,9 +163,9 @@ div.buttons, span.buttons { display: inline-block; }
     .current-user-rating,
     .current-rating {
         background-image: data-uri('../images/icons/rating_star_small.gif');
+        background-position: 0px 0px;   // grey star
+        outline: none;
     }
-
-    background-position: 0px 0px;       // grey star
 
     .current-rating {
         background-position: 0px -30px; // blue star
@@ -174,6 +173,8 @@ div.buttons, span.buttons { display: inline-block; }
     .current-user-rating {
         background-position: 0px -10px; // yellow star
     }
+    a:active,
+    a:focus,
     a:hover {
         background-position: 0px -20px; // green star
     }

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -130,15 +130,6 @@ div.buttons, span.buttons { display: inline-block; }
 ** RATINGS
 */
 
-.star-rating,
-.star-rating a:hover,
-.star-rating a:active,
-.star-rating a:focus,
-.star-rating .current-user-rating,
-.star-rating .current-rating {
-    background-image: data-uri('../images/icons/rating_star_small.gif');
-}
-
 .star-rating {
     position:relative;
     display:block;
@@ -149,60 +140,64 @@ div.buttons, span.buttons { display: inline-block; }
     list-style:none;
     margin:0;
     padding:0;
-    background-position: 0px 0px;
-}
 
-.star-rating li {
-    display: inline;
-}
+    li {
+        display: inline;
+    }
 
-.star-rating a,
-.star-rating .current-user-rating,
-.star-rating .current-rating {
-    position:absolute;
-    top:0;
-    left:0;
-    text-indent:-1000em;
-    outline:none;
-    overflow:hidden;
-    border: none;
-}
+    a,
+    .current-user-rating,
+    .current-rating {
+        position:absolute;
+        top:0;
+        left:0;
+        text-indent:-1000em;
+        outline:none;
+        overflow:hidden;
+        border: none;
+    }
 
-.star-rating a:hover {
-    background-position: 0px -20px;
-}
+    &,
+    a:hover,
+    a:active,
+    a:focus,
+    .current-user-rating,
+    .current-rating {
+        background-image: data-uri('../images/icons/rating_star_small.gif');
+    }
 
-.star-rating a.stars-1 {
-    width:20%;
-    z-index:6;
-}
+    background-position: 0px 0px;       // grey star
 
-.star-rating a.stars-2 {
-    width:40%;
-    z-index:5;
-}
+    .current-rating {
+        background-position: 0px -30px; // blue star
+    }
+    .current-user-rating {
+        background-position: 0px -10px; // yellow star
+    }
+    a:hover {
+        background-position: 0px -20px; // green star
+    }
 
-.star-rating a.stars-3 {
-    width:60%;
-    z-index:4;
-}
-
-.star-rating a.stars-4 {
-    width:80%;
-    z-index:3;
-}
-
-.star-rating a.stars-5 {
-    width:100%;
-    z-index:2;
-}
-
-.star-rating .current-rating {
-    background-position: 0px -30px;
-}
-
-.star-rating .current-user-rating {
-    background-position: 0px -10px;
+    a.stars-1 {
+        width:20%;
+        z-index:6;
+    }
+    a.stars-2 {
+        width:40%;
+        z-index:5;
+    }
+    a.stars-3 {
+        width:60%;
+        z-index:4;
+    }
+    a.stars-4 {
+        width:80%;
+        z-index:3;
+    }
+    a.stars-5 {
+        width:100%;
+        z-index:2;
+    }
 }
 
 /* for an inline rater */

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -203,8 +203,6 @@ div.buttons, span.buttons { display: inline-block; }
 
 /* for an inline rater */
 .inline-rating {
-    display:-moz-inline-block;
-    display:-moz-inline-box;
     display:inline-block;
 }
 


### PR DESCRIPTION
Short description of the problem:

> Rating links became grey when having focus, such as after a mouse click, partially covering the current rating and the other rating links; in many cases, it appeared to the user as if clicking had not had any effect. The regular display was restored only when the user clicked elsewhere, thereby removing the focus from the rating link.

The details are a bit complicated, please see the individual commits for them. The first commit only does a refactoring of the existing CSS for ratings to make it more LESS, without actually changing anything. The second commit is the actual fix, with a detailed explanation. The third commit is mostly unrelated and removes some CSS statements that were last needed for Firefox 2.