### PR TITLE
MBS-8236: Recognise artist and ensemble for Classical Archives URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1003,7 +1003,7 @@ const CLEANUPS = {
   },
   otherdatabases: {
     match: [
-      new RegExp("^(https?://)?(www\\.)?classicalarchives\\.com/(album|composer|work)/", "i"),
+      new RegExp("^(https?://)?(www\\.)?classicalarchives\\.com/(album|artist|composer|ensemble|work)/", "i"),
       new RegExp("^(https?://)?(www\\.)?rateyourmusic\\.com/", "i"),
       new RegExp("^(https?://)?(www\\.)?worldcat\\.org/", "i"),
       new RegExp("^(https?://)?(www\\.)?musicmoz\\.org/", "i"),
@@ -1061,7 +1061,7 @@ const CLEANUPS = {
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
       // Standardising ClassicalArchives.com
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?classicalarchives\.com\/(album|composer|work)\/([^\/?#]+)(?:.*)?$/, "http://www.classicalarchives.com/$1/$2");
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?classicalarchives\.com\/(album|artist|composer|ensemble|work)\/([^\/?#]+)(?:.*)?$/, "http://www.classicalarchives.com/$1/$2");
       // Removing cruft from Worldcat URLs
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, "http://www.worldcat.org/oclc/$1");
       // Standardising IBDb not to use www

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -614,10 +614,22 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
         },
         // Classical Archives
         {
+                             input_url: 'http://www.classicalarchives.com/artist/27956.html',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://www.classicalarchives.com/artist/27956.html',
+        },
+        {
                              input_url: 'www.classicalarchives.com/composer/2806.html#tvf=tracks&tv=albums',
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://www.classicalarchives.com/composer/2806.html',
+        },
+        {
+                             input_url: 'http://www.classicalarchives.com/ensemble/10.html',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://www.classicalarchives.com/ensemble/10.html',
         },
         {
                              input_url: 'http://classicalarchives.com/album/menlo-201409.html?test',


### PR DESCRIPTION
Fix `otherdatabases` entry for Classical Archives URLs with both `/artist/` and `/ensemble/` paths.