### PR TITLE
MBS-9696: Replace @users.musicbrainz.org with noreply@musicbrainz.org in hidden email From field

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -43,7 +43,7 @@ our %EXPORT_TAGS = (
         qw( $ELECTION_VOTE_YES $ELECTION_VOTE_NO $ELECTION_VOTE_ABSTAIN )
     ],
     email_addresses => [
-        qw( $EMAIL_NOREPLY_ADDRESS $EMAIL_SUPPORT_ADDRESS )
+        qw( $EMAIL_NOREPLY_ADDR_SPEC $EMAIL_NOREPLY_ADDRESS $EMAIL_SUPPORT_ADDRESS )
     ],
 );
 
@@ -290,7 +290,8 @@ Readonly our $ELECTION_ACCEPTED   => 4;
 Readonly our $ELECTION_REJECTED   => 5;
 Readonly our $ELECTION_CANCELLED  => 6;
 
-Readonly our $EMAIL_NOREPLY_ADDRESS => 'MusicBrainz Server <noreply@musicbrainz.org>';
+Readonly our $EMAIL_NOREPLY_ADDR_SPEC => 'noreply@musicbrainz.org';
+Readonly our $EMAIL_NOREPLY_ADDRESS => 'MusicBrainz Server <' . $EMAIL_NOREPLY_ADDR_SPEC . '>';
 Readonly our $EMAIL_SUPPORT_ADDRESS => 'MusicBrainz <support@musicbrainz.org>';
 
 Readonly our $VOTE_ABSTAIN => -1;

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -50,7 +50,7 @@ sub _user_address
     my ($user, $hidden) = @_;
 
     my $quoted_name = _encode_header($user->name);
-    my $email = $hidden ? 'noreply@musicbrainz.org' : $user->email;
+    my $email = $hidden ? $EMAIL_NOREPLY_ADDR_SPEC : $user->email;
 
     return Email::Address->new($quoted_name, $email)->format;
 }

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -50,14 +50,9 @@ sub _user_address
     my ($user, $hidden) = @_;
 
     my $quoted_name = _encode_header($user->name);
+    my $email = $hidden ? 'noreply@musicbrainz.org' : $user->email;
 
-    if ($hidden) {
-        # Hide the real address
-        my $email = sprintf '"%s"@users.musicbrainz.org', $quoted_name;
-        return Email::Address->new($quoted_name, $email)->format;
-    }
-
-    return Email::Address->new($quoted_name, $user->email)->format;
+    return Email::Address->new($quoted_name, $email)->format;
 }
 
 sub _message_id

--- a/t/lib/t/MusicBrainz/Server/Email.pm
+++ b/t/lib/t/MusicBrainz/Server/Email.pm
@@ -47,7 +47,7 @@ test all => sub {
     is($delivery->{envelope}->{from}, 'noreply@musicbrainz.org', "Envelope from is noreply@...");
     my $e = $delivery->{email};
     $email->transport->clear_deliveries;
-    is($e->get_header('From'), '"Editor 1" <"Editor 1"@users.musicbrainz.org>', 'Header from is Editor 1 @users.musicbrainz.org');
+    is($e->get_header('From'), '"Editor 1" <noreply@musicbrainz.org>', 'Header from is "Editor 1" <noreply@musicbrainz.org>');
     is($e->get_header('Reply-To'), 'MusicBrainz Server <noreply@musicbrainz.org>', 'Reply-To is noreply@');
     is($e->get_header('To'), '"Editor 2" <bar@example.com>', 'To is Editor 2, bar@example.com');
     is($e->get_header('BCC'), undef, 'BCC is undefined');
@@ -81,7 +81,7 @@ test all => sub {
     my $delivery = $email->transport->shift_deliveries;
     is($delivery->{envelope}->{from}, 'noreply@musicbrainz.org', "Envelope from is noreply@...");
     my $e = $delivery->{email};
-    is($e->get_header('From'), '"Editor 1" <"Editor 1"@users.musicbrainz.org>', 'Header from is Editor 1 @users.musicbrainz.org');
+    is($e->get_header('From'), '"Editor 1" <noreply@musicbrainz.org>', 'Header from is "Editor 1" <noreply@musicbrainz.org>');
     is($e->get_header('Reply-To'), '"Editor 1" <foo@example.com>', 'Reply-To is Editor 1, foo@example.com');
     is($e->get_header('To'), '"Editor 2" <bar@example.com>', 'To is Editor 2, bar@example.com');
     is($e->get_header('BCC'), undef, 'BCC is undefined');
@@ -102,7 +102,7 @@ test all => sub {
     is($delivery->{envelope}->{from}, 'noreply@musicbrainz.org');
     $e = $delivery->{email};
     $email->transport->clear_deliveries;
-    is($e->get_header('From'), '"Editor 1" <"Editor 1"@users.musicbrainz.org>', 'Header from is Editor 1 @users.musicbrainz.org');
+    is($e->get_header('From'), '"Editor 1" <noreply@musicbrainz.org>', 'Header from is "Editor 1" <noreply@musicbrainz.org>');
     is($e->get_header('Reply-To'), '"Editor 1" <foo@example.com>', 'Reply-To is Editor 1, foo@example.com');
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('BCC'), undef, 'BCC is undefined');
@@ -283,7 +283,7 @@ EOS
     is($delivery->{envelope}->{from}, 'noreply@musicbrainz.org', 'Envelope from is noreply@...');
     my $e = $delivery->{email};
     $email->transport->clear_deliveries;
-    is($e->get_header('From'), '"Editor 2" <"Editor 2"@users.musicbrainz.org>', 'From is Editor 2, @users.musicbrainz.org');
+    is($e->get_header('From'), '"Editor 2" <noreply@musicbrainz.org>', 'Header from is "Editor 2" <noreply@musicbrainz.org>');
     is($e->get_header('To'), '"Editor 1" <foo@example.com>', 'To is Editor 1, foo@example.com');
     is($e->get_header('Subject'), 'Note added to edit #1234', 'Subject is Note added to edit #1234');
     is($e->get_header('References'), sprintf('<edit-1234@%s>', DBDefs->WEB_SERVER_USED_IN_EMAIL) , 'References edit-1234');
@@ -315,7 +315,7 @@ EOS
     is($delivery->{envelope}->{from}, 'noreply@musicbrainz.org', 'Envelope from is noreply@...');
     my $e = $delivery->{email};
     $email->transport->clear_deliveries;
-    is($e->get_header('From'), '"Editor 1" <"Editor 1"@users.musicbrainz.org>', 'From is Editor 1, @users.musicbrainz.org');
+    is($e->get_header('From'), '"Editor 1" <noreply@musicbrainz.org>', 'Header from is "Editor 1" <noreply@musicbrainz.org>');
     is($e->get_header('To'), '"Editor 2" <bar@example.com>', 'To is Editor 2, bar@example.com');
     is($e->get_header('Subject'), 'Note added to your edit #9000', 'Subject is Note added to your edit #9000');
     like($e->get_header('Message-Id'), qr{<edit-9000-4444-edit-note-\d+@.*>} , 'Message ID has right format');


### PR DESCRIPTION
The purpose of this change is to provide DKIM signature.
See https://tickets.metabrainz.org/browse/MBS-9696