### PR TITLE
MBS-9687: Fix editing forms field error message localization

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -133,8 +133,8 @@ sub _send_password_reset_email
     }
     catch {
         $c->flash->{message} = l(
-            'We were unable to send login information to your email address.  Please try again,
-             however if you continue to experience difficulty contact us at support@musicbrainz.org.'
+            'We were unable to send login information to your email address.  Please try again, ' .
+            'however if you continue to experience difficulty contact us at support@musicbrainz.org.'
         );
     };
 }
@@ -340,9 +340,9 @@ sub edit : Local RequireAuth DenyWhenReadonly {
 
         if ($verification_sent) {
             $flash .= ' ';
-            $flash .= l('We have sent you a verification email to <code>{email}</code>.
-                         Please check your mailbox and click on the link in the email
-                         to verify the new email address.',
+            $flash .= l('We have sent you a verification email to <code>{email}</code>. ' .
+                        'Please check your mailbox and click on the link in the email ' .
+                        'to verify the new email address.',
                         { email => encode_entities($new_email) });
         }
 
@@ -560,9 +560,9 @@ sub _send_confirmation_email
     }
     catch {
         $c->flash->{message} = l(
-            '<strong>We were unable to send a confirmation email to you.</strong><br/>Please confirm that you have entered a valid
-             address by editing your {settings|account settings}. If the problem still persists, please contact us at
-             {mail|support@musicbrainz.org}.',
+            '<strong>We were unable to send a confirmation email to you.</strong><br/>Please confirm that you have entered a valid ' .
+            'address by editing your {settings|account settings}. If the problem still persists, please contact us at ' .
+            '{mail|support@musicbrainz.org}.',
             {
                 settings => $c->uri_for_action('/account/edit'),
                 mail => 'mailto:support@musicbrainz.org'

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -4,7 +4,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use namespace::autoclean;
 use Digest::SHA qw(sha1_base64);
-use MusicBrainz::Server::Translation qw(l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( encode_entities is_positive_integer );
 use Try::Tiny;
 use Captcha::reCAPTCHA;

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -29,7 +29,7 @@ with 'MusicBrainz::Server::Controller::Role::Collection' => {
 use List::Util qw( first );
 use List::MoreUtils qw( part uniq );
 use List::UtilsBy 'nsort_by';
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Constants qw( :edit_type $MAX_INITIAL_MEDIUMS );
 use MusicBrainz::Server::ControllerUtils::Delete qw( cancel_or_action );
 use MusicBrainz::Server::Form::Utils qw(

--- a/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
@@ -3,6 +3,7 @@ package MusicBrainz::Server::Form::Admin::LinkAttributeType;
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Form::Utils qw( select_options_tree );
 use MusicBrainz::Server::Constants qw( $INSTRUMENT_ROOT_ID );
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -45,7 +46,7 @@ after validate => sub {
 
     my $root = defined $parent ? ($parent->root_id // $parent->id) : 0;
     if ($root == $INSTRUMENT_ROOT_ID) {
-        $self->field('parent_id')->add_error('Cannot add or edit instruments here; use the instrument editing forms instead');
+        $self->field('parent_id')->add_error(l('Cannot add or edit instruments here; use the instrument editing forms instead'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
@@ -46,7 +46,7 @@ after validate => sub {
 
     my $root = defined $parent ? ($parent->root_id // $parent->id) : 0;
     if ($root == $INSTRUMENT_ROOT_ID) {
-        $self->field('parent_id')->add_error(l('Cannot add or edit instruments here; use the instrument editing forms instead'));
+        $self->field('parent_id')->add_error(l('Cannot add or edit instruments here; use the instrument editing forms instead.'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/Alias.pm
+++ b/lib/MusicBrainz/Server/Form/Alias.pm
@@ -115,7 +115,7 @@ after validate => sub {
                                      type_id => $self->field('type_id')->value,
                                      not_id => $self->init_object ? $self->init_object->{id} : undef,
                                  })) {
-        $self->field('name')->add_error(l('This alias already exists'));
+        $self->field('name')->add_error(l('This alias already exists.'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/Alias.pm
+++ b/lib/MusicBrainz/Server/Form/Alias.pm
@@ -3,7 +3,7 @@ use HTML::FormHandler::Moose;
 
 use DateTime::Locale;
 use List::UtilsBy 'sort_by';
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Form::Utils qw( select_options_tree indentation );
 
 extends 'MusicBrainz::Server::Form';

--- a/lib/MusicBrainz/Server/Form/Alias.pm
+++ b/lib/MusicBrainz/Server/Form/Alias.pm
@@ -115,7 +115,7 @@ after validate => sub {
                                      type_id => $self->field('type_id')->value,
                                      not_id => $self->init_object ? $self->init_object->{id} : undef,
                                  })) {
-        $self->field('name')->add_error('This alias already exists');
+        $self->field('name')->add_error(l('This alias already exists'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/Application.pm
+++ b/lib/MusicBrainz/Server/Form/Application.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Application;
 
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
 
@@ -36,7 +37,7 @@ sub validate
 
     if ($self->field('oauth_type')->value eq 'web') {
         if (!$self->field('oauth_redirect_uri')->value) {
-            $self->field('oauth_redirect_uri')->add_error('Redirect URL must be entered for web applications.');
+            $self->field('oauth_redirect_uri')->add_error(l('Redirect URL must be entered for web applications.'));
         }
     }
 }

--- a/lib/MusicBrainz/Server/Form/Artist.pm
+++ b/lib/MusicBrainz/Server/Form/Artist.pm
@@ -69,21 +69,21 @@ sub validate {
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 2) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error(l('Group artists cannot have a gender'));
+            $self->field('gender_id')->add_error(l('Group artists cannot have a gender.'));
         }
     }
 
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 5) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error(l('Orchestras cannot have a gender'));
+            $self->field('gender_id')->add_error(l('Orchestras cannot have a gender.'));
         }
     }
 
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 6) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error(l('Choirs cannot have a gender'));
+            $self->field('gender_id')->add_error(l('Choirs cannot have a gender.'));
         }
     }
 }

--- a/lib/MusicBrainz/Server/Form/Artist.pm
+++ b/lib/MusicBrainz/Server/Form/Artist.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Artist;
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Form::Utils qw( select_options_tree );
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -68,21 +69,21 @@ sub validate {
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 2) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error('Group artists cannot have a gender');
+            $self->field('gender_id')->add_error(l('Group artists cannot have a gender'));
         }
     }
 
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 5) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error('Orchestras cannot have a gender');
+            $self->field('gender_id')->add_error(l('Orchestras cannot have a gender'));
         }
     }
 
     if ($self->field('type_id')->value &&
         $self->field('type_id')->value == 6) {
         if ($self->field('gender_id')->value) {
-            $self->field('gender_id')->add_error('Choirs cannot have a gender');
+            $self->field('gender_id')->add_error(l('Choirs cannot have a gender'));
         }
     }
 }

--- a/lib/MusicBrainz/Server/Form/CDStub.pm
+++ b/lib/MusicBrainz/Server/Form/CDStub.pm
@@ -78,7 +78,7 @@ sub validate
 {
     my $self = shift;
     if ($self->field('multiple_artists')->value) {
-        $self->field('artist')->add_error('You may not specify a release artist while also specifying track artists')
+        $self->field('artist')->add_error(l('You may not specify a release artist while also specifying track artists'))
             if $self->field('artist')->value;
 
         for my $field ($self->field('tracks')->fields) {
@@ -93,7 +93,7 @@ sub validate
 
         for my $field ($self->field('tracks')->fields) {
             $field = $field->field('artist');
-            $field->add_error('You may not specify a combination of track artists and a release artist')
+            $field->add_error(l('You may not specify a combination of track artists and a release artist'))
                 if $field->value;
         }
     }

--- a/lib/MusicBrainz/Server/Form/CDStub.pm
+++ b/lib/MusicBrainz/Server/Form/CDStub.pm
@@ -78,7 +78,7 @@ sub validate
 {
     my $self = shift;
     if ($self->field('multiple_artists')->value) {
-        $self->field('artist')->add_error(l('You may not specify a release artist while also specifying track artists'))
+        $self->field('artist')->add_error(l('You may not specify a release artist while also specifying track artists.'))
             if $self->field('artist')->value;
 
         for my $field ($self->field('tracks')->fields) {
@@ -93,7 +93,7 @@ sub validate
 
         for my $field ($self->field('tracks')->fields) {
             $field = $field->field('artist');
-            $field->add_error(l('You may not specify a combination of track artists and a release artist'))
+            $field->add_error(l('You may not specify a combination of track artists and a release artist.'))
                 if $field->value;
         }
     }

--- a/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Compound';
 use MusicBrainz::Server::Edit::Utils qw( clean_submitted_artist_credits );
 use MusicBrainz::Server::Entity::ArtistCredit;
 use MusicBrainz::Server::Entity::ArtistCreditName;
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 
 has_field 'names'             => ( type => 'Repeatable', num_when_empty => 1 );
 has_field 'names.name'        => ( type => '+MusicBrainz::Server::Form::Field::Text');

--- a/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
@@ -52,8 +52,8 @@ around 'validate_field' => sub {
         {
             # FIXME: better error message.
             $self->add_error(
-                l('Artist "{artist}" is unlinked, please select an existing artist.
-                   You may need to add a new artist to MusicBrainz first.',
+                l('Artist "{artist}" is unlinked, please select an existing artist. ' .
+                  'You may need to add a new artist to MusicBrainz first.',
                   { artist => ($name || $artist_name) }));
         }
         elsif (!$artist_id)

--- a/lib/MusicBrainz/Server/Form/Field/Barcode.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Barcode.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Form::Field::Barcode;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
 use MusicBrainz::Server::Validation;
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/DatePeriod.pm
+++ b/lib/MusicBrainz/Server/Form/Field/DatePeriod.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Form::Field::DatePeriod;
 use HTML::FormHandler::Moose;
 use Date::Calc;
 use List::MoreUtils 'any';
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 extends 'HTML::FormHandler::Field::Compound';
 

--- a/lib/MusicBrainz/Server/Form/Field/DiscID.pm
+++ b/lib/MusicBrainz/Server/Form/Field/DiscID.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply([
     {
         check => sub { is_valid_discid(shift) },
-        message => l('This is not a valid disc ID')
+        message => sub { l('This is not a valid disc ID') }
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/FreeDBID.pm
+++ b/lib/MusicBrainz/Server/Form/Field/FreeDBID.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply([
     {
         check => sub { is_freedb_id(shift) },
-        message => l('This is not a valid FreeDB ID')
+        message => sub { l('This is not a valid FreeDB ID') }
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/GID.pm
+++ b/lib/MusicBrainz/Server/Form/Field/GID.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply([
     {
         check => sub { is_guid(shift) },
-        message => l('This is not a valid MBID')
+        message => sub { l('This is not a valid MBID') }
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/IPI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/IPI.pm
@@ -9,11 +9,11 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         transform => sub { return format_ipi(shift) },
-        message => sub { 'This is not a valid IPI' },
+        message => sub { 'This is not a valid IPI.' },
     },
     {
         check => sub { is_valid_ipi(shift) },
-        message => sub { 'This is not a valid IPI' },
+        message => sub { 'This is not a valid IPI.' },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/IPI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/IPI.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Field::IPI;
 use HTML::FormHandler::Moose;
 
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_ipi format_ipi );
 
 extends 'HTML::FormHandler::Field::Text';
@@ -8,11 +9,11 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         transform => sub { return format_ipi(shift) },
-        message => 'This is not a valid IPI',
+        message => sub { 'This is not a valid IPI' },
     },
     {
         check => sub { is_valid_ipi(shift) },
-        message => 'This is not a valid IPI',
+        message => sub { 'This is not a valid IPI' },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISNI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISNI.pm
@@ -9,11 +9,11 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         transform => sub { return format_isni(shift) },
-        message => sub { 'This is not a valid ISNI' },
+        message => sub { 'This is not a valid ISNI.' },
     },
     {
         check => sub { is_valid_isni(shift) },
-        message => sub { 'This is not a valid ISNI' },
+        message => sub { 'This is not a valid ISNI.' },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISNI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISNI.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISNI;
 use HTML::FormHandler::Moose;
 
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_isni format_isni );
 
 extends 'HTML::FormHandler::Field::Text';
@@ -8,11 +9,11 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         transform => sub { return format_isni(shift) },
-        message => 'This is not a valid ISNI',
+        message => sub { 'This is not a valid ISNI' },
     },
     {
         check => sub { is_valid_isni(shift) },
-        message => 'This is not a valid ISNI',
+        message => sub { 'This is not a valid ISNI' },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_1.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_1.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         check => sub { is_valid_iso_3166_1(shift) },
-        message => l('This is not a valid ISO 3166-1 code'),
+        message => sub { l('This is not a valid ISO 3166-1 code') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_1.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_1.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISO_3166_1;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_iso_3166_1 );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_2.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_2.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISO_3166_2;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_iso_3166_2 );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_2.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_2.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         check => sub { is_valid_iso_3166_2(shift) },
-        message => l('This is not a valid ISO 3166-2 code'),
+        message => sub { l('This is not a valid ISO 3166-2 code') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_3.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_3.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         check => sub { is_valid_iso_3166_3(shift) },
-        message => l('This is not a valid ISO 3166-3 code'),
+        message => sub { l('This is not a valid ISO 3166-3 code') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISO_3166_3.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISO_3166_3.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISO_3166_3;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_iso_3166_3 );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/ISRC.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISRC.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISRC;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_isrc format_isrc );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/ISRC.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISRC.pm
@@ -11,11 +11,11 @@ has '+minlength' => ( default => 12 );
 apply ([
     {
         transform => sub { return format_isrc(shift) },
-        message => l('This is not a valid ISRC'),
+        message => sub { l('This is not a valid ISRC') },
     },
     {
         check => sub { is_valid_isrc(shift) },
-        message => l('This is not a valid ISRC.'),
+        message => sub { l('This is not a valid ISRC.') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/ISWC.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISWC.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::ISWC;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_iswc format_iswc );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/ISWC.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ISWC.pm
@@ -9,11 +9,11 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         transform => sub { return format_iswc(shift) },
-        message => l('This is not a valid ISWC'),
+        message => sub { l('This is not a valid ISWC') },
     },
     {
         check => sub { is_valid_iswc(shift) },
-        message => l('This is not a valid ISWC'),
+        message => sub { l('This is not a valid ISWC') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/Length.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Length.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Form::Field::Length;
 use Moose;
 
 use MusicBrainz::Server::Track;
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use Try::Tiny;
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/Relationship.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Relationship.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Form::Field::Relationship;
 
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Translation qw( l N_l );
 extends 'HTML::FormHandler::Field::Compound';
 
 has_field 'relationship_id' => (

--- a/lib/MusicBrainz/Server/Form/Field/Setlist.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Setlist.pm
@@ -9,7 +9,7 @@ extends 'HTML::FormHandler::Field::Text';
 apply ([
     {
         check => sub { is_valid_setlist(shift) },
-        message => l('Please ensure all lines start with @, * or #, followed by a space.'),
+        message => sub { l('Please ensure all lines start with @, * or #, followed by a space.') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/Setlist.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Setlist.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::Setlist;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_setlist );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/Time.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Time.pm
@@ -1,7 +1,7 @@
 package MusicBrainz::Server::Form::Field::Time;
 use HTML::FormHandler::Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_time );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Field/Time.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Time.pm
@@ -13,7 +13,7 @@ has '+deflate_method' => (
 apply ([
     {
         check => sub { is_valid_time(shift) },
-        message => l('This is not a valid time.'),
+        message => sub { l('This is not a valid time.') },
     }
 ]);
 

--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Form::Field::URL;
 use URI;
 use Moose;
 
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_url );
 
 extends 'HTML::FormHandler::Field::Text';

--- a/lib/MusicBrainz/Server/Form/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Recording.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Recording;
 use HTML::FormHandler::Moose;
 use List::AllUtils qw( uniq );
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
 
@@ -56,10 +57,10 @@ after 'validate' => sub {
 
     if ($self->used_by_tracks && defined($length->value) &&
         $length->value != $length->init_value) {
-        $length->add_error(
+        $length->add_error(l(
             "This recording's duration is determined by the tracks that are " .
             "linked to it, and cannot be changed directly"
-        );
+        ));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Recording.pm
@@ -1,4 +1,5 @@
 package MusicBrainz::Server::Form::Recording;
+use utf8;
 use HTML::FormHandler::Moose;
 use List::AllUtils qw( uniq );
 use MusicBrainz::Server::Translation qw( l );
@@ -58,8 +59,8 @@ after 'validate' => sub {
     if ($self->used_by_tracks && defined($length->value) &&
         $length->value != $length->init_value) {
         $length->add_error(l(
-            "This recording's duration is determined by the tracks that are " .
-            "linked to it, and cannot be changed directly"
+            "This recording’s duration is determined by the tracks that are " .
+            "linked to it, and cannot be changed directly."
         ));
     }
 };

--- a/lib/MusicBrainz/Server/Form/Role/EditNote.pm
+++ b/lib/MusicBrainz/Server/Form/Role/EditNote.pm
@@ -8,7 +8,6 @@ has 'requires_edit_note' => ( is => 'ro', default => 0 );
 has_field 'edit_note' => (
     type => 'TextArea',
     label => 'Edit note:',
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
 );
 
 has_field 'make_votable' => (
@@ -16,15 +15,11 @@ has_field 'make_votable' => (
     default => 0,
 );
 
-sub requires_edit_note_text {
-    l("You must provide an edit note");
-}
-
 after validate => sub {
     my $self = shift;
 
     if ($self->requires_edit_note && (!defined $self->field('edit_note')->value || $self->field('edit_note')->value eq '')) {
-        $self->field('edit_note')->add_error($self->requires_edit_note_text);
+        $self->field('edit_note')->add_error(l('You must provide an edit note'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Form/User/EditProfile.pm
+++ b/lib/MusicBrainz/Server/Form/User/EditProfile.pm
@@ -93,7 +93,7 @@ sub validate_birth_date {
         $field->field('year')->add_error(l('Birth year must be after 1900'));
     }
 
-    return $field->add_error("invalid date") unless Date::Calc::check_date($year, $month, $day);
+    return $field->add_error(l("invalid date")) unless Date::Calc::check_date($year, $month, $day);
 }
 
 1;

--- a/lib/MusicBrainz/Server/Form/User/EditProfile.pm
+++ b/lib/MusicBrainz/Server/Form/User/EditProfile.pm
@@ -26,7 +26,7 @@ has_field 'website' => (
     maxlength => 255,
     apply     => [ {
         check => sub { is_valid_url($_[0]) },
-        message => l('Invalid URL format'),
+        message => sub { l('Invalid URL format') },
     } ],
 );
 

--- a/lib/MusicBrainz/Server/Form/User/Login.pm
+++ b/lib/MusicBrainz/Server/Form/User/Login.pm
@@ -1,6 +1,6 @@
 package MusicBrainz::Server::Form::User::Login;
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l N_l );
 extends 'HTML::FormHandler';
 
 with 'MusicBrainz::Server::Form::Role::ToJSON';
@@ -8,14 +8,16 @@ with 'MusicBrainz::Server::Form::Role::ToJSON';
 has_field 'username' => (
     type => 'Text',
     required => 1,
-    messages => { required => l('Username field is required') }
+    messages => { required => N_l('Username field is required') },
+    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
 );
 
 has_field 'password' => (
     type => 'Password',
     required => 1,
     min_length => 1,
-    messages => { required => l('Password field is required') }
+    messages => { required => N_l('Password field is required') },
+    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
 );
 
 has_field 'remember_me' => (

--- a/lib/MusicBrainz/Server/Form/User/Register.pm
+++ b/lib/MusicBrainz/Server/Form/User/Register.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Form::User::Register;
 
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Form::Utils qw( validate_username );
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l N_l );
 
 extends 'MusicBrainz::Server::Form';
 
@@ -20,7 +20,8 @@ has_field 'password' => (
     required  => 1,
     minlength => 1,
     maxlength => 64,
-    messages  => { required => l('Please enter a password in this field') }
+    messages  => { required => N_l('Please enter a password in this field') },
+    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
 );
 
 has_field 'confirm_password' => (
@@ -28,7 +29,8 @@ has_field 'confirm_password' => (
     password_field => 'password',
     required       => 1,
     minlength      => 1,
-    messages       => { pass_conf_not_matched => l('The password confirmation does not match the password') }
+    messages       => { pass_conf_not_matched => N_l('The password confirmation does not match the password') },
+    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
 );
 
 has_field 'email' => (


### PR DESCRIPTION
### Fix [MBS-9687](https://tickets.metabrainz.org/browse/MBS-9687): Field error messages are not always translated

Move localization of these error messages from Moose code to templates.