### PR TITLE
MBS-9237: Fix complex artist credit detection

### DIFF
--- a/root/static/scripts/common/immutable-entities.js
+++ b/root/static/scripts/common/immutable-entities.js
@@ -37,7 +37,7 @@ const reduceArtistCredit = ac => ac.names.reduce(reduceName, '');
 const isComplexArtistCredit = function (ac) {
   const firstName = ac.names.get(0);
   if (firstName && hasArtist(firstName)) {
-     return firstName.artist.name !== reduceArtistCredit(ac);
+     return !nonEmpty(firstName.name) || firstName.artist.name !== reduceArtistCredit(ac);
   }
   return false;
 };

--- a/root/static/scripts/tests/common/immutable-entities.js
+++ b/root/static/scripts/tests/common/immutable-entities.js
@@ -5,7 +5,11 @@
 
 const test = require('tape');
 
+const Immutable = require('immutable');
+
 const {
+    ArtistCredit,
+    ArtistCreditName,
     artistCreditFromArray,
     artistCreditsAreEqual,
     isComplexArtistCredit,
@@ -15,13 +19,20 @@ const bowie = {id: 956, gid: '5441c29d-3602-4898-b1a1-b77fa23b8e50', name: 'davi
 const crosby = {id: 99, gid: '2437980f-513a-44fc-80f1-b90d9d7fcf8f', name: 'bing crosby'};
 
 test('isComplexArtistCredit', function (t) {
-  t.plan(3);
+  t.plan(4);
 
   let ac = artistCreditFromArray([{artist: bowie, name: 'david bowie'}]);
   t.equal(isComplexArtistCredit(ac), false, 'david bowie is not complex');
 
   ac = artistCreditFromArray([{artist: bowie, name: 'david robert jones'}]);
   t.equal(isComplexArtistCredit(ac), true, 'david robert jones is complex');
+
+  ac = new ArtistCredit({
+    names: Immutable.List([
+      new ArtistCreditName({artist: bowie, name: ''})
+    ])
+  });
+  t.equal(isComplexArtistCredit(ac), true, 'empty artist credit is complex');
 
   ac = artistCreditFromArray([
     {artist: bowie, name: 'david bowie', joinPhrase: ' & '},


### PR DESCRIPTION
Fix [MBS-9237: Don't immediately fill back the default AC while editor is typing](https://tickets.metabrainz.org/browse/MBS-9237).

Previously, empty Artist Credits were mistakenly considered as simple, so triggering the Artist field Autocomplete to fill back user emptied Artist Credit in the Artist Credit editor bubble. This is because empty artist credit is reduced to artist name.

This patch fixes the `isComplexArtistCredit` to consider empty Artist Credit as complex.  This prevents the automatic fill-back of Artist Credit field in the Artist Credit editor to mistakenly happen before the field looses focus. See `onNameBlur` for proper fill-back.