### PR TITLE
MBS-9372: Allow notes from voting-disabled editor

### DIFF
--- a/root/edit/cannot_vote.tt
+++ b/root/edit/cannot_vote.tt
@@ -1,0 +1,4 @@
+[% WRAPPER 'layout.tt' full_width=1 title=l('Error Voting on Edits') %]
+    <h1>[% l('Error Voting on Edits') %]</h1>
+    <p>[% l('You’re not currently allowed to vote, please read the banner.') %]</p>
+[% END %]


### PR DESCRIPTION
Fix bug [MBS-9372](https://tickets.metabrainz.org/browse/MBS-9372): Revoking editing/voting editor rights also renders them unable to write edit notes.

Prior to this patch, if admin revoked editing/voting privileges of any editor, this editor would not be able to submit edit notes, since it would be incidentally disallowed at the same time as votes.

This patch refines permissions to submit edit notes and votes so to allow submitting edit notes when editor is editing/voting-disabled and no vote is submitted.  If any vote is submitted at the same time, edit notes are rejected as well and an error page is returned.