### PR TITLE
 Handle now-unexpected alerts in selenium tests

### DIFF
--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -1,3 +1,15 @@
+const DBDefs = require('./common/DBDefs');
+const MB = require('./common/MB');
+
+if (DBDefs.DEVELOPMENT_SERVER) {
+  // Used by the Selenium tests under /t/selenium/ to make sure that no errors
+  // occurred on the page.
+  MB.js_errors = [];
+  window.onerror = function (err) {
+    MB.js_errors.push(err);
+  };
+}
+
 require('./common/raven');
 
 window.ko = require("knockout");
@@ -6,8 +18,6 @@ window.$ = window.jQuery = require("jquery");
 
 require("../lib/jquery.ui/ui/jquery-ui.custom");
 
-require("./common/DBDefs");
-require("./common/MB");
 require("./common/i18n");
 require("./common/text-collapse");
 require("./common/artworkViewer");

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -9,6 +9,7 @@ const jsdom = require('jsdom');
 const path = require('path');
 const shell = require('shelljs');
 const test = require('tape');
+const utf8 = require('utf8');
 const webdriver = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 const {UnexpectedAlertOpenError} = require('selenium-webdriver/lib/error');
@@ -156,7 +157,11 @@ async function handleCommand(command, target, value, baseURL, t) {
     return handleCommandAndWait.apply(null, arguments);
   }
 
-  t.comment(`${command} target=${JSON.stringify(target)} value=${JSON.stringify(value)}`);
+  t.comment(
+    command +
+    ' target=' + utf8.encode(JSON.stringify(target)) +
+    ' value=' + utf8.encode(JSON.stringify(value))
+  );
 
   let element;
   switch (command) {

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -121,6 +121,15 @@ async function handleCommandAndWait(command, target, value, baseURL, t) {
 }
 
 async function handleCommand(command, target, value, baseURL, t) {
+  // Die if there are any JS errors on the page since the previous command.
+  const errors = await driver.executeScript('return ((window.MB || {}).js_errors || [])');
+  if (errors.length) {
+    throw new Error(
+      'Errors were found on the page since executing the previous command:\n' +
+      errors.join('\n\n')
+    );
+  }
+
   if (/AndWait$/.test(command)) {
     return handleCommandAndWait.apply(null, arguments);
   }

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -134,6 +134,8 @@ async function handleCommand(command, target, value, baseURL, t) {
     return handleCommandAndWait.apply(null, arguments);
   }
 
+  t.comment(`${command} target=${JSON.stringify(target)} value=${JSON.stringify(value)}`);
+
   let element;
   switch (command) {
     case 'assertAttribute':
@@ -151,7 +153,6 @@ async function handleCommand(command, target, value, baseURL, t) {
       return;
 
     case 'assertEval':
-      t.comment(`assertEval: String(${target}) === ${JSON.stringify(value)}`);
       t.equal(await driver.executeScript(`return String(${target})`), value);
       return;
 

--- a/t/selenium/Artist_Credit_Editor.html
+++ b/t/selenium/Artist_Credit_Editor.html
@@ -16,11 +16,6 @@
 	<td>/recording/create</td>
 	<td></td>
 </tr>
-<tr>
-	<td>runScript</td>
-	<td>document.body.setAttribute('js-error', ''); window.onerror = function (err) { document.body.setAttribute('js-error', err); };</td>
-	<td></td>
-</tr>
 <!--hidden inputs-->
 <tr>
 	<td>click</td>
@@ -299,20 +294,10 @@
 	<td>window.document.getElementById('ac-source-artist-0').classList.contains('lookup-performed')</td>
 	<td>false</td>
 </tr>
-<tr>
-	<td>assertAttribute</td>
-	<td>css=body@js-error</td>
-	<td></td>
-</tr>
 <!--creating a new artist from the track AC bubble should not close it (MBS-7251)-->
 <tr>
 	<td>open</td>
 	<td>/release/add</td>
-	<td></td>
-</tr>
-<tr>
-	<td>runScript</td>
-	<td>document.body.setAttribute('js-error', ''); window.onerror = function (err) { document.body.setAttribute('js-error', err); };</td>
 	<td></td>
 </tr>
 <tr>
@@ -382,11 +367,6 @@
 	<td>assertEval</td>
 	<td>window.$('#artist-credit-bubble').is(':visible')</td>
 	<td>false</td>
-</tr>
-<tr>
-	<td>assertAttribute</td>
-	<td>css=body@js-error</td>
-	<td></td>
 </tr>
 
 </tbody></table>

--- a/t/selenium/MBS-7456.html
+++ b/t/selenium/MBS-7456.html
@@ -17,11 +17,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>runScript</td>
-	<td>document.body.setAttribute('js-error', ''); window.onerror = function (err) { document.body.setAttribute('js-error', err); };</td>
-	<td></td>
-</tr>
-<tr>
 	<td>click</td>
 	<td>id=ui-id-3</td>
 	<td></td>
@@ -79,11 +74,6 @@
 <tr>
 	<td>click</td>
 	<td>id=parse-tracks</td>
-	<td></td>
-</tr>
-<tr>
-	<td>assertAttribute</td>
-	<td>css=body@js-error</td>
 	<td></td>
 </tr>
 </tbody></table>


### PR DESCRIPTION
The `confirm()` dialog in the release editor that tells you you're going to lose all your changes is now breaking the tests, because it prevents subsequent commands from running.

It's unclear why it worked previously, but an update to chrome broke it.

Also included are two unrelated improvements to selenium.js: checking if errors occurred on the page after every command, and logging every command (so when it fails we can see where it was at).