### PR TITLE
MBS-9365: Create event_meta_fk_id for old standalone DBs

### DIFF
--- a/admin/sql/updates/20170604-mbs-9365.sql
+++ b/admin/sql/updates/20170604-mbs-9365.sql
@@ -1,0 +1,12 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+ALTER TABLE event_meta DROP CONSTRAINT IF EXISTS event_meta_fk_id;
+
+ALTER TABLE event_meta
+   ADD CONSTRAINT event_meta_fk_id
+   FOREIGN KEY (id)
+   REFERENCES event(id)
+   ON DELETE CASCADE;
+
+COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -58,5 +58,9 @@
                    "20170401-mbs-8393-entity-attributes-fks.sql",
                    "20170329-mbs-5452-fks.sql",
                    "20170503-mbs-9329-event-meta-standalone.sql"]
+  },
+
+  "25": {
+    "standalone": ["20170604-mbs-9365.sql"]
   }
 }


### PR DESCRIPTION
It wasn't included in the upgrade script when events were originally added.