### PR TITLE
MBS-9672: Prevent alphabetical sorting of search options with ESLint & Vertically align values

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -85,7 +85,7 @@ rules:
   implicit-arrow-linebreak: [warn, beside]
   indent: [warn, 2, {SwitchCase: 1}]
   jsx-quotes: [warn, prefer-double]
-  key-spacing: [warn, {beforeColon: false, afterColon: true}]
+  key-spacing: [warn, {mode: minimum}]
   keyword-spacing: [warn, {before: true, after: true}]
   linebreak-style: [warn, unix]
   lines-between-class-members: [warn, always]

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -11,48 +11,57 @@ import React from 'react';
 
 import * as manifest from '../../static/manifest';
 import * as DBDefs from '../../static/scripts/common/DBDefs';
-import {compare, l, lp} from '../../static/scripts/common/i18n';
+import {compare, l, lp, N_l, N_lp} from '../../static/scripts/common/i18n';
 
 const TYPE_OPTION_GROUPS = [
   {
-    artist:        l('Artist'),
+    artist:        N_l('Artist'),
   },
   { // musical production
-    event:         l('Event'),
-    recording:     l('Recording'),
-    release:       l('Release'),
-    release_group: l('Release Group'),
-    series:        lp('Series', 'singular'),
-    work:          l('Work'),
+    event:         N_l('Event'),
+    recording:     N_l('Recording'),
+    release:       N_l('Release'),
+    release_group: N_l('Release Group'),
+    series:        N_lp('Series', 'singular'),
+    work:          N_l('Work'),
   },
   { // other core entities
-    area:          l('Area'),
-    instrument:    l('Instrument'),
-    label:         l('Label'),
-    place:         l('Place'),
+    area:          N_l('Area'),
+    instrument:    N_l('Instrument'),
+    label:         N_l('Label'),
+    place:         N_l('Place'),
   },
   { // derived data
-    annotation:    l('Annotation'),
-    tag:           lp('Tag', 'noun'),
+    annotation:    N_l('Annotation'),
+    tag:           N_lp('Tag', 'noun'),
   },
   {
-    cdstub:        l('CD Stub'),
+    cdstub:        N_l('CD Stub'),
   },
   {
-    editor:        l('Editor'),
+    editor:        N_l('Editor'),
   },
   {
-    doc:           DBDefs.GOOGLE_CUSTOM_SEARCH ? l('Documentation') : null,
+    doc:           DBDefs.GOOGLE_CUSTOM_SEARCH ? N_l('Documentation') : null,
   },
 ];
