### PR TITLE
Remove removed endpoint from UnconfirmedEmailAddresses test

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -114,7 +114,6 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Artist::credit",
   "Controller::Artist::details",
   "Controller::Artist::edits",
-  "Controller::Artist::import",
   "Controller::Artist::latest_annotation",
   "Controller::Artist::open_edits",
   "Controller::Artist::ratings",


### PR DESCRIPTION
Test fix, forgotten in commit ef1ea4a18901d69c2d47f040ee2d836982343cb0.