### PR TITLE
MBS-9658: /instruments page breaks if a new instrument type is added but not used

### DIFF
--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -53,7 +53,7 @@ const InstrumentList = () => {
           <Frag>
             <h2>{lp_attributes(type.name, 'instrument_type')}</h2>
             <ul>
-              {instrumentsByType[type.id].map(instrument => (
+              {(instrumentsByType[type.id] || []).map(instrument => (
                 <Instrument key={instrument.id} instrument={instrument} />
               ))}
             </ul>

--- a/root/types.js
+++ b/root/types.js
@@ -19,8 +19,8 @@ type CatalystContextT = {
 
 type CatalystStashT = {
   instruments_by_type?: {
-    [number]: Array<InstrumentT>,
-    unknown: Array<InstrumentT>,
+    [number]: ?Array<InstrumentT>,
+    unknown: ?Array<InstrumentT>,
   },
   instrument_types?: Array<InstrumentTypeT>,
 };


### PR DESCRIPTION
Handles cases where `instrumentsByType` returns undefined for unused types.

I changed the Flow type to indicate the key can be unset. You can't do `[number]?` as I thought for indexer props, but `?Array<InstrumentT>` should be equivalent for our needs.