### PR TITLE
MBS-8578: Handle NoChanges edits better in the release editor

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -66,6 +66,7 @@ our @EXPORT_OK = (
         $MAX_POSTGRES_INT $MAX_POSTGRES_BIGINT
         @FULL_TABLE_LIST
         $CONTACT_URL
+        $WS_EDIT_RESPONSE_OK $WS_EDIT_RESPONSE_NO_CHANGES
         %ENTITIES entities_with
     ),
 );
@@ -359,6 +360,9 @@ Readonly our $MAX_POSTGRES_INT => 2147483647;
 Readonly our $MAX_POSTGRES_BIGINT => 9223372036854775807;
 
 Readonly our $CONTACT_URL => 'https://metabrainz.org/contact';
+
+Readonly our $WS_EDIT_RESPONSE_OK => 1;
+Readonly our $WS_EDIT_RESPONSE_NO_CHANGES => 2;
 
 Readonly our %ENTITIES => %{
     decode_json(read_file(File::Spec->catfile(dirname(__FILE__), '../../../entities.json')))

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -24,6 +24,8 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_RELATIONSHIP_DELETE
     $EDIT_WORK_CREATE
     $UNTRUSTED_FLAG
+    $WS_EDIT_RESPONSE_OK
+    $WS_EDIT_RESPONSE_NO_CHANGES
 );
 use MusicBrainz::Server::ControllerUtils::Relationship qw( merge_link_attributes );
 use MusicBrainz::Server::Data::Utils qw(
@@ -51,7 +53,6 @@ no if $] >= 5.018, warnings => "experimental::smartmatch";
 
 Readonly our $ERROR_NOT_LOGGED_IN => 1;
 Readonly our $ERROR_NON_EXISTENT_ENTITIES => 2;
-Readonly our $ERROR_NO_CHANGES => 3;
 
 our $ALLOWED_EDIT_TYPES = [
     $EDIT_RELEASE_CREATE,
@@ -558,7 +559,10 @@ sub create_edits {
             if (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::Forbidden') {
                 $c->forward('/ws/js/detach_with_error', ['editor is forbidden to enter this edit', 403]);
             } elsif (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::NoChanges') {
-                $c->forward('/ws/js/detach_with_error', [{errorCode => $ERROR_NO_CHANGES}]);
+                # The data submitted doesn't change anything. This happens
+                # occasionally when stale search indexes are used as a source
+                # for comparison. But, these exceptions shouldn't cause the
+                # request to fail, so pass.
             } elsif (ref($_) eq 'MusicBrainz::Server::Edit::Exceptions::FailedDependency') {
                 $c->forward('/ws/js/detach_with_error', ["$_"]);
             } else {
@@ -656,7 +660,7 @@ sub submit_edits {
         my $response;
 
         if (defined $edit) {
-            $response = { edit_type => $edit->edit_type, message => "OK" };
+            $response = { edit_type => $edit->edit_type, response => $WS_EDIT_RESPONSE_OK };
 
             if ($edit->isa('MusicBrainz::Server::Edit::Generic::Create') &&
                 !$edit->isa('MusicBrainz::Server::Edit::Relationship::Create')) {
@@ -683,7 +687,7 @@ sub submit_edits {
                 };
             }
         } else {
-            $response = { message => "no changes" };
+            $response = { response => $WS_EDIT_RESPONSE_NO_CHANGES };
         }
 
         $response


### PR DESCRIPTION
Prior to this patch, if an edit threw a NoChanges exception it'd cause the request to 400, and cause it to stop processing edits (a submission could contain multiple edits). This was a problem, because the release editor batches recording and medium edits together in one request; at the same time, the JavaScript ignored 400 errors caused by NoChanges exceptions (which were indicated by a specific code in the response), and continued submitting other edits. The result was usually a stub release with no mediums.

The fix is simply that NoChanges exceptions will no longer cause a request to /ws/js/edit to fail (though they are still indicated in the response).