### PR TITLE
MBS-9164: Show edit history (but not notes) when not logged in

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -55,7 +55,7 @@ sub _load
     return $c->model('Edit')->get_by_id($edit_id);
 }
 
-sub show : Chained('load') PathPart('') RequireAuth
+sub show : Chained('load') PathPart('')
 {
     my ($self, $c) = @_;
     my $edit = $c->stash->{edit};
@@ -190,7 +190,7 @@ Show a list of open moderations
 
 =cut
 
-sub open : Local RequireAuth
+sub open : Local
 {
     my ($self, $c) = @_;
 
@@ -204,7 +204,7 @@ sub open : Local RequireAuth
     $c->form(add_edit_note => 'EditNote');
 }
 
-sub search : Path('/search/edits') RequireAuth
+sub search : Path('/search/edits')
 {
     my ($self, $c) = @_;
     my $coll = $c->get_collator();

--- a/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
@@ -6,7 +6,7 @@ use MusicBrainz::Server::Constants qw( :edit_status );
 
 requires '_load_paged';
 
-sub edits : Chained('load') PathPart RequireAuth
+sub edits : Chained('load') PathPart
 {
     my ($self, $c) = @_;
     $self->_list($c, sub {
@@ -26,11 +26,11 @@ sub edits : Chained('load') PathPart RequireAuth
               'conditions.0.operator' => '=',
               'conditions.0.name' => $c->stash->{ $self->{entity_name} }->name,
               'conditions.0.args.0' => $c->stash->{ $self->{entity_name} }->id,
-              'conditions.0.user_id' => $c->user->id },
+              $c->user_exists ? ('conditions.0.user_id' => $c->user->id) : () },
     );
 }
 
-sub open_edits : Chained('load') PathPart RequireAuth
+sub open_edits : Chained('load') PathPart
 {
     my ($self, $c) = @_;
     $self->_list($c, sub {
@@ -51,7 +51,7 @@ sub open_edits : Chained('load') PathPart RequireAuth
               'conditions.0.operator' => '=',
               'conditions.0.name' => $c->stash->{ $self->{entity_name} }->name,
               'conditions.0.args.0' => $c->stash->{ $self->{entity_name} }->id,
-              'conditions.0.user_id' => $c->user->id,
+              $c->user_exists ? ('conditions.0.user_id' => $c->user->id) : (),
               'conditions.1.field' => 'status',
               'conditions.1.operator' => '=',
               'conditions.1.args' => $STATUS_OPEN },

--- a/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
@@ -25,8 +25,7 @@ sub edits : Chained('load') PathPart
               'conditions.0.field' => model_to_type( $self->{model} ),
               'conditions.0.operator' => '=',
               'conditions.0.name' => $c->stash->{ $self->{entity_name} }->name,
-              'conditions.0.args.0' => $c->stash->{ $self->{entity_name} }->id,
-              $c->user_exists ? ('conditions.0.user_id' => $c->user->id) : () },
+              'conditions.0.args.0' => $c->stash->{ $self->{entity_name} }->id },
     );
 }
 
@@ -51,7 +50,6 @@ sub open_edits : Chained('load') PathPart
               'conditions.0.operator' => '=',
               'conditions.0.name' => $c->stash->{ $self->{entity_name} }->name,
               'conditions.0.args.0' => $c->stash->{ $self->{entity_name} }->id,
