### PR TITLE
MBS-9323: Fix long URLs distorting page layout.

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -18,7 +18,7 @@ body {
 a {
     color:@link-default;
     text-decoration: none;
-    word-break: keep-all;
+    word-break: break-all;
 
     &:visited {
         color:@link-visited;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -18,6 +18,7 @@ body {
 a {
     color:@link-default;
     text-decoration: none;
+    word-break: keep-all;
 
     &:visited {
         color:@link-visited;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -19,10 +19,6 @@ a {
     color:@link-default;
     text-decoration: none;
     
-    &#sidebar {
-        word-break: break-all;
-    }
-
     &:visited {
         color:@link-visited;
     }
@@ -388,6 +384,10 @@ div.warning img.warning {
 
 #sidebar p {
     margin-top: 0;
+}
+
+#sidebar a {
+    word-break: break-all;
 }
 
 #sidebar ul.links {

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -386,10 +386,6 @@ div.warning img.warning {
     margin-top: 0;
 }
 
-#sidebar ul.external_links {
-    word-break: break-all;
-}
-
 #sidebar ul.links {
     margin: 0;
     padding-left: 1.5em;
@@ -400,6 +396,7 @@ div.warning img.warning {
     padding-left: 0;
     list-style-image: none;
     list-style-type: none;
+    word-break: break-all;
 }
 
 #sidebar ul.external_links li {

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -18,7 +18,7 @@ body {
 a {
     color:@link-default;
     text-decoration: none;
-    
+
     &:visited {
         color:@link-visited;
     }

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -18,7 +18,10 @@ body {
 a {
     color:@link-default;
     text-decoration: none;
-    word-break: break-all;
+    
+    &#sidebar {
+        word-break: break-all;
+    }
 
     &:visited {
         color:@link-visited;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -386,7 +386,7 @@ div.warning img.warning {
     margin-top: 0;
 }
 
-#sidebar a {
+#sidebar ul.external_links {
     word-break: break-all;
 }
 


### PR DESCRIPTION
Long URLs do not wrap and cause page distortion e.g. in https://musicbrainz.org/artist/f2b1690b-7b7a-4364-9764-098ecf87f794 a Wikipedia url with a very long #id caused the sidebar to take c. 80% of page width.

This proposed fix is applied to all `<a>` tags on every page. Further selectors can be added to e.g. restrict this to the sidebar if that is prefered. e.g. 
```
&#sidebar {
    word-break: break-all;
}
```
Resolves https://tickets.metabrainz.org/browse/MBS-9323