### PR TITLE
MBS-9368: Ask for confirmation when leaving format empty

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -280,17 +280,24 @@
         <td class="format">
           <label data-bind="attr: { for: 'disc-format-' + uniqueID }">[% l('Format:') %]</label>
           <select data-bind="value: formatID, attr: { id: 'disc-format-' + uniqueID }">
-            <option value="" selected="selected">&#160;</option>
+            <option value="" selected="selected">—</option>
             [%- FOR format=formats %]
             <option value="[% format.value %]">[% format.label %]</option>
             [%- END %]
           </select>
+          <label>
+            <input type="checkbox" data-bind="checked: formatUnknownToUser, enable: formatID() == ''" />
+            [% l('I don’t know') %]
+          </label>
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
             <label data-bind="attr: { for: 'disc-title-' + uniqueID }">[% l('Disc title:') %]</label>
             <input type="text" data-bind="value: name, attr: { id: 'disc-title-' + uniqueID }" />
             <button type="button" class="icon guesscase-title" title="[% l('Guess case disc title') %]" data-click="guessCaseMediumName"></button>
           <!-- /ko -->
+          <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">
+            [%~ l('A format is required. If you don’t know it, tick the “I don’t know” checkbox next to the format dropdown.') %]
+          </p>
         </td>
 
         <td class="icon" style="text-align: right">

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -298,6 +298,7 @@ class Medium {
         this.name = ko.observable(data.name);
         this.position = ko.observable(data.position || 1);
         this.formatID = ko.observable(data.formatID);
+        this.formatUnknownToUser = ko.observable(Boolean(data.id && !data.formatID));
 
         var tracks = data.tracks;
         this.tracks = ko.observableArray(utils.mapChild(this, tracks, Track));
@@ -395,6 +396,16 @@ class Medium {
 
         this.needsTracks = ko.computed(function () {
             return self.loaded() && self.tracks().length === 0;
+        });
+
+        this.needsFormat = validation.errorField(function() {
+            return !(self.formatID() || self.formatUnknownToUser());
+        });
+
+        this.formatID.subscribe(function (value) {
+            if (value) {
+                self.formatUnknownToUser(false);
+            }
         });
     }
 


### PR DESCRIPTION
After some discussion with @chhavijustme and @reosarevok:

https://chatlogs.metabrainz.org/brainzbot/metabrainz/2018-01-12/?msg=4096763&page=1
https://chatlogs.metabrainz.org/brainzbot/metabrainz/2018-01-12/?msg=4096935&page=2

We decided that a checkbox affirming that the user doesn't know what the format would result in a better UX.

https://tickets.metabrainz.org/browse/MBS-9368