### PR TITLE
s/show_in_sidebar/show_in_external_links/g

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL.pm
+++ b/lib/MusicBrainz/Server/Entity/URL.pm
@@ -121,8 +121,8 @@ around TO_JSON => sub {
 
     return {
         %{ $self->$orig },
-        $self->can('show_in_sidebar') ?
-            (show_in_sidebar => $self->show_in_sidebar) : (),
+        $self->can('show_in_external_links') ?
+            (show_in_external_links => $self->show_in_external_links) : (),
         $self->can('sidebar_name') ?
             (sidebar_name => $self->sidebar_name) : (),
         href_url => $self->href_url,

--- a/lib/MusicBrainz/Server/Entity/URL/Commons.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Commons.pm
@@ -5,7 +5,7 @@ use Moose;
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::MediaWiki';
 
-sub show_in_sidebar { 0 }
+sub show_in_external_links { 0 }
 
 sub url_is_scheme_independent { 1 }
 

--- a/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/IMSLP.pm
@@ -32,13 +32,13 @@ sub sidebar_name {
     }
 }
 
-=method show_in_sidebar
+=method show_in_external_links
 
 IMSLP URLs are only show in the sidebar if the URL can be decoded from utf-8
 
 =cut
 
-sub show_in_sidebar { !shift->uses_legacy_encoding }
+sub show_in_external_links { !shift->uses_legacy_encoding }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/URL/Sidebar.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Sidebar.pm
@@ -3,13 +3,13 @@ use Moose::Role;
 
 requires 'sidebar_name';
 
-=method show_in_sidebar
+=method show_in_external_links
 
 Returns true if this URL should be displayed in the sidebar, or false if it
 should not. Allows URLs to do per-value checks on URLs.
 
 =cut
 
-sub show_in_sidebar { 1 }
+sub show_in_external_links { 1 }
 
 1;

--- a/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikipedia.pm
@@ -41,13 +41,13 @@ sub language
     }
 }
 
-=method show_in_sidebar
+=method show_in_external_links
 
 Wikipedia URLs are only show in the sidebar if the URL can be decoded from utf-8
 
 =cut
 
-sub show_in_sidebar { !shift->uses_legacy_encoding }
+sub show_in_external_links { !shift->uses_legacy_encoding }
 
 sub url_is_scheme_independent { 1 }
 

--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -73,7 +73,7 @@ const ExternalLinks = ({entity, empty, heading}) => {
           text={l('Official homepage')}
         />
       );
-    } else if (target.show_in_sidebar) {
+    } else if (target.show_in_external_links) {
       otherLinks.push(relationship);
     }
   }


### PR DESCRIPTION
The old name is misleading, because e.g. it's disabled for licenses even
though those are displayed in the sidebar, just in a different location.

The actual usage of this is whether the link appears under the 'External
links' section.