### PR TITLE
MBS-9173: Support serializing of instrument and series lists.

### DIFF
--- a/lib/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Collection.pm
@@ -7,6 +7,8 @@ sub find_by_collection {
     my ($self, $collection_id, $limit, $offset, $order) = @_;
 
     my ($order_by, $extra_join, $also_select) = $self->_order_by($order);
+    $extra_join //= '';
+
     my $table = $self->_table;
     my $type = $self->_type;
 


### PR DESCRIPTION
The JSON serializer does not currently support serializing lists of series or instruments, breaking browse requests for those entities.
This small patch resolves that, and also fixes a perl warning seen for browse requests (both XML and JSON).