### PR TITLE
MBS-9264: Don't leave broken Leaflet symlinks

### DIFF
--- a/script/compile_resources.sh
+++ b/script/compile_resources.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+shopt -s failglob
+
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 cd "$MB_SERVER_ROOT"
 
@@ -8,6 +11,9 @@ mkdir -p "$BUILD_DIR"
 
 pushd root/static/images/leaflet/ > /dev/null
 ln -sf ../../../../node_modules/leaflet/dist/images/*.png .
+# Remove broken symlinks. These can exist because of MBS-9264, or because
+# Leaflet removed an image in an update.
+find . -type l ! -exec test -e '{}' \; -exec rm '{}' \;
 popd > /dev/null
 
 ./script/dbdefs_to_js.pl --client


### PR DESCRIPTION
The '*.png' glob will fail if compile_resources.sh is run before `npm install`, creating a broken symlink.

Setting failglob was suggested by Mineo.