### PR TITLE
MBS-9409: Disallow merging mediums with & without pregaps

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -548,12 +548,13 @@ around _merge_submit => sub {
         };
     }
 
-    if ($c->model('Release')->can_merge(%merge_opts)) {
+    if ($c->model('Release')->can_merge(\%merge_opts)) {
         $self->$orig($c, $form, $entities);
     } else {
         $form->field('merge_strategy')->add_error(
             l('This merge strategy is not applicable to the releases you have selected.')
         );
+        $form->field('merge_strategy')->add_error(l($merge_opts{_cannot_merge_reason}));
     }
 };
 

--- a/lib/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -276,13 +276,8 @@ sub do_merge
         medium_names => $medium_names
     );
 
-    if (!$self->c->model('Release')->can_merge(%opts)) {
-        my $message = 'These releases could not be merged';
-        if ($self->data->{merge_strategy} == $MusicBrainz::Server::Data::Release::MERGE_MERGE) {
-            $message .= ' because the track counts on at least one set of corresponding mediums did not match.';
-        } elsif ($self->data->{merge_strategy} == $MusicBrainz::Server::Data::Release::MERGE_APPEND) {
-            $message .= ' because medium positions conflicted.';
-        }
+    if (!$self->c->model('Release')->can_merge(\%opts)) {
+        my $message = 'These releases could not be merged: ' . $opts{_cannot_merge_reason};
         MusicBrainz::Server::Edit::Exceptions::GeneralError->throw($message);
     }
 

--- a/lib/MusicBrainz/Server/Test/HTML5.pm
+++ b/lib/MusicBrainz/Server/Test/HTML5.pm
@@ -5,9 +5,8 @@ use DBDefs;
 use Encode;
 use File::Temp qw( tempfile );
 use JSON;
-use XML::LibXML;
 
-use Sub::Exporter -setup => { exports => [ qw(xhtml_ok html5_ok) ] };
+use Sub::Exporter -setup => { exports => [ qw(html5_ok) ] };
 
 =func ignore_warning
 
@@ -101,37 +100,6 @@ sub save_html
         $Test->diag("failed output written to $filename");
     };
 }
-
-
-=func xhtml_ok
-
-Check if the document is well-formed xhtml. (== well-formed xml, but
-html character entities are allowed without an external DTD).
-
-=cut
-
-sub xhtml_ok
-{
-    my ($Test, $content, $message) = @_;
-
-    $message ||= "well-formed XHTML";
-
-    eval { XML::LibXML->load_xml(string => $content); };
-    if ($@)
-    {
-        foreach (split "\n", $@->as_string())
-        {
-            $Test->diag($_);
-        }
-        save_html($Test, $content, ".xml");
-        return $Test->ok(0, $message);
-    }
-    else
-    {
-        return $Test->ok(1, $message);
-    }
-}
-
 
 =func html5_ok
 

--- a/root/account/edit.tt
+++ b/root/account/edit.tt
@@ -80,7 +80,7 @@
         </ul>
       [% END %]
 
-      <script>//<![CDATA[
+      <script>
       $(function () {
           $(document.body).append( $('#add-language-template') );
           $('#add-language-template').children().removeAttr('id').removeAttr('name');
@@ -106,7 +106,7 @@
               languageCount++;
           });
       });
-      //]]></script>
+      </script>
 
       <div class="row no-label" id="edit-profile-submit">
         <span class="buttons">
@@ -115,8 +115,8 @@
       </div>
     </form>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       MB.Control.EntityAutocomplete({ inputs: $("span.area.autocomplete") });
-    //]]></script>
+    </script>
 
 [% END %]

--- a/root/account/register_application.tt
+++ b/root/account/register_application.tt
@@ -14,7 +14,7 @@
         </div>
     </form>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       (function () {
         var $oauthType = $("#id-application\\.oauth_type");
         var $oauthRedirectURI = $("#id-application\\.oauth_redirect_uri");
@@ -26,6 +26,6 @@
 
         $oauthType.change();
       }());
-    //]]></script>
+    </script>
 
 [% END %]

