### PR TITLE
Generate all URL validation rules

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -294,6 +294,26 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "https://www.discogs.com/$1");
       url = url.replace(/^(https:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
       return url;
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/www\.discogs\.com\/(?:(artist|label|master|release)\/[1-9][0-9]*|(user)\/.+)$/.exec(url);
+      if (m) {
+        var prefix = m[1] || m[2];
+        switch (id) {
+          case LINK_TYPES.discogs.artist:
+            return prefix === 'artist' || prefix === 'user';
+          case LINK_TYPES.discogs.label:
+          case LINK_TYPES.discogs.series:
+            return prefix === 'label';
+          case LINK_TYPES.discogs.place:
+            return prefix === 'artist' || prefix === 'label';
+          case LINK_TYPES.discogs.release_group:
+            return prefix === 'master';
+          case LINK_TYPES.discogs.release:
+            return prefix === 'release';
+        }
+      }
+      return false;
     }
   },
   geonames: {
@@ -968,30 +988,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow Discogs page only for the correct entities
-validationRules[LINK_TYPES.discogs.artist] = function (url) {
-  return /^https:\/\/www\.discogs\.com\/(?:artist\/[0-9]+|user\/.+)$/.test(url);
-};
-
-function validateDiscogsLabel(url) {
-  return /^https:\/\/www\.discogs\.com\/label\/[0-9]+$/.test(url);
-}
-
-validationRules[LINK_TYPES.discogs.label] = validateDiscogsLabel;
-validationRules[LINK_TYPES.discogs.series] = validateDiscogsLabel;
-
-validationRules[LINK_TYPES.discogs.place] = function (url) {
-  return /^https:\/\/www\.discogs\.com\/(?:artist|label)\/[0-9]+$/.test(url);
-};
-
-validationRules[LINK_TYPES.discogs.release_group] = function (url) {
-  return /^https:\/\/www\.discogs\.com\/master\/[0-9]+$/.test(url);
-};
-
-validationRules[LINK_TYPES.discogs.release] = function (url) {
-  return /^https:\/\/www\.discogs\.com\/release\/[0-9]+$/.test(url);
-};
 
 // allow Allmusic page only for the correct entities
 validationRules[LINK_TYPES.allmusic.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1105,12 +1105,6 @@ validationRules[LINK_TYPES.setlistfm.place] = function (url) {
   return /setlist\.fm\/venue\//.test(url);
 };
 
-// avoid wikipedia being added as release-level discography entry
-var isWikipedia = /^(https?:\/\/)?([^.]+\.)?wikipedia\.org\//;
-validationRules[LINK_TYPES.discographyentry.release] = function (url) {
-  return !isWikipedia.test(url);
-};
-
 function validateFacebook(url) {
   if (/facebook.com\/pages\//.test(url)) {
     return /\/pages\/[^\/?#]+\/\d+/.test(url);
@@ -1141,6 +1135,15 @@ _.each(LINK_TYPES, function (linkType) {
     }
   });
 });
+
+// avoid Wikipedia being added as release-level discography entry
+var originalRule = validationRules[LINK_TYPES.discographyentry.release];
+validationRules[LINK_TYPES.discographyentry.release] = function (url) {
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
+    return false;
+  }
+  return originalRule(url);
+};
 
 function guessType(sourceType, currentURL) {
   var cleanup = _.find(CLEANUPS, function (cleanup) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -398,6 +398,9 @@ const CLEANUPS = {
     type: LINK_TYPES.bookbrainz,
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:[^.]+\.)?bookbrainz\.org\/([^\/]*)\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:[#\/?].*)?$/, "https://bookbrainz.org/$1/$2");
+    },
+    validate: function (url, id) {
+      return /^https:\/\/bookbrainz\.org\/[^\/]+\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(url);
     }
   },
   cdbaby: {
@@ -984,15 +987,6 @@ validationRules[LINK_TYPES.allmusic.release] = function (url) {
 validationRules[LINK_TYPES.bbcmusic.artist] = function (url) {
   return /bbc\.co\.uk\/music\/artists\//.test(url);
 };
-
-// allow only BookBrainz entity pages with the BookBrainz rel
-function validateBookBrainz(url) {
-  return /bookbrainz\.org\/[^\/]*\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/.test(url);
-}
-
-_.each(LINK_TYPES.bookbrainz, function (id) {
-  validationRules[id] = validateBookBrainz;
-});
 
 // allow only Wikipedia pages with the Wikipedia rel
 function validateWikipedia(url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1101,14 +1101,6 @@ function testAll(tests, text) {
 
 const validationRules = {};
 
-// NOTE: Below validation rules (legacy) definitions are deprecated
-// and need to be replaced by CLEANUPS.*.validate functions.  They
-// don’t interact with each other, CLEANUPS.*.validate functions are
-// just ignored when validation rules defintion already exists.
-
-// NOTE: Above validation rules (legacy) definitions are not altered
-// by the below validation rules generation.  See also above note.
-
 _.each(LINK_TYPES, function (linkType) {
   _.each(linkType, function (id, entityType) {
     if (!validationRules[id]) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -363,6 +363,25 @@ const CLEANUPS = {
     type: LINK_TYPES.allmusic,
     clean: function (url) {
       return url.replace(/^https?:\/\/(?:[^.]+\.)?allmusic\.com\/(artist|album(?:\/release)?|composition|song|performance)\/(?:[^\/]*-)?((?:mn|mw|mc|mt|mq|mr)[0-9]+).*/, "http://www.allmusic.com/$1/$2");
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/www\.allmusic\.com\/([a-z\/]+)[0-9]{10}$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.allmusic.artist:
+            return prefix === 'artist/mn';
+          case LINK_TYPES.allmusic.recording:
+            return prefix === 'performance/mq';
+          case LINK_TYPES.allmusic.release:
+            return prefix === 'album/release/mr';
+          case LINK_TYPES.allmusic.release_group:
+            return prefix === 'album/mw';
+          case LINK_TYPES.allmusic.work:
+            return prefix === 'composition/mc' || prefix === 'song/mt';
+        }
+      }
+      return false;
     }
   },
   amazon: {
@@ -988,27 +1007,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow Allmusic page only for the correct entities
-validationRules[LINK_TYPES.allmusic.artist] = function (url) {
-  return /allmusic\.com\/artist\/mn/.test(url);
-};
-
-validationRules[LINK_TYPES.allmusic.release_group] = function (url) {
-  return /allmusic\.com\/album\/mw/.test(url);
-};
-
-validationRules[LINK_TYPES.allmusic.work] = function (url) {
-  return /allmusic\.com\/composition\/mc|song\/mt/.test(url);
-};
-
-validationRules[LINK_TYPES.allmusic.recording] = function (url) {
-  return /allmusic\.com\/performance\/mq/.test(url);
-};
-
-validationRules[LINK_TYPES.allmusic.release] = function (url) {
-  return /allmusic\.com\/album\/release\/mr/.test(url);
-};
 
 // allow only VGMdb pages with the VGMdb rel
 validationRules[LINK_TYPES.vgmdb.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -653,7 +653,22 @@ const CLEANUPS = {
   },
   secondhandsongs: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?secondhandsongs\\.com/", "i")],
-    type: LINK_TYPES.secondhandsongs
+    type: LINK_TYPES.secondhandsongs,
+    validate: function (url, id) {
+      var m = /secondhandsongs\.com\/([a-z]+)\//.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.secondhandsongs.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.secondhandsongs.release:
+            return prefix === 'release';
+          case LINK_TYPES.secondhandsongs.work:
+            return prefix === 'work';
+        }
+      }
+      return false;
+    }
   },
   songfacts: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?songfacts\\.com/", "i")],
@@ -1052,19 +1067,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only SecondHandSongs pages with the SecondHandSongs rel and at the right level
-validationRules[LINK_TYPES.secondhandsongs.artist] = function (url) {
-  return /secondhandsongs\.com\/artist\//.test(url);
-};
-
-validationRules[LINK_TYPES.secondhandsongs.release] = function (url) {
-  return /secondhandsongs\.com\/release\//.test(url);
-};
-
-validationRules[LINK_TYPES.secondhandsongs.work] = function (url) {
-  return /secondhandsongs\.com\/work\//.test(url);
-};
 
 // allow only top-level Bandcamp pages as artist/label URLs
 validationRules[LINK_TYPES.bandcamp.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -422,6 +422,9 @@ const CLEANUPS = {
       if (tld !== "" && asin !== "") {
         return "https://www.amazon." + tld + "/gp/product/" + asin;
       }
+    },
+    validate: function (url, id) {
+      return /^https:\/\/www\.amazon\.(com|ca|co\.uk|fr|at|de|it|co\.jp|jp|cn|es|in|com\.br|com\.mx)\//.test(url);
     }
   },
   archive: {
@@ -1030,11 +1033,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only Amazon pages with the Amazon rel
-validationRules[LINK_TYPES.amazon.release] = function (url) {
-  return /amazon\.(com|ca|co\.uk|fr|at|de|it|co\.jp|jp|cn|es|in|com\.br|com\.mx)\//.test(url);
-};
 
 // allow only IMDb pages with the IMDb rels
 validationRules[LINK_TYPES.imdb.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -510,6 +510,9 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?bbc\.co\.uk\/music\/artists\/([0-9a-f-]+).*$/, "http://www.bbc.co.uk/music/artists/$1");
       return url;
     },
+    validate: function (url, id) {
+      return /^http:\/\/www\.bbc\.co\.uk\/music\/artists\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(url);
+    }
   },
   wikimediacommons: {
     match: [new RegExp("^(https?://)?(commons\\.(?:m\\.)?wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],
@@ -985,11 +988,6 @@ validationRules[LINK_TYPES.allmusic.recording] = function (url) {
 
 validationRules[LINK_TYPES.allmusic.release] = function (url) {
   return /allmusic\.com\/album\/release\/mr/.test(url);
-};
-
-// allow only artist pages in BBC Music links
-validationRules[LINK_TYPES.bbcmusic.artist] = function (url) {
-  return /bbc\.co\.uk\/music\/artists\//.test(url);
 };
 
 // allow only Wikipedia pages with the Wikipedia rel

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -510,15 +510,19 @@ const CLEANUPS = {
       return url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
     },
     validate: function (url, id) {
-      if (id === LINK_TYPES.downloadpurchase.artist) {
-        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?artist\/id[0-9]+$/.test(url);
-      } else if (id === LINK_TYPES.downloadpurchase.recording) {
-        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?music-video\/id[0-9]+$/.test(url);
-      } else if (id === LINK_TYPES.downloadpurchase.release) {
-        return /^https:\/\/itunes\.apple\.com\/([a-z]{2}\/)?(album|audiobook|podcast|preorder)\/id[0-9]+$/.test(url);
-      } else {
-        return false;
+      var m = /^https:\/\/itunes\.apple\.com\/(?:[a-z]{2}\/)?([a-z-]{3,})\/id[0-9]+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.downloadpurchase.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.downloadpurchase.recording:
+            return prefix === 'music-video';
+          case LINK_TYPES.downloadpurchase.release:
+            return /^(album|audiobook|podcast|preorder)$/.test(prefix);
+        }
       }
+      return false;
     }
   },
   jamendo: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1030,13 +1030,17 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
-      if (id === LINK_TYPES.otherdatabases.artist) {
-        return /^http:\/\/soundtrackcollector\.com\/composer\/[0-9]+\/$/.test(url);
-      } else if (id === LINK_TYPES.otherdatabases.release_group) {
-        return /^http:\/\/soundtrackcollector\.com\/title\/[0-9]+\/$/.test(url);
-      } else {
-        return false;
+      var m = /^http:\/\/soundtrackcollector\.com\/([a-z]+)\/[0-9]+\/$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix === 'composer';
+          case LINK_TYPES.otherdatabases.release_group:
+            return prefix === 'title';
+        }
       }
+      return false;
     }
   },
   thesession: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -842,6 +842,14 @@ const CLEANUPS = {
     type: LINK_TYPES.bandcamp,
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com(?:\/(((album|track)\/([^\/\?]+)))?)?.*$/, "http://$1.bandcamp.com/$2");
+    },
+    validate: function (url, id) {
+      switch (id) {
+        case LINK_TYPES.bandcamp.artist:
+        case LINK_TYPES.bandcamp.label:
+          return /^http:\/\/[^\/]+\.bandcamp\.com\/$/.test(url);
+      }
+      return false;
     }
   },
   songkick: {
@@ -1067,15 +1075,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only top-level Bandcamp pages as artist/label URLs
-validationRules[LINK_TYPES.bandcamp.artist] = function (url) {
-  return /\.bandcamp\.com\/$/.test(url);
-};
-
-validationRules[LINK_TYPES.bandcamp.label] = function (url) {
-  return /\.bandcamp\.com\/$/.test(url);
-};
 
 // allow only Songkick pages with the Songkick rel
 validationRules[LINK_TYPES.songkick.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -597,7 +597,6 @@ const CLEANUPS = {
   },
   socialnetwork: {
     match: [
-      new RegExp("^(https?://)?([^/]+\\.)?facebook\\.com/", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/user/", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?reverbnation\\.com/", "i"),
       new RegExp("^(https?://)?([^/]+\\.)?plus\\.google\\.com/", "i"),
@@ -611,21 +610,6 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.socialnetwork,
     clean: function (url) {
-      url = url.replace(/^(https?:\/\/)?([^\/]+\.)?facebook\.com(\/#!)?/, "https://www.facebook.com");
-      if (url.match(/^https:\/\/www\.facebook\.com.*$/)) {
-        // Remove ref (where the user came from), sk (subpages in a page, since we want the main link) and a couple others
-        url = url.replace(new RegExp("([&?])(sk|ref|fref|sid_reminder|ref_dashboard_filter)=([^?&]*)", "g"), "$1");
-        // Ensure the first parameter left uses ? not to break the URL
-        url = url.replace(/([&?])&+/, "$1");
-        url = url.replace(/[&?]$/, "");
-        // Remove trailing slashes
-        if (url.match(/\?/)) {
-          url = url.replace(/\/\?/, "?");
-        } else {
-          url = url.replace(/(facebook\.com\/.*)\/$/, "$1");
-        }
-        url = url.replace(/\/event\.php\?eid=/, "/events/");
-      }
       url = url.replace(/^(?:https?:\/\/)?plus\.google\.com\/(?:u\/[0-9]\/)?([0-9]+)(\/.*)?$/, "https://plus.google.com/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\/@?([^\/?#]+)(?:[\/?#].*)?$/, "https://twitter.com/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:(?:www|m)\.)?reverbnation\.com(?:\/#!)?\//, "http://www.reverbnation.com/");
@@ -635,6 +619,34 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/(.+\.)?foursquare\.com/, "https://foursquare.com");
       return url;
     }
+  },
+  facebook: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?facebook\\.com/", "i")],
+    type: LINK_TYPES.socialnetwork,
+    clean: function (url) {
+      url = url.replace(/^(https?:\/\/)?([^\/]+\.)?facebook\.com(\/#!)?/, "https://www.facebook.com");
+      // Remove ref (where the user came from), sk (subpages in a page, since we want the main link) and a couple others
+      url = url.replace(new RegExp("([&?])(sk|ref|fref|sid_reminder|ref_dashboard_filter)=([^?&]*)", "g"), "$1");
+      // Ensure the first parameter left uses ? not to break the URL
+      url = url.replace(/([&?])&+/, "$1");
+      url = url.replace(/[&?]$/, "");
+      // Remove trailing slashes
+      if (url.match(/\?/)) {
+        url = url.replace(/\/\?/, "?");
+      } else {
+        url = url.replace(/(facebook\.com\/.*)\/$/, "$1");
+      }
+      url = url.replace(/\/event\.php\?eid=/, "/events/");
+      return url;
+    },
+    validate: function (url, id) {
+      switch (id) {
+        case LINK_TYPES.socialnetwork.artist:
+        case LINK_TYPES.socialnetwork.label:
+          return /\/pages\/[^\/?#]+\/\d+/.test(url);
+      }
+      return true;
+    },
   },
   soundcloud: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?soundcloud\\.com","i")],
@@ -1107,16 +1119,6 @@ validationRules[LINK_TYPES.setlistfm.event] = function (url) {
 validationRules[LINK_TYPES.setlistfm.place] = function (url) {
   return /setlist\.fm\/venue\//.test(url);
 };
-
-function validateFacebook(url) {
-  if (/facebook.com\/pages\//.test(url)) {
-    return /\/pages\/[^\/?#]+\/\d+/.test(url);
-  }
-  return true;
-}
-
-validationRules[LINK_TYPES.socialnetwork.artist] = validateFacebook;
-validationRules[LINK_TYPES.socialnetwork.label] = validateFacebook;
 
 // NOTE: Above validation rules (legacy) definitions are not altered
 // by the below validation rules generation.  See also above note.

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -676,6 +676,9 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?viaf\.org\/viaf\/([0-9]+).*$/,
         "http://viaf.org/viaf/$1");
       return url;
+    },
+    validate: function (url, id) {
+      return /^http:\/\/viaf\.org\/viaf\/[1-9][0-9]*$/.test(url);
     }
   },
   vimeo: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -322,6 +322,9 @@ const CLEANUPS = {
     type: LINK_TYPES.myspace,
     clean: function (url) {
       return url.replace(/^(https?:\/\/)?([^.]+\.)?myspace\.(com|de|fr)/, "https://myspace.com");
+    },
+    validate: function (url, id) {
+      return /^https:\/\/myspace\.com\//.test(url);
     }
   },
   purevolume: {
@@ -991,15 +994,6 @@ validationRules[LINK_TYPES.allmusic.recording] = function (url) {
 
 validationRules[LINK_TYPES.allmusic.release] = function (url) {
   return /allmusic\.com\/album\/release\/mr/.test(url);
-};
-
-// allow only Myspace pages with the Myspace rel
-validationRules[LINK_TYPES.myspace.artist] = function (url) {
-  return /myspace\.com\//.test(url);
-};
-
-validationRules[LINK_TYPES.myspace.label] = function (url) {
-  return /myspace\.com\//.test(url);
 };
 
 // allow only Soundcloud pages with the Soundcloud rel

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -272,6 +272,17 @@ function disallow(url, id) {
   return false;
 }
 
+/**
+ * CLEANUPS entries have 2 to 4 of the following properties:
+ * 
+ * - match: Array of regexps to match a given URL with the entry.
+ *          It is the only mandatory property.
+ * - type: Set of relationship types to be auto-selected for matched URL.
+ *         It contains at most 1 relationship type by entity type.
+ * - clean: Function to clean up/normalize matched URL.
+ * - validate: Function to validate matched (clean) URL
+ *             for an auto-selected relationship type.
+ **/
 const CLEANUPS = {
   wikipedia: {
     match: [new RegExp("^(https?://)?(([^/]+\\.)?wikipedia|secure\\.wikimedia)\\.","i")],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -281,6 +281,9 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?([a-z-]+)(?:\.m)?\.wikipedia\.org\/[a-z-]+\/([^?]+)$/, "https://$1.wikipedia.org/wiki/$2");
       url = reencode_mediawiki_localpart(url);
       return url;
+    },
+    validate: function (url, id) {
+      return /^https:\/\/[a-z]+\.wikipedia\.org\/wiki\//.test(url);
     }
   },
   discogs: {
@@ -989,15 +992,6 @@ validationRules[LINK_TYPES.allmusic.recording] = function (url) {
 validationRules[LINK_TYPES.allmusic.release] = function (url) {
   return /allmusic\.com\/album\/release\/mr/.test(url);
 };
-
-// allow only Wikipedia pages with the Wikipedia rel
-function validateWikipedia(url) {
-  return /wikipedia\.org\//.test(url);
-}
-
-_.each(LINK_TYPES.wikipedia, function (id) {
-  validationRules[id] = validateWikipedia;
-});
 
 // allow only Myspace pages with the Myspace rel
 validationRules[LINK_TYPES.myspace.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1050,17 +1050,21 @@ const CLEANUPS = {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?)(?:\/.*)?\/([0-9]+)(?:.*)?$/, "http://thesession.org/$1/$2");
     },
     validate: function (url, id) {
-      if (id === LINK_TYPES.otherdatabases.artist) {
-        return /^http:\/\/thesession\.org\/recordings\/artists\/[0-9]+$/.test(url);
-      } else if (id === LINK_TYPES.otherdatabases.event) {
-        return /^http:\/\/thesession\.org\/events\/[0-9]+$/.test(url);
-      } else if (id === LINK_TYPES.otherdatabases.release_group) {
-        return /^http:\/\/thesession\.org\/recordings\/[0-9]+$/.test(url);
-      } else if (id === LINK_TYPES.otherdatabases.work) {
-        return /^http:\/\/thesession\.org\/tunes\/[0-9]+$/.test(url);
-      } else {
-        return false;
+      var m = /^http:\/\/thesession\.org\/([a-z\/]+)\/[0-9]+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix === 'recordings/artists';
+          case LINK_TYPES.otherdatabases.event:
+            return prefix === 'events';
+          case LINK_TYPES.otherdatabases.release_group:
+            return prefix === 'recordings';
+          case LINK_TYPES.otherdatabases.work:
+            return prefix === 'tunes';
+        }
       }
+      return false;
     }
   },
   patronage: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -331,6 +331,25 @@ const CLEANUPS = {
     type: LINK_TYPES.imdb,
     clean: function (url) {
       return url.replace(/^https?:\/\/([^.]+\.)?imdb\.(com|de|it|es|fr|pt)\/([a-z]+\/[a-z0-9]+)(\/.*)*$/, "http://www.imdb.com/$3/");
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/www\.imdb\.com\/(name\/nm|title\/tt|character\/ch|company\/co)[0-9]{7}\/$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.imdb.artist:
+            return prefix === 'name/nm' || prefix === 'character/ch' || prefix === 'company/co';
+          case LINK_TYPES.imdb.label:
+          case LINK_TYPES.imdb.place:
+            return prefix === 'company/co';
+          case LINK_TYPES.imdb.recording:
+          case LINK_TYPES.imdb.release:
+          case LINK_TYPES.imdb.release_group:
+          case LINK_TYPES.imdb.work:
+            return prefix === 'title/tt';
+        }
+      }
+      return false;
     }
   },
   mora: {
@@ -1033,27 +1052,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only IMDb pages with the IMDb rels
-validationRules[LINK_TYPES.imdb.artist] = function (url) {
-  return /imdb\.com\/(name|character|company)/.test(url);
-};
-
-validationRules[LINK_TYPES.imdb.label] = function (url) {
-  return /imdb\.com\/company/.test(url);
-};
-
-validationRules[LINK_TYPES.imdb.release_group] = function (url) {
-  return /imdb\.com\/title/.test(url);
-};
-
-validationRules[LINK_TYPES.imdb.recording] = function (url) {
-  return /imdb\.com\//.test(url);
-};
-
-validationRules[LINK_TYPES.imdb.release] = function (url) {
-  return /imdb\.com\//.test(url);
-};
 
 // allow only SecondHandSongs pages with the SecondHandSongs rel and at the right level
 validationRules[LINK_TYPES.secondhandsongs.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -135,9 +135,12 @@ const LINK_TYPES = {
     recording: "7e41ef12-a124-4324-afdb-fdbae687a89c",
     release: "08445ccf-7b99-4438-9f9a-fb9ac18099ee"
   },
-  vimeo: {
+  videochannel: {
     artist: "d86c9450-b6d0-4760-a275-e7547495b48b",
+    event: "1f3df2eb-3d0b-44f1-9599-1309c692bc7c",
     label: "20ad367c-cba0-4c02-bd61-2df3ae8cc799",
+    place: "e5c5a0f6-9581-44d8-a5fb-d3688254dc9f",
+    series: "71774032-781b-468c-9cbf-8a9a2f8eda13",
   },
   vgmdb: {
     artist: "0af15ab3-c615-46d6-b95b-a5fcd2a92ed9",
@@ -253,7 +256,7 @@ const RESTRICTED_LINK_TYPES = _.reduce([
   LINK_TYPES.wikipedia,
   LINK_TYPES.vgmdb,
   LINK_TYPES.viaf,
-  LINK_TYPES.vimeo,
+  LINK_TYPES.videochannel,
   LINK_TYPES.youtube,
 ], function (result, linkType) {return result.concat(_.values(linkType));}, []);
 
@@ -737,7 +740,7 @@ const CLEANUPS = {
   },
   vimeo: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?(vimeo\\.com/)", "i")],
-    type: _.defaults({}, LINK_TYPES.vimeo, LINK_TYPES.streamingmusic),
+    type: _.defaults({}, LINK_TYPES.videochannel, LINK_TYPES.streamingmusic),
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?vimeo\.com/, "http://vimeo.com");
       // Remove query string, just the video id should be enough.

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -767,7 +767,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?vgmdb\\.(net|com)/", "i")],
     type: LINK_TYPES.vgmdb,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?vgmdb\.(?:net|com)\/(album|artist|org)\/([0-9]+).*$/, "http://vgmdb.net/$1/$2");
+      return url.replace(/^(?:https?:\/\/)?vgmdb\.(?:net|com)\/(album|artist|event|org)\/([0-9]+).*$/, "http://vgmdb.net/$1/$2");
     }
   },
   wikidata: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -761,6 +761,9 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?youtube\.com\/(?:embed|v)\/([a-zA-Z0-9_-]+)/, "https://www.youtube.com/watch?v=$1");
       url = url.replace(/\/user\/([^\/\?#]+).*$/, "/user/$1");
       return url;
+    },
+    validate: function (url, id) {
+      return /^https:\/\/www\.youtube\.com\//.test(url);
     }
   },
   vgmdb: {
@@ -1027,15 +1030,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only YouTube pages with the YouTube rel
-validationRules[LINK_TYPES.youtube.artist] = function (url) {
-  return /youtube\.com\//.test(url);
-};
-
-validationRules[LINK_TYPES.youtube.label] = function (url) {
-  return /youtube\.com\//.test(url);
-};
 
 // allow only Amazon pages with the Amazon rel
 validationRules[LINK_TYPES.amazon.release] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -768,6 +768,23 @@ const CLEANUPS = {
     type: LINK_TYPES.vgmdb,
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?vgmdb\.(?:net|com)\/(album|artist|event|org)\/([0-9]+).*$/, "http://vgmdb.net/$1/$2");
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/vgmdb\.net\/(album|artist|org|event)\/[1-9][0-9]*$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.vgmdb.artist:
+            return prefix === 'artist' || prefix === 'org';
+          case LINK_TYPES.vgmdb.release:
+            return prefix === 'album';
+          case LINK_TYPES.vgmdb.label:
+            return prefix === 'org';
+          case LINK_TYPES.vgmdb.event:
+            return prefix === 'event';
+        }
+      }
+      return false;
     }
   },
   wikidata: {
@@ -1010,23 +1027,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only VGMdb pages with the VGMdb rel
-validationRules[LINK_TYPES.vgmdb.artist] = function (url) {
-  return /vgmdb\.net\/(?:artist|org)\//.test(url);
-};
-
-validationRules[LINK_TYPES.vgmdb.release] = function (url) {
-  return /vgmdb\.net\/album\//.test(url);
-};
-
-validationRules[LINK_TYPES.vgmdb.label] = function (url) {
-  return /vgmdb\.net\/org\//.test(url);
-};
-
-validationRules[LINK_TYPES.vgmdb.event] = function (url) {
-  return /vgmdb\.net\/event\//.test(url);
-};
 
 // allow only YouTube pages with the YouTube rel
 validationRules[LINK_TYPES.youtube.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -653,6 +653,9 @@ const CLEANUPS = {
     type: LINK_TYPES.soundcloud,
     clean: function (url) {
       return url.replace(/^(https?:\/\/)?((www|m)\.)?soundcloud\.com(\/#!)?/, "https://soundcloud.com");
+    },
+    validate: function (url, id) {
+      return /^https:\/\/soundcloud\.com\/(?!(search|tags)[\/?#])/.test(url);
     }
   },
   blog: {
@@ -1010,15 +1013,6 @@ validationRules[LINK_TYPES.allmusic.recording] = function (url) {
 validationRules[LINK_TYPES.allmusic.release] = function (url) {
   return /allmusic\.com\/album\/release\/mr/.test(url);
 };
-
-// allow only Soundcloud pages with the Soundcloud rel
-function validateSoundCloud(url) {
-  return /soundcloud\.com\/(?!(search|tags)[\/?#])/.test(url);
-}
-
-_.each(LINK_TYPES.soundcloud, function (id) {
-  validationRules[id] = validateSoundCloud;
-});
 
 // allow only VGMdb pages with the VGMdb rel
 validationRules[LINK_TYPES.vgmdb.artist] = function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -876,7 +876,22 @@ const CLEANUPS = {
   },
   setlistfm: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?setlist\\.fm","i")],
-    type: LINK_TYPES.setlistfm
+    type: LINK_TYPES.setlistfm,
+    validate: function (url, id) {
+      var m = /setlist\.fm\/([a-z]+)\//.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.setlistfm.artist:
+            return prefix === 'setlists';
+          case LINK_TYPES.setlistfm.event:
+            return prefix === 'setlist' || prefix === 'festival';
+          case LINK_TYPES.setlistfm.place:
+            return prefix === 'venue';
+        }
+      }
+      return false;
+    }
   },
   imslp: {
     match: [new RegExp("^(https?://)?(www\\.)?imslp\\.org/", "i")],
@@ -1090,19 +1105,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only setlist.fm pages with the setlist.fm rel
-validationRules[LINK_TYPES.setlistfm.artist] = function (url) {
-  return /setlist\.fm\/setlists\//.test(url);
-};
-
-validationRules[LINK_TYPES.setlistfm.event] = function (url) {
-  return /setlist\.fm\/(setlist|festival)\//.test(url);
-};
-
-validationRules[LINK_TYPES.setlistfm.place] = function (url) {
-  return /setlist\.fm\/venue\//.test(url);
-};
 
 // NOTE: Above validation rules (legacy) definitions are not altered
 // by the below validation rules generation.  See also above note.

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -505,7 +505,11 @@ const CLEANUPS = {
   },
   bbcmusic: {
     match: [new RegExp("^(https?://)?(www\\.)?bbc\\.co\\.uk/music/artists/", "i")],
-    type: LINK_TYPES.bbcmusic
+    type: LINK_TYPES.bbcmusic,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?bbc\.co\.uk\/music\/artists\/([0-9a-f-]+).*$/, "http://www.bbc.co.uk/music/artists/$1");
+      return url;
+    },
   },
   wikimediacommons: {
     match: [new RegExp("^(https?://)?(commons\\.(?:m\\.)?wikimedia\\.org|upload\\.wikimedia\\.org/wikipedia/commons/)","i")],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -857,6 +857,21 @@ const CLEANUPS = {
     type: LINK_TYPES.songkick,
     clean: function (url) {
       return url.replace(/^http:\/\//, "https://");
+    },
+    validate: function (url, id) {
+      var m = /songkick\.com\/([a-z]+)\//.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.songkick.artist:
+            return prefix === 'artists';
+          case LINK_TYPES.songkick.event:
+            return prefix === 'concerts' || prefix === 'festivals';
+          case LINK_TYPES.songkick.place:
+            return prefix === 'venues' || prefix === 'festivals';
+        }
+      }
+      return false;
     }
   },
   setlistfm: {
@@ -1075,19 +1090,6 @@ const validationRules = {};
 // and need to be replaced by CLEANUPS.*.validate functions.  They
 // don’t interact with each other, CLEANUPS.*.validate functions are
 // just ignored when validation rules defintion already exists.
-
-// allow only Songkick pages with the Songkick rel
-validationRules[LINK_TYPES.songkick.artist] = function (url) {
-  return /songkick\.com\/artists\//.test(url);
-};
-
-validationRules[LINK_TYPES.songkick.event] = function (url) {
-  return /songkick\.com\/(concerts|festivals)\//.test(url);
-};
-
-validationRules[LINK_TYPES.songkick.place] = function (url) {
-  return /songkick\.com\/(venues|festivals)\//.test(url);
-};
 
 // allow only setlist.fm pages with the setlist.fm rel
 validationRules[LINK_TYPES.setlistfm.artist] = function (url) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -231,9 +231,10 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         },
         // BBC Music
         {
-                             input_url: 'http://www.bbc.co.uk/music/artists/b52dd210-909c-461a-a75d-19e85a522042',
+                             input_url: 'http://www.bbc.co.uk/music/artists/b52dd210-909c-461a-a75d-19e85a522042#tracks',
                      input_entity_type: 'artist',
             expected_relationship_type: 'bbcmusic',
+                    expected_clean_url: 'http://www.bbc.co.uk/music/artists/b52dd210-909c-461a-a75d-19e85a522042'
         },
         // Beatport
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -79,6 +79,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'release',
             expected_relationship_type: 'amazon',
                     expected_clean_url: 'https://www.amazon.co.uk/gp/product/B00005JIWP',
+               only_valid_entity_types: ['release']
         },
         {
                              input_url: 'http://amazon.com.br/dp/B00T8E47G2',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -732,16 +732,25 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'http://www.imdb.com/name/nm1539156/',
                      input_entity_type: 'artist',
             expected_relationship_type: 'imdb',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://www.imdb.com/character/ch0003553/',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'imdb',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://www.imdb.com/company/co0109498/',
                      input_entity_type: 'label',
             expected_relationship_type: 'imdb',
+               only_valid_entity_types: ['artist', 'label', 'place']
         },
         {
                              input_url: 'http://www.imdb.com/title/tt0421082/',
                      input_entity_type: 'release_group',
             expected_relationship_type: 'imdb',
+               only_valid_entity_types: ['recording', 'release', 'release_group', 'work']
         },
         // IMSLP (International Music Score Library Project)
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1865,6 +1865,13 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'it.wikipedia.org/wiki/Foo',
                     expected_clean_url: 'https://it.wikipedia.org/wiki/Foo',
         },
+        {
+                             input_url: 'https://en.wikipedia.org/wiki/Some_Album',
+                     input_entity_type: 'release',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'discographyentry',
+               only_valid_entity_types: [],
+        },
         // Wikisource
         {
                              input_url: 'https://pt.wikisource.org/wiki/A_Portuguesa',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1596,35 +1596,34 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'work',
             expected_relationship_type: 'lyrics',
         },
-        // VGMDb
-        {
-                             input_url: 'http://vgmdb.com/org/284',
-                     input_entity_type: 'artist',
-            expected_relationship_type: 'vgmdb',
-        },
-        {
-                             input_url: 'http://vgmdb.com/org/284',
-                     input_entity_type: 'label',
-            expected_relationship_type: 'vgmdb',
-        },
-        // VGMDb (Video Game Music and Anime Soundtrack Database)
+        // VGMdb (Video Game Music and Anime Soundtrack Database)
         {
                              input_url: 'https://vgmdb.net/artist/431',
                      input_entity_type: 'artist',
             expected_relationship_type: 'vgmdb',
                     expected_clean_url: 'http://vgmdb.net/artist/431',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://vgmdb.com/event/197',
+                     input_entity_type: 'event',
+            expected_relationship_type: 'vgmdb',
+                    expected_clean_url: 'http://vgmdb.net/event/197',
+               only_valid_entity_types: ['event']
         },
         {
                              input_url: 'https://vgmdb.com/org/284',
                      input_entity_type: 'label',
             expected_relationship_type: 'vgmdb',
                     expected_clean_url: 'http://vgmdb.net/org/284',
+               only_valid_entity_types: ['artist', 'label']
         },
         {
                              input_url: 'vgmdb.net/album/29727',
                      input_entity_type: 'release',
             expected_relationship_type: 'vgmdb',
                     expected_clean_url: 'http://vgmdb.net/album/29727',
+               only_valid_entity_types: ['release']
         },
         // VIAF (Virtual International Authority File)
         {


### PR DESCRIPTION
Previously, old-fashion hand-coded `validationRules` coexisted with generated ones.

This pull request replaces all hand-coded `validationRules` by `CLEANUPS.*.validate` functions which are used to generate new `validationRules` instead.

Incidentally, validation rules have been tightened for Bandcamp, IMDb, Amazon, YouTube, VGMdb, AllMusic, Discogs, SoundCloud, VIAF, Myspace, Wikipedia, and BBC Music URLs.

Additionally, clean-up has been added for BBC Music URLs and VGMdb event URLs.

It is a revision of PR #366 by @uklauer, see [changes made](https://github.com/y-van-z/musicbrainz-server/commits/validation_rules_wiping) since then.