### PR TITLE
MBS-9215: Add entity type to attribute editing form

### DIFF
--- a/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
@@ -1,12 +1,13 @@
 package MusicBrainz::Server::Form::Admin::Attributes;
 
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Form::Utils qw( select_options_tree );
+use MusicBrainz::Server::Form::Utils qw( select_options select_options_tree );
+use MusicBrainz::Server::Constants qw( entities_with );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 
-sub edit_field_names { qw( parent_id child_order name description year has_discids free_text ) }
+sub edit_field_names { qw( parent_id child_order name description year has_discids free_text entity_type ) }
 
 has '+name' => ( default => 'attr' );
 
@@ -41,9 +42,18 @@ has_field 'free_text' => (
     type => 'Boolean',
 );
 
+has_field 'entity_type' => (
+    type => 'Select',
+);
+
 sub options_parent_id {
     my ($self, $model) = @_;
     return select_options_tree($self->ctx, $self->ctx->stash->{model}, accessor => 'name');
+}
+
+sub options_entity_type {
+    my ($self) = @_;
+    return map { $_ => $_ } sort { $a cmp $b } entities_with('collections');
 }
 
 1;

--- a/root/admin/attributes/form.tt
+++ b/root/admin/attributes/form.tt
@@ -36,6 +36,16 @@
     [% ELSE %]
         [%~ IF model == "CollectionType" || model == "SeriesType" ~%]
             [% form_row_select(r, 'entity_type', add_colon(l('Entity type'))) %]
+            [%~ IF c.action.name == "edit" ~%]
+                <script>//<![CDATA[
+                    $(function () {
+                        $('#id-attr\\.entity_type').prop('disabled', true);
+                        $('form[action="[% c.req.uri %]"]').bind('submit', function () {
+                            $('#id-attr\\.entity_type').prop('disabled', false);
+                        });
+                    });
+                //]]></script>
+            [%~ END ~%]
         [%~ END ~%]
 
         [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]

--- a/root/admin/attributes/form.tt
+++ b/root/admin/attributes/form.tt
@@ -34,6 +34,10 @@
         </p>
 
     [% ELSE %]
+        [%~ IF model == "CollectionType" || model == "SeriesType" ~%]
+            [% form_row_select(r, 'entity_type', add_colon(l('Entity type'))) %]
+        [%~ END ~%]
+
         [% form_row_select(r, 'parent_id', add_colon(l('Parent'))) %]
 
         [% WRAPPER form_row %]


### PR DESCRIPTION
Collection and series types admin editing form missed entity type.

This adds support for entering entity type without specific check.