### PR TITLE
MBS-9566: Add http://brahms.ircam.fr to the otherdbs whitelist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1367,6 +1367,26 @@ const CLEANUPS = {
       return false;
     }
   },
+  brahms: {
+    match: [new RegExp("^(https?://)?brahms\\.ircam\\.fr/", "i")],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?brahms\.ircam\.fr\/((works\/work)(?:\/)([0-9]+)|(?!works)[^?\/#]+).*$/, "http://brahms.ircam.fr/$1");
+    },
+    validate: function (url, id) {
+      var m = /^(?:https?:\/\/)?brahms\.ircam\.fr\/(works\/work|(?!works)[^?\/#]+).*$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.work:
+            return prefix == 'works/work';
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix !== 'works/work';	
+        }
+      }
+      return false;
+    }
+  },
   cancionerosmewiki: {
     match: [new RegExp("^(https?://)?(www\\.)?cancioneros\\.si/mediawiki/", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -609,6 +609,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'bookbrainz',
                     expected_clean_url: 'https://bookbrainz.org/work/65e71f2e-7245-42df-b93e-89463a28f75c',
         },
+        // Brahms Ircam
+        {
+                             input_url: 'http://brahms.ircam.fr/gilbert-amy#parcours',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://brahms.ircam.fr/gilbert-amy',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://brahms.ircam.fr/works/work/6385/',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'http://brahms.ircam.fr/works/work/6385',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'http://brahms.ircam.fr/works/genre/328/?test/',
+                     input_entity_type: 'work',
+               input_relationship_type: 'otherdatabases', 
+            expected_relationship_type: undefined,
+               only_valid_entity_types: []
+        },
         // Cancioneros Musicales Españoles (CME)
         {
                              input_url: 'cancioneros.si/mediawiki/index.php?title=Cancionero_Musical_de_Palacio#RELACI.C3.93N_DE_OBRAS',


### PR DESCRIPTION
For [brahms.ircam.fr](http://brahms.ircam.fr):
1. Allow to enter as `otherdatabases` relationship (with auto-selection, cleaning-up, and validation)

Link to issue: [MBS-9566](https://tickets.metabrainz.org/browse/MBS-9566)