### PR TITLE
MBS-9691: Fix aliases editing links

### DIFF
--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -18,11 +18,11 @@ const AliasTable = require('./AliasTable');
 type Props = {
   +$c: CatalystContextT,
   +aliases: $ReadOnlyArray<AliasT>,
+  +allowEditing?: boolean,
   +entity: $Subtype<CoreEntityT>,
 };
 
-const Aliases = ({$c, aliases, entity}: Props) => {
-  const allowEditing = $c.user ? $c.user.is_location_editor : false;
+const Aliases = ({$c, aliases, allowEditing = $c.user ? !$c.user.is_editing_disabled : false, entity}: Props) => {
   return (
     <Frag>
       <h2>{l('Aliases')}</h2>


### PR DESCRIPTION
### Fix [MBS-9691](https://tickets.metabrainz.org/browse/MBS-9691): Beta: Alias editing links are gone

The issue was about computing permissions to display edit links:

1. Default editing permission has been given to location editor only
2. There were no input Prop to override the default permission

This patch fixes both by adding `allowEditing` as a Prop and setting
default value to whether user is a logged-in not-disabled editor.

`allowEditing` values for area and instrument were correctly set.