### PR TITLE
MBS-9002: Automatically disable and tick ended date checkbox in editors

### DIFF
--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -15,15 +15,7 @@
       [%- form_row_text_list(r, 'iso_3166_3', l('ISO 3166-3:'), l('ISO 3166-3')) -%]
     </fieldset>
 
-    <fieldset>
-      <legend>[% l('Date Period') %]</legend>
-      <p>
-        [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
-      </p>
-      [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
-      [% form_row_date(r, 'period.end_date', l('End date:')) %]
-      [% form_row_checkbox(r, 'period.ended', l('This area has ended.')) %]
-    </fieldset>
+    [% date_range_fieldset(r, 'area', l('This area has ended.')) %]
 
     [% PROCESS 'forms/relationship-editor.tt' %]
 

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -182,6 +182,18 @@
     [% END %]
 [%- END -%]
 
+[%- MACRO date_range_fieldset(r, type, ended_label) BLOCK -%]
+    <fieldset>
+      <legend>[% l('Date Period') %]</legend>
+      <p>
+        [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
+      </p>
+      [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+      [% form_row_date(r, 'period.end_date', l('End date:')) %]
+      [% form_row_checkbox(r, 'period.ended', ended_label) %]
+    </fieldset>
+[%- END -%]
+
 [%- MACRO form_row_paragraph(message, label) BLOCK -%]
     [% WRAPPER form_row %]
       <label>[%- IF label -%][%- label -%][%- ELSE -%]&#xa0;[%- END -%]</label>

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -192,6 +192,9 @@
       [% form_row_date(r, 'period.end_date', l('End date:')) %]
       [% form_row_checkbox(r, 'period.ended', ended_label) %]
     </fieldset>
+    <script type="text/javascript">//<![CDATA[
+      MB.initializeToggleEnded('id-edit-[% type %]');
+    //]]></script>
 [%- END -%]
 
 [%- MACRO form_row_paragraph(message, label) BLOCK -%]

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -142,7 +142,7 @@
     <tr>
       <td colspan="2">
         <label>
-          <input type="checkbox" data-bind="checked: relationship().period.ended" />
+          <input type="checkbox" data-bind="checked: relationship().period.ended, disable: relationship().disableEndedCheckBox" />
           [% l('This relationship has ended.') %]
         </label>
       </td>

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -140,7 +140,8 @@
     </tr>
     <!-- /ko -->
     <tr>
-      <td colspan="2">
+      <td></td>
+      <td>
         <label>
           <input type="checkbox" data-bind="checked: relationship().period.ended, disable: relationship().disableEndedCheckBox" />
           [% l('This relationship has ended.') %]

--- a/root/entity/alias/edit_form.tt
+++ b/root/entity/alias/edit_form.tt
@@ -21,16 +21,7 @@
       [% form_row_select(r, 'type_id', l('Type:')) %]
     </fieldset>
 
-    <fieldset>
-      <legend>[% l('Date Period') %]</legend>
-      <p>
-        [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM
-               or just YYYY are OK, or you can omit the date entirely.') -%]
-      </p>
-      [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
-      [% form_row_date(r, 'period.end_date', l('End date:')) %]
-      [% form_row_checkbox(r, 'period.ended', l('This alias is no longer current.')) %]
-    </fieldset>
+    [% date_range_fieldset(r, 'alias', l('This alias is no longer current.')) %]
 
     [% INCLUDE 'forms/edit-note.tt' %]
     [% enter_edit() %]

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -34,15 +34,7 @@
         [%- form_row_text_list(r, 'isni_codes', l('ISNI codes:'), l('ISNI code')) -%]
       </fieldset>
 
-      <fieldset>
-        <legend>[% l('Date Period') %]</legend>
-        <p>
-            [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
-        </p>
-        [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
-        [% form_row_date(r, 'period.end_date', l('End date:')) %]
-        [% form_row_checkbox(r, 'period.ended', l('This label has ended.')) %]
-      </fieldset>
+      [% date_range_fieldset(r, 'label', l('This label has ended.')) %]
 
       [% PROCESS 'forms/relationship-editor.tt' %]
 

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -30,15 +30,7 @@
         <ul class="errors coordinates-errors" style="display:none"><li>[% l('These coordinates could not be parsed.') %]</li></ul>
       </fieldset>
 
-      <fieldset>
-        <legend>[% l('Date Period') %]</legend>
-        <p>
-            [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
-        </p>
-        [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
-        [% form_row_date(r, 'period.end_date', l('End date:')) %]
-        [% form_row_checkbox(r, 'period.ended', l('This place has ended.')) %]
-      </fieldset>
+      [% date_range_fieldset(r, 'place', l('This place has ended.')) %]
 
       [% PROCESS 'forms/relationship-editor.tt' %]
 

--- a/root/static/scripts/edit.js
+++ b/root/static/scripts/edit.js
@@ -22,6 +22,7 @@ require("./edit/forms");
 require("./edit/validation");
 require("./edit/externalLinks");
 require("./edit/utility/guessFeat");
+require("./edit/utility/toggleEnded");
 require("./edit/MB/Control/Area");
 require("./edit/components/ArtistCreditEditor");
 require("./edit/components/forms");

--- a/root/static/scripts/edit/utility/toggleEnded.js
+++ b/root/static/scripts/edit/utility/toggleEnded.js
@@ -1,0 +1,24 @@
+// This file is part of MusicBrainz, the open internet music database.
+// Copyright (C) 2017 MetaBrainz Foundation
+// Licensed under the GPL version 2, or (at your option) any later version:
+// http://www.gnu.org/licenses/gpl-2.0.txt
+
+MB.initializeToggleEnded = function (formID) {
+    $(function () {
+        const endYear = '#' + formID + '\\.period\\.end_date\\.year';
+        const ended = '#' + formID + '\\.period\\.ended';
+
+        const wasEnded = $(ended).prop('checked');
+
+        function toggleEnded() {
+            var autoEnded = $(endYear).val() != '';
+            $(ended).prop('checked', autoEnded || wasEnded);
+            $(ended).prop('disabled', autoEnded);
+        }
+
+        $(endYear).keyup(toggleEnded).change(toggleEnded);
+        toggleEnded();
+    });
+};
+
+module.exports = MB.initializeToggleEnded;

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -54,6 +54,11 @@ const mergeDates = require('./mergeDates');
                 endDate: setPartialDate({}, data.endDate || {}),
                 ended: ko.observable(!!data.ended)
             };
+            this.disableEndedCheckBox = ko.computed(function() {
+                var hasEndDate = dates.formatDate(this.period.endDate) != "";
+                this.period.ended(hasEndDate || data.ended);
+                return hasEndDate;
+            }, this);
 
             this.attributes = ko.observableArray([]);
             this.setAttributes(data.attributes);


### PR DESCRIPTION
Automatically tick and disable the “ended” date checkbox when the `end_date.year` field is filled in alias, (Area, Artist, Label, and Place) entity and relationship editors.

When the `end_date.year` field is emptied, it restores the state of the “ended” date checkbox.

Additionally factorize date range field set templates, and align the “ended” checkbox with the “end date” text input in the relationship editor, that is, in the same way as in the other editors.