### PR TITLE
MBS-9645, MBS-9648: Update URL cleanup with Geonames and lyrics websites

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1593,6 +1593,16 @@ const CLEANUPS = {
       return false;
     }
   },
+  onlinebijbel: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?online-bijbel\\.nl/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?online-bijbel\.nl\/(12gezang|gezang|psalm)\/(\d+).*$/, "http://www.online-bijbel.nl/$1/$2/");
+    },
+    validate: function (url, id) {
+      return id === LINK_TYPES.lyrics.work && /^http:\/\/www.online-bijbel\.nl\/(12gezang|gezang|psalm)\/\d+\/$/.test(url);
+    }
+  },
   operabase: {
     match: [new RegExp("^(https?://)?(www\\.)?operabase\\.com", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1672,6 +1672,16 @@ const CLEANUPS = {
       return false;
     }
   },
+  runeberg: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?runeberg\\.org/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?runeberg\.org\/(.*)$/, "http://runeberg.org/$1");
+    },
+    validate: function (url, id) {
+      return id === LINK_TYPES.lyrics.work && /^http:\/\/runeberg\.org\/[\w-\/]+\/\d+\.html$/.test(url);
+    }
+  },
   soundtrackcollector: {
     match: [new RegExp("^(https?://)?(www\\.)?soundtrackcollector\\.com", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -206,7 +206,8 @@ const LINK_TYPES = {
     place: "751e8fb1-ed8d-4a94-b71b-a38065054f5d"
   },
   geonames: {
-    area: "c52f14c0-e9ac-4a8a-8f7a-c47328de168f"
+    area: "c52f14c0-e9ac-4a8a-8f7a-c47328de168f",
+    place: "c4c6356f-9cbc-4e26-ae76-63eef96d059d"
   },
   imslp: {
     artist: "8147b6a2-ad14-4ce7-8f0a-697f9a31f68f"

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1294,6 +1294,16 @@ const CLEANUPS = {
       return false;
     }
   },
+  animationsong: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?animationsong\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?animationsong\.com\/(archives\/\d+\.html).*$/, "http://animationsong.com/$1");
+    },
+    validate: function (url, id) {
+      return id === LINK_TYPES.lyrics.work && /^http:\/\/animationsong\.com\/archives\/\d+\.html$/.test(url);
+    }
+  },
   anisongeneration: {
     match: [new RegExp("^(?:https?://)?anison\\.info/", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1561,6 +1561,26 @@ const CLEANUPS = {
       return false;
     }
   },
+  lyricevesta: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?lyric\\.evesta\\.jp/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?lyric\.evesta\.jp\/([al]\w+\.html).*$/, "http://lyric.evesta.jp/$1");
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/lyric\.evesta\.jp\/(a|l)\w+\.html$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'a';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'l';
+        }
+      }
+      return false;
+    }
+  },
   musicapopularcl: {
     match: [new RegExp("^(https?://)?(www\\.)?musicapopular\\.cl", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1535,6 +1535,33 @@ const CLEANUPS = {
       return false;
     }
   },
+  kashinavi: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?kashinavi\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      var m = /^(?:https?:\/\/)?(?:[^\/]+\.)?kashinavi\.com\/(.*)$/.exec(url);
+      if (m) {
+        var tail = m[1];
+        tail = tail.replace(/^(song_view\.html\?\d+).*$/, "$1");
+        tail = tail.replace(/^(kashu\.php\?).*(artist=\d+).*$/, "$1$2");
+        url = "http://kashinavi.com/" + tail;
+      }
+      return url;
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/kashinavi\.com\/(.+)$/.exec(url);
+      if (m) {
+        var tail = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return /^kashu\.php\?artist=\d+$/.test(tail);
+          case LINK_TYPES.lyrics.work:
+            return /^song_view\.html\?\d+$/.test(tail);
+        }
+      }
+      return false;
+    }
+  },
   kget: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?kget\\.jp/", "i")],
     type: LINK_TYPES.lyrics,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1535,6 +1535,33 @@ const CLEANUPS = {
       return false;
     }
   },
