### PR TITLE
MBS-9707: Add space before locale attribute primary

### DIFF
--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -44,7 +44,12 @@ const AliasTableRow = ({alias, allowEditing, entity, row}: Props) => (
     <td>
       {alias.locale ? locales[alias.locale] : null}
       {alias.primary_for_locale
-        ? bracketed(<span className="comment">{l('primary')}</span>, {__react: true})
+        ? (
+          <Frag>
+            {' '}
+            {bracketed(<span className="comment">{l('primary')}</span>, {__react: true})}
+          </Frag>
+        )
         : null}
     </td>
     <td>


### PR DESCRIPTION
### Fix [MBS-9707](https://tickets.metabrainz.org/browse/MBS-9707): Missing space between Language and (primary)

Complete f809ef73e8e68c0e99db8de2c471c26941ff9e96 which removed space from the function `bracketed`.