### PR TITLE
MBS-9455: Show orderable relationship attributes absent grouping

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -237,11 +237,7 @@ sub _interpolate {
     foreach my $attr (@attrs) {
         my $name = lc $attr->type->root->name;
 
-        if (exists $attrs{$name}) {
-            push @{$attrs{$name}}, $attr->html;
-        } else {
-            $attrs{$name} = [ $attr->html ];
-        }
+        push @{$attrs{$name}}, $attr->html;
     }
     my %extra_attrs = %attrs;
 

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -219,6 +219,15 @@ sub _build_verbose_phrase {
     $self->_interpolate($self->link->type->l_long_link_phrase);
 }
 
+=method _build_grouping_phrase
+
+For ordered relationships (such as those in a series), builds a phrase with
+attributes removed, so that these relationships can remain grouped together
+under the same phrase in our relationships display, even if their attributes
+differ.
+
+=cut
+
 sub _build_grouping_phrase {
     my ($self) = @_;
     $self->_interpolate(
@@ -241,9 +250,12 @@ sub _interpolate {
     }
     my %extra_attrs = %attrs;
 
-    # Ordered relationships in a series should all share the same link phrase,
-    # even if their attributes differ, so that they remain grouped together
-    # in the relationships display.
+    # In order to keep relationships grouped together under the same link
+    # phrase, set %attrs (which contains the replacement values) to (). Now,
+    # all attributes will be replaced with the empty string in the phrase,
+    # and moved to @extra_attrs so that they can appear in a comma-separated
+    # list after the relationship target link. (Normally, @extra_attrs only
+    # contains attributes which don't appear in the phrase at all.)
     %attrs = () if $for_grouping;
 
     my $replace_attrs = sub {

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -80,6 +80,12 @@ has '_verbose_phrase' => (
     lazy => 1
 );
 
+has '_grouping_phrase' => (
+    is => 'ro',
+    builder => '_build_grouping_phrase',
+    lazy => 1,
+);
+
 sub entity_is_orderable {
     my ($self, $entity) = @_;
 
@@ -195,6 +201,10 @@ sub extra_verbose_phrase_attributes
     return $self->_verbose_phrase->[1];
 }
 
+sub grouping_phrase { shift->_grouping_phrase->[0] }
+
+sub extra_grouping_phrase_attributes { shift->_grouping_phrase->[1] }
+
 sub _build_phrase {
     my ($self) = @_;
     $self->_interpolate(
@@ -209,8 +219,18 @@ sub _build_verbose_phrase {
     $self->_interpolate($self->link->type->l_long_link_phrase);
 }
 
+sub _build_grouping_phrase {
+    my ($self) = @_;
+    $self->_interpolate(
+        ($self->direction == $DIRECTION_FORWARD
+            ? $self->link->type->l_link_phrase
+            : $self->link->type->l_reverse_link_phrase),
+        ($self->link->type->orderable_direction > 0),
+    );
+}
+
 sub _interpolate {
-    my ($self, $phrase) = @_;
+    my ($self, $phrase, $for_grouping) = @_;
 
     my @attrs = $self->link->all_attributes;
     my %attrs;
@@ -224,12 +244,11 @@ sub _interpolate {
         }
     }
     my %extra_attrs = %attrs;
-    my $type_is_orderable = $self->link->type->orderable_direction > 0;
 
     # Ordered relationships in a series should all share the same link phrase,
     # even if their attributes differ, so that they remain grouped together
     # in the relationships display.
-    %attrs = () if $type_is_orderable;
+    %attrs = () if $for_grouping;
 
     my $replace_attrs = sub {
         my ($name, $alt) = @_;
@@ -237,7 +256,7 @@ sub _interpolate {
         # placeholders for entity names which are processed elsewhere
         return "{$name}" if $name eq "entity0" || $name eq "entity1";
 
-        delete $extra_attrs{$name} unless $type_is_orderable;
+        delete $extra_attrs{$name} unless $for_grouping;
         if (!$alt) {
             return '' unless exists $attrs{$name};
             return comma_list(@{ $attrs{$name} });

--- a/lib/MusicBrainz/Server/Entity/Role/Linkable.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Linkable.pm
@@ -36,7 +36,7 @@ sub grouped_relationships
     for my $relationship (@relationships) {
         next if ($filter_present && !$filter{ $relationship->target_type });
 
-        my $phrase = $relationship->phrase;
+        my $phrase = $relationship->grouping_phrase;
         if ($relationship->source_credit) {
             $phrase = l('{role} (as {credited_name})', {
                 role => $phrase,

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -932,14 +932,14 @@ END ~%]
   [%- END -%]
 [%- END -%]
 
-[%~ MACRO relationship_target_links(rel) BLOCK;
+[%~ MACRO relationship_target_links(rel, for_grouping) BLOCK;
     '<span class="mp mp-rel">' IF rel.edits_pending;
     IF rel.target.artist_credit AND rel.target.artist_credit.name == hide_ac;
         link_entity(rel.target, 'show', '', rel.target_credit);
     ELSE;
         descriptive_link(rel.target, rel.target_credit);
     END;
-    bracketed(rel.extra_phrase_attributes);
+    bracketed(for_grouping ? rel.extra_grouping_phrase_attributes : rel.extra_phrase_attributes);
     bracketed(rel.link.formatted_date);
     '</span>' IF rel.edits_pending;
 END ~%]

--- a/root/components/medium.tt
+++ b/root/components/medium.tt
@@ -1,27 +1,39 @@
 [%~ MACRO grouped_relationships(source) BLOCK ~%]
+  [%- has_work_relationships = 0 %]
   [%- FOR target_type_group=source.grouped_relationships.pairs %]
-    [%- NEXT IF target_type_group.key == 'url' %]
+    [%- IF target_type_group.key == 'work';
+          has_work_relationships = 1;
+          NEXT;
+        END;
+        NEXT IF target_type_group.key == 'url' %]
     <dl class="ars">
       [%- FOR link_type_group=target_type_group.value.pairs %]
-        [%- IF target_type_group.key == 'work' %]
-          [%- FOR relationship IN link_type_group.value %]
-            [%- work = relationship.target %]
-            <dt>[% add_colon(link_type_group.key) %]</dt>
-            <dd>
-              [%- link_entity(work) %]
-              [%- bracketed(relationship.link.formatted_date) %]
-              [%- grouped_relationships(work) %]
-            </dd>
-          [%- END %]
-        [%- ELSE %]
-          <dt>[% add_colon(link_type_group.key) %]</dt>
-          [%- links = [] %]
-          [%- FOR relationship IN link_type_group.value %]
-            [% links.push(relationship_target_links(relationship)) %]
-          [%- END %]
-          <dd>[% comma_list(links) %]</dd>
+        <dt>[% add_colon(link_type_group.key) %]</dt>
+        [%- links = [] %]
+        [%- FOR relationship IN link_type_group.value %]
+          [% links.push(relationship_target_links(relationship)) %]
         [%- END %]
+        <dd>[% comma_list(links) %]</dd>
       [%- END %]
+    </dl>
+  [%- END %]
+  [%# Work relationships are not grouped together on a single line, because
+      we have to output the relationships of the work under its parent
+      recording-work relationship. So it's intentional that we use
+      relationship.phrase instead of relationship.grouping_phrase here. %]
+  [%- IF has_work_relationships %]
+    <dl class="ars">
+    [%- FOR relationship=source.relationships %]
+      [%- IF relationship.target_type == 'work' %]
+        [%- work = relationship.target %]
+        <dt>[% add_colon(relationship.phrase) %]</dt>
+        <dd>
+          [%- link_entity(work) %]
+          [%- bracketed(relationship.link.formatted_date) %]
+          [%- grouped_relationships(work) %]
+        </dd>
+      [%- END %]
+    [%- END %]
     </dl>
   [%- END %]
 [%~ END ~%]

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -185,7 +185,7 @@
       [% bracketed(l('ended')) | html %]
     <!-- /ko -->
   <!-- /ko -->
-  <!-- ko with: relationship.phraseAndExtraAttributes()[2] -->
+  <!-- ko with: relationship.phraseAndExtraAttributes()[2 + (forGrouping ? 3 : 0)] -->
     (<!-- ko text: $data --><!-- /ko -->)
   <!-- /ko -->
 </script>

--- a/root/components/relationships.tt
+++ b/root/components/relationships.tt
@@ -13,9 +13,9 @@
               <td>
                   [% FOR rel IN relationship.value %]
                       [% IF relationship.value.size > 1 && rel.link_order && rel.entity_is_orderable(rel.target) %]
-                        [% l('{num}. {relationship}', { num => rel.link_order, relationship => relationship_target_links(rel) }) %]
+                        [% l('{num}. {relationship}', { num => rel.link_order, relationship => relationship_target_links(rel, 1) }) %]
                       [% ELSE %]
-                        [% relationship_target_links(rel) %]
+                        [% relationship_target_links(rel, 1) %]
                       [% END %]
                       <br />
                   [% END %]

--- a/root/forms/relationship-editor.tt
+++ b/root/forms/relationship-editor.tt
@@ -48,7 +48,7 @@
             <!-- /ko -->
             <!-- ko template: {
                       name: "template.extra-attributes-and-dates",
-                      data: { source: $parent, relationship: $data }
+                      data: { source: $parent, relationship: $data, forGrouping: $data.hasOrderableLinkType() }
                     } --><!-- /ko -->
           </div>
         </td>

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -189,7 +189,7 @@
                            css: { 'rel-edit': editsPending }"></span>
           <!-- ko template: {
                     name: "template.extra-attributes-and-dates",
-                    data: { source: $parents, relationship: $data }
+                    data: { source: $parents, relationship: $data, forGrouping: false }
                   }
             --><!-- /ko -->
         </div>

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -34,21 +34,16 @@ exports.clean = _.memoize(function (linkType, backward) {
     }));
 }, (a, b) => a + String(b));
 
-exports.interpolate = function (linkType, attributes) {
-    var typeInfo = MB.typeInfoByID[linkType];
-
+exports.interpolate = function (typeInfo, attributes) {
     if (!typeInfo) {
         return ['', '', ''];
     }
 
     var phrase = typeInfo.phrase;
     var reversePhrase = typeInfo.reversePhrase;
-
-    if (typeInfo.orderableDirection > 0) {
-        phrase = exports.clean(typeInfo.id, false);
-        reversePhrase = exports.clean(typeInfo.id, true);
-    }
-
+    var cleanPhrase = '';
+    var cleanReversePhrase = '';
+    var cleanExtraAttributes;
     var attributesByName = {};
     var usedAttributes = [];
 
@@ -89,9 +84,23 @@ exports.interpolate = function (linkType, attributes) {
         return replacement;
     }
 
+    phrase = clean(phrase.replace(attributeRegex, interpolate));
+    reversePhrase = clean(reversePhrase.replace(attributeRegex, interpolate));
+    const extraAttributes = commaOnlyList(_(attributesByName).omit(usedAttributes).values().flatten().value());
+
+    if (typeInfo.orderableDirection > 0) {
+        usedAttributes = [];
+        cleanPhrase = clean(exports.clean(typeInfo.id, false).replace(attributeRegex, interpolate));
+        cleanReversePhrase = clean(exports.clean(typeInfo.id, true).replace(attributeRegex, interpolate));
+        cleanExtraAttributes = commaOnlyList(_(attributesByName).omit(usedAttributes).values().flatten().value());
+    }
+
     return [
-        clean(phrase.replace(attributeRegex, interpolate)),
-        clean(reversePhrase.replace(attributeRegex, interpolate)),
-        commaOnlyList(_(attributesByName).omit(usedAttributes).values().flatten().value())
+        phrase,
+        reversePhrase,
+        extraAttributes,
+        cleanPhrase,
+        cleanReversePhrase,
+        cleanExtraAttributes,
     ];
 };

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -77,7 +77,7 @@ function getDirection(relationship, source) {
             var self = this;
 
             function linkPhrase(relationship) {
-                return relationship.linkPhrase(self);
+                return relationship.groupingLinkPhrase(self);
             }
 
             function openAddDialog(source, event) {

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -308,11 +308,31 @@ const mergeDates = require('./mergeDates');
         }
 
         _phraseAndExtraAttributes() {
-            return linkPhrase.interpolate(this.linkTypeID(), this.attributes());
+            const typeInfo = this.linkTypeInfo();
+            return linkPhrase.interpolate(typeInfo, this.attributes());
+        }
+
+        _linkPhrase(source, clean) {
+            const index = _.indexOf(this.entities(), source) +
+                (clean ? 3 : 0);
+            return this.phraseAndExtraAttributes()[index];
         }
 
         linkPhrase(source) {
-            return this.phraseAndExtraAttributes()[_.indexOf(this.entities(), source)];
+            return this._linkPhrase(source, false);
+        }
+
+        hasOrderableLinkType() {
+            const typeInfo = this.linkTypeInfo();
+            return !!(typeInfo && typeInfo.orderableDirection > 0);
+        }
+
+        // Same as linkPhrase, but if the link type is orderable, then
+        // also stripped of non-required attributes so that `groupBy` keeps
+        // ordered relationships together even if they have different
+        // attributes.
+        groupingLinkPhrase(source) {
+            return this._linkPhrase(source, this.hasOrderableLinkType());
         }
 
         lowerCasePhrase(source) {


### PR DESCRIPTION
For orderable link types, we "cleaned" non-required attributes from the link phrases in `interpolate` so that they are grouped together in the relationships display and editor UIs. However, the release relationship editor as well as recording-work relationships on the release page don't require any grouping, so this had the effect of hiding those attributes there. This patch makes that behavior optional, so that the cleaned phrases are only used where grouping is intended.