### PR TITLE
Add TO_JSON method to PartialDate.

### DIFF
--- a/lib/MusicBrainz/Server/Entity/PartialDate.pm
+++ b/lib/MusicBrainz/Server/Entity/PartialDate.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Entity::PartialDate;
 use Moose;
 
+extends 'MusicBrainz::Server::Entity';
+
 use Date::Calc;
 use List::AllUtils qw( any first_index );
 use MusicBrainz::Server::Data::Utils qw( take_while );


### PR DESCRIPTION
Changes introduced in 23e11bd break *Add release* page because `PartialDate`do not have `TO_JSON` method:

```
Caught exception in MusicBrainz::Server::Controller::ReleaseEditor->add "Can't locate object method "TO_JSON" via package "MusicBrainz::Server::Entity::PartialDate" at lib/MusicBrainz/Server/Entity/Role/DatePeriod.pm line 76."
```