### PR TITLE
MBS-9271: Prevent usernames from being reused

### DIFF
--- a/admin/ExportAllTables
+++ b/admin/ExportAllTables
@@ -331,6 +331,7 @@ my @group_private = qw(
     instrument_tag_raw
     label_rating_raw
     label_tag_raw
+    old_editor_name
     place_tag_raw
     recording_rating_raw
     recording_tag_raw

--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -146,6 +146,16 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE OR REPLACE FUNCTION check_editor_name() RETURNS trigger AS $$
+BEGIN
+    IF (SELECT 1 FROM old_editor_name WHERE lower(name) = lower(NEW.name))
+    THEN
+        RAISE EXCEPTION 'Attempt to use a previously-used editor name.';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
 -----------------------------------------------------------------------
 -- instrument triggers
 -----------------------------------------------------------------------

--- a/admin/sql/CreateIndexes.sql
+++ b/admin/sql/CreateIndexes.sql
@@ -57,6 +57,7 @@ CREATE INDEX cdtoc_raw_track_offset ON cdtoc_raw (track_offset);
 CREATE UNIQUE INDEX cdtoc_raw_toc ON cdtoc_raw (track_count, leadout_offset, track_offset);
 
 CREATE UNIQUE INDEX editor_idx_name ON editor (LOWER(name));
+CREATE UNIQUE INDEX old_editor_name_idx_name ON old_editor_name (LOWER(name));
 CREATE INDEX editor_language_idx_language ON editor_language (language);
 
 CREATE INDEX editor_oauth_token_idx_editor ON editor_oauth_token (editor);

--- a/admin/sql/CreateTables.sql
+++ b/admin/sql/CreateTables.sql
@@ -526,6 +526,10 @@ CREATE TABLE editor
     deleted             BOOLEAN NOT NULL DEFAULT FALSE
 );
 
