### PR TITLE
Upgrade React to v16

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -23,7 +23,6 @@
     "jsx-control-statements",
     "transform-react-jsx",
     "transform-react-constant-elements",
-    "transform-react-inline-elements",
     "transform-runtime"
   ]
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ Prerequisites
     This is only needed where it exists, so a warning about the package not being
     found is not a problem.
 
-    For npm, at least version 3 is required. If your distribution has an older
+    For npm, at least version 4 is required. If your distribution has an older
     version (`npm --version` to check), you can use that to install a newer
     version of itself:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2251,9 +2251,9 @@
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
-      "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
         "core-js": "1.2.7",
         "isomorphic-fetch": "2.2.1",
@@ -4330,7 +4330,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.1",
+        "node-fetch": "1.7.2",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -4487,13 +4487,6 @@
             "amdefine": "1.0.1"
           }
         }
-      }
-    },
-    "jsx-control-statements": {
-      "version": "github:AlexGilleran/jsx-control-statements#af1f0133f03a7ac0d0723361dd2ef804ac6d4204",
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-plugin-syntax-jsx": "6.18.0"
       }
     },
     "jszip": {
@@ -5184,9 +5177,9 @@
       "integrity": "sha1-yrMxPfq4yG5yeJLGHc31dD5HZdY="
     },
     "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -5581,6 +5574,16 @@
         "asap": "2.0.6"
       }
     },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -5675,22 +5678,57 @@
       "integrity": "sha1-d5RXrHkQUSw8LMm7bQqe61mpaew="
     },
     "react": {
-      "version": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",
-      "integrity": "sha1-LSTu81QSmiWDjmUT4FAckYXB/uo=",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.0.0.tgz",
+      "integrity": "sha1-zn348ZQbA28Cssyp29DLHw6FXi0=",
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.14"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
-    "react-addons-test-utils": {
-      "version": "https://github.com/mwiencek/react-packages/raw/master/react-addons-test-utils.tgz",
-      "integrity": "sha1-c7V3S8wS56yoQKQ2HDqtGelbARk=",
-      "dev": true
-    },
     "react-dom": {
-      "version": "https://github.com/mwiencek/react-packages/raw/master/react-dom.tgz",
-      "integrity": "sha1-OH6CbNJvSWiQRDgB9cVbpHGMOng="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
+      "integrity": "sha1-nMMHnD3NcNTG4BuEqrKn40wwP1g=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
     },
     "readable-stream": {
       "version": "1.1.14",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "querystring": "0.2.0",
     "raven": "2.0.0",
     "raven-js": "3.17.0",
-    "react": "https://github.com/mwiencek/react-packages/raw/master/react.tgz",
-    "react-dom": "https://github.com/mwiencek/react-packages/raw/master/react-dom.tgz",
+    "react": "16.0.0",
+    "react-dom": "16.0.0",
     "redux": "3.6.0",
     "shell-quote": "1.4.3",
     "shelljs": "0.5.3",
@@ -69,7 +69,6 @@
     "file-url": "2.0.2",
     "gulp-watch": "4.3.5",
     "jsdom": "11.1.0",
-    "react-addons-test-utils": "https://github.com/mwiencek/react-packages/raw/master/react-addons-test-utils.tgz",
     "selenium-webdriver": "3.5.0",
     "tape": "4.7.0",
     "utf8": "2.1.2"

--- a/root/components/Frag.js
+++ b/root/components/Frag.js
@@ -1,0 +1,8 @@
+// This file is part of MusicBrainz, the open internet music database.
+// Copyright (C) 2017 MetaBrainz Foundation
+// Licensed under the GPL version 2, or (at your option) any later version:
+// http://www.gnu.org/licenses/gpl-2.0.txt
+
+const Frag = ({children}) => children;
+
+module.exports = Frag;

--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -6,6 +6,7 @@
 const React = require('react');
 const URL = require('url');
 
+const Frag = require('../../components/Frag');
 const EntityLink =
   require('../../static/scripts/common/components/EntityLink');
 const {FAVICON_CLASSES} = require('../../static/scripts/common/constants');
@@ -90,7 +91,7 @@ const ExternalLinks = ({entity, empty, heading}) => {
   }));
 
   return (
-    <frag>
+    <Frag>
       <h2 className="external-links">
         {heading || l('External links')}
       </h2>
@@ -108,7 +109,7 @@ const ExternalLinks = ({entity, empty, heading}) => {
           </li>
         </If>
       </ul>
-    </frag>
+    </Frag>
   );
 };
 

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -5,6 +5,7 @@
 
 const React = require('react');
 