--- a/root/admin/attributes/form.tt
+++ b/root/admin/attributes/form.tt
@@ -37,14 +37,14 @@
         [%~ IF model == "CollectionType" || model == "SeriesType" ~%]
             [% form_row_select(r, 'entity_type', add_colon(l('Entity type'))) %]
             [%~ IF c.action.name == "edit" ~%]
-                <script>//<![CDATA[
+                <script>
                     $(function () {
                         $('#id-attr\\.entity_type').prop('disabled', true);
                         $('form[action="[% c.req.uri %]"]').bind('submit', function () {
                             $('#id-attr\\.entity_type').prop('disabled', false);
                         });
                     });
-                //]]></script>
+                </script>
             [%~ END ~%]
         [%~ END ~%]
 

--- a/root/annotation/history.tt
+++ b/root/annotation/history.tt
@@ -43,7 +43,7 @@
 </form>
 [% END %]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     var $table = $("#annotation-history");
 
@@ -67,5 +67,5 @@
     reset();
     $table.find("input.old, input.new").change(reset);
   }());
-//]]></script>
+</script>
 [%~ END ~%]

--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -32,8 +32,8 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     MB.Control.initialize_guess_case("area", "id-edit-area");
   }());
-//]]></script>
+</script>

--- a/root/artist/edit_credit.tt
+++ b/root/artist/edit_credit.tt
@@ -24,10 +24,10 @@
      </div>
    </form>
 
-  <script type="text/javascript">//<![CDATA[
+  <script type="text/javascript">
       MB.initializeArtistCredit(
         [% closing_tag_escape(form.to_encoded_json) %],
         [% closing_tag_escape(form.field('artist_credit').json) %]
       );
-  //]]></script>
+  </script>
 [% END %]

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -99,7 +99,7 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     var edit = MB.Control.ArtistEdit();
 
@@ -109,4 +109,4 @@
 
     MB.initializeDuplicateChecker('artist');
   }());
-//]]></script>
+</script>

--- a/root/artist/split.tt
+++ b/root/artist/split.tt
@@ -41,11 +41,11 @@
      </div>
    </form>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
         MB.initializeArtistCredit(
           [% closing_tag_escape(form.to_encoded_json) %],
           [% closing_tag_escape(form.field('artist_credit').json) %]
         );
-    //]]></script>
+    </script>
    [% END %]
 [% END %]

--- a/root/cdstub/edit_form.tt
+++ b/root/cdstub/edit_form.tt
@@ -25,7 +25,7 @@
         </div>
     </form>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
         function vaswitch(artist_value)
         {
             var va_checkbox = document.getElementById("id-CDStub.multiple_artists");
@@ -69,4 +69,4 @@
                 vaswitch(artist_value);
             });
         }
-    //]]></script>
+    </script>

--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -45,7 +45,7 @@
 [% END %]
 
 [% MACRO attach_list_script BLOCK %]
-  <script>//<![CDATA[
+  <script>
     $(".tracklist").hide();
 
     $(document).on("click", ".toggle", function () {
@@ -57,5 +57,5 @@
         $(this).text("[% l('hide tracklist') | js %]");
       }
     });
-  //]]></script>
+  </script>
 [% END %]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -883,14 +883,14 @@ END ~%]
         [%- INCLUDE 'components/wikipedia_extract.tt' -%]
     [%- ELSIF wikipedia_extract_url -%]
         <span style="display:none" id="wikipedia-insertion-point"></span>
-        <script type="text/javascript">//<![CDATA[
+        <script type="text/javascript">
             $.get('[% wikipedia_extract_url %]',
                   function (data) {
                       $('#wikipedia-insertion-point').replaceWith(data);
                       MB.makeCollapsible('wikipedia-extract');
                   },
                   'html');
-        //]]></script>
+        </script>
     [%- END -%]
 [%- END -%]
 
@@ -899,13 +899,13 @@ END ~%]
         [%- INCLUDE 'components/commons-image.tt' -%]
     [%- ELSIF image_url -%]
         <span style="display:none" id="image-insertion-point"></span>