+  kget: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?kget\\.jp/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      var m = /^(?:https?:\/\/)?(?:[^\/]+\.)?kget\.jp\/(.*)$/.exec(url);
+      if (m) {
+        var tail = m[1];
+        tail = tail.replace(/^(lyric\/\d+)(?:\/.*)?$/, "$1/");
+        tail = tail.replace(/^(search\/index.php\?).*(r=[^&#]+).*$/, "$1$2");
+        url = "http://www.kget.jp/" + tail;
+      }
+      return url;
+    },
+    validate: function (url, id) {
+      var m = /^http:\/\/www\.kget\.jp\/(lyric(?=\/)|search\/index(?=\.))(?:\/\d+\/|\.php\?r=[^&#]+)$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'search/index';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'lyric';
+        }
+      }
+      return false;
+    }
+  },
   livefans: {
     match: [new RegExp("^(https?://)?(www\\.)?livefans\\.jp", "i")],
     type: LINK_TYPES.otherdatabases,

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1884,6 +1884,26 @@ const CLEANUPS = {
       return url;
     }
   },
+  utanet: {
+    match: [new RegExp("^(https?://)?([^/]+\\.)?uta-net\\.com/", "i")],
+    type: LINK_TYPES.lyrics,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?uta-net\.com\/(artist|song)\/(\d+).*$/, "https://www.uta-net.com/$1/$2/");
+    },
+    validate: function (url, id) {
+      var m = /^https:\/\/www\.uta-net\.com\/(artist|song)\/\d+\/$/.exec(url);
+      if (m) {
+        var prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.lyrics.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.lyrics.work:
+            return prefix === 'song';
+        }
+      }
+      return false;
+    }
+  },
   utaten: {
     match: [new RegExp("^(https?://)?([^/]+\\.)?utaten\\.com/", "i")],
     type: LINK_TYPES.lyrics,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -253,6 +253,14 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'label',
             expected_relationship_type: 'blog',
         },
+        // Animationsong.com
+        {
+                             input_url: 'http://animationsong.com/archives/816073.html#post-13222',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://animationsong.com/archives/816073.html',
+               only_valid_entity_types: ['work']
+        },
         // Anime News Network
         {
                              input_url: 'http://animenewsnetwork.com/encyclopedia/people.php?id=59062',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1613,6 +1613,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://loudr.fm/release/dearly-beloved-2014/Vv2cZ',
         },
+        // lyric.evesta.jp
+        {
+                             input_url: 'http://lyric.evesta.jp/a7d0991.html',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://lyric.evesta.jp/a7d0991.html',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'www.lyric.evesta.jp/l7a75fa.html#lyrictitle',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://lyric.evesta.jp/l7a75fa.html',
+               only_valid_entity_types: ['work']
+        },
         // LYRICSnMUSIC
         {
                              input_url: 'http://www.lyricsnmusic.com/david-hasselhoff/white-christmas-lyrics/27952232',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1471,6 +1471,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'discographyentry',
         },
+        // Kashinavi.com
+        {
+                             input_url: 'http://kashinavi.com/kashu.php?artist=103530&kashu=%8A%99%93c%8F%CD%8C%E1&start=1',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://kashinavi.com/kashu.php?artist=103530',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'www.kashinavi.com/song_view.html?68574',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://kashinavi.com/song_view.html?68574',
+               only_valid_entity_types: ['work']
+        },
         // Kget.jp
         {
                              input_url: 'http://www.kget.jp/search/index.php?c=0&r=%E3%83%A4%E3%83%B3%E3%82%B0%E3%83%BB%E3%83%95%E3%83%AC%E3%83%83%E3%82%B7%E3%83%A5&t=&v=&f=',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1158,6 +1158,14 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'area',
             expected_relationship_type: 'geonames',
                     expected_clean_url: 'http://sws.geonames.org/6255147/',
+               only_valid_entity_types: ['area', 'place']
+        },
+        {
+                             input_url: 'http://www.geonames.org/6698548/jaani-kirik.html',
+                     input_entity_type: 'area',
+            expected_relationship_type: 'geonames',
+                    expected_clean_url: 'http://sws.geonames.org/6698548/',
+               only_valid_entity_types: ['area', 'place']
         },
         // Google
         {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2156,6 +2156,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'otherdatabases',
         },