+const Frag = require('../../components/Frag');
 const DBDefs = require('../../static/scripts/common/DBDefs');
 const {l} = require('../../static/scripts/common/i18n');
 const formatUserDate = require('../../utility/formatUserDate');
@@ -45,14 +46,14 @@ const Footer = (props) => {
         ]}
 
         <If condition={stash.last_replication_date}>
-          <frag>
+          <Frag>
             <br />
             {l('Last replication packet received at {datetime}', {
                 datetime: $c.user ?
                   formatUserDate($c.user, stash.last_replication_date) :
                   stash.last_replication_date
             })}
-          </frag>
+          </Frag>
         </If>
       </p>
 

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -6,6 +6,7 @@
 
 require('leaflet.markercluster/dist/leaflet.markercluster-src');
 const _ = require('lodash');
+const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 
 const manifest = require('../../manifest');

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -3,6 +3,8 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const React = require('react');
+
 const EntityLink = require('./EntityLink');
 
 const ArtistCreditLink = ({artistCredit, showDeleted = true, ...props}) => {
@@ -28,7 +30,7 @@ const ArtistCreditLink = ({artistCredit, showDeleted = true, ...props}) => {
     }
     parts.push(credit.joinPhrase);
   }
-  return <frag>{parts}</frag>;
+  return parts;
 };
 
 module.exports = ArtistCreditLink;

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -22,7 +22,7 @@ class Autocomplete extends React.Component {
     this._currentSelection = currentSelection;
     this._subscription = currentSelection.subscribe(this.props.onChange);
 
-    this._autocomplete = $(this.refs.name).autocomplete(options).data('ui-autocomplete');
+    this._autocomplete = $(this._nameInput).autocomplete(options).data('ui-autocomplete');
     currentSelection(this._autocomplete._dataToEntity(this.props.currentSelection));
   }
 
