### PR TITLE
MBS-9540: Add ratings for non top level entities

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -85,11 +85,10 @@ sub serialize
     {
         # MBS-9129: If ratings are requested (even though a release doesn't have
         # any), those of the release group should be serialized (to match the
-        # behaviour of the XML serializer). So we call `serialize_rating`
-        # directly on the release group, setting `$toplevel` to 1.
+        # behaviour of the XML serializer). So we override a package variable to
+        # force the ratings to be serialized despite not being top-level.
         local $MusicBrainz::Server::WebService::Serializer::JSON::2::Utils::force_ratings = 1;
-        my $output = serialize_entity($entity->release_group, $inc, $stash);
-        $body{"release-group"} = $output;
+        $body{"release-group"} = serialize_entity($entity->release_group, $inc, $stash);
     }
 
     if ($toplevel)

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -114,6 +114,11 @@ sub serialize
 
     if ($inc && ($inc->media || $inc->discids || $inc->recordings))
     {
+        # MBS-9540: If ratings are requested (even though a release doesn't have
+        # any), those of the related entities should be displayed. So we override
+        # a package variable to force the ratings to be serialized despite not
+        # being top-level.
+        local $MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating::forced = 1;
         $body{media} = [
             map { serialize_entity($_, $inc, $stash) }
             $entity->all_mediums ];

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Release.pm
@@ -87,8 +87,8 @@ sub serialize
         # any), those of the release group should be serialized (to match the
         # behaviour of the XML serializer). So we call `serialize_rating`
         # directly on the release group, setting `$toplevel` to 1.
+        local $MusicBrainz::Server::WebService::Serializer::JSON::2::Utils::force_ratings = 1;
         my $output = serialize_entity($entity->release_group, $inc, $stash);
-        serialize_rating($output, $entity->release_group, $inc, $stash, 1);
         $body{"release-group"} = $output;
     }
 
@@ -118,7 +118,7 @@ sub serialize
         # any), those of the related entities should be displayed. So we override
         # a package variable to force the ratings to be serialized despite not
         # being top-level.
-        local $MusicBrainz::Server::WebService::Serializer::JSON::2::Role::Rating::forced = 1;
+        local $MusicBrainz::Server::WebService::Serializer::JSON::2::Utils::force_ratings = 1;
         $body{media} = [
             map { serialize_entity($_, $inc, $stash) }
             $entity->all_mediums ];

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Utils.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Utils.pm
@@ -20,6 +20,8 @@ our @EXPORT_OK = qw(
     serializer
 );
 
+our $force_ratings = 0;
+
 my %serializers =
     map {
         my $class = "MusicBrainz::Server::WebService::Serializer::JSON::2::$_";
@@ -219,7 +221,7 @@ sub serialize_rating {
     my ($into, $entity, $inc, $stash, $toplevel) = @_;
 
     return unless
-        ($toplevel &&
+        (($toplevel || $force_ratings) &&
          (defined $inc && ($inc->ratings || $inc->user_ratings)));
 
     my $opts = $stash->store($entity);


### PR DESCRIPTION
This is used in picard to get track ratings. 