### PR TITLE
MBS-8905, MBS-8927, MBS-9120: Allow for more auto-edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -123,7 +123,7 @@ around allow_auto_edit => sub {
     foreach my $prop (qw(time setlist)) {
         my ($old_prop, $new_prop) = normalise_strings(
             $self->data->{old}{$prop}, $self->data->{new}{$prop});
-        return 0 if $old_prop ne $new_prop;
+        return 0 if $old_prop ne '' && $old_prop ne $new_prop;
     }
 
     return $self->$orig(@args);

--- a/lib/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -64,6 +64,8 @@ around _build_related_entities => sub {
     return $related;
 };
 
+sub allow_auto_edit { shift->can_amend }
+
 sub alter_edit_pending
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -521,6 +521,8 @@ sub allow_auto_edit
 {
     my $self = shift;
 
+    return 1 if $self->can_amend;
+
     my ($old_name, $new_name) = normalise_strings($self->data->{old}{name},
                                                   $self->data->{new}{name});
 

--- a/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
@@ -3,13 +3,14 @@ use Moose;
 use Method::Signatures::Simple;
 use MooseX::Types::Moose qw( Int Str );
 use MooseX::Types::Structured qw( Dict );
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_CHANGE_QUALITY );
+use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_CHANGE_QUALITY $QUALITY_HIGH );
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Release';
+with 'MusicBrainz::Server::Edit::Role::AllowAmendingRelease';
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 
@@ -86,6 +87,12 @@ method accept
         $self->release_id,
         { quality => $self->data->{new}{quality} }
     );
+}
+
+sub allow_auto_edit
+{
+    my $self = shift;
+    return $self->data->{new}{quality} != $QUALITY_HIGH && $self->can_amend;
 }
 
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -326,6 +326,8 @@ before accept => sub {
 around allow_auto_edit => sub {
     my ($orig, $self, @args) = @_;
 
+    return 1 if $self->can_amend;
+
     return 0 if defined $self->data->{old}{packaging_id};
     return 0 if defined $self->data->{old}{status_id};
     return 0 if defined $self->data->{old}{barcode};

--- a/lib/MusicBrainz/Server/Edit/Role/AllowAmendingRelease.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/AllowAmendingRelease.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_CREATE );
 
 requires 'release_id';
 
-around allow_auto_edit => sub {
-    my ($orig, $self) = @_;
+sub can_amend {
+    my ($self) = @_;
 
     # Allow being an auto-edit if the release-add edit was opened by the same
     # editor less than an hour ago.
@@ -21,8 +21,7 @@ around allow_auto_edit => sub {
            AND (now() - edit.open_time) < interval '1 hour'
 EOSQL
 
-    return 1 if defined $add_release_edit;
-    return $self->$orig;
+    return defined $add_release_edit;
 };
 
 1;


### PR DESCRIPTION
Allow for auto-edits in the three following cases:
- Editing release in a 1 hour delay, see [MBS-8905](https://tickets.metabrainz.org/browse/MBS-8905)
- Lowering release data quality in a 1 hour delay, see [MBS-8927](https://tickets.metabrainz.org/browse/MBS-8927)
- Adding time and setlist to an event that doesn’t have one, see [MBS-9120](https://tickets.metabrainz.org/browse/MBS-9120)

Although there is no test for amending release for now, this change doesn’t conceal other tests.