### PR TITLE
MBS-9175: Include non-TOC mediums in “Attach TOC” search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -509,7 +509,6 @@ sub find_for_cdtoc
         LEFT JOIN release_event ON release_event.release = release.id
         WHERE track_count_matches_cdtoc(medium, ?)
           AND acn.artist = ?
-          AND (medium_format.id IS NULL OR medium_format.has_discids)
         ORDER BY release.id, release.release_group,
           date_year, date_month, date_day, musicbrainz_collate(release.name)
       ) s

--- a/root/cdtoc/attach_filter_release.tt
+++ b/root/cdtoc/attach_filter_release.tt
@@ -17,7 +17,7 @@
     [% r.hidden('query') %]
     [%- IF results.size -%]
       <p>
-        [% ln('{num} release found matching your query.', '{num} release found matching your query.',
+        [% ln('{num} release found matching your query.', '{num} releases found matching your query.',
                 results.size, { num => results.size }) %]
       </p>
 


### PR DESCRIPTION
When searching for a medium to attach a TOC to, only mediums of a type that supports TOCs (such as CD) are candidates. However, it is desirable to show even other mediums with the right number of tracks: Not doing so confuses users (“I’m dead sure this artist has a release with 5 tracks!”), and mediums of the wrong type may serve as model for a release duplicate in the right type. For these reasons, a search by release title has always returned all mediums with matching track count (selecting one of a non-TOC type was disabled in the UI); a search by artist, however, did not include mediums of types that don’t support TOCs.

Make this consistent by returning non-TOC mediums when searching by artist, too. They will be disabled UI-wise in the same way as they already were for a search by release title.