### PR TITLE
MBS-9224: The gulpfile sometimes produces a corrupt rev-manifest bundle

### DIFF
--- a/docker/musicbrainz-tests/run_tests.sh
+++ b/docker/musicbrainz-tests/run_tests.sh
@@ -15,6 +15,10 @@ while true; do
     fi
 done
 
+# Tests require rev-manifest.json to exist.
+sudo -E -H -u musicbrainz \
+    carton exec -- ./script/compile_resources.sh
+
 exec sudo -E -H -u musicbrainz carton exec -- prove \
     --pgtap-option dbname=musicbrainz_test \
     --pgtap-option host=musicbrainz-test-database \

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2780,6 +2780,19 @@
     },
     "leaflet": {
       "version": "1.0.2"
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.2.2",
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "less-plugin-clean-css": "1.5.1",
     "leven": "2.0.0",
     "lodash": "3.10.1",
+    "merge-stream": "1.0.1",
     "moment": "2.10.6",
     "moment-strftime": "0.1.5",
     "moment-timezone": "0.4.1",

--- a/root/edit/notes-received.tt
+++ b/root/edit/notes-received.tt
@@ -34,5 +34,5 @@
     [% END %]
   </div>
 
-  [% script_manifest('edit-notes-received.js') %]
+  [% script_manifest('edit/notes-received.js') %]
 [% END %]

--- a/root/static/gulpfile.js
+++ b/root/static/gulpfile.js
@@ -5,6 +5,7 @@ const less = require('gulp-less');
 const rev = require('gulp-rev');
 const streamify = require('gulp-streamify');
 const _ = require('lodash');
+const mergeStream = require('merge-stream');
 const path = require('path');
 const po2json = require('po2json');
 const Q = require('q');
@@ -15,8 +16,11 @@ const source = require('vinyl-source-stream');
 const yarb = require('yarb');
 
 const {findObjectFile} = require('../server/gettext');
+const DBDefs = require('./scripts/common/DBDefs');
 
-const CACHED_BUNDLES = {};
+process.env.NODE_ENV = DBDefs.DEVELOPMENT_SERVER ? 'development' : 'production';
+
+const SCRIPT_BUNDLES = {};
 const CHECKOUT_DIR = path.resolve(__dirname, '../../');
 const PO_DIR = path.resolve(CHECKOUT_DIR, 'po');
 const ROOT_DIR = path.resolve(CHECKOUT_DIR, 'root');
@@ -26,7 +30,17 @@ const BUILD_DIR = process.env.MBS_STATIC_BUILD_DIR || path.resolve(STATIC_DIR, '
 const SCRIPTS_DIR = path.resolve(STATIC_DIR, 'scripts');
 const IMAGES_DIR = path.resolve(STATIC_DIR, 'images');
 
-const revManifest = {};
+const revManifestContents = {};
+
+// This file must exist for any task that runs.
+const REV_MANIFEST_PATH = path.join(BUILD_DIR, 'rev-manifest.json');
+if (!fs.existsSync(REV_MANIFEST_PATH)) {
+  fs.writeFileSync(REV_MANIFEST_PATH, '{}');
+}
+
+const revManifestBundle = runYarb('rev-manifest.js', function (b) {
+  b.expose(path.join(BUILD_DIR, 'rev-manifest.json'), 'rev-manifest.json');
+});
 
 const JED_OPTIONS_EN = {
   domain: 'mb_server',
@@ -35,7 +49,7 @@ const JED_OPTIONS_EN = {
   },
 };
 
-function writeResource(stream) {
+function writeResources(stream, writeManifest = true) {
   var deferred = Q.defer();
 
   stream
@@ -51,37 +65,62 @@ function writeResource(stream) {
       transformer: {
         parse: JSON.parse,
         stringify: function (contents) {
-          return canonicalJSON(_.assign(revManifest, contents));
+          return canonicalJSON(_.assign(revManifestContents, contents));
         },
       },
     }))
     .pipe(gulp.dest(BUILD_DIR))
     .on('finish', function () {
-      deferred.resolve();
+      if (writeManifest) {
+        writeResources(bundleScripts(revManifestBundle, 'rev-manifest.js'), false)
+          .done(deferred.resolve);
+      } else {
+        deferred.resolve();
+      }
     });
 
   return deferred.promise;
 }
 
-function buildStyles(callback) {
-  return writeResource(
-    gulp.src([
-      path.resolve(STYLES_DIR, 'common.less'),
-      path.resolve(STYLES_DIR, 'icons.less'),
-      path.resolve(STYLES_DIR, 'statistics.less'),
-    ], {base: STATIC_DIR})
-    .pipe(less({
-      rootpath: '/static/',
-      relativeUrls: true,
-      plugins: [
-        new (require('less-plugin-clean-css'))({compatibility: 'ie8'})
-      ]
-    }))
-  ).done(callback);
+const STYLE_GLOBS = [
+  'common.less',
+  'icons.less',
+  'statistics.less',
+];
+
+function buildStyles() {
+  return gulp.src(
+    STYLE_GLOBS.map(x => path.resolve(STYLES_DIR, x)),
+    {base: STATIC_DIR}
+  ).pipe(less({
+    rootpath: '/static/',
+    relativeUrls: true,
+    plugins: [
+      new (require('less-plugin-clean-css'))({compatibility: 'ie8'})
+    ]
+  }));
 }
 
-function transformBundle(bundle) {
-  const DBDefs = require('./scripts/common/DBDefs');
+function bundleScripts(bundle, name) {
+  return bundle
+    .bundle()
+    .on('error', console.error)
+    .pipe(source('scripts/' + name));
+}
+
+function runYarb(resourceName, vinyl, callback) {
+  if (!vinyl || typeof vinyl === 'function') {
+    callback = vinyl;
+    vinyl = new File({
+      base: STATIC_DIR,
+      path: path.resolve(SCRIPTS_DIR, resourceName),
+    });
+    vinyl.contents = fs.createReadStream(vinyl.path);
+  }
+
+  var bundle = yarb(vinyl, {
+    debug: DBDefs.DEVELOPMENT_SERVER,
+  });
 
   bundle.transform('babelify');
   bundle.transform('envify', {global: true});
@@ -101,40 +140,12 @@ function transformBundle(bundle) {
     });
   }
 
-  return bundle;
-}
-
-function runYarb(resourceName, callback) {
-  const DBDefs = require('./scripts/common/DBDefs');
-
-  if (CACHED_BUNDLES[resourceName]) {
-    return CACHED_BUNDLES[resourceName];
-  }
-
-  const vinyl = new File({
-    base: STATIC_DIR,
-    path: path.resolve(SCRIPTS_DIR, resourceName),
-  });
-  vinyl.contents = fs.createReadStream(vinyl.path);
-
-  var bundle = transformBundle(yarb(vinyl, {
-    debug: DBDefs.DEVELOPMENT_SERVER,
-  }));
-
   if (callback) {
     callback(bundle);
   }
 
-  CACHED_BUNDLES[resourceName] = bundle;
+  SCRIPT_BUNDLES[resourceName] = bundle;
   return bundle;
-}
-
-function bundleScripts(b, resourceName) {
-  return b.bundle().on('error', console.log).pipe(source('scripts/' + resourceName));
-}
-
-function writeScript(b, resourceName) {
-  return writeResource(bundleScripts(b, resourceName));
 }
 
 function createLangVinyl(lang, jedOptions) {
@@ -150,149 +161,98 @@ function langToPosix(lang) {
   });
 }
 