@@ -31,7 +31,7 @@ class Autocomplete extends React.Component {
     this._subscription = null;
     this._currentSelection = null;
     this._autocomplete = null;
-    $(this.refs.name).autocomplete('destroy');
+    $(this._nameInput).autocomplete('destroy');
   }
 
   componentWillReceiveProps(nextProps) {
@@ -71,7 +71,7 @@ class Autocomplete extends React.Component {
           className={className}
           disabled={disabled}
           id={inputID}
-          ref="name"
+          ref={input => this._nameInput = input}
           type="text" />
       </span>
     );

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -23,7 +23,7 @@ const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
 
   if (entity.artistCredit) {
     return l('{entity} by {artist}', {
-      __react: 'frag',
+      __react: true,
       entity: link,
       artist: (
         <ArtistCreditLink
@@ -36,7 +36,7 @@ const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
 
   if (entity.entityType === 'place' && entity.area) {
     return l('{place} in {area}', {
-      __react: 'frag',
+      __react: true,
       place: link,
       area: <AreaWithContainmentLink area={entity.area} key={1} />
     });

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -7,6 +7,7 @@ const ko = require('knockout');
 const _ = require('lodash');
 const React = require('react');
 
+const Frag = require('../../../../components/Frag');
 const {ENTITIES, AREA_TYPE_COUNTRY} = require('../constants');
 const {l} = require('../i18n');
 const bracketed = require('../utility/bracketed');
@@ -29,10 +30,10 @@ const DeletedLink = ({name, allowNew}) => {
 };
 
 const Comment = ({className, comment}) => (
-  <frag>
+  <Frag>
     {' '}
     <span className={className}>({isolateText(comment)})</span>
-  </frag>
+  </Frag>
 );
 
 class EventDisambiguation extends React.Component {
@@ -43,14 +44,14 @@ class EventDisambiguation extends React.Component {
       return null;
     }
     return (
-      <frag>
+      <Frag>
         <If condition={dates}>
           {bracketed(dates)}
         </If>
         <If condition={event.cancelled}>
           <Comment className="cancelled" comment={l('cancelled')} />
         </If>
-      </frag>
+      </Frag>
     );
   }
 }
@@ -80,11 +81,11 @@ class AreaDisambiguation extends React.Component {
 }
 
 const NoInfoURL = ({url, allowNew}) => (
-  <frag>
+  <Frag>
     <a href={url}>{url}</a>
     {' '}
     <DeletedLink name={'[' + l('info') + ']'} allowNew={allowNew} />
-  </frag>
+  </Frag>
 );
 
 const EntityLink = (props = {}) => {
@@ -176,7 +177,7 @@ const EntityLink = (props = {}) => {
   }
 
   return (
-    <frag>
+    <Frag>
       {content}
       <If condition={showDisambiguation}>
         <If condition={entityType === 'event'}>
@@ -193,7 +194,7 @@ const EntityLink = (props = {}) => {
         {' '}
         [<a href={infoLink}>{l('info')}</a>]
       </If>
-    </frag>
+    </Frag>
   );
 };
 

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -204,8 +204,7 @@ class TagEditor extends React.Component {
   addTags(event) {
     event.preventDefault();
 
-    var input = this.refs.tags;
-    var tags = input.value;
+    var tags = this._tagsInput.value;
 
     this.updateTags(
       _(tags.split(','))
@@ -229,7 +228,7 @@ class TagEditor extends React.Component {
       this.updateTags(JSON.parse(data).updates);
     });
 
-    input.value = '';
+    this._tagsInput.value = '';
   }
 
   updateVote(index, vote) {
@@ -305,7 +304,7 @@ class MainTagEditor extends TagEditor {
             {tagdocs: '/doc/Folksonomy_Tagging'})}}></p>
         <form id="tag-form" onSubmit={this.addTags}>
           <p>
-            <textarea row="5" cols="50" ref="tags"></textarea>
+            <textarea row="5" cols="50" ref={input => this._tagsInput = input}></textarea>
           </p>
           <button type="submit" className="styled-button">
             {l('Submit tags')}
@@ -323,7 +322,9 @@ class SidebarTagEditor extends TagEditor {
         <ul className="tag-list">
           {this.createTagRows()}
           {this.props.more &&
-            <li>
+            // createTagRows uses tags as keys; \0 is simply used here to
+            // guarantee that there isn't any conflict.
+            <li key="\0:more">
               <a href={getTagsPath(this.props.entity)}>{l('more...')}</a>
             </li>}
         </ul>

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -5,6 +5,7 @@
 
 const ko = require('knockout');
 const _ = require('lodash');
+const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 
 const ArtistCreditLink = require('./components/ArtistCreditLink');

--- a/root/static/scripts/common/i18n.js
+++ b/root/static/scripts/common/i18n.js
@@ -40,11 +40,7 @@ function wrapGettext(method) {
         if (expandArgs) {
             let react = expandArgs.__react;
             if (react) {
-                let parts = expandToArray(string, expandArgs);
-                if (react === 'frag') {
-                    return <frag>{parts}</frag>;
-                }
-                return parts;
+                return expandToArray(string, expandArgs);
             }
             return exports.expand(string, expandArgs);
         }

--- a/root/static/scripts/common/i18n/commaList.js
+++ b/root/static/scripts/common/i18n/commaList.js
@@ -3,8 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const React = require('react');
-
 const {l} = require('../i18n');
 
 function commaList(items, props = {}) {
@@ -31,7 +29,7 @@ function commaList(items, props = {}) {
     });
   }
 
-  return props.react ? <frag>{output}</frag> : output;
+  return output;
 }
 
 module.exports = commaList;

--- a/root/static/scripts/common/i18n/commaOnlyList.js
+++ b/root/static/scripts/common/i18n/commaOnlyList.js
@@ -3,8 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const React = require('react');
-
 const {l} = require('../i18n');
 
 function commaOnlyList(items, props = {}) {
@@ -27,7 +25,7 @@ function commaOnlyList(items, props = {}) {
     });
   }
 
-  return props.react ? <frag>{output}</frag> : output;
+  return output;
 }
 
 module.exports = commaOnlyList;

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -10,6 +10,7 @@ const _ = require('lodash');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
+const Frag = require('../../../../components/Frag');
 const Autocomplete = require('../../common/components/Autocomplete');
 const {l} = require('../../common/i18n');
 const {
@@ -144,7 +145,7 @@ class ArtistCreditEditor extends React.Component {
       return;
     }
 
-    const $button = $(this.refs.button);
+    const $button = $(this._editButton);
     let position = {of: $button[0], collision: 'fit none', within: $('body')};
     let maxWidth;
     let tailClass;
@@ -226,7 +227,7 @@ class ArtistCreditEditor extends React.Component {
   hide(stealFocus = true) {
     const $bubble = $('#artist-credit-bubble').hide();
     if (stealFocus) {
-      this.refs.button.focus();
+      this._editButton.focus();
     }
     // Defer until after the doneCallback() executes (if done() called us).
     _.defer(function () {
@@ -345,8 +346,8 @@ class ArtistCreditEditor extends React.Component {
     }
 
     return (
-      <frag>
-        <table className="artist-credit-editor">
+      <Frag>
+        <table key="artist-credit-editor" className="artist-credit-editor">
           <tbody>
             <tr>
               <td>
@@ -374,7 +375,11 @@ class ArtistCreditEditor extends React.Component {
                   showStatus={false} />
               </td>
               <td className="open-ac-cell">
-                <button className="open-ac" ref="button" type="button" onClick={this.toggleBubble}>
+                <button
+                  className="open-ac"
+                  ref={button => this._editButton = button}
+                  type="button"
+                  onClick={this.toggleBubble}>
                   {l('Edit')}
                 </button>
               </td>
@@ -383,10 +388,10 @@ class ArtistCreditEditor extends React.Component {
         </table>
         <If condition={this.props.hiddenInputs}>
           <For each="data" of={this.getHiddenInputs()}>
-            <input type="hidden" name={data.name} value={nonEmpty(data.value) ? data.value : ''} />
+            <input key={data.name} type="hidden" name={data.name} value={nonEmpty(data.value) ? data.value : ''} />
           </For>
         </If>
-      </frag>
+      </Frag>
     );
   }
 }

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -16,8 +16,7 @@ class HelpIcon extends React.Component {
   render() {
     return (
       <div style={{position: 'relative', display: 'inline-block'}}>
-        <div ref="help"
-             className="img icon help"
+        <div className="img icon help"
              onMouseEnter={() => this.setState({ hover: true })}
              onMouseLeave={() => this.setState({ hover: false })}>
         </div>

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
+const Frag = require('../../../components/Frag');
 const {l} = require('../common/i18n');
 const {reduceArtistCredit} = require('../common/immutable-entities');
 const ArtistCreditEditor = require('../edit/components/ArtistCreditEditor');
@@ -55,14 +56,14 @@ ko.bindingHandlers.artistCreditEditor = {
 
     extraButtons: function () {
         return (
-            <frag>
+            <Frag>
                 <button type="button" style={{float: 'right'}} onClick={this.nextTrack}>
                     {l('Next')}
                 </button>
                 <button type="button" style={{float: 'right'}} onClick={this.previousTrack}>
                     {l('Previous')}
                 </button>
-            </frag>
+            </Frag>
         );
     },
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -5,8 +5,6 @@
 
 const ko = require('knockout');
 const _ = require('lodash');
-const React = require('react');
-const ReactDOM = require('react-dom');
 
 require('knockout-arraytransforms');
 

--- a/root/static/scripts/tests/external-links-editor/utils.js
+++ b/root/static/scripts/tests/external-links-editor/utils.js
@@ -1,5 +1,4 @@
-const React = require('react');
-const ReactTestUtils = require('react-addons-test-utils');
+const ReactTestUtils = require('react-dom/test-utils');
 
 exports.triggerChange = function (node, value) {
     ReactTestUtils.Simulate.change(node, { target: { value: value } });

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -9,7 +9,7 @@ const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
 const test = require('tape');
-const ReactTestUtils = require('react-addons-test-utils');
+const ReactTestUtils = require('react-dom/test-utils');
 const ReactDOM = require('react-dom');
 
 const validation = require('../../edit/validation');


### PR DESCRIPTION
Note: This is based on https://github.com/metabrainz/musicbrainz-server/pull/550 to avoid conflicts with the PropType removals. Just see the last commit here.

We haven't been able to update to any of the intermediate v15 releases, because we're relying on my fork which adds a `<frag>` builtin. Subsequent v15 releases made it very difficult for me to rebase that work.

React v16 supports fragments (returning an array of elements from `render()`) natively, so we no longer need to rely on my fork. We'll keep the `<Frag>` idea by defining a wrapper component, because returning an array is awkward in some instances (unnecessary key props, literals requiring commas).

The `transform-react-inline-elements` babel plugin has been removed because it causes spurious unique key prop warnings. This revealed some files in which we weren't importing React.