### PR TITLE
MBS-9439: Allow auto-editing URL to shift protocol from HTTP to HTTPS

### DIFF
--- a/lib/MusicBrainz/Server/Edit/URL/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/URL/Edit.pm
@@ -76,7 +76,9 @@ after initialize => sub {
 };
 
 override allow_auto_edit => sub {
-    return 0;
+    my $self = shift;
+    return 0 unless defined $self->data->{old}{url} && defined $self->data->{new}{url};
+    return ($self->data->{old}{url} =~ s/^http:/https:/r) eq $self->data->{new}{url};
 };
 
 around accept => sub {

--- a/t/lib/t/MusicBrainz/Server/Edit/URL/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/URL/Edit.pm
@@ -128,6 +128,16 @@ test 'Check conflicts (conflicting edits)' => sub {
     is($url->url, 'http://musicbrainz.org/rocks', 'url renamed');
 };
 
+test 'Changing URL scheme from HTTP to HTTPS is an auto-edit (MBS-9439)' => sub {
+    my $test = shift;
+
+    my $edit = _build_edit($test, 'https://musicbrainz.org/', 1);
+    is $edit->status, $STATUS_APPLIED;
+
+    my $edit = _build_edit($test, 'http://musicbrainz.org/', 1);
+    is $edit->status, $STATUS_OPEN, 'Moving from HTTPS to HTTP is not an auto edit';
+};
+
 sub _build_edit {
     my ($test, $url, $url_to_edit) = @_;
     $test->c->model('Edit')->create(


### PR DESCRIPTION
### [MBS-9439](https://tickets.metabrainz.org/browse/MBS-9439): Allow auto-editing URL to shift protocol from HTTP to HTTPS

And not the other way around.