### PR TITLE
MBS-9342: Fix imports with DBD::Pg 3.6.0

### DIFF
--- a/admin/MBImport.pl
+++ b/admin/MBImport.pl
@@ -288,6 +288,8 @@ sub ImportTable
                         # replaces any invalid UTF-8 character with special 0xFFFD codepoint
                         # and warn on any such occurence
                         $t = Encode::decode("UTF-8", $t, Encode::FB_DEFAULT | Encode::WARN_ON_ERR);
+                } else {
+                        $t = Encode::decode("UTF-8", $t, Encode::FB_CROAK);
                 }
                 if (!$dbh->pg_putcopydata($t))
                 {

--- a/admin/replication/ImportReplicationChanges
+++ b/admin/replication/ImportReplicationChanges
@@ -140,7 +140,7 @@ sub ImportTable
 
     eval
     {
-        open(LOAD, "<", $file) or die "open $file: $!";
+        open(LOAD, "<:encoding(utf8)", $file) or die "open $file: $!";
 
         $sql->begin;
         my $dbh = $sql->dbh; # issues a ping, must be done before COPY

--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -38,7 +38,9 @@ sub _build_conn
     my $db = $self->database;
     my $conn = DBIx::Connector->new($dsn, $db->username, $db->password, {
         pg_enable_utf8    => 1,
-        pg_server_prepare => 0, # XXX Still necessary?
+        # Prepared statements are not shared across database connections,
+        # meaning they won't work alongside pgbouncer.
+        pg_server_prepare => 0,
         HandleError       => sub {
             my ($msg, $h) = @_;
             my $state = $h->state;

--- a/lib/MusicBrainz/Server/Connector.pm
+++ b/lib/MusicBrainz/Server/Connector.pm
@@ -37,7 +37,6 @@ sub _build_conn
 
     my $db = $self->database;
     my $conn = DBIx::Connector->new($dsn, $db->username, $db->password, {
-        pg_enable_utf8    => 1,
         # Prepared statements are not shared across database connections,
         # meaning they won't work alongside pgbouncer.
         pg_server_prepare => 0,

--- a/t/script/ExportAllTables.t
+++ b/t/script/ExportAllTables.t
@@ -95,9 +95,6 @@ EOSQL
             File::Spec->catfile($output_dir, 'mbdump-derived.tar.bz2'),
     );
 
-    system 'sh', '-c' => "$psql TEST < " .
-        File::Spec->catfile($root, 'admin/sql/ReplicationSetup.sql');
-
     $exec_sql->(<<EOSQL);
     SET client_min_messages TO WARNING;
     TRUNCATE replication_control CASCADE;


### PR DESCRIPTION
DBD::Pg 3.6.0 fixed their UTF8 flag handling with respect to the pg_(get|put)copydata methods, and the effect is that we now have to decode our strings before passing them into those functions.

This change also works with DBD::Pg 3.5.3. The way they changed the UTF8 handling is a bit hard to follow since it deals with Perl internals, but it must have only worked accidentally before, if the behavior we were relying on wasn't intended.