### PR TITLE
Fix encoding of CSS `>` immediate children selector in HTML `<style>` tag

### DIFF
--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -64,9 +64,10 @@ const Head = (props) => (
     <link rel="search" type="application/opensearchdescription+xml" title={l('MusicBrainz: Track')} href="/static/search_plugins/opensearch/musicbrainz_track.xml" />
 
     <noscript>
-      <style type="text/css">
-        {'.header > .right > .bottom > .menu > li:focus > ul { left: auto; }'}
-      </style>
+      <style
+        dangerouslySetInnerHTML={{__html: '.header > .right > .bottom > .menu > li:focus > ul { left: auto; }'}}
+        type="text/css"
+      />
     </noscript>
 
     {manifest.js('rev-manifest')}


### PR DESCRIPTION
Pages header did not pass HTML validation because of the presence of ampersand `&` character in `<style>` tag which is supposed to contain character data.

This patch prevents encoding `>` as HTML entity `&gt;` here.