### PR TITLE
MBS-9258: Map "Accept: application/json" to "fmt=json" for search server WS requests.

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Format.pm
+++ b/lib/MusicBrainz/Server/WebService/Format.pm
@@ -49,9 +49,9 @@ role {
         }
 
         $c->stash->{error} = 'Invalid format. Either set an Accept header'
-            . ' (recognized mime types are '. join (' and ', keys %accepted)
+            . ' (recognized mime types are '. join (' and ', sort keys %accepted)
             . '), or include a fmt= argument in the query string (valid values'
-            . ' for fmt are '. join (' and ', keys %formats) . ').';
+            . ' for fmt are '. join (' and ', sort keys %formats) . ').';
 
         my $ser = $role->serializers->[0];
 

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -328,6 +328,10 @@ role {
                 }
             }
 
+            # MBS-9258: Map "Accept: application/json" to "fmt=json"
+            $c->stash->{args}->{fmt} = $c->stash->{serializer}->fmt
+                unless exists($c->stash->{args}->{fmt});
+
             # MBS-8994. Adding this here so we don't have to change every
             # 'optional' search attribute in every Controller::WS::2 class,
             # and it's an undocumented hack anyway, so this'll be easier to

--- a/t/lib/t/MusicBrainz/Server/WebService/Format.pm
+++ b/t/lib/t/MusicBrainz/Server/WebService/Format.pm
@@ -1,0 +1,130 @@
+package t::MusicBrainz::Server::WebService::Format;
+
+use JSON qw( decode_json encode_json );
+use Test::JSON import => [qw( is_valid_json is_json )];
+use Test::More;
+use Test::Routine;
+use Test::XML::SemanticCompare;
+
+with 't::Mechanize', 't::Context';
+
+test 'webservice request format handling (XML)' => sub {
+
+    my $test = shift;
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+webservice');
+
+    my $mech = $test->mech;
+
+    my $Test = Test::Builder->new();
+
+    my $expected = '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <artist type="Person" type-id="b6e035f4-3ce9-331c-97df-83397230b0df" id="472bc127-8861-45e8-bc9e-31e8dd32de7a">
+        <name>Distance</name><sort-name>Distance</sort-name>
+        <disambiguation>UK dubstep artist Greg Sanders</disambiguation>
+    </artist>
+</metadata>';
+
+    $Test->note('Accept: <blank>');
+    $mech->default_header('Accept' => '');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a');
+    ok($mech->success, 'request successful');
+    is_xml_same($mech->content, $expected);
+
+    $Test->note('Accept: */*');
+    $mech->default_header('Accept' => '*/*');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a');
+    ok($mech->success, 'request successful');
+    is_xml_same($mech->content, $expected);
+
+    $Test->note('Accept: application/xml');
+    $mech->default_header('Accept' => 'application/xml');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a');
+    ok($mech->success, 'request successful');
+    is_xml_same($mech->content, $expected);
+
+    $Test->note('fmt=xml');
+    $mech->default_header('Accept' => 'application/something-else');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a?fmt=xml');
+    ok($mech->success, 'request successful');
+    is_xml_same($mech->content, $expected);
+
+};
+
+test 'webservice request format handling (JSON)' => sub {
+
+    my $test = shift;
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+webservice');
+
+    my $mech = $test->mech;
+
+    my $Test = Test::Builder->new();
+
+    my $expected = {
+        id => '472bc127-8861-45e8-bc9e-31e8dd32de7a',
+        name => 'Distance',
+        'sort-name' => 'Distance',
+        country => JSON::null,
+        area => JSON::null,
+        begin_area => JSON::null,
+        end_area => JSON::null,
+        disambiguation => 'UK dubstep artist Greg Sanders',
+        'life-span' => {
+            begin => JSON::null,
+            end => JSON::null,
+            ended => JSON::false,
+        },
+        type => 'Person',
+        'type-id' => 'b6e035f4-3ce9-331c-97df-83397230b0df',
+        ipis => [],
+        isnis => [],
+        gender => JSON::null,
+        'gender-id' => JSON::null,
+    };
+
+    $Test->note('Accept: application/json');
+    $mech->default_header('Accept' => 'application/json');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a');
+    ok($mech->success, 'request successful');
+    is_valid_json($mech->content, 'well-formed JSON');
+    is_json($mech->content, encode_json($expected), 'expected contents');
+
+    $Test->note('fmt=json');
+    $mech->default_header('Accept' => 'application/something-else');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a?fmt=json');
+    ok($mech->success, 'request successful');
+    is_valid_json($mech->content, 'well-formed JSON');
+    is_json($mech->content, encode_json($expected), 'expected contents');
+
+};
+
+test 'webservice request format handling (errors)' => sub {
+
+    my $test = shift;
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+webservice');
+
+    my $mech = $test->mech;
+
+    my $Test = Test::Builder->new();
+
+    my $expected = '<?xml version="1.0"?>
+<error>
+  <text>Invalid format. Either set an Accept header (recognized mime types are application/json and application/xml), or include a fmt= argument in the query string (valid values for fmt are json and xml).</text>
+  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+</error>';
+
+    $Test->note('Accept: application/something-else');
+    $mech->default_header('Accept' => 'application/something-else');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a');
+    is($mech->status, 406, 'server reports 406 - Not Acceptable');
+    is_xml_same($mech->content, $expected);
+
+    $Test->note('fmt=unicorn');
+    $mech->default_header('Accept' => 'application/json');
+    $mech->get('/ws/2/artist/472bc127-8861-45e8-bc9e-31e8dd32de7a?fmt=unicorn');
+    is($mech->status, 406, 'server reports 406 - Not Acceptable');
+    is_xml_same($mech->content, $expected);
+
+};
+
+1;


### PR DESCRIPTION
Only question is whether or not it's safe to modify the args entry in the stash, or whether I should make a copy before adding the fmt value.
Alternatively, maybe it's Format.pm that should handle this by guaranteeing that fmt will be set appropriately (it already looks at the Accept header).
