### PR TITLE
Update moment and moment-strftime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5140,9 +5140,9 @@
       "integrity": "sha1-bLIZZ8ecunsMpeZmRPFzZis++nc="
     },
     "moment-strftime": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/moment-strftime/-/moment-strftime-0.1.5.tgz",
-      "integrity": "sha1-7ZO/cioyp6zDw/7+sNNW260luoE=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/moment-strftime/-/moment-strftime-0.2.3.tgz",
+      "integrity": "sha512-5RbAIRaTQZ1KP5OLKS5t5dZ1zYkT8I9IQiPjRsgvjpYdMJFh8A38x/46A3WakOen1gjgNk/AxaY+nY3WFhHrfQ==",
       "requires": {
         "moment": "2.10.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5135,16 +5135,16 @@
       "integrity": "sha1-mi3sg4Bvuy2XXyK+7IWcoms5OqE="
     },
     "moment": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
-      "integrity": "sha1-bLIZZ8ecunsMpeZmRPFzZis++nc="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "moment-strftime": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/moment-strftime/-/moment-strftime-0.2.3.tgz",
       "integrity": "sha512-5RbAIRaTQZ1KP5OLKS5t5dZ1zYkT8I9IQiPjRsgvjpYdMJFh8A38x/46A3WakOen1gjgNk/AxaY+nY3WFhHrfQ==",
       "requires": {
-        "moment": "2.10.6"
+        "moment": "2.20.1"
       }
     },
     "moment-timezone": {
@@ -5152,7 +5152,7 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
       "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
       "requires": {
-        "moment": "2.10.6"
+        "moment": "2.20.1"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "4.17.4",
     "merge-stream": "1.0.1",
     "moment": "2.10.6",
-    "moment-strftime": "0.1.5",
+    "moment-strftime": "0.2.3",
     "moment-timezone": "0.4.1",
     "node-gettext": "1.0.1",
     "po2json": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "leven": "2.0.0",
     "lodash": "4.17.4",
     "merge-stream": "1.0.1",
-    "moment": "2.10.6",
+    "moment": "2.20.1",
     "moment-strftime": "0.2.3",
     "moment-timezone": "0.4.1",
     "node-gettext": "1.0.1",


### PR DESCRIPTION
The only purpose of updating `moment` is to get rid of the awful vulnerability alert that shows up on GitHub. Indeed, the spotted ReDoS vulnerability cannot be exploited on MusicBrainz server, since `moment` is running client-side and its only input is controlled (entity’s last modification time).
Updating `moment-strftime` too is needed to fix dependency issues.
