### PR TITLE
Object type spreads

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-flowtype": "2.44.0",
     "eslint-plugin-react": "7.6.1",
     "file-url": "2.0.2",
-    "flow-bin": "0.66.0",
+    "flow-bin": "0.68.0",
     "gulp-watch": "4.3.5",
     "jsdom": "11.1.0",
     "selenium-webdriver": "3.5.0",

--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -14,7 +14,7 @@ const {l} = require('../../static/scripts/common/i18n');
 type Props = {
   +aliases: $ReadOnlyArray<AliasT>,
   +allowEditing: boolean,
-  +entity: $Subtype<CoreEntityT>,
+  +entity: CoreEntityT,
 };
 
 const AliasTable = (props: Props) => (

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -16,7 +16,7 @@ const SubHeader = require('./SubHeader');
 
 type Props = {|
   +editTab?: React.Node,
-  +entity: $Subtype<CoreEntityT>,
+  +entity: CoreEntityT,
   +headerClass: string,
   +heading?: string | React.Node,
   +page: string,

--- a/root/components/EntityTabLink.js
+++ b/root/components/EntityTabLink.js
@@ -12,7 +12,7 @@ const EntityLink = require('../static/scripts/common/components/EntityLink');
 
 type Props = {|
   +content: string,
-  +entity: EntityT,
+  +entity: CoreEntityT,
   +selected: boolean,
   +subPath: string,
 |};

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -47,7 +47,7 @@ const buildLink = (
 );
 
 function buildLinks(
-  entity: $Subtype<EntityT>,
+  entity: CoreEntityT,
   page: string,
   editTab: React.Node,
   hideEditTab: boolean,
@@ -91,7 +91,7 @@ function buildLinks(
 
 type Props = {|
   +editTab: React.Node,
-  +entity: EntityT,
+  +entity: CoreEntityT,
   +hideEditTab?: boolean,
   +page: string,
 |};

--- a/root/static/scripts/common/components/CodeLink.js
+++ b/root/static/scripts/common/components/CodeLink.js
@@ -19,6 +19,7 @@ const CodeLink = ({code}: Props) => {
   let link = (
     <a href={entityHref(code)}>
       <bdi>
+        {/* $FlowFixMe */}
         <code>{code[code.entityType]}</code>
       </bdi>
     </a>

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -145,6 +145,7 @@ class TagRow extends React.Component<TagRowProps> {
 
 type TagEditorProps = {
   entity: CoreEntityT,
+  more: boolean,
 };
 
 type TagEditorState = {

--- a/root/static/scripts/common/utility/entityHref.js
+++ b/root/static/scripts/common/utility/entityHref.js
@@ -14,8 +14,13 @@ const nonEmpty = require('./nonEmpty');
 
 const leadingSlash = /^\/?(.*)/;
 
+type LinkableEntity =
+  | CoreEntityT
+  | IsrcT
+  | IswcT;
+
 function entityHref(
-  entity: EntityT | CoreEntityT,
+  entity: LinkableEntity,
   subPath?: string,
 ) {
   const entityType = entity.entityType;

--- a/root/types.js
+++ b/root/types.js
@@ -16,30 +16,28 @@
  * how data is serialized for us.
  */
 
-declare type AliasT =
-  & DatePeriodRoleT
-  & EntityT
-  & EditableRoleT
-  & TypeRoleT<AliasTypeT>
-  & {|
-      +entityType: 'alias',
-      +locale: string | null,
-      +name: string,
-      +primary_for_locale: boolean,
-      +sort_name: string,
-    |};
+declare type AliasT = {|
+  ...DatePeriodRoleT,
+  ...EditableRoleT,
+  ...EntityRoleT,
+  ...TypeRoleT<AliasTypeT>,
+  +entityType: 'alias',
+  +locale: string | null,
+  +name: string,
+  +primary_for_locale: boolean,
+  +sort_name: string,
+|};
 
 export opaque type AliasTypeT: OptionTreeT = OptionTreeT;
 
-declare type AreaT =
-  & CommentRoleT
-  & CoreEntityT
-  & DatePeriodRoleT
-  & TypeRoleT<AreaTypeT>
-  & {|
-      +containment: $ReadOnlyArray<AreaT>,
-      +entityType: 'area',
-    |};
+declare type AreaT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...DatePeriodRoleT,
+  ...TypeRoleT<AreaTypeT>,
+  +containment: $ReadOnlyArray<AreaT>,
+  +entityType: 'area',
+|};
 
 export opaque type AreaTypeT: OptionTreeT = OptionTreeT;
 
@@ -55,14 +53,14 @@ declare type ArtistCreditRoleT = {|
 
 declare type ArtistCreditT = $ReadOnlyArray<ArtistCreditNameT>;
 
-declare type ArtistT =
-  & CommentRoleT
-  & CoreEntityT
-  & TypeRoleT<ArtistTypeT>
-  & {|
-      +entityType: 'artist',
-      +sort_name: string,
-    |};
+declare type ArtistT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  ...TypeRoleT<ArtistTypeT>,
+  +entityType: 'artist',
+  +sort_name: string,
+|};
 
 export opaque type ArtistTypeT: OptionTreeT = OptionTreeT;
 
@@ -115,10 +113,25 @@ declare type CompoundFieldT<F: {+[string]: mixed}> = {|
   +id: number,
 |};
 
-declare type CoreEntityT = EntityT & {|
+declare type CoreEntityRoleT = {|
+  ...EntityRoleT,
   +gid: string,
   +name: string,
 |};
+
+declare type CoreEntityT =
+  | AreaT
+  | ArtistT
+  | EventT
+  | InstrumentT
+  | LabelT
+  | PlaceT
+  | RecordingT
+  | ReleaseGroupT
+  | ReleaseT
+  | SeriesT
+  | UrlT
+  | WorkT;
 
 declare type DatePeriodRoleT = {|
   +begin_date: PartialDateT | null,
@@ -130,7 +143,7 @@ declare type EditableRoleT = {|
   +editsPending: boolean,
 |};
 
-declare type EntityT = {|
+declare type EntityRoleT = {|
   +entityType: string,
   +id: number,
 |};
@@ -161,51 +174,48 @@ declare type GroupedOptionsT = $ReadOnlyArray<{|
   |}>,
 |}>;
 
-declare type InstrumentT =
-  & CommentRoleT
-  & CoreEntityT
-  & TypeRoleT<InstrumentTypeT>
-  & {|
-      +description: string,
-      +entityType: 'instrument',
-    |};
+declare type InstrumentT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...TypeRoleT<InstrumentTypeT>,
+  +description: string,
+  +entityType: 'instrument',
+|};
 
 export opaque type InstrumentTypeT: OptionTreeT = OptionTreeT;
 
-declare type EventT =
-  & CommentRoleT
-  & CoreEntityT
-  & TypeRoleT<EventTypeT>
-  & {|
-      +entityType: 'event',
-    |};
+declare type EventT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  ...TypeRoleT<EventTypeT>,
+  +entityType: 'event',
+|};
 
 export opaque type EventTypeT: OptionTreeT = OptionTreeT;
 
-declare type IsrcT =
-  & EditableRoleT
-  & EntityT
-  & {|
-      +entityType: 'isrc',
-      +isrc: string,
-      +recording_id: number,
-    |};
+declare type IsrcT = {|
+  ...EditableRoleT,
+  ...EntityRoleT,
+  +entityType: 'isrc',
+  +isrc: string,
+  +recording_id: number,
+|};
 
-declare type IswcT =
-  & EditableRoleT
-  & EntityT
-  & {|
-      +entityType: 'iswc',
-      +iswc: string,
-      +work_id: number,
-    |};
+declare type IswcT = {|
+  ...EditableRoleT,
+  ...EntityRoleT,
+  +entityType: 'iswc',
+  +iswc: string,
+  +work_id: number,
+|};
 
-declare type LabelT =
-  & CommentRoleT
-  & CoreEntityT
-  & {|
-      +entityType: 'label',
-    |};
+declare type LabelT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  +entityType: 'label',
+|};
 
 declare type LinkTypeAttrTypeT = {|
   attribute: AttrInfoT,
@@ -237,15 +247,14 @@ declare type OptionListT = $ReadOnlyArray<{|
   +text: string,
 |}>;
 
-declare type OptionTreeT =
-  & EntityT
-  & {|
-      +gid: string,
-      +name: string,
-      +parentID: number | null,
-      +childOrder: number,
-      +description: string,
-    |};
+declare type OptionTreeT = {|
+  ...EntityRoleT,
+  +gid: string,
+  +name: string,
+  +parentID: number | null,
+  +childOrder: number,
+  +description: string,
+|};
 
 declare type PartialDateT = {|
   +day: number | null,
@@ -253,52 +262,58 @@ declare type PartialDateT = {|
   +year: number | null,
 |};
 
-declare type PlaceT =
-  & CommentRoleT
-  & CoreEntityT
-  & TypeRoleT<PlaceTypeT>
-  & {|
-      +entityType: 'place',
-    |};
+declare type PlaceT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...TypeRoleT<PlaceTypeT>,
+  +entityType: 'place',
+|};
 
 export opaque type PlaceTypeT: OptionTreeT = OptionTreeT;
 
-declare type RatableT = CoreEntityT & {|
+declare type RatableRoleT = {|
   +rating: number | null,
   +rating_count: number,
   +user_rating: number | null,
 |};
 
-declare type RecordingT =
-  & CommentRoleT
-  & ArtistCreditRoleT
-  & CoreEntityT
-  & {|
-      +entityType: 'recording',
-      +isrcs: $ReadOnlyArray<IsrcT>,
-      +length: number,
-      +video: boolean,
-    |};
+declare type RatableT =
+  | ArtistT
+  | EventT
+  | LabelT
+  | RecordingT
+  | ReleaseGroupT
+  | WorkT;
 
-declare type ReleaseGroupT =
-  & CommentRoleT
-  & ArtistCreditRoleT
-  & CoreEntityT
-  & {|
-      +entityType: 'release_group',
-    |};
+declare type RecordingT = {|
+  ...ArtistCreditRoleT,
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  +entityType: 'recording',
+  +isrcs: $ReadOnlyArray<IsrcT>,
+  +length: number,
+  +video: boolean,
+|};
 
-declare type ReleaseT =
-  & CommentRoleT
-  & CoreEntityT
-  & {|
-      +barcode: string | null,
-      +entityType: 'release',
-      +languageID: number | null,
-      +packagingID: number | null,
-      +scriptID: number | null,
-      +statusID: number | null,
-    |};
+declare type ReleaseGroupT = {|
+  ...ArtistCreditRoleT,
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  +entityType: 'release_group',
+|};
+
+declare type ReleaseT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  +barcode: string | null,
+  +entityType: 'release',
+  +languageID: number | null,
+  +packagingID: number | null,
+  +scriptID: number | null,
+  +statusID: number | null,
+|};
 
 declare type RepeatableFieldT<F> = {|
   +errors: $ReadOnlyArray<string>,
@@ -307,25 +322,23 @@ declare type RepeatableFieldT<F> = {|
   +id: number,
 |};
 
-declare type SeriesT =
-  & CommentRoleT
-  & CoreEntityT
-  & {|
-      +entityType: 'series',
-    |};
+declare type SeriesT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  +entityType: 'series',
+|};
 
 declare type TypeRoleT<T: OptionTreeT> = {|
   +typeID: number | null,
   +typeName?: string,
 |};
 
-declare type UrlT =
-  & CoreEntityT
-  & EditableRoleT
-  & {|
-      +decoded: string,
-      +entityType: 'url',
-    |};
+declare type UrlT = {|
+  ...CoreEntityRoleT,
+  ...EditableRoleT,
+  +decoded: string,
+  +entityType: 'url',
+|};
 
 declare type UserTagT = {|
   +count: number,
@@ -333,39 +346,44 @@ declare type UserTagT = {|
   +vote: 1 | -1,
 |};
 
-declare type WorkT =
-  & CommentRoleT
-  & CoreEntityT
-  & TypeRoleT<WorkTypeT>
-  & {|
-      +entityType: 'work',
-    |};
+declare type WorkT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT,
+  ...RatableRoleT,
+  ...TypeRoleT<WorkTypeT>,
+  +entityType: 'work',
+|};
 
 export opaque type WorkTypeT: OptionTreeT = OptionTreeT;
 
-declare type WorkAttributeTypeAllowedValueT =
-  & EntityT
-  & OptionTreeT
-  & {|+workAttributeTypeID: number, +value: string|};
+declare type WorkAttributeTypeAllowedValueT = {|
+  ...EntityRoleT,
+  ...OptionTreeT,
+  +workAttributeTypeID: number,
+  +value: string,
+|};
 
 // See MusicBrainz::Server::Controller::Work::stash_work_form_json
-declare type WorkAttributeTypeAllowedValueTreeT =
-  & WorkAttributeTypeAllowedValueT
-  & {|+children?: $ReadOnlyArray<WorkAttributeTypeAllowedValueTreeT>|};
+declare type WorkAttributeTypeAllowedValueTreeT = {|
+  ...WorkAttributeTypeAllowedValueT,
+  +children?: $ReadOnlyArray<WorkAttributeTypeAllowedValueTreeT>,
+|};
 
 declare type WorkAttributeTypeAllowedValueTreeRootT =
   {|+children: $ReadOnlyArray<WorkAttributeTypeAllowedValueTreeT>|};
 
-declare type WorkAttributeTypeT =
-  & CommentRoleT
-  & EntityT
-  & OptionTreeT
-  & {|+freeText: boolean|};
+declare type WorkAttributeTypeT = {|
+  ...CommentRoleT,
+  ...EntityRoleT,
+  ...OptionTreeT,
+  +freeText: boolean,
+|};
 
 // See MusicBrainz::Server::Controller::Work::stash_work_form_json
-declare type WorkAttributeTypeTreeT =
-  & WorkAttributeTypeT
-  & {|+children?: $ReadOnlyArray<WorkAttributeTypeTreeT>|};
+declare type WorkAttributeTypeTreeT = {|
+  ...WorkAttributeTypeT,
+  +children?: $ReadOnlyArray<WorkAttributeTypeTreeT>,
+|};
 
 declare type WorkAttributeTypeTreeRootT =
   {|+children: $ReadOnlyArray<WorkAttributeTypeTreeT>|};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,9 +1951,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
+flow-bin@0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 fobject@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
The previous code is wrong because an object can't simultaneously satisfy two distinct, *exact* object types.

The correct way is using object type spreads as described here: facebook/flow#2626

I'm not sure why things currently type-check.