### PR TITLE
MBS-9391: Update import_db.sh to retry downloading dumps.

### DIFF
--- a/docker/scripts/import_db.sh
+++ b/docker/scripts/import_db.sh
@@ -10,11 +10,14 @@ if ! script/database_exists $DATABASE; then
         RM_DUMPS=true
         curl -o $DIRECTORY/LATEST http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/LATEST
         LATEST="$(cat $DIRECTORY/LATEST)"
-        curl -o $DIRECTORY/mbdump-derived.tar.bz2 http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/$LATEST/mbdump-derived.tar.bz2
-        curl -o $DIRECTORY/mbdump.tar.bz2 http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/$LATEST/mbdump.tar.bz2
+        echo "Downloading dump: mbdump-derived.tar.bz2"
+        curl -o $DIRECTORY/mbdump-derived.tar.bz2 --retry 15 -C - http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/$LATEST/mbdump-derived.tar.bz2
+        echo "Downloading dump: mbdump.tar.bz2"
+        curl -o $DIRECTORY/mbdump.tar.bz2 --retry 15 -C - http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/$LATEST/mbdump.tar.bz2
     fi
     ./admin/InitDb.pl --createdb --database $DATABASE --import $DIRECTORY/mbdump*.tar.bz2 --echo
     if $RM_DUMPS; then
         rm $DIRECTORY/*
     fi
+    echo "Completed populating the database."
 fi


### PR DESCRIPTION
Added option `--retry 15` in the `curl` command for making it retry downloading the dumps. Now, the import fails if the downloading fails (without retrying).