### PR TITLE
Sentry fixes

### DIFF
--- a/admin/BuildIncrementalSitemaps.pl
+++ b/admin/BuildIncrementalSitemaps.pl
@@ -7,7 +7,11 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use MooseX::Runnable::Run;
-run_application 'MusicBrainz::Server::Sitemap::Incremental', @ARGV;
+use MusicBrainz::Sentry qw( capture_exceptions );
+
+capture_exceptions(sub {
+    run_application 'MusicBrainz::Server::Sitemap::Incremental', @ARGV;
+});
 
 =head1 SYNOPSIS
 

--- a/lib/Catalyst/Plugin/Sentry.pm
+++ b/lib/Catalyst/Plugin/Sentry.pm
@@ -5,98 +5,19 @@ use strict;
 use warnings;
 
 use CGI::Simple::Util qw( escape );
-use DBDefs;
-use Devel::StackTrace;
-use IO::File;
-use Moose;
-use Scalar::Util qw( blessed );
 use Sentry::Raven;
+use MusicBrainz::Sentry qw( send_error_to_sentry sig_die_handler );
 
 our $suppress = 0;
-
-sub get_error_message {
-    my $error = shift;
-
-    my $message;
-    # Some exception classes which overload q{""} include the entire trace
-    # in as_string, which we don't want. If we can get the message on its
-    # own, do that.
-    if (blessed($error) && $error->can('message')) {
-        $message = $error->message;
-    } else {
-        $message = "$error";
-    }
-    # For ad-hoc (string) exceptions, Catalyst chomps the message and wraps
-    # it in some "Caught exception in ..." text, so we'll need to munge
-    # things appropriately.
-    chomp $message;
-    $message =~ s/^Caught exception in [^"]+ "(.*)"$/$1/s;
-    # Remove lines added when errors are rethrown.
-    $message =~ s/^ at .+ line [0-9]+.*\.$//m;
-    # Chomp again, since blank lines can be left.
-    chomp $message;
-    return $message;
-}
-
-sub ignored_error {
-    my $error = shift;
-
-    # These aren't actual errors, and are always caught in their respective
-    # modules.
-    my $class = blessed $error;
-    return ($class && (
-            $class eq 'Catalyst::Exception::Detach' ||
-            $class eq 'Redis::X::Reconnect'));
-}
 
 sub execute {
     my $c = shift;
 
-    # Since Catalyst runs all actions within an eval, we depend on the
-    # "feature" that the __DIE__ handler is even invoked inside evals, even
-    # though the perlvar docs say this was a mistake and is deprecated.
-    # Unfortunately, there doesn't seem to be any other way to implement this.
-    # Overriding CORE::GLOBAL::die doesn't work with C modules, for example,
-    # because they don't invoke `die` through Perl.
+    my $frame_filter = qr/^MusicBrainz::Server/;
+    my $stack_traces = ($c->stash->{stack_trace} //= {});
+
     local $SIG{__DIE__} = sub {
-        my $error = shift;
-
-        return if ignored_error($error);
-
-        my $message = get_error_message($error);
-        # If an exception is caught and then re-thrown, __DIE__ will run
-        # twice, but we want to keep the original stack trace.
-        my $stacktrace = $c->stash->{stack_trace}{$message};
-        return if $stacktrace;
-
-        {
-            local $@;
-            eval { $stacktrace = Devel::StackTrace->new };
-        };
-        return unless $stacktrace;
-
-        my $app = "$c" =~ s/=.*//r;
-        my $frames = Sentry::Raven->_get_frames_from_devel_stacktrace($stacktrace);
-        my @app_frames;
-        my $i = -1;
-
-        for my $frame (reverse $stacktrace->frames) {
-            ++$i;
-
-            next unless $frame->package =~ /^$app/;
-
-            my %context;
-            {
-                local $@;
-                eval {
-                    %context = get_context($frame->filename, $frame->line);
-                };
-            };
-
-            push @app_frames, { %{ $frames->[$i] }, %context };
-        }
-
-        $c->stash->{stack_trace}{$message} = [reverse @app_frames];
+        sig_die_handler(shift, $stack_traces, $frame_filter);
     };
 
     return $c->next::method(@_);
@@ -136,53 +57,8 @@ sub finalize_error {
         );
     }
 
-    my $message = get_error_message($c->error->[0]);
-    my @stacktrace = reverse @{ $c->stash->{stack_trace}{$message} // [] };
-    if (@stacktrace) {
-        push @context, Sentry::Raven->stacktrace_context(\@stacktrace);
-    }
-
-    state $sentry = Sentry::Raven->new(
-        sentry_dsn => DBDefs->SENTRY_DSN,
-        environment => DBDefs->GIT_BRANCH,
-        tags => {
-            git_commit => DBDefs->GIT_SHA,
-        },
-    );
-    $sentry->capture_exception($message, @context);
-}
-
-# Based on Catalyst::Plugin::ErrorCatcher; modified to output context in the
-# format expected by Sentry::Raven.
-sub get_context {
-    my ($file, $lineno) = @_;
-
-    return unless -f $file;
-
-    my %context;
-    my $start = $lineno - 5;
-    my $end = $lineno + 5;
-    $start = $start < 1 ? 1 : $start;
-
-    if (my $fh = IO::File->new($file, 'r')) {
-        my $cur_lineno = 0;
-
-        while (my $line = <$fh>) {
-            ++$cur_lineno;
-            last if $cur_lineno > $end;
-            next if $cur_lineno < $start;
-
-            if ($cur_lineno == $lineno) {
-                $context{context_line} = $line;
-            } elsif ($cur_lineno < $lineno) {
-                push @{ $context{pre_context} }, $line;
-            } else {
-                push @{ $context{post_context} }, $line;
-            }
-        }
-    }
-
-    return %context;
+    my $stack_traces = ($c->stash->{stack_trace} //= {});
+    send_error_to_sentry($c->error->[0], $stack_traces, @context);
 }
 
 1;
@@ -196,7 +72,6 @@ temporarily give C<$suppress> a true value.
 =head1 COPYRIGHT
 
 Copyright (C) 2017 MetaBrainz Foundation
-Copyright (C) 2015 Chisel Wright
 Copyright (C) 2015 Ulrich Klauer
 
 This program is free software; you can redistribute it and/or

--- a/lib/MusicBrainz/Sentry.pm
+++ b/lib/MusicBrainz/Sentry.pm
@@ -13,8 +13,14 @@ use Sentry::Raven;
 
 our @EXPORT_OK = qw(
     send_error_to_sentry
+    sentry_enabled
     sig_die_handler
 );
+
+sub sentry_enabled () {
+    return 1 if (DBDefs->SENTRY_DSN && !$ENV{MUSICBRAINZ_RUNNING_TESTS});
+    return 0;
+}
 
 sub get_error_message {
     my $error = shift;

--- a/lib/MusicBrainz/Sentry.pm
+++ b/lib/MusicBrainz/Sentry.pm
@@ -1,0 +1,176 @@
+package MusicBrainz::Sentry;
+
+use v5.10;
+use strict;
+use warnings;
+
+use base 'Exporter';
+use DBDefs;
+use Devel::StackTrace;
+use IO::File;
+use Scalar::Util qw( blessed );
+use Sentry::Raven;
+
+our @EXPORT_OK = qw(
+    send_error_to_sentry
+    sig_die_handler
+);
+
+sub get_error_message {
+    my $error = shift;
+
+    my $message;
+    # Some exception classes which overload q{""} include the entire trace
+    # in as_string, which we don't want. If we can get the message on its
+    # own, do that.
+    if (blessed($error) && $error->can('message')) {
+        $message = $error->message;
+    } else {
+        $message = "$error";
+    }
+    # For ad-hoc (string) exceptions, Catalyst chomps the message and wraps
+    # it in some "Caught exception in ..." text, so we'll need to munge
+    # things appropriately.
+    chomp $message;
+    $message =~ s/^Caught exception in [^"]+ "(.*)"$/$1/s;
+    # Remove lines added when errors are rethrown.
+    $message =~ s/^ at .+ line [0-9]+.*\.$//m;
+    # Chomp again, since blank lines can be left.
+    chomp $message;
+    return $message;
+}
+
+sub ignored_error {
+    my $error = shift;
+
+    # These aren't actual errors, and are always caught in their respective
+    # modules.
+    my $class = blessed $error;
+    return ($class && (
+            $class eq 'Catalyst::Exception::Detach' ||
+            $class eq 'Redis::X::Reconnect'));
+}
+
+# Since Catalyst runs all actions within an eval, we depend on the "feature"
+# that the __DIE__ handler is even invoked inside evals, even though the
+# perlvar docs say this was a mistake and is deprecated. Unfortunately, there
+# doesn't seem to be any other way to implement this. Overriding
+# CORE::GLOBAL::die doesn't work with C modules, for example, because they
+# don't invoke `die` through Perl.
+sub sig_die_handler {
+    my ($error, $stack_traces, $frame_filter) = @_;
+
+    return if ignored_error($error);
+
+    my $message = get_error_message($error);
+    # If an exception is caught and then re-thrown, __DIE__ will run
+    # twice, but we want to keep the original stack trace.
+    my $stacktrace = $stack_traces->{$message};
+    return if $stacktrace;
+
+    {
+        local $@;
+        eval { $stacktrace = Devel::StackTrace->new };
+    };
+    return unless $stacktrace;
+
+    my $frames = Sentry::Raven->_get_frames_from_devel_stacktrace($stacktrace);
+    my @included_frames;
+    my $i = -1;
+
+    for my $frame (reverse $stacktrace->frames) {
+        ++$i;
+
+        if (defined $frame_filter) {
+            next unless $frame->package =~ $frame_filter;
+        }
+
+        my %context;
+        {
+            local $@;
+            eval {
+                %context = get_context($frame->filename, $frame->line);
+            };
+        };
+
+        push @included_frames, { %{ $frames->[$i] }, %context };
+    }
+
+    $stack_traces->{$message} = [reverse @included_frames];
+}
+
+sub send_error_to_sentry {
+    my ($error, $stack_traces, @context) = @_;
+
+    my $message = get_error_message($error);
+    my @stacktrace = reverse @{ $stack_traces->{$message} // [] };
+    if (@stacktrace) {
+        push @context, Sentry::Raven->stacktrace_context(\@stacktrace);
+    }
+
+    state $sentry = Sentry::Raven->new(
+        sentry_dsn => DBDefs->SENTRY_DSN,
+        environment => DBDefs->GIT_BRANCH,
+        tags => {
+            git_commit => DBDefs->GIT_SHA,
+        },
+    );
+    $sentry->capture_exception($message, @context);
+}
+
+# Based on Catalyst::Plugin::ErrorCatcher; modified to output context in the
+# format expected by Sentry::Raven.
+sub get_context {
+    my ($file, $lineno) = @_;
+
+    return unless -f $file;
+
+    my %context;
+    my $start = $lineno - 5;
+    my $end = $lineno + 5;
+    $start = $start < 1 ? 1 : $start;
+
+    if (my $fh = IO::File->new($file, 'r')) {
+        my $cur_lineno = 0;
+
+        while (my $line = <$fh>) {
+            ++$cur_lineno;
+            last if $cur_lineno > $end;
+            next if $cur_lineno < $start;
+
+            if ($cur_lineno == $lineno) {
+                $context{context_line} = $line;
+            } elsif ($cur_lineno < $lineno) {
+                push @{ $context{pre_context} }, $line;
+            } else {
+                push @{ $context{post_context} }, $line;
+            }
+        }
+    }
+
+    return %context;
+}
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2017 MetaBrainz Foundation
+Copyright (C) 2015 Chisel Wright
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+=cut

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -87,7 +87,7 @@ if ($ENV{'MUSICBRAINZ_USE_PROXY'})
     __PACKAGE__->config( using_frontend_proxy => 1 );
 }
 
-if (DBDefs->SENTRY_DSN) {
+if (DBDefs->SENTRY_DSN && !$ENV{MUSICBRAINZ_RUNNING_TESTS}) {
     push @args, 'Sentry';
 }
 

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -8,6 +8,7 @@ use DBDefs;
 use Encode;
 use JSON;
 use Moose::Util qw( does_role );
+use MusicBrainz::Sentry qw( sentry_enabled );
 use MusicBrainz::Server::Log qw( logger );
 use POSIX qw(SIGALRM);
 use Sys::Hostname;
@@ -87,7 +88,7 @@ if ($ENV{'MUSICBRAINZ_USE_PROXY'})
     __PACKAGE__->config( using_frontend_proxy => 1 );
 }
 
-if (DBDefs->SENTRY_DSN && !$ENV{MUSICBRAINZ_RUNNING_TESTS}) {
+if (sentry_enabled) {
     push @args, 'Sentry';
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2954,6 +2954,26 @@
       "version": "3.10.0",
       "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+    },
+    "raven": {
+      "version": "1.2.0",
+      "dependencies": {
+        "json-stringify-safe": {
+          "version": "5.0.1"
+        },
+        "lsmod": {
+          "version": "1.0.0"
+        },
+        "cookie": {
+          "version": "0.3.1"
+        },
+        "uuid": {
+          "version": "3.0.0"
+        },
+        "stack-trace": {
+          "version": "0.0.9"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "po2json": "0.4.1",
     "q": "1.4.1",
     "querystring": "0.2.0",
+    "raven": "1.2.0",
     "raven-js": "3.10.0",
     "rcss": "0.1.5",
     "react": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",


### PR DESCRIPTION
Fixes a couple issues I found, and notably, also enables Sentry in our Node.js template renderer, and our sitemaps/ModBot scripts. A general approach for enabling Sentry in every ./admin/ script is pretty difficult, but we can add calls to `capture_exceptions` wherever they're useful, or we can report all cron errors with a bit of engineering too. But those are later issues.