+
+function localizedTypeOption(group, key) {
+  return (key === 'series' || key === 'tag') ? lp(group[key])
+    : (key === 'doc' && group[key] === null) ? null
+      : l(group[key]);
+}
 
 const searchOptions = (
   <select id="headerid-type" name="type">
     {TYPE_OPTION_GROUPS.map(<TogT: {}>(group: TogT, groupIndex) => (
       Object.keys(group).sort(function (a, b) {
-        return compare(group[a], group[b]);
+        return compare(
+          localizedTypeOption(group, a),
+          localizedTypeOption(group, b),
+        );
       }).map(function (key, index) {
-        const text = group[key];
+        const text = localizedTypeOption(group, key);
         if (!text) {
           return null;
         }

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -13,24 +13,26 @@ import * as manifest from '../../static/manifest';
 import * as DBDefs from '../../static/scripts/common/DBDefs';
 import {l, lp} from '../../static/scripts/common/i18n';
 
+/* eslint-disable sort-keys, flowtype/sort-keys */
 const TYPE_OPTIONS = {
-  artist:         l('Artist'),
-  release_group:  l('Release Group'),
-  release:        l('Release'),
-  recording:      l('Recording'),
-  work:           l('Work'),
-  label:          l('Label'),
-  area:           l('Area'),
-  place:          l('Place'),
-  annotation:     l('Annotation'),
-  cdstub:         l('CD Stub'),
-  editor:         l('Editor'),
-  tag:            lp('Tag', 'noun'),
-  instrument:     l('Instrument'),
-  series:         lp('Series', 'singular'),
-  event:          l('Event'),
-  doc:            DBDefs.GOOGLE_CUSTOM_SEARCH ? l('Documentation') : null,
+  artist:        l('Artist'),
+  release_group: l('Release Group'),
+  release:       l('Release'),
+  recording:     l('Recording'),
+  work:          l('Work'),
+  label:         l('Label'),
+  area:          l('Area'),
+  place:         l('Place'),
+  annotation:    l('Annotation'),
+  cdstub:        l('CD Stub'),
+  editor:        l('Editor'),
+  tag:           lp('Tag', 'noun'),
+  instrument:    l('Instrument'),
+  series:        lp('Series', 'singular'),
+  event:         l('Event'),
+  doc:           DBDefs.GOOGLE_CUSTOM_SEARCH ? l('Documentation') : null,
 };
+/* eslint-enable sort-keys, flowtype/sort-keys */
 
 const searchOptions = (
   <select id="headerid-type" name="type">

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -11,38 +11,54 @@ import React from 'react';
 
 import * as manifest from '../../static/manifest';
 import * as DBDefs from '../../static/scripts/common/DBDefs';
-import {l, lp} from '../../static/scripts/common/i18n';
+import {compare, l, lp} from '../../static/scripts/common/i18n';
 
-/* eslint-disable sort-keys, flowtype/sort-keys */
-const TYPE_OPTIONS = {
-  artist:        l('Artist'),
-  release_group: l('Release Group'),
-  release:       l('Release'),
-  recording:     l('Recording'),
-  work:          l('Work'),
-  label:         l('Label'),
-  area:          l('Area'),
-  place:         l('Place'),
-  annotation:    l('Annotation'),
-  cdstub:        l('CD Stub'),
-  editor:        l('Editor'),
-  tag:           lp('Tag', 'noun'),
-  instrument:    l('Instrument'),
-  series:        lp('Series', 'singular'),
-  event:         l('Event'),
-  doc:           DBDefs.GOOGLE_CUSTOM_SEARCH ? l('Documentation') : null,
-};
-/* eslint-enable sort-keys, flowtype/sort-keys */
+const TYPE_OPTION_GROUPS = [
+  {
+    artist:        l('Artist'),
+  },
+  { // musical production
+    event:         l('Event'),
+    recording:     l('Recording'),
+    release:       l('Release'),
+    release_group: l('Release Group'),
+    series:        lp('Series', 'singular'),
+    work:          l('Work'),
+  },
+  { // other core entities
+    area:          l('Area'),
+    instrument:    l('Instrument'),
+    label:         l('Label'),
+    place:         l('Place'),
+  },
+  { // derived data
+    annotation:    l('Annotation'),
+    tag:           lp('Tag', 'noun'),
+  },
+  {
+    cdstub:        l('CD Stub'),
+  },
+  {
+    editor:        l('Editor'),
+  },
+  {
+    doc:           DBDefs.GOOGLE_CUSTOM_SEARCH ? l('Documentation') : null,
+  },
+];
 
 const searchOptions = (
   <select id="headerid-type" name="type">
-    {Object.keys(TYPE_OPTIONS).map(function (key, index) {
-      const text = TYPE_OPTIONS[key];
-      if (!text) {
-        return null;
-      }
-      return <option key={index} value={key}>{text}</option>;
-    })}
+    {TYPE_OPTION_GROUPS.map(<TogT: {}>(group: TogT, groupIndex) => (
+      Object.keys(group).sort(function (a, b) {
+        return compare(group[a], group[b]);
+      }).map(function (key, index) {
+        const text = group[key];
+        if (!text) {
+          return null;
+        }
+        return <option key={groupIndex + '.' + index} value={key}>{text}</option>;
+      })
+    ))}
   </select>
 );
 

--- a/root/server/response.js
+++ b/root/server/response.js
@@ -50,7 +50,8 @@ function getResponse(requestBody, context) {
   // Set the current translations to be used for this request based on the
   // given 'lang' cookie.
   const gettext = require('./gettext');
-  gettext.setLocale(getCookie('lang') || 'en');
+  const bcp47Locale = getCookie('lang') || 'en';
+  gettext.setLocale(bcp47Locale.replace("-", "_"));
 
   try {
     Page = getExport(require(pathFromRoot(requestBody.component)));


### PR DESCRIPTION
[MBS-9672](https://tickets.metabrainz.org/browse/MBS-9672) is already fixed in `beta` with https://github.com/metabrainz/musicbrainz-server/commit/caec7c46a6a3fdadd2ab00e4b2d4250c17920b41 (cherry-picked to `master` as https://github.com/metabrainz/musicbrainz-server/commit/54579586754c51c92614c86488a8c87739a50c37).

This display bug has been inadvertently introduced by running `eslint`. This patch:

1. disables ESLint `sort-keys` rule for search type options,
2. sets ESLint `key-spacing` rule to vertically align values in object literal props.