### PR TITLE
MBS-9289: Area places map doesn't display

### DIFF
--- a/root/static/scripts/common/utility/getScriptArgs.js
+++ b/root/static/scripts/common/utility/getScriptArgs.js
@@ -3,16 +3,20 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-let currentScript = document.currentScript;
+function getCurrentScript() {
+  let currentScript = document.currentScript;
 
-// IE11. Likely doesn't work with async or defer.
-if (!currentScript) {
-  const scripts = document.getElementsByTagName('script');
-  currentScript = scripts[scripts.length - 1];
+  // IE11. Likely doesn't work with async or defer.
+  if (!currentScript) {
+    const scripts = document.getElementsByTagName('script');
+    currentScript = scripts[scripts.length - 1];
+  }
+
+  return currentScript;
 }
 
 function getScriptArgs() {
-  const args = currentScript.getAttribute('data-args');
+  const args = getCurrentScript().getAttribute('data-args');
   if (args) {
     return JSON.parse(args);
   }


### PR DESCRIPTION
`getScriptArgs` can be executed multiple times from different scripts, but `currentScript` is only calculated once. Calculate it every time `getScriptArgs` is called, because it's obviously dynamic.