### PR TITLE
Revert "Fix SEARCH_X_ACCEL_REDIRECT to work with solr"

### DIFF
--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -218,8 +218,7 @@ sub xml_search
     }
 
     if (DBDefs->SEARCH_X_ACCEL_REDIRECT) {
-        my $redirect_url = (DBDefs->SEARCH_ENGINE eq 'LUCENE') ? '/internal/search/' : '/internal/solr/';
-        return { redirect_url => $redirect_url . DBDefs->SEARCH_SERVER . $url_ext };
+        return { redirect_url => '/internal/search/' . DBDefs->SEARCH_SERVER . $url_ext }
     } else {
         my $url = 'http://' . DBDefs->SEARCH_SERVER . $url_ext;
         my $response = $self->c->lwp->get($url);


### PR DESCRIPTION
Reverts metabrainz/musicbrainz-server#600

So @zas finally figured out why the redirect was working with the current search and not solr.

It is because of the way nginx is configured. We do not set the host header while doing a redirect. 
https://github.com/metabrainz/openresty-gateways/blob/master/files/nginx/includes/musicbrainz-website_common.conf#L1

But it still works since instead of using a host, we use the consul service name in our docker configs like so - https://github.com/metabrainz/docker-server-configs/blob/master/consul/services/prod.musicbrainz-server.json#L26

This makes the redirect work and also allows us to redirect from http -> https solr.

So we should change the current config on https://github.com/metabrainz/docker-server-configs/blob/master/consul/services/test.musicbrainz-server.json#L14 to use a consul service name.