### PR TITLE
MBS-9205: Fix validation of Facebook URLs on beta

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -742,10 +742,8 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
-      switch (id) {
-        case LINK_TYPES.socialnetwork.artist:
-        case LINK_TYPES.socialnetwork.label:
-          return /\/pages\/[^\/?#]+\/\d+/.test(url);
+      if (/facebook.com\/pages\//.test(url)) {
+        return /\/pages\/[^\/?#]+\/\d+/.test(url);
       }
       return true;
     },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -583,24 +583,28 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'artist',
             expected_relationship_type: 'socialnetwork',
                     expected_clean_url: 'https://www.facebook.com/pages/De_Tot_Cor/133207893384897',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
         },
         {
                              input_url: 'http://www.facebook.com/sininemusic',
                      input_entity_type: 'artist',
             expected_relationship_type: 'socialnetwork',
                     expected_clean_url: 'https://www.facebook.com/sininemusic',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
         },
         {
                              input_url: 'https://www.facebook.com/RomanzMusic?fref=ts',
                      input_entity_type: 'artist',
             expected_relationship_type: 'socialnetwork',
                     expected_clean_url: 'https://www.facebook.com/RomanzMusic',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
         },
         {
                              input_url: 'https://www.facebook.com/event.php?eid=129606980393356',
                      input_entity_type: 'event',
             expected_relationship_type: 'socialnetwork',
                     expected_clean_url: 'https://www.facebook.com/events/129606980393356',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
         },
         {
                              input_url: 'https://www.facebook.com/events/779218695457920/?ref=2&ref_dashboard_filter=past&sid_reminder=1385056373762424832',


### PR DESCRIPTION
Previous refactoring of Facebook URLs validation was bogus, refusing any URL i but clean `/pages/` ones for Artists and Labels.

This gets fixed that by checking only `/pages/` URLs for cleanness, while accepting all non-`/pages/` URLs, just as before ddb1eba21e31d41828d7fa9551a4db12ad0437eb.
    
Additionally, it extends this check to all other entity types, that is, Events, Places, and Series.

Tests are added for Facebook URLs validation.
