### PR TITLE
MBS-9193: Report instruments without image

### DIFF
--- a/lib/MusicBrainz/Server/Report/InstrumentReport.pm
+++ b/lib/MusicBrainz/Server/Report/InstrumentReport.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Report::InstrumentReport;
+use Moose::Role;
+
+with 'MusicBrainz::Server::Report::QueryReport';
+
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $items = $self->$orig(@_);
+
+    my $instruments = $self->c->model('Instrument')->get_by_ids(
+        map { $_->{instrument_id} } @$items
+    );
+    $self->c->model('InstrumentType')->load(values %$instruments);
+
+    return [
+        map +{
+            %$_,
+            instrument => $instruments->{ $_->{instrument_id} }
+        },
+            @$items
+    ];
+};
+
+1;
+
+=head1 COPYRIGHT
+
+This file is part of MusicBrainz, the open internet music database.
+Copyright (C) 2017 MetaBrainz Foundation
+Licensed under the GPL version 2, or (at your option) any later version:
+http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Report/InstrumentsWithoutAnImage.pm
+++ b/lib/MusicBrainz/Server/Report/InstrumentsWithoutAnImage.pm
@@ -1,0 +1,38 @@
+package MusicBrainz::Server::Report::InstrumentsWithoutAnImage;
+use Moose;
+
+with 'MusicBrainz::Server::Report::InstrumentReport';
+
+sub table { 'instruments_without_an_image' }
+
+sub query
+{
+    q{
+        SELECT
+            i.id AS instrument_id,
+            row_number() OVER (ORDER BY i.type, musicbrainz_collate(i.name))
+        FROM
+            instrument i
+            LEFT JOIN l_instrument_url liu ON i.id = liu.entity0
+            LEFT JOIN link l ON liu.link = l.id AND l.link_type IN (
+                SELECT lt.id
+                FROM link_type lt
+                WHERE lt.name IN ('image', 'wikidata')
+            )
+        WHERE
+            liu.link IS NULL
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT
+
+This file is part of MusicBrainz, the open internet music database.
+Copyright (C) 2017 MetaBrainz Foundation
+Licensed under the GPL version 2, or (at your option) any later version:
+http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -47,6 +47,7 @@ use MusicBrainz::Server::PagedReport;
     FeaturingRecordings
     FeaturingReleaseGroups
     FeaturingReleases
+    InstrumentsWithoutAnImage
     ISRCsWithManyRecordings
     ISWCsWithManyWorks
     LabelsDisambiguationSameName
@@ -118,6 +119,7 @@ use MusicBrainz::Server::Report::DuplicateReleaseGroups;
 use MusicBrainz::Server::Report::FeaturingRecordings;
 use MusicBrainz::Server::Report::FeaturingReleaseGroups;
 use MusicBrainz::Server::Report::FeaturingReleases;
+use MusicBrainz::Server::Report::InstrumentsWithoutAnImage;
 use MusicBrainz::Server::Report::ISRCsWithManyRecordings;
 use MusicBrainz::Server::Report::ISWCsWithManyWorks;
 use MusicBrainz::Server::Report::LabelsDisambiguationSameName;
@@ -175,6 +177,7 @@ sub create_report
 =head1 COPYRIGHT
 
 Copyright (C) 2009 Lukas Lalinsky
+Copyright (C) 2017 MetaBrainz Foundation
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -187,7 +190,6 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 =cut

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -35,6 +35,12 @@
             <li><a href="[% c.uri_for_action('/report/show', 'DuplicateEvents') %]">[% l('Possibly duplicate events') %]</a></li>
         </ul>
 
+        <h2>[% l('Instruments') %]</h2>
+
+        <ul>
+            <li><a href="[% c.uri_for_action('/report/show', 'InstrumentsWithoutAnImage') %]">[% l('Instruments without an image') %]</a></li>
+        </ul>
+
         <h2>[% l('Labels') %]</h2>
 
         <ul>

--- a/root/report/instruments_without_an_image.tt
+++ b/root/report/instruments_without_an_image.tt
@@ -1,0 +1,42 @@
+[%- WRAPPER 'layout.tt' title=l('Instruments without an image') full_width=1 -%]
+
+<h1>[% l('Instruments without an image') %]</h1>
+
+<ul>
+    <li>[% l('This report shows instruments without {image_rel}
+              relationships or {wikidata_rel} relationships.', {
+              image_rel => 'image', wikidata_rel => 'wikidata' }) %]</li>
+    <li>[% l('Total instruments found: {count}', { count => pager.total_entries }) %]</li>
+    <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
+</ul>
+
+[%- WRAPPER 'components/with-pager.tt' -%]
+<table class="tbl">
+    <thead>
+        <tr>
+            [% BLOCK extra_header_start %][% END %]
+            [%- PROCESS extra_header_start -%]
+            <th>[% l('Instrument') %]</th>
+            <th>[% l('Type') %]</th>
+            <th>[% l('Last updated') %]</th>
+            [% BLOCK extra_header_end %][% END %]
+            [%- PROCESS extra_header_end -%]
+        </tr>
+    </thead>
+    <tbody>
+        [%- FOR item IN items -%]
+        <tr class="[% loop.parity %]">
+            [% BLOCK extra_row_start %][% END %]
+            [%- PROCESS extra_row_start -%]
+            <td>[% link_entity(item.instrument) %]</td>
+            <td>[% item.instrument.l_type_name || l('Unclassified instrument') %]</td>
+            <td>[% UserDate.format(item.instrument.last_updated) %]</td>
+            [% BLOCK extra_row_end %][% END %]
+            [%- PROCESS extra_row_end -%]
+        </tr>
+        [%- END -%]
+    </tbody>
+</table>
+[%- END -%]
+
+[%- END -%]


### PR DESCRIPTION
# [MBS-9193](https://tickets.metabrainz.org/browse/MBS-9193)
- Actually report instruments with neither `image` URL relationship nor `wikidata` URL relationship.
- Columns are (linked) instrument name, type, and last updated.
- Rows are sorted by type id, then by instrument name, that is, in the same way as `/instruments` list.