### PR TITLE
MBS-9582: Add UtaTen to the lyrics whitelist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1656,6 +1656,26 @@ const CLEANUPS = {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?kickstarter\.com\/projects\/(\d+)\/([\w\-]+)(?:[\/?#].*)?$/, "https://www.kickstarter.com/projects/$1/$2");
       return url;
     }
+  },
+  utaten: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?utaten\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?utaten\.com\/(artist|lyric\/.+)\/([^\/?#]+).*$/, "https://utaten.com/$1/$2");
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/utaten\.com\/(artist|lyric)\/.+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'lyric';
+        }
+      }
+      return false;
+    }
   }
 };
 

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -282,7 +282,7 @@ function disallow(url, id) {
 
 /**
  * CLEANUPS entries have 2 to 4 of the following properties:
- * 
+ *
  * - match: Array of regexps to match a given URL with the entry.
  *          It is the only mandatory property.
  * - type: Set of relationship types to be auto-selected for matched URL.

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2408,6 +2408,29 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'work',
             expected_relationship_type: 'lyrics',
         },
+        // Utaten
+        {
+                             input_url: 'utaten.com/artist/fripSide?sort=popular_sort_asc',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://utaten.com/artist/fripSide',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://utaten.com/lyric/fripSide/prominence#sort=popular_sort_asc',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://utaten.com/lyric/fripSide/prominence',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'https://utaten.com/news/index/14365',
+                     input_entity_type: 'artist',
+            expected_relationship_type: undefined,
+                    expected_clean_url: 'https://utaten.com/news/index/14365',
+               input_relationship_type: 'lyrics',
+               only_valid_entity_types: []
+        },
         // VGMdb (Video Game Music and Anime Soundtrack Database)
         {
                              input_url: 'https://vgmdb.net/artist/431',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1681,7 +1681,7 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'discographyentry',
         },
-        // Ney Nota Arşivi 
+        // Ney Nota Arşivi
         {
                              input_url: 'http://www.neyzen.com/nota_arsivi/02_klasik_eserler/054_mahur_buselik/mahur_buselik_ss_aydin_oran.pdf',
                      input_entity_type: 'work',
@@ -2504,13 +2504,13 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'artist',
             expected_relationship_type: 'socialnetwork',
         },
-        // VKontakte 
+        // VKontakte
         {
                              input_url: 'http://vk.com/tin_sontsya',
                      input_entity_type: 'artist',
             expected_relationship_type: 'socialnetwork',
         },
-        // Weibo 
+        // Weibo
         {
                              input_url: 'www.weibo.com/mchotdog2010#test',
                      input_entity_type: 'artist',


### PR DESCRIPTION
As part of Google Code-in, here's code that adds UtaTen to the lyrics whitelist. It also performs cleaning of the input URL and validates to make sure that the URL conforms to the entity type being entered.