### PR TITLE
MBS-9767: Hide search scores from the UI

### DIFF
--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -27,8 +27,7 @@ function buildResult(result, index) {
   const score = result.score;
 
   return (
-    <tr className={loopParity(index)} key={area.id}>
-      <td>{score}</td>
+    <tr className={loopParity(index)} data-score={score} key={area.id}>
       <td>
         <DescriptiveLink entity={area} />
       </td>
@@ -54,7 +53,6 @@ const AreaResults = ({
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={[
-        l('Score'),
         l('Name'),
         l('Type'),
         l('Code'),

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -27,8 +27,7 @@ function buildResult(result, index) {
   const score = result.score;
 
   return (
-    <tr className={loopParity(index)} key={artist.id}>
-      <td>{result.score}</td>
+    <tr className={loopParity(index)} data-score={score} key={artist.id}>
       <td>
         <EntityLink entity={artist} />
       </td>
@@ -66,7 +65,6 @@ const ArtistResults = ({
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={[
-        l('Score'),
         l('Name'),
         l('Sort Name'),
         l('Type'),

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -28,8 +28,7 @@ function buildResult(result, index) {
   const score = result.score;
 
   return (
-    <tr className={loopParity(index)} key={event.id}>
-      <td>{score}</td>
+    <tr className={loopParity(index)} data-score={score} key={event.id}>
       <td>
         <DescriptiveLink entity={event} />
       </td>
@@ -82,7 +81,6 @@ const EventResults = ({
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={[
-        l('Score'),
         l('Name'),
         l('Type'),
         l('Artists'),

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -24,8 +24,7 @@ function buildResult(result, index) {
   const score = result.score;
 
   return (
-    <tr className={loopParity(index)} key={series.id}>
-      <td>{result.score}</td>
+    <tr className={loopParity(index)} data-score={score} key={series.id}>
       <td>
         <EntityLink entity={series} />
       </td>
@@ -47,7 +46,7 @@ const SeriesResults = ({
   <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
-      columns={[l('Score'), l('Name'), l('Type')]}
+      columns={[l('Name'), l('Type')]}
       pager={pager}
       query={query}
       results={results}

--- a/root/search/lib/inline-results-artist.tt
+++ b/root/search/lib/inline-results-artist.tt
@@ -3,7 +3,6 @@
   <table class="tbl">
     <thead>
       <tr>
-        <th>[% l('Score') %]</th>
         <th>[% l('Name') %]</th>
         <th>[% l('Sort Name') %]</th>
         <th>[% l('Type') %]</th>
@@ -17,8 +16,7 @@
     </thead>
     <tbody>
       [%- FOR result=results -%]
-      <tr class="[% loop.parity %]">
-        <td>[% result.score %]</td>
+      <tr class="[% loop.parity %]" data-score="[% result.score %]">
         <td>
           [% link_entity(result.entity) %]
         </td>

--- a/root/search/lib/inline-results-recording.tt
+++ b/root/search/lib/inline-results-recording.tt
@@ -3,7 +3,6 @@
   <table class="tbl">
     <thead>
       <tr>
-        <th>[% l('Score') %]</th>
         <th class="video c"></th>
         <th>[% l('Name') %]</th>
         <th class="treleases">[% l('Length') %]</th>
@@ -23,9 +22,8 @@
       [%- FOR result=results -%]
         [% IF result.extra.size %]
           [%- FOR release=result.extra -%]
-            <tr[% ' class="even"' IF linenum % 2 == 0 %]>
+            <tr[% ' class="even"' IF linenum % 2 == 0 %][% ' data-score="' _ result.score _ '"' IF results.0.score.defined %]>
               [%- IF loop.count == 1 -%]
-                <td>[% result.score %]</td>
                 <td class="video c[%- IF result.entity.video %] is-video[%- END -%]"[% IF result.entity.video %] title="[% l("This recording is a video") %]"[% END %]></td>
                 <td>[% link_entity(result.entity) %]</td>
                 <td>[% result.entity.length | format_length %]</td>
@@ -49,8 +47,7 @@
             </tr>
           [%- END -%]
         [% ELSE %]
-          <tr[% ' class="even"' IF linenum % 2 == 0 %]>
-            <td>[% result.score %]</td>
+          <tr[% ' class="even"' IF linenum % 2 == 0 %] data-score="[% result.score %]">
             <td class="video c[%- IF result.entity.video %] is-video[%- END -%]"[% IF result.entity.video %] title="[% l("This recording is a video") %]"[% END %]></td>
             <td>[% link_entity(result.entity) %]</td>
             <td>[% result.entity.length | format_length %]</td>

--- a/root/search/lib/inline-results-release.tt
+++ b/root/search/lib/inline-results-release.tt
@@ -3,9 +3,6 @@
   <table class="tbl">
     <thead>
       <tr>
-        [%- IF results.0.score.defined -%]
-          <th>[% l('Score') %]</th>
-        [%- END -%]
         <th>[% l('Name') %]</th>
         <th>[% l('Artist') %]</th>
         <th>[% l('Format') %]</th>
@@ -25,10 +22,7 @@
     </thead>
     <tbody>
       [%- FOR result=results -%]
-        <tr class="[% loop.parity %]">
-          [%- IF results.0.score.defined -%]
-            <td>[% result.score %]</td>
-          [%- END -%]
+        <tr class="[% loop.parity %]"[% ' data-score="' _ result.score _ '"' IF results.0.score.defined %]>
           <td>[% link_entity(result.entity) %]</td>
           <td>[% artist_credit(result.entity.artist_credit) %]</td>
           <td>[% html_escape(result.entity.combined_format_name) or "-" %]</td>

--- a/root/search/results-annotation.tt
+++ b/root/search/results-annotation.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Type') %]</th>
                             <th>[% l('Name') %]</th>
                             <th>[% l('Annotation') %]</th>
@@ -12,8 +11,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[% format_entity_type_name(result.type) %]</td>
                             <td>[% link_entity(result.entity.parent) %]</td>
                             <td>[% result.entity.text | format_wikitext %]</td>

--- a/root/search/results-cdstub.tt
+++ b/root/search/results-cdstub.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('CD Stub') %]</th>
                             <th>[% l('Artist') %]</th>
                             <th>[% l('Tracks') %]</th>
@@ -12,8 +11,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[% link_cdstub(result.entity, "show", result.entity.title) %]</td>
                             <td>[% result.entity.artist %]</td>
                             <td>[% result.entity.track_count %]</td>

--- a/root/search/results-editor.tt
+++ b/root/search/results-editor.tt
@@ -4,14 +4,12 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Name') %]</th>
                         </tr>
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td class="pos">[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[% link_editor(result.entity) %]</td>
                         </tr>
                         [%- END -%]

--- a/root/search/results-instrument.tt
+++ b/root/search/results-instrument.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Name') %]</th>
                             <th>[% l('Type') %]</th>
                             <th>[% l('Description') %]</th>
@@ -12,8 +11,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>
                                 [% link_entity(result.entity) %]
                             </td>

--- a/root/search/results-label.tt
+++ b/root/search/results-label.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Name') %]</th>
                             <th>[% l('Type') %]</th>
                             <th>[% l('Code') %]</th>
@@ -15,8 +14,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>
                                 [% link_entity(result.entity) %]
                             </td>

--- a/root/search/results-place.tt
+++ b/root/search/results-place.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Name') %]</th>
                             <th>[% l('Type') %]</th>
                             <th>[% l('Address') %]</th>
@@ -15,8 +14,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>
                                 [% link_entity(result.entity) %]
                             </td>

--- a/root/search/results-release_group.tt
+++ b/root/search/results-release_group.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Release Group') %]</th>
                             <th>[% l('Artist') %]</th>
                             <th>[% l('Type') %]</th>
@@ -12,8 +11,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[% link_entity(result.entity) %]</td>
                             <td>[% artist_credit(result.entity.artist_credit) %]</td>
                             <td>[% result.entity.l_type_name %]</td>

--- a/root/search/results-tag.tt
+++ b/root/search/results-tag.tt
@@ -4,14 +4,12 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[% l('Score') %]</th>
                             <th>[% l('Name') %]</th>
                         </tr>
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[% result.score %]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[% link_tag(result.entity) %]</td>
                         </tr>
                         [%- END -%]

--- a/root/search/results-work.tt
+++ b/root/search/results-work.tt
@@ -4,7 +4,6 @@
                 <table class="tbl">
                     <thead>
                         <tr>
-                            <th>[%- l('Score') -%]</th>
                             <th>[%- l('Name') -%]</th>
                             <th>[%- l('Writers') -%]</th>
                             <th>[%- l('Artists') -%]</th>
@@ -15,8 +14,7 @@
                     </thead>
                     <tbody>
                         [%- FOR result=results -%]
-                        <tr class="[% loop.parity %]">
-                            <td>[%- result.score -%]</td>
+                        <tr class="[% loop.parity %]" data-score="[% result.score %]">
                             <td>[%- link_entity(result.entity) -%]</td>
                             <td>
                               <ul>


### PR DESCRIPTION
# Resolve [MBS-9767](https://tickets.metabrainz.org/browse/MBS-9767):

Hide search scores from the UI by moving it to the added attribute `data-score` for each result.