### PR TITLE
Fail edits trying to set empty credited-as AC names

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Utils.pm
+++ b/lib/MusicBrainz/Server/Edit/Utils.pm
@@ -58,6 +58,11 @@ sub verify_artist_credits
         for (@{ $ac->{names} })
         {
             push @artist_ids, $_->{artist}->{id};
+            if ($_->{name} eq '') {
+                MusicBrainz::Server::Edit::Exceptions::GeneralError->throw(
+                    'The credited-as name in an artist credit cannot be empty'
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Due to a bug (see MBS-8750), there are edits trying to set an empty artist credit name (Artist Foo as `""`). Those edits would never close.

Test for this case when applying an edit and explicitly fail if necessary.