### PR TITLE
MBS-9743: Fix Beatport URL cleanup for artist names starting with digit

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -598,10 +598,10 @@ const CLEANUPS = {
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:(?:classic|pro|www)\.)?beatport\.com\//, "https://www.beatport.com/");
       url = url.replace(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/0*([0-9]+)\/([\w-]+).*$/, "$1/$2/$4/$3");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/0*([0-9]+).*$/, "$1/$2/-/$3");
+      url = url.replace(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/-/$3");
       url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/([\w-]+)\/0*([0-9]+).*$/, "$1/$2/$3/$4");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/\/*0*([0-9]+).*$/, "$1/$2/-/$3");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/0*([0-9]+).*$/, "$1/$2/$3");
+      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/\/+0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/-/$3");
+      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/$3");
       return url;
     },
     validate: function (url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -485,6 +485,13 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                only_valid_entity_types: ['artist']
         },
         {
+                             input_url: 'https://www.beatport.com/artist/4orcedj/208047',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/artist/4orcedj/208047',
+               only_valid_entity_types: ['artist']
+        },
+        {
                              input_url: 'https://www.beatport.com/release/pryda-10-vol-i/1563118',
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',


### PR DESCRIPTION
### Fix [MBS-9743](https://tickets.metabrainz.org/browse/MBS-9743): Beatport URL cleanup fails for artist names starting with digit