### PR TITLE
MBS-9709: Only trigger change on visible inputs

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -70,7 +70,7 @@ releaseEditor.init = function (options) {
              * Workaround for buggy dictation software which may not trigger
              * change events after setting input values.
              */
-            $('input:enabled', ui.oldPanel).change();
+            $('input:enabled:visible', ui.oldPanel).change();
         },
 
         activate: function (event, ui) {


### PR DESCRIPTION
### Fix [MBS-9709](https://tickets.metabrainz.org/browse/MBS-9709): Beta: Re-using the existing recording will use a different one from the suggested list

Complete bfc4aa4cbcf834ee2b9de04329f747f0cfc05c13

Fix issue MBS-9709 where clicking on button ‘Done’ rather than the button ‘Next’ in the recording association bubble would set the recording in the tab ‘Recordings’ only, not in the tab ‘Edit Note’.