### PR TITLE
MBS-9525: retry fullexport rsync if it fails

### DIFF
--- a/admin/functions.sh
+++ b/admin/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 make_temp_dir()
 {
@@ -19,4 +19,25 @@ make_temp_dir()
     # trade-off; we opt to not lose any files accidentally, at the risk of perhaps
     # accumulating temporary directories over time.
     trap 'rmdir "$TEMP_DIR"' 0 1 2 3 15
+}
+
+retry() {
+    local attempts_remaining=5
+    local delay=15
+    while true; do
+        "$@"
+        status=$?
+        if [[ $status -eq 0 ]]; then
+            break
+        fi
+        let 'attempts_remaining -= 1'
+        if [[ $attempts_remaining -gt 0 ]]; then
+            echo "Command failed with exit status $status; retrying in $delay seconds"
+            sleep $delay
+            let 'delay *= 2'
+        else
+            echo 'Failed to execute command after 5 attempts'
+            break
+        fi
+    done
 }

--- a/bin/rsync-fullexport-files
+++ b/bin/rsync-fullexport-files
@@ -6,11 +6,12 @@ MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 cd "$MB_SERVER_ROOT"
 
 source admin/config.sh
+source admin/functions.sh
 
 if [ -n "$RSYNC_FULLEXPORT_HOST" ]; then
     RSYNC_FULLEXPORT_PORT=${RSYNC_FULLEXPORT_PORT:-22}
 
-    rsync \
+    retry rsync \
         --archive \
         --delete \
         --exclude='latest-is*' \
@@ -20,7 +21,7 @@ if [ -n "$RSYNC_FULLEXPORT_HOST" ]; then
         brainz@$RSYNC_FULLEXPORT_HOST:./
 
     if [ -n "$RSYNC_LATEST_KEY" ]; then
-        rsync \
+        retry rsync \
             --archive \
             --rsh "ssh -i $RSYNC_LATEST_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT" \
             --verbose \


### PR DESCRIPTION
This has failed twice recently: https://community.metabrainz.org/t/mbdump-tar-bz2-missing-from-latest-full-export/333175/5

This just retries it forever, sleeping for 30 seconds between each attempt.