### PR TITLE
MBS-9266: Fix subheader of area pages

### DIFF
--- a/root/area/header.tt
+++ b/root/area/header.tt
@@ -2,10 +2,14 @@
     <h1>[%- link_entity(area) %]</h1>
     <p class="subheader">
         <span class="prefix">~</span>
-        [% html_escape(area.l_type_name) or l('Area') %]
-        [%- IF area.parent_country || area.parent_subdivision || area.parent_city %],
-            [% l('in {parent_areas}', parent_areas => link_area_containment(area)) -%]
-        [%- END -%]
+        [%= l_area_type_name = html_escape(area.l_type_name) or l('Area') -%]
+        [%- IF area.parent_country || area.parent_subdivision || area.parent_city -%]
+            [%- l('{area_type} in {parent_areas}',
+               area_type => l_area_type_name,
+               parent_areas => link_area_containment(area)) -%]
+        [%- ELSE -%]
+            [%- l_area_type_name -%]
+        [%- END %]
     </p>
 </div>
 

--- a/root/area/header.tt
+++ b/root/area/header.tt
@@ -2,10 +2,10 @@
     <h1>[%- link_entity(area) %]</h1>
     <p class="subheader">
         <span class="prefix">~</span>
-             [% html_escape(area.l_type_name) or l('Area') %]
-             [%- IF area.parent_country || area.parent_subdivision || area.parent_city %],
-                 [% l('in {parent_areas}', parent_areas => link_area_containment(area)) -%]
-             [%- END -%]
+        [% html_escape(area.l_type_name) or l('Area') %]
+        [%- IF area.parent_country || area.parent_subdivision || area.parent_city %],
+            [% l('in {parent_areas}', parent_areas => link_area_containment(area)) -%]
+        [%- END -%]
     </p>
 </div>
 


### PR DESCRIPTION
Fix [MBS-9266](https://tickets.metabrainz.org/browse/MBS-9266):
- Make sub-header more easy to translate as a single string
- Remove incidental comma and properly chomp white-spaces