### PR TITLE
MBS-9297: Set track lengths from CD TOC only if different

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -59,12 +59,9 @@ sub show : Chained('load') PathPart('')
     my $cdtoc = $c->stash->{cdtoc};
     my $medium_cdtocs = $self->_load_releases($c, $cdtoc);
 
-    for my $mc (@$medium_cdtocs) {
-        $mc->perfect_match = $c->model('Medium')->perfect_match_cdtoc(
-            $mc->medium->id,
-            $mc->cdtoc->id
-        );
-    }
+    $c->model('Track')->load_for_mediums(
+        map { $_->medium } @{$medium_cdtocs}
+    );
 
     $c->stash(
         medium_cdtocs => $medium_cdtocs,

--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -57,9 +57,17 @@ sub show : Chained('load') PathPart('')
     my ($self, $c) = @_;
 
     my $cdtoc = $c->stash->{cdtoc};
+    my $medium_cdtocs = $self->_load_releases($c, $cdtoc);
+
+    for my $mc (@$medium_cdtocs) {
+        $mc->perfect_match = $c->model('Medium')->perfect_match_cdtoc(
+            $mc->medium->id,
+            $mc->cdtoc->id
+        );
+    }
 
     $c->stash(
-        medium_cdtocs => $self->_load_releases($c, $cdtoc),
+        medium_cdtocs => $medium_cdtocs,
         template      => 'cdtoc/index.tt',
     );
 }

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -196,30 +196,6 @@ sub find_for_cdstub {
     );
 }
 
-sub perfect_match_cdtoc
-{
-    my ($self, $medium_id, $cdtoc_id) = @_;
-    my $cdtoc = $self->c->model('CDTOC')->get_by_id($cdtoc_id)
-        or die "Could not load CDTOC";
-
-    my $medium = $self->get_by_id($medium_id)
-        or die "Could not load tracklist";
-
-    $self->c->model('Track')->load_for_mediums($medium);
-
-    my @info = @{ $cdtoc->track_details };
-    my @medium_tracks = @{ $medium->cdtoc_tracks };
-
-    return 0 unless $#info == $#medium_tracks;
-
-    for my $i (0..$#info) {
-        return 0 unless defined $medium_tracks[$i] && $medium_tracks[$i]->length == $info[$i]->{length_time};
-        $i++;
-    }
-
-    return 1;
-}
-
 sub set_lengths_to_cdtoc
 {
     my ($self, $medium_id, $cdtoc_id) = @_;

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -196,6 +196,30 @@ sub find_for_cdstub {
     );
 }
 
