### PR TITLE
Reject edits with empty name to mitigate MBS-9512

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -210,7 +210,10 @@ sub trim_string {
 sub process_entity {
     my ($c, $loader, $data) = @_;
 
-    trim_string($data, 'name');
+    if (exists $data->{name}) {
+        trim_string($data, 'name');
+        die 'empty name' unless non_empty($data->{name});
+    }
 
     if ($data->{comment}) {
         trim_string($data, 'comment');

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -12,6 +12,7 @@ import {reduceArtistCredit} from '../common/immutable-entities';
 import MB from '../common/MB';
 import clean from '../common/utility/clean';
 import debounce from '../common/utility/debounce';
+import isBlank from '../common/utility/isBlank';
 import isPositiveInteger from '../edit/utility/isPositiveInteger';
 import * as validation from '../edit/validation';
 
@@ -168,7 +169,7 @@ releaseEditor.edits = {
                     var oldRecording = track.recording.savedEditData;
 
                     if (oldRecording) {
-                        if (track.updateRecordingTitle()) {
+                        if (track.updateRecordingTitle() && !isBlank(trackData.name)) {
                             newRecording.name = trackData.name;
                         }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -17,6 +17,7 @@ import {
 import MB from '../common/MB';
 import clean from '../common/utility/clean';
 import formatTrackLength from '../common/utility/formatTrackLength';
+import isBlank from '../common/utility/isBlank';
 import request from '../common/utility/request';
 import MB_edit from '../edit/MB/edit';
 import * as dates from '../edit/utility/dates';
@@ -274,7 +275,7 @@ class Track {
     }
 
     hasNameAndArtist() {
-        return this.name() && isCompleteArtistCredit(this.artistCredit());
+        return !isBlank(this.name()) && isCompleteArtistCredit(this.artistCredit());
     }
 
     hasVariousArtists() {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -466,6 +466,24 @@ test 'previewing/creating/editing a release group and release' => sub {
     $c->model('Track')->load_for_mediums($medium2);
     $c->model('Recording')->load($medium2->all_tracks);
 
+    # MBS-9512
+    @edits = capture_edits {
+        post_json($mech, '/ws/js/edit/create', encode_json({
+            edits => [
+                {
+                    edit_type   => $EDIT_RECORDING_EDIT,
+                    name        => '',
+                    to_edit     => $medium2->tracks->[0]->recording->gid,
+                },
+            ],
+            makeVotable => 0,
+        }));
+    } $c;
+
+    ok(scalar(@edits) == 0, 'recording edit with empty name is not created');
+    $response = from_json($mech->content);
+    like($response->{error}, qr/^empty name/, 'error is returned for empty recording name');
+
     $medium_edits = [
         {
             # No changes. Shouldn't cause an error, but should be indicated


### PR DESCRIPTION
Mitigate bug [MBS-9512](https://tickets.metabrainz.org/browse/MBS-9512) _(Changing recording name to empty string should not be allowed)_ by rejecting edits which violate `only_non_empty` and `only_non_empty_sort_name` constraints.