### PR TITLE
MBS-9313, MBS-9505: Auto-editing release event, amending within one day

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -340,7 +340,7 @@ around allow_auto_edit => sub {
     return 0 if defined $self->data->{old}{language_id};
     return 0 if defined $self->data->{old}{script_id};
 
-    return 0 if defined $self->data->{old}{events};
+    return 0 if defined $self->data->{old}{events} && scalar @{ $self->data->{old}{events} } > 0;
 
     return 0 if exists $self->data->{old}{release_group_id};
 

--- a/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
@@ -28,7 +28,7 @@ if it has been created by the same editor less than an hour ago.
              WHERE edit_$entity_type.$entity_type = ?
                AND edit.editor = ?
                AND edit.type = $create_edit_type
-               AND (now() - edit.open_time) < interval '1 hour'
+               AND (now() - edit.open_time) < interval '1 day'
         ", $amended_entity_id, $self->editor_id);
 
         return defined $add_entity_edit;

--- a/t/lib/t/MusicBrainz/Server/Edit/Role/AllowAmending.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Role/AllowAmending.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Constants qw( $EDIT_MEDIUM_EDIT $EDIT_RELEASE_CREATE );
 
 use MusicBrainz::Server::Edit::Medium::Edit;
 
-test 'Allow amending entity within one hour' => sub {
+test 'Allow amending entity within one day' => sub {
     my $test = shift;
     my $c = $test->c;
 
@@ -18,18 +18,18 @@ test 'Allow amending entity within one hour' => sub {
     my $edit;
     my $medium = $c->model('Medium')->get_by_id(1);
 
-    subtest 'Auto-edit amending entity created by the same editor within one hour' => sub {
+    subtest 'Auto-edit amending entity created by the same editor within one day' => sub {
         $edit = create_edit($c, $medium, 1411452, 30171);
         is($edit->can_amend(1), 1, 'amending allowed');
     };
 
-    subtest 'Non-auto-edit amending entity created by another editor within one hour' => sub {
+    subtest 'Non-auto-edit amending entity created by another editor within one day' => sub {
         $edit = create_edit($c, $medium, 1411453, 30172);
         is($edit->can_amend(1), '', 'amending disallowed');
     };
 
-    subtest 'Non-auto-edit amending entity created by the same editor after one hour' => sub {
-        $test->c->sql->do("UPDATE edit SET open_time = NOW() - INTERVAL '1 hour' WHERE type = $EDIT_RELEASE_CREATE;");
+    subtest 'Non-auto-edit amending entity created by the same editor after one day' => sub {
+        $test->c->sql->do("UPDATE edit SET open_time = NOW() - INTERVAL '1 day' WHERE type = $EDIT_RELEASE_CREATE;");
         $edit = create_edit($c, $medium, 1411454, 30171);
         is($edit->can_amend(1), '', 'amending disallowed');
     };


### PR DESCRIPTION
- Fix bug [MBS-9313](https://tickets.metabrainz.org/browse/MBS-9313): Adding first release event should be an auto-edit.
- Implement [MBS-9505](https://tickets.metabrainz.org/browse/MBS-9505): Extend amending delay from one hour to one day.