### PR TITLE
MBS-9471: Do not map undefined rel attribute

### DIFF
--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -13,7 +13,9 @@ const clean = require('../../common/utility/clean');
 var attributeRegex = /\{(.*?)(?::(.*?))?\}/g;
 
 function mapNameToID(result, info, id) {
-    result[info.attribute.name] = id;
+    if (info.attribute !== undefined) {
+        result[info.attribute.name] = id;
+    }
 }
 
 exports.clean = _.memoize(function (linkType, backward) {


### PR DESCRIPTION
### Fix [MBS-9471](https://tickets.metabrainz.org/browse/MBS-9471): TypeError: Cannot read property 'name' of undefined
Should hotfix beta/production, since editing form is currently unusable for most works with relationships.