### PR TITLE
Make use of non-destructive substitution and transliteration

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -300,9 +300,7 @@ sub with_translations {
     my $cookie_lang = Translation->instance->language_from_cookie($c->request->cookies->{lang});
     $c->set_language_cookie($c->request->cookies->{lang}->value) if defined $c->request->cookies->{lang};
     my $lang = Translation->instance->set_language($cookie_lang);
-    # because s///r is a perl 5.14 feature
-    my $html_lang = $lang;
-    $html_lang =~ s/_([A-Z]{2})/-\L$1/;
+    my $html_lang = $lang =~ s/_([A-Z]{2})/-\L$1/r;
 
     $c->stash(
         current_language => $lang,
@@ -330,9 +328,8 @@ around dispatch => sub {
     if (DBDefs->BETA_REDIRECT_HOSTNAME &&
             $beta_redirect && !$unset_beta &&
             !($c->req->uri =~ /set-beta-preference$/)) {
-        my $new_url = $c->req->uri;
         my $ws = DBDefs->WEB_SERVER;
-        $new_url =~ s/$ws/DBDefs->BETA_REDIRECT_HOSTNAME/e;
+        my $new_url = $c->req->uri =~ s/$ws/DBDefs->BETA_REDIRECT_HOSTNAME/er;
         $c->res->redirect($new_url, 307);
     } else {
         $c->with_translations(sub {

--- a/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
@@ -52,8 +52,7 @@ sub create : Local Args(0) RequireAuth(wiki_transcluder) Edit
 
     if ($c->form_posted && $form->process( params => $c->req->params )) {
         my $values = $form->values;
-        my $page = $values->{page};
-        $page =~ s/ /_/g;
+        my $page = $values->{page} =~ s/ /_/gr;
         $c->model('MB')->with_transaction(sub {
             my $edit = $c->model('Edit')->create(
                 edit_type   => $EDIT_WIKIDOC_CHANGE,

--- a/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
@@ -52,7 +52,7 @@ sub create : Local Args(0) RequireAuth(wiki_transcluder) Edit
 
     if ($c->form_posted && $form->process( params => $c->req->params )) {
         my $values = $form->values;
-        my $page = $values->{page} =~ s/ /_/gr;
+        my $page = $values->{page} =~ tr/ /_/r;
         $c->model('MB')->with_transaction(sub {
             my $edit = $c->model('Edit')->create(
                 edit_type   => $EDIT_WIKIDOC_CHANGE,

--- a/lib/MusicBrainz/Server/Controller/Doc.pm
+++ b/lib/MusicBrainz/Server/Controller/Doc.pm
@@ -11,7 +11,7 @@ sub show : Path('')
     my ($self, $c, @args) = @_;
 
     my $id = join '/', @args;
-    $id =~ s/ /_/g;
+    $id =~ tr/ /_/;
 
     my $version = $c->model('WikiDocIndex')->get_page_version($id);
     my $page = $c->model('WikiDoc')->get_page($id, $version);

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -337,8 +337,7 @@ sub edit_type : Path('/doc/Edit_Types') Args(1) {
     my ($self, $c, $edit_type) = @_;
 
     my $class = EditRegistry->class_from_type($edit_type);
-    my $id = 'Edit Type/$class->edit_name';
-    $id =~ s/ /_/g;
+    my $id = 'Edit Type/$class->edit_name' =~ s/ /_/gr;
 
     my $version = $c->model('WikiDocIndex')->get_page_version($id);
     my $page = $c->model('WikiDoc')->get_page($id, $version);

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -337,7 +337,7 @@ sub edit_type : Path('/doc/Edit_Types') Args(1) {
     my ($self, $c, $edit_type) = @_;
 
     my $class = EditRegistry->class_from_type($edit_type);
-    my $id = 'Edit Type/$class->edit_name' =~ s/ /_/gr;
+    my $id = 'Edit Type/$class->edit_name' =~ tr/ /_/r;
 
     my $version = $c->model('WikiDocIndex')->get_page_version($id);
     my $page = $c->model('WikiDoc')->get_page($id, $version);

--- a/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
@@ -469,8 +469,7 @@ sub _seeded_track
     }
 
     if (my $number = _seeded_string($params->{number}, "$field_name.number", $errors)) {
-        $result->{number} = trim($number);
-        $result->{number} =~ s/^0+(\d+)/$1/g;
+        $result->{number} = trim($number) =~ s/^0+(\d+)/$1/gr;
     }
 
     if (my $ac = $params->{artist_credit}) {

--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -110,10 +110,8 @@ sub countries : Local
     foreach my $stat_name
         (rev_nsort_by { $stats->statistic($_) } $stats->statistic_names) {
         if (my ($iso_code) = $stat_name =~ /^$artist_country_prefix\.(.*)$/) {
-            my $release_stat = $stat_name;
-            my $label_stat = $stat_name;
-            $release_stat =~ s/$artist_country_prefix/$release_country_prefix/;
-            $label_stat =~ s/$artist_country_prefix/$label_country_prefix/;
+            my $release_stat = $stat_name =~ s/$artist_country_prefix/$release_country_prefix/r;
+            my $label_stat = $stat_name =~ s/$artist_country_prefix/$label_country_prefix/r;
             push(@$country_stats, ({'entity' => $countries{$iso_code}, 'artist_count' => $stats->statistic($stat_name), 'release_count' => $stats->statistic($release_stat), 'label_count' => $stats->statistic($label_stat)}));
         }
     }
@@ -224,8 +222,7 @@ sub formats : Path('formats')
     foreach my $stat_name
         (rev_nsort_by { $stats->statistic($_) } $stats->statistic_names) {
         if (my ($format_id) = $stat_name =~ /^$medium_format_prefix\.(.*)$/) {
-            my $release_stat = $stat_name;
-            $release_stat =~ s/$medium_format_prefix/$release_format_prefix/;
+            my $release_stat = $stat_name =~ s/$medium_format_prefix/$release_format_prefix/r;
             push(@$format_stats, ({'entity' => $formats{$format_id}, 'medium_count' => $stats->statistic($stat_name), 'medium_stat' => $stat_name, 'release_count' => $stats->statistic($release_stat), 'release_stat' => $release_stat}));
         }
     }

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -237,8 +237,7 @@ sub collection_browse : Private {
             show_private => $show_private,
         }, $limit, $offset);
     } else {
-        my $entity_type = $resource;
-        $entity_type =~ s/-/_/g;
+        my $entity_type = $resource =~ s/-/_/gr;
         my $entity = $c->model(type_to_model($entity_type))->get_by_gid($id);
         $c->detach('not_found') unless $entity;
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -237,7 +237,7 @@ sub collection_browse : Private {
             show_private => $show_private,
         }, $limit, $offset);
     } else {
-        my $entity_type = $resource =~ s/-/_/gr;
+        my $entity_type = $resource =~ tr/-/_/r;
         my $entity = $c->model(type_to_model($entity_type))->get_by_gid($id);
         $c->detach('not_found') unless $entity;
 

--- a/lib/MusicBrainz/Server/ControllerUtils/CDTOC.pm
+++ b/lib/MusicBrainz/Server/ControllerUtils/CDTOC.pm
@@ -11,8 +11,7 @@ sub add_dash
    my ($c, $discid) = @_;
 
    if (substr($discid,length($discid)-1,1) ne '-') {
-       my $redir = $c->relative_uri;
-       $redir =~ s/$discid/$discid-/;
+       my $redir = $c->relative_uri =~ s/$discid/$discid-/r;
        $c->response->redirect($redir);
        $c->detach;
    }

--- a/lib/MusicBrainz/Server/Data/CommonsImage.pm
+++ b/lib/MusicBrainz/Server/Data/CommonsImage.pm
@@ -31,7 +31,7 @@ sub _commons_image_callback
 {
     my (%opts) = @_;
     if ($opts{fetched}{content}) {
-        my ($thumb, $image) = map { s/^https?://; $_ } ($opts{fetched}{content}[0]{thumburl}, $opts{fetched}{content}[0]{url});
+        my ($thumb, $image) = map { s/^https?://r } ($opts{fetched}{content}[0]{thumburl}, $opts{fetched}{content}[0]{url});
         return CommonsImage->new( title => $opts{fetched}{title},
                                   thumb_url => $thumb,
                                   image_url => $image);

--- a/lib/MusicBrainz/Server/Data/DurationLookup.pm
+++ b/lib/MusicBrainz/Server/Data/DurationLookup.pm
@@ -49,7 +49,7 @@ sub lookup
 {
     my ($self, $toc, $fuzzy) = @_;
 
-    $toc =~ s/\+/ /g;
+    $toc =~ tr/+/ /;
     my %toc_info = _parse_toc($toc);
     return undef unless scalar(%toc_info);
 

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -216,8 +216,7 @@ sub search
         $extra_columns .= 'entity.time, entity.cancelled, entity.begin_date_year, entity.begin_date_month, entity.begin_date_day,
                 entity.end_date_year, entity.end_date_month, entity.end_date_day, entity.ended,' if $type eq 'event';
 
-        my $extra_groupby_columns = $extra_columns;
-        $extra_groupby_columns =~ s/[^ ,]+ AS //g;
+        my $extra_groupby_columns = $extra_columns =~ s/[^ ,]+ AS //gr;
 
         my $extra_joins = '';
         if ($type eq 'area') {
@@ -394,8 +393,7 @@ sub schema_fixup
     }
     if ($type eq 'area') {
         for my $prop (qw( iso_3166_1 iso_3166_2 iso_3166_3 )) {
-            my $json_prop = $prop . '-codes';
-            $json_prop =~ s/_/-/g;
+            my $json_prop = ($prop =~ s/_/-/gr) . '-codes';
             if (defined $data->{$json_prop}) {
                 $data->{$prop} = $data->{$json_prop};
                 delete $data->{$json_prop};
@@ -404,8 +402,7 @@ sub schema_fixup
     }
     if ($type eq 'artist' || $type eq 'label' || $type eq 'place') {
         for my $prop (qw( area begin_area end_area )) {
-            my $json_prop = $prop;
-            $json_prop =~ s/_/-/;
+            my $json_prop = $prop =~ s/_/-/gr;
             if (defined $data->{$json_prop})
             {
                 my $area = delete $data->{$json_prop};
@@ -907,10 +904,8 @@ sub xml_search
                         parameter => 'title',
                         escape    => 1,
                         process => sub {
-                            my $term = shift;
-                            $term =~ s/\s*(.*?)\s*$/$1/;
-                            $term =~ tr/A-Z/a-z/;
-                            $term;
+                            shift =~ s/\s*(.*?)\s*$/$1/r
+                                  =~ tr/A-Z/a-z/r
                         },
                         split     => 1,
                         predicate => sub { shift }
@@ -923,7 +918,7 @@ sub xml_search
                         parameter => 'artist',
                         escape    => 1,
                         split     => 1,
-                        process   => sub { my $term = shift; $term =~ s/\s*(.*?)\s*$/$1/; $term }
+                        process   => sub { shift =~ s/\s*(.*?)\s*$/$1/r }
                     },
                     type => {
                         parameter => 'releasetype',
@@ -954,10 +949,8 @@ sub xml_search
                         parameter => 'title',
                         escape    => 1,
                         process => sub {
-                            my $term = shift;
-                            $term =~ s/\s*(.*?)\s*$/$1/;
-                            $term =~ tr/A-Z/a-z/;
-                            $term;
+                            shift =~ s/\s*(.*?)\s*$/$1/r
+                                  =~ tr/A-Z/a-z/r
                         },
                         split     => 1,
                         predicate => sub { shift }
@@ -970,7 +963,7 @@ sub xml_search
                         parameter => 'artist',
                         escape    => 1,
                         split     => 1,
-                        process   => sub { my $term = shift; $term =~ s/\s*(.*?)\s*$/$1/; $term }
+                        process   => sub { shift =~ s/\s*(.*?)\s*$/$1/r }
                     },
                     type => {
                         parameter => 'releasetype',
@@ -987,10 +980,8 @@ sub xml_search
                         parameter => 'title',
                         escape    => 1,
                         process => sub {
-                            my $term = shift;
-                            $term =~ s/\s*(.*?)\s*$/$1/;
-                            $term =~ tr/A-Z/a-z/;
-                            $term;
+                            shift =~ s/\s*(.*?)\s*$/$1/r
+                                  =~ tr/A-Z/a-z/r
                         },
                         predicate => sub { shift },
                         split     => 1,
@@ -1003,7 +994,7 @@ sub xml_search
                         parameter => 'artist',
                         escape    => 1,
                         split     => 1,
-                        process   => sub { my $term = shift; $term =~ s/\s*(.*?)\s*$/$1/; $term }
+                        process   => sub { shift =~ s/\s*(.*?)\s*$/$1/r }
                     },
                     reid => {
                         parameter => 'releaseid',

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -393,7 +393,7 @@ sub schema_fixup
     }
     if ($type eq 'area') {
         for my $prop (qw( iso_3166_1 iso_3166_2 iso_3166_3 )) {
-            my $json_prop = ($prop =~ s/_/-/gr) . '-codes';
+            my $json_prop = ($prop =~ tr/_/-/r) . '-codes';
             if (defined $data->{$json_prop}) {
                 $data->{$prop} = $data->{$json_prop};
                 delete $data->{$json_prop};
@@ -402,7 +402,7 @@ sub schema_fixup
     }
     if ($type eq 'artist' || $type eq 'label' || $type eq 'place') {
         for my $prop (qw( area begin_area end_area )) {
-            my $json_prop = $prop =~ s/_/-/gr;
+            my $json_prop = $prop =~ tr/_/-/r;
             if (defined $data->{$json_prop})
             {
                 my $area = delete $data->{$json_prop};

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -74,12 +74,10 @@ our @EXPORT_OK = qw(
 Readonly my %TYPE_TO_MODEL => map { $_ => $ENTITIES{$_}{model} } grep { $ENTITIES{$_}{model} } keys %ENTITIES;
 
 sub copy_escape {
-    my $str = shift;
-    $str =~ s/\n/\\n/g;
-    $str =~ s/\t/\\t/g;
-    $str =~ s/\r/\\r/g;
-    $str =~ s/\\/\\\\/g;
-    return $str;
+    shift =~ s/\n/\\n/gr
+          =~ s/\t/\\t/gr
+          =~ s/\r/\\r/gr
+          =~ s/\\/\\\\/gr
 }
 
 sub ref_to_type
@@ -272,18 +270,16 @@ sub add_coordinates_to_row
 }
 
 sub collapse_whitespace {
-    my $t = shift;
+    shift
 
     # Replace all spaces with U+0020
-    $t =~ s/\s/ /g;
+    =~ s/\s/ /gr
 
     # Remove non-printable characters.
-    $t =~ s/[^[:print:]]//g;
+    =~ s/[^[:print:]]//gr
 
     # Compress whitespace
-    $t =~ s/\s{2,}/ /g;
-
-    return $t;
+    =~ s/\s{2,}/ /gr
 }
 
 sub sanitize {
@@ -324,7 +320,7 @@ sub remove_direction_marks {
             } {$1}gx;
 
     # Remove LRM/RLM from strings without RTL characters
-    my $stripped = $t; $stripped =~ s/[\x{200E}\x{200F}]//g;
+    my $stripped = $t =~ s/[\x{200E}\x{200F}]//gr;
     unless ($stripped =~ /[\p{Bidi_Class=Right_To_Left}\p{Bidi_Class=Arabic_Letter}]/)
         # The test must be done on $stripped because RLM is in Right_To_Left itself.
     {
@@ -335,13 +331,12 @@ sub remove_direction_marks {
 }
 
 sub remove_invalid_characters {
-    my $t = shift;
+    shift
     # trim XML-invalid characters
-    $t =~ s/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]//go;
+    =~ s/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]//gor
     # trim other undesirable characters
-    $t =~ s/[\x{200B}\x{00AD}]//go;
-    #        zwsp    shy
-    return $t
+    =~ s/[\x{200B}\x{00AD}]//gor
+    #     zwsp    shy
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -12,11 +12,8 @@ use URI::Escape qw( uri_escape_utf8 );
 with 'MusicBrainz::Server::Data::Role::Context';
 
 # Escape special characters in a Lucene search query
-sub escape_query
-{
-    my $str = shift;
-    $str =~  s/([+\-&|!(){}\[\]\^"~*?:\\])/\\$1/g;
-    return $str;
+sub escape_query {
+    shift =~ s/([+\-&|!(){}\[\]\^"~*?:\\])/\\$1/gr
 }
 
 # construct a lucene search query based on the args given and then pass it to a search server.

--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -99,7 +99,7 @@ sub _create_page
 {
     my ($self, $id, $version, $content, $index) = @_;
 
-    my $title = $id =~ s/_/ /gr;
+    my $title = $id =~ tr/_/ /r;
     # Create hierarchy for displaying in the h1
     my @hierarchy = split('/',$title);
 

--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -99,8 +99,7 @@ sub _create_page
 {
     my ($self, $id, $version, $content, $index) = @_;
 
-    my $title = $id;
-    $title =~ s/_/ /g;
+    my $title = $id =~ s/_/ /gr;
     # Create hierarchy for displaying in the h1
     my @hierarchy = split('/',$title);
 

--- a/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Data/WikipediaExtract.pm
@@ -109,8 +109,7 @@ sub _wikidata_languages_callback
         my @langs;
         for my $wiki (keys %{ $opts{fetched}{content}{sitelinks} }) {
             if ($wiki =~ /wiki$/ and $wiki ne 'commonswiki') {
-                my $lang = $wiki;
-                $lang =~ s/wiki$//;
+                my $lang = $wiki =~ s/wiki$//r;
                 my $page = $opts{fetched}{content}{sitelinks}{$wiki}{title};
                 push @langs, {"lang" => $lang, "title" => $page}
             }

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -25,12 +25,8 @@ sub edit_name { die 'Unimplemented' }
 sub edit_kind { die 'Unimplemented' }
 sub l_edit_name { l(shift->edit_name) }
 
-sub edit_template
-{
-    my $self = shift;
-    my $name = lc($self->edit_name);
-    $name =~ s/\s+/_/g;
-    return $name;
+sub edit_template {
+    lc(shift->edit_name) =~ s/\s+/_/gr
 }
 
 has 'c' => (

--- a/lib/MusicBrainz/Server/Entity/URL/LastFM.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/LastFM.pm
@@ -6,13 +6,7 @@ extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
 sub sidebar_name {
-    my $self = shift;
-
-    my $name = $self->decoded_local_part;
-    $name =~ s{^/music/}{};
-    $name =~ tr/+/ /;
-
-    return $name;
+    shift->decoded_local_part =~ s{^/music/}{}r =~ tr/+/ /r
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -169,14 +169,11 @@ sub _display_trimmed {
 }
 
 sub normalise_url {
-    my $url = shift;
     # The regular expression in format_editnote is not clever enough to handle
     # percent encoded parenthesis.
 
-    $url =~ s/%28/\(/g;
-    $url =~ s/%29/\)/g;
-
-    return $url;
+    shift =~ s/%28/\(/gr
+          =~ s/%29/\)/gr
 }
 
 sub format_editnote

--- a/lib/MusicBrainz/Server/Form.pm
+++ b/lib/MusicBrainz/Server/Form.pm
@@ -76,8 +76,7 @@ sub serialize
     # iterate over all fields instead of walking the tree.
     for my $full_name (keys %$fif)
     {
-        my $field = $full_name;
-        $field =~ s/^\Q$name.\E//;
+        my $field = $full_name =~ s/^\Q$name.\E//r;
 
         $attributes->{$full_name} = { map {
             $_ => $self->field($field)->$_
@@ -102,8 +101,7 @@ sub unserialize
 
     for my $full_name (keys %{ $data->{'attributes'} })
     {
-        my $field = $full_name;
-        $field =~ s/^\Q$name.\E//;
+        my $field = $full_name =~ s/^\Q$name.\E//r;
 
         next unless $self->field($field);
 

--- a/lib/MusicBrainz/Server/Sitemap/Builder.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Builder.pm
@@ -224,8 +224,7 @@ sub build_one_sitemap {
     die "Too many URLs for one sitemap: $filename" if scalar @urls > $MAX_SITEMAP_SIZE;
 
     my $local_filename = File::Spec->catfile($self->output_dir, $filename);
-    my $local_xml_filename = $local_filename;
-    $local_xml_filename =~ s/\.gz$//;
+    my $local_xml_filename = $local_filename =~ s/\.gz$//r;
     my $remote_filename = DBDefs->CANONICAL_SERVER . '/' . $filename;
     my $existing_md5;
 

--- a/lib/MusicBrainz/Server/Sitemap/Incremental.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Incremental.pm
@@ -302,7 +302,7 @@ sub get_primary_keys($$$) {
 
     map {
         # Some columns are wrapped in quotes, others aren't...
-        $_ =~ s/^"(.*?)"$/$1/; $_
+        s/^"(.*?)"$/$1/r
     } $c->sql->dbh->primary_key(undef, $schema, $table);
 }
 
@@ -699,9 +699,8 @@ sub get_current_replication_sequence {
     }
 
     my $replication_info = decode_json($response->content);
-    my $current_seq = $replication_info->{last_packet};
-    $current_seq =~ s/^replication-([0-9]+)\.tar\.bz2$/$1/;
-    return $current_seq;
+
+    $replication_info->{last_packet} =~ s/^replication-([0-9]+)\.tar\.bz2$/$1/r
 }
 
 sub run {

--- a/lib/MusicBrainz/Server/Translation.pm
+++ b/lib/MusicBrainz/Server/Translation.pm
@@ -133,11 +133,8 @@ sub set_language
     }
     # Strip off charset
     $set_lang =~ s/\.utf-8//;
-    # because s///r is a perl 5.14 feature
-    my $set_lang_munge = $set_lang;
-    $set_lang_munge =~ s/_([A-Z]{2})/-\L$1/;
-    my $set_lang_nocountry = $set_lang;
-    $set_lang_nocountry =~ s/_[A-Z]{2}//;
+    my $set_lang_munge = $set_lang =~ s/_([A-Z]{2})/-\L$1/r;
+    my $set_lang_nocountry = $set_lang =~ s/_[A-Z]{2}//r;
     # Change en_AQ back to en-aq to compare with MB_LANGUAGES
     if (grep { $set_lang eq $_ || $set_lang_munge eq $_ } DBDefs->MB_LANGUAGES) {
         return $set_lang;
@@ -181,12 +178,12 @@ sub all_languages
                            map { [ $_ => DateTime::Locale->load($_) ] }
                            grep { my $l = $_;
                                   grep { $l eq $_ } DateTime::Locale->ids() }
-                           map { s/-([a-z]{2})/-\U$1/; $_; } DBDefs->MB_LANGUAGES;
+                           map { s/-([a-z]{2})/-\U$1/r } DBDefs->MB_LANGUAGES;
     my @lang_without_locale = sort_by { $_->[1]->{id} }
                               map { [ $_ => {'id' => $_, 'native_language' => ''} ] }
                               grep { my $l = $_;
                                      !(grep { $l eq $_ } DateTime::Locale->ids()) }
-                              map { s/-([a-z]{2})/-\U$1/; $_; } DBDefs->MB_LANGUAGES;
+                              map { s/-([a-z]{2})/-\U$1/r } DBDefs->MB_LANGUAGES;
     my @languages = (@lang_with_locale, @lang_without_locale);
     return \@languages;
 }

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -175,11 +175,8 @@ sub is_valid_isni
     return $isni =~ /^[0-9]{15}[0-9X]$/;
 }
 
-sub format_isni
-{
-    my $isni = shift;
-    $isni =~ s/[\s\.]//g;
-    return $isni;
+sub format_isni {
+    shift =~ s/[\s\.]//gr
 }
 
 sub is_valid_url

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -229,17 +229,14 @@ sub _with_primary_alias {
     my @output;
     if (@$results) {
         my $munge_lang = sub {
-            my $lang = shift;
-            $lang =~ s/_[A-Z]{2}/_/;
-            return $lang;
+            shift =~ s/_[A-Z]{2}/_/r
         };
 
         my %alias_preference = (
             en => 2,
             en_ => 1
         );
-        my $lang = $munge_lang->($results->[0]->{current_language});
-        $lang =~ s/_$//;
+        my $lang = $munge_lang->($results->[0]->{current_language}) =~ s/_$//r;
         $alias_preference{$lang} = 4 if $lang ne 'en';
         $alias_preference{$lang . '_'} = 3 if $lang ne 'en';
 

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -16,7 +16,7 @@ sub serialize
 {
     my ($self, $type, @data) = @_;
 
-    $type =~ s/-/_/g;
+    $type =~ tr/-/_/;
 
     my $override = $self->meta->find_method_by_name($type);
     return $override->execute($self, @data) if $override;

--- a/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
+++ b/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
@@ -52,7 +52,7 @@ sub BUILD
     {
         foreach my $rel (@{$args->{relations}})
         {
-            $rel =~ s/-/_/g;
+            $rel =~ tr/-/_/;
             $methods{$rel}->set_value($self, 1);
         }
     }
@@ -60,7 +60,7 @@ sub BUILD
     foreach my $arg (@{$args->{inc}})
     {
         $arg = lc($arg);
-        $arg =~ s/-/_/g;
+        $arg =~ tr/-/_/;
         $arg =~ s/mediums/media/;
 
         MusicBrainz::Server::WebService::Exceptions::UnknownIncParameter->throw( parameter => $arg )

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -1306,8 +1306,7 @@ sub serialize
 
     my $gen = MusicBrainz::XML->new();
 
-    my $method = $type . "_resource";
-    $method =~ s/-/_/g;
+    my $method = ($type =~ s/-/_/gr) . "_resource";
     my $xml = $xml_decl_begin;
     $xml .= $self->$method($gen, $entity, $inc, $stash);
     $xml .= $xml_decl_end;

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -1306,7 +1306,7 @@ sub serialize
 
     my $gen = MusicBrainz::XML->new();
 
-    my $method = ($type =~ s/-/_/gr) . "_resource";
+    my $method = ($type =~ tr/-/_/r) . "_resource";
     my $xml = $xml_decl_begin;
     $xml .= $self->$method($gen, $entity, $inc, $stash);
     $xml .= $xml_decl_end;

--- a/lib/MusicBrainz/XML.pm
+++ b/lib/MusicBrainz/XML.pm
@@ -5,7 +5,7 @@ sub AUTOLOAD {
     my $self = shift;
 
     my ($tag) = our $AUTOLOAD =~ /.*::(.*)/;
-    $tag =~ s/_/-/g;
+    $tag =~ tr/_/-/;
 
     my %attrs = ref($_[0]) eq 'HASH' ? %{ shift() } : ();
 

--- a/lib/Sql.pm
+++ b/lib/Sql.pm
@@ -583,8 +583,7 @@ sub DEMOLISH
 {
     my $self = shift;
     my $t = tv_interval($self->t0);
-    my $sql = $self->sql;
-    $sql =~ s/\s+/ /sg;
+    my $sql = $self->sql =~ s/\s+/ /sgr;
 
     # Uncomment this if you're only interested in queries which take longer
     # than $somelimit


### PR DESCRIPTION
Simplify some parts by using the `/r` non-destructive flag to the substitution operator (new since Perl 5.14): `$foo =~ s/bar/baz/r` doesn’t modify `$foo` as it would do without the `/r`, but simply returns a value with the substitution applied. Furthermore, replace simple character substitutions with transliterations (`tr///`).