### PR TITLE
MBS-8868: Show label logo from Commons in the sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/CommonsImage.pm
@@ -36,7 +36,7 @@ sub _get_commons_image {
             $_->target;
         } grep {
             $_->target->isa('MusicBrainz::Server::Entity::URL::Commons')
-        } @{ $entity->relationships_by_link_type_names('image') };
+        } @{ $entity->relationships_by_link_type_names('image', 'logo') };
     if ($commons_link) {
         $title = $commons_link->page_name;
     }


### PR DESCRIPTION
Up to now, only label logos available via Wikidata were shown in the sidebar, but not any that are possibly directly linked on Wikimedia Commons. Make it as it is for artist images and fall back to Commons directly if there wouldn’t otherwise be an image to display.