### PR TITLE
MBS-9180: Near-identical duplicates of common-xxx.js

### DIFF
--- a/script/compile_resources.sh
+++ b/script/compile_resources.sh
@@ -3,6 +3,8 @@
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 cd "$MB_SERVER_ROOT"
 
-./script/dbdefs_to_js.pl
+./script/dbdefs_to_js.pl --client
 
 ./node_modules/.bin/gulp $@
+
+./script/dbdefs_to_js.pl

--- a/script/dbdefs_to_js.pl
+++ b/script/dbdefs_to_js.pl
@@ -42,7 +42,7 @@ for my $def (@BOOLEAN_DEFS) {
     $code .= "exports.$def = $value;\n";
 }
 
-my $json = JSON->new->allow_nonref->ascii;
+my $json = JSON->new->allow_nonref->ascii->canonical;
 
 for my $def (@HASH_DEFS, @NUMBER_DEFS, @STRING_DEFS) {
     my $value = DBDefs->$def;


### PR DESCRIPTION
Two changes here. The first is to add `->canonical` to the JSON object, so that the keys aren't outputted in random order. The second is to remove unused settings from the client JS altogether. I think the first fix is still good to have independent of the second fix, because we may have object-like DBDefs settings in the client JS in the future.