### PR TITLE
Fix WS/1 search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -1031,7 +1031,8 @@ sub xml_search
 
     my $search_url_string;
     if (DBDefs->SEARCH_ENGINE eq 'LUCENE') {
-        $search_url_string = "http://%s/ws/%d/%s/?query=%s&offset=%s&max=%s&fmt=xml";
+        $search_url_string = "http://%s/ws/$version/%s/?query=%s&offset=%s&max=%s&fmt=xml";
+        print $search_url_string;
     } else {
         $search_url_string = "http://%s/%s/select?q=%s&start=%s&rows=%s&wt=mbxml&fl=score";
     }


### PR DESCRIPTION
The search query was missing the version parameter, as a result
WS/1 searches were returning errors. Fixed this for now, but this opens
up a whole new problem. Solr output isn't compatible with WS/1. so will
we finally deprecate WS/1 or keep on running search.mb.org