### PR TITLE
MBS-9608: Update URL cleanup to handle new Bandsintown’s URL format

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1053,18 +1053,18 @@ const CLEANUPS = {
       if (m) {
         var prefix = m[1];
         var number = m[2];
-        url = "https://bandsintown.com/" + prefix + "/" + number;
+        url = "https://www.bandsintown.com/" + prefix + "/" + number;
       } else {
         m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/([^\/?#]+)(?:[\/?#].*)?$/);
         if (m) {
           var name = m[1];
-          url = "https://bandsintown.com/" + name.toLowerCase();
+          url = "https://www.bandsintown.com/" + name.toLowerCase();
         }
       }
       return url;
     },
     validate: function (url, id) {
-      var m = /^https:\/\/bandsintown\.com\/(?:(a|e|v)\/)?([^\/?#]+)$/.exec(url);
+      var m = /^https:\/\/www.bandsintown\.com\/(?:(a|e|v)\/)?([^\/?#]+)$/.exec(url);
       if (m) {
         var prefix = m[1];
         var target = m[2];

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1049,7 +1049,7 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?((m|www)\\.)?bandsintown\\.com","i")],
     type: LINK_TYPES.bandsintown,
     clean: function (url) {
-      var m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(event|venue)\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
+      var m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(a(?=rtist|\/)|e(?=vent|\/)|v(?=enue|\/))[a-z]*\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
       if (m) {
         var prefix = m[1];
         var number = m[2];
@@ -1064,17 +1064,17 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
-      var m = /^https:\/\/bandsintown\.com\/(?:(event|venue)\/)?([^\/?#]+)$/.exec(url);
+      var m = /^https:\/\/bandsintown\.com\/(?:(a|e|v)\/)?([^\/?#]+)$/.exec(url);
       if (m) {
         var prefix = m[1];
         var target = m[2];
         switch (id) {
           case LINK_TYPES.bandsintown.artist:
-            return prefix === undefined && target !== undefined;
+            return prefix === undefined && target !== undefined || prefix === 'a' && /^[1-9][0-9]*$/.test(target);
           case LINK_TYPES.bandsintown.event:
-            return prefix === 'event' && /^[1-9][0-9]*$/.test(target);
+            return prefix === 'e' && /^[1-9][0-9]*$/.test(target);
           case LINK_TYPES.bandsintown.place:
-            return prefix === 'venue' && /^[1-9][0-9]*$/.test(target);
+            return prefix === 'v' && /^[1-9][0-9]*$/.test(target);
         }
       }
       return false;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -634,8 +634,8 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
         {
                              input_url: 'http://brahms.ircam.fr/works/genre/328/?test/',
                      input_entity_type: 'work',
-               input_relationship_type: 'otherdatabases', 
             expected_relationship_type: undefined,
+               input_relationship_type: 'otherdatabases',
                only_valid_entity_types: []
         },
         // Cancioneros Musicales Españoles (CME)

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -395,17 +395,24 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                only_valid_entity_types: ['artist']
         },
         {
+                             input_url: 'https://www.bandsintown.com/a/159526#',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'bandsintown',
+                    expected_clean_url: 'https://bandsintown.com/a/159526',
+               only_valid_entity_types: ['artist']
+        },
+        {
                              input_url: 'https://www.bandsintown.com/event/13245613-the-accidentals-santa-barbara-soho-restaurant-and-music-club-2017?artist=The+Accidentals&came_from=174',
                      input_entity_type: 'event',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/event/13245613',
+                    expected_clean_url: 'https://bandsintown.com/e/13245613',
                only_valid_entity_types: ['event']
         },
         {
                              input_url: 'bandsintown.com/venue/846942-soho-restaurant-and-music-club-santa-barbara-ca-tickets-and-schedule',
                      input_entity_type: 'place',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/venue/846942',
+                    expected_clean_url: 'https://bandsintown.com/v/846942',
                only_valid_entity_types: ['place']
         },
         // BBC Music

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -384,35 +384,35 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: "https://m.bandsintown.com/MattDobberteen's50thBirthday?came_from=178",
                      input_entity_type: 'artist',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: "https://bandsintown.com/mattdobberteen's50thbirthday",
+                    expected_clean_url: "https://www.bandsintown.com/mattdobberteen's50thbirthday",
                only_valid_entity_types: ['artist']
         },
         {
-                             input_url: 'http://bandsintown.com/1%252F2Orchestra/past_events',
+                             input_url: 'http://www.bandsintown.com/1%252F2Orchestra/past_events',
                      input_entity_type: 'artist',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/1%252f2orchestra',
+                    expected_clean_url: 'https://www.bandsintown.com/1%252f2orchestra',
                only_valid_entity_types: ['artist']
         },
         {
-                             input_url: 'https://www.bandsintown.com/a/159526#',
+                             input_url: 'https://bandsintown.com/a/159526#',
                      input_entity_type: 'artist',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/a/159526',
+                    expected_clean_url: 'https://www.bandsintown.com/a/159526',
                only_valid_entity_types: ['artist']
         },
         {
-                             input_url: 'https://www.bandsintown.com/event/13245613-the-accidentals-santa-barbara-soho-restaurant-and-music-club-2017?artist=The+Accidentals&came_from=174',
+                             input_url: 'https://bandsintown.com/event/13245613-the-accidentals-santa-barbara-soho-restaurant-and-music-club-2017?artist=The+Accidentals&came_from=174',
                      input_entity_type: 'event',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/e/13245613',
+                    expected_clean_url: 'https://www.bandsintown.com/e/13245613',
                only_valid_entity_types: ['event']
         },
         {
                              input_url: 'bandsintown.com/venue/846942-soho-restaurant-and-music-club-santa-barbara-ca-tickets-and-schedule',
                      input_entity_type: 'place',
             expected_relationship_type: 'bandsintown',
-                    expected_clean_url: 'https://bandsintown.com/v/846942',
+                    expected_clean_url: 'https://www.bandsintown.com/v/846942',
                only_valid_entity_types: ['place']
         },
         // BBC Music


### PR DESCRIPTION
## [MBS-9608](https://tickets.metabrainz.org/browse/MBS-9608): Update Bandsintown URL cleanup to the new format

Bandsintown recently changed its default URL pattern:  It uses one-letter prefix (instead of no prefix for artist and type name for `event` and `venue`) and numeric ID everywhere (instead of artist name).
While Bandinstown correctly redirect URLs using the old format, MusicBrainz doesn’t accept entering URLs in the new format yet.
    
This patch updates Bandsintown URL cleanup to handle both URL formats from user input, to convert input URLs in old format to the new format, and to validate URLs in the new format only.

Additionally, it normalizes Bandsintown URLs to use the new default subdomain `ẁww` of `bandsintown.com`. It should prevent potential further reopening of [MBS-9559](https://tickets.metabrainz.org/browse/MBS-9559).