+CREATE TABLE old_editor_name (
+    name    VARCHAR(64) NOT NULL
+);
+
 CREATE TYPE FLUENCY AS ENUM ('basic', 'intermediate', 'advanced', 'native');
 
 CREATE TABLE editor_language (

--- a/admin/sql/CreateTriggers.sql
+++ b/admin/sql/CreateTriggers.sql
@@ -67,6 +67,9 @@ CREATE TRIGGER b_upd_editor BEFORE UPDATE ON editor
 CREATE TRIGGER a_ins_editor AFTER INSERT ON editor
     FOR EACH ROW EXECUTE PROCEDURE a_ins_editor();
 
+CREATE TRIGGER check_editor_name BEFORE UPDATE OR INSERT ON editor
+    FOR EACH ROW EXECUTE PROCEDURE check_editor_name();
+
 CREATE TRIGGER b_upd_event BEFORE UPDATE ON event
     FOR EACH ROW EXECUTE PROCEDURE b_upd_last_updated_table();
 

--- a/admin/sql/DropFunctions.sql
+++ b/admin/sql/DropFunctions.sql
@@ -35,6 +35,7 @@ DROP FUNCTION a_upd_track();
 DROP FUNCTION b_ins_edit_materialize_status();
 DROP FUNCTION b_upd_last_updated_table();
 DROP FUNCTION b_upd_recording();
+DROP FUNCTION check_editor_name();
 DROP FUNCTION check_has_dates();
 DROP FUNCTION controlled_for_whitespace(TEXT);
 DROP FUNCTION create_bounding_cube(durations INTEGER[], fuzzy INTEGER);

--- a/admin/sql/DropIndexes.sql
+++ b/admin/sql/DropIndexes.sql
@@ -314,6 +314,7 @@ DROP INDEX medium_cdtoc_idx_uniq;
 DROP INDEX medium_format_idx_gid;
 DROP INDEX medium_idx_track_count;
 DROP INDEX medium_index_idx;
+DROP INDEX old_editor_name_idx_name;
 DROP INDEX place_alias_idx_place;
 DROP INDEX place_alias_idx_primary;
 DROP INDEX place_alias_type_idx_gid;

--- a/admin/sql/DropTables.sql
+++ b/admin/sql/DropTables.sql
@@ -210,6 +210,7 @@ DROP TABLE medium;
 DROP TABLE medium_cdtoc;
 DROP TABLE medium_format;
 DROP TABLE medium_index;
+DROP TABLE old_editor_name;
 DROP TABLE orderable_link_type;
 DROP TABLE place;
 DROP TABLE place_alias;

--- a/admin/sql/DropTriggers.sql
+++ b/admin/sql/DropTriggers.sql
@@ -23,6 +23,7 @@ DROP TRIGGER search_hint ON artist_alias;
 DROP TRIGGER b_upd_artist_tag ON artist_tag;
 DROP TRIGGER b_upd_editor ON editor;
 DROP TRIGGER a_ins_editor ON editor;
+DROP TRIGGER check_editor_name ON editor;
 DROP TRIGGER b_upd_event ON event;
 DROP TRIGGER end_date_implies_ended ON event;
 DROP TRIGGER b_upd_event_alias ON event_alias;

--- a/admin/sql/updates/20170327-mbs-9271-standalone.sql
+++ b/admin/sql/updates/20170327-mbs-9271-standalone.sql
@@ -1,0 +1,7 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+CREATE TRIGGER check_editor_name BEFORE UPDATE OR INSERT ON editor
+    FOR EACH ROW EXECUTE PROCEDURE check_editor_name();
+
+COMMIT;

--- a/admin/sql/updates/20170327-mbs-9271.sql
+++ b/admin/sql/updates/20170327-mbs-9271.sql
@@ -1,0 +1,20 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+CREATE TABLE old_editor_name (
+    name    VARCHAR(64) NOT NULL
+);
+
+CREATE UNIQUE INDEX old_editor_name_idx_name ON old_editor_name (LOWER(name));
+
+CREATE OR REPLACE FUNCTION check_editor_name() RETURNS trigger AS $$
+BEGIN
+    IF (SELECT 1 FROM old_editor_name WHERE lower(name) = lower(NEW.name))
+    THEN
+        RAISE EXCEPTION 'Attempt to use a previously-used editor name.';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+COMMIT;

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -617,6 +617,7 @@ Readonly our @FULL_TABLE_LIST => qw(
     medium_cdtoc
     medium_format
     medium_index
+    old_editor_name
     orderable_link_type
     place
     place_alias

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -107,7 +107,12 @@ sub delete_user : Path('/admin/user/delete') Args(1) RequireAuth HiddenOnSlaves 
     $c->stash( user => $editor );
 
     if ($c->form_posted) {
-        $c->model('Editor')->delete($id);
+        my $allow_reuse = 0;
+        if ($id != $c->user->id && $c->user->is_account_admin) {
+            $allow_reuse = 1 if ($c->req->params->{allow_reuse} // '') eq '1';
+        }
+
+        $c->model('Editor')->delete($id, $allow_reuse);
         if ($id == $c->user->id) { # don't log out an admin deleting a different user
             MusicBrainz::Server::Controller::User->_clear_login_cookie($c);
             $c->logout;

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -243,8 +243,7 @@ sub validate_username {
             if ($username =~ qr{^deleted editor \#\d+$}i) {
                 $self->add_error(l('This username is reserved for internal use.'));
             }
-            my $editor = $self->form->ctx->model('Editor')->get_by_name($username);
-            if (defined $editor) {
+            if ($self->form->ctx->model('Editor')->is_name_used($username)) {
                 $self->add_error(l('Please choose another username, this one is already taken.'));
             }
         }

--- a/root/admin/delete_user.tt
+++ b/root/admin/delete_user.tt
@@ -5,6 +5,12 @@
     <p>[% l('Are you sure you want to delete all information about {e}? This cannot be undone!',
         { e => link_editor(user) }) %]</p>
     <form action="[% c.req.uri %]" method="post" id="delete-account-form">
+      <p>
+        <label>
+          <input type="checkbox" name="allow_reuse" value="1" checked="checked" />
+          [%= l('Allow the name “{editor_name}” to be reused.', { editor_name => user.name }) ~%]
+        </label>
+      </p>
       <span class="buttons">
         <button class="negative" type="submit">[% l('Delete {e}', { e => user.name } ) %]</button>
       </span>

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -94,6 +94,16 @@ test 'Trying to register with an existing name' => sub {
 
     like($mech->uri, qr{/register}, 'stays on registration page');
     $mech->content_contains('already taken', 'form has error message');
+
+    # Try with a previously-used name (MBS-9271).
+    $mech->submit_form( with_fields => {
+        'register.username' => 'im_gone',
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('already taken', 'form has error message');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -246,6 +246,11 @@ EOSQL
     is($edit_counts->{failed_count}, 1);
     is($bob->deleted, 1);
 
+    # The name should be prevented from being reused by default (MBS-9271).
+    ok($c->sql->select_single_value(
+        'SELECT 1 FROM old_editor_name WHERE name = ?', 'Bob'
+    ));
+
     # Ensure all other attributes are cleared
     my $exclusions = Set::Scalar->new(
         qw( id name password privileges last_login_date languages

--- a/t/sql/editor.sql
+++ b/t/sql/editor.sql
@@ -44,3 +44,5 @@ INSERT INTO editor_collection_release (collection, release)
     VALUES (1, 1), (1, 2);
 
 INSERT INTO annotation (editor) VALUES (2); -- so Alice is not fully deleted
+
+INSERT INTO old_editor_name (name) VALUES ('im_gone');

--- a/upgrade.json
+++ b/upgrade.json
@@ -48,7 +48,7 @@
   },
 
   "24": {
-    "slave": [],
-    "standalone": []
+    "slave": ["20170327-mbs-9271.sql"],
+    "standalone": ["20170327-mbs-9271-standalone.sql"]
   }
 }


### PR DESCRIPTION
On the account deletion page, admins will have a choice of whether to allow the name to be reused. It's checked by default, since I assume they'll mostly be deleting spam accounts. People deleting their own accounts can't toggle this.

I didn't add a way to allow admins to force-rename a user even if the name was previously used, but I assume it won't happen often and it's easy enough to get someone to delete the entry from the `old_editor_name` table.