+        // Runeberg
+        {
+                             input_url: 'http://runeberg.org/f3gd/31/0194.html',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://runeberg.org/f3gd/31/0194.html',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'www.runeberg.org/kacpoet/0023.html',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://runeberg.org/kacpoet/0023.html',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'https://runeberg.org/saol/9-5/0593.html',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://runeberg.org/saol/9-5/0593.html',
+               only_valid_entity_types: ['work']
+        },
         // SecondHandSongs
         {
                              input_url: 'http://www.secondhandsongs.com/artist/103',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1471,6 +1471,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'discographyentry',
         },
+        // Kget.jp
+        {
+                             input_url: 'http://www.kget.jp/search/index.php?c=0&r=%E3%83%A4%E3%83%B3%E3%82%B0%E3%83%BB%E3%83%95%E3%83%AC%E3%83%83%E3%82%B7%E3%83%A5&t=&v=&f=',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://www.kget.jp/search/index.php?r=%E3%83%A4%E3%83%B3%E3%82%B0%E3%83%BB%E3%83%95%E3%83%AC%E3%83%83%E3%82%B7%E3%83%A5',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'http://www.kget.jp/lyric/173795/VAMOLA%21%E3%82%AD%E3%83%A7%E3%82%A6%E3%83%AA%E3%83%A5%E3%82%A6%E3%82%B8%E3%83%A3%E3%83%BC_%E9%8E%8C%E7%94%B0%E7%AB%A0%E5%90%BE',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://www.kget.jp/lyric/173795/',
+               only_valid_entity_types: ['work']
+        },
         // Kickstarter
         {
                              input_url: 'https://www.kickstarter.com/profile/0123456789/bio',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2640,6 +2640,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'work',
             expected_relationship_type: 'lyrics',
         },
+        // Uta-Net
+        {
+                             input_url: 'http://uta-net.com/artist/9208/4/',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.uta-net.com/artist/9208/',
+               only_valid_entity_types: ['artist']
+        },
+        {
+                             input_url: 'www.uta-net.com/song/188300/',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://www.uta-net.com/song/188300/',
+               only_valid_entity_types: ['work']
+        },
         // Utaten
         {
                              input_url: 'utaten.com/artist/fripSide?sort=popular_sort_asc',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1825,6 +1825,28 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'otherdatabases',
                     expected_clean_url: 'http://trove.nla.gov.au/work/9438679',
         },
+        // Online-Bijbel.nl
+        {
+                             input_url: 'http://www.online-bijbel.nl/12gezang/12/',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://www.online-bijbel.nl/12gezang/12/',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'http://online-bijbel.nl/gezang/231',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://www.online-bijbel.nl/gezang/231/',
+               only_valid_entity_types: ['work']
+        },
+        {
+                             input_url: 'www.online-bijbel.nl/psalm/136/8',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'http://www.online-bijbel.nl/psalm/136/',
+               only_valid_entity_types: ['work']
+        },
         // Open Library
         {
                              input_url: 'http://openlibrary.org/authors/OL23919A/',


### PR DESCRIPTION
Address 2 issues (actually related to 8 STYLE issues) about handling external URLs:
* [MBS-9645](https://tickets.metabrainz.org/browse/MBS-9645): Extend Geonames autoselect to places
* [MBS-9648](https://tickets.metabrainz.org/browse/MBS-9648): Add a bunch of lyrics sites to the whitelist