-              $c->user_exists ? ('conditions.0.user_id' => $c->user->id) : (),
               'conditions.1.field' => 'status',
               'conditions.1.operator' => '=',
               'conditions.1.args' => $STATUS_OPEN },

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import RequestLogin from '../../components/RequestLogin';
 import VotingPeriod from '../../components/VotingPeriod';
 import {
   EDIT_STATUS_OPEN,
@@ -84,9 +85,11 @@ const EditSidebar = ({$c, edit}: Props) => (
     </SidebarProperties>
 
     <p>
-      <a href={`/edit/${edit.id}/data`}>
-        <bdi>{l('Raw edit data for this edit')}</bdi>
-      </a>
+      {$c.user_exists ? (
+        <a href={`/edit/${edit.id}/data`}>
+          <bdi>{l('Raw edit data for this edit')}</bdi>
+        </a>
+      ) : null}
     </p>
 
     <p>{l('For more information:')}</p>

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -48,7 +48,7 @@ const EditSummary = ({$c, edit, index}: Props) => {
 
       <Vote edit={edit} index={index} summary />
 
-      {!DBDefs.DB_READ_ONLY && (mayAddNote || mayApprove || mayCancel) ? (
+      {$c.user_exists && !DBDefs.DB_READ_ONLY && (mayAddNote || mayApprove || mayCancel) ? (
         <div className="cancel-edit buttons">
           {mayAddNote ? (
             <a className="positive edit-note-toggle">{l('Add Note')}</a>

--- a/root/edit/edit_header.tt
+++ b/root/edit/edit_header.tt
@@ -10,7 +10,7 @@
                                 <strong>[%- l('Their vote: ') -%]</strong>
                                 [%- lp(edit.latest_vote_for_editor(voter.id).vote_name, 'vote') ~%]
                             </div>
-                        [%~ ELSE ~%]
+                        [%~ ELSIF c.user.id ~%]
                           [%~ IF edit.latest_vote_for_editor(c.user.id) ~%]
                               <div class="my-vote">
                                   <strong>[%- l('My vote: ') -%]</strong>
@@ -31,7 +31,12 @@
                     </td>
                     <td class="vote-count">
                         [%~ IF edit.latest_vote_for_editor(c.user.id) || c.user.id == edit.editor_id || !edit.is_open ~%]
-                            <div>[%- vote_tally(edit) -%]</div>
+                            <div>
+                                [%~ IF !c.user_exists ~%]
+                                    <strong>[%- add_colon(l('Vote tally')) _ ' ' -%]</strong>
+                                [%~ END ~%]
+                                [%- vote_tally(edit) -%]
+                            </div>
                         [%~ END ~%]
                     </td>
                 </tr>
@@ -55,7 +60,7 @@
             [%~ link_edit(edit, show, l('Edit #{id} - {name}', { id => edit.id, name => edit.l_edit_name})) ~%]
         </h2>
     [%~ ELSE ~%]
-        [%~ IF edit.editor_may_approve(c.user) || edit.editor_may_cancel(c.user) ~%]
+        [%~ IF c.user_exists && (edit.editor_may_approve(c.user) || edit.editor_may_cancel(c.user)) ~%]
             <div class="cancel-edit buttons">
                 [%~ IF edit.editor_may_approve(c.user) ~%]
                     <a class="positive" href="[% c.uri_for_action('/edit/approve', [ edit.id ], { returnto=c.req.uri }) %]">[% l('Approve edit') %]</a>
@@ -73,8 +78,15 @@
 
     <p class="subheader">
         <span class="prefix">~</span>
-        [% l('Edit by {editor}',
-            { editor => link_entity(edit.editor) }) %]
-        [%- editor_type_info(edit.editor) -%]
+        [%~ IF c.user_exists ~%]
+            [% l('Edit by {editor}',
+                { editor => link_entity(edit.editor) }) %]
+            [%- editor_type_info(edit.editor) -%]
+        [%~ ELSE ~%]
+            [% # We show editor type since knowing if it's, say, a bot edit is useful %]
+            [% l('Editor hidden') ~%]
+            [%- editor_type_info(edit.editor) ~%]
+            [%- bracketedWithSpace(request_login(l('log in to see who'))) -%]
+        [%~ END ~%]
     </p>
 </div>

--- a/root/edit/index.tt
+++ b/root/edit/index.tt
@@ -22,29 +22,31 @@
 
           <table class="vote-tally">
             <tr class="noborder">
-                <th>[% l('Vote tally:') %]</th>
+                <th>[% add_colon(l('Vote tally')) %]</th>
                 <td class="vote">[%- vote_tally(edit) -%]</td>
             </tr>
-            [% IF edit.editor_may_vote(c.user) %]
-                <tr class="noborder">
-                        <th>[% l('My vote:') %]</th>
+            [%~ IF c.user_exists ~%]
+                [% IF edit.editor_may_vote(c.user) %]
+                    <tr class="noborder">
+                            <th>[% l('My vote:') %]</th>
+                            <td class="vote">
+                                [% React.embed(c, 'edit/components/Vote', {edit => edit}) %]
+                            </td>
+                    </tr>
+                [% END %]
+                [% FOR vote=edit.votes %]
+                    <tr class="[% 'superseded' IF vote.superseded %][% 'first' IF edit.votes.size == 1 %]">
+                        <th>[% link_entity(vote.editor) %]</th>
                         <td class="vote">
-                            [% React.embed(c, 'edit/components/Vote', {edit => edit}) %]
+                            [% lp(vote.vote_name, 'vote') %]
+                            <span class="date">[% UserDate.format(vote.vote_time) %]</span>
                         </td>
-                </tr>
-            [% END %]
-            [% FOR vote=edit.votes %]
-                <tr class="[% 'superseded' IF vote.superseded %][% 'first' IF edit.votes.size == 1 %]">
-                    <th>[% link_entity(vote.editor) %]</th>
-                    <td class="vote">
-                        [% lp(vote.vote_name, 'vote') %]
-                        <span class="date">[% UserDate.format(vote.vote_time) %]</span>
-                    </td>
-                </tr>
-            [% END %]
+                    </tr>
+                [% END %]
+            [%~ END ~%]
         </table>
 
-        [% IF edit.is_open && !edit.editor_may_vote(c.user) && (edit.editor_id != c.user.id) %]
+        [% IF edit.is_open && c.user_exists && !edit.editor_may_vote(c.user) && (edit.editor_id != c.user.id) %]
             [%# The current user check is necessary because !edit.editor_may_vote
             comes back true when the current user is the edit.editor. %]
             <p>
@@ -64,18 +66,26 @@
             [% END %]
         [% ELSE %]
             <p>
-                [%- l('You must be logged in to vote on edits') -%]
-                [%- request_login() -%]
+                [%- l('You must be logged in to vote on edits.') =%]
+                [%= request_login() -%]
             </p>
         [% END %]
 
-            <h2>[% l('Edit notes') %]</h2>
+        <h2>[% l('Edit notes') %]</h2>
+        [%~ IF c.user_exists ~%]
             [% INCLUDE 'edit/notes.tt' %]
             [%- IF edit.editor_may_vote(c.user) -%]
                     [%- form_submit(l('Submit vote and note')) -%]
             [%- ELSIF edit.editor_may_add_note(c.user) -%]
                     [%- form_submit(l('Submit note')) -%]
             [%- END -%]
+        [%~ ELSE ~%]
+            <p>
+                [%- l('You must be logged in to see edit notes.') %]
+                [% request_login() -%]
+            </p>
+        [%~ END ~%]
+            
         </form>
     </div>
 

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -66,17 +66,21 @@
                         [% END %]
                     </div>
 
-                    [% INCLUDE 'edit/notes.tt' verbose='not-verbose' hide=1 rows=1 index=loop.index %]
-
+                    [%~ IF c.user_exists ~%]
+                        [% INCLUDE 'edit/notes.tt' verbose='not-verbose' hide=1 rows=1 index=loop.index %]
+                    [%~ END ~%]
                     <div class="seperator">
                     </div>
                 </div>
             [%- END -%]
 
             <input type="hidden" name="url" value="[% c.req.uri %]" />
-            <div class="align-right row no-label" >
-                [% form_submit(l('Submit votes &amp; edit notes')) %]
-            </div>
+
+            [%~ IF c.user_exists ~%]
+                <div class="align-right row no-label" >
+                    [% form_submit(l('Submit votes &amp; edit notes')) %]
+                </div>
+            [%~ END ~%]
         </form>
     [% END %]
     </div>

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -247,6 +247,16 @@
   </span>
 [% END %]
 
+[% MACRO predicate_edit_notes(field, field_contents) BLOCK %]
+  [%~ IF c.user_exists ~%]
+    [% predicate_link(field, undef, 'editor') %]
+  [%~ ELSE ~%]
+    [% WRAPPER wfield predicate="set" %]
+      [%~ needs_login() ~%]
+    [% END %]        
+  [%~ END ~%]
+[% END %]
+
 [% MACRO predicate_voter(field, field_contents) WRAPPER wfield predicate="voter" %]
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ]
@@ -363,6 +373,11 @@
   </select>
 [% END %]
 
+[% BLOCK needs_login %]
+  [%~ l('You must be logged in to use this option.') %]
+  [% request_login() -%]
+[% END %]
+
 [% MACRO select_field(field_contents) BLOCK %]
   <select name="field" class="field">
     [% UNLESS field_contents %]
@@ -375,7 +390,7 @@
                    [ 'status', lp('Status', 'edit status') ],
                    [ 'type', l('Type') ],
                    [ 'vote_count', l('Vote tally') ],
-                   [ 'edit_note_author', l('Edit Note Author') ],
+                   [ 'edit_note_author', l('Edit Note Author'), {requires_login => 1} ],
                    [ 'area', l('Area') ],
                    [ 'artist', l('Artist') ],
                    [ 'event', l('Event') ],
@@ -387,20 +402,22 @@
                    [ 'release_group', l('Release Group') ],
                    [ 'series', lp('Series', 'singular') ],
                    [ 'work', l('Work') ],
-                   [ 'editor', l('Editor') ],
-                   [ 'voter', l('Voter') ]
+                   [ 'editor', l('Editor'), {requires_login => 1} ],
+                   [ 'voter', l('Voter'), {requires_login => 1} ]
                    [ 'release_language', l('Release Language') ],
                    [ 'release_quality', l('Release Quality') ],
                    [ 'artist_area', l('Artist Area') ],
                    [ 'label_area', l('Label Area') ]
                    [ 'release_country', l('Release Country') ]
                    [ 'link_type', l('Relationship Type') ],
-                   [ 'editor_flag', l('Editor Flag') ],
-                   [ 'applied_edits', l('Applied Edit Count of Editor') ],
+                   [ 'editor_flag', l('Editor Flag'), {requires_login => 1} ],
+                   [ 'applied_edits', l('Applied Edit Count of Editor'), {requires_login => 1} ],
                    ] -%]
-    <option
-       [%~ ' selected="selected"' IF field_contents.field_name == field.0 =%]
-       value="[% html_escape(field.0) %]">[% html_escape(field.1) %]</option>
+      [% UNLESS (field.2.requires_login && !c.user_exists) %]
+        <option
+          [%~ ' selected="selected"' IF field_contents.field_name == field.0 =%]
+          value="[% html_escape(field.0) %]">[% html_escape(field.1) %]</option>
+      [% END %]
     [% END %]
   </select>
 [% END %]
@@ -413,7 +430,7 @@
     [% predicate_set('status', status, [], 8) %]
     [% predicate_set('release_quality', quality) %]
     [% predicate_vote_count('vote_count') %]
-    [% predicate_user('edit_note_author') %]
+    [% predicate_edit_notes('edit_note_author') %]
 
     [% FOR linked_type=[ 'artist', 'label', 'series' ];
          predicate_subscription(linked_type);

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -183,7 +183,7 @@ const ProductsMenu = () => (
   </li>
 );
 
-const SearchMenu = withCatalystContext(({$c}: {+$c: CatalystContextT}) => (
+const SearchMenu = () => (
   <li className="search" tabIndex="-1">
     <span className="menu-header">
       {l('Search')}
@@ -193,11 +193,9 @@ const SearchMenu = withCatalystContext(({$c}: {+$c: CatalystContextT}) => (
       <li>
         <a href="/search">{l('Search Entities')}</a>
       </li>
-      {$c.user_exists ? (
-        <li>
-          <a href="/search/edits">{l('Search Edits')}</a>
-        </li>
-      ) : null}
+      <li>
+        <a href="/search/edits">{l('Search Edits')}</a>
+      </li>
       <li>
         <a href="/tags">{l('Tags')}</a>
       </li>
@@ -206,7 +204,7 @@ const SearchMenu = withCatalystContext(({$c}: {+$c: CatalystContextT}) => (
       </li>
     </ul>
   </li>
-));
+);
 
 const EditingMenu = () => (
   <li className="editing" tabIndex="-1">

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -9,7 +9,6 @@
 
 import * as React from 'react';
 
-import RequestLogin from '../../../components/RequestLogin';
 import {withCatalystContext} from '../../../context';
 import EditorLink from '../../../static/scripts/common/components/EditorLink';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
@@ -45,28 +44,20 @@ const CollectionSidebar = ({$c, collection}: Props) => {
       <h2 className="editing">{l('Editing')}</h2>
 
       <ul className="links">
-        {$c.user_exists ? (
-          <>
-            <li>
-              <EntityLink
-                content={l('Open edits')}
-                entity={collection}
-                subPath="open_edits"
-              />
-            </li>
-            <li>
-              <EntityLink
-                content={l('Editing history')}
-                entity={collection}
-                subPath="edits"
-              />
-            </li>
-          </>
-        ) : (
-          <li>
-            <RequestLogin $c={$c} text={l('Log in to edit')} />
-          </li>
-        )}
+        <li>
+          <EntityLink
+            content={l('Open edits')}
+            entity={collection}
+            subPath="open_edits"
+          />
+        </li>
+        <li>
+          <EntityLink
+            content={l('Editing history')}
+            entity={collection}
+            subPath="edits"
+          />
+        </li>
       </ul>
 
       {$c.user_exists ? (

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -23,29 +23,28 @@ const EditLinks = ({$c, children, entity}: Props) => (
   <>
     <h2 className="editing">{l('Editing')}</h2>
     <ul className="links">
-      {$c.user_exists ? (
+      {$c.user_exists ? children : (
         <>
-          {children}
           <li>
-            <EntityLink
-              content={l('Open edits')}
-              entity={entity}
-              subPath="open_edits"
-            />
+            <RequestLogin $c={$c} text={l('Log in to edit')} />
           </li>
-          <li>
-            <EntityLink
-              content={l('Editing history')}
-              entity={entity}
-              subPath="edits"
-            />
-          </li>
+          <li className="separator" role="separator" />
         </>
-      ) : (
-        <li>
-          <RequestLogin $c={$c} text={l('Log in to edit')} />
-        </li>
       )}
+      <li>
+        <EntityLink
+          content={l('Open edits')}
+          entity={entity}
+          subPath="open_edits"
+        />
+      </li>
+      <li>
+        <EntityLink
+          content={l('Editing history')}
+          entity={entity}
+          subPath="edits"
+        />
+      </li>
     </ul>
   </>
 );

--- a/root/robots.txt.production
+++ b/root/robots.txt.production
@@ -7,6 +7,7 @@ Disallow: /cdstub/
 Disallow: /cdtoc/attach
 Disallow: /collection/
 Disallow: /edit/
+Disallow: /*/edits
 Disallow: /election/
 Disallow: /elections
 Disallow: /isrc/


### PR DESCRIPTION
Submitting a WIP PR for [MBS-9164](https://tickets.metabrainz.org/browse/MBS-9164) per bitmap's request. 

Displaying edits seems to work pretty much fine, although I don't discount the possibility of there being some issue I haven't noticed yet. 

Edit search needs to be restricted properly so that it won't actually submit when the non-logged-in options are selected, and it also needs to be restricted so that if someone constructs a URL (or clicks a link) involving the logged-in-only options when not logged in, it will actually reject it and ask for login. 

I haven't looked at tests yet, so I expect this to break a ton of them.