### PR TITLE
MBS-9462: Create missing l_event_url triggers

### DIFF
--- a/admin/sql/updates/20170909-mbs-9462-missing-event-triggers.sql
+++ b/admin/sql/updates/20170909-mbs-9462-missing-event-triggers.sql
@@ -1,0 +1,25 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+DROP TRIGGER IF EXISTS b_upd_l_event_url ON l_event_url;
+DROP TRIGGER IF EXISTS remove_unused_links ON l_event_url;
+DROP TRIGGER IF EXISTS url_gc_a_del_l_event_url ON l_event_url;
+DROP TRIGGER IF EXISTS url_gc_a_upd_l_event_url ON l_event_url;
+
+CREATE TRIGGER b_upd_l_event_url
+    BEFORE UPDATE ON l_event_url
+    FOR EACH ROW EXECUTE PROCEDURE b_upd_last_updated_table();
+
+CREATE CONSTRAINT TRIGGER remove_unused_links
+    AFTER DELETE OR UPDATE ON l_event_url DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE PROCEDURE remove_unused_links();
+
+CREATE CONSTRAINT TRIGGER url_gc_a_del_l_event_url
+    AFTER DELETE ON l_event_url DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE PROCEDURE remove_unused_url();
+
+CREATE CONSTRAINT TRIGGER url_gc_a_upd_l_event_url
+    AFTER UPDATE ON l_event_url DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE PROCEDURE remove_unused_url();
+
+COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -61,6 +61,7 @@
   },
 
   "25": {
-    "standalone": ["20170604-mbs-9365.sql"]
+    "standalone": ["20170604-mbs-9365.sql",
+                   "20170909-mbs-9462-missing-event-triggers.sql"]
   }
 }


### PR DESCRIPTION
...for standalone databases created before schema 21.

Ran manually on the prod DB already.