### PR TITLE
MBS-9353: Fix RequireAuth attributes for user profile and collection

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -14,7 +14,7 @@ with 'MusicBrainz::Server::Controller::Role::Subscribe';
 use MusicBrainz::Server::Data::Utils qw( model_to_type type_to_model load_everything_for_edits );
 use MusicBrainz::Server::Constants qw( :edit_status entities_with %ENTITIES );
 
-sub base : Chained('/') PathPart('collection') CaptureArgs(0) RequireAuth { }
+sub base : Chained('/') PathPart('collection') CaptureArgs(0) { }
 
 after 'load' => sub {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -71,7 +71,7 @@ sub remove : Chained('own_collection') RequireAuth {
     $self->_do_add_or_remove($c, 'remove_entities_from_collection');
 }
 
-sub show : Chained('load') PathPart('') {
+sub show : Chained('load') PathPart('') RequireAuth {
     my ($self, $c) = @_;
 
     my $collection = $c->stash->{collection};

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -303,7 +303,7 @@ sub contact : Chained('load') RequireAuth HiddenOnSlaves
     }
 }
 
-sub collections : Chained('load') PathPart('collections')
+sub collections : Chained('load') PathPart('collections') RequireAuth
 {
     my ($self, $c) = @_;
 
@@ -331,7 +331,7 @@ sub collections : Chained('load') PathPart('collections')
     $c->stash(user => $user, no_collections => $no_collections);
 }
 
-sub profile : Chained('load') PathPart('') HiddenOnSlaves
+sub profile : Chained('load') PathPart('') RequireAuth HiddenOnSlaves
 {
     my ($self, $c) = @_;
 
@@ -353,7 +353,7 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     );
 }
 
-sub rating_summary : Chained('load') PathPart('ratings') Args(0) HiddenOnSlaves
+sub rating_summary : Chained('load') PathPart('ratings') Args(0) RequireAuth HiddenOnSlaves
 {
     my ($self, $c) = @_;
 
@@ -376,7 +376,7 @@ sub rating_summary : Chained('load') PathPart('ratings') Args(0) HiddenOnSlaves
     );
 }
 
-sub ratings : Chained('load') PathPart('ratings') Args(1) HiddenOnSlaves
+sub ratings : Chained('load') PathPart('ratings') Args(1) RequireAuth HiddenOnSlaves
 {
     my ($self, $c, $type) = @_;
 
@@ -411,7 +411,7 @@ sub ratings : Chained('load') PathPart('ratings') Args(1) HiddenOnSlaves
     );
 }
 
-sub tags : Chained('load') PathPart('tags')
+sub tags : Chained('load') PathPart('tags') RequireAuth
 {
     my ($self, $c) = @_;
 
@@ -434,7 +434,7 @@ sub tags : Chained('load') PathPart('tags')
     );
 }
 
-sub tag : Chained('load') PathPart('tag') Args(1)
+sub tag : Chained('load') PathPart('tag') Args(1) RequireAuth
 {
     my ($self, $c, $tag_name) = @_;
     my $user = $c->stash->{user};

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -216,7 +216,7 @@ sub _renew_login_cookie
     };
 }
 
-sub base : Chained PathPart('user') CaptureArgs(0) RequireAuth HiddenOnSlaves { }
+sub base : Chained PathPart('user') CaptureArgs(0) HiddenOnSlaves { }
 
 sub _load
 {

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -84,11 +84,11 @@ EOSQL
 
     $mech->get_ok('/user/ocharles%2Fbot');
     html_ok($mech->content);
-    $mech->content_contains('ocharles/bot');
-    $mech->follow_link_ok({ url_regex => qr{/login} });
+    $mech->content_contains('You need to be logged in to view this page');
     $mech->submit_form(
         with_fields => { username => 'ocharles/bot', password => 'mb' }
     );
+    $mech->content_contains('ocharles/bot');
     like($mech->uri->path, qr{/user/ocharles%2Fbot});
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Ratings.pm
@@ -19,17 +19,17 @@ TRUNCATE artist_rating_raw CASCADE;
 INSERT INTO artist_rating_raw (artist, editor, rating) VALUES (7, 1, 80);
 ");
 
-$mech->get('/user/new_editor/ratings');
-$mech->content_contains('Kate Bush', "new_editor has rated Kate Bush");
-
 $mech->get('/user/alice/ratings');
-is ($mech->status(), 403, "alice' ratings are private");
+$mech->content_contains('You need to be logged in to view this page.', "user ratings require login");
 
 $mech->get('/login');
 $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
 $mech->get('/user/alice/ratings');
 is ($mech->status(), 403, "alice' ratings are still private");
+
+$mech->get('/user/new_editor/ratings');
+$mech->content_contains('Kate Bush', "new_editor has rated Kate Bush");
 
 $mech->get('/logout');
 $mech->get('/login');

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
@@ -13,14 +13,24 @@ my $c    = $test->c;
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
 
-$mech->get('/user/new_editor');
-$mech->content_contains('Collection', "Collection tab appears on profile of user");
+$mech->get('/user/alice');
+$mech->content_contains('You need to be logged in to view this page.', "user profile requires login");
 
 $mech->get('/login');
 $mech->submit_form( with_fields => { username => 'alice', password => 'secret1' } );
 
+$mech->get('/user/new_editor');
+$mech->content_contains('Collection', "Collection tab appears on profile of user");
+
 $mech->get('/user/alice');
 $mech->content_contains('Collection', "Collection tab appears on own profile, even if marked private");
+
+$mech->get('/logout');
+$mech->get('/login');
+$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+$mech->get('/user/alice');
+$mech->content_contains('Collection', "Collection tab doesn't appear on profile if marked private");
 
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Tags.pm
@@ -19,11 +19,8 @@ test all => sub {
     INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (7, 1, 1, 't');
 EOSQL
 
-    $mech->get('/user/new_editor/tags');
-    $mech->content_contains('not a musical', "new_editor has used the tag 'not a musical'");
-
     $mech->get('/user/alice/tags');
-    is($mech->status, 403, "alice' tags are private");
+    $mech->content_contains('You need to be logged in to view this page.', "user tags require login");
 
     $mech->get('/login');
     $mech->submit_form(with_fields => { username => 'new_editor', password => 'password' });
@@ -38,6 +35,9 @@ EOSQL
     $mech->get('/user/alice/tags');
     is($mech->status, 200, "alice can view her own tags");
     $mech->content_contains('Alice has not tagged anything', "alice has not tagged anything");
+
+    $mech->get('/user/new_editor/tags');
+    $mech->content_contains('not a musical', "new_editor has used the tag 'not a musical'");
 };
 
 1;


### PR DESCRIPTION
[MBS-9353](https://tickets.metabrainz.org/browse/MBS-9353): Do not show collections or user profiles to people not logged in

Set `RequireAuth` attribute to every subroutine of Collection & User rather than `base` subroutine.