-        <script type="text/javascript">//<![CDATA[
+        <script type="text/javascript">
             $.get('[% image_url %]',
                   function (data) {
                       $('#image-insertion-point').replaceWith(data);
                   },
                   'html');
-        //]]></script>
+        </script>
     [%- END -%]
 [%- END -%]
 

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -192,9 +192,9 @@
       [% form_row_date(r, 'period.end_date', l('End date:')) %]
       [% form_row_checkbox(r, 'period.ended', ended_label) %]
     </fieldset>
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       MB.initializeToggleEnded('id-edit-[% type %]');
-    //]]></script>
+    </script>
 [%- END -%]
 
 [%- MACRO form_row_paragraph(message, label) BLOCK -%]

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -85,8 +85,8 @@
 
 [% script_manifest('voting.js') %]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   [% IF c.user.is_auto_editor %]
     MB.Control.EditList("#edits");
   [% END %]
-//]]></script>
+</script>

--- a/root/edit/search_results.tt
+++ b/root/edit/search_results.tt
@@ -11,12 +11,12 @@
         [% INCLUDE 'edit/list.tt' guess_search=1 %]
     </div>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       $('.search-refine select').attr('size', '10');
 
       $('.search-toggle a').click(function () {
         $('.search-refine').slideToggle('500');
         return false;
       });
-    //]]></script>
+    </script>
 [% END %]

--- a/root/entity/alias/edit_form.tt
+++ b/root/entity/alias/edit_form.tt
@@ -34,7 +34,7 @@
 
 [%- guesscase_options() -%]
 
-<script>//<![CDATA[
+<script>
 (function () {
     function togglePrimaryForLocale() {
         var allowed = $('#id-edit-alias\\\.locale').val() != '';
@@ -61,4 +61,4 @@
 
     MB.Control.initialize_guess_case('[% entity_type %]', 'id-edit-alias');
 }());
-//]]></script>
+</script>

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -56,8 +56,8 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     MB.Control.initialize_guess_case("event", "id-edit-event");
   }());
-//]]></script>
+</script>

--- a/root/forms/relationship-editor.tt
+++ b/root/forms/relationship-editor.tt
@@ -74,7 +74,7 @@
   </table>
 </fieldset>
 
-<script>//<![CDATA[
+<script>
   $(function () {
     MB.formWasPosted = [% c.form_posted ? 'true' : 'false' %];
     MB.userIsLocationEditor = [% c.user.is_location_editor ? 'true' : 'false' %];
@@ -87,4 +87,4 @@
         attrInfo: [% closing_tag_escape(attr_info) %]
     });
   });
-//]]></script>
+</script>

--- a/root/instrument/edit_form.tt
+++ b/root/instrument/edit_form.tt
@@ -32,8 +32,8 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     MB.Control.initialize_guess_case("instrument", "id-edit-instrument");
   }());
-//]]></script>
+</script>

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -56,7 +56,7 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   (function () {
     MB.Control.initialize_guess_case("label", "id-edit-label");
 
@@ -64,4 +64,4 @@
 
     MB.initializeDuplicateChecker('label');
   }());
-//]]></script>
+</script>

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -52,7 +52,7 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   $(function () {
     MB.initializeArtistCredit(
       [% closing_tag_escape(form.to_encoded_json) %],
@@ -62,4 +62,4 @@
     MB.Control.initGuessFeatButton('edit-recording');
     MB.Control.initializeBubble("#isrcs-bubble", "input[name=edit-recording\\.isrcs\\.0]");
   });
-//]]></script>
+</script>

--- a/root/recording/fingerprints.tt
+++ b/root/recording/fingerprints.tt
@@ -2,7 +2,7 @@
 
     <h2 id="acoustids">[%- l('Associated AcoustIDs') -%]</h2>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
 
         function buildAcoustidTable(tracks, mbid) {
             var tbl = $('<table class="tbl"><thead><tr><th>AcoustID<\/th><th style="width:5em;">[% l('Actions') %]<\/th><\/tr><\/thead><tbody><\/tbody><\/table>');
@@ -48,6 +48,6 @@
             }
         );
 
