### PR TITLE
Add an Object.assign polyfill for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "balanced-match": "0.2.0",
     "canonical-json": "0.0.4",
     "cookie": "0.2.3",
+    "core-js": "2.5.3",
     "detect-node": "2.0.3",
     "envify": "3.4.0",
     "filesize": "2.0.4",

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -1,3 +1,6 @@
+// IE 11 doesn't support Object.assign.
+require('core-js/modules/es6.object.assign');
+
 const DBDefs = require('./common/DBDefs');
 const MB = require('./common/MB');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,13 +1373,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-js@2.5.3, core-js@^2.4.0, core-js@^2.5.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
-core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-js@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes [MBS-9628](https://tickets.metabrainz.org/browse/MBS-9628) and probably many other issues in IE11.

Note: core-js is what babel-polyfill uses, but by using it directly we can include just the parts we need.