### PR TITLE
MBS-9757: Search page form is sometimes in the wrong language

### DIFF
--- a/root/components/FormRowRadio.js
+++ b/root/components/FormRowRadio.js
@@ -41,7 +41,7 @@ const FormRowRadio = ({
               value={option.value}
             />
             {' '}
-            {option.label}
+            {option.label.toLocaleString()}
           </label>
           {index < options.length - 1 ? <br /> : null}
         </Frag>

--- a/root/components/SelectField.js
+++ b/root/components/SelectField.js
@@ -13,7 +13,7 @@ import getSelectValue from '../utility/getSelectValue';
 
 const buildOption = (option: SelectOptionT, index: number) => (
   <option key={index} value={option.value}>
-    {option.label}
+    {option.label.toLocaleString()}
   </option>
 );
 

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -47,9 +47,8 @@ const TYPE_OPTION_GROUPS = [
 ];
 
 function localizedTypeOption(group, key) {
-  return (key === 'series' || key === 'tag') ? lp(group[key])
-    : (key === 'doc' && group[key] === null) ? null
-      : l(group[key]);
+  const option = group[key];
+  return option ? option.toLocaleString() : null;
 }
 
 const SearchOptions = () => (

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -9,7 +9,7 @@
 
 import noop from 'lodash/noop';
 import React from 'react';
-import {l, lp} from '../../static/scripts/common/i18n';
+import {l, N_l, N_lp} from '../../static/scripts/common/i18n';
 import DBDefs from '../../static/scripts/common/DBDefs';
 import FieldErrors from '../../components/FieldErrors';
 import FormRow from '../../components/FormRow';
@@ -26,47 +26,47 @@ type Props = {|
 const limitOptions = {
   grouped: false,
   options: [
-    {label: l('Up to {n}', {n: 25}), value: 25},
-    {label: l('Up to {n}', {n: 50}), value: 50},
-    {label: l('Up to {n}', {n: 100}), value: 100},
+    {label: N_l('Up to {n}', {n: 25}), value: 25},
+    {label: N_l('Up to {n}', {n: 50}), value: 50},
+    {label: N_l('Up to {n}', {n: 100}), value: 100},
   ],
 };
 
 const typeOptions = {
   grouped: false,
   options: [
-    {label: l('Artist'), value: 'artist'},
-    {label: l('Release Group'), value: 'release_group'},
-    {label: l('Release'), value: 'release'},
-    {label: l('Recording'), value: 'recording'},
-    {label: l('Work'), value: 'work'},
-    {label: l('Label'), value: 'label'},
-    {label: l('Area'), value: 'area'},
-    {label: l('Place'), value: 'place'},
-    {label: l('Annotation'), value: 'annotation'},
-    {label: l('CD Stub'), value: 'cdstub'},
-    {label: l('Editor'), value: 'editor'},
-    {label: lp('Tag', 'noun'), value: 'tag'},
-    {label: l('Instrument'), value: 'instrument'},
-    {label: lp('Series', 'singular'), value: 'series'},
-    {label: l('Event'), value: 'event'},
+    {label: N_l('Artist'), value: 'artist'},
+    {label: N_l('Release Group'), value: 'release_group'},
+    {label: N_l('Release'), value: 'release'},
+    {label: N_l('Recording'), value: 'recording'},
+    {label: N_l('Work'), value: 'work'},
+    {label: N_l('Label'), value: 'label'},
+    {label: N_l('Area'), value: 'area'},
+    {label: N_l('Place'), value: 'place'},
+    {label: N_l('Annotation'), value: 'annotation'},
+    {label: N_l('CD Stub'), value: 'cdstub'},
+    {label: N_l('Editor'), value: 'editor'},
+    {label: N_lp('Tag', 'noun'), value: 'tag'},
+    {label: N_l('Instrument'), value: 'instrument'},
+    {label: N_lp('Series', 'singular'), value: 'series'},
+    {label: N_l('Event'), value: 'event'},
   ],
 };
 
 if (DBDefs.GOOGLE_CUSTOM_SEARCH) {
-  typeOptions.options.push({label: l('Documentation'), value: 'doc'});
+  typeOptions.options.push({label: N_l('Documentation'), value: 'doc'});
 }
 
 const methodOptions = [
-  {label: l('Indexed search'), value: 'indexed'},
+  {label: N_l('Indexed search'), value: 'indexed'},
   {
-    label: l('Indexed search with {doc|advanced query syntax}', {
+    label: N_l('Indexed search with {doc|advanced query syntax}', {
       __react: true,
       doc: '/doc/Indexed_Search_Syntax',
     }),
     value: 'advanced',
   },
-  {label: l('Direct database search'), value: 'direct'},
+  {label: N_l('Direct database search'), value: 'direct'},
 ];
 
 const SearchForm = ({form}: Props) => {

--- a/root/static/scripts/common/i18n.js
+++ b/root/static/scripts/common/i18n.js
@@ -3,8 +3,6 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const sliced = require('sliced');
-
 const expand = require('./i18n/expand');
 const NopArgs = require('./i18n/NopArgs');
 const wrapGettext = require('./i18n/wrapGettext');
@@ -13,16 +11,16 @@ const l = wrapGettext('dgettext', 'mb_server');
 const ln = wrapGettext('dngettext', 'mb_server');
 const lp = wrapGettext('dpgettext', 'mb_server');
 
-function noop() {
-    return new NopArgs(sliced(arguments));
+function noop(func) {
+    return (...args) => new NopArgs(func, args);
 }
 
 exports.l = l;
 exports.ln = ln;
 exports.lp = lp;
-exports.N_l = noop;
-exports.N_ln = noop;
-exports.N_lp = noop;
+exports.N_l = noop(l);
+exports.N_ln = noop(ln);
+exports.N_lp = noop(lp);
 exports.expand = expand;
 
 let documentLang = 'en';

--- a/root/static/scripts/common/i18n/NopArgs.js
+++ b/root/static/scripts/common/i18n/NopArgs.js
@@ -9,11 +9,27 @@
 
 type Args = $ReadOnlyArray<string>;
 
+type Func = (...Args) => string;
+
 class NopArgs {
   args: Args;
+  func: Func;
 
-  constructor(args: Args) {
+  constructor(func: Func, args: Args) {
+    this.func = func;
     this.args = args;
+  }
+
+  /*
+   * This is what `Object.prototype.toLocaleString` does, but it's
+   * also implemented here for clarity.
+   */
+  toLocaleString() {
+    return this.toString();
+  }
+
+  toString() {
+    return this.func.apply(null, this.args);
   }
 }
 

--- a/root/types.js
+++ b/root/types.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import NopArgs from './static/scripts/common/i18n/NopArgs';
 
 /*
  * Types are in alphabetical order.
@@ -485,7 +486,7 @@ declare type SearchResultT<T> = {|
  * FIXME(michael): Consolidate with OptionListT.
  */
 declare type SelectOptionT = {|
-  +label: string,
+  +label: string | NopArgs,
   +value: number | string,
 |};
 


### PR DESCRIPTION
Fixes the same bug as MBS-9673 (see ccdb147). The idea is to delay the localization of the strings from when the module is loaded until the request lifecycle.