-    //]]></script>
+    </script>
 
 [%- END -%]

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -1,22 +1,22 @@
 [%- WRAPPER "release/layout.tt" title=lp('Add Cover Art', 'header') page='add_cover_art' -%]
   [%- script_manifest('edit.js') -%]
 
-  <script type="text/javascript">//<![CDATA[
+  <script type="text/javascript">
     MB.cover_art_types_json = [% cover_art_types_json %];
-  //]]></script>
+  </script>
 
   <h2>[%- lp('Add Cover Art', 'header') -%]</h2>
 
   [%~ javascript_required() ~%]
 
   <div style="display:none">[% warning(l('The Cover Art Archive is currently experiencing difficulties. Adding images for this release is unlikely to work at the moment.'), 'caa-warning') %]</div>
-  <script type="text/javascript">//<![CDATA[
+  <script type="text/javascript">
     $.getJSON("//s3.us.archive.org/?check_limit=1&accesskey=[% access_key %]&bucket=mbid-[% entity.gid %]", function (data) {
         if (data.over_limit == 1) {
             $(".caa-warning").parent().toggle();
         }
     }).fail(function () { $(".caa-warning").parent().toggle(); });
-  //]]</script>
+  </script>
 
   <form id="add-cover-art" class="cover-art" action="[% c.req.uri %]" method="post" >
     [%- USE r = FormRenderer(form) -%]

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -245,7 +245,7 @@
       </div>
     </script>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       $(function () {
         var RE = MB.relationshipEditor;
 
@@ -257,6 +257,6 @@
 
         MB.confirmNavigationFallback();
       });
-    //]]></script>
+    </script>
 
 [%- END -%]

--- a/root/release/merge.tt
+++ b/root/release/merge.tt
@@ -131,7 +131,7 @@
     </form>
     </div>
 
