### PR TITLE
MBS-9250: Places map displays over header menus

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -275,7 +275,7 @@ pre code {
                 ul {
                     position: absolute;
                     left: -10000px;
-                    z-index: 9;
+                    z-index: 500;
                     padding: 1px;
                     background-color: @musicbrainz-orange;
                     li {


### PR DESCRIPTION
The menu z-index must be above the one of leaflet map (z-index 400)