### PR TITLE
MBS-8206: Add Disc ID report

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesMissingDiscIds.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesMissingDiscIds.pm
@@ -1,0 +1,36 @@
+package MusicBrainz::Server::Report::ReleasesMissingDiscIds;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {
+    q{
+        SELECT DISTINCT ON (r.id)
+            r.id AS release_id,
+            row_number() OVER (ORDER BY r.artist_credit, r.name)
+        FROM
+        ( SELECT r.id, r.artist_credit, r.name
+          FROM release r
+          WHERE id IN (
+              SELECT release FROM medium
+              WHERE (SELECT has_discids FROM medium_format WHERE medium_format.id = medium.format)
+              AND id NOT IN (SELECT medium FROM medium_cdtoc)
+          )
+        ) r
+        WHERE r.status NOT IN (3, 4) -- ignore psuedo and bootleg releases
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2017 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -73,6 +73,7 @@ use MusicBrainz::Server::PagedReport;
     ReleasesWithoutVACredit
     ReleasesWithoutVALink
     ReleasesWithUnlikelyLanguageScript
+    ReleasesMissingDiscIds
     SeparateDiscs
     SetInDifferentRG
     SingleMediumReleasesWithMediumTitles
@@ -146,6 +147,7 @@ use MusicBrainz::Server::Report::ReleasesWithNoMediums;
 use MusicBrainz::Server::Report::ReleasesWithoutVACredit;
 use MusicBrainz::Server::Report::ReleasesWithoutVALink;
 use MusicBrainz::Server::Report::ReleasesWithUnlikelyLanguageScript;
+use MusicBrainz::Server::Report::ReleasesMissingDiscIds;
 use MusicBrainz::Server::Report::SeparateDiscs;
 use MusicBrainz::Server::Report::SetInDifferentRG;
 use MusicBrainz::Server::Report::SingleMediumReleasesWithMediumTitles;

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -108,6 +108,7 @@
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithNoMediums') %]">[% l('Releases with no mediums') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVACredit') %]">[% l('Releases not credited to "Various Artists" but linked to VA') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVALink') %]">[% l('Releases credited to "Various Artists" but not linked to VA') %]</a></li>
+            <li><a href="[% c.uri_for_action('/report/show', 'ReleasesMissingDiscIds') %]">[% l('Releases missing Disc IDs') %]</a></li>
         </ul>
 
         <h2>[% l('Recordings') %]</h2>

--- a/root/report/releases_missing_disc_ids.tt
+++ b/root/report/releases_missing_disc_ids.tt
@@ -1,0 +1,17 @@
+[%- WRAPPER 'layout.tt' title=l('Releases Missing Disc IDs') full_width=1 -%]
+
+<h1>[% l('Releases Missing Disc IDs') %]</h1>
+
+<ul>
+    <li>[% l('This report shows releases (official and promotional only)
+              that have at least one medium with a format that supports Disc ID, but is missing one.') %]</li>
+    <li>[% l('For instructions on how  to add one, see the {add_discids|documentation page}.',
+              { add_discids => doc_link('How_to_Add_Disc_IDs') }) %]</li>
+    <li>[% l('Total releases found: {count}', { count => pager.total_entries }) %]</li>
+    <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
+    [%- INCLUDE 'report/filter_link.tt' -%]
+</ul>
+
+[%- INCLUDE 'report/release_list.tt' -%]
+
+[%- END -%]


### PR DESCRIPTION
This report shows all the releases that have at least one medium that has a format with the `has_discids` property, but that don't actually have a Disc ID attached to it.