### PR TITLE
MBS-8465, MBS-9288: Improve changing other relationship credits

### DIFF
--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -32,7 +32,7 @@
     <td class="section" data-bind="text: MB.i18n.addColon(MB.i18n.strings.entityName[source.entityType])"></td>
     <td>
       <span data-bind="html: source.html({ 'target': '_blank', creditedAs: relationship().creditField(source)() })"></span>
-      <!-- ko template: {name: "template.dialog-entity-credit", data: {entity: source, relationship: relationship()}} --><!-- /ko -->
+      <!-- ko template: {name: "template.dialog-entity-credit", data: {entity: source, relationship: relationship(), role: "source"}} --><!-- /ko -->
     </td>
   </tr>
 </script>
@@ -47,21 +47,21 @@
     </div>
     <div>
       <label>
-        <input type="checkbox" data-bind="checked: $parent.changeOtherRelationshipCredits" />
+        <input type="checkbox" data-bind="checked: $parent.changeOtherRelationshipCredits[role]" />
         <span data-bind="html: MB.i18n.l('Change credits for other {entity} relationships on the page.', {entity: entity.html()})">
         </span>
       </label>
     </div>
-    <div data-bind="visible: $parent.changeOtherRelationshipCredits">
+    <div data-bind="visible: $parent.changeOtherRelationshipCredits[role]">
       <div>
         <label>
-          <input type="radio" value="all" data-bind="checked: $parent.selectedRelationshipCredits" />
+          <input type="radio" value="all" data-bind="checked: $parent.selectedRelationshipCredits[role]" />
           [% l('All of these relationships.'); %]
         </label>
       </div>
       <div>
         <label>
