### PR TITLE
Trigger inputs in release editor on tab change

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -65,6 +65,14 @@ releaseEditor.init = function (options) {
 
     var $pageContent = $("#release-editor").tabs({
 
+        beforeActivate: function (event, ui) {
+            /*
+             * Workaround for buggy dictation software which may not trigger
+             * change events after setting input values.
+             */
+            $('input', ui.oldPanel).change();
+        },
+
         activate: function (event, ui) {
             var panel = ui.newPanel;
 


### PR DESCRIPTION
This hopefully works around the issue described in https://community.metabrainz.org/t/a-problem-with-dictation-software-and-musicbrainz/376046

My guess is that the Chrome extension is modifying input values, but not triggering any `input` or `change` event to signal a change. Clearly, the Knockout model would update if an event was triggered.

You can simulate this by adding a single track with a title and artist set, opening the console, and running this:

```JavaScript
document.querySelector('.track-length').value = '3:33';
```

Moving to the recordings tab will show the track as having no time set.

The workaround is to trigger change events on all inputs on the active tab before it's changed.