### PR TITLE
MBS-9693: Fix display of tags without current user’s vote

### DIFF
--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -418,6 +418,8 @@ function init_tag_editor(Component, mountPoint) {
       if (userTag) {
         t.vote = userTag.vote;
         userTag.used = true;
+      } else {
+        t.vote = 0;
       }
 
       return _.clone(t);


### PR DESCRIPTION
### Fix [MBS-9693](https://tickets.metabrainz.org/browse/MBS-9693): Tags without vote are not immediately visible

Aggregate tags come without vote property.
This property was set for user (up/down) voted tags.
It has not been set for tags not voted by the current user.

This patch sets default vote to 0 (withdrawn) rather than undefined.

It fixes every vote comparison in tag editor.