### PR TITLE
MBS-9675, MBS-9676: Fix work attributes localization issues in the work creation dialog

### DIFF
--- a/root/forms/dialog.tt
+++ b/root/forms/dialog.tt
@@ -8,8 +8,15 @@
       </script>
     </head>
   [% ELSE %]
-    [%- React.embed(c, 'layout/components/Head', {
+    [%- IF !gettext_domains;
+          SET gettext_domains = [];
+        END;
+        IF dialog_template == "work/edit_form.tt";
+          gettext_domains.push('attributes');
+        END;
+        React.embed(c, 'layout/components/Head', {
             canonical_url => canonical_url,
+            gettext_domains => gettext_domains,
             homepage => homepage,
             no_icons => no_icons,
             pager => pager,

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) gettext_domains=['attributes'] -%]
+[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) -%]
     [% script_manifest('edit.js') %]
 
     [% PROCESS 'components/relationship-editor.tt' %]


### PR DESCRIPTION
### Fix both bugs [MBS-9675](https://tickets.metabrainz.org/browse/MBS-9675) and [MBS-9676](https://tickets.metabrainz.org/browse/MBS-9676) for good

Cause was translation domain `attributes` was not loaded from the work creation dialog (opened from the release relationship editor), whereas it is required for adding new works when no existing work is found.

It reverts change from PR #673, and load gettext domain “attributes” for work creation dialog specifically.