-function buildScripts() {
-  const DBDefs = require('./scripts/common/DBDefs');
+const commonBundle = runYarb('common.js', function (b) {
+  b.external(revManifestBundle);
+});
 
-  process.env.NODE_ENV = DBDefs.DEVELOPMENT_SERVER ? 'development' : 'production';
+_(DBDefs.MB_LANGUAGES || '')
+  .split(/\s+/)
+  .compact()
+  .without('en')
+  .map(langToPosix)
+  .transform(function (result, lang) {
+    var srcPo = shellQuote.quote([findObjectFile('mb_server', lang, 'po')]);
+    var tmpPo = shellQuote.quote([path.resolve(PO_DIR, `javascript.${lang}.po`)]);
 
-  var commonBundle = runYarb('common.js');
+    // msggrep's -N option supports wildcards which use fnmatch internally.
+    // The '*' cannot match path separators, so we must generate a list of
+    // possible terminal paths.
+    let scriptsDir = shellQuote.quote([SCRIPTS_DIR]);
+    let nestedDirs = shell.exec(`find ${scriptsDir} -type d`, {silent: true}).output.split('\n');
+    let msgLocations = _(nestedDirs)
+      .compact()
+      .map(dir => '-N ' + shellQuote.quote(['..' + dir.replace(CHECKOUT_DIR, '') + '/*.js']))
+      .join(' ');
 
-  // The client JS needs access to rev-manifest.json too. We obviously can't
-  // know its contents yet. So, create an empty Vinyl and expose this as the
-  // global ID "rev-manifest.json" for modules to require(). Later, once the
-  // `revManifest` object is populated, we can set the contents buffer on this
-  // currently-empty Vinyl.
-  const manifestContents = new File({
-    path: path.resolve(BUILD_DIR, 'rev-manifest.json'),
-    contents: null,
-  });
+    // Create a temporary .po file containing only the strings used by root/static/scripts.
+    shell.exec(`msggrep ${msgLocations} ${srcPo} -o ${tmpPo}`);
 
-  const manifestBundle = runYarb('rev-manifest.js');
-  manifestBundle.expose(manifestContents, 'rev-manifest.json');
-  commonBundle.external(manifestBundle);
+    result[lang] = po2json.parseFileSync(tmpPo, {format: 'jed1.x', domain: 'mb_server'});
 
-  _(DBDefs.MB_LANGUAGES || '')
-    .split(/\s+/)
-    .compact()
-    .without('en')
-    .map(langToPosix)
-    .transform(function (result, lang) {
-      var srcPo = shellQuote.quote([findObjectFile('mb_server', lang, 'po')]);
-      var tmpPo = shellQuote.quote([path.resolve(PO_DIR, `javascript.${lang}.po`)]);
+    fs.unlinkSync(tmpPo);
+  }, {})
+  .assign({en: JED_OPTIONS_EN})
+  .each(function (jedOptions, lang) {
+    const langVinyl = createLangVinyl(lang, jedOptions);
 
-      // msggrep's -N option supports wildcards which use fnmatch internally.
-      // The '*' cannot match path separators, so we must generate a list of
-      // possible terminal paths.
-      let scriptsDir = shellQuote.quote([SCRIPTS_DIR]);
-      let nestedDirs = shell.exec(`find ${scriptsDir} -type d`, {silent: true}).output.split('\n');
-      let msgLocations = _(nestedDirs)
-        .compact()
-        .map(dir => '-N ' + shellQuote.quote(['..' + dir.replace(CHECKOUT_DIR, '') + '/*.js']))
-        .join(' ');
+    runYarb(`jed-${lang}.js`, langVinyl, function (b) {
+      b.expose(langVinyl, 'jed-data');
+      commonBundle.external(b);
+    });
+  })
+  .value();
 
-      // Create a temporary .po file containing only the strings used by root/static/scripts.
-      shell.exec(`msggrep ${msgLocations} ${srcPo} -o ${tmpPo}`);
+runYarb('debug.js', function (b) {
+  b.external(commonBundle);
+});
 
-      result[lang] = po2json.parseFileSync(tmpPo, {format: 'jed1.x', domain: 'mb_server'});
+const editBundle = runYarb('edit.js', function (b) {
+  b.external(commonBundle);
+});
 
-      fs.unlinkSync(tmpPo);
-    }, {})
-    .assign({en: JED_OPTIONS_EN})
-    .each(function (jedOptions, lang) {
-      var bundle = transformBundle(yarb().expose(createLangVinyl(lang, jedOptions), 'jed-data'));
-      commonBundle.external(bundle);
-      writeScript(bundle, 'jed-' + lang + '.js');
-    })
-    .value();
+runYarb('edit/notes-received.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var editBundle = runYarb('edit.js', function (b) {
-    b.external(commonBundle);
-  });
+const guessCaseBundle = runYarb('guess-case.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var editNotesReceivedBundle = runYarb('edit/notes-received.js', function (b) {
-    b.external(commonBundle);
-  });
+const placeMapBundle = runYarb('place/map.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var guessCaseBundle = runYarb('guess-case.js', function (b) {
-    b.external(commonBundle);
-  });
+runYarb('place.js', function (b) {
+  b.external(placeMapBundle).external(editBundle).external(guessCaseBundle);
+});
 