-          <input type="radio" value="same-entity-types" data-bind="checked: $parent.selectedRelationshipCredits" />
+          <input type="radio" value="same-entity-types" data-bind="checked: $parent.selectedRelationshipCredits[role]" />
           <span data-bind="html: MB.i18n.l('Only relationships to {entity_type} entities.',
                                            {entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
           </span>
@@ -69,7 +69,7 @@
       </div>
       <div>
         <label>
-          <input type="radio" value="same-relationship-type" data-bind="checked: $parent.selectedRelationshipCredits" />
+          <input type="radio" value="same-relationship-type" data-bind="checked: $parent.selectedRelationshipCredits[role]" />
           <span data-bind="html: MB.i18n.l('Only “{relationship_type}” relationships to {entity_type} entities.',
                                            {relationship_type: $parent.linkTypeName(),
                                             entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
@@ -91,7 +91,7 @@
         <input class="name" type="text" data-bind="relationshipEditorAutocomplete: $data" />
       </span>
       <div class="error" data-bind="text: targetEntityError()"></div>
-      <!-- ko template: {name: "template.dialog-entity-credit", data: {entity: relationship().target(source), relationship: relationship()}} --><!-- /ko -->
+      <!-- ko template: {name: "template.dialog-entity-credit", data: {entity: relationship().target(source), relationship: relationship(), role: "target"}} --><!-- /ko -->
     </td>
   </tr>
 </script>

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -47,10 +47,35 @@
     </div>
     <div>
       <label>
-        <input type="checkbox" data-bind="checked: $parent.changeAllRelationshipCredits" />
-        <span data-bind="html: MB.i18n.l('Change all relationship credits for {entity} on the page.', {entity: entity.html({target: '_blank'})})">
+        <input type="checkbox" data-bind="checked: $parent.changeOtherRelationshipCredits" />
+        <span data-bind="html: MB.i18n.l('Change credits for other {entity} relationships on the page.', {entity: entity.html()})">
         </span>
       </label>
+    </div>
+    <div data-bind="visible: $parent.changeOtherRelationshipCredits">
+      <div>
+        <label>
+          <input type="radio" value="all" data-bind="checked: $parent.selectedRelationshipCredits" />
+          [% l('All of these relationships.'); %]
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="radio" value="same-entity-types" data-bind="checked: $parent.selectedRelationshipCredits" />
+          <span data-bind="html: MB.i18n.l('Only relationships to {entity_type} entities.',
+                                           {entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
+          </span>
+        </label>
+      </div>
+      <div>
+        <label>
+          <input type="radio" value="same-relationship-type" data-bind="checked: $parent.selectedRelationshipCredits" />
+          <span data-bind="html: MB.i18n.l('Only “{relationship_type}” relationships to {entity_type} entities.',
+                                           {relationship_type: $parent.linkTypeName(),
+                                            entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
+          </span>
+        </label>
+      </div>
     </div>
   <!-- /ko -->
 </script>

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -194,8 +194,8 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             this.targetType = ko.observable(target.entityType);
             this.targetType.subscribe(this.targetTypeChanged, this);
 
-            this.changeOtherRelationshipCredits = ko.observable(false);
-            this.selectedRelationshipCredits = ko.observable('all');
+            this.changeOtherRelationshipCredits = {source: ko.observable(false), target: ko.observable(false)};
+            this.selectedRelationshipCredits = {source: ko.observable('all'), target: ko.observable('all')};
             this.setupUI();
         },
 
@@ -233,13 +233,13 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
         accept: function (inner) {
             if (!this.hasErrors()) {
                 inner && inner.apply(this, _.toArray(arguments).slice(1));
-
-                if (this.changeOtherRelationshipCredits()) {
+                for (var role in this.changeOtherRelationshipCredits) {
+                if (this.changeOtherRelationshipCredits[role]()) {
                     var vm = this.viewModel;
                     var relationship = this.relationship();
-                    var target = relationship.target(this.source);
+                    var target = role === 'source' ? this.source : relationship.target(this.source);
                     var targetCredit = relationship.creditField(target)();
-                    var relationshipFilter = this.selectedRelationshipCredits();
+                    var relationshipFilter = this.selectedRelationshipCredits[role]();
 
                     // XXX HACK XXX
                     // MB.entityCache isn't supposed to be exposed outside of
@@ -266,6 +266,7 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                             });
                         }
                     });
+                }
                 }
 
                 this.close(false);

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -234,39 +234,39 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             if (!this.hasErrors()) {
                 inner && inner.apply(this, _.toArray(arguments).slice(1));
                 for (var role in this.changeOtherRelationshipCredits) {
-                if (this.changeOtherRelationshipCredits[role]()) {
-                    var vm = this.viewModel;
-                    var relationship = this.relationship();
-                    var target = role === 'source' ? this.source : relationship.target(this.source);
-                    var targetCredit = relationship.creditField(target)();
-                    var relationshipFilter = this.selectedRelationshipCredits[role]();
+                    if (this.changeOtherRelationshipCredits[role]()) {
+                        var vm = this.viewModel;
+                        var relationship = this.relationship();
+                        var target = role === 'source' ? this.source : relationship.target(this.source);
+                        var targetCredit = relationship.creditField(target)();
+                        var relationshipFilter = this.selectedRelationshipCredits[role]();
 
-                    // XXX HACK XXX
-                    // MB.entityCache isn't supposed to be exposed outside of
-                    // whatever module it's defined in, but there's no easier
-                    // way to iterate over all entities on the page.
+                        // XXX HACK XXX
+                        // MB.entityCache isn't supposed to be exposed outside of
+                        // whatever module it's defined in, but there's no easier
+                        // way to iterate over all entities on the page.
 
-                    _.each(MB.entityCache, function (entity, gid) {
-                        if (gid === target.gid) {
-                            _.each(entity.displayableRelationships(vm)(), function (r) {
-                                switch (relationshipFilter) {
-                                  case 'same-entity-types': if (r.entityTypes !== relationship.entityTypes) { return; }; break;
-                                  case 'same-relationship-type': if (r.linkTypeID() !== relationship.linkTypeID()) { return; }; break;
-                                }
+                        _.each(MB.entityCache, function (entity, gid) {
+                            if (gid === target.gid) {
+                                _.each(entity.displayableRelationships(vm)(), function (r) {
+                                    switch (relationshipFilter) {
+                                      case 'same-entity-types': if (r.entityTypes !== relationship.entityTypes) { return; }; break;
+                                      case 'same-relationship-type': if (r.linkTypeID() !== relationship.linkTypeID()) { return; }; break;
+                                    }
 
-                                var entities = r.entities();
+                                    var entities = r.entities();
 
-                                if (entities[0].gid === gid) {
-                                    r.entity0_credit(targetCredit);
-                                }
+                                    if (entities[0].gid === gid) {
+                                        r.entity0_credit(targetCredit);
+                                    }
 
-                                if (entities[1].gid === gid) {
-                                    r.entity1_credit(targetCredit);
-                                }
-                            });
-                        }
-                    });
-                }
+                                    if (entities[1].gid === gid) {
+                                        r.entity1_credit(targetCredit);
+                                    }
+                                });
+                            }
+                        });
+                    }
                 }
 
                 this.close(false);


### PR DESCRIPTION
Previously, relationship editor had an option to change artist credits for all relationships on the page at the same time. 

Improvement [MBS-8465](https://tickets.metabrainz.org/browse/MBS-8465) involves allowing editor to change a subset only of these relationships, filtered either by type or by entity types.

To that end, this patch adds three radio buttons to the current checkbox input which is now labelled “Change other” rather than “Change all”.  Radio buttons are visible if and only if input is checked.  Label lines are wrapped if translation is too long.

Additionally, it fixes bug [MBS-9288](https://tickets.metabrainz.org/browse/MBS-9288) which prevented to change other relationship credits for source Artist from an Artist-Artist relationship.