### PR TITLE
MBS-9214: Fix cover art tick boxes for Opera

### DIFF
--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -81,9 +81,11 @@
               <label>[%- l("Type:") -%]</label>
               <ul class="checkboxes" data-bind="foreach: types">
                 <li>
-                  <label style="white-space:nowrap;">
+                  <label>
+                    <span style="white-space:nowrap;">
                       <input type="checkbox" class="type" data-bind="checked: checked, value: id" />
                       <span style="white-space:normal;" data-bind="text: name" />
+                    </span>
                   </label>
                 </li>
               </ul>


### PR DESCRIPTION
Tiny bug fix for [MBS-9214: Cover art types tick boxes are listed with scrollbars in Opera 42 Stable](https://tickets.metabrainz.org/browse/MBS-9214).

Insert a `<span>` element to work around still modern Opera’s lack of support for `white-space` CSS property on `<li>` and `<label>` elements.

This affects tick boxes and their labels for cover art type field in release cover art adding form.