### PR TITLE
MBS-9734: Fix invalid format for ISRCs while parsing WS/2 json search…

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -563,7 +563,9 @@ sub schema_fixup
 
     if ($type eq 'recording' && defined $data->{'isrcs'}) {
         $data->{isrcs} = [
-            map { MusicBrainz::Server::Entity::ISRC->new( isrc => $_->{id} ) } @{ $data->{'isrcs'} }
+            map { MusicBrainz::Server::Entity::ISRC->new(
+                isrc => (DBDefs->SEARCH_ENGINE eq 'LUCENE') ? $_->{id} : $_
+            ) } @{ $data->{'isrcs'} }
         ];
     }
 


### PR DESCRIPTION
… output

Currently JSON search outputs ISRCs as

`"isrcs": [{"id": "XYZ"}]`

This changes it to be consistent with WS/2 lookup
`"isrcs": ["XYZ"]`

Also - this is currently dependent on Solr search, so only deploy it once Solr is deployed.