### PR TITLE
MBS-9309: Ignore swapped recordings in medium merges

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Data/Medium.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Medium.pm
@@ -140,4 +140,18 @@ test 'Reordering mediums' => sub {
     is($c->model('Medium')->get_by_id(2)->position => 1);
 };
 
+test 'Merging mediums with swapped recordings (MBS-9309)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_raw_test_database($c, '+mbs-9309');
+
+    $c->model('Medium')->merge(1, 2);
+
+    my $medium = $c->model('Medium')->get_by_id(1);
+    $c->model('Track')->load_for_mediums($medium);
+
+    is_deeply([map { $_->recording_id } $medium->all_tracks], [1, 2]);
+};
+
 1;

--- a/t/sql/mbs-9309.sql
+++ b/t/sql/mbs-9309.sql
@@ -1,0 +1,31 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO artist (id, gid, name, sort_name, begin_date_year, begin_date_month, begin_date_day, type)
+VALUES (7, '4b585938-f271-45e2-b19a-91c634b5e396', 'Kate Bush', 'Bush, Kate', 1958, 7, 30, 1);
+
+INSERT INTO artist_credit (id, name, artist_count)
+VALUES (1, 'Kate Bush', 1);
+
+INSERT INTO artist_credit_name (artist_credit, position, artist, name)
+VALUES (1, 0, 7, 'Kate Bush');
+
+INSERT INTO recording (id, gid, name, artist_credit, length)
+VALUES (1, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'King of the Mountain', 1, 293720),
+       (2, '659f405b-b4ee-4033-868a-0daa27784b89', 'π', 1, 369680);
+
+INSERT INTO release_group (id, gid, name, artist_credit, type)
+VALUES (1, '7c3218d7-75e0-4e8c-971f-f097b6c308c5', 'Aerial', 1, 1);
+
+INSERT INTO release (id, gid, name, artist_credit, release_group)
+VALUES (1, 'f205627f-b70a-409d-adbe-66289b614e80', 'Aerial', 1, 1),
+       (2, '9b3d9383-3d2a-417f-bfbb-56f7c15f075b', 'Aerial', 1, 1);
+
+INSERT INTO medium (id, release, position, format, name)
+VALUES (1, 1, 1, NULL, 'A Sea of Honey'),
+       (2, 2, 1, NULL, 'A Sky of Honey');
+
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length)
+VALUES (1, '66c2ebff-86a8-4e12-a9a2-1650fb97d9d8', 1, 1, '1', 1, 'King of the Mountain', 1, NULL),
+       (2, 'b0caa7d1-0d1e-483e-b22b-ec6ab7fada06', 1, 2, '2', 2, 'π', 1, NULL),
+       (3, 'f891acda-39d6-4a7f-a9d1-dd87b7c46a0a', 2, 1, '1', 2, 'π', 1, NULL),
+       (4, '6c04d03c-4995-43be-8530-215ca911dcbf', 2, 2, '2', 1, 'King of the Mountain', 1, NULL);


### PR DESCRIPTION
If two mediums are being merged, where recording 1 on medium 1 is being merged into recording 2 on medium 2, and recording 2 on medium 2 is being merged into recording 1 on medium 1 (because the positions are swapped), then the current merge logic will fail, because after performing the first merge, it proceeds to try and merge the same recording into itself.

This situation is now ignored, so no merge is performed, which I think is safer (it certainly wouldn't have been intended in edit #40241956). I'm not even sure it makes sense to support the scenario in MBS-8614 anymore; that should probably fail the edit and at the very least display a warning.

I think we should show a warning in this case, too, but we have separate pieces of logic which should probably be unified first (calculate_recording_merges, determine_recording_merges, this), and the edit referenced in the ticket has already been open for 10 months, so that can probably wait.