### PR TITLE
MBS-9673: Delay localization of search options (2)

### DIFF
--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -52,7 +52,7 @@ function localizedTypeOption(group, key) {
       : l(group[key]);
 }
 
-const searchOptions = (
+const SearchOptions = () => (
   <select id="headerid-type" name="type">
     {TYPE_OPTION_GROUPS.map(<TogT: {}>(group: TogT, groupIndex) => (
       Object.keys(group).sort(function (a, b) {
@@ -80,7 +80,7 @@ const Search = () => (
       required
       type="text"
     />
-    {' '}{searchOptions}{' '}
+    {' '}<SearchOptions />{' '}
     <input
       id="headerid-method"
       name="method"


### PR DESCRIPTION
### Fix [MBS-9673](https://tickets.metabrainz.org/browse/MBS-9673) for good.

Define a component rather than a constant for search options.