### PR TITLE
MBS-9730: Auto-select, clean and validate Bandcamp Daily review page URL in release group relationships

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1089,15 +1089,23 @@ const CLEANUPS = {
   },
   bandcamp: {
     match: [new RegExp("^(https?://)?([^/]+)\\.bandcamp\\.com","i")],
-    type: LINK_TYPES.bandcamp,
+    type: _.defaults({}, LINK_TYPES.bandcamp, LINK_TYPES.review),
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com(?:\/(((album|track)\/([^\/\?]+)))?)?.*$/, "https://$1.bandcamp.com/$2");
+      url = url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com([\/?#].*)?$/, "https://$1.bandcamp.com$2");
+      if (/^https:\/\/daily\.bandcamp\.com/.test(url)) {
+        url = url.replace(/^(?:https?:\/\/)?daily\.bandcamp\.com\/(\d+\/\d+\/\d+\/[\w-]+)(?:[\/?#].*)?$/, "https://daily.bandcamp.com/$1/");
+      } else {
+        url = url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com(?:\/(((album|track)\/([^\/\?]+)))?)?.*$/, "https://$1.bandcamp.com/$2");
+      }
+      return url;
     },
     validate: function (url, id) {
       switch (id) {
         case LINK_TYPES.bandcamp.artist:
         case LINK_TYPES.bandcamp.label:
           return /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url);
+        case LINK_TYPES.review.release_group:
+          return /^https:\/\/daily\.bandcamp\.com\/\d+\/\d+\/\d+\/[\w-]+-review\/$/.test(url);
       }
       return false;
     }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -387,6 +387,20 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                input_relationship_type: 'downloadpurchase',
                only_valid_entity_types: ['recording', 'release']
         },
+        {
+                             input_url: 'daily.bandcamp.com/2018/05/30/brownout-fear-of-a-brown-planet-album-review/#more-90177',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: 'review',
+                    expected_clean_url: 'https://daily.bandcamp.com/2018/05/30/brownout-fear-of-a-brown-planet-album-review/',
+               only_valid_entity_types: ['release_group']
+        },
+        {
+                             input_url: 'http://daily.bandcamp.com/2018/05/30/gnawa-bandcamp-list',
+                     input_entity_type: 'release_group',
+            expected_relationship_type: 'review',
+                    expected_clean_url: 'https://daily.bandcamp.com/2018/05/30/gnawa-bandcamp-list/',
+               only_valid_entity_types: []
+        },
         // Bandsintown
         {
                              input_url: "https://m.bandsintown.com/MattDobberteen's50thBirthday?came_from=178",


### PR DESCRIPTION
### Fix [MBS-9730](https://tickets.metabrainz.org/browse/MBS-9730): Cannot link to a Bandcamp Daily review page in release group relationships

Only accept `https://daily.bandcamp.com/YYYY/MM/DD/*-review/` URLs.