### PR TITLE
MBS-9704: Skip checking credentials twice for WS

### DIFF
--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -129,7 +129,7 @@ sub authenticate {
     my ($self, $c, $scope) = @_;
 
     try {
-        $c->authenticate({}, 'musicbrainz.org');
+        $c->authenticate({}, 'musicbrainz.org') unless $c->user_exists;
     } catch {
         # A 400 response code is already set in this case.
         $c->detach if $c->stash->{bad_auth_encoding};


### PR DESCRIPTION
### Fix [MBS-9704](https://tickets.metabrainz.org/browse/MBS-9704): 400 Bad Request error when requesting user-tags (or user-ratings) and user-collections

`WS::2 'authenticate'` is used to authenticate user from credentials and to check authorization scope.

Calling it twice was calling `Catalyst 'authenticate'` twice in a row which is not supposed to happen, thus returning 400 Bad Request error.

This patch skips authenticating from credentials again if user already exists, that is, it has already been successfully authenticated from credentials.

`WS::2 'authenticate'` still checks authorization scope.

