### PR TITLE
MBS-9471: Relationship editor breaks if two link attribute types have the same name

### DIFF
--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -218,7 +218,7 @@ sub build_attr_info {
         return $attr;
     }
 
-    return { map { $_->name => build_attr($_) } $root->all_children };
+    return { map { $_->gid => build_attr($_) } $root->all_children };
 }
 
 sub build_child_info {

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -27,7 +27,6 @@ const fields = require('./fields');
 
     RE.exportTypeInfo = _.once(function (typeInfo, attrInfo) {
         MB.typeInfo = typeInfo;
-        MB.attrInfo = attrInfo;
 
         MB.typeInfoByID = _(typeInfo).values().flatten().transform(mapItems, {}).value();
         MB.attrInfoByID = _(attrInfo).values().transform(mapItems, {}).value();


### PR DESCRIPTION
It appears that `build_attr_info` is only used to pass data to `exportTypeInfo` in the JS.

It also appears that in `exportTypeInfo`, we completely disregard the key. This patch just makes sure the keys are unique, so that one attribute type doesn't clobber another with the same name.