### PR TITLE
Reload domain when locale changes (MBS-9668)

### DIFF
--- a/root/static/scripts/common/i18n/wrapGettext.js
+++ b/root/static/scripts/common/i18n/wrapGettext.js
@@ -22,13 +22,12 @@ if (isNodeJS) {
   gettext = new Jed(jedData[jedData.locale]);
 }
 
-function wrapGettext(method, domain) {
-  let domainLoaded = !isNodeJS;
+const canLoadDomain = typeof gettext.loadDomain === 'function';
 
+function wrapGettext(method, domain) {
   return function () {
-    if (!domainLoaded) {
+    if (canLoadDomain && !gettext.options.locale_data[domain]) {
       gettext.loadDomain(domain);
-      domainLoaded = true;
     }
 
     let args = sliced(arguments);


### PR DESCRIPTION
The `domainLoaded` flag in `wrapGettext` wasn't working as intended.
(Note: this flag was only initialized to `false` in Node.js, because on
the client, all required domains are loaded via JS bundles.)

 * It didn't make sense to have a single `domainLoaded` flag, because
   `gettext.loadDomain` only loads a given domain for the *current
   locale*. If the locale changes, the domain will no longer be loaded,
   yet `domainLoaded` will be set to true. This caused MBS-9668.

 * It also didn't make sense for `domainLoaded` to be local to the
   `wrapGettext` closure. This meant, for whatever locale was loaded
   at the time, the domain would have been reloaded (unnecessarily) up
   to three times if all of `l`, `ln`, and `lp` were called. This didn't
   cause any issue in practice. However, it did make the behavior in the
   point above a bit more confusing; if one page was loaded and called
   `l_attributes` and `ln_attributes` in the en locale, and another page
   was loaded and called `lp_attributes` in the de locale, then both en
   and de would have the attributes domain loaded, but other languages
   would remain broken.

The solution is to check if the domain is loaded directly, rather than
relying on a flag.

MBS-9668 was only reproducible with `DEVELOPMENT_SERVER` set to `0`,
because when enabled it clears the require cache before each request.