### PR TITLE
Fix i18n text selection (related to MBS-7795)

### DIFF
--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -76,7 +76,7 @@ if (places.length) {
       popupText += _.escape(ln(
         '… and {place_count} other',
         '… and {place_count} others',
-        CLUSTER_POPUP_LIMIT,
+        markers.length - CLUSTER_POPUP_LIMIT,
         {place_count: markers.length - CLUSTER_POPUP_LIMIT}
       ));
     }


### PR DESCRIPTION
'… and {place_count} other' should be displayed when markers.length == CLUSTER_POPUP_LIMIT + 1

The bug can be seen e.g. on https://beta.musicbrainz.org/area/74e50e58-5deb-4b99-93a2-decbb365c07f/places when unzooming one step on the map (there's a cluster with 11 entities)