### PR TITLE
MBS-3643: Add Musixmatch to the lyrics whitelist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1571,6 +1571,28 @@ const CLEANUPS = {
       return false;
     }
   },
+  musixmatch: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?musixmatch\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?musixmatch\.com\/(artist)\/([^\/?#]+).*$/, "https://www.musixmatch.com/$1/$2");
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?musixmatch\.com\/(lyrics)\/([^\/?#]+)\/([^\/?#]+).*$/, "https://www.musixmatch.com/$1/$2/$3");
+      return url;
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/www.musixmatch\.com\/(artist|lyrics)\/[^?#]+$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'lyrics';
+        }
+      }
+      return false;
+    }
+  },
   operabase: {
     match: [new RegExp("^(https?://)?(www\\.)?operabase\\.com", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1736,6 +1736,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'https://www.musik-sammler.de/media/594158/',
         },
+        // Musixmatch
+        {
+                             input_url: 'https://www.musixmatch.com/artist/Bruno-Mars/community/2',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.musixmatch.com/artist/Bruno-Mars',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'https://www.musixmatch.com/album/Bruno-Mars/This-Is-My-Love-Remixes-3',
+                     input_entity_type: 'album',
+            expected_relationship_type: undefined,
+               input_relationship_type: 'lyrics',
+               only_valid_entity_types: []
+        },
+        {
+                             input_url: 'https://www.musixmatch.com/lyrics/Mark-Ronson-feat-Bruno-Mars/Uptown-Funk/translation/spanish',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.musixmatch.com/lyrics/Mark-Ronson-feat-Bruno-Mars/Uptown-Funk',
+               only_valid_entity_types: ['work']
+        },
         // mvdbase.com (The Music Video DataBase)
         {
                              input_url: 'http://www.mvdbase.com/video.php?id=4',


### PR DESCRIPTION
## [MBS-3643](https://tickets.metabrainz.org/browse/MBS-3643): Add Musixmatch to the lyrics whitelist

Add auto-select, cleanup and validation for Musixmatch _artist_ and _lyrics_ URLs to be linked to MusicBrainz _artist_ and _work_, respectively.

It doesn’t allow linking Musixmatch _album_ which matches neither MusicBrainz _release group_ nor _release_.