### PR TITLE
MBS-9374: Display multiple lyrics languages in work search result

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -666,9 +666,7 @@ sub schema_fixup
         if (@languages) {
             $data->{languages} = [map {
                 MusicBrainz::Server::Entity::WorkLanguage->new({
-                    language => MusicBrainz::Server::Entity::Language->new({
-                        iso_code_3 => $_,
-                    }),
+                    language => $self->c->model('Language')->find_by_code($_),
                 })
             } @languages];
         }

--- a/root/search/results-work.tt
+++ b/root/search/results-work.tt
@@ -10,7 +10,7 @@
                             <th>[%- l('Artists') -%]</th>
                             <th>[%- l('ISWC') -%]</th>
                             <th>[%- l('Type') -%]</th>
-                            <th>[%- l('Language') -%]</th>
+                            <th>[%- l('Languages') -%]</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -45,9 +45,15 @@
                                 [% result.entity.type.l_name %]
                             </td>
                             <td>
-                              <abbr title="[% result.entity.language.l_name %]">
-                                [% result.entity.language.iso_code_3 %]
-                              </abbr>
+                              <ul>
+                              [%- FOR work_language=result.entity.languages %]
+                                <li>
+                                  <abbr title="[% work_language.language.l_name %]">
+                                    [% work_language.language.iso_code_3 %]
+                                  </abbr>
+                                </li>
+                              [%- END %]
+                              </ul>
                             </td>
                         </tr>
                         [%- END -%]

--- a/root/search/results-work.tt
+++ b/root/search/results-work.tt
@@ -10,7 +10,7 @@
                             <th>[%- l('Artists') -%]</th>
                             <th>[%- l('ISWC') -%]</th>
                             <th>[%- l('Type') -%]</th>
-                            <th>[%- l('Languages') -%]</th>
+                            <th>[%- l('Lyrics Languages') -%]</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## Fix [MBS-9374](https://tickets.metabrainz.org/browse/MBS-9374): Langcode not displayed when searching works

Since MBS-5452 has been implemented, lyrics language was not displayed anymore in work search result.
  