### PR TITLE
MBS-9401: Fix sql query to fetch releases in dump-entities-sql.pl

### DIFF
--- a/script/dump-entities-sql.pl
+++ b/script/dump-entities-sql.pl
@@ -324,7 +324,7 @@ sub dump_release_groups {
     my $rows = get_core_entities_by_gids($c, 'release_group', $gids);
 
     my $release_ids = $c->sql->select_single_column_array(
-        'SELECT release FROM release_group WHERE id = any(?) ORDER BY release',
+        'SELECT release.id FROM release WHERE release_group = any(?) ORDER BY release.id',
         pluck('id', $rows)
     );
 


### PR DESCRIPTION
The sql generation fails presently for release group (in function `dump_release_groups`) with this [error]( https://gist.github.com/ferbncode/0f289e7368d58f3b4eae522d965d844f#file-error-L147-L150). Updated the query according to the present schema.