### PR TITLE
MBS-8931: Invalid ISRC causes an ISE

### DIFF
--- a/lib/MusicBrainz/Server/Form.pm
+++ b/lib/MusicBrainz/Server/Form.pm
@@ -193,7 +193,9 @@ sub TO_JSON {
             html_name => $field->html_name,
             label => $field->label,
             value => $field->value,
-            ($field->can('error_fields') ? (error_fields => [$field->error_fields]) : ()),
+            ($field->can('error_fields') ? (
+                error_fields => [map +{ errors => $_->errors }, $field->error_fields]
+            ) : ()),
         };
     }
     $result;


### PR DESCRIPTION
The `TO_JSON` method on `Server::Form` is used to encode values and errors from FormHandler for display by the JavaScript. Specifically, just the artist credit editor right now. Unfortunately, the `error_fields` property would sometimes contain blessed objects, as was the case with ISRCs. To fix this, only output the parts of `error_fields` which we actually need, and know not to include any blessed objects.

This wasn't a problem for ISWCs because we don't use `to_encoded_json` on the work edit page (as stated, it's only needed for artist credits right now).