### PR TITLE
MBS-9669: Fix UI language selector menu header for locale with country code

### DIFF
--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -48,18 +48,18 @@ const LanguageLink = ({language}: {|+language: ServerLanguageT|}) => (
 );
 
 type LanguageMenuProps = {|
-  +currentLanguage: string,
+  +currentBCP47Language: string,
   +serverLanguages: $ReadOnlyArray<ServerLanguageT>,
 |};
 
 const LanguageMenu = ({
-  currentLanguage,
+  currentBCP47Language,
   serverLanguages,
 }: LanguageMenuProps) => (
   <li className="language-selector" tabIndex="-1">
     <span className="menu-header">
       {languageName(
-        _.find(serverLanguages, x => x.name === currentLanguage),
+        _.find(serverLanguages, x => x.name === currentBCP47Language),
         true,
       )}
     </span>
@@ -67,7 +67,7 @@ const LanguageMenu = ({
       {serverLanguages.map(function (language, index) {
         let inner = <LanguageLink language={language} />;
 
-        if (language.name === currentLanguage) {
+        if (language.name === currentBCP47Language) {
           inner = <strong>{inner}</strong>;
         }
 
@@ -296,22 +296,25 @@ const DocumentationMenu = () => (
   </li>
 );
 
-const BottomMenu = ({$c}: {|+$c: CatalystContextT|}) => (
-  <div className="bottom">
-    <ul className="menu">
-      <AboutMenu />
-      <ProductsMenu />
-      <SearchMenu />
-      {$c.user_exists ? <EditingMenu /> : null}
-      <DocumentationMenu />
-      {$c.stash.server_languages && $c.stash.server_languages.length > 1 ? (
-        <LanguageMenu
-          currentLanguage={$c.stash.current_language}
-          serverLanguages={$c.stash.server_languages}
-        />
-      ) : null}
-    </ul>
-  </div>
-);
+const BottomMenu = ({$c}: {|+$c: CatalystContextT|}) => {
+  const serverLanguages = $c.stash.server_languages;
+  return (
+    <div className="bottom">
+      <ul className="menu">
+        <AboutMenu />
+        <ProductsMenu />
+        <SearchMenu />
+        {$c.user_exists ? <EditingMenu /> : null}
+        <DocumentationMenu />
+        {serverLanguages && serverLanguages.length > 1 ? (
+          <LanguageMenu
+            currentBCP47Language={$c.stash.current_language.replace('_', '-')}
+            serverLanguages={serverLanguages}
+          />
+        ) : null}
+      </ul>
+    </div>
+  );
+};
 
 export default withCatalystContext(BottomMenu);

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -422,6 +422,7 @@ const seleniumTests = [
   {name: 'Create_Account.html'},
   {name: 'MBS-7456.html', login: true},
   {name: 'MBS-9548.html'},
+  {name: 'MBS-9669.html'},
   {name: 'MBS-9941.html', login: true},
   {name: 'Artist_Credit_Editor.html', login: true},
   {name: 'External_Links_Editor.html', login: true},

--- a/t/selenium/MBS-9669.html
+++ b/t/selenium/MBS-9669.html
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost:5000" />
+<title>UI language menu not available in Spanish and Greek (MBS-9669)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">UI language menu not available in Spanish and Greek (MBS-9669)</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/set-language/el-GR</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.document.querySelector('.language-selector .menu-header').innerHTML</td>
+	<td>Ελληνικά (Ελλάδα) ▾</td>
+</tr>
+<tr>
+	<td>open</td>
+	<td>/set-language/es-ES</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+  <td>window.document.querySelector('.language-selector .menu-header').innerHTML</td>
+	<td>Español (España) ▾</td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
### Fix [MBS-9669](https://tickets.metabrainz.org/browse/MBS-9669): UI language menu not available in Spanish and Greek

Locale code is displayed in BCP 47 format in URL, cookie, and UI language selector menu, but it is used in POSIX format internally for Jed and PO files. The bug was to compare current language code in internal POSIX format with available UI languages code in BCP 47 format.

This patch calls component `LanguageMenu` with current language in BCP 47 format.