### PR TITLE
MBS-9168: Re-enable indentation of certain locales

### DIFF
--- a/lib/MusicBrainz/Server/Form/Alias.pm
+++ b/lib/MusicBrainz/Server/Form/Alias.pm
@@ -85,7 +85,7 @@ sub options_locale {
     my ($self, $field) = @_;
     return [
         map {
-            $_->id => indentation($_->id =~ /_/ ? 1 : 0) . _locale_name_special_cases($_)
+            $_->id => indentation($_->id =~ /-/ ? 1 : 0) . _locale_name_special_cases($_)
         }
             sort_by { $_->name }
             sort_by { $_->id }


### PR DESCRIPTION
Since the update to DateTime::Locale 1.10, parts in locale strings are delimited by hyphens instead of underscores. Change the code that detects sub-locales accordingly, so that they can be indented again for visual grouping.