### PR TITLE
Remove RCSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,11 +1179,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1394,11 +1389,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -1469,11 +1459,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
-    },
-    "deep-extend": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-      "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1726,11 +1711,6 @@
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5441,18 +5421,6 @@
       "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.17.0.tgz",
       "integrity": "sha1-d5RXrHkQUSw8LMm7bQqe61mpaew="
     },
-    "rcss": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/rcss/-/rcss-0.1.5.tgz",
-      "integrity": "sha1-6hnLRaQB46+6anw2QEbD+xxHjfU=",
-      "requires": {
-        "deep-extend": "0.2.11",
-        "escape-html": "1.0.3",
-        "sha1": "1.1.1",
-        "valid-css-props": "0.0.5",
-        "valid-media-queries": "0.0.3"
-      }
-    },
     "react": {
       "version": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",
       "integrity": "sha1-LSTu81QSmiWDjmUT4FAckYXB/uo=",
@@ -5853,15 +5821,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "sha1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
-      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2"
-      }
     },
     "shell-quote": {
       "version": "1.4.3",
@@ -6440,16 +6399,6 @@
       "requires": {
         "user-home": "1.1.1"
       }
-    },
-    "valid-css-props": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/valid-css-props/-/valid-css-props-0.0.5.tgz",
-      "integrity": "sha1-S8EBpTZudhkK8Su8gyeCFdsjrfE="
-    },
-    "valid-media-queries": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/valid-media-queries/-/valid-media-queries-0.0.3.tgz",
-      "integrity": "sha1-UOGIxA0L+sq7soiBXmsl/kJoidc="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "querystring": "0.2.0",
     "raven": "2.0.0",
     "raven-js": "3.17.0",
-    "rcss": "0.1.5",
     "react": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",
     "react-dom": "https://github.com/mwiencek/react-packages/raw/master/react-dom.tgz",
     "redux": "3.6.0",

--- a/root/static/scripts/edit/components/Tooltip.js
+++ b/root/static/scripts/edit/components/Tooltip.js
@@ -9,70 +9,7 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const RCSS = require('rcss');
 const PropTypes = React.PropTypes;
-
-var colors = {
-  grayLight: '#aaa',
-  basicBorderColor: '#ccc',
-  white: '#fff'
-};
-
-var infoTipContainer = RCSS.registerClass({
-  position: 'absolute',
-  top: '-12px',
-  left: '22px',
-  zIndex: '1000'
-});
-
-var triangleBeforeAfter = {
-  borderBottom: '9px solid transparent',
-  borderTop: '9px solid transparent',
-  content: ' ',
-  height: '0',
-  position: 'absolute',
-  top: '0',
-  width: '0'
-};
-
-var infoTipTriangle = RCSS.registerClass({
-  height: '10px',
-  left: '0',
-  position: 'absolute',
-  top: '8px',
-  width: '0',
-  zIndex: '1',
-
-  ':before': RCSS.cascade(triangleBeforeAfter, {
-    borderRight: '9px solid #bbb',
-    right: '0',
-  }),
-
-  ':after': RCSS.cascade(triangleBeforeAfter, {
-    borderRight: `9px solid ${colors.white}`,
-    right: '-1px'
-  })
-});
-
-var basicBorder = {
-  border: `1px solid ${colors.basicBorderColor}`
-};
-
-var verticalShadow = RCSS.cascade(
-  basicBorder,
-  { boxShadow: `0 1px 3px ${colors.basicBorderColor}` },
-  { borderBottom: `1px solid ${colors.grayLight}` }
-);
-
-var infoTipContentContainer = RCSS.registerClass(
-  RCSS.cascade(verticalShadow, {
-    background: colors.white,
-    padding: '5px 10px',
-    width: '240px'
-  })
-);
-
-RCSS.injectAll();
 
 class Tooltip extends React.Component {
   componentDidMount() {
@@ -82,11 +19,11 @@ class Tooltip extends React.Component {
   render() {
     var hoverCallback = this.props.hoverCallback;
     return (
-      <div className={infoTipContainer.className}
+      <div className="tooltip-container"
            onMouseEnter={() => hoverCallback(true)}
            onMouseLeave={() => hoverCallback(false)}>
-        <div className={infoTipTriangle.className} />
-        <div className={infoTipContentContainer.className} dangerouslySetInnerHTML={{__html: this.props.html}} />
+        <div className="tooltip-triangle" />
+        <div className="tooltip-content" dangerouslySetInnerHTML={{__html: this.props.html}} />
       </div>
     );
   }

--- a/root/static/styles/common.less
+++ b/root/static/styles/common.less
@@ -7,6 +7,7 @@
 @import "layout.less";
 @import "release-editor.less";
 @import "relationship-editor.less";
+@import "tooltip.less";
 @import "widgets.less";
 @import "multiselect.less";
 @import "extra/homepage.less";

--- a/root/static/styles/tooltip.less
+++ b/root/static/styles/tooltip.less
@@ -1,0 +1,47 @@
+@import "colors.less";
+
+.tooltip-container {
+    position: absolute;
+    top: -12px;
+    left: 22px;
+    z-index: 1000;
+
+    .tooltip-triangle-mixin {
+        border-bottom: 9px solid transparent;
+        border-top: 9px solid transparent;
+        content: " ";
+        height: 0;
+        position: absolute;
+        top: 0;
+        width: 0;
+    }
+
+    .tooltip-triangle {
+        height: 10px;
+        left: 0;
+        position: absolute;
+        top: 8px;
+        width: 0;
+        z-index: 1;
+
+        &:before {
+            .tooltip-triangle-mixin;
+            border-right: 9px solid @medium-border;
+            right: 0;
+        }
+
+        &:after {
+            .tooltip-triangle-mixin;
+            border-right: 9px solid @text-white;
+            right: -1px;
+        }
+    }
+
+    .tooltip-content {
+        background: @text-white;
+        border: 1px solid @medium-border;
+        box-shadow: 0 2px 5px @medium-border;
+        padding: 5px 10px;
+        width: 240px;
+    }
+}


### PR DESCRIPTION
RCSS is deprecated and isn't a very good idea for us, since for server rendering it'd mean sending CSS twice (in the JavaScript, and in the compiled CSS it injects).

This changes the style of the tooltip very slightly to use existing colors defined in colors.less.