-    <script type="text/javascript">//<![CDATA[
+    <script type="text/javascript">
       (function () {
         function updateStrategy(val) {
           $(".merge-strategy").hide();
@@ -141,6 +141,6 @@
         $("#id-merge\\.merge_strategy").change(function () { updateStrategy($(this).val()) });
         updateStrategy($("#id-merge\\.merge_strategy").val());
       }());
-    //]]></script>
+    </script>
 
 [% END %]

--- a/root/release_group/edit_form.tt
+++ b/root/release_group/edit_form.tt
@@ -33,7 +33,7 @@
 
 [%- guesscase_options() -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   $(function () {
     MB.initializeArtistCredit(
       [% closing_tag_escape(form.to_encoded_json) %],
@@ -42,4 +42,4 @@
     MB.Control.initialize_guess_case("release-group", "id-edit-release-group");
     MB.Control.initGuessFeatButton('edit-release-group');
   });
-//]]></script>
+</script>

--- a/root/release_group/set_cover_art.tt
+++ b/root/release_group/set_cover_art.tt
@@ -53,13 +53,13 @@
   </p>
 [%- END -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   $('button.set-cover-art').bind('click.mb', function (event) {
     event.preventDefault();
     $('#id-set-cover-art\\.release').val($(this).data("gid"));
     $('div.editimage').removeClass("selected");
     $(this).closest('div.editimage').addClass("selected");
   });
-//]]></script>
+</script>
 
 [%- END -%]

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -43,12 +43,12 @@
 
 [%- guesscase_options() -%]
 
-<script>//<![CDATA[
+<script>
 $(function () {
   [%- USE JSON.Escape -%]
   MB.seriesTypesByID = [% series_types.json %];
   MB.orderingTypesByID = [% series_ordering_types.json %];
 });
-//]]></script>
+</script>
 
 [% script_manifest('series.js') %]

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -127,11 +127,7 @@ const guessFeat = require('../edit/utility/guessFeat');
 
             if (track.isDataTrack() && (!previous || !previous.isDataTrack())) {
                 track.isDataTrack(false);
-            } else {
-                // can't move pregap tracks
-                if (!previous || previous.position() == 0) {
-                    return false;
-                }
+            } else if (previous) {
                 this.swapTracks(track, previous, track.medium);
             }
 
@@ -196,15 +192,16 @@ const guessFeat = require('../edit/utility/guessFeat');
             var medium = track.medium;
             var tracks = medium.tracks;
             var index = tracks.indexOf(track);
+            var offset = medium.hasPregap() ? 0 : 1;
 
             tracks.remove(track)
             tracks = tracks.peek();
 
             for (var i = index; track = tracks[i]; i++) {
-                track.position(i + 1);
+                track.position(i + offset);
 
-                if (track.number.peek() == i + 2) {
-                    track.number(i + 1);
+                if (track.number.peek() == (i + offset + 1)) {
+                    track.number(i + offset);
                 }
             }
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -186,6 +186,17 @@ const guessFeat = require('../edit/utility/guessFeat');
             tracks.notifySubscribers(underlyingTracks);
         },
 
+        resetTrackPositions: function (tracks, start, offset, removed) {
+            let track;
+            for (let i = start; track = tracks[i]; i++) {
+                track.position(i + offset);
+
+                if (track.number.peek() == (i + offset + removed)) {
+                    track.number(i + offset);
+                }
+            }
+        },
+
         removeTrack: function (track) {
             var focus = track.next() || track.previous();
             var $medium = $("#" + track.elementID).parents(".advanced-disc");
@@ -195,15 +206,7 @@ const guessFeat = require('../edit/utility/guessFeat');
             var offset = medium.hasPregap() ? 0 : 1;
 
             tracks.remove(track)
-            tracks = tracks.peek();
-
-            for (var i = index; track = tracks[i]; i++) {
-                track.position(i + offset);
-
-                if (track.number.peek() == (i + offset + 1)) {
-                    track.number(i + offset);
-                }
-            }
+            releaseEditor.resetTrackPositions(tracks.peek(), index, offset, 1);
 
             if (focus) {
                 deferFocus("button.remove-item", "#" + focus.elementID);

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -185,8 +185,8 @@ const guessFeat = require('../edit/utility/guessFeat');
             track2.number(number1);
             track2.isDataTrack(dataTrack1);
 
-            underlyingTracks[position1 - 1] = track2;
-            underlyingTracks[position2 - 1] = track1;
+            underlyingTracks[position1 - offset] = track2;
+            underlyingTracks[position2 - offset] = track1;
             tracks.notifySubscribers(underlyingTracks);
         },
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -296,7 +296,14 @@ const validation = require('../edit/validation');
                     var oldValue = hasPregap();
 
                     if (oldValue && !newValue) {
-                        self.tracks.shift();
+                        const tracks = self.tracks.peek();
+                        const pregap = tracks[0];
+
+                        if (pregap.id) {
+                            releaseEditor.resetTrackPositions(tracks, 0, 1, -1);
+                        } else {
+                            self.tracks.shift();
+                        }
                     } else if (newValue && !oldValue) {
                         self.tracks.unshift(fields.Track({ position: 0, number: 0 }, self));
                     }

--- a/root/statistics/countries.tt
+++ b/root/statistics/countries.tt
@@ -39,12 +39,12 @@
 
 [%- script_manifest('statistics.js') -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   $('table.tbl').tablesorter({
       widgets: [ 'indexFirstColumn', 'evenRowClasses' ],
       headers: { 0: {sorter: false}, 2: { sorter: 'fancyNumber' }, 3: { sorter: 'fancyNumber' }, 4: { sorter: 'fancyNumber' }, 5: { sorter: 'fancyNumber' } },
       sortList: [ [5,1], [1,0] ] // order by descending number of entities, then name
   });
-//]]></script>
+</script>
 
 [% END %]

--- a/root/statistics/languages_scripts.tt
+++ b/root/statistics/languages_scripts.tt
@@ -65,7 +65,7 @@
 
 [%- script_manifest('statistics.js') -%]
 
-<script type="text/javascript">//<![CDATA[
+<script type="text/javascript">
   $('#languages-table').tablesorter({
       widgets: [ 'indexFirstColumn', 'evenRowClasses' ],
       headers: { 0: {sorter: false}, 2: { sorter: 'fancyNumber' }, 3: { sorter: 'fancyNumber' }, 4: { sorter: 'fancyNumber' } },
@@ -76,6 +76,6 @@
       headers: { 0: {sorter: false}, 2: { sorter: 'fancyNumber' } },
       sortList: [ [2,1], [1,0] ] // order by descending number of entities, then name
   });
-//]]></script>
+</script>
 
 [% END %]

--- a/t/lib/t/MusicBrainz/Server/Data/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Release.pm
@@ -118,37 +118,37 @@ test 'can_merge for the merge strategy' => sub {
     MusicBrainz::Server::Test->prepare_test_database($test->c, '+release');
 
     ok(
-        $test->c->model('Release')->can_merge(
+        $test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 6, old_ids => [ 7 ]
-        ),
+        }),
         'can merge 2 discs with equal track counts'
     );
 
     ok(
-        $test->c->model('Release')->can_merge(
+        $test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 7,
             old_ids => [ 6 ]
-        ),
+        }),
         'can merge 2 discs with equal track counts in opposite direction'
     );
 
     ok(
-        !$test->c->model('Release')->can_merge(
+        !$test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 6,
             old_ids => [ 3 ]
-        ),
+        }),
         'cannot merge releases with different track counts'
     );
 
     ok(
-        !$test->c->model('Release')->can_merge(
+        !$test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 3,
             old_ids => [ 6 ]
-        ),
+        }),
         'cannot merge releases with different track counts in opposite direction'
     );
 
