### PR TITLE
MBS-9347: Fix regression regarding page titles

### DIFF
--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -18,7 +18,7 @@ function canonicalize(url) {
 function getTitle(props) {
   let {title, pager} = props;
 
-  if (props.homepage) {
+  if (!props.homepage) {
     let parts = [];
 
     if (title) {


### PR DESCRIPTION
Fix [MBS-9347](https://tickets.metabrainz.org/browse/MBS-9347): append “- MusicBrainz” to the title of all pages but the homepage.