### PR TITLE
Fix checking MBS_ADMIN_CONFIG env var

### DIFF
--- a/admin/config.sh
+++ b/admin/config.sh
@@ -4,7 +4,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")"
 
 source config.default.sh
 
-if [[ ! -z "$MBS_ADMIN_CONFIG" && -e "$MBS_ADMIN_CONFIG" ]]; then
+if [[ -v MBS_ADMIN_CONFIG && -e "$MBS_ADMIN_CONFIG" ]]; then
     source "$MBS_ADMIN_CONFIG"
 fi
 


### PR DESCRIPTION
not to fail when MBS_ADMIN_CONFIG is not defined and shell flag `errexit` is set in caller.