+sub perfect_match_cdtoc
+{
+    my ($self, $medium_id, $cdtoc_id) = @_;
+    my $cdtoc = $self->c->model('CDTOC')->get_by_id($cdtoc_id)
+        or die "Could not load CDTOC";
+
+    my $medium = $self->get_by_id($medium_id)
+        or die "Could not load tracklist";
+
+    $self->c->model('Track')->load_for_mediums($medium);
+
+    my @info = @{ $cdtoc->track_details };
+    my @medium_tracks = @{ $medium->cdtoc_tracks };
+
+    return 0 unless $#info == $#medium_tracks;
+
+    for my $i (0..$#info) {
+        return 0 unless defined $medium_tracks[$i] && $medium_tracks[$i]->length == $info[$i]->{length_time};
+        $i++;
+    }
+
+    return 1;
+}
+
 sub set_lengths_to_cdtoc
 {
     my ($self, $medium_id, $cdtoc_id) = @_;

--- a/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
@@ -93,6 +93,9 @@ sub initialize {
     my $cdtoc_id = $opts{cdtoc_id}
         or die 'Missing CDTOC ID';
 
+    MusicBrainz::Server::Edit::Exceptions::NoChanges->throw
+        if $self->c->model('Medium')->perfect_match_cdtoc($medium_id, $cdtoc_id);
+
     my $medium = $self->c->model('Medium')->get_by_id($medium_id);
 
     $self->c->model('Release')->load($medium);

--- a/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
@@ -10,6 +10,7 @@ use MusicBrainz::Server::Translation qw( N_l );
 
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 use aliased 'MusicBrainz::Server::Entity::Medium';
+use aliased 'MusicBrainz::Server::Entity::MediumCDTOC';
 use aliased 'MusicBrainz::Server::Entity::Release';
 
 extends 'MusicBrainz::Server::Edit';
@@ -93,9 +94,6 @@ sub initialize {
     my $cdtoc_id = $opts{cdtoc_id}
         or die 'Missing CDTOC ID';
 
-    MusicBrainz::Server::Edit::Exceptions::NoChanges->throw
-        if $self->c->model('Medium')->perfect_match_cdtoc($medium_id, $cdtoc_id);
-
     my $medium = $self->c->model('Medium')->get_by_id($medium_id);
 
     $self->c->model('Release')->load($medium);
@@ -103,6 +101,9 @@ sub initialize {
     $self->c->model('Track')->load_for_mediums($medium);
 
     my $cdtoc = $self->c->model('CDTOC')->get_by_id($cdtoc_id);
+
+    MusicBrainz::Server::Edit::Exceptions::NoChanges->throw
+        if MediumCDTOC->new(cdtoc => $cdtoc, medium => $medium)->is_perfect_match;
 
     $self->data({
         medium_id => $medium_id,

--- a/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::MediumCDTOC;
 
+use List::AllUtils qw( all pairs zip );
 use Moose;
 use MusicBrainz::Server::Entity::Types;
 
@@ -25,6 +26,17 @@ has 'medium' => (
     is => 'rw',
     isa => 'Medium'
 );
+
+sub is_perfect_match {
+    my ($self) = @_;
+
+    my @cdtoc_info = @{ $self->cdtoc->track_details };
+    my @medium_tracks = @{ $self->medium->cdtoc_tracks };
+
+    return (@cdtoc_info == @medium_tracks) && all {
+      $_->[0]{length_time} == $_->[1]->length
+    } (pairs (zip @cdtoc_info, @medium_tracks));
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -42,7 +42,7 @@
             [% END %]
             [% IF edit_links AND c.user_exists %]
             <td>
-            [%- IF !medium_cdtoc.perfect_match %]
+            [%- IF !medium_cdtoc.is_perfect_match %]
               <a href="[% c.uri_for_action('/cdtoc/set_durations',
                               [ cdtoc.discid ], { medium => medium.id }) %]">
                 [% l('Set track durations') %]

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -42,10 +42,12 @@
             [% END %]
             [% IF edit_links AND c.user_exists %]
             <td>
+            [%- IF !medium_cdtoc.perfect_match %]
               <a href="[% c.uri_for_action('/cdtoc/set_durations',
                               [ cdtoc.discid ], { medium => medium.id }) %]">
                 [% l('Set track durations') %]
               </a> |
+            [%- END %]
               <a href="[% c.uri_for_action('cdtoc/remove',
                                            { cdtoc_id  => medium_cdtoc.cdtoc.id,
                                              medium_id => medium.id }) %]">

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
@@ -1,6 +1,7 @@
 package t::MusicBrainz::Server::Edit::Medium::SetTrackLengths;
 use Test::Routine;
 use Test::More;
+use Test::Fatal;
 
 with 't::Edit';
 with 't::Context';
@@ -31,6 +32,15 @@ test all => sub {
     is($medium->tracks->[4]->length, 719666);
     is($medium->tracks->[5]->length, 276933);
     is($medium->tracks->[6]->length, 94200);
+
+    isa_ok exception {
+        $c->model('Edit')->create(
+            edit_type => $EDIT_SET_TRACK_LENGTHS,
+            editor_id => 1,
+            medium_id => 1,
+            cdtoc_id => 1
+        )
+    }, 'MusicBrainz::Server::Edit::Exceptions::NoChanges';
 };
 
 test 'Setting track lengths on medium with pregap track' => sub {
@@ -39,17 +49,32 @@ test 'Setting track lengths on medium with pregap track' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+tracklist');
 
+    # Note: Hidden pre-gap track is ignored on purpose, as pre-gap
+    # duration is considered as a maximum for hidden track length.
+
+    isa_ok exception {
+        $c->model('Edit')->create(
+            edit_type => $EDIT_SET_TRACK_LENGTHS,
+            editor_id => 1,
+            medium_id => 4,
+            cdtoc_id => 2
+        )
+    }, 'MusicBrainz::Server::Edit::Exceptions::NoChanges';
+
     my $edit = $c->model('Edit')->create(
         edit_type => $EDIT_SET_TRACK_LENGTHS,
         editor_id => 1,
-        medium_id => 4,
+        medium_id => 5,
         cdtoc_id => 2
     );
     isa_ok($edit => 'MusicBrainz::Server::Edit::Medium::SetTrackLengths');
 
-    my $medium = $c->model('Medium')->get_by_id(4);
+    my $medium = $c->model('Medium')->get_by_id(5);
     $c->model('Track')->load_for_mediums($medium);
+
+    # Hidden pre-gap track length is untouched on purpose, see above.
     is($medium->tracks->[0]->length, 148);
+
     is($medium->tracks->[1]->length, 86186);
     is($medium->tracks->[2]->length, 342306);
     is($medium->tracks->[3]->length, 290053);

--- a/t/sql/tracklist.sql
+++ b/t/sql/tracklist.sql
@@ -30,7 +30,8 @@ INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES (1, '7c321
 
 INSERT INTO release (id, gid, name, artist_credit, release_group)
     VALUES (1, 'f205627f-b70a-409d-adbe-66289b614e80', 'Aerial', 1, 1),
-           (2, '9b3d9383-3d2a-417f-bfbb-56f7c15f075b', 'Aerial', 1, 1);
+           (2, '9b3d9383-3d2a-417f-bfbb-56f7c15f075b', 'Aerial', 1, 1),
+           (3, 'ab3d9383-3d2a-417f-bfbb-56f7c15f075b', 'Aerial', 1, 1);
 
 INSERT INTO release_unknown_country (release, date_year)
 VALUES (1, 2007), (2, 2008);
@@ -41,6 +42,8 @@ INSERT INTO medium (id, release, position, format, name) VALUES (2, 1, 2, 123465
 
 INSERT INTO medium (id, release, position, format, name) VALUES (3, 2, 1, 123465, 'A Sea of Honey');
 INSERT INTO medium (id, release, position, format, name) VALUES (4, 2, 2, 123465, 'A Sky of Honey');
+
+INSERT INTO medium (id, release, position, format, name) VALUES (5, 3, 1, 123465, 'A Sky of Honey');
 
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
     VALUES (1, '66c2ebff-86a8-4e12-a9a2-1650fb97d9d8', 1, 1, 1, 1, 'King of the Mountain', 1, NULL),
@@ -82,6 +85,18 @@ INSERT INTO track (id, gid, medium, position, number, recording, name, artist_cr
            (31, '14767038-01d2-4763-911a-10269df14d1b', 4, 8, 8, 15, 'Nocturn', 1, 514679),
            (32, '0a989191-d8ec-4147-9915-9ddcf59fea95', 4, 9, 9, 16, 'Aerial', 1, 472880),
            (33, 'b5c9ac02-dc07-4850-9338-03a4588de554', 4, 0, 0, 17, '[pregap]', 1, 148);
+
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+    VALUES (34, '17e1a081-ecf8-4ac4-92dd-6697c775b341', 5, 1, 1, 8, 'Prelude', 1, 86186),
+           (35, 'fe10482e-d2e5-4204-9e26-7289e5f9f39d', 5, 2, 2, 9, 'Prologue', 1, 342306),
+           (36, '2e394020-16e1-49d6-ac78-d6c8d833b775', 5, 3, 3, 10, 'An Architect''s Dream', 1, 290053),
+           (37, '15262836-6f29-4807-9b2c-f07b5d5eeb33', 5, 4, 4, 11, 'The Painter''s Link', 1, 95933),
+           (38, '43e4113d-97ce-4ad0-9642-3420d0440a5b', 5, 5, 5, 12, 'Sunset', 1, 358573),
+           (39, 'd05600b8-8ff4-4c66-bd57-b6690252e4f3', 5, 6, 6, 13, 'Aerial Tal', 1, 61333),
+           (40, '6cebf694-6346-44be-9724-375c08864a9d', 5, 7, 7, 14, 'Somewhere in Between', 1, 300626),
+           (41, '24767038-01d2-4763-911a-10269df14d1b', 5, 8, 8, 15, 'Nocturn', 1, 514679),
+           (42, '1a989191-d8ec-4147-9915-9ddcf59fea95', 5, 9, 9, 16, 'Aerial', 1, 123456),
+           (43, 'c5c9ac02-dc07-4850-9338-03a4588de554', 5, 0, 0, 17, '[pregap]', 1, 148);
 
 INSERT INTO cdtoc (id, discid, freedb_id, track_count, leadout_offset, track_offset, degraded)
        VALUES (1, 'BySFY0Ymit0miawEWumIN8Nvx-', '4b094107', 7, 171327,

--- a/t/sql/tracklist.sql
+++ b/t/sql/tracklist.sql
@@ -42,42 +42,46 @@ INSERT INTO medium (id, release, position, format, name) VALUES (2, 1, 2, 123465
 INSERT INTO medium (id, release, position, format, name) VALUES (3, 2, 1, 123465, 'A Sea of Honey');
 INSERT INTO medium (id, release, position, format, name) VALUES (4, 2, 2, 123465, 'A Sky of Honey');
 
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (1, '66c2ebff-86a8-4e12-a9a2-1650fb97d9d8', 1, 1, 1, 1, 'King of the Mountain', 1, NULL);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (2, 'b0caa7d1-0d1e-483e-b22b-ec6ab7fada06', 1, 2, 2, 2, 'π', 1, 369680);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (3, 'f891acda-39d6-4a7f-a9d1-dd87b7c46a0a', 1, 3, 3, 3, 'Bertie', 1, 258839);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (4, '6c04d03c-4995-43be-8530-215ca911dcbf', 1, 4, 4, 4, 'Mrs. Bartolozzi', 1, 358960);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (5, '849dc232-c33a-4611-a6a5-5a0969d63422', 1, 5, 5, 5, 'How to Be Invisible', 1, 332613);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (6, '72469a76-7c28-4a84-b7da-174c1034cd0a', 1, 6, 6, 6, 'Joanni', 1, 296160);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (7, '5d54de57-561d-4ee2-9ced-af4327249d66', 1, 7, 7, 7, 'A Coral Room', 1, 372386);
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+    VALUES (1, '66c2ebff-86a8-4e12-a9a2-1650fb97d9d8', 1, 1, 1, 1, 'King of the Mountain', 1, NULL),
+           (2, 'b0caa7d1-0d1e-483e-b22b-ec6ab7fada06', 1, 2, 2, 2, 'π', 1, 369680),
+           (3, 'f891acda-39d6-4a7f-a9d1-dd87b7c46a0a', 1, 3, 3, 3, 'Bertie', 1, 258839),
+           (4, '6c04d03c-4995-43be-8530-215ca911dcbf', 1, 4, 4, 4, 'Mrs. Bartolozzi', 1, 358960),
+           (5, '849dc232-c33a-4611-a6a5-5a0969d63422', 1, 5, 5, 5, 'How to Be Invisible', 1, 332613),
+           (6, '72469a76-7c28-4a84-b7da-174c1034cd0a', 1, 6, 6, 6, 'Joanni', 1, 296160),
+           (7, '5d54de57-561d-4ee2-9ced-af4327249d66', 1, 7, 7, 7, 'A Coral Room', 1, 372386);
 
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (8, 'c49c5a81-99c7-4b78-bfbc-8dc3d99242d2', 2, 1, 1, 8, 'Prelude', 1, 86186);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (9, '1f1f4f87-df59-4024-bcf3-ec2459496556', 2, 2, 2, 9, 'Prologue', 1, 342306);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (10, 'ec9872dd-173a-4eff-8f64-f265cc36c910', 2, 3, 3, 10, 'An Architect''s Dream', 1, 290053);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (11, 'c156351f-52fe-48e4-b056-d08a5d9b02a9', 2, 4, 4, 11, 'The Painter''s Link', 1, 95933);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (12, '3ec7a73f-c880-485c-ba93-17bcdab71212', 2, 5, 5, 12, 'Sunset', 1, 358573);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (13, '8fda3eaa-1b5f-4dbc-8f70-b59592ab6ba7', 2, 6, 6, 13, 'Aerial Tal', 1, 61333);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (14, 'c9ac9c6f-e56c-43e3-bdb7-717970a2800c', 2, 7, 7, 14, 'Somewhere in Between', 1, 300626);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (15, 'b4788492-ae09-46f9-80b1-92af9397bff4', 2, 8, 8, 15, 'Nocturn', 1, 514679);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (16, '74978be6-e8d2-479d-9207-b5708fd3f48b', 2, 9, 9, 16, 'Aerial', 1, 472880);
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+    VALUES (8, 'c49c5a81-99c7-4b78-bfbc-8dc3d99242d2', 2, 1, 1, 8, 'Prelude', 1, 86186),
+           (9, '1f1f4f87-df59-4024-bcf3-ec2459496556', 2, 2, 2, 9, 'Prologue', 1, 342306),
+           (10, 'ec9872dd-173a-4eff-8f64-f265cc36c910', 2, 3, 3, 10, 'An Architect''s Dream', 1, 290053),
+           (11, 'c156351f-52fe-48e4-b056-d08a5d9b02a9', 2, 4, 4, 11, 'The Painter''s Link', 1, 95933),
+           (12, '3ec7a73f-c880-485c-ba93-17bcdab71212', 2, 5, 5, 12, 'Sunset', 1, 358573),
+           (13, '8fda3eaa-1b5f-4dbc-8f70-b59592ab6ba7', 2, 6, 6, 13, 'Aerial Tal', 1, 61333),
+           (14, 'c9ac9c6f-e56c-43e3-bdb7-717970a2800c', 2, 7, 7, 14, 'Somewhere in Between', 1, 300626),
+           (15, 'b4788492-ae09-46f9-80b1-92af9397bff4', 2, 8, 8, 15, 'Nocturn', 1, 514679),
+           (16, '74978be6-e8d2-479d-9207-b5708fd3f48b', 2, 9, 9, 16, 'Aerial', 1, 472880);
 
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (17, '8bfb9e69-c42d-4677-be1c-35deac370812', 3, 1, 1, 1, 'King of the Mountain', 1, NULL);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (18, '63dfa68e-4e17-4830-8c10-c0fe12d62bcc', 3, 2, 2, 2, 'π', 1, 369680);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (19, 'cd2c1b6b-59cb-403d-9281-c0a54d185755', 3, 3, 3, 3, 'Bertie', 1, 258839);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (20, 'b3e6f1fa-09e6-467d-aa58-f598f2ad9215', 3, 4, 4, 4, 'Mrs. Bartolozzi', 1, 358960);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (21, '4ee82e1a-7b32-420d-a138-5c6bb9d3b79d', 3, 5, 5, 5, 'How to Be Invisible', 1, 332613);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (22, '0056c1e6-e3ac-4b0c-8c22-0986c89e8ac5', 3, 6, 6, 6, 'Joanni', 1, 296160);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (23, 'f921c8a9-4731-4083-b2ea-e8735fb89034', 3, 7, 7, 7, 'A Coral Room', 1, 372386);
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+    VALUES (17, '8bfb9e69-c42d-4677-be1c-35deac370812', 3, 1, 1, 1, 'King of the Mountain', 1, NULL),
+           (18, '63dfa68e-4e17-4830-8c10-c0fe12d62bcc', 3, 2, 2, 2, 'π', 1, 369680),
+           (19, 'cd2c1b6b-59cb-403d-9281-c0a54d185755', 3, 3, 3, 3, 'Bertie', 1, 258839),
+           (20, 'b3e6f1fa-09e6-467d-aa58-f598f2ad9215', 3, 4, 4, 4, 'Mrs. Bartolozzi', 1, 358960),
+           (21, '4ee82e1a-7b32-420d-a138-5c6bb9d3b79d', 3, 5, 5, 5, 'How to Be Invisible', 1, 332613),
+           (22, '0056c1e6-e3ac-4b0c-8c22-0986c89e8ac5', 3, 6, 6, 6, 'Joanni', 1, 296160),
+           (23, 'f921c8a9-4731-4083-b2ea-e8735fb89034', 3, 7, 7, 7, 'A Coral Room', 1, 372386);
 
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (24, '07e1a081-ecf8-4ac4-92dd-6697c775b341', 4, 1, 1, 8, 'Prelude', 1, 86186);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (25, 'ee10482e-d2e5-4204-9e26-7289e5f9f39d', 4, 2, 2, 9, 'Prologue', 1, 342306);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (26, '1e394020-16e1-49d6-ac78-d6c8d833b775', 4, 3, 3, 10, 'An Architect''s Dream', 1, 290053);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (27, '05262836-6f29-4807-9b2c-f07b5d5eeb33', 4, 4, 4, 11, 'The Painter''s Link', 1, 95933);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (28, '33e4113d-97ce-4ad0-9642-3420d0440a5b', 4, 5, 5, 12, 'Sunset', 1, 358573);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (29, 'c05600b8-8ff4-4c66-bd57-b6690252e4f3', 4, 6, 6, 13, 'Aerial Tal', 1, 61333);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (30, '5cebf694-6346-44be-9724-375c08864a9d', 4, 7, 7, 14, 'Somewhere in Between', 1, 300626);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (31, '14767038-01d2-4763-911a-10269df14d1b', 4, 8, 8, 15, 'Nocturn', 1, 514679);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (32, '0a989191-d8ec-4147-9915-9ddcf59fea95', 4, 9, 9, 16, 'Aerial', 1, 472880);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (33, 'b5c9ac02-dc07-4850-9338-03a4588de554', 4, 0, 0, 17, '[pregap]', 1, 148);
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+    VALUES (24, '07e1a081-ecf8-4ac4-92dd-6697c775b341', 4, 1, 1, 8, 'Prelude', 1, 86186),
+           (25, 'ee10482e-d2e5-4204-9e26-7289e5f9f39d', 4, 2, 2, 9, 'Prologue', 1, 342306),
+           (26, '1e394020-16e1-49d6-ac78-d6c8d833b775', 4, 3, 3, 10, 'An Architect''s Dream', 1, 290053),
+           (27, '05262836-6f29-4807-9b2c-f07b5d5eeb33', 4, 4, 4, 11, 'The Painter''s Link', 1, 95933),
+           (28, '33e4113d-97ce-4ad0-9642-3420d0440a5b', 4, 5, 5, 12, 'Sunset', 1, 358573),
+           (29, 'c05600b8-8ff4-4c66-bd57-b6690252e4f3', 4, 6, 6, 13, 'Aerial Tal', 1, 61333),
+           (30, '5cebf694-6346-44be-9724-375c08864a9d', 4, 7, 7, 14, 'Somewhere in Between', 1, 300626),
+           (31, '14767038-01d2-4763-911a-10269df14d1b', 4, 8, 8, 15, 'Nocturn', 1, 514679),
+           (32, '0a989191-d8ec-4147-9915-9ddcf59fea95', 4, 9, 9, 16, 'Aerial', 1, 472880),
+           (33, 'b5c9ac02-dc07-4850-9338-03a4588de554', 4, 0, 0, 17, '[pregap]', 1, 148);
 
 INSERT INTO cdtoc (id, discid, freedb_id, track_count, leadout_offset, track_offset, degraded)
        VALUES (1, 'BySFY0Ymit0miawEWumIN8Nvx-', '4b094107', 7, 171327,


### PR DESCRIPTION
[MBS-9297](https://tickets.metabrainz.org/browse/MBS-9297): Set track lengths from CD TOC only if different

Until then, it was possible to set track durations from CD TOC for any attached medium even if it does not change a millisecond of it.

This patch hides unnecessary links to `/set-durations` and disallows `SetTrackLengths` medium edits with no change.

Note about hidden pre-gap tracks: these are ignored at purpose, because CD TOC is not considered reliable regarding their lengths.