-  var placeMapBundle = runYarb('place/map.js', function (b) {
-    b.external(commonBundle);
-  });
+runYarb('release-editor.js', function (b) {
+  b.external(commonBundle).external(editBundle);
+});
 
-  var placeBundle = runYarb('place.js', function (b) {
-    b.external(placeMapBundle).external(editBundle).external(guessCaseBundle);
-  });
+runYarb('series.js', function (b) {
+  b.external(editBundle).external(guessCaseBundle);
+});
 
-  var releaseEditorBundle = runYarb('release-editor.js', function (b) {
-    b.external(commonBundle).external(editBundle);
-  });
+runYarb('statistics.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var seriesBundle = runYarb('series.js', function (b) {
-    b.external(editBundle).external(guessCaseBundle);
-  });
+runYarb('timeline.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var statisticsBundle = runYarb('statistics.js', function (b) {
-    b.external(commonBundle);
-  });
+runYarb('url.js', function (b) {
+  b.external(editBundle);
+});
 
-  var timelineBundle = runYarb('timeline.js', function (b) {
-    b.external(commonBundle);
-  });
+runYarb('voting.js', function (b) {
+  b.external(commonBundle);
+});
 
-  var urlBundle = runYarb('url.js', function (b) {
-    b.external(editBundle);
-  });
-
-  var votingBundle = runYarb('voting.js', function (b) {
-    b.external(commonBundle);
-  });
-
-  var workBundle = runYarb('work.js', function (b) {
-    b.external(editBundle).external(guessCaseBundle);
-  });
-
-  return Q.all([
-    writeScript(commonBundle, 'common.js'),
-    writeScript(editBundle, 'edit.js'),
-    writeScript(editNotesReceivedBundle, 'edit-notes-received.js'),
-    writeScript(guessCaseBundle, 'guess-case.js'),
-    writeScript(placeBundle, 'place.js'),
-    writeScript(placeMapBundle, 'place/map.js'),
-    writeScript(releaseEditorBundle, 'release-editor.js'),
-    writeScript(seriesBundle, 'series.js'),
-    writeScript(statisticsBundle, 'statistics.js'),
-    writeScript(timelineBundle, 'timeline.js'),
-    writeScript(urlBundle, 'url.js'),
-    writeScript(votingBundle, 'voting.js'),
-    writeScript(workBundle, 'work.js'),
-    writeScript(runYarb('debug.js', function (b) {
-      b.external(commonBundle);
-    }), 'debug.js')
-  ]).then(function () {
-    manifestContents.contents = new Buffer(canonicalJSON(revManifest));
-
-    // Note that writeResource will change the contents of revManifest, and
-    // write a new rev-manifest.json, before we write our bundled version with
-    // the contents above. This is okay, because the client will never need
-    // to lookup "rev-manifest.js". It'll be included on every page by the
-    // server, which'll have access to the final rev-manifest.json on disk.
-    return writeScript(manifestBundle, 'rev-manifest.js');
-  });
-}
-
-function buildImages() {
-  return Q.all([
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'entity/*'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'icons/*'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'image404-125.png'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'layout/*'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'leaflet/*'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'licenses/*'), {base: STATIC_DIR})),
-    writeResource(gulp.src(path.join(IMAGES_DIR, 'logos/*'), {base: STATIC_DIR})),
-  ]);
-}
+runYarb('work.js', function (b) {
+  b.external(editBundle).external(guessCaseBundle);
+});
 
 gulp.task('watch', ['default'], function () {
   let watch = require('gulp-watch');
@@ -300,52 +260,80 @@ gulp.task('watch', ['default'], function () {
   watch(path.resolve(STATIC_DIR, '**/*.less'), function () {
     process.stdout.write('Rebuilding styles ... ');
 
-    buildStyles(function () {
+    writeResources(buildStyles()).done(function () {
       process.stdout.write('done.\n');
     });
   });
 
-  function rebundle(b, resourceName, file) {
-    var rebuild = false;
-
+  function shouldRebuild(b, resourceName, file) {
     switch (file.event) {
       case 'add':
-        rebuild = true;
-        break;
+        return true;
       case 'change':
       case 'unlink':
-        rebuild = b.has(file.path);
-        break;
+        return b.has(file.path);
     }
-
-    if (rebuild) {
-      process.stdout.write(`Rebuilding ${resourceName} (${file.event}: ${file.path}) ... `);
-      writeScript(b, resourceName).done(function () {
-        process.stdout.write('done.\n');
-      });
-    }
+    return false;
   }
 
   watch(path.resolve(SCRIPTS_DIR, '**/*.js'), function (file) {
-    _.each(CACHED_BUNDLES, function (bundle, resourceName) {
-      rebundle(bundle, resourceName, file);
+    const changed = {};
+
+    _.each(SCRIPT_BUNDLES, function (bundle, resourceName) {
+      if (shouldRebuild(bundle, resourceName, file)) {
+        changed[resourceName] = bundle;
+      }
     });
+
+    if (!_.isEmpty(changed)) {
+      const changedNames = Object.keys(changed).sort().join(', ');
+
+      process.stdout.write(`Rebuilding ${changedNames} ... `);
+
+      writeResources(mergeStream.apply(null, _.map(changed, bundleScripts)))
+        .done(function () {
+          process.stdout.write('done.\n');
+        });
+    }
   });
 });
 
 gulp.task('tests', function () {
   process.env.NODE_ENV = 'development';
 
-  return bundleScripts(
-    runYarb('tests/browser-runner.js', function (b) {
-      b.expose(createLangVinyl('en', JED_OPTIONS_EN), 'jed-data');
-    }),
-    'tests.js'
-  ).pipe(gulp.dest(BUILD_DIR));
+  runYarb('tests/browser-runner.js', function (bundle) {
+    bundleScripts(
+      bundle
+        .expose(path.join(BUILD_DIR, 'rev-manifest.json'), 'rev-manifest.json')
+        .expose(createLangVinyl('en', JED_OPTIONS_EN), 'jed-data'),
+      'tests.js',
+    ).pipe(gulp.dest(BUILD_DIR));
+  });
 });
 
 gulp.task('default', function () {
-  // Scripts cannot be built without images or styles. The client JS needs
-  // access to the final paths for these resources.
-  return Q.all([buildImages(), buildStyles()]).then(buildScripts);
+  const IMAGE_GLOBS = [
+    'entity/*',
+    'icons/*',
+    'image404-125.png',
+    'layout/*',
+    'leaflet/*',
+    'licenses/*',
+    'logos/*',
+  ];
+
+  return writeResources(mergeStream.apply(null, [
+    gulp.src(
+      IMAGE_GLOBS.map(x => path.join(IMAGES_DIR, x)),
+      {base: STATIC_DIR}
+    ),
+
+    // The rev-manifest.js bundle can't be written until all other resources
+    // are written (because we obviously don't know its contents otherwise,
+    // which includes the final hashes of every resource). This is handled
+    // by writeResources.
+    _.map(_.omit(SCRIPT_BUNDLES, 'rev-manifest.js'), bundleScripts),
+
+    buildStyles()
+  ]));
 });

--- a/root/static/scripts/tests/all.html
+++ b/root/static/scripts/tests/all.html
@@ -5,6 +5,6 @@
     <title>MusicBrainz test runner</title>
   </head>
   <body>
-    <script src="../../build/tests.js"></script>
+    <script src="../../build/scripts/tests.js"></script>
   </body>
 </html>

--- a/script/compile_resources.sh
+++ b/script/compile_resources.sh
@@ -3,6 +3,9 @@
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 cd "$MB_SERVER_ROOT"
 
+BUILD_DIR=${MBS_STATIC_BUILD_DIR:-root/static/build/}
+mkdir -p "$BUILD_DIR"
+
 # Remove the symbolic link first. Since it points to a directory, we'd
 # otherwise need to pass the no-dereference flag to ln, but the name of that
 # flag differs between GNU coreutils and BSD/macOS.


### PR DESCRIPTION
This was almost certainly due to concurrent asynchronous writes to rev-manifest.json, through `writeResource`. The code has been modified to only write rev-manifest.json once at the end of the build, rather than for each bundle, so that there are no longer any concurrent writes. After these changes, I can no longer reproduce the issue after many attempts.

I tested that the new bundles didn't throw any errors on several edit pages, including under different languages. I also checked that the file hashes didn't change between builds.

I adapted the "watch" mode for these changes too, but it seems to have already been broken before this patch (and I didn't fix it).