### PR TITLE
MBS-9562, MBS-9587, MBS-9597, MBS-9612: Update URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1141,19 +1141,19 @@ const CLEANUPS = {
     type: _.defaults({}, LINK_TYPES.imslp, LINK_TYPES.score)
   },
   lastfm: {
-    match: [new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/(music|label|venue|event|festival)/", "i")],
+    match: [new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/([a-z]{2}/)?(music|label|venue|event|festival)/", "i")],
     type: LINK_TYPES.lastfm,
     clean: function (url) {
-      url = url.replace(/^(https?:\/\/)?((www|cn|m)\.)?(last\.fm|lastfm\.(com\.br|com\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/, "http://www.last.fm");
-      url = url.replace(/^http:\/\/www\.last\.fm\/music\/([^?]+).*/, "http://www.last.fm/music/$1");
+      url = url.replace(/^(https?:\/\/)?((www|cn|m)\.)?(last\.fm|lastfm\.(com\.br|com\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))\/([a-z]{2}\/)?/, "http://www.last.fm/");
+      url = url.replace(/^http:\/\/www\.last\.fm\/(?:[a-z]{2}\/)?([a-z]+)\/([^?#]+).*$/, "http://www.last.fm/$1/$2");
       return url;
     }
   },
   onlinecommunity: {
-    match: [new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/group/", "i")],
+    match: [new RegExp("^(https?://)?([^/]+\\.)?(last\\.fm|lastfm\\.(com\\.br|com\\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/([a-z]{2}/)?group/", "i")],
     type: LINK_TYPES.onlinecommunity,
     clean: function (url) {
-      url = url.replace(/^(https?:\/\/)?((www|cn|m)\.)?(last\.fm|lastfm\.(com\.br|com\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))/, "http://www.last.fm");
+      url = url.replace(/^(https?:\/\/)?((www|cn|m)\.)?(last\.fm|lastfm\.(com\.br|com\.tr|at|com|de|es|fr|it|jp|pl|pt|ru|se))\/([a-z]{2}\/)?/, "http://www.last.fm/");
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1537,6 +1537,28 @@ const CLEANUPS = {
       return id === LINK_TYPES.otherdatabases.artist && /^http:\/\/operabase\.com\/a\/[^\/?#]+\/[0-9]+$/.test(url);
     }
   },
+  petitlyrics: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?petitlyrics\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?petitlyrics\.com\/(lyrics(?:\/artist)?\/\d+|lyrics\/album\/[^?]+).*$/, "https://petitlyrics.com/$1");
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/petitlyrics\.com\/(lyrics(?:\/album|\/artist)?)\/.+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'lyrics/artist';
+          case LINK_TYPES.lyrics.release_group:
+            return prefix === 'lyrics/album';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'lyrics';
+        }
+      }
+      return false;
+    }
+  },
   rockcomar: {
     match: [new RegExp("^(https?://)?(www\\.)?rock\\.com\\.ar", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1461,6 +1461,30 @@ const CLEANUPS = {
             || id === LINK_TYPES.otherdatabases.work);
     }
   },
+  hoick: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?hoick\\.jp/", "i")],
+    type: _.defaults({}, LINK_TYPES.lyrics, LINK_TYPES.mailorder),
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?hoick\.jp\/(mdb\/detail\/\d+|mdb\/author|products\/detail\/\d+)\/([^\/?#]+).*$/, "https://hoick.jp/$1/$2");
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/hoick\.jp\/(mdb|products)\/(author|detail)(\/\d+)?\/[^\/?#]+$/.exec(url);
+      if (m) {
+        var db = m[1];
+        var type = m[2];
+        var slashRef = m[3];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return db === 'mdb' && type === 'author' && slashRef === undefined;
+          case LINK_TYPES.mailorder.release:
+            return db === 'products' && type === 'detail' && slashRef !== undefined;
+          case LINK_TYPES.lyrics.work:
+            return db === 'mdb' && type === 'detail' && slashRef !== undefined;
+        }
+      }
+      return false;
+    }
+  },
   irishtune: {
     match: [new RegExp("^(https?://)?(www\\.)?irishtune\\.info","i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1481,6 +1481,26 @@ const CLEANUPS = {
       return false;
     }
   },
+  joysound: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?joysound\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?joysound\.com\/(web\/search\/(?:artist|song)\/\d+).*$/, "https://www.joysound.com/$1");
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/www.joysound\.com\/web\/search\/(artist|song)\/\d+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'song';
+        }
+      }
+      return false;
+    }
+  },
   livefans: {
     match: [new RegExp("^(https?://)?(www\\.)?livefans\\.jp", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1015,10 +1015,10 @@ const CLEANUPS = {
     match: [new RegExp("^(https?://)?vgmdb\\.(net|com)/", "i")],
     type: LINK_TYPES.vgmdb,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?vgmdb\.(?:net|com)\/(album|artist|event|org)\/([0-9]+).*$/, "http://vgmdb.net/$1/$2");
+      return url.replace(/^(?:https?:\/\/)?vgmdb\.(?:net|com)\/(album|artist|event|org)\/([0-9]+).*$/, "https://vgmdb.net/$1/$2");
     },
     validate: function (url, id) {
-      var m = /^http:\/\/vgmdb\.net\/(album|artist|org|event)\/[1-9][0-9]*$/.exec(url);
+      var m = /^https:\/\/vgmdb\.net\/(album|artist|org|event)\/[1-9][0-9]*$/.exec(url);
       if (m) {
         var prefix = m[1];
         switch (id) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -855,7 +855,7 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.streamingmusic,
     clean: function (url) {
-      url = url.replace(/^https?:\/\/(www\.)?deezer\.com\/(\w+)\/(\d+).*$/, "https://www.deezer.com/$2/$3");
+      url = url.replace(/^https?:\/\/(www\.)?deezer\.com\/(?:[a-z]{2}\/)?(\w+)\/(\d+).*$/, "https://www.deezer.com/$2/$3");
       return url;
     }
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -857,6 +857,21 @@ const CLEANUPS = {
     clean: function (url) {
       url = url.replace(/^https?:\/\/(www\.)?deezer\.com\/(?:[a-z]{2}\/)?(\w+)\/(\d+).*$/, "https://www.deezer.com/$2/$3");
       return url;
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/www\.deezer\.com\/([a-z]+)\/(?:\d+)$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.streamingmusic.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.streamingmusic.release:
+            return prefix === 'album';
+          case LINK_TYPES.streamingmusic.recording:
+            return prefix === 'track';
+        }
+      }
+      return false;
     }
   },
   spotifyuseraccount: {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1196,6 +1196,36 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'otherdatabases',
                only_valid_entity_types: []
         },
+        // Hoick Music Search
+        {
+                             input_url: 'http://hoick.jp/mdb/author/%E4%BD%90%E7%80%AC%E5%AF%BF%E4%B8%80',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://hoick.jp/mdb/author/%E4%BD%90%E7%80%AC%E5%AF%BF%E4%B8%80',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'hoick.jp/mdb/detail/3467/%E3%81%8A%E3%82%88%E3%81%92!%E3%81%9F%E3%81%84%E3%82%84%E3%81%8D%E3%81%8F%E3%82%93#rev_conte',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://hoick.jp/mdb/detail/3467/%E3%81%8A%E3%82%88%E3%81%92!%E3%81%9F%E3%81%84%E3%82%84%E3%81%8D%E3%81%8F%E3%82%93',
+               only_valid_entity_types: ['work']
+        },
+        // Hoick Online Shop
+        {
+                             input_url: 'http://hoick.jp/products/detail/18578/%E3%81%9F%E3%81%A3%E3%81%B7%E3%82%8A!%E3%81%95%E3%81%84%E3%81%97%E3%82%93%E3%82%AD%E3%83%83%E3%82%BA%E3%82%BD%E3%83%B3%E3%82%B0%20%E3%82%B6%E3%83%BB%E3%83%99%E3%82%B9%E3%83%8851#review_contents',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'mailorder',
+                    expected_clean_url: 'https://hoick.jp/products/detail/18578/%E3%81%9F%E3%81%A3%E3%81%B7%E3%82%8A!%E3%81%95%E3%81%84%E3%81%97%E3%82%93%E3%82%AD%E3%83%83%E3%82%BA%E3%82%BD%E3%83%B3%E3%82%B0%20%E3%82%B6%E3%83%BB%E3%83%99%E3%82%B9%E3%83%8851',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'https://hoick.jp/products/detail/18578/%E3%81%9F%E3%81%A3%E3%81%B7%E3%82%8A!%E3%81%95%E3%81%84%E3%81%97%E3%82%93%E3%82%AD%E3%83%83%E3%82%BA%E3%82%BD%E3%83%B3%E3%82%B0%20%E3%82%B6%E3%83%BB%E3%83%99%E3%82%B9%E3%83%8851',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'lyrics',
+               only_valid_entity_types: []
+        },
         // (VICTOR STUDIO) HD-Music.
         {
                              input_url: 'http://hd-music.info/album.cgi/913',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1395,6 +1395,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'downloadfree',
                     expected_clean_url: 'http://www.jamendo.com/album/56372',
         },
+        // JOYSOUND
+        {
+                             input_url: 'https://www.joysound.com/web/search/artist/5169?startIndex=20#songlist',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.joysound.com/web/search/artist/5169',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'https://www.joysound.com/web/search/song/155526#lyrics',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.joysound.com/web/search/song/155526',
+               only_valid_entity_types: ['work']
+        },
         // JUGEM
         {
                              input_url: 'http://milk-pu-rin.jugem.jp/',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1523,6 +1523,10 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'http://www.lastfm.com/music/Carving+Colours',
                     expected_clean_url: 'http://www.last.fm/music/Carving+Colours',
         },
+        {
+                             input_url: 'https://www.last.fm/it/label/Shyrec#shoutbox',
+                    expected_clean_url: 'http://www.last.fm/label/Shyrec',
+        },
         // LiederNet Archive
         {
                              input_url: 'http://www.lieder.net/lieder/get_text.html?TextId=6448',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -853,9 +853,10 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'streamingmusic',
         },
         {
-                             input_url: 'http://www.deezer.com/album/497382',
+                             input_url: 'http://www.deezer.com/en/album/497382',
                      input_entity_type: 'release',
             expected_relationship_type: 'streamingmusic',
+                    expected_clean_url: 'https://www.deezer.com/album/497382',
         },
         // DHHU
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2545,28 +2545,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'https://vgmdb.net/artist/431',
                      input_entity_type: 'artist',
             expected_relationship_type: 'vgmdb',
-                    expected_clean_url: 'http://vgmdb.net/artist/431',
+                    expected_clean_url: 'https://vgmdb.net/artist/431',
                only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://vgmdb.com/event/197',
                      input_entity_type: 'event',
             expected_relationship_type: 'vgmdb',
-                    expected_clean_url: 'http://vgmdb.net/event/197',
+                    expected_clean_url: 'https://vgmdb.net/event/197',
                only_valid_entity_types: ['event']
         },
         {
                              input_url: 'https://vgmdb.com/org/284',
                      input_entity_type: 'label',
             expected_relationship_type: 'vgmdb',
-                    expected_clean_url: 'http://vgmdb.net/org/284',
+                    expected_clean_url: 'https://vgmdb.net/org/284',
                only_valid_entity_types: ['artist', 'label']
         },
         {
                              input_url: 'vgmdb.net/album/29727',
                      input_entity_type: 'release',
             expected_relationship_type: 'vgmdb',
-                    expected_clean_url: 'http://vgmdb.net/album/29727',
+                    expected_clean_url: 'https://vgmdb.net/album/29727',
                only_valid_entity_types: ['release']
         },
         // VIAF (Virtual International Authority File)

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -834,29 +834,41 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'http://www.deezer.com/artist/243332',
                      input_entity_type: 'artist',
             expected_relationship_type: 'streamingmusic',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'http://www.deezer.com/artist/6509511?test',
                      input_entity_type: 'artist',
             expected_relationship_type: 'streamingmusic',
                     expected_clean_url: 'https://www.deezer.com/artist/6509511',
+               only_valid_entity_types: ['artist']
         },
         {
                              input_url: 'https://deezer.com/album/8935347',
                      input_entity_type: 'release',
             expected_relationship_type: 'streamingmusic',
                     expected_clean_url: 'https://www.deezer.com/album/8935347',
+               only_valid_entity_types: ['release']
         },
         {
                              input_url: 'http://www.deezer.com/track/3437226',
                      input_entity_type: 'recording',
             expected_relationship_type: 'streamingmusic',
+               only_valid_entity_types: ['recording']
         },
         {
                              input_url: 'http://www.deezer.com/en/album/497382',
                      input_entity_type: 'release',
             expected_relationship_type: 'streamingmusic',
                     expected_clean_url: 'https://www.deezer.com/album/497382',
+               only_valid_entity_types: ['release']
+        },
+        {
+                             input_url: 'https://www.deezer.com/profile/18671676',
+                     input_entity_type: 'artist',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'streamingmusic',
+               only_valid_entity_types: []
         },
         // DHHU
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1820,6 +1820,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                              input_url: 'https://www.paypal.me/example?q=test',
                     expected_clean_url: 'https://www.paypal.me/example',
         },
+        // Petit Lyrics
+        {
+                             input_url: 'https://petitlyrics.com/lyrics/artist/24786/2-1.html',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://petitlyrics.com/lyrics/artist/24786',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'petitlyrics.com/lyrics/1039367',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://petitlyrics.com/lyrics/1039367',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'https://petitlyrics.com/lyrics/album/4e484be3818ae3818be38182e38195e38293e381a8e38184e381a3e38197e3828720e69c80e696b0e38399e382b9e38388e3808ce381bfe38293e381aae381aee383aae382bae383a0e3808d?artist=%E6%A8%AA%E5%B1%B1%E3%81%A0%E3%81%84%E3%81%99%E3%81%91%2C%E4%B8%89%E8%B0%B7%E3%81%9F%E3%81%8F%E3%81%BF',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://petitlyrics.com/lyrics/album/4e484be3818ae3818be38182e38195e38293e381a8e38184e381a3e38197e3828720e69c80e696b0e38399e382b9e38388e3808ce381bfe38293e381aae381aee383aae382bae383a0e3808d',
+               only_valid_entity_types: ['release_group']
+        },
         // Pinterest
         {
                              input_url: 'uk.pinterest.com/tucenter/pins/#',


### PR DESCRIPTION
## [MBS-9562](https://tickets.metabrainz.org/browse/MBS-9562): Improve Deezer URL cleanup
Additionally, validate Deezer URLs for streaming relationships.
## [MBS-9587](https://tickets.metabrainz.org/browse/MBS-9587): Add a few Japanese lyrics sites to the whitelist
Actually, Hoick, JOYSOUND, and Petit Lyrics, with auto-select, cleanup and validation.
## [MBS-9597](https://tickets.metabrainz.org/browse/MBS-9597): Update VGMdb URL cleanup to use HTTPS
Still it doesn’t change existing URLs as requested. This should be done later on with ModBot.
## [MBS-9612](https://tickets.metabrainz.org/browse/MBS-9612): Remove locale from Last.fm URLs
It used to be rely on TLD name, but it is actually also set through path prefix and/or query parameter. This patch removes both.
