### PR TITLE
MBS-9710: Only trigger tracklist inputs

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -70,7 +70,9 @@ releaseEditor.init = function (options) {
              * Workaround for buggy dictation software which may not trigger
              * change events after setting input values.
              */
-            $('input:enabled:visible', ui.oldPanel).change();
+            if (ui.oldPanel[0].id === 'tracklist') {
+              $('.medium.tbl input:enabled:visible', ui.oldPanel).change();
+            }
         },
 
         activate: function (event, ui) {


### PR DESCRIPTION
### Fix [MBS-9710](https://tickets.metabrainz.org/browse/MBS-9710): Changes discarded from recording tab in release editor

Steps to reproduce the issue were:
- open the tab “Recordings” of the release editor;
- select a different recording for a track, without hitting the button “Done”;
- switch to any other tab and the above change is lost!