### PR TITLE
Renderer socket fixes

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -43,7 +43,6 @@ BEGIN {
             use POSIX;
             my $action = POSIX::SigAction->new(sub {
                 kill 'TERM', $child;
-                unlink DBDefs->RENDERER_SOCKET;
                 exit;
             });
             $action->safe(1);

--- a/root/server.js
+++ b/root/server.js
@@ -90,7 +90,6 @@ if (cluster.isMaster) {
     for (const id in cluster.workers) {
       killWorker(cluster.workers[id], signal);
     }
-    fs.unlinkSync(SOCKET_PATH);
     process.exit();
   });
 


### PR DESCRIPTION
This seems to fix cases where the renderer socket file doesn't get removed after server.js exits. I then removed the explicit `unlink` calls I added in places, which were causing their own problems (sometimes the socket file would get removed, so the unlink would fail).

No idea if it fixes issues like [MBS-9370](https://tickets.metabrainz.org/browse/MBS-9370).