### PR TITLE
MBS-8576: Show work type descriptions in work creation form

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -186,6 +186,12 @@ after create => sub {
     stash_work_form_json($c);
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %work_types = map {$_->id => $_} $c->model('WorkType')->get_all();
+    $c->stash->{work_types} = \%work_types;
+};
+
 1;
 
 =head1 COPYRIGHT

--- a/lib/MusicBrainz/Server/Data/WorkType.pm
+++ b/lib/MusicBrainz/Server/Data/WorkType.pm
@@ -38,6 +38,14 @@ sub in_use {
         $id);
 }
 
+sub get_description
+{
+    my ($self, $id) = @_;
+    return $self->sql->select_single_value(
+        'SELECT description FROM work_type WHERE id = ? LIMIT 1',
+        $id);
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Data/WorkType.pm
+++ b/lib/MusicBrainz/Server/Data/WorkType.pm
@@ -38,14 +38,6 @@ sub in_use {
         $id);
 }
 
-sub get_description
-{
-    my ($self, $id) = @_;
-    return $self->sql->select_single_value(
-        'SELECT description FROM work_type WHERE id = ? LIMIT 1',
-        $id);
-}
-
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/WorkType.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkType.pm
@@ -14,6 +14,11 @@ sub l_name {
     return lp($self->name, 'work_type')
 }
 
+sub l_description {
+    my $self = shift;
+    return lp($self->description, 'work_type');
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -189,3 +189,16 @@ store.subscribe(renderWorkLanguages);
 renderWorkLanguages();
 
 MB.Control.initializeBubble('#iswcs-bubble', 'input[name=edit-work\\.iswcs\\.0]');
+
+let typeIdField = 'select[name=edit-work\\.type_id]';
+MB.Control.initializeBubble('#type-bubble', typeIdField);
+$(typeIdField).on('change', function() {
+  if (!this.value.match(/\S/g)) {
+    $('.type-bubble-description').hide();
+    $('#type-bubble-default').show();
+  } else {
+    $('#type-bubble-default').hide();
+    $('.type-bubble-description').hide();
+    $(`#type-bubble-description-${this.value}`).show();
+  }
+});

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -99,6 +99,18 @@
 
   <div class="documentation">
     [%- iswc_bubble(link_entity(work)) -%]
+
+    <div class="bubble" id="type-bubble">
+      <span id="type-bubble-default">
+        [%- l('Select any type from the list to see its description. If the work
+               doesn’t seem to match any type, just leave this blank.') -%]
+      </span>
+      [% FOREACH id IN form.field('type_id').options %]
+         <span style="display:none" class="type-bubble-description" id="type-bubble-description-[%- id.value -%]">
+           <strong>[%- add_colon(l('Description')) -%] </strong>[%- c.model('WorkType').get_description(id.value) -%]
+         </span>
+      [% END %]
+    </div>
   </div>
 
 </form>

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -106,8 +106,9 @@
                doesn’t seem to match any type, just leave this blank.') -%]
       </span>
       [% FOREACH id IN form.field('type_id').options %]
-         <span style="display:none" class="type-bubble-description" id="type-bubble-description-[%- id.value -%]">
-           <strong>[%- add_colon(l('Description')) -%] </strong>[%- c.model('WorkType').get_description(id.value) -%]
+         [%- id = id.value -%]
+         <span style="display:none" class="type-bubble-description" id="type-bubble-description-[% id %]">
+           <strong>[%- add_colon(l('Description')) -%] </strong>[%- work_types.$id.l_description -%]
          </span>
       [% END %]
     </div>


### PR DESCRIPTION
Show the description of the selected type next to the type dropdown. Somewhat inelegant solution with a bunch of preloaded `<span>`s, but works well. 