### PR TITLE
Tooling: Normalize external links to https & Set default blog link

### DIFF
--- a/admin/NormalizeToHTTPS
+++ b/admin/NormalizeToHTTPS
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use MusicBrainz::Server::Context;
+use MusicBrainz::Server::Validation qw( is_positive_integer );
+
+my $usage = "\"Usage: $0 number_of_rows domain.name [domain.name ...]\"";
+
+my $number_of_rows = shift;
+is_positive_integer($number_of_rows) or warn $usage and die "invalid number of rows";
+
+my @domain_names;
+while (my $domain_name = shift) {
+    $domain_name =~ /^(?:[\w-]+\.)+\w+$/n or warn $usage and die "invalid domain name";
+    push @domain_names, $domain_name;
+}
+if (scalar @domain_names == 0) {
+    warn $usage and die "missing domain name";
+}
+
+my $regexp =
+    '^http://' .
+    '(?:[\w-]+\.)*' .
+    '(?:' . (join '|', map { $_ =~ s/\./\\./gr } @domain_names) . ')' .
+    '(?:[:/?#]|$)';
+
+my $c = MusicBrainz::Server::Context->create_script_context(database => 'READWRITE');
+
+$c->sql->auto_commit;
+$c->sql->do(<<'EOF', $regexp, $number_of_rows);
+WITH updateable AS (
+    SELECT A.id
+      FROM url A
+     WHERE A.edits_pending = 0
+       AND A.url ~ ?
+       AND NOT EXISTS (
+               SELECT 1
+                 FROM url B
+                WHERE B.url = 'https' || substr(A.url, 5)
+           )
+     LIMIT ?
+       FOR UPDATE
+)
+UPDATE url
+   SET url = 'https' || substr(url, 5)
+ WHERE id IN (SELECT id FROM updateable);
+EOF
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2016 Ulrich Klauer
+Copyright (C) 2018 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/fabfile.py
+++ b/fabfile.py
@@ -80,8 +80,16 @@ def deploy(deploy_env="prod"):
     local("sleep 15")
 
 def tag():
-    tag = prompt("Tag name", default='v-' + date.today().strftime("%Y-%m-%d"))
-    blog_url = prompt("Blog post URL", validate=r'^http.*')
+    year  = date.today().strftime("%Y")
+    month = date.today().strftime("%m")
+    day   = date.today().strftime("%d")
+    tag = prompt("Tag name", default="-".join("v", year, month, day))
+    blog_url = prompt(
+            "Blog post URL", validate=r'^http.*',
+            default="https://blog.musicbrainz.org/" +
+            "/".join(year, month, day) + "/" +
+            "-".join("server", "update", year, month, day) + "/"
+            )
     no_local_changes()
     local("git tag -u 'CE33CF04' %s -m '%s' production" % (tag, blog_url))
     local("git push origin %s" % (tag))


### PR DESCRIPTION
### Improve admin/dev tooling:
* Add an admin script to normalize external links to `https`
  This script is not for use in `hourly.sh` since it may last for more than 1h if called with a large number of rows during busy hours. It is currently running in a shell of `cron` container for [MBS-9646](https://tickets.metabrainz.org/browse/MBS-9646).
* Set default blog link in `fab tag`