### PR TITLE
Kill aclass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,11 +50,6 @@
         }
       }
     },
-    "aclass": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/aclass/-/aclass-0.5.1.tgz",
-      "integrity": "sha1-DC5+aYfzhJWvAm6Mm4Euulcl7vo="
-    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "license": "GPLv2+",
   "dependencies": {
-    "aclass": "0.5.1",
     "babel-core": "6.25.0",
     "babel-plugin-transform-react-constant-elements": "6.23.0",
     "babel-plugin-transform-react-inline-elements": "6.22.0",

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -253,7 +253,7 @@
           [% closing_tag_escape(type_info) %],
           [% closing_tag_escape(attr_info) %]
         );
-        RE.ReleaseViewModel({ sourceData: [% closing_tag_escape(source_entity) %] });
+        new RE.ReleaseViewModel({ sourceData: [% closing_tag_escape(source_entity) %] });
 
         MB.confirmNavigationFallback();
       });

--- a/root/static/lib/libraries.txt
+++ b/root/static/lib/libraries.txt
@@ -66,14 +66,6 @@ version:     0.1.3
 author:      Ryan Niemeyer
 url:         https://github.com/rniemeyer/knockout-delegatedEvents
 
--- aclass/aclass.js --
-
-library:     aclass
-license:     MIT
-version:     0.5.1
-author:      Michael Wiencek
-url:         https://github.com/mwiencek/aclass
-
 -- lodash/lodash.compat.js
 
 library:    Lo-Dash

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -1,6 +1,5 @@
 require('./common/raven');
 
