### PR TITLE
MBS-9705: Hide /show subpath from Overview tab

### DIFF
--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -70,7 +70,7 @@ function buildLinks(
   page: string,
   editTab: React.Node,
 ): React.Node {
-  const links = [buildLink(l('Overview'), entity, 'show', page, 'index')];
+  const links = [buildLink(l('Overview'), entity, '', page, 'index')];
 
   const entityProperties = ENTITIES[entity.entityType];
 


### PR DESCRIPTION
### Fix [MBS-9705](https://tickets.metabrainz.org/browse/MBS-9705): Overview tab link is now appended with /show

Both URLs are correct, but `/show` subpath is unneeded and was not returned by `uri_for`.
