### PR TITLE
MBS-9675, MBS-9676: Fix work attributes localization issues in the release relationship editor

### DIFF
--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) -%]
+[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) gettext_domains=['attributes'] -%]
     [% script_manifest('edit.js') %]
 
     [% PROCESS 'components/relationship-editor.tt' %]


### PR DESCRIPTION
### Fix both bugs [MBS-9675](https://tickets.metabrainz.org/browse/MBS-9675) and [MBS-9676](https://tickets.metabrainz.org/browse/MBS-9676)

Cause was translation domain `attributes` was not loaded from the relationship editor, whereas it is required for adding new works when no existing work is found.