### PR TITLE
Move Privacy Policy and Social Contract to MetaBrainz website

### DIFF
--- a/admin/nginx/mbserver-rewrites.conf
+++ b/admin/nginx/mbserver-rewrites.conf
@@ -54,6 +54,10 @@ rewrite ^/doc/MusicBrainz_Picard/Tags$                     http://picard.musicbr
 rewrite ^/doc/MusicBrainz_Picard/Tags/Mapping$             http://picard.musicbrainz.org/docs/mappings/            permanent;
 rewrite ^/doc/MusicBrainz_Picard/Troubleshooting$          http://picard.musicbrainz.org/docs/troubleshooting/     permanent;
 rewrite ^/doc/Contact_Us$                                  https://metabrainz.org/contact                          permanent;
+rewrite ^/privacy$                                         https://metabrainz.org/privacy                          permanent;
+rewrite ^/doc/About/Privacy_Policy$                        https://metabrainz.org/privacy                          permanent;
+rewrite ^/contract\.html$                                  https://metabrainz.org/social-contract                  permanent;
+rewrite ^/doc/Social_Contract$                             https://metabrainz.org/social-contract                  permanent;
 rewrite ^/doc/About/Team$                                  https://metabrainz.org/team                             permanent;
 rewrite ^/bio\.html$                                       https://metabrainz.org/team                             permanent;
 
@@ -65,7 +69,6 @@ rewrite ^/about/logos\.html$                     $mb_server/doc/About/Logos     
 rewrite ^/about/licenses\.html$                  $mb_server/doc/About/Data_License           permanent;
 rewrite ^/about/stats\.html$                     $mb_server/doc/Server_Statistics            permanent;
 rewrite ^/cd_submission\.html$                   $mb_server/doc/How_to_Add_Disc_IDs          permanent;
-rewrite ^/contract\.html$                        $mb_server/doc/Social_Contract              permanent;
 rewrite ^/db_structure\.html$                    $mb_server/doc/MusicBrainz_Database/Schema  permanent;
 rewrite ^/development/mmd$                       $mb_server/doc/Development/XML_Web_Service  permanent;
 rewrite ^/development/mmd/(.*)$                  $mb_server/doc/Development/XML_Web_Service  permanent;
@@ -81,7 +84,6 @@ rewrite ^/mod_faq\.html$                         $mb_server/doc/Editing_FAQ     
 rewrite ^/mod_intro\.html$                       $mb_server/doc/How_Editing_Works            permanent;
 rewrite ^/news/licenses\.html$                   $mb_server/doc/About/Data_License           permanent;
 rewrite ^/press\.html$                           $mb_server/doc/About/Press                  permanent;
-rewrite ^/privacy$                               $mb_server/doc/About/Privacy_Policy         permanent;
 rewrite ^/products/libdiscid$                    $mb_server/doc/libdiscid                    permanent;
 rewrite ^/products/libmusicbrainz$               $mb_server/doc/libmusicbrainz               permanent;
 rewrite ^/products/python-musicbrainz2           $mb_server/doc/python-musicbrainz2          permanent;

--- a/lib/MusicBrainz/Server/Controller/Doc.pm
+++ b/lib/MusicBrainz/Server/Controller/Doc.pm
@@ -4,6 +4,7 @@ use Moose;
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 
 use DBDefs;
+use HTTP::Status qw( HTTP_MOVED_PERMANENTLY );
 use MusicBrainz::Server::Validation qw( is_guid );
 
 sub show : Path('')
@@ -21,7 +22,7 @@ sub show : Path('')
         my ($path, $fragment) = split /\#/, $page->{canonical}, 2;
         $fragment = $fragment ? '#'.$fragment : '';
 
-        $c->response->redirect($c->uri_for('/doc', $path).$fragment, 301);
+        $c->response->redirect($c->uri_for('/doc', $path).$fragment, HTTP_MOVED_PERMANENTLY);
         return;
     }
 
@@ -67,6 +68,7 @@ no Moose;
 =head1 COPYRIGHT
 
 Copyright (C) 2009 Lukas Lalinsky
+Copyright (C) 2018 MetaBrainz Foundation
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/root/account/register.tt
+++ b/root/account/register.tt
@@ -16,7 +16,7 @@
         <p>[%- l('MusicBrainz believes strongly in the privacy of its users! Any personal
                   information you choose to provide will not be sold or shared with anyone else.
                   For full details, please read our {doc|Privacy Policy}.',
-                  {doc => doc_link('About/Privacy_Policy')}) -%]</p>
+                  {doc => { href => 'https://metabrainz.org/privacy' } }) -%]</p>
 
 
 

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -85,13 +85,13 @@ const AboutMenu = () => (
         <a href="/doc/About/Data_License">{l('Data Licenses')}</a>
       </li>
       <li>
-        <a href="/doc/Social_Contract">{l('Social Contract')}</a>
+        <a href="https://metabrainz.org/social-contract">{l('Social Contract')}</a>
       </li>
       <li>
         <a href="/doc/Code_of_Conduct">{l('Code of Conduct')}</a>
       </li>
       <li>
-        <a href="/doc/About/Privacy_Policy">{l('Privacy Policy')}</a>
+        <a href="https://metabrainz.org/privacy">{l('Privacy Policy')}</a>
       </li>
       <li className="separator">
         <a href="/elections">{l('Auto-editor Elections')}</a>

--- a/root/layout/header/bottom.tt
+++ b/root/layout/header/bottom.tt
@@ -31,13 +31,13 @@
                 <a href="[% doc_link('About/Data_License') %]">[% l('Data Licenses') %]</a>
             </li>
             <li>
-                <a href="[% doc_link('Social_Contract') %]">[% l('Social Contract') %]</a>
+                <a href="https://metabrainz.org/social-contract">[% l('Social Contract') %]</a>
             </li>
             <li>
                 <a href="[% doc_link('Code_of_Conduct') %]">[% l('Code of Conduct') %]</a>
             </li>
             <li>
-                <a href="[% doc_link('About/Privacy_Policy') %]">[% l('Privacy Policy') %]</a>
+                <a href="https://metabrainz.org/privacy">[% l('Privacy Policy') %]</a>
             </li>
             <li class="separator">
                 <a href="[% c.uri_for_action('/elections/index') %]">[% l('Auto-editor Elections') %]</a>


### PR DESCRIPTION
Following https://github.com/metabrainz/metabrainz.org/pull/299, this patch updates **links** and **redirects** to replace:
* https://musicbrainz.org/doc/Social_Contract with https://metabrainz.org/social-contract
* https://musicbrainz.org/doc/About/Privacy_Policy with https://metabrainz.org/privacy

Third commit is a small code style fix only.