### PR TITLE
MBS-9260: Make changing ellipsis version an auto-edit

### DIFF
--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -355,6 +355,11 @@ sub normalise_strings
         # 05BE Hebrew maqaf, 2010 hyphen, 2012 figure dash, 2013 en-dash, 2212 minus
         $t =~ tr/\x{05BE}\x{2010}\x{2012}\x{2013}\x{2212}/-/;
 
+        # Horizontal three-dots ellipses
+        # 2026 horizontal ellipsis,
+        # 22EF midline horizontal ellipsis
+        $t =~ s/[\x{2026}\x{22EF}]/.../g;
+
         # Unaccent what's left
         decode("utf-16", unaccent_utf16(encode("utf-16", $t)));
     } @_;

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -250,6 +250,9 @@ test 'Test normalise_strings' => sub {
     is(normalise_strings('–'), '-', 'U+2013 EN DASH');
     is(normalise_strings('−'), '-', 'U+2212 MINUS SIGN');
 
+    is(normalise_strings('…'), '...', 'U+2026 HORIZONTAL ELLIPSIS');
+    is(normalise_strings('⋯'), '...', 'U+22EF MIDLINE HORIZONTAL ELLIPSIS');
+
     is(normalise_strings('ı'), 'i', 'U+0131 LATIN SMALL LETTER DOTLESS I -> i');
 
     is(normalise_strings('ABCDE'), 'abcde', 'ASCII lc');


### PR DESCRIPTION
[MBS-9260](https://tickets.metabrainz.org/browse/MBS-9260): Make changing between version (visually similar to three dots) of an ellipsis an auto-edit.