-window.aclass = require("aclass");
 window.ko = require("knockout");
 window._ = require("lodash");
 window.$ = window.jQuery = require("jquery");

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -201,7 +201,7 @@ $.widget("ui.autocomplete", $.ui.autocomplete, {
     _dataToEntity: function (data) {
         try {
             if (this.options.entityConstructor) {
-                return this.options.entityConstructor(data);
+                return new this.options.entityConstructor(data);
             }
             return MB_entity(data, this.entity);
         } catch (e) {

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const ko = require('knockout');
 const _ = require('lodash');
 const ReactDOMServer = require('react-dom/server');
@@ -29,22 +28,22 @@ const formatTrackLength = require('./utility/formatTrackLength');
     // Base class that both core and non-core entities inherit from. The only
     // purpose this really serves is allowing the `data instanceof Entity`
     // check in MB.entity() to work.
-    var Entity = aclass({
+    class Entity {
 
-        init: function (data) {
+        constructor(data) {
             _.assign(this, data);
             this.name = this.name || "";
-        },
+        }
 
-        toJSON: function () {
+        toJSON() {
             var key, result = {};
             for (key in this) {
                 toJSON(result, this[key], key);
             }
             return result;
-        },
+        }
 
-        renderArtistCredit: function (ac) {
+        renderArtistCredit(ac) {
             ac = ko.unwrap(ac);
             // XXX For suggested recording data in the release editor,
             // which root/release/edit/recordings.tt passes into here as plain
@@ -55,16 +54,16 @@ const formatTrackLength = require('./utility/formatTrackLength');
             return ReactDOMServer.renderToStaticMarkup(
                 <ArtistCreditLink artistCredit={ac} target="_blank" />
             );
-        },
+        }
 
-        isCompleteArtistCredit: function (ac) {
+        isCompleteArtistCredit(ac) {
             ac = ko.unwrap(ac);
             if (Array.isArray(ac)) {
                 ac = artistCreditFromArray(ac);
             }
             return isCompleteArtistCredit(ac);
-        },
-    });
+        }
+    }
 
     var primitiveTypes = /^(boolean|number|string)$/;
 
@@ -120,38 +119,26 @@ const formatTrackLength = require('./utility/formatTrackLength');
         return entity;
     };
 
-    MB.entity.Entity = Entity;
-
     // Used by MB.entity() above to cache everything with a GID.
     MB.entityCache = {};
 
-    MB.entity.CoreEntity = aclass(Entity, {
+    class CoreEntity extends Entity {
 
-        template: _.template(
-            "<% if (data.editsPending) { %><span class=\"mp\"><% } %>" +
-            "<% if (data.nameVariation) { %><span class=\"name-variation\" title=\"<%- data.name %>\"><% } %>" +
-            "<a href=\"/<%= data.entityType %>/<%- data.gid %>\"" +
-            "<% if (data.target) { %> target=\"_blank\"<% } %>" +
-            "<% if (data.sort_name) { %> title=\"<%- data.sort_name %>\"" +
-            "<% } %>><bdi><%- data.creditedAs || data.name %></bdi></a>" +
-            "<% if (data.comment) { %> " +
-            "<span class=\"comment\">(<%- data.comment %>)</span><% } %>" +
-            "<% if (data.video) { %> <span class=\"comment\">" +
-            "(<%- data.videoString %>)</span><% } %>" +
-            "<% if (data.nameVariation) { %></span><% } %>" +
-            "<% if (data.editsPending) { %></span><% } %>",
-            {variable: "data"}
-        ),
+        constructor(data) {
+            super(data);
 
-        after$init: function (data) {
             this.relationships = ko.observableArray([]);
 
             if (data.artistCredit) {
                 this.artistCredit = artistCreditFromArray(data.artistCredit);
             }
-        },
 
-        html: function (renderParams) {
+            if (this._afterCoreEntityCtor) {
+                this._afterCoreEntityCtor(data);
+            }
+        }
+
+        html(renderParams) {
             var json = this.toJSON();
 
             json.entityType = json.entityType.replace("_", "-");
@@ -161,59 +148,87 @@ const formatTrackLength = require('./utility/formatTrackLength');
                 return this.template(_.extend(renderParams || {}, json));
             }
             return json.name;
-        },
+        }
 
-        around$toJSON: function (supr) {
-            var json = supr();
+        toJSON() {
+            var json = super.toJSON();
 
             if (this.artistCredit) {
                 json.artistCredit = ko.unwrap(this.artistCredit).names.toJS();
             }
             return json;
-        },
+        }
 
-        canTakeName: function (name) {
+        canTakeName(name) {
             name = clean(name);
             return name && name !== ko.unwrap(this.name);
-        },
+        }
 
-        canTakeArtist: function (ac) {
+        canTakeArtist(ac) {
             ac = ko.unwrap(ac);
             return isCompleteArtistCredit(ac) && !this.isArtistCreditEqual(ac);
-        },
+        }
 
-        isArtistCreditEqual: function (ac) {
+        isArtistCreditEqual(ac) {
             ac = ko.unwrap(ac);
             return artistCreditsAreEqual(ko.unwrap(this.artistCredit), ac);
         }
-    });
+    }
 
-    MB.entity.Editor = aclass(MB.entity.CoreEntity, {
-        entityType: "editor",
+    CoreEntity.prototype.template = _.template(
+        "<% if (data.editsPending) { %><span class=\"mp\"><% } %>" +
+        "<% if (data.nameVariation) { %><span class=\"name-variation\" title=\"<%- data.name %>\"><% } %>" +
+        "<a href=\"/<%= data.entityType %>/<%- data.gid %>\"" +
+        "<% if (data.target) { %> target=\"_blank\"<% } %>" +
+        "<% if (data.sort_name) { %> title=\"<%- data.sort_name %>\"" +
+        "<% } %>><bdi><%- data.creditedAs || data.name %></bdi></a>" +
+        "<% if (data.comment) { %> " +
+        "<span class=\"comment\">(<%- data.comment %>)</span><% } %>" +
+        "<% if (data.video) { %> <span class=\"comment\">" +
+        "(<%- data.videoString %>)</span><% } %>" +
+        "<% if (data.nameVariation) { %></span><% } %>" +
+        "<% if (data.editsPending) { %></span><% } %>",
+        {variable: "data"}
+    );
 
-        template: _.template(
-            "<a href=\"/<%= data.entityType %>/<%- data.name %>\">" +
-            "<bdi><%- data.name %></bdi></a>",
-            {variable: "data"}
-        )
-    });
+    class Editor extends CoreEntity {}
 
-    MB.entity.Artist = aclass(MB.entity.CoreEntity, { entityType: "artist" });
+    Editor.prototype.entityType = 'editor';
 
-    MB.entity.Event = aclass(MB.entity.CoreEntity, { entityType: "event" });
+    Editor.prototype.template = _.template(
+        "<a href=\"/<%= data.entityType %>/<%- data.name %>\">" +
+        "<bdi><%- data.name %></bdi></a>",
+        {variable: "data"}
+    );
 
-    MB.entity.Instrument = aclass(MB.entity.CoreEntity, { entityType: "instrument" });
+    class Artist extends CoreEntity {}
 
-    MB.entity.Label = aclass(MB.entity.CoreEntity, { entityType: "label" });
+    Artist.prototype.entityType = 'artist';
 
-    MB.entity.Area = aclass(MB.entity.CoreEntity, { entityType: "area" });
+    class Event extends CoreEntity {}
 
-    MB.entity.Place = aclass(MB.entity.CoreEntity, { entityType: "place" });
+    Event.prototype.entityType = 'event';
 
-    MB.entity.Recording = aclass(MB.entity.CoreEntity, {
-        entityType: "recording",
+    class Instrument extends CoreEntity {}
 
-        after$init: function (data) {
+    Instrument.prototype.entityType = 'instrument';
+
+    class Label extends CoreEntity {}
+
+    Label.prototype.entityType = 'label';
+
+    class Area extends CoreEntity {}
+
+    Area.prototype.entityType = 'area';
+
+    class Place extends CoreEntity {}
+
+    Place.prototype.entityType = 'place';
+
+    class Recording extends CoreEntity {
+        constructor(data) {
+            super(data);
+
             this.formattedLength = formatTrackLength(data.length);
 
             // Returned from the /ws/js/recording search.
@@ -234,37 +249,44 @@ const formatTrackLength = require('./utility/formatTrackLength');
 
             this.relatedArtists = relatedArtists(data.relationships);
             this.isProbablyClassical = isProbablyClassical(data);
-        },
 
-        around$html: function (supr, params) {
+            if (this._afterRecordingCtor) {
+                this._afterRecordingCtor(data);
+            }
+        }
+
+        html(params) {
             params = params || {};
             params.videoString = i18n.l("video");
-            return supr(params);
-        },
-
-        around$toJSON: function (supr) {
-            return _.assign(supr(), { isrcs: this.isrcs, appearsOn: this.appearsOn });
+            return super.html(params);
         }
-    });
 
-    MB.entity.Release = aclass(MB.entity.CoreEntity, {
-        entityType: "release",
+        toJSON() {
+            return _.assign(super.toJSON(), { isrcs: this.isrcs, appearsOn: this.appearsOn });
+        }
+    }
 
-        after$init: function (data) {
+    Recording.prototype.entityType = 'recording';
+
+    class Release extends CoreEntity {
+
+        constructor(data) {
+            super(data);
+
             if (data.releaseGroup) {
                 this.releaseGroup = MB.entity(data.releaseGroup, "release_group");
             }
 
             if (data.mediums) {
-                this.mediums = _.map(data.mediums, MB.entity.Medium);
+                this.mediums = _.map(data.mediums, x => new Medium(x));
             }
 
             this.relatedArtists = relatedArtists(data.relationships);
             this.isProbablyClassical = isProbablyClassical(data);
-        },
+        }
 
-        around$toJSON: function (supr) {
-            var object = supr();
+        toJSON() {
+            var object = super.toJSON();
 
             if (_.isArray(this.events)) {
                 object.events = _.cloneDeep(this.events);
@@ -276,20 +298,24 @@ const formatTrackLength = require('./utility/formatTrackLength');
 
             return object;
         }
-    });
+    }
 
-    MB.entity.ReleaseGroup = aclass(MB.entity.CoreEntity, { entityType: "release_group" });
+    Release.prototype.entityType = 'release';
 
-    MB.entity.Series = aclass(MB.entity.CoreEntity, {
-        entityType: "series",
+    class ReleaseGroup extends CoreEntity {}
 
-        after$init: function (data) {
+    ReleaseGroup.prototype.entityType = 'release_group';
+
+    class Series extends CoreEntity {
+
+        constructor(data) {
+            super(data);
             this.type = ko.observable(data.type);
             this.typeID = ko.observable(data.type && data.type.id);
             this.orderingTypeID = ko.observable(data.orderingTypeID);
-        },
+        }
 
-        getSeriesItems: function (viewModel) {
+        getSeriesItems(viewModel) {
             var type = this.type();
             if (!type) return [];
 
@@ -299,33 +325,36 @@ const formatTrackLength = require('./utility/formatTrackLength');
             return _.filter(this.displayableRelationships(viewModel)(), function (r) {
                 return r.linkTypeID() === linkTypeID;
             });
-        },
+        }
 
-        around$toJSON: function (supr) {
-            return _.assign(supr(), {
+        toJSON() {
+            return _.assign(super.toJSON(), {
                 type: this.type(),
                 typeID: this.typeID,
                 orderingTypeID: this.orderingTypeID
             });
         }
-    });
+    }
 
-    MB.entity.Track = aclass(MB.entity.CoreEntity, {
-        entityType: "track",
+    Series.prototype.entityType = 'series';
 
-        after$init: function (data) {
+    class Track extends CoreEntity {
+
+        constructor(data) {
+            super(data);
+
             this.formattedLength = formatTrackLength(this.length);
 
             if (data.recording) {
                 this.recording = MB.entity(data.recording, "recording");
             }
-        },
+        }
 
-        around$html: function (supr, renderParams) {
+        html(renderParams) {
             var recording = this.recording;
 
             if (!recording) {
-                return supr(renderParams);
+                return super.html(renderParams);
             }
 
             return this.template(
@@ -341,21 +370,27 @@ const formatTrackLength = require('./utility/formatTrackLength');
                 )
             );
         }
-    });
+    }
 
-    MB.entity.URL = aclass(MB.entity.CoreEntity, { entityType: "url" });
+    Track.prototype.entityType = 'track';
 
-    MB.entity.Work = aclass(MB.entity.CoreEntity, {
-        entityType: "work",
+    class URL extends CoreEntity {}
 
-        around$toJSON: function (supr) {
-            return _.assign(supr(), { artists: this.artists });
+    URL.prototype.entityType = 'url';
+
+    class Work extends CoreEntity {
+        toJSON() {
+            return _.assign(super.toJSON(), { artists: this.artists });
         }
-    });
+    }
 
-    MB.entity.Medium = aclass(Entity, {
-        after$init: function (data) {
-            this.tracks = _.map(data.tracks, MB.entity.Track);
+    Work.prototype.entityType = 'work';
+
+    class Medium extends Entity {
+        constructor(data) {
+            super(data);
+
+            this.tracks = _.map(data.tracks, x => new Track(x));
 
             var positionName;
             if (this.name) {
@@ -370,7 +405,25 @@ const formatTrackLength = require('./utility/formatTrackLength');
                 title: this.name
             });
         }
-    });
+    }
+
+    MB.entity.Area = Area;
+    MB.entity.Artist = Artist;
+    MB.entity.CoreEntity = CoreEntity;
+    MB.entity.Editor = Editor;
+    MB.entity.Entity = Entity;
+    MB.entity.Event = Event;
+    MB.entity.Instrument = Instrument;
+    MB.entity.Label = Label;
+    MB.entity.Medium = Medium;
+    MB.entity.Place = Place;
+    MB.entity.Recording = Recording;
+    MB.entity.Release = Release;
+    MB.entity.ReleaseGroup = ReleaseGroup;
+    MB.entity.Series = Series;
+    MB.entity.Track = Track;
+    MB.entity.URL = URL;
+    MB.entity.Work = Work;
 
     function relatedArtists(relationships) {
         return _(relationships).filter({target: {entityType: 'artist'}}).pluck('target').value();
@@ -388,20 +441,20 @@ const formatTrackLength = require('./utility/formatTrackLength');
     // usually includes a lower-case type name, which is used as the key.
 
     var coreEntityMapping = {
-        artist:        MB.entity.Artist,
-        event:         MB.entity.Event,
-        instrument:    MB.entity.Instrument,
-        label:         MB.entity.Label,
-        area:          MB.entity.Area,
-        place:         MB.entity.Place,
-        recording:     MB.entity.Recording,
-        release:       MB.entity.Release,
-        release_group: MB.entity.ReleaseGroup,
-        series:        MB.entity.Series,
-        track:         MB.entity.Track,
-        work:          MB.entity.Work,
-        url:           MB.entity.URL,
-        editor:        MB.entity.Editor
+        artist:        Artist,
+        event:         Event,
+        instrument:    Instrument,
+        label:         Label,
+        area:          Area,
+        place:         Place,
+        recording:     Recording,
+        release:       Release,
+        release_group: ReleaseGroup,
+        series:        Series,
+        track:         Track,
+        work:          Work,
+        url:           URL,
+        editor:        Editor
     };
 }());
 

--- a/root/static/scripts/edit/MB/Control/Area.js
+++ b/root/static/scripts/edit/MB/Control/Area.js
@@ -4,9 +4,11 @@
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
 MB.Control.Area = function () {
-    var bubble =  MB.Control.BubbleDoc().extend({
-        canBeShown: function (viewModel) { return viewModel.area().gid }
-    });
+    var bubble = new MB.Control.BubbleDoc();
+
+    bubble.canBeShown = function (viewModel) {
+        return viewModel.area().gid;
+    };
 
     ko.applyBindingsToNode($("#area-bubble")[0], { bubble: bubble });
 

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -23,9 +23,16 @@ var bubble = initializeBubble('#coordinates-bubble', 'input[name=edit-place\\.co
 
 // The map is hidden by default, which means it can't position itself correctly.
 // This tells it to update its position once it's visible.
-bubble.after("show", _.once(function () {
+const afterBubbleShow = _.once(function () {
     map.invalidateSize();
-}));
+});
+
+const bubbleShow = bubble.show;
+
+bubble.show = function () {
+    bubbleShow.apply(this, arguments);
+    afterBubbleShow();
+};
 
 map.on('click', function (e) {
     if (map.getZoom() > 11) {

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
@@ -126,14 +125,14 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             });
 
             if (!instruments.peek().length) {
-                addInstrument(MB.entity.Instrument({}));
+                addInstrument(new MB.entity.Instrument({}));
             }
 
             var vm = {
                 instruments: instruments,
 
                 addItem: function () {
-                    addInstrument(MB.entity.Instrument({}));
+                    addInstrument(new MB.entity.Instrument({}));
                     focusLastInput();
                 },
 
@@ -162,21 +161,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
     };
 
 
-    var Dialog = aclass({
+    class Dialog {
 
-        loading: ko.observable(false),
-        showAttributesHelp: ko.observable(false),
-        showLinkTypeHelp: ko.observable(false),
-
-        uiOptions: {
-            dialogClass: "rel-editor-dialog",
-            draggable: false,
-            resizable: false,
-            autoOpen: false,
-            width: "auto"
-        },
-
-        init: function (options) {
+        constructor(options) {
             var self = this;
 
             this.viewModel = options.viewModel;
@@ -205,19 +192,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             this.changeOtherRelationshipCredits = {source: ko.observable(false), target: ko.observable(false)};
             this.selectedRelationshipCredits = {source: ko.observable('all'), target: ko.observable('all')};
             this.setupUI();
-        },
+        }
 
-        setupUI: _.once(function () {
-            var $dialog = $("#dialog").dialog(this.uiOptions);
-
-            var widget = $dialog.data("ui-dialog");
-            widget.uiDialog.find(".ui-dialog-titlebar").remove();
-
-            Dialog.extend({ $dialog: $dialog, widget: widget });
-            ko.applyBindings(this.viewModel, $dialog[0]);
-        }),
-
-        open: function (positionBy) {
+        open(positionBy) {
             this.viewModel.activeDialog(this);
 
             var widget = this.widget;
@@ -236,11 +213,13 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             this.positionBy(positionBy);
 
             this.$dialog.find(".link-type").focus();
-        },
+        }
 
-        accept: function (inner) {
+        accept() {
             if (!this.hasErrors()) {
-                inner && inner.apply(this, _.toArray(arguments).slice(1));
+                if (this._accept) {
+                    this._accept.apply(this, arguments);
+                }
                 for (var role in this.changeOtherRelationshipCredits) {
                     if (this.changeOtherRelationshipCredits[role]()) {
                         var vm = this.viewModel;
@@ -279,14 +258,14 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
 
                 this.close(false);
             }
-        },
+        }
 
-        close: function () {
+        close() {
             this.viewModel.activeDialog(null);
             this.widget && this.widget.close();
-        },
+        }
 
-        clickEvent: function (data, event) {
+        clickEvent(data, event) {
             if (!event.isDefaultPrevented()) {
                 var $menu = this.$dialog.find(".menu");
 
@@ -296,9 +275,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return true;
-        },
+        }
 
-        keydownEvent: function (data, event) {
+        keydownEvent(data, event) {
             if (event.isDefaultPrevented()) {
                 return;
             }
@@ -324,31 +303,31 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return true;
-        },
+        }
 
-        toggleAttributesHelp: function () {
+        toggleAttributesHelp() {
             this.showAttributesHelp(!this.showAttributesHelp());
-        },
+        }
 
-        changeDirection: function () {
+        changeDirection() {
             var relationship = this.relationship.peek();
             relationship.entities(relationship.entities().slice(0).reverse());
-        },
+        }
 
-        backward: function () {
+        backward() {
             return this.source === this.relationship().entities()[1];
-        },
+        }
 
-        toggleLinkTypeHelp: function () {
+        toggleLinkTypeHelp() {
             this.showLinkTypeHelp(!this.showLinkTypeHelp.peek());
-        },
+        }
 
-        linkTypeName: function () {
+        linkTypeName() {
             var linkTypeID = this.relationship().linkTypeID();
             return linkTypeID ? linkPhrase.clean(linkTypeID, this.backward()) : "";
-        },
+        }
 
-        linkTypeDescription: function () {
+        linkTypeDescription() {
             var typeInfo = this.relationship().linkTypeInfo();
             var description;
 
@@ -360,15 +339,15 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return description || "";
-        },
+        }
 
-        positionBy: function (element) {
+        positionBy(element) {
             this.widget._setOption("position", {
                 my: "top center", at: "center", of: element
             });
-        },
+        }
 
-        linkTypeOptions: function (entityTypes) {
+        linkTypeOptions(entityTypes) {
             var options = MB.forms.linkTypeOptions(
                 { children: MB.typeInfo[entityTypes] }, this.backward()
             );
@@ -387,9 +366,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return options;
-        },
+        }
 
-        targetTypeOptions: function () {
+        targetTypeOptions() {
             var sourceType = this.source.entityType;
             var targetTypes = _.without(MB.allowedRelations[sourceType], 'url');
 
@@ -414,9 +393,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             });
 
             return options;
-        },
+        }
 
-        targetTypeChanged: function (newType) {
+        targetTypeChanged(newType) {
             if (!newType) return;
 
             var currentRelationship = this.relationship();
@@ -456,9 +435,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                 ac.clear();
                 ac.changeEntity(newType);
             }
-        },
+        }
 
-        linkTypeError: function () {
+        linkTypeError() {
             var typeInfo = this.relationship().linkTypeInfo();
 
             if (!typeInfo) {
@@ -476,9 +455,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return "";
-        },
+        }
 
-        targetEntityError: function () {
+        targetEntityError() {
             var relationship = this.relationship();
             var target = relationship.target(this.source);
             var typeInfo = relationship.linkTypeInfo() || {};
@@ -496,14 +475,14 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return "";
-        },
+        }
 
-        dateError: function (date) {
+        dateError(date) {
             var valid = dates.isDateValid(date.year(), date.month(), date.day());
             return valid ? "" : i18n.l("The date you've entered is not valid.");
-        },
+        }
 
-        datePeriodError: function () {
+        datePeriodError() {
             var relationship = this.relationship();
 
             var a = relationship.begin_date;
@@ -516,9 +495,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             }
 
             return "";
-        },
+        }
 
-        hasErrors: function () {
+        hasErrors() {
             var relationship = this.relationship();
 
             return this.linkTypeError() ||
@@ -529,6 +508,30 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                    this.dateError(relationship.end_date) ||
                    this.datePeriodError();
         }
+    }
+
+    _.assign(Dialog.prototype, {
+        loading: ko.observable(false),
+        showAttributesHelp: ko.observable(false),
+        showLinkTypeHelp: ko.observable(false),
+
+        uiOptions: {
+            dialogClass: "rel-editor-dialog",
+            draggable: false,
+            resizable: false,
+            autoOpen: false,
+            width: "auto"
+        },
+
+        setupUI: _.once(function () {
+            var $dialog = $("#dialog").dialog(this.uiOptions);
+
+            var widget = $dialog.data("ui-dialog");
+            widget.uiDialog.find(".ui-dialog-titlebar").remove();
+
+            _.assign(Dialog.prototype, {$dialog, widget});
+            ko.applyBindings(this.viewModel, $dialog[0]);
+        }),
     });
 
     function addRelationships(relationships, source, viewModel) {
@@ -557,38 +560,39 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
         });
     }
 
-    const AddDialog = aclass(Dialog, {
+    class AddDialog extends Dialog {
 
-        dialogTemplate: "template.relationship-dialog",
-        disableTypeSelection: false,
-
-        augment$accept: function () {
+        _accept() {
             addRelationships(splitByCreditableAttributes(this.relationship()), this.source, this.viewModel);
-        },
+        }
 
-        before$close: function (cancel) {
+        close(cancel) {
             if (cancel !== false) {
                 this.relationship().remove();
             }
+            super.close(cancel);
         }
+    }
+
+    _.assign(AddDialog.prototype, {
+        dialogTemplate: "template.relationship-dialog",
+        disableTypeSelection: false,
     });
 
+    class EditDialog extends Dialog {
 
-    const EditDialog = aclass(Dialog, {
-
-        dialogTemplate: "template.relationship-dialog",
-        disableTypeSelection: true,
-
-        before$init: function (options) {
+        constructor(options) {
             // originalRelationship is a copy of the relationship when the dialog
             // was opened, i.e. before the user edits it. if they cancel the
             // dialog, this is what gets copied back to revert their changes.
-            this.originalRelationship = options.relationship.editData();
-            this.editing = options.relationship;
-            options.relationship = this.editing.clone();
-        },
+            const relationship = options.relationship;
+            options.relationship = relationship.clone();
+            super(options);
+            this.originalRelationship = relationship.editData();
+            this.editing = relationship;
+        }
 
-        augment$accept: function () {
+        _accept() {
             var relationships = splitByCreditableAttributes(this.relationship()),
                 relationship = relationships.shift();
 
@@ -597,9 +601,9 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             if (relationships.length) {
                 addRelationships(relationships, this.source, this.viewModel);
             }
-        },
+        }
 
-        before$close: function (cancel) {
+        close(cancel) {
             if (cancel !== false) {
                 var relationship = this.relationship();
 
@@ -607,25 +611,27 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                     relationship.fromJS(this.originalRelationship);
                 }
             }
+            super.close(cancel);
         }
+    }
+
+    _.assign(EditDialog.prototype, {
+        dialogTemplate: "template.relationship-dialog",
+        disableTypeSelection: true,
     });
 
+    class BatchRelationshipDialog extends Dialog {
 
-    const BatchRelationshipDialog = aclass(Dialog, {
+        constructor(options) {
+            options.source = MB.entity({}, options.sources[0].entityType);
+            options.target = options.target || new MB.entity.Artist({});
 
-        dialogTemplate: "template.batch-relationship-dialog",
-        disableTypeSelection: false,
+            super(options);
 
-        around$init: function (supr, options) {
             this.sources = options.sources;
+        }
 
-            options.source = MB.entity({}, this.sources[0].entityType);
-            options.target = options.target || MB.entity.Artist({});
-
-            supr(options);
-        },
-
-        augment$accept: function (callback) {
+        _accept(callback) {
             var vm = this.viewModel;
             var model = _.omit(this.relationship().editData(), "id", "entities");
 
@@ -640,23 +646,22 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                 }
             });
         }
+    }
+
+    _.assign(BatchRelationshipDialog.prototype, {
+        dialogTemplate: "template.batch-relationship-dialog",
+        disableTypeSelection: false,
     });
 
+    class BatchCreateWorksDialog extends BatchRelationshipDialog {
 
-    const BatchCreateWorksDialog = aclass(BatchRelationshipDialog, {
-
-        dialogTemplate: "template.batch-create-works-dialog",
-        workType: ko.observable(null),
-        workLanguage: ko.observable(null),
-
-        around$init: function (supr, options) {
+        constructor(options) {
+            super(_.assign(options, { target: new MB.entity.Work({}) }));
             this.error = ko.observable(false);
-            supr(_.assign(options, { target: MB.entity.Work({}) }));
-        },
+        }
 
-        around$accept: function (supr) {
-            var self = this,
-                workType = this.workType(),
+        accept() {
+            var workType = this.workType(),
                 workLang = this.workLanguage();
 
             this.loading(true);
@@ -672,29 +677,34 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
             });
 
             this.createEdits(edits)
-                .done(function (data) {
+                .done((data) => {
                     var works = _.pluck(data.edits, "entity");
 
-                    supr(function (relationshipData) {
+                    super.accept(function (relationshipData) {
                         relationshipData.target = MB.entity(works.shift(), "work");
                         return true;
                     });
 
-                    self.loading(false);
+                    this.loading(false);
                 })
-                .fail(function () {
-                    self.loading(false);
-                    self.error(true);
+                .fail(() => {
+                    this.loading(false);
+                    this.error(true);
                 });
-        },
+        }
 
-        createEdits: function (edits) {
+        createEdits(edits) {
             return MB.edit.create({ editNote: "", makeVotable: false, edits: edits });
-        },
+        }
 
-        targetEntityError: function () { return "" }
+        targetEntityError() { return "" }
+    }
+
+    _.assign(BatchCreateWorksDialog.prototype, {
+        dialogTemplate: "template.batch-create-works-dialog",
+        workType: ko.observable(null),
+        workLanguage: ko.observable(null),
     });
-
 
     function defaultLinkType(root) {
         var child, id, i = 0;

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -27,12 +27,14 @@ function getDirection(relationship, source) {
 
 (function (RE) {
 
-    MB.entity.CoreEntity.extend({
+    const coreEntityPrototype = MB.entity.CoreEntity.prototype;
 
-        after$init: function () {
-            this.uniqueID = _.uniqueId("entity-");
-            this.relationshipElements = {};
-        },
+    coreEntityPrototype._afterCoreEntityCtor = function () {
+        this.uniqueID = _.uniqueId("entity-");
+        this.relationshipElements = {};
+    };
+
+    _.assign(coreEntityPrototype, {
 
         parseRelationships: function (relationships) {
             var self = this;
@@ -80,7 +82,7 @@ function getDirection(relationship, source) {
                 var relationships = this.values(),
                     firstRelationship = relationships[0];
 
-                var dialog = RE.UI.AddDialog({
+                var dialog = new RE.UI.AddDialog({
                     source: self,
                     target: MB.entity({}, firstRelationship.target(self).entityType),
                     direction: getDirection(firstRelationship, self),
@@ -180,14 +182,11 @@ function getDirection(relationship, source) {
         }
     });
 
+    const recordingPrototype = MB.entity.Recording.prototype;
 
-    MB.entity.Recording.extend({
-
-        after$init: function () {
-            this.performances = this.relationships.filter(isPerformance);
-        }
-    });
-
+    recordingPrototype._afterRecordingCtor = function () {
+        this.performances = this.relationships.filter(isPerformance);
+    };
 
     function isPerformance(relationship) {
         return relationship.entityTypes === "recording-work";

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const ko = require('knockout');
 const _ = require('lodash');
 
@@ -27,9 +26,9 @@ const mergeDates = require('./mergeDates');
     var fields = RE.fields = RE.fields || {};
 
 
-    fields.Relationship = aclass({
+    class Relationship {
 
-        init: function (data, source, parent) {
+        constructor(data, source, parent) {
             var self = this;
 
             this.parent = parent;
@@ -116,13 +115,13 @@ const mergeDates = require('./mergeDates');
 
             // By default, show all existing relationships on the page.
             if (this.id) this.show();
-        },
+        }
 
-        formatDatePeriod: function () {
+        formatDatePeriod() {
             return formatDatePeriod(this);
-        },
+        }
 
-        fromJS: function (data) {
+        fromJS(data) {
             this.linkTypeID(data.linkTypeID);
             this.entities([MB_entity(data.entities[0]), MB_entity(data.entities[1])]);
             this.entity0_credit(data.entity0_credit || '');
@@ -136,18 +135,18 @@ const mergeDates = require('./mergeDates');
             this.linkOrder(data.linkOrder || 0);
 
             _.has(data, "removed") && this.removed(!!data.removed);
-        },
+        }
 
-        target: function (source) {
+        target(source) {
             var entities = this.entities();
 
             if (source === entities[0]) return entities[1];
             if (source === entities[1]) return entities[0];
 
             throw new Error("The given entity is not used by this relationship");
-        },
+        }
 
-        linkTypeIDChanged: function () {
+        linkTypeIDChanged() {
             var typeInfo = this.linkTypeInfo();
 
             if (!typeInfo) {
@@ -170,28 +169,28 @@ const mergeDates = require('./mergeDates');
                     --len;
                 }
             }
-        },
+        }
 
-        linkTypeInfo: function () {
+        linkTypeInfo() {
             return MB.typeInfoByID[this.linkTypeID()];
-        },
+        }
 
-        hasDates: function () {
+        hasDates() {
             var typeInfo = this.linkTypeInfo();
             return typeInfo ? (typeInfo.hasDates !== false) : true;
-        },
+        }
 
-        added: function () { return !this.id },
+        added() { return !this.id }
 
-        edited: function () {
+        edited() {
             return !_.isEqual(this.original, this.editData());
-        },
+        }
 
-        hasChanges: function () {
+        hasChanges() {
             return this.added() || this.removed() || this.edited();
-        },
+        }
 
-        show: function () {
+        show() {
             var entities = this.entities();
 
             if (entities[0].relationships.indexOf(this) < 0) {
@@ -201,9 +200,9 @@ const mergeDates = require('./mergeDates');
             if (entities[1].relationships.indexOf(this) < 0) {
                 entities[1].relationships.push(this);
             }
-        },
+        }
 
-        entitiesChanged: function (newEntities) {
+        entitiesChanged(newEntities) {
             var oldEntities = this.entities.saved;
 
             var entity0 = newEntities[0];
@@ -236,23 +235,23 @@ const mergeDates = require('./mergeDates');
             }
 
             this.entities.saved = [entity0, entity1];
-        },
+        }
 
-        loadWorkRelationships: function (work) {
+        loadWorkRelationships(work) {
             var args = { url: "/ws/js/entity/" + work.gid + "?inc=rels" };
 
             request(args).done(function (data) {
                 work.parseRelationships(data.relationships);
             });
-        },
+        }
 
-        clone: function () {
-            var clone = fields.Relationship(_.omit(this.editData(), "id"));
+        clone() {
+            var clone = new fields.Relationship(_.omit(this.editData(), "id"));
             clone.parent = this.parent;
             return clone;
-        },
+        }
 
-        remove: function () {
+        remove() {
             if (this.removed() === true) return;
 
             var entities = this.entities();
@@ -262,35 +261,35 @@ const mergeDates = require('./mergeDates');
 
             delete this.parent.cache[this.entityTypes + "-" + this.id];
             this.removed(true);
-        },
+        }
 
-        getAttribute: function (typeGID) {
+        getAttribute(typeGID) {
             var attributes = this.attributes();
 
             for (var i = 0, linkAttribute; linkAttribute = attributes[i]; i++) {
                 if (linkAttribute.type.gid === typeGID) return linkAttribute;
             }
             return new fields.LinkAttribute({ type: { gid: typeGID }});
-        },
+        }
 
-        setAttributes: function (attributes) {
+        setAttributes(attributes) {
             this.attributes(_.map(validAttributes(this, attributes), function (data) {
                 return new fields.LinkAttribute(data);
             }));
-        },
+        }
 
-        addAttribute: function (typeGID) {
+        addAttribute(typeGID) {
             var attribute = new fields.LinkAttribute({ type: { gid: typeGID } });
             this.attributes.push(attribute);
             return attribute;
-        },
+        }
 
-        linkTypeAttributes: function () {
+        linkTypeAttributes() {
             var typeInfo = this.linkTypeInfo();
             return typeInfo ? _.values(typeInfo.attributes) : [];
-        },
+        }
 
-        attributeError: function (rootInfo) {
+        attributeError(rootInfo) {
             var min = rootInfo.min;
 
             if (min > 0) {
@@ -306,25 +305,25 @@ const mergeDates = require('./mergeDates');
             }
 
             return "";
-        },
+        }
 
-        _phraseAndExtraAttributes: function () {
+        _phraseAndExtraAttributes() {
             return linkPhrase.interpolate(this.linkTypeID(), this.attributes());
-        },
+        }
 
-        linkPhrase: function (source) {
+        linkPhrase(source) {
             return this.phraseAndExtraAttributes()[_.indexOf(this.entities(), source)];
-        },
+        }
 
-        lowerCasePhrase: function (source) {
+        lowerCasePhrase(source) {
             return this.linkPhrase(source).toLowerCase();
-        },
+        }
 
-        lowerCaseTargetName: function (source) {
+        lowerCaseTargetName(source) {
             return ko.unwrap(this.target(source).name).toLowerCase();
-        },
+        }
 
-        paddedSeriesNumber: function () {
+        paddedSeriesNumber() {
             var attributes = this.attributes(), numberAttribute;
 
             for (var i = 0; numberAttribute = attributes[i]; i++) {
@@ -347,9 +346,9 @@ const mergeDates = require('./mergeDates');
             }
 
             return parts.join("");
-        },
+        }
 
-        entityIsOrdered: function (entity) {
+        entityIsOrdered(entity) {
             var typeInfo = this.linkTypeInfo();
             if (!typeInfo) return false;
 
@@ -367,9 +366,9 @@ const mergeDates = require('./mergeDates');
             }
 
             return false;
-        },
+        }
 
-        entityCanBeReordered: function (entity) {
+        entityCanBeReordered(entity) {
             if (!this.entityIsOrdered(entity)) {
                 return false;
             }
@@ -381,9 +380,9 @@ const mergeDates = require('./mergeDates');
             }
 
             return true;
-        },
+        }
 
-        _moveEntity: function (offset) {
+        _moveEntity(offset) {
             var vm = this.parent;
             var relationships = vm.source.getRelationshipGroup(this, vm);
             var index = _.indexOf(relationships, this);
@@ -398,21 +397,21 @@ const mergeDates = require('./mergeDates');
                     r.linkOrder(i + 1);
                 });
             }
-        },
+        }
 
-        moveEntityUp: function () {
+        moveEntityUp() {
             this._moveEntity(-1);
-        },
+        }
 
-        moveEntityDown: function () {
+        moveEntityDown() {
             this._moveEntity(1);
-        },
+        }
 
-        showLinkOrder: function (source) {
+        showLinkOrder(source) {
             return this.linkOrder() > 0 && this.entityCanBeReordered(this.target(source));
-        },
+        }
 
-        isDuplicate: function (other) {
+        isDuplicate(other) {
             return (
                 this !== other &&
                 this.linkTypeID() == other.linkTypeID() &&
@@ -422,9 +421,9 @@ const mergeDates = require('./mergeDates');
                 mergeDates(this.end_date, other.end_date) &&
                 attributesAreEqual(this.attributes(), other.attributes())
             );
-        },
+        }
 
-        openEdits: function () {
+        openEdits() {
             var entities = this.original.entities;
             var entity0 = MB_entity(entities[0]);
             var entity1 = MB_entity(entities[1]);
@@ -444,9 +443,9 @@ const mergeDates = require('./mergeDates');
                 '&conditions.2.args=92&conditions.3.field=status&conditions.3.operator=%3D' +
                 '&conditions.3.args=1&field=Please+choose+a+condition'
             );
-        },
+        }
 
-        creditField: function (entity) {
+        creditField(entity) {
             var entities = this.entities();
 
             if (entity === entities[0]) {
@@ -457,8 +456,9 @@ const mergeDates = require('./mergeDates');
                 return this.entity1_credit;
             }
         }
-    });
+    }
 
+    fields.Relationship = Relationship;
 
     fields.LinkAttribute = function (data) {
         var type = this.type = MB.attrInfoByID[data.type.gid];

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const ko = require('knockout');
 
 const clean = require('../../common/utility/clean');
@@ -11,9 +10,9 @@ const deferFocus = require('../../edit/utility/deferFocus');
 
 (function () {
 
-    var Multiselect = aclass({
+    class Multiselect {
 
-        init: function (params, $element) {
+        constructor(params, $element) {
             this.$element = $element;
             this.$menu = $element.find("div.menu").data("multiselect", this);
             this.$items = $element.find("div.items");
@@ -65,21 +64,21 @@ const deferFocus = require('../../edit/utility/deferFocus');
             this.optionNodes = optionNodes.slice(0);
             this.$menu.empty().append(optionNodes);
             this.firstVisibleOption = ko.observable(this.optionNodes[0]);
-        },
+        }
 
-        termChanged: function (term) {
+        termChanged(term) {
             term = clean(term);
             this.updateOptions(term);
             this.menuVisible(!!term);
-        },
+        }
 
-        menuVisibleChanged: function (visible) {
+        menuVisibleChanged(visible) {
             if (visible) {
                 this.$menu.css("top", this.$element.outerHeight() + "px");
             }
-        },
+        }
 
-        updateOptions: function (term) {
+        updateOptions(term) {
             var selected = this.relationship.attributes.peek();
             var self = this;
             var menu = this.$menu[0];
@@ -102,17 +101,17 @@ const deferFocus = require('../../edit/utility/deferFocus');
 
             menu.style.display = previousDisplay;
             this.firstVisibleOption(optionNodes[0]);
-        },
+        }
 
-        select: function (option) {
+        select(option) {
             this.relationship.addAttribute(option.value);
             this.menuVisible(false);
             this.term("");
             this.inputHasFocus(true);
             this.updateOptions("");
-        },
+        }
 
-        deselect: function (event) {
+        deselect(event) {
             event.preventDefault();
 
             var attribute = ko.dataFor(event.target);
@@ -140,14 +139,14 @@ const deferFocus = require('../../edit/utility/deferFocus');
             } else {
                 this.inputHasFocus(true);
             }
-        },
+        }
 
-        inputClick: function (event) {
+        inputClick(event) {
             this.menuVisible(!this.menuVisible());
             event.preventDefault();
-        },
+        }
 
-        inputKeydown: function (event) {
+        inputKeydown(event) {
             var keyCode = event.keyCode;
             var menuVisible = this.menuVisibleWithOptions();
 
@@ -175,9 +174,9 @@ const deferFocus = require('../../edit/utility/deferFocus');
                     }
                     break;
             }
-        },
+        }
 
-        menuKeydown: function (event) {
+        menuKeydown(event) {
             var keyCode = event.keyCode;
             var activeElement = document.activeElement;
             var menuItemActive = activeElement.parentNode === this.$menu[0];
@@ -215,12 +214,12 @@ const deferFocus = require('../../edit/utility/deferFocus');
                     }
                     break;
             }
-        },
+        }
 
-        menuVisibleWithOptions: function () {
+        menuVisibleWithOptions() {
             return this.menuVisible() && this.firstVisibleOption();
         }
-    });
+    }
 
     function matchIndex(option, term) {
         if (option.data.unaccented) {

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
@@ -66,22 +65,19 @@ const fields = require('./fields');
     });
 
 
-    exports.ViewModel = aclass({
+    class ViewModel {
 
-        relationshipClass: fields.Relationship,
-        activeDialog: ko.observable(),
-
-        init: function (options) {
+        constructor(options) {
             this.source = options.source;
             this.uniqueID = _.uniqueId("relationship-editor-");
             this.cache = {};
-        },
+        }
 
-        getRelationship: function (data, source) {
+        getRelationship(data, source) {
             return MB.getRelationship(data, source);
-        },
+        }
 
-        removeRelationship: function (relationship) {
+        removeRelationship(relationship) {
             if (relationship.added()) {
                 relationship.remove();
             } else if (relationship.removed()) {
@@ -92,14 +88,21 @@ const fields = require('./fields');
                 }
                 relationship.removed(true);
             }
-        },
+        }
 
-        _sortedRelationships: function (relationships, source) {
+        _sortedRelationships(relationships, source) {
             return relationships
                 .sortBy(function (r) { return r.lowerCaseTargetName(source) })
                 .sortBy("linkOrder");
         }
+    }
+
+    _.assign(ViewModel.prototype, {
+        relationshipClass: fields.Relationship,
+        activeDialog: ko.observable(),
     });
+
+    exports.ViewModel = ViewModel;
 
 }(MB.relationshipEditor = MB.relationshipEditor || {}));
 
@@ -121,7 +124,7 @@ MB.initRelationshipEditors = function (args) {
         vmClass = require('../generic').GenericEntityViewModel;
     }
 
-    vmClass(vmArgs);
+    new vmClass(vmArgs);
 
     var externalLinksEditor = $('#external-links-editor-container')[0];
     if (externalLinksEditor) {
@@ -168,7 +171,7 @@ MB.getRelationship = function (data, source) {
                 return cached;
             }
         }
-        var relationship = viewModel.relationshipClass(data, source, viewModel);
+        var relationship = new viewModel.relationshipClass(data, source, viewModel);
         return data.id ? (viewModel.cache[cacheKey] = relationship) : relationship;
     }
 };

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
@@ -19,10 +18,11 @@ const {ViewModel} = require('./common/viewModel');
 
     var UI = RE.UI = RE.UI || {};
 
-    exports.GenericEntityViewModel = aclass(ViewModel, {
-        fieldName: "rel",
+    class GenericEntityViewModel extends ViewModel {
 
-        after$init: function () {
+        constructor(options) {
+            super(options);
+
             MB.sourceRelationshipEditor = this;
 
             var source = this.source;
@@ -32,30 +32,30 @@ const {ViewModel} = require('./common/viewModel');
                     return !r.linkTypeID() || !r.target(source).gid;
                 })
             );
-        },
+        }
 
-        openAddDialog: function (source, event) {
+        openAddDialog(source, event) {
             var targetType = _.without(MB.allowedRelations[source.entityType], 'url')[0];
 
-            UI.AddDialog({
+            new UI.AddDialog({
                 source: source,
                 target: MB.entity({}, targetType),
                 viewModel: this
             }).open(event.target);
-        },
+        }
 
-        openEditDialog: function (relationship, event) {
+        openEditDialog(relationship, event) {
             if (!relationship.removed()) {
-                UI.EditDialog({
+                new UI.EditDialog({
                     relationship: relationship,
                     source: ko.contextFor(event.target).$parents[1],
                     viewModel: this
                 }).open(event.target);
             }
-        },
+        }
 
-        around$_sortedRelationships: function (supr, relationships, source) {
-            var result = supr(relationships, source);
+        _sortedRelationships(relationships, source) {
+            var result = super._sortedRelationships(relationships, source);
 
             if (source.entityType === "series") {
                 var sorted = ko.observableArray(result());
@@ -80,7 +80,11 @@ const {ViewModel} = require('./common/viewModel');
 
             return result;
         }
-    });
+    }
+
+    GenericEntityViewModel.prototype.fieldName = 'rel';
+
+    exports.GenericEntityViewModel = GenericEntityViewModel;
 
     var seriesOrdering = {
         event: function (relationships, series) {

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
@@ -19,9 +18,11 @@ require('./common/entity');
     var UI = RE.UI = RE.UI || {};
 
 
-    const ReleaseViewModel = aclass(ViewModel, {
+    class ReleaseViewModel extends ViewModel {
 
-        after$init: function (options) {
+        constructor(options) {
+            super(options);
+
             MB.releaseRelationshipEditor = this;
 
             this.editNote = ko.observable("");
@@ -73,9 +74,9 @@ require('./common/entity');
                     return event.returnValue;
                 }
             });
-        },
+        }
 
-        loadRelease: function () {
+        loadRelease() {
             const self = this;
             const url = '/ws/js/release/' + this.source.gid + '?inc=rels+recordings';
 
@@ -86,9 +87,9 @@ require('./common/entity');
                 .always(function () {
                     self.loadingRelease(false);
                 });
-        },
+        }
 
-        getEdits: function (addChanged) {
+        getEdits(addChanged) {
             var self = this;
             var release = this.source;
 
@@ -118,9 +119,9 @@ require('./common/entity');
             _.each(rg.relationships(), function (r) {
                 addChanged(r, rg);
             });
-        },
+        }
 
-        submit: function (data, event) {
+        submit(data, event) {
             event.preventDefault();
 
             var self = this;
@@ -182,14 +183,14 @@ require('./common/entity');
                         this.submissionError(jqXHR.responseText);
                     }
                 });
-        },
+        }
 
-        submissionDone: function () {
+        submissionDone() {
             this.redirecting = true;
             window.location.replace("/release/" + this.source.gid);
-        },
+        }
 
-        releaseLoaded: function (data) {
+        releaseLoaded(data) {
             var release = this.source;
 
             release.mediums(_.map(data.mediums, function (mediumData) {
@@ -198,71 +199,73 @@ require('./common/entity');
                         trackData.recording.relationships
                     );
                 });
-                return MB.entity.Medium(mediumData, release);
+                return new MB.entity.Medium(mediumData, release);
             }));
 
             var trackCount = _.reduce(release.mediums(),
                 function (memo, medium) { return memo + medium.tracks.length }, 0);
 
             initCheckboxes(this.checkboxes, trackCount);
-        },
+        }
 
-        openAddDialog: function (source, event) {
-            UI.AddDialog({
+        openAddDialog(source, event) {
+            new UI.AddDialog({
                 source: source,
-                target: MB.entity.Artist({}),
+                target: new MB.entity.Artist({}),
                 viewModel: this
             }).open(event.target);
-        },
+        }
 
-        openEditDialog: function (relationship, event) {
+        openEditDialog(relationship, event) {
             if (!relationship.removed()) {
-                UI.EditDialog({
+                new UI.EditDialog({
                     relationship: relationship,
                     source: ko.contextFor(event.target).$parent,
                     viewModel: this
                 }).open(event.target);
             }
-        },
+        }
 
-        openBatchRecordingsDialog: function () {
+        openBatchRecordingsDialog() {
             var sources = UI.checkedRecordings();
 
             if (sources.length > 0) {
-                UI.BatchRelationshipDialog({ sources: sources, viewModel: this }).open();
+                new UI.BatchRelationshipDialog({ sources: sources, viewModel: this }).open();
             }
-        },
+        }
 
-        openBatchWorksDialog: function () {
+        openBatchWorksDialog() {
             var sources = UI.checkedWorks();
 
             if (sources.length > 0) {
-                UI.BatchRelationshipDialog({ sources: sources, viewModel: this }).open();
+                new UI.BatchRelationshipDialog({ sources: sources, viewModel: this }).open();
             }
-        },
+        }
 
-        openBatchCreateWorksDialog: function () {
+        openBatchCreateWorksDialog() {
             var sources = _.filter(UI.checkedRecordings(), function (recording) {
                 return recording.performances().length === 0;
             });
 
             if (sources.length > 0) {
-                UI.BatchCreateWorksDialog({ sources: sources, viewModel: this }).open();
+                new UI.BatchCreateWorksDialog({ sources: sources, viewModel: this }).open();
             }
-        },
+        }
 
-        openRelateToWorkDialog: function (track) {
+        openRelateToWorkDialog(track) {
             var source = track.recording;
-            var target = MB.entity.Work({ name: source.name });
+            var target = new MB.entity.Work({ name: source.name });
 
-            UI.AddDialog({
+            new UI.AddDialog({
                 source: source,
                 target: target,
                 viewModel: this
             }).open();
-        },
+        }
 
-        after$removeRelationship: function (relationship, event) {
+        removeRelationship(relationship, event) {
+            super.removeRelationship(relationship, event);
+
             if (relationship.added()) {
                 $(event.target)
                     .parent()
@@ -270,9 +273,9 @@ require('./common/entity');
                     .prop("checked", false)
                     .click();
             }
-        },
+        }
 
-        _sortedRelationships: function (relationships, source) {
+        _sortedRelationships(relationships, source) {
             var self = this;
 
             return relationships.filter(function (relationship) {
@@ -284,12 +287,12 @@ require('./common/entity');
             }).sortBy("linkOrder").sortBy(function (relationship) {
                 return relationship.lowerCasePhrase(source);
             });
-        },
+        }
 
-        _createEdit: function () {
+        _createEdit () {
             return MB.edit.create.apply(MB.edit, arguments);
-        },
-    });
+        }
+    }
 
     RE.ReleaseViewModel = ReleaseViewModel;
     exports.ReleaseViewModel = ReleaseViewModel;

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -48,7 +48,7 @@ const actions = {
     copyArtistToReleaseGroup: ko.observable(false),
 
     addReleaseEvent: function (release) {
-        release.events.push(fields.ReleaseEvent({}, release));
+        release.events.push(new fields.ReleaseEvent({}, release));
     },
 
     removeReleaseEvent: function (releaseEvent) {
@@ -56,7 +56,7 @@ const actions = {
     },
 
     addReleaseLabel: function (release) {
-        release.labels.push(fields.ReleaseLabel({}, release));
+        release.labels.push(new fields.ReleaseLabel({}, release));
     },
 
     removeReleaseLabel: function (releaseLabel) {

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -3,10 +3,14 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const _ = require('lodash');
+
 const releaseEditor = require('./viewModel');
 
 function bubbleDoc(options) {
-    return MB.Control.BubbleDoc("Information").extend(options || {});
+    var bubble = new MB.Control.BubbleDoc("Information");
+    _.assign(bubble, options);
+    return bubble;
 }
 
 releaseEditor.releaseGroupBubble = bubbleDoc({
@@ -47,10 +51,9 @@ releaseEditor.annotationBubble = bubbleDoc();
 
 releaseEditor.commentBubble = bubbleDoc();
 
+class RecordingBubble extends MB.Control.BubbleDoc {
 
-var trackBubble = {
-
-    previousTrack: function (data, event, stealFocus) {
+    previousTrack(data, event, stealFocus) {
         event && event.stopPropagation();
 
         var track = this.currentTrack().previous();
@@ -63,9 +66,9 @@ var trackBubble = {
             this.moveToTrack(track, stealFocus === true);
             return true;
         }
-    },
+    }
 
-    nextTrack: function (data, event, stealFocus) {
+    nextTrack(data, event, stealFocus) {
         event && event.stopPropagation();
 
         var track = this.currentTrack().next();
@@ -74,9 +77,9 @@ var trackBubble = {
             this.moveToTrack(track, stealFocus === true);
             return true;
         }
-    },
+    }
 
-    submit: function () {
+    submit() {
         // stealFocus set to true causes the bubble to move focus to the
         // first input in the bubble. This is useful here, but not if the
         // user explicitly presses a next/previous button.
@@ -85,24 +88,22 @@ var trackBubble = {
             this.hide();
         }
     }
-};
 
-
-var RecordingBubble = aclass(MB.Control.BubbleDoc, trackBubble)
-.extend({
-    before$show: function (control) {
+    show(control) {
         var track = ko.dataFor(control);
 
         if (track && !track.hasExistingRecording()) {
             releaseEditor.recordingAssociation.findRecordingSuggestions(track);
         }
-    },
 
-    currentTrack: function () { return this.target() },
+        super.show(control);
+    }
 
-    moveToTrack: function (track, stealFocus) {
+    currentTrack() { return this.target() }
+
+    moveToTrack(track, stealFocus) {
         this.show(track.bubbleControlRecording, stealFocus);
     }
-});
+}
 
-releaseEditor.recordingBubble = RecordingBubble("Recording");
+releaseEditor.recordingBubble = new RecordingBubble("Recording");

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -20,14 +20,14 @@ releaseEditor.baseRelease.subscribe(function (gid) {
     var release = releaseEditor.rootField.release();
 
     if (!gid) {
-        release.mediums([ releaseEditor.fields.Medium({}, release) ]);
+        release.mediums([ new releaseEditor.fields.Medium({}, release) ]);
         return;
     }
 
     releaseEditor.loadRelease(gid, function (data) {
         release.mediums(
             _.map(data.mediums, function (m) {
-                return releaseEditor.fields.Medium(
+                return new releaseEditor.fields.Medium(
                     utils.reuseExistingMediumData(m), release
                 );
             })
@@ -122,7 +122,7 @@ function pluck(chain, name) { return chain.pluck(name).compact() }
 
 
 function formatReleaseData(release) {
-    var clean = MB.entity.Release(utils.cleanWebServiceData(release));
+    var clean = new MB.entity.Release(utils.cleanWebServiceData(release));
 
     var events = _(release["release-events"]);
     var labels = _(release["label-info"]);
@@ -137,7 +137,7 @@ function formatReleaseData(release) {
         .flatten().compact().uniq().value();
 
     clean.labels = pluck(labels, "label").map(function (info) {
-        return MB.entity.Label({ gid: info.id, name: info.name });
+        return new MB.entity.Label({ gid: info.id, name: info.name });
     }).value();
 
     clean.catalogNumbers = pluck(labels, "catalog-number").value();

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -547,7 +547,7 @@ releaseEditor.orderedEditSubmissions = [
             var edit = edits[0];
 
             if (edit.edit_type == MB.edit.TYPES.EDIT_RELEASEGROUP_CREATE) {
-                release.releaseGroup(releaseEditor.fields.ReleaseGroup(edits[0].entity));
+                release.releaseGroup(new releaseEditor.fields.ReleaseGroup(edits[0].entity));
             }
         }
     },

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -272,7 +272,7 @@ releaseEditor.releaseLoaded = function (data) {
         releaseEditor.createExternalLinksEditor(data, $('#external-links-editor-container')[0]);
     });
 
-    var release = fields.Release(data);
+    var release = new fields.Release(data);
 
     if (seed) this.seedRelease(release, seed);
 

--- a/root/static/scripts/release-editor/seeding.js
+++ b/root/static/scripts/release-editor/seeding.js
@@ -39,7 +39,7 @@ releaseEditor.seed = function (data) {
             releaseData.relationships = seed.relationships;
         }
 
-        var release = fields.Release(releaseData);
+        var release = new fields.Release(releaseData);
         this.seedRelease(release, seed);
         this.rootField.release(release);
     }
@@ -97,7 +97,7 @@ releaseEditor.seedRelease = function (release, data) {
         // Knockout.js will do a strict comparison when rendering the
         // input. See MBS-7828.
         data.releaseGroup.secondaryTypeIDs = data.releaseGroup.secondaryTypeIDs.map(String);
-        release.releaseGroup(fields.ReleaseGroup(data.releaseGroup));
+        release.releaseGroup(new fields.ReleaseGroup(data.releaseGroup));
     }
 
     if (data.mediums) {

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -180,7 +180,7 @@ releaseEditor.trackParser = {
                 return matchedTrack;
             }
 
-            return fields.Track(data, medium);
+            return new fields.Track(data, medium);
         });
 
         if (medium) {
@@ -224,7 +224,7 @@ releaseEditor.trackParser = {
                 newTracks.splice.apply(
                     newTracks,
                     [newAudioTrackCount, 0].concat(_.times(difference, function (n) {
-                        return fields.Track({
+                        return new fields.Track({
                             length: currentTracks[newAudioTrackCount + n].length.peek()
                         }, medium);
                     }))

--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -23,7 +23,7 @@ releaseEditor.utils = utils;
 
 utils.mapChild = function (parent, children, type) {
     return _.map(children || [], function (data) {
-        return type(data, parent);
+        return new type(data, parent);
     });
 };
 

--- a/root/static/scripts/series.js
+++ b/root/static/scripts/series.js
@@ -24,13 +24,13 @@ $(function () {
 
   series.orderingTypeID($orderingType.val());
 
-  series.typeBubble = MB.Control.BubbleDoc().extend({
-    canBeShown: function () {
-      return !!series.type();
-    }
-  });
+  series.typeBubble = new MB.Control.BubbleDoc();
 
-  series.orderingTypeBubble = MB.Control.BubbleDoc();
+  series.typeBubble.canBeShown = function () {
+    return !!series.type();
+  };
+
+  series.orderingTypeBubble = new MB.Control.BubbleDoc();
 
   ko.computed(function () {
     series.type(MB.seriesTypesByID[series.typeID()]);

--- a/root/static/scripts/tests/externalLinks.js
+++ b/root/static/scripts/tests/externalLinks.js
@@ -114,7 +114,7 @@ externalLinksTest("deprecated link type detection for existing links (MBS-8408)"
 [
     {
         id: 1,
-        target: MB_entity.URL({ name: "http://www.example.com/" }),
+        target: new MB_entity.URL({ name: "http://www.example.com/" }),
         linkTypeID: 179
     }
 ]);
@@ -159,7 +159,7 @@ externalLinksTest("hidden input data for form submission", function (t, $mountPo
 [
     {
         id: 1,
-        target: MB_entity.URL({ name: "https://en.wikipedia.org/wiki/Deerhunter" }),
+        target: new MB_entity.URL({ name: "https://en.wikipedia.org/wiki/Deerhunter" }),
         linkTypeID: 179
     }
 ]);

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -301,7 +301,7 @@ test('guessing feat. artists', function (t) {
     }
 
     _.each(trackTests, function (x) {
-        var release = fields.Release({
+        var release = new fields.Release({
             artistCredit: [],
             mediums: [{tracks: [x.input]}],
         });
@@ -310,6 +310,6 @@ test('guessing feat. artists', function (t) {
     });
 
     _.each(releaseTests, function (x) {
-        runTest(x, fields.Release(x.input));
+        runTest(x, new fields.Release(x.input));
     });
 });

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -5,7 +5,6 @@
 
 require('./typeInfo');
 
-const aclass = require('aclass');
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
@@ -24,18 +23,19 @@ const {
     } = require('../relationship-editor/generic');
 const {ReleaseViewModel} = require('../relationship-editor/release');
 
-const FakeRelationship = aclass(Relationship, {
-    loadWorkRelationships: _.noop,
-});
+class FakeRelationship extends Relationship {}
 
-const FakeGenericEntityViewModel = aclass(GenericEntityViewModel, {
-    relationshipClass: FakeRelationship,
-});
+FakeRelationship.prototype.loadWorkRelationships = _.noop;
 
-const FakeReleaseViewModel = aclass(ReleaseViewModel, {
-    loadRelease: _.noop,
-    relationshipClass: FakeRelationship,
-});
+class FakeGenericEntityViewModel extends GenericEntityViewModel {}
+
+FakeGenericEntityViewModel.prototype.relationshipClass = FakeRelationship;
+
+class FakeReleaseViewModel extends ReleaseViewModel {}
+
+FakeReleaseViewModel.prototype.loadRelease = _.noop;
+
+FakeReleaseViewModel.prototype.relationshipClass = FakeRelationship;
 
 var fakeGID0 = "a0ba91b0-c564-4eec-be2e-9ff071a47b59";
 var fakeGID1 = "acb75d59-b0dc-4105-bad6-81ac8c66da4d";
@@ -112,7 +112,7 @@ function id2attr(id) { return { type: MB.attrInfoByID[id] } }
 function ids2attrs(ids) { return _.map(ids, id2attr) }
 
 function setupReleaseRelationshipEditor() {
-    var vm = FakeReleaseViewModel({
+    var vm = new FakeReleaseViewModel({
         sourceData: _.omit(testRelease, "mediums")
     });
 
@@ -359,7 +359,7 @@ relationshipEditorTest("dialog backwardness", function (t) {
 
     _.each(tests, function (test) {
         var options = _.assign({ viewModel: vm }, test.input);
-        var dialog = AddDialog(options);
+        var dialog = new AddDialog(options);
 
         t.equal(dialog.backward(), test.expected.backward)
         t.deepEqual(dialog.relationship().entities(), test.expected.entities);
@@ -376,7 +376,7 @@ relationshipEditorTest("AddDialog", function (t) {
     var source = vm.source.mediums()[0].tracks[0].recording;
     var target = MB.entity({ entityType: "artist", gid: fakeGID0 });
 
-    var dialog = AddDialog({ source: source, target: target, viewModel: vm });
+    var dialog = new AddDialog({ source: source, target: target, viewModel: vm });
     var relationship = dialog.relationship();
 
     relationship.linkTypeID(148);
@@ -396,7 +396,7 @@ relationshipEditorTest("BatchRelationshipDialog", function (t) {
     var target = MB.entity({ entityType: "artist", gid: fakeGID0 });
     var recordings = _.pluck(vm.source.mediums()[0].tracks, "recording");
 
-    var dialog = BatchRelationshipDialog({
+    var dialog = new BatchRelationshipDialog({
         sources: recordings,
         target: target,
         viewModel: vm
@@ -430,7 +430,7 @@ relationshipEditorTest("BatchCreateWorksDialog", function (t) {
 
     var recordings = _.pluck(vm.source.mediums()[0].tracks, "recording");
 
-    var dialog = BatchCreateWorksDialog({
+    var dialog = new BatchCreateWorksDialog({
         sources: recordings, viewModel: vm
     });
 
@@ -467,7 +467,7 @@ relationshipEditorTest("canceling an edit dialog reverts the changes", function 
         attributes: [],
     }, source);
 
-    var dialog = EditDialog({
+    var dialog = new EditDialog({
         relationship: relationship,
         source: source,
         viewModel: vm
@@ -499,7 +499,7 @@ relationshipEditorTest("MBS-5389: added recording-recording relationship appears
     var recording0 = tracks[0].recording;
     var recording1 = tracks[1].recording;
 
-    var dialog = AddDialog({ source: recording1, target: recording0, viewModel: vm });
+    var dialog = new AddDialog({ source: recording1, target: recording0, viewModel: vm });
 
     var relationship = dialog.relationship();
     relationship.linkTypeID(231);
@@ -892,7 +892,7 @@ relationshipEditorTest("attributes are cleared when the target type is changed (
     var relationship = vm.source.relationships()[0];
     t.equal(relationship.attributes().length, 1);
 
-    var dialog = EditDialog({
+    var dialog = new EditDialog({
         relationship: relationship,
         source: vm.source,
         viewModel: vm
@@ -974,7 +974,7 @@ relationshipEditorTest("empty dates are submitted as a hash, not as undef (MBS-8
         verbosePhrase: "{additional} composer",
     };
 
-    var vm = FakeReleaseViewModel({
+    var vm = new FakeReleaseViewModel({
         sourceData: {
             entityType: "release",
             name: "3 Great Piano Sonatas (Wilhelm Backhaus)",

--- a/root/static/scripts/tests/release-editor/actions.js
+++ b/root/static/scripts/tests/release-editor/actions.js
@@ -31,8 +31,8 @@ test("removing a medium should change the medium positions", function (t) {
     var release = common.setupReleaseEdit();
 
     release.mediums.push(
-        fields.Medium(common.testMedium),
-        fields.Medium({ tracks: [], position: 3 })
+        new fields.Medium(common.testMedium),
+        new fields.Medium({ tracks: [], position: 3 })
     );
 
     var mediums = release.mediums();

--- a/root/static/scripts/tests/release-editor/common.js
+++ b/root/static/scripts/tests/release-editor/common.js
@@ -22,7 +22,7 @@ exports.setupReleaseAdd = function (data) {
 
 exports.setupReleaseEdit = function () {
     releaseEditor.action = "edit";
-    var release = fields.Release(exports.testRelease);
+    var release = new fields.Release(exports.testRelease);
     releaseEditor.rootField.release(release);
     return release;
 };

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -88,7 +88,7 @@ dialogTest("switching to the tracklist tab opens the add-disc dialog if there's 
     t.ok(!uiDialog.isOpen(), "add-disc dialog is closed after switching back to the information tab");
 
     release.mediums()[0].tracks.push(
-        fields.Track({ name: "~fooo~", position: 1, length: 12345 })
+        new fields.Track({ name: "~fooo~", position: 1, length: 12345 })
     );
 
     releaseEditor.activeTabID("#information");
@@ -103,7 +103,7 @@ dialogTest("clearing the tracks of an existing medium via the track parser doesn
     var medium = release.mediums()[0];
 
     medium.tracks.push(
-        fields.Track({ name: "~fooo~", position: 1, length: 12345 })
+        new fields.Track({ name: "~fooo~", position: 1, length: 12345 })
     );
 
     t.ok(medium.hasTracks(), "medium has tracks");
@@ -124,7 +124,7 @@ dialogTest("adding a new medium does not cause reorder edits (MBS-7412)", functi
     t.plan(1);
 
     release.mediums([
-        fields.Medium(
+        new fields.Medium(
             _.assign(_.omit(common.testMedium, "id"), { position: 1 })
         )
     ]);

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -141,13 +141,13 @@ addReleaseTest("recordingEdit edits are generated for new mediums (MBS-7271)", f
     };
 
     release.mediums.push(
-        fields.Medium({ tracks: [ trackData ] })
+        new fields.Medium({ tracks: [ trackData ] })
     );
 
     var track = release.mediums()[1].tracks()[0];
     var recordingData = _.extend({ gid: "80f797aa-2077-435d-85e2-c22e31a654f4" }, trackData);
 
-    track.recording(MB.entity.Recording(recordingData));
+    track.recording(new MB.entity.Recording(recordingData));
     track.name("foobar");
 
     var edits = _.filter(releaseEditor.edits.medium(release),
@@ -172,7 +172,7 @@ addReleaseTest("mediumCreate edits are generated for new release", function (t, 
     t.plan(1);
 
     release.mediums.push(
-      fields.Medium(_.omit(common.testMedium, "id"))
+      new fields.Medium(_.omit(common.testMedium, "id"))
     );
 
     t.deepEqual(releaseEditor.edits.medium(release), [
@@ -291,7 +291,7 @@ addReleaseTest("mediumAddDiscID edits are generated for new release", function (
 test("releaseReorderMediums edits are not generated for new releases", function (t) {
     t.plan(1);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         mediums: [
             { position: 1, tracks: [ { name: "foo" } ] },
             { position: 2, tracks: [ { name: "bar" } ] },
@@ -308,7 +308,7 @@ test("releaseReorderMediums edits are not generated for new releases", function 
 test("MBS-7453: release group edits strip whitespace from name", function (t) {
     t.plan(1);
 
-    var release = fields.Release({ name: "  Foo  oo " });
+    var release = new fields.Release({ name: "  Foo  oo " });
 
     t.equal(releaseEditor.edits.releaseGroup(release)[0].name, "Foo oo");
 });
@@ -316,7 +316,7 @@ test("MBS-7453: release group edits strip whitespace from name", function (t) {
 test("releaseGroupCreate edits", function (t) {
     t.plan(1);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         name: "Chocolate Synthesizer",
         artistCredit: common.testArtistCredit,
         releaseGroup: { typeID: 1 }
@@ -413,7 +413,7 @@ editReleaseTest("releaseDeleteReleaseLabel edit is generated when label/catalog 
     t.plan(1);
 
     var releaseLabel = release.labels()[0];
-    releaseLabel.label(MB.entity.Label({}));
+    releaseLabel.label(new MB.entity.Label({}));
     releaseLabel.catalogNumber("");
 
     t.deepEqual(releaseEditor.edits.releaseLabel(release), [
@@ -677,7 +677,7 @@ editReleaseTest("releaseGroupEdit edits should not include unchanged fields (MBS
 test("mediumEdit and releaseReorderMediums edits are generated for non-loaded mediums", function (t) {
     t.plan(6);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         gid: "f4c552ab-515e-42df-a9ee-a370867d29d1",
         mediums: [
             { id: 123, name: "foo", position: 1 },
@@ -745,7 +745,7 @@ test("mediumEdit and releaseReorderMediums edits are generated for non-loaded me
 test("mediumCreate edits are not given conflicting positions", function (t) {
     t.plan(2);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         gid: "f4c552ab-515e-42df-a9ee-a370867d29d1",
         mediums: [
             { id: 123, position: 1 },
@@ -761,19 +761,19 @@ test("mediumCreate edits are not given conflicting positions", function (t) {
 
     medium1.position(4);
 
-    var newMedium1 = fields.Medium({
+    var newMedium1 = new fields.Medium({
         name: "foo",
         position: 1
     });
 
-    newMedium1.tracks.push(fields.Track({}, newMedium1));
+    newMedium1.tracks.push(new fields.Track({}, newMedium1));
 
-    var newMedium2 = fields.Medium({
+    var newMedium2 = new fields.Medium({
         name: "bar",
         position: 2
     });
 
-    newMedium2.tracks.push(fields.Track({}, newMedium2));
+    newMedium2.tracks.push(new fields.Track({}, newMedium2));
     mediums.push(newMedium1, newMedium2);
 
     var mediumCreateEdits = _.map(
@@ -827,7 +827,7 @@ test("mediumCreate edits are not given conflicting positions", function (t) {
 test("mediumCreate positions don't conflict with removed mediums (MBS-7952)", function (t) {
     t.plan(1);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         gid: "f4c552ab-515e-42df-a9ee-a370867d29d1",
         mediums: [{ id: 123, position: 1 }]
     });
@@ -835,9 +835,9 @@ test("mediumCreate positions don't conflict with removed mediums (MBS-7952)", fu
     releaseEditor.rootField.release(release);
 
     var mediums = release.mediums;
-    var newMedium = fields.Medium({ position: 2 });
+    var newMedium = new fields.Medium({ position: 2 });
 
-    newMedium.tracks.push(fields.Track({}, newMedium));
+    newMedium.tracks.push(new fields.Track({}, newMedium));
     mediums.push(newMedium);
     releaseEditor.removeMedium(mediums()[0]);
     common.createMediums(release);
@@ -866,7 +866,7 @@ test("mediumCreate positions don't conflict with removed mediums (MBS-7952)", fu
 test("releaseDeleteReleaseLabel edits are not generated for non-existent release labels (MBS-7455)", function (t) {
     t.plan(1);
 
-    var release = fields.Release({
+    var release = new fields.Release({
         gid: "f4c552ab-515e-42df-a9ee-a370867d29d1",
         labels: [
             { id: 123, label: null, catalogNumber: "foo123" },

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -50,12 +50,12 @@ fieldTest("mediums having their \"loaded\" observable set correctly", function (
     var mediums = release.mediums;
 
     mediums([
-        fields.Medium({ tracks: [] }),
-        fields.Medium({ tracks: [ {} ] }),
-        fields.Medium({ id: 1, tracks: [] }),
-        fields.Medium({ originalID: 1, tracks: [] }),
-        fields.Medium({ id: 1, tracks: [ {} ] }),
-        fields.Medium({ originalID: 1, tracks: [ {} ] })
+        new fields.Medium({ tracks: [] }),
+        new fields.Medium({ tracks: [ {} ] }),
+        new fields.Medium({ id: 1, tracks: [] }),
+        new fields.Medium({ originalID: 1, tracks: [] }),
+        new fields.Medium({ id: 1, tracks: [ {} ] }),
+        new fields.Medium({ originalID: 1, tracks: [ {} ] })
     ]);
 
     t.equal(mediums()[0].loaded(), true, "medium without id or tracks is considered loaded");
@@ -70,7 +70,7 @@ fieldTest("mediums having their \"loaded\" observable set correctly", function (
 fieldTest("loading a medium doesn't overwrite its original edit data", function (t, release) {
     t.plan(11);
 
-    var medium = fields.Medium({
+    var medium = new fields.Medium({
         id: 123,
         position: 1,
         formatID: 1,
@@ -114,7 +114,7 @@ fieldTest("loading a medium doesn't overwrite its original edit data", function 
 fieldTest("data tracks are appended with a correct position if there's a pregap (MBS-8013)", function (t, release) {
     t.plan(1);
 
-    var medium = fields.Medium({ tracks: [] }, release);
+    var medium = new fields.Medium({ tracks: [] }, release);
     medium.hasPregap(true);
     medium.hasDataTracks(true);
 
@@ -151,7 +151,7 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
         { length: 737000, position: 5 }
     ];
 
-    var medium = fields.Medium({ tracks: [] }, release);
+    var medium = new fields.Medium({ tracks: [] }, release);
 
     // 7 tracks added
     medium.toc(toc1);

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -160,7 +160,7 @@ parserTest("internal track positions are updated appropriately after being reuse
     });
 
     var re = releaseEditor;
-    releaseEditor.rootField.release(fields.Release(common.testRelease));
+    releaseEditor.rootField.release(new fields.Release(common.testRelease));
 
     var release = releaseEditor.rootField.release();
     var medium = release.mediums()[0];
@@ -182,7 +182,7 @@ parserTest("MBS-7451: track parser can clear TOC track lengths", function (t) {
     t.plan(1);
 
     var re = releaseEditor;
-    releaseEditor.rootField.release(fields.Release(common.testRelease));
+    releaseEditor.rootField.release(new fields.Release(common.testRelease));
 
     var release = releaseEditor.rootField.release();
     var medium = release.mediums()[0];
@@ -226,7 +226,7 @@ parserTest("MBS-7456: Failing to parse artists does not break track autocomplete
         useTrackArtists: true
     });
 
-    var release = fields.Release({
+    var release = new fields.Release({
         mediums: [{
             tracks: [{
                 name: "foo"
@@ -261,7 +261,7 @@ parserTest("can parse only numbers, titles, artists, or lengths (MBS-3730, MBS-3
         useTrackNumbers: true
     });
 
-    var release = fields.Release({
+    var release = new fields.Release({
         mediums: [{
             tracks: [{
                 number: "1",
@@ -338,7 +338,7 @@ parserTest("Does not lose previous recordings (MBS-7719)", function (t) {
         useTrackNames: true
     });
 
-    var release = fields.Release({
+    var release = new fields.Release({
         mediums: [
             {
                 tracks: [
@@ -430,7 +430,7 @@ parserTest("parses track times for data tracks if there's a disc ID (MBS-8409)",
     var trackParser = releaseEditor.trackParser;
     _.assign(trackParser.options, {useTrackLengths: true});
 
-    var release = fields.Release({
+    var release = new fields.Release({
         id: 1,
         mediums: [
             {
@@ -471,7 +471,7 @@ parserTest("data track boundary is unchanged if the track count is >= the previo
     var trackParser = releaseEditor.trackParser;
     trackParser.options.useTrackNames = true;
 
-    var release = fields.Release({
+    var release = new fields.Release({
         id: 1,
         mediums: [
             {
@@ -506,7 +506,7 @@ parserTest("force number of tracks to equal CD TOC", function (t) {
 
     trackParser.options.useTrackNames = true;
 
-    var release = fields.Release({
+    var release = new fields.Release({
         id: 1,
         mediums: [
             {

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -3,7 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const aclass = require('aclass');
 const _ = require('lodash');
 const test = require('tape');
 
@@ -15,13 +14,13 @@ require('../../release-editor/init');
 
 function validationTest(name, callback) {
     test(name, function (t) {
-        const Release = fields.Release;
-        fields.Release = aclass(Release, {loadMedia: _.noop});
+        const loadMedia = fields.Release.prototype.loadMedia;
+        fields.Release.prototype.loadMedia = _.noop;
 
         callback(t);
 
         validation.errorFields([]);
-        fields.Release = Release;
+        fields.Release.prototype.loadMedia = loadMedia;
     });
 }
 

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -7,8 +7,9 @@ require('./jquery.flot.musicbrainz_events');
 
 MB.Timeline = {};
 
-MB.Timeline.TimelineViewModel = aclass({
-    init: function (initialLines) {
+class TimelineViewModel {
+
+    constructor(initialLines) {
         var self = this;
         self.categories = ko.observableArray([]);
         self.enabledCategories = ko.computed(function () {
@@ -153,9 +154,9 @@ MB.Timeline.TimelineViewModel = aclass({
             },
             disposeWhen: self.loadedEvents
         });
-    },
+    }
 
-    _getLocationHashSettings: function () {
+    _getLocationHashSettings() {
         // XXX: reset to defaults when preference is not expressed
         var parts = _.filter(location.hash.replace(/^#/, '').split('+'));
         var self = this;
@@ -178,31 +179,31 @@ MB.Timeline.TimelineViewModel = aclass({
                 if (line) { line.enabled(!(match[1] === '-')) }
             }
         });
-    },
+    }
 
-    addCategory: function(category) {
+    addCategory(category) {
         this.categories.push(category);
         return category
-    },
+    }
 
-    addLine: function(name) {
+    addLine(name) {
         var newLine = MB.text.Timeline.Stat(name)
         var category = _.find(this.categories(), { name: newLine.Category });
 
         if (!category) {
             var newCategory = MB.text.Timeline.Category[newLine.Category];
-            category = this.addCategory(MB.Timeline.TimelineCategory(newLine.Category, newCategory.Label, !newCategory.Hide));
+            category = this.addCategory(new TimelineCategory(newLine.Category, newCategory.Label, !newCategory.Hide));
         }
 
-        category.addLine(MB.Timeline.TimelineLine(name, newLine.Label, newLine.Color, !newLine.Hide));
-    },
+        category.addLine(new TimelineLine(name, newLine.Label, newLine.Color, !newLine.Hide));
+    }
 
-    addLines: function(names) {
+    addLines(names) {
         var self = this;
         _.forEach(names, function (name) { self.addLine(name) });
-    },
+    }
 
-    loadEvents: function () {
+    loadEvents() {
         var self = this;
         self.loadingEvents(true);
         $.ajax({
@@ -220,10 +221,11 @@ MB.Timeline.TimelineViewModel = aclass({
             self.loadingEvents(false);
         });
     }
-});
+}
 
-MB.Timeline.TimelineCategory = aclass({
-    init: function(name, label, enabledByDefault) {
+class TimelineCategory {
+
+    constructor(name, label, enabledByDefault) {
         var self = this;
         if (enabledByDefault === undefined) {
             enabledByDefault = false;
@@ -252,12 +254,14 @@ MB.Timeline.TimelineCategory = aclass({
         debounce(function () {
             _.forEach(self.needLoadingLines(), function (line) { line.loadData() });
         }, 1);
-    },
-    addLine: function(line) { this.lines.push(line); }
-});
+    }
 
-MB.Timeline.TimelineLine = aclass({
-    init: function(name, label, color, enabledByDefault) {
+    addLine(line) { this.lines.push(line); }
+}
+
+class TimelineLine {
+
+    constructor(name, label, color, enabledByDefault) {
         var self = this;
         if (enabledByDefault === undefined) {
             enabledByDefault = false;
@@ -274,8 +278,9 @@ MB.Timeline.TimelineLine = aclass({
         self.rateData = ko.computed(function () {
             return self.calculateRateData(self.data());
         });
-    },
-    loadData: function () {
+    }
+
+    loadData () {
         var self = this;
         self.loading(true);
         $.ajax({
@@ -289,8 +294,9 @@ MB.Timeline.TimelineLine = aclass({
         }).always(function () {
             self.loading(false);
         });
-    },
-    calculateRateData: function (data) {
+    }
+
+    calculateRateData (data) {
         if (!data || !data.length) { return {data: [], thresholds: {min: null, max: null}}; }
         var weekData = [];
         var oneDay = 1000 * 60 * 60 * 24;
@@ -333,8 +339,9 @@ MB.Timeline.TimelineLine = aclass({
                           max: mean + 3 * standardDeviation};
 
         return {data: weekData, thresholds: thresholds};
-    },
-    calculateRateBounds: function(data, thresholds, dateThresholds) {
+    }
+
+    calculateRateBounds(data, thresholds, dateThresholds) {
         var rateBounds = {min: thresholds.max, max: thresholds.min};
         $.each(data, function (index, value) {
                 if (value[1] > thresholds.min &&
@@ -355,7 +362,9 @@ MB.Timeline.TimelineLine = aclass({
         }
         return rateBounds;
     }
-});
+}
+
+MB.Timeline.TimelineViewModel = TimelineViewModel;
 
 (function () {
     // Closure over utility functions.

--- a/root/statistics/timeline.tt
+++ b/root/statistics/timeline.tt
@@ -59,7 +59,7 @@
 <script type="text/javascript">
   $(function () {
     ko.applyBindings(
-      MB.Timeline.TimelineViewModel([
+      new MB.Timeline.TimelineViewModel([
         [%~ FOREACH dataset_key = stats ~%]
           "[%- dataset_key -%]"[%~ IF NOT loop.last() ~%],[%~ END ~%]
         [%~ END ~%]


### PR DESCRIPTION
Replaces aclass with standard ES6 classes. The major change involved in doing this was adding `new` to all the instantiations.