### PR TITLE
MBS-9519: Hide biography, website/homepage, and collections description of limiter users from not-logged-in users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -71,7 +71,7 @@ sub remove : Chained('own_collection') RequireAuth {
     $self->_do_add_or_remove($c, 'remove_entities_from_collection');
 }
 
-sub show : Chained('load') PathPart('') RequireAuth {
+sub show : Chained('load') PathPart('') {
     my ($self, $c) = @_;
 
     my $collection = $c->stash->{collection};

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -303,7 +303,7 @@ sub contact : Chained('load') RequireAuth HiddenOnSlaves
     }
 }
 
-sub collections : Chained('load') PathPart('collections') RequireAuth
+sub collections : Chained('load') PathPart('collections')
 {
     my ($self, $c) = @_;
 
@@ -331,7 +331,7 @@ sub collections : Chained('load') PathPart('collections') RequireAuth
     $c->stash(user => $user, no_collections => $no_collections);
 }
 
-sub profile : Chained('load') PathPart('') RequireAuth HiddenOnSlaves
+sub profile : Chained('load') PathPart('') HiddenOnSlaves
 {
     my ($self, $c) = @_;
 
@@ -353,7 +353,7 @@ sub profile : Chained('load') PathPart('') RequireAuth HiddenOnSlaves
     );
 }
 
-sub rating_summary : Chained('load') PathPart('ratings') Args(0) RequireAuth HiddenOnSlaves
+sub rating_summary : Chained('load') PathPart('ratings') Args(0) HiddenOnSlaves
 {
     my ($self, $c) = @_;
 
@@ -376,7 +376,7 @@ sub rating_summary : Chained('load') PathPart('ratings') Args(0) RequireAuth Hid
     );
 }
 
-sub ratings : Chained('load') PathPart('ratings') Args(1) RequireAuth HiddenOnSlaves
+sub ratings : Chained('load') PathPart('ratings') Args(1) HiddenOnSlaves
 {
     my ($self, $c, $type) = @_;
 
@@ -411,7 +411,7 @@ sub ratings : Chained('load') PathPart('ratings') Args(1) RequireAuth HiddenOnSl
     );
 }
 
-sub tags : Chained('load') PathPart('tags') RequireAuth
+sub tags : Chained('load') PathPart('tags')
 {
     my ($self, $c) = @_;
 
@@ -434,7 +434,7 @@ sub tags : Chained('load') PathPart('tags') RequireAuth
     );
 }
 
