### PR TITLE
MBS-9129: Adjust JSON serialization for RG ratings on release request.

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -7,7 +7,6 @@ extends 'MusicBrainz::Server::WebService::Serializer::JSON::2';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Aliases';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Annotation';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::GID';
-with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Relationships';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Tags';
 

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -81,8 +81,15 @@ sub serialize
     $body{collections} = list_of($entity, $inc, $stash, "collections")
         if $inc && ($inc->collections || $inc->user_collections);
 
-    $body{"release-group"} = serialize_entity($entity->release_group, $inc, $stash)
-        if $inc && $inc->release_groups;
+    if ($inc && $inc->release_groups)
+    {
+        # MBS-9129: If ratings are requested (even though a release doesn't have
+        # any), those of the release group should be serialized (to match the
+        # behaviour of the XML serializer). So we override a package variable to
+        # force the ratings to be serialized despite not being top-level.
+        local $MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating::forced = 1;
+        $body{"release-group"} = serialize_entity($entity->release_group, $inc, $stash);
+    }
 
     if ($toplevel)
     {
@@ -119,7 +126,7 @@ no Moose;
 
 # =head1 COPYRIGHT
 
-# Copyright (C) 2011,2012 MetaBrainz Foundation
+# Copyright (C) 2011,2012,2017 MetaBrainz Foundation
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Role/Rating.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Role/Rating.pm
@@ -2,12 +2,15 @@ package MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating;
 use Moose::Role;
 use MusicBrainz::Server::WebService::Serializer::JSON::2::Utils qw( number );
 
+# This allows overriding the "top-level entities only" restriction.
+our $forced = 0;
+
 around serialize => sub {
     my ($orig, $self, $entity, $inc, $stash, $toplevel) = @_;
     my $ret = $self->$orig($entity, $inc, $stash, $toplevel);
 
-    return $ret unless $toplevel && defined $inc &&
-        ($inc->ratings || $inc->user_ratings);
+    return $ret unless $toplevel || $forced;
+    return $ret unless defined($inc) && ($inc->ratings || $inc->user_ratings);
 
     my $opts = $stash->store($entity);
 
@@ -29,7 +32,7 @@ no Moose::Role;
 
 =head1 COPYRIGHT
 
-Copyright (C) 2012 MetaBrainz Foundation
+Copyright (C) 2012,2017 MetaBrainz Foundation
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The first commit is straightforward - a release has no ratings so should not try to serialize them.

The second part aims to replicate the XML serializer's behaviour - a request for ratings on a release is "forwarded" to the release's RG (if it's also requested).
However, the JSON serializer is made up of a bunch of disjoint sources, and the bit that handles ratings has no way of knowing it's handling a release group that is being serialized as part of a release request.
If I change MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating to ignore the toplevel flag, all release groups (including those in (requested) relationships) in all requests will serialize their ratings; instead I (ab)use $inc to pass a special flag for it to pick up.

I'm not very happy with that, but the only other way I see is to change the basic serialize() signature and either add an extra parameter, or change the semantics of the current $toplevel flag (e.g. by calling it $flags, and changing tests of $toplevel to checks for $flags->{TOPLEVEL}). Other approaches/suggestions welcome.