### PR TITLE
Set x-archive-meta-noindex on CAA uploads

### DIFF
--- a/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
+++ b/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
@@ -52,6 +52,7 @@ sub post_fields {
         "x-archive-auto-make-bucket" => '1',
         "x-archive-meta-collection" => 'coverartarchive',
         "x-archive-meta-mediatype" => 'image',
+        "x-archive-meta-noindex" => 'true',
     );
 
     my $policy = {

--- a/t/lib/t/MusicBrainz/Server/Data/CoverArtArchive.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/CoverArtArchive.pm
@@ -36,12 +36,14 @@ EOSQL
                     'VnIl0sWyJlcSIsIiR4LWFyY2hpdmUtYXV0by1tYWtlLWJ1Y2tldCIs' .
                     'IjEiXSxbImVxIiwiJHgtYXJjaGl2ZS1tZXRhLWNvbGxlY3Rpb24iLC' .
                     'Jjb3ZlcmFydGFyY2hpdmUiXSxbImVxIiwiJHgtYXJjaGl2ZS1tZXRh' .
-                    'LW1lZGlhdHlwZSIsImltYWdlIl1dLCJleHBpcmF0aW9uIjoiMjAxNS' .
-                    '0wOS0wOVQwMDo1MTozNy4wMDBaIn0=',
-        'signature' => 'gZnqIhkxf8Alfzbuwc9xlXiSpOk=',
+                    'LW1lZGlhdHlwZSIsImltYWdlIl0sWyJlcSIsIiR4LWFyY2hpdmUtbW' .
+                    'V0YS1ub2luZGV4IiwidHJ1ZSJdXSwiZXhwaXJhdGlvbiI6IjIwMTUt' .
+                    'MDktMDlUMDA6NTE6MzcuMDAwWiJ9',
+        'signature' => 'wkU8IRrcTn7BX67kmUDrfDpjnP8=',
         'x-archive-auto-make-bucket' => '1',
         'x-archive-meta-collection' => 'coverartarchive',
         'x-archive-meta-mediatype' => 'image',
+        'x-archive-meta-noindex' => 'true',
     });
 };
 


### PR DESCRIPTION
The IA has requested we set this flag on new uploads to prevent them from getting added to their public search index. They've already purged previous uploads from the index.

Their reasoning was,

  "We've been digitizing CDs lately and we're finding people somewhat
   confused by whether they're going to get an image or an actual CD
   when looking at search results."

This doesn't affect anything on our side and we'll still be able to search the entire CAA collection on their side through https://archive.org/metamgr.php (though it's an admin tool so it requires the coverartarchive login in syswiki).

As far as the code changes here, they stated we should only need the noindex tag "once on [our] initial `PUT`" (so I believe this is the right spot), and that they'd prefer we "use the value `true` [instead of `1`], just to be consistent with most of the other noindex items on the site."