### PR TITLE
MBS-9176: make Create RG form consistent with others (and less ugly)

### DIFF
--- a/root/release_group/create.tt
+++ b/root/release_group/create.tt
@@ -1,8 +1,7 @@
 [% WRAPPER 'layout.tt' title=l('Add Release Group') full_width=1 %]
-   [% INCLUDE 'artist/header.tt' artist=initial_artist IF initial_artist %]
-
-   <h1>[% l('Add Release Group') %]</h1>
-   [%~ javascript_required() ~%]
-
-   [% INCLUDE 'release_group/edit_form.tt' new=1 %]
+    <div id="content">
+        <h1>[%- lp('Add Release Group', 'header') -%]</h1>
+        [%~ javascript_required() ~%]
+        [% INCLUDE 'release_group/edit_form.tt' new=1 %]
+    </div>
 [% END %]


### PR DESCRIPTION
As I mentioned on [MBS-9176](https://tickets.metabrainz.org/browse/MBS-9176), this gets rid of the artist info on top of the create RG form, which isn't there when you click Add recording, Add work, nor Add release (and looks very out of place, too).

Wrapping it into a content div like the other forms for consistency too.