### PR TITLE
MBS-8249: Standardise and validate Spotify URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -819,7 +819,8 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.streamingmusic,
     clean: function (url) {
-      url = url.replace(/^https?:\/\/embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, "http://open.spotify.com/$1/$2");
+      url = url.replace(/^(?:https?:\/\/)?embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, "https://open.spotify.com/$1/$2");
+      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/([a-z]+)\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/, "https://open.spotify.com/$1/$2");
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -813,9 +813,22 @@ const CLEANUPS = {
       return url;
     }
   },
+  spotifyuseraccount: {
+    match: [
+      new RegExp("^(https?://)?([^/]+\\.)?(spotify\\.com)/user", "i")
+    ],
+    type: LINK_TYPES.socialnetwork,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/user\/([a-zA-Z0-9_-]+)\/?(?:[?#].*)?$/, "https://open.spotify.com/user/$1");
+      return url;
+    },
+    validate: function (url, id) {
+      return /^https:\/\/open\.spotify\.com\/user\/[a-zA-Z0-9_-]+$/.test(url);
+    }
+  },
   spotify: {
     match: [
-      new RegExp("^(https?://)?([^/]+\\.)?(spotify\\.com)", "i")
+      new RegExp("^(https?://)?([^/]+\\.)?(spotify\\.com)/(?!user)", "i")
     ],
     type: LINK_TYPES.streamingmusic,
     clean: function (url) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -822,6 +822,21 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, "https://open.spotify.com/$1/$2");
       url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/([a-z]+)\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/, "https://open.spotify.com/$1/$2");
       return url;
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/open\.spotify\.com\/([a-z]+)\/(?:[a-zA-Z0-9_-]+)$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.streamingmusic.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.streamingmusic.release:
+            return prefix === 'album';
+          case LINK_TYPES.streamingmusic.recording:
+            return prefix === 'track';
+        }
+      }
+      return false;
     }
   },
   viaf: {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -803,14 +803,22 @@ const CLEANUPS = {
       return url;
     }
   },
-  streaming: {
+  deezer: {
     match: [
       new RegExp("^(https?://)?([^/]+\\.)?(deezer\\.com)", "i"),
-      new RegExp("^(https?://)?([^/]+\\.)?(spotify\\.com)", "i")
     ],
     type: LINK_TYPES.streamingmusic,
     clean: function (url) {
       url = url.replace(/^https?:\/\/(www\.)?deezer\.com\/(\w+)\/(\d+).*$/, "https://www.deezer.com/$2/$3");
+      return url;
+    }
+  },
+  spotify: {
+    match: [
+      new RegExp("^(https?://)?([^/]+\\.)?(spotify\\.com)", "i")
+    ],
+    type: LINK_TYPES.streamingmusic,
+    clean: function (url) {
       url = url.replace(/^https?:\/\/embed\.spotify\.com\/\?uri=spotify:([a-z]+):([a-zA-Z0-9_-]+)$/, "http://open.spotify.com/$1/$2");
       return url;
     }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1896,7 +1896,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                              input_url: 'https://embed.spotify.com/?uri=spotify:track:7gwRSZ0EmGWa697ZrE58GA',
                      input_entity_type: 'recording',
             expected_relationship_type: 'streamingmusic',
-                    expected_clean_url: 'http://open.spotify.com/track/7gwRSZ0EmGWa697ZrE58GA',
+                    expected_clean_url: 'https://open.spotify.com/track/7gwRSZ0EmGWa697ZrE58GA',
         },
         // Ted Crane
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1939,6 +1939,26 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             expected_relationship_type: 'streamingmusic',
                only_valid_entity_types: []
         },
+        {
+                             input_url: 'http://play.spotify.com/user/scotchbonnetrecords',
+                     input_entity_type: 'label',
+            expected_relationship_type: 'socialnetwork',
+                    expected_clean_url: 'https://open.spotify.com/user/scotchbonnetrecords',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
+        },
+        {
+                             input_url: 'https://play.spotify.com/user/1254688529/playlist/0MRy5cv9ZktSjysDEIP72H',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'socialnetwork',
+               only_valid_entity_types: []
+        },
+        {
+                             input_url: 'play.spotify.com/user/1254688529/',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'socialnetwork',
+                    expected_clean_url: 'https://open.spotify.com/user/1254688529',
+               only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series']
+        },
         // Ted Crane
         {
                              input_url: 'http://tedcrane.com/DanceDB/DisplayIdent.com?key=DONNA_HUNT',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1897,6 +1897,47 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
                      input_entity_type: 'recording',
             expected_relationship_type: 'streamingmusic',
                     expected_clean_url: 'https://open.spotify.com/track/7gwRSZ0EmGWa697ZrE58GA',
+               only_valid_entity_types: ['recording']
+        },
+        {
+                             input_url: 'http://open.spotify.com/track/1SI5O5cu8AM19cninxf9RZ',
+                     input_entity_type: 'recording',
+            expected_relationship_type: 'streamingmusic',
+                    expected_clean_url: 'https://open.spotify.com/track/1SI5O5cu8AM19cninxf9RZ',
+               only_valid_entity_types: ['recording']
+        },
+        {
+                             input_url: 'http://play.spotify.com/album/3rFPzWNUrtoqMd9yNGaFMr?play=true&utm_source=open.spotify.com&utm_medium=open',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'streamingmusic',
+                    expected_clean_url: 'https://open.spotify.com/album/3rFPzWNUrtoqMd9yNGaFMr',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'https://play.spotify.com/artist/5zS2OG2kKeGYFqX6lcuVOt?play=true&utm_source=google&utm_medium=growth_paid&utm_campaign=pla_US&gclid=CN-m_fOj3cMCFUJk7AodTBsA8g',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'streamingmusic',
+                    expected_clean_url: 'https://open.spotify.com/artist/5zS2OG2kKeGYFqX6lcuVOt',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'open.spotify.com/album/0tabKG66W34Ms0SsovkP6Q/6yVKnHVFGkg4OQ8IrgQVpZ',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'streamingmusic',
+                    expected_clean_url: 'https://open.spotify.com/album/0tabKG66W34Ms0SsovkP6Q',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'http://open.spotify.com/local/Electrolyze/Single/Belief/265',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'streamingmusic',
+               only_valid_entity_types: []
+        },
+        {
+                             input_url: 'https://play.spotify.com/search/The%20Most%20Essential%20Bossa%20Nova',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'streamingmusic',
+               only_valid_entity_types: []
         },
         // Ted Crane
         {


### PR DESCRIPTION
# [MBS-8249](https://tickets.metabrainz.org/browse/MBS-8249): Standardise and validate Spotify URLs 
## Auto-select
- Match Spotify `user` account URLs with _social network_ relationship
- (Keep matching Spotify `album`, `artist`, and `track` URLs with _streaming music_ relationship)
## Clean up
- Standardise to `https` scheme and `open.spotify.com` host ([MBS-9062](https://tickets.metabrainz.org/browse/MBS-9062))
- (Keep converting `embed.spotify.com` URLs)
- Remove trailing subpaths (but for `user`), slash, query (`?…`) and fragment (`#…`)
- Do not convert playlist URLs into user account URLs
## Validate
- Validate clean user account URLs with any _social network_ relationship
- Specifically reject playlist URLs
- Validate clean URLs with _streaming music_ relationships with:
  - `album` path only for Release-URL
  - `artist` path only for Artist-URL
  - `track` path only for Recording-URL

Update tests accordingly