### PR TITLE
MBS-9435: Update URL Cleanup for Rock.com.ar 2017 Relaunch

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1472,10 +1472,25 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?(www\\.)?rock\\.com\\.ar", "i")],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?rock\.com\.ar\/([^#]+)(?:#.*)?$/, "http://rock.com.ar/$1");
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rock\.com\.ar\/([^#]+)(?:#.*)?$/, "http://rock.com.ar/$1");
+      url = url.replace(/^(http:\/\/rock\.com\.ar\/artistas\/[1-9][0-9]*)\/(?:[a-z]*|fotos\/[1-9][0-9]*)?$/, "$1");
+      return url;
     },
     validate: function (url, id) {
-      var m = /^http:\/\/rock\.com\.ar\/(?:(bios|discos|letras)(?:\/[0-9]+){2}\.shtml|(artistas)\/.+)$/.exec(url);
+      var m = /^http:\/\/rock\.com\.ar\/artistas\/[1-9][0-9]*(?:\/(discos|letras)\/[1-9][0-9]*)?$/.exec(url);
+      if (m) {
+        var subsection = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return !subsection;
+          case LINK_TYPES.otherdatabases.release_group:
+            return subsection === 'discos';
+          case LINK_TYPES.otherdatabases.work:
+            return subsection === 'letras';
+        }
+      }
+      // Keep validating URLs from before Rock.com.ar 2017 relaunch
+      m = /^http:\/\/rock\.com\.ar\/(?:(bios|discos|letras)(?:\/[0-9]+){2}\.shtml|(artistas)\/.+)$/.exec(url);
       if (m) {
         var prefix = m[1] || m[2];
         switch (id) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1472,10 +1472,10 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?(www\\.)?rock\\.com\\.ar", "i")],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?rock\.com\.ar\/([^#]+)(?:#.*)?$/, "http://www.rock.com.ar/$1");
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?rock\.com\.ar\/([^#]+)(?:#.*)?$/, "http://rock.com.ar/$1");
     },
     validate: function (url, id) {
-      var m = /^http:\/\/www\.rock\.com\.ar\/(?:(bios|discos|letras)(?:\/[0-9]+){2}\.shtml|(artistas)\/.+)$/.exec(url);
+      var m = /^http:\/\/rock\.com\.ar\/(?:(bios|discos|letras)(?:\/[0-9]+){2}\.shtml|(artistas)\/.+)$/.exec(url);
       if (m) {
         var prefix = m[1] || m[2];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1805,6 +1805,49 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
         },
         // Rock.com.ar
         {
+                             input_url: 'http://rock.com.ar/artistas/200',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/200',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://rock.com.ar/artistas/168/biografia',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/168',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://rock.com.ar/artistas/239/fotos/13',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/239',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'rock.com.ar/artistas/11752/discos/10703',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/11752/discos/10703',
+               only_valid_entity_types: ['release_group']
+        },
+        {
+                             input_url: 'rock.com.ar/artistas/11752/discos',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/11752',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'www.rock.com.ar/artistas/11752/letras/19898',
+                     input_entity_type: 'recording',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://rock.com.ar/artistas/11752/letras/19898',
+               only_valid_entity_types: ['work']
+        },
+        // Rock.com.ar (from before its 2017 relaunch)
+        {
                              input_url: 'http://www.rock.com.ar/artistas/soda-stereo#contenedor',
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1805,10 +1805,10 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
         },
         // Rock.com.ar
         {
-                             input_url: 'http://www.rock.com.ar/artistas/soda-stero#contenedor',
+                             input_url: 'http://www.rock.com.ar/artistas/soda-stereo#contenedor',
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
-                    expected_clean_url: 'http://www.rock.com.ar/artistas/soda-stero',
+                    expected_clean_url: 'http://www.rock.com.ar/artistas/soda-stereo',
                only_valid_entity_types: ['artist']
         },
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1808,14 +1808,14 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'http://www.rock.com.ar/artistas/soda-stereo#contenedor',
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
-                    expected_clean_url: 'http://www.rock.com.ar/artistas/soda-stereo',
+                    expected_clean_url: 'http://rock.com.ar/artistas/soda-stereo',
                only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://www.rock.com.ar/bios/0/168.shtml',
                      input_entity_type: 'artist',
             expected_relationship_type: 'otherdatabases',
-                    expected_clean_url: 'http://www.rock.com.ar/bios/0/168.shtml',
+                    expected_clean_url: 'http://rock.com.ar/bios/0/168.shtml',
                only_valid_entity_types: ['artist']
         },
         {
@@ -1828,14 +1828,14 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'www.rock.com.ar/discos/10/10703.shtml',
                      input_entity_type: 'release',
             expected_relationship_type: 'otherdatabases',
-                    expected_clean_url: 'http://www.rock.com.ar/discos/10/10703.shtml',
+                    expected_clean_url: 'http://rock.com.ar/discos/10/10703.shtml',
                only_valid_entity_types: ['release_group']
         },
         {
                              input_url: 'rock.com.ar/letras/19/19898.shtml',
                      input_entity_type: 'recording',
             expected_relationship_type: 'otherdatabases',
-                    expected_clean_url: 'http://www.rock.com.ar/letras/19/19898.shtml',
+                    expected_clean_url: 'http://rock.com.ar/letras/19/19898.shtml',
                only_valid_entity_types: ['work']
         },
         // Rockens Danmarkskort


### PR DESCRIPTION
## [MBS-9435](https://tickets.metabrainz.org/browse/MBS-9435): Update Rock.com.ar URL format

Rock.com.ar’s URL format has been revamped for its relaunch in 2017.
- Domain name now defaults to `rock.com.ar` (`www` subdomain is a redirect).
- Validate paths starting with `/artistas/<ID>` as well as sub-paths `/discos/<ID>` and `/letras/<ID>`
- Worthless sub-paths `/`, `/biografia`, `/discos`, `/fotos`, `/fotos/*`, `/letras are removed

Old format URLs, properly redirected, are still recognized, cleaned and validated.