### PR TITLE
MBS-9246: Load extra data for Artist Credit field

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
@@ -122,8 +122,8 @@ sub json {
 
     my $artists = $c->model('Artist')->get_by_ids(map { $_->{artist}->{id} } @$names);
     for my $name (@$names) {
-        $name->{artist}->{entityType} = 'artist';
-        $name->{artist}->{gid} = $artists->{$name->{artist}->{id}}->gid if $artists->{$name->{artist}->{id}};
+        my $artist = $artists->{$name->{artist}->{id}};
+        $name->{artist} = $artist->TO_JSON if $artist;
         $name->{joinPhrase} = delete $name->{join_phrase};
     }
 


### PR DESCRIPTION
Fix [MBS-9246 Tool-tips displaying "undefined" text](https://tickets.metabrainz.org/browse/MBS-9246).

Previously, only artist name, id, gid, and type were loaded for preview in the Artist Credit editor.  Consequently, tool-tips did not contain sort name or disambiguation comment (but _undefined_ instead), and artists with pending edits were not highlighted. It affects Artist Credit field editor of editing forms for recording, release-group, artist credit, and artist split. Only Artist Credit field of release editor is unaffected, because it is initialized in a different way using React.

This patch loads all JSON-serialized artist fields including sort name, disambiguation comment, and status regarding pending edits to the Artist Credit form field. All of the above mentioned bugs are fixed, ensuring consistency with release editor.