### PR TITLE
MBS-8640: Make adding work attribute auto-edit

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -194,9 +194,28 @@ around allow_auto_edit => sub {
 
     return 0 if defined $self->data->{old}{language_id};
     return 0 if @{ $self->data->{old}{languages} // [] };
-    return 0 if defined $self->data->{old}{attributes};
 
-    return $self->$orig(@args);
+    return 0 if !$self->$orig(@args);
+
+    return 1 if defined $self->data->{old}{attributes} && scalar $self->data->{old}{attributes} == 0;
+
+    if (exists $self->data->{new}{attributes}) {
+        my %new = $self->grouped_attributes_by_type($self->data->{new}{attributes});
+        my %old = $self->grouped_attributes_by_type($self->data->{old}{attributes});
+
+        my $changed_types = Set::Scalar->new(keys %new, keys %old);
+
+        while (defined(my $type = $changed_types->each)) {
+            my @new_values = map { $_->l_value } @{ $new{$type} //= [] };
+            my @old_values = map { $_->l_value } @{ $old{$type} //= [] };
+
+            unless (scalar @old_values == 0 || Set::Scalar->new(@new_values) == Set::Scalar->new(@old_values)) {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
 };
 
 sub current_instance {

--- a/t/lib/t/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -161,6 +161,153 @@ test 'Changing work language is not an auto-edit for non-auto-editors' => sub {
     accept_edit($c, $edit);
 };
 
+test 'Adding first work attributes is an auto-edit for non-auto-editors' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
+
+    my $work = $c->model('Work')->get_by_id(1);
+    $c->model('WorkAttribute')->load_for_works($work);
+
+    my $edit = create_edit(
+        $c,
+        $work,
+        attributes => [
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 10,
+                attribute_text => undef,
+            },
+            {
+                attribute_type_id => 2,
+                attribute_text => 'Attr value',
+                attribute_value_id => undef
+            }
+        ]
+    );
+
+    ok(!$edit->is_open);
+};
+
+test 'Adding first work attribute of a kind is an auto-edit for non-auto-editors' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
+    $c->sql->do('INSERT INTO work_attribute (id, work, work_attribute_type, work_attribute_type_allowed_value) VALUES (1, 1, 1, 10)');
+
+    my $work = $c->model('Work')->get_by_id(1);
+    $c->model('WorkAttribute')->load_for_works($work);
+
+    create_edit(
+        $c, $c->model('Work')->get_by_id(1),
+        attributes => [
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 10,
+                attribute_text => undef,
+            }
+        ]
+    );
+
+    my $edit = create_edit(
+        $c,
+        $work,
+        attributes => [
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 10,
+                attribute_text => undef,
+            },
+            {
+                attribute_type_id => 2,
+                attribute_text => 'Attr value',
+                attribute_value_id => undef
+            }
+        ]
+    );
+
+    ok(!$edit->is_open);
+};
+
+test 'Adding work attribute of existing kind is not an auto-edit for non-auto-editors' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
+    $c->sql->do('INSERT INTO work_attribute (id, work, work_attribute_type, work_attribute_type_allowed_value) VALUES (1, 1, 1, 10)');
+
+    my $work = $c->model('Work')->get_by_id(1);
+    $c->model('WorkAttribute')->load_for_works($work);
+
+    my $edit = create_edit(
+        $c,
+        $work,
+        attributes => [
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 10,
+                attribute_text => undef,
+            },
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 2,
+                attribute_text => undef,
+            }
+        ]
+    );
+
+    ok($edit->is_open);
+    accept_edit($c, $edit);
+};
+
+test 'Changing work attribute is not an auto-edit for non-auto-editors' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
+    $c->sql->do('INSERT INTO work_attribute (id, work, work_attribute_type, work_attribute_type_allowed_value) VALUES (1, 1, 1, 10)');
+
+    my $work = $c->model('Work')->get_by_id(1);
+    $c->model('WorkAttribute')->load_for_works($work);
+
+    my $edit = create_edit(
+        $c,
+        $work,
+        attributes => [
+            {
+                attribute_type_id => 1,
+                attribute_value_id => 2,
+                attribute_text => undef,
+            }
+        ]
+    );
+
+    ok($edit->is_open);
+    accept_edit($c, $edit);
+};
+
+test 'Deleting work attribute is not an auto-edit for non-auto-editors' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
+    $c->sql->do('INSERT INTO work_attribute (id, work, work_attribute_type, work_attribute_type_allowed_value) VALUES (1, 1, 1, 10)');
+
+    my $work = $c->model('Work')->get_by_id(1);
+    $c->model('WorkAttribute')->load_for_works($work);
+
+    my $edit = create_edit(
+        $c,
+        $work,
+        attributes => []
+    );
+
+    ok($edit->is_open);
+    accept_edit($c, $edit);
+};
+
 test 'Check conflicts (non-conflicting edits)' => sub {
     my $test = shift;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -165,17 +165,7 @@ test 'Check conflicts (non-conflicting edits)' => sub {
     my $test = shift;
     my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work');
-    $c->sql->do(<<EOSQL);
-INSERT INTO work_attribute_type (id, gid, name, free_text)
-VALUES
-  (1, '325c079d-374e-4436-9448-da92dedef3ca', 'Attribute', false),
-  (2, '525c079d-374e-4436-9448-da92dedef3cd', 'Type two', true);
-INSERT INTO work_attribute_type_allowed_value (id, gid, work_attribute_type, value)
-VALUES
-  (10, 'b598f04f-5918-4713-aebc-f7d3d9c2d089', 1, 'Value'),
-  (2, '12a64964-902d-4917-9036-d505dafce0b4', 1, 'Value 2');
-EOSQL
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_work_attributes');
 
     my $edit_1 = create_edit(
         $c,

--- a/t/sql/edit_work_attributes.sql
+++ b/t/sql/edit_work_attributes.sql
@@ -1,0 +1,18 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, '32552f80-755f-11de-8a39-0800200c9a66', 'Artist', 'Artist');
+
+INSERT INTO artist_credit (id, name, artist_count) VALUES (1, 'Artist', 1);
+INSERT INTO artist_credit_name (artist_credit, name, artist, position, join_phrase)
+    VALUES (1, 'Artist', 1, 0, '');
+
+INSERT INTO work (id, gid, name) VALUES (1, '581556f0-755f-11de-8a39-0800200c9a66', 'Traits (remix)');
+
+INSERT INTO work_attribute_type (id, gid, name, free_text)
+    VALUES (1, '325c079d-374e-4436-9448-da92dedef3ca', 'Attribute', false),
+           (2, '525c079d-374e-4436-9448-da92dedef3cd', 'Type two', true);
+
+INSERT INTO work_attribute_type_allowed_value (id, gid, work_attribute_type, value)
+    VALUES (10, 'b598f04f-5918-4713-aebc-f7d3d9c2d089', 1, 'Value'),
+           (2, '12a64964-902d-4917-9036-d505dafce0b4', 1, 'Value 2');


### PR DESCRIPTION
[MBS-8640](https://tickets.metabrainz.org/browse/MBS-8640): Make adding work attribute auto-edit

Previously, adding work attribute was not an auto-edit, both because of a potential deliberate choice and a bug in implementation (`old` `attributes` array is always defined when adding work attributes).

This patch allows adding work attributes to be an auto-edit, only if there is no existing attribute of the same type for this work.

It doesn't allow modifying/deleting work attributes to be auto-edit.