### PR TITLE
Fix running tests in browser

### DIFF
--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -9,7 +9,6 @@ const _ = require('lodash');
 
 const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/URLCleanup');
 
-test('URL cleanup component: auto-select, clean-up, and validation', {}, function (t) {
     const test_data = [
         // 45cat
         {
@@ -2552,7 +2551,7 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
     }
 
     _.each(test_data, function (subtest, i) {
-        t.test('input URL [' + i + '] = ' + subtest.input_url, {}, function(st) {
+        test('input URL [' + i + '] = ' + subtest.input_url, {}, function(st) {
             var tested = false;
             if (!subtest.input_url) {
                 st.fail('Test is invalid: "input_url" is missing: ' + JSON.stringify(subtest));
@@ -2621,6 +2620,3 @@ test('URL cleanup component: auto-select, clean-up, and validation', {}, functio
             st.end();
         });
     });
-
-    t.end();
-});

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -9,6 +9,10 @@ const test = require('tape');
 const setCookie = require('../common/utility/setCookie');
 const modes = require('../guess-case/modes');
 
+setCookie('guesscase_roman', 'false');
+gc.CFG_UC_UPPERCASED = 'false';
+gc.mode = modes.English;
+
 test('Sortname', function (t) {
     t.plan(6);
 


### PR DESCRIPTION
Fix two small bugs while running tests in browser, as reported in https://github.com/metabrainz/musicbrainz-server/pull/449#issuecomment-277520087:

1. `too much recursion` error caused by tests nesting, resolved by splitting URL Cleanup test (currently composed of subtests) into a myriad of tests
2. Label guess case test failure using Turkish mode, resolved by initializing user settings as necessary