### PR TITLE
MBS-9542: Update iTunes URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -568,7 +568,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?([^/]+\\.)?itunes\\.apple\\.com/", "i")],
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
-      return url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(id[0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/$3");
+      return url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, "https://itunes.apple.com/$1$2/id$3");
     },
     validate: function (url, id) {
       var m = /^https:\/\/itunes\.apple\.com\/(?:[a-z]{2}\/)?([a-z-]{3,})\/id[0-9]+$/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1285,6 +1285,13 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                     expected_clean_url: 'https://itunes.apple.com/ir/podcast/id469326376',
                only_valid_entity_types: ['release']
         },
+        {
+                             input_url: 'https://itunes.apple.com/jp/album/uchiagehanabi-single/1263790414',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://itunes.apple.com/jp/album/id1263790414',
+               only_valid_entity_types: ['release']
+        },
         // Jamendo Music
         {
                              input_url: 'http://www.jamendo.com/en/track/725574/giraffe',


### PR DESCRIPTION
### Fix [MBS-9542](https://tickets.metabrainz.org/browse/MBS-9542): New default iTunes link format (without “id” characters) is denied.

Update iTunes URL cleanup to add `id` characters which are now missing from new default iTunes link format. Validation is unchanged.