### PR TITLE
Fix key attributes for some React components

### DIFF
--- a/root/components/Aliases/AliasTableBody.js
+++ b/root/components/Aliases/AliasTableBody.js
@@ -21,7 +21,7 @@ const AliasTableBody = ({aliases, ...props}: Props) => {
   const aliasRows = [];
   for (let i = 0; i < aliases.length; i++) {
     const alias = aliases[i];
-    aliasRows.push(<AliasTableRow alias={alias} row={i % 2 ? 'even' : 'odd'} {...props} />);
+    aliasRows.push(<AliasTableRow alias={alias} key={alias.id} row={i % 2 ? 'even' : 'odd'} {...props} />);
   }
   return <tbody>{aliasRows}</tbody>;
 };

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -25,7 +25,7 @@ type Props = {
 };
 
 const AliasTableRow = ({alias, allowEditing, entity, row}: Props) => (
-  <tr className={row} key={alias.id}>
+  <tr className={row}>
     <td colSpan={alias.name === alias.sort_name ? 2 : 1}>
       {alias.editsPending
         ? <span className="mp">{isolateText(alias.name)}</span>

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -32,7 +32,7 @@ const Aliases = ({$c, aliases, allowEditing = $c.user ? !$c.user.is_editing_disa
       </p>
       {aliases && aliases.length
         ? <AliasTable aliases={aliases} allowEditing={allowEditing} entity={entity} />
-        : <p>{l('{entity} has no aliases.', {__react: true, entity: <EntityLink entity={entity} />})}</p>}
+        : <p>{l('{entity} has no aliases.', {__react: true, entity: <EntityLink entity={entity} key='entity' />})}</p>}
       {allowEditing
         ? (
           <p>

--- a/root/elections/Nominate.js
+++ b/root/elections/Nominate.js
@@ -19,7 +19,7 @@ const Nominate = ({candidate}: {+candidate: EditorT}) => (
     <p>
       {l('Are you sure you want to nominate the editor {editor} for auto-editor status?', {
         __react: true,
-        editor: <EditorLink editor={candidate} />,
+        editor: <EditorLink editor={candidate} key='editor' />,
       })}
     </p>
     <form method="post">

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -39,7 +39,7 @@ const Footer = ({$c, ...props}) => {
           <br />,
           l('Running: {git_details}',
             {__react: true,
-             git_details: <span className="tooltip" title={DBDefs.GIT_MSG}>
+             git_details: <span className="tooltip" key='git_details' title={DBDefs.GIT_MSG}>
                             {DBDefs.GIT_BRANCH} ({DBDefs.GIT_SHA})
                           </span>
             })

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -43,7 +43,7 @@ const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
     return l('{place} in {area}', {
       __react: true,
       place: link,
-      area: <AreaWithContainmentLink area={entity.area} key={1} />
+      area: <AreaWithContainmentLink area={entity.area} key='area' />
     });
   }
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -202,7 +202,7 @@ class ExternalLinksEditor extends React.Component<LinksEditorProps, LinksEditorS
               // Kludge for MBS-9515 to be replaced with the more general MBS-9516
               error = l('Links to specific sections of Wikipedia articles are not allowed. Please remove “{fragment}” if still appropriate. See the {url|guidelines}.', {
                 __react: true,
-                fragment: <span className='url-quote'>{link.url.replace(/^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/, '#$1')}</span>,
+                fragment: <span className='url-quote' key='fragment'>{link.url.replace(/^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/, '#$1')}</span>,
                 url: { href: '/relationship/' + linkType.gid, target: '_blank' }
               });
             } else if ((linksByTypeAndUrl[linkTypeAndUrlString(link)] || []).length > 1) {


### PR DESCRIPTION
Two small fixes about `key` attributes of some React components:
1. Take misplaced `key` from `tr` to parent component `AliasTableRow`.
2. Add missing `key` attributes for React components given as parameters of calls to the localization function `l`.
  Enforce as code style to use the placeholder name as key value in such case.