### PR TITLE
SOLR-90: Fix tag lookups for artist

### DIFF
--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -3,7 +3,7 @@ use Moose;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use MusicBrainz::Server::Form::TagLookup;
-use MusicBrainz::Server::Data::Search qw( alias_query escape_query );
+use MusicBrainz::Server::Data::Search qw( escape_query );
 
 use constant LOOKUPS_PER_NAG => 5;
 

--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -144,12 +144,7 @@ sub external : Private
     my @search_modifiers;
     for my $term (keys %terms) {
         my $value = escape_query($terms{$term});
-        if ($term eq 'artist') {
-            push @search_modifiers, alias_query('artist', $value);
-        }
-        else {
-            push @search_modifiers, "$term:" . q{"} . $value . q{"};
-        }
+        push @search_modifiers, "$term:" . q{"} . $value . q{"};
     }
 
     # Try and find the most exact search

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -8,7 +8,7 @@ use JSON qw( encode_json decode_json );
 use List::UtilsBy qw( uniq_by );
 use MusicBrainz::Server::WebService::Validator;
 use MusicBrainz::Server::Filters;
-use MusicBrainz::Server::Data::Search qw( escape_query alias_query );
+use MusicBrainz::Server::Data::Search qw( escape_query );
 use MusicBrainz::Server::Constants qw( entities_with );
 use MusicBrainz::Server::Validation qw( is_guid );
 use Readonly;

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -71,7 +71,7 @@ no if $] >= 5.018, warnings => "experimental::smartmatch";
 extends 'MusicBrainz::Server::Data::Entity';
 
 use Sub::Exporter -setup => {
-    exports => [qw( escape_query alias_query )]
+    exports => [qw( escape_query )]
 };
 
 sub search
@@ -719,19 +719,6 @@ sub escape_query
 
     $str =~  s/([+\-&|!(){}\[\]\^"~*?:\\\/])/\\$1/g;
     return $str;
-}
-
-# add alias/sortname queries for entity
-sub alias_query
-{
-    my ($type, $query) = @_;
-
-    return "$type:\"$query\"^1.6 " .
-        "(+sortname:\"$query\"^1.6 -$type:\"$query\") " .
-        "(+alias:\"$query\" -$type:\"$query\" -sortname:\"$query\") " .
-        "(+($type:($query)^0.8) -$type:\"$query\" -sortname:\"$query\" -alias:\"$query\") " .
-        "(+(sortname:($query)^0.8) -$type:($query) -sortname:\"$query\" -alias:\"$query\") " .
-        "(+(alias:($query)^0.4) -$type:($query) -sortname:($query) -alias:\"$query\")";
 }
 
 sub external_search


### PR DESCRIPTION
Tag lookups for artist was using a search modifier to search for sortnames and aliases with a particular boost. This is not needed or supported anymore (since it uses a weird syntax) with Solr since these fields are searched by default with a particular set of boosts