### PR TITLE
MBS-9416: Handle new Wikidata URL format redirect

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1022,7 +1022,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?([^/]+\\.)?wikidata\\.org","i")],
     type: LINK_TYPES.wikidata,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/(?:wiki|entity)\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?wikidata\.org\/(?:wiki(?:\/Special:EntityPage)?|entity)\/(Q([0-9]+)).*$/, "https://www.wikidata.org/wiki/$1");
     },
     validate: function (url, id) {
       return /^https:\/\/www\.wikidata\.org\/wiki\/Q[1-9][0-9]*$/.test(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2431,6 +2431,12 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                     expected_clean_url: 'https://www.wikidata.org/wiki/Q14005',
         },
         {
+                             input_url: 'https://www.wikidata.org/wiki/Special:EntityPage/Q339359',
+                     input_entity_type: 'instrument',
+                    expected_clean_url: 'https://www.wikidata.org/wiki/Q339359',
+            expected_relationship_type: 'wikidata',
+        },
+        {
                              input_url: 'http://www.wikidata.org/entity/Q4655955',
                      input_entity_type: 'artist',
                     expected_clean_url: 'https://www.wikidata.org/wiki/Q4655955',


### PR DESCRIPTION
# [MBS-9416](https://tickets.metabrainz.org/browse/MBS-9416): wikidata url format redirect addition

Clean the new format of Wikidata URLs found in Wikipedia pages, for example,
from https://www.wikidata.org/wiki/Special:EntityPage/Q339359
to https://www.wikidata.org/wiki/Q339359