### PR TITLE
MBS-9198: Show down arrow in a dropdown even in Firefox

### DIFF
--- a/root/static/images/icons/dropdown-arrow.svg
+++ b/root/static/images/icons/dropdown-arrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' version='1.1'>
+  <text x='0' y='15' fill='black' font-size='15'>&#x25BE;</text>
+</svg>

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -198,9 +198,8 @@ pre code {
                         -webkit-appearance: none;
                         -moz-appearance: none;
                         border-radius: 0;
-                        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1…0px'><text x='0' y='15' fill='black' font-size='15'>&#x25BE;</text></svg>");
-                        background-position-x: 100px;
-                        background-position-y: 1px;
+                        background-image: data-uri('../images/icons/dropdown-arrow.svg');
+                        background-position: 100px 1px;
                         position: absolute;
                         left: 149px;
                     }


### PR DESCRIPTION
The entity type dropdown in the search form in the page header is supposed to show a down arrow. This worked in Chromium, but not in Firefox.

There were three separate issues:
- Firefox doesn’t support the individual CSS properties `background-position-{x,y}` before version 49. Use the combined `background-position` instead.
- When embedding an image as a data URI, it needs to be properly percent-encoded. Move the image to a separate file and let `data-uri()` handle the encoding. (Chromium seems to be less strict here.)
- The SVG file used an invalid SVG version. Set it to version 1.1.