### PR TITLE
MBS-8354: Make replacing em-dash and horizontal bar auto-edits

### DIFF
--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -352,8 +352,8 @@ sub normalise_strings
         $t =~ tr/"\x{0060}\x{00B4}\x{00AB}\x{00BB}\x{02BB}\x{05F3}\x{05F4}\x{2018}-\x{201F}\x{2032}\x{2033}\x{2039}\x{203A}/'/;
 
         # Dashes
-        # 05BE Hebrew maqaf, 2010 hyphen, 2012 figure dash, 2013 en-dash, 2212 minus
-        $t =~ tr/\x{05BE}\x{2010}\x{2012}\x{2013}\x{2212}/-/;
+        # 05BE Hebrew maqaf, 2010 hyphen, 2012 figure dash, 2013 en-dash, 2014 em-dash, 2015 horizontal bar, 2212 minus
+        $t =~ tr/\x{05BE}\x{2010}\x{2012}\x{2013}\x{2014}\x{2015}\x{2212}/-/;
 
         # Unaccent what's left
         decode("utf-16", unaccent_utf16(encode("utf-16", $t)));

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -248,6 +248,8 @@ test 'Test normalise_strings' => sub {
     is(normalise_strings('‐'), '-', 'U+2010 HYPHEN');
     is(normalise_strings('‒'), '-', 'U+2012 FIGURE DASH');
     is(normalise_strings('–'), '-', 'U+2013 EN DASH');
+    is(normalise_strings('—'), '-', 'U+2014 EM DASH');
+    is(normalise_strings('―'), '-', 'U+2015 HORIZONTAL BAR');
     is(normalise_strings('−'), '-', 'U+2212 MINUS SIGN');
 
     is(normalise_strings('ı'), 'i', 'U+0131 LATIN SMALL LETTER DOTLESS I -> i');


### PR DESCRIPTION
Fix [MBS-8354](https://tickets.metabrainz.org/browse/MBS-8354).

Add em-dash and horizontal bar to the class of dash characters for auto-edits.