### PR TITLE
Use more compatible robots.txt syntax

### DIFF
--- a/root/robots.txt.staging
+++ b/root/robots.txt.staging
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: *
+Disallow: /


### PR DESCRIPTION
While more modern versions of the `robots.txt` quasi-standard allow wildcards in `Allow`/`Disallow` directives, those aren’t part of the original version and may not be understood by all crawlers. Since we don’t actually need them, use the traditional syntax in the `robots.txt` for the beta server.