### PR TITLE
MBS-8748: Wrap medium name in release tracklist

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -828,15 +828,14 @@ END -%]
 [%- END -%]
 
 [%~ MACRO medium_description(medium) BLOCK;
-    args = {
+    format_position = l('{medium_format} {position}', {
         medium_format => medium_format_name(medium),
         position => medium.position,
-    };
+    });
     IF medium.name != '';
-        args.medium_name = isolate_text(medium.name);
-        l('{medium_format} {position}: {medium_name}', args);
+        '<span>' _ add_colon(format_position) _ '</span> <span class="medium-name">' _ isolate_text(medium.name) _ '</span>';
     ELSE;
-        l('{medium_format} {position}', args);
+        '<span>' _ format_position _ '</span>';
     END;
 END ~%]
 

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -590,6 +590,18 @@ table.tbl {
 
         a {
             color: @text-black;
+
+            > * {
+                display: table-cell;
+            }
+
+            > :not(:last-child) {
+                padding-right: 0.3em;
+            }
+
+            .medium-name {
+                white-space: normal;
+            }
         }
 
         &:first-child {


### PR DESCRIPTION
[MBS-8748](https://tickets.metabrainz.org/browse/MBS-8748): Long medium names caused horizontal scrolling on release pages.

This patch wraps medium name and visually split the header line into (borderless) cells so that medium format and medium number are clearly distinguished from wrapped medium name.