@@ -163,30 +163,48 @@ test 'can_merge for the merge strategy' => sub {
     );
 
     ok(
-        $test->c->model('Release')->can_merge(
+        $test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 6,
             old_ids => [ 8 ]
-        ),
+        }),
         'can merge with differing medium counts as long as position/track count matches'
     );
 
     ok(
-        !$test->c->model('Release')->can_merge(
+        !$test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 6,
             old_ids => [ 3 ]
-        ),
+        }),
         'cannot merge with differing medium counts when there is a track count mismatch'
     );
 
     ok(
-        !$test->c->model('Release')->can_merge(
+        !$test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
             new_id => 8,
             old_ids => [ 6]
-        ),
+        }),
         'cannot merge when old mediums are not accounted for'
+    );
+
+    ok(
+        !$test->c->model('Release')->can_merge({
+            merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
+            new_id => 110,
+            old_ids => [100],
+        }),
+        'cannot merge a release with a pregap into one without a pregap'
+    );
+
+    ok(
+        !$test->c->model('Release')->can_merge({
+            merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE,
+            new_id => 100,
+            old_ids => [110],
+        }),
+        'cannot merge a release without a pregap into one with a pregap'
     );
 };
 
@@ -213,7 +231,7 @@ INSERT INTO medium (id, release, position, track_count)
 EOSQL
 
     ok(
-        $test->c->model('Release')->can_merge(
+        $test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_APPEND,
             new_id => 1,
             old_ids => [ 3 ],
@@ -221,7 +239,7 @@ EOSQL
                 1 => 1,
                 3 => 2
             }
-        )
+        })
     );
 
     $test->c->model('Release')->merge(
@@ -235,7 +253,7 @@ EOSQL
     );
 
     ok(
-        $test->c->model('Release')->can_merge(
+        $test->c->model('Release')->can_merge({
             merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_APPEND,
             new_id => 1,
             old_ids => [ 2 ],
@@ -244,7 +262,7 @@ EOSQL
                 2 => 2,
                 3 => 3,
             }
-        )
+        })
     );
 };
 
@@ -335,8 +353,8 @@ $release = $release_data->get_by_id(2);
 is( $release->quality, $QUALITY_UNKNOWN_MAPPED );
 
 my ($releases, $hits) = $release_data->find_by_artist(1, 100, 0);
-is( $hits, 6 );
-is( scalar(@$releases), 6 );
+is( $hits, 8 );
+is( scalar(@$releases), 8 );
 ok( (grep { $_->id == 1 } @$releases), 'found release by artist');
 ok( (grep { $_->id == 2 } @$releases), 'found release by artist');
 
@@ -577,7 +595,7 @@ EOSQL
     my ($releases, undef) = $c->model('Release')->find_by_artist(1, 10, 0);
     is_deeply(
         [map { $_->id } @$releases],
-        [8, 7, 1, 9, 2, 6]
+        [8, 7, 1, 9, 110, 100, 2, 6]
     );
 };
 
@@ -615,7 +633,7 @@ test 'find_by_cdtoc' => sub {
     my ($releases, undef) = $c->model('Release')->find_for_cdtoc(1, 1);
     is_deeply(
       [map { $_->id } @$releases],
-      [8, 9, 6, 7]
+      [8, 9, 6, 7, 100]
     );
 };
 

--- a/t/sql/release.sql
+++ b/t/sql/release.sql
@@ -64,11 +64,15 @@ INSERT INTO release (id, gid, name, artist_credit, release_group) VALUES (5, '53
 ;
 
 -- test merge strategies
+INSERT INTO release_group (id, gid, name, artist_credit)
+    VALUES (100, '7a14d050-759c-41c0-b7a0-71424d1b177a', 'Pregap?', 1);
 INSERT INTO release (id, gid, name, release_group, artist_credit)
     VALUES (6, '7a906020-72db-11de-8a39-0800200c9a70', 'The Prologue (disc 1)', 1, 1),
            (7, '7a906020-72db-11de-8a39-0800200c9a71', 'The Prologue (disc 2)', 1, 1),
            (8, '7a906020-72db-11de-8a39-0800200c9a72', 'Subversion EP (disc 1)', 1, 1),
-           (9, '7a906020-72db-11de-8a39-0800200c9a73', 'Subversion EP (disc 2)', 1, 1);
+           (9, '7a906020-72db-11de-8a39-0800200c9a73', 'Subversion EP (disc 2)', 1, 1),
+           (100, '6b89a7f7-ac01-4b57-ab0a-381b10523b34', 'Pregap', 100, 1),
+           (110, '94a44113-f3e7-4bf1-8d68-0d71922ac346', 'No pregap', 100, 1);
 INSERT INTO recording (id, gid, name, artist_credit)
     VALUES (2, '50a772b0-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
            (3, '5d9cb570-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
@@ -76,12 +80,15 @@ INSERT INTO recording (id, gid, name, artist_credit)
            (5, '691ee030-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1);
 INSERT INTO medium (id, release, track_count, position)
     VALUES (2, 6, 0, 1), (3, 7, 0, 1),
-           (4, 8, 0, 1), (5, 9, 0, 1);
+           (4, 8, 0, 1), (5, 9, 0, 1),
+           (60, 100, 1, 1), (70, 110, 1, 1);
 INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recording)
     VALUES (2, 'd6de1f70-4a29-4cce-a35b-aa2b56265583', 'Track on recording', 1, 2, 1, 1, 2),
            (3, '929e5fb9-cfe7-4764-b3f6-80e056f0c1da', 'Track on recording', 1, 3, 1, 1, 3),
            (4, '7e489434-e293-44e9-9254-8dec56a0c0c6', 'Track on recording', 1, 4, 1, 1, 4),
-           (5, 'a833f5c7-dd13-40ba-bb5b-dc4e35d2bb90', 'Track on recording', 1, 5, 1, 1, 5);
+           (5, 'a833f5c7-dd13-40ba-bb5b-dc4e35d2bb90', 'Track on recording', 1, 5, 1, 1, 5),
+           (60, 'fb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'Pregap', 1, 60, 0, '', 2),
+           (70, '0f4846f2-f96b-4fc3-b979-5fce32f193e5', 'Not pregap', 1, 70, 1, '1', 2);
 
 -- Test for searching by track artist
 INSERT INTO artist_credit (id, name, artist_count) VALUES (3, 'Various Artists', 2);


### PR DESCRIPTION
This does what the title says (because I believe allowing it would be annoying and error-prone), and also fixes the UI to allow moving track 1 to track 0, so that such releases can be made mergeable if it's correct to. That can be accomplished by enabling the pregap track and (1) moving track 1 up and deleting the now-empty track 1, or (2) removing the empty track 0 (which now moves track 1 into its place).