### PR TITLE
MBS-9186: Gulpfile fails to build scripts in website containers

### DIFF
--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -158,16 +158,17 @@ function buildScripts() {
   var commonBundle = runYarb('common.js');
 
   // The client JS needs access to rev-manifest.json too. We obviously can't
-  // know its contents yet. So, create an empty Vinyl whose path is set to
-  // rev-manifest.json. Yarb will use this instead of attempting to read that
-  // path from disk. Later, once the `revManifest` object is populated, we
-  // can set the contents buffer on this currently-empty Vinyl.
+  // know its contents yet. So, create an empty Vinyl and expose this as the
+  // global ID "rev-manifest.json" for modules to require(). Later, once the
+  // `revManifest` object is populated, we can set the contents buffer on this
+  // currently-empty Vinyl.
   const manifestContents = new File({
     path: path.resolve(BUILD_DIR, 'rev-manifest.json'),
     contents: null,
   });
 
   const manifestBundle = runYarb('rev-manifest.js');
+  manifestBundle.expose(manifestContents, 'rev-manifest.json');
   commonBundle.external(manifestBundle);
 
   _(DBDefs.MB_LANGUAGES || '')

--- a/root/static/manifest.js
+++ b/root/static/manifest.js
@@ -45,7 +45,7 @@ if (isNodeJS) {
   };
 } else {
   pathTo = function (manifest) {
-    return _pathTo(manifest, require('./build/rev-manifest.json'));
+    return _pathTo(manifest, require('rev-manifest.json'));
   };
 }
 

--- a/root/static/scripts/rev-manifest.js
+++ b/root/static/scripts/rev-manifest.js
@@ -1,1 +1,1 @@
-module.exports = require('../build/rev-manifest.json');
+module.exports = require('rev-manifest.json');


### PR DESCRIPTION
The Vinyl object mentioned in the comment in the gulpfile wasn't actually being used anywhere. So now it is. And instead of having it being required based on the build path (which can be variable), it now uses an ID, "rev-manifest.json". (Note, if a string passed to `require` doesn't look like a path, yarb will treat it as a module name relative to node_modules/, or as a global ID assigned via a call to `expose`.)