### PR TITLE
MBS-9561: Add Anison.info to otherdbs whitelist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1279,6 +1279,28 @@ const CLEANUPS = {
       return false;
     }
   },
+  anisongeneration: {
+    match: [new RegExp("^(?:https?://)?anison\\.info/", "i")],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?anison\.info\/data\/(person|source|song)\/([0-9]+)\.html.*$/, "http://anison.info/data/$1/$2.html");
+      },
+    validate: function (url, id) {
+      var m = /^http:\/\/anison\.info\/data\/(person|source|song)\/([0-9]+)\.html$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix === 'person';
+          case LINK_TYPES.otherdatabases.release:
+            return prefix === 'source';
+          case LINK_TYPES.otherdatabases.recording:
+            return prefix === 'song';
+        }
+      }
+      return false;
+    }
+  },
   baidubaike: {
     match: [new RegExp("^(https?://)?baike\\.baidu\\.com/", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -266,6 +266,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://www.animenewsnetwork.com/encyclopedia/company.php?id=10510',
         },
+        // Anison Generation
+        {
+                             input_url: 'http://anison.info/data/person/1878.html',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://anison.info/data/person/1878.html',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://anison.info/data/source/15524.html?test',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://anison.info/data/source/15524.html',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'http://anison.info/data/song/5227.html#test',
+                     input_entity_type: 'recording',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://anison.info/data/song/5227.html',
+               only_valid_entity_types: ['recording']
+        },
         // (Internet) Archive
         {
                              input_url: 'http://web.archive.org/web/20100904165354/i265.photobucket.com/albums/ii229/drsaunde/487015.jpg',


### PR DESCRIPTION
For [Anison Generation](http://anison.info/):
1. Allow to enter as `otherdatabases` relationship (with auto-selection, cleaning-up, and validation)

Link to issue: [MBS-9561](https://tickets.metabrainz.org/browse/MBS-9561)