-sub tag : Chained('load') PathPart('tag') Args(1) RequireAuth
+sub tag : Chained('load') PathPart('tag') Args(1)
 {
     my ($self, $c, $tag_name) = @_;
     my $user = $c->stash->{user};

--- a/lib/MusicBrainz/Server/Form/User/EditProfile.pm
+++ b/lib/MusicBrainz/Server/Form/User/EditProfile.pm
@@ -96,13 +96,13 @@ sub validate_birth_date {
     return $field->add_error("invalid date") unless Date::Calc::check_date($year, $month, $day);
 }
 
-sub _requires_not_limited {
+sub _requires_email {
     my ($self, $field) = @_;
-    return $field->add_error('Spammers are not welcome, go away.') if $self->ctx->user->is_limited;
+    return $field->add_error(l('Biography and website fields may not be edited until your email address is confirmed.')) unless $self->ctx->user->has_confirmed_email_address;
 }
 
-sub validate_biography { return _requires_not_limited(@_); }
-sub validate_website { return _requires_not_limited(@_); }
+sub validate_biography { return _requires_email(@_); }
+sub validate_website { return _requires_email(@_); }
 
 1;
 

--- a/root/account/edit.tt
+++ b/root/account/edit.tt
@@ -18,9 +18,7 @@
       <div class="no-label">
         [% l('If you change your email address, you will be required to verify it.') %]
       </div>
-      [%- IF !c.user.is_limited -%]
       [% form_row_url_long(r, 'website', l('Website:')) %]
-      [%- END -%]
       [% form_row_select(r, 'gender_id', l('Gender:')) %]
       [% WRAPPER form_row %]
         [% area_field = form.field('area.name') %]
@@ -44,13 +42,11 @@
       <div class="no-label">
         [% l('We will use your birth date to display your age in years on your profile page.') %]
       </div>
-      [%- IF !c.user.is_limited -%]
       [% WRAPPER form_row %]
         [% r.label('biography', l('Bio:')) %]
         [% r.textarea('biography', { cols => 80, rows => 5 }) %]
         [% field_errors(form, 'biography') %]
       [% END %]
-      [%- END -%]
 
       [% WRAPPER form_row %]
         [% r.label('languages', l('Languages Known:'), fake => 1) %]

--- a/root/collection/index.tt
+++ b/root/collection/index.tt
@@ -2,7 +2,13 @@
     <div class="description">
        [%- IF collection.description -%]
           <h2>[% l('Description') %]</h2>
-          [% collection.description | format_wikitext  %]
+          [%- IF !collection.user.is_limited || c.user_exists -%]
+              [% collection.description | format_wikitext  %]
+          [%- ELSE -%]
+              <p class="deleted">[%- l('This content is hidden to prevent spam.
+                                        To view it, please {url|log in}.',
+                                       { url => c.uri_for_action('user/login') }) -%]</p>
+          [%- END -%]
        [%- END -%]
     </div>
 

--- a/root/user/profile.tt
+++ b/root/user/profile.tt
@@ -103,11 +103,18 @@
             END;
            END %]
 
-        [% IF user.website && (!c.user.is_limited || c.user.is_account_admin) %]
+        [% IF user.website %]
             [% WRAPPER property name=l("Homepage:") %]
-                <a href="[% user.website | html %]" rel="nofollow">
-                    [%~ user.website | html ~%]
-                </a>
+                [%- IF !user.is_limited || c.user_exists -%]
+                    [% user.website | format_wikitext %]
+                    <a href="[% user.website | html %]" rel="nofollow">
+                        [%~ user.website | html ~%]
+                    </a>
+                [%- ELSE -%]
+                    <p class="deleted">[%- l('This content is hidden to prevent spam.
+                                              To view it, please {url|log in}.',
+                                             { url => c.uri_for_action('user/login') }) -%]</p>
+                [%- END -%]
             [% END %]
         [% END %]
 
@@ -127,9 +134,15 @@
             [% END %]
         [% END %]
 
-        [% IF user.biography && (!c.user.is_limited || c.user.is_account_admin) %]
+        [% IF user.biography %]
             [% WRAPPER property name=l("Bio:") class='biography' %]
-                [% user.biography | format_wikitext %]
+                [%- IF !user.is_limited || c.user_exists -%]
+                    [% user.biography | format_wikitext %]
+                [%- ELSE -%]
+                    <p class="deleted">[%- l('This content is hidden to prevent spam.
+                                              To view it, please {url|log in}.',
+                                             { url => c.uri_for_action('user/login') }) -%]</p>
+                [%- END -%]
             [% END %]
         [% END %]
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Login.pm
@@ -84,11 +84,11 @@ EOSQL
 
     $mech->get_ok('/user/ocharles%2Fbot');
     html_ok($mech->content);
-    $mech->content_contains('You need to be logged in to view this page');
+    $mech->content_contains('ocharles/bot');
+    $mech->follow_link_ok({ url_regex => qr{/login} });
     $mech->submit_form(
         with_fields => { username => 'ocharles/bot', password => 'mb' }
     );
-    $mech->content_contains('ocharles/bot');
     like($mech->uri->path, qr{/user/ocharles%2Fbot});
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Ratings.pm
@@ -19,17 +19,17 @@ TRUNCATE artist_rating_raw CASCADE;
 INSERT INTO artist_rating_raw (artist, editor, rating) VALUES (7, 1, 80);
 ");
 
+$mech->get('/user/new_editor/ratings');
+$mech->content_contains('Kate Bush', "new_editor has rated Kate Bush");
+
 $mech->get('/user/alice/ratings');
-$mech->content_contains('You need to be logged in to view this page.', "user ratings require login");
+is ($mech->status(), 403, "alice' ratings are private");
 
 $mech->get('/login');
 $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
 $mech->get('/user/alice/ratings');
 is ($mech->status(), 403, "alice' ratings are still private");
-
-$mech->get('/user/new_editor/ratings');
-$mech->content_contains('Kate Bush', "new_editor has rated Kate Bush");
 
 $mech->get('/logout');
 $mech->get('/login');

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
@@ -13,24 +13,14 @@ my $c    = $test->c;
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
 
-$mech->get('/user/alice');
-$mech->content_contains('You need to be logged in to view this page.', "user profile requires login");
+$mech->get('/user/new_editor');
+$mech->content_contains('Collection', "Collection tab appears on profile of user");
 
 $mech->get('/login');
 $mech->submit_form( with_fields => { username => 'alice', password => 'secret1' } );
 
-$mech->get('/user/new_editor');
-$mech->content_contains('Collection', "Collection tab appears on profile of user");
-
 $mech->get('/user/alice');
 $mech->content_contains('Collection', "Collection tab appears on own profile, even if marked private");
-
-$mech->get('/logout');
-$mech->get('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
-
-$mech->get('/user/alice');
-$mech->content_contains('Collection', "Collection tab doesn't appear on profile if marked private");
 
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Tags.pm
@@ -19,8 +19,11 @@ test all => sub {
     INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (7, 1, 1, 't');
 EOSQL
 
+    $mech->get('/user/new_editor/tags');
+    $mech->content_contains('not a musical', "new_editor has used the tag 'not a musical'");
+
     $mech->get('/user/alice/tags');
-    $mech->content_contains('You need to be logged in to view this page.', "user tags require login");
+    is($mech->status, 403, "alice' tags are private");
 
     $mech->get('/login');
     $mech->submit_form(with_fields => { username => 'new_editor', password => 'password' });
@@ -35,9 +38,6 @@ EOSQL
     $mech->get('/user/alice/tags');
     is($mech->status, 200, "alice can view her own tags");
     $mech->content_contains('Alice has not tagged anything', "alice has not tagged anything");
-
-    $mech->get('/user/new_editor/tags');
-    $mech->content_contains('not a musical', "new_editor has used the tag 'not a musical'");
 };
 
 1;


### PR DESCRIPTION
## [MBS-9519](https://tickets.metabrainz.org/browse/MBS-9519): Hide biography, homepage, and collections description of limiter users from not-logged-in users

This supersedes [MBS-9353](https://tickets.metabrainz.org/browse/MBS-9353) (completly hide user profiles and collection pages) and [MBS-9355](https://tickets.metabrainz.org/browse/MBS-9355) (disable editing biography and homepage/website for limited users).