### PR TITLE
MBS-9362: Restore work language edit data

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -210,6 +210,17 @@ after accept => sub {
     }
 };
 
+sub restore {
+    my ($self, $data) = @_;
+
+    for my $side (qw( old new )) {
+        $data->{$side}{languages} = [ delete $data->{$side}{language_id} // () ]
+            if exists $data->{$side}{language_id};
+    }
+
+    $self->data($data);
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 


### PR DESCRIPTION
Fix [MBS-9362](https://tickets.metabrainz.org/browse/MBS-9362)

Prior to schema change 2017 Q2 update, work lyrics language was represented by a single value in `language_id` field.  It is now represented as a set of values in `languages` array field.

This patch allows to apply work edits made before the schema change.

This pull request is made against `beta` branch in order to hot fix 125 pending edits.
There is no conflict with `master`.