### PR TITLE
Render entity links in release/relationship editors with React

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -230,9 +230,6 @@ sub show : PathPart('') Chained('load')
     $c->stash(
         recordings => $recordings,
         recordings_jsonld => {items => $recordings},
-        show_video => scalar(grep {
-            $_->video
-        } @$recordings),
         release_groups => $release_groups,
         release_groups_jsonld => {items => $release_groups},
         show_artists => scalar grep {
@@ -340,9 +337,6 @@ sub recordings : Chained('load')
         recordings_jsonld => {items => $recordings},
         show_artists => scalar(grep {
             $_->artist_credit->name ne $artist->name
-        } @$recordings),
-        show_video => scalar(grep {
-            $_->video
         } @$recordings),
     );
 }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -383,7 +383,7 @@ sub schema_fixup
             if (defined $data->{'life-span'}->{begin});
         $data->{end_date} = MusicBrainz::Server::Entity::PartialDate->new($data->{'life-span'}->{end})
             if (defined $data->{'life-span'}->{end});
-        $data->{ended} = $data->{'life-span'}->{ended} eq 'true'
+        $data->{ended} = $data->{'life-span'}->{ended} == 1
             if defined $data->{'life-span'}->{ended};
     }
     if ($type eq 'area') {
@@ -570,7 +570,7 @@ sub schema_fixup
     }
 
     if ($type eq 'recording') {
-        $data->{video} = defined $data->{video} && $data->{video} eq 'true';
+        $data->{video} = defined $data->{video} && $data->{video} == 1;
     }
 
     if (defined $data->{"relations"} &&

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -159,14 +159,6 @@ sub has_multiple_artists {
     return 0;
 }
 
-sub includes_video {
-    my ($self) = @_;
-    foreach my $track ($self->all_tracks) {
-        return 1 if $track->recording->video;
-    }
-    return 0;
-}
-
 has 'combined_track_relationships' => (
     is => 'ro',
     builder => '_build_combined_track_relationships',

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -330,6 +330,8 @@ END -%]
                 content _ bracketedWithSpace(dates);
             CASE 'avatar'; # add. parameter: avatar
                 '<img src="' _ avatar _ '" height="' _ image_size _ '" width="' _ image_size _ '" class="gravatar" alt="" />' _ content;
+            CASE 'video';
+                '<span class="video" title="' _ html_escape(l('This recording is a video')) _ '"></span>' _ content;
         END;
     END;
     content;
@@ -372,6 +374,10 @@ END -%]
         options.unshift('info_link');
         infolink = link;
         link = entity.href_url;
+    END;
+
+    IF action == 'show' AND type == 'recording' AND entity.video;
+        options.unshift('video');
     END;
 
     INCLUDE _wrap_text options=options content=mod_content link=link hover=hover flag=flag infolink=infolink dates=dates;

--- a/root/components/medium.tt
+++ b/root/components/medium.tt
@@ -41,18 +41,11 @@
   [%- END %]
 [%~ END ~%]
 
-[%~ MACRO medium_track_row(track, show_video, show_artists) BLOCK ~%]
+[%~ MACRO medium_track_row(track, show_artists) BLOCK ~%]
   <tr class="[% loop.parity %][% ' mp' IF track.edits_pending %]" id="[% track.gid %]">
     <td class="pos t">
       <a href="[% c.uri_for_action('/track/show', [track.gid]) %]">[% track.number %]</a>
     </td>
-    [% IF show_video %]
-      [% IF track.recording.video %]
-        <td class="video c is-video" title="[% l('This recording is a video') %]"></td>
-      [% ELSE %]
-        <td class="video c"></td>
-      [% END %]
-    [% END %]
     <td>
       [%- link_recording(track.recording, 'show', track.name) -%]
       <br/>
@@ -73,13 +66,10 @@
 [%~ END ~%]
 
 [%~ MACRO medium_body(medium) BLOCK ~%]
-  [% show_video = medium.includes_video; show_artists = medium.has_multiple_artists %]
+  [% show_artists = medium.has_multiple_artists %]
   <tbody>
     <tr class="subh">
       <th class="pos t">[%~ l('#') ~%]</th>
-      [% IF show_video %]
-        <th class="video c"></th>
-      [% END %]
       <th>[% l('Title') %]</th>
       [% IF show_artists %]
         <th>[% l('Artist') %]</th>
@@ -89,7 +79,7 @@
     </tr>
 
     [% FOR track IN medium.audio_tracks %]
-      [% medium_track_row(track, show_video, show_artists) %]
+      [% medium_track_row(track, show_artists) %]
     [% END %]
 
     [% IF medium.data_tracks.size %]
@@ -100,7 +90,7 @@
         </td>
       </tr>
       [% FOR track IN medium.data_tracks %]
-        [% medium_track_row(track, show_video, show_artists) %]
+        [% medium_track_row(track, show_artists) %]
       [% END %]
     [% END %]
   </tbody>

--- a/root/components/recordings-list.tt
+++ b/root/components/recordings-list.tt
@@ -21,9 +21,6 @@
             [% IF series_item_numbers %]
               <th style="width: 1em">[% l('#') %]</th>
             [% END %]
-            [%- IF show_video -%]
-                <th class="video c"></th>
-            [%- END -%]
             <th>[%~ sortable ? sortable_table_header('name', l('Name')) : l('Name') ~%]</th>
             [%- IF show_artists -%]
                 <th>[%~ sortable ? sortable_table_header('artist', l('Artist')) : l('Artist') ~%]</th>
@@ -45,9 +42,6 @@
                   [% recording_id=recording.id; series_item_numbers.$recording_id %]
                 </td>
               [% END %]
-              [%- IF show_video -%]
-                  <td class="video c[%- IF recording.video %] is-video[%- END -%]"[% IF recording.video %] title="[% l("This recording is a video") %]"[% END %]></td>
-              [%- END -%]
               <td>
                 [%~ link_entity(recording) ~%]
               </td>
@@ -73,9 +67,6 @@
           [% ELSE %]
           <tr class="[% loop.parity %]">
               [% PROCESS recording_row_checkbox %]
-              [%- IF show_video -%]
-                  <td class="video c[%- IF recording.video %] is-video[%- END -%]"[% IF recording.video %] title="[% l("This recording is a video") %]"[% END %]></td>
-              [%- END -%]
               <td>
                 [% link_entity(recording) %]
               </td>

--- a/root/edit/details/merge_recordings.tt
+++ b/root/edit/details/merge_recordings.tt
@@ -3,7 +3,7 @@
     <th>[% l('Merge:') %]</th>
     <td>
       [% INCLUDE 'components/recordings-list.tt' recordings=edit.display_data.old
-           show_artists=1 show_video=1 checkboxes='' no_ratings=1
+           show_artists=1 checkboxes='' no_ratings=1
            length_class=(edit.display_data.large_spread ? 'warn-lengths' : '') %]
     </td>
   </tr>
@@ -11,7 +11,7 @@
     <th>[% l('Into:') %]</th>
     <td>
       [% INCLUDE 'components/recordings-list.tt' recordings=[edit.display_data.new]
-            show_artists=1 show_video=1 checkboxes='' no_ratings=1
+            show_artists=1 checkboxes='' no_ratings=1
            length_class=(edit.display_data.large_spread ? 'warn-lengths' : '') %]
     </td>
   </tr>

--- a/root/medium/tracklist.tt
+++ b/root/medium/tracklist.tt
@@ -42,9 +42,6 @@ dl.ars dt {
       <span style="display: none">[% track.position %]</span>
       [%- track.number -%]
     </td>
-    [%- IF show_video -%]
-        <td class="video c[%- IF recording.video %] is-video[%- END -%]"[% IF recording.video %] title="[% l("This recording is a video") %]"[% END %]></td>
-    [%- END -%]
     <td>
       [%~ link_entity(recording, 'show', track.name) ~%]
       [% IF recording.relationships.size %]

--- a/root/recording/merge.tt
+++ b/root/recording/merge.tt
@@ -19,7 +19,7 @@
           </td>
         [% END %]
         [% INCLUDE 'components/recordings-list.tt' recordings=to_merge show_artists=1
-             show_video=1 select_all=0 no_ratings=1 checkboxes='' merging=1 %]
+             select_all=0 no_ratings=1 checkboxes='' merging=1 %]
         [% field_errors(form, 'target') %]
 
         [% INCLUDE "forms/edit-note.tt" %]

--- a/root/release/index.tt
+++ b/root/release/index.tt
@@ -17,7 +17,7 @@
         <table class="tbl medium">
           <thead>
             <tr[% ' class="mp"' IF medium.edits_pending %]>
-              <th colspan="[% 4 + (medium.includes_video ? 1 : 0) + (medium.has_multiple_artists ? 1 : 0) %]">
+              <th colspan="[% 4 + (medium.has_multiple_artists ? 1 : 0) %]">
                 <a class="expand-medium" id="disc[% medium.position %]" data-medium-id="[% medium.id %]"
                    href="[% c.uri_for_action('/release/show', [medium.release.gid]) _
                             '/disc/' _ medium.position _ '#disc' _ medium.position %]">

--- a/root/search/lib/inline-results-recording.tt
+++ b/root/search/lib/inline-results-recording.tt
@@ -3,7 +3,6 @@
   <table class="tbl">
     <thead>
       <tr>
-        <th class="video c"></th>
         <th>[% l('Name') %]</th>
         <th class="treleases">[% l('Length') %]</th>
         <th>[% l('Artist') %]</th>
@@ -24,7 +23,6 @@
           [%- FOR release=result.extra -%]
             <tr[% ' class="even"' IF linenum % 2 == 0 %][% ' data-score="' _ result.score _ '"' IF results.0.score.defined %]>
               [%- IF loop.count == 1 -%]
-                <td class="video c[%- IF result.entity.video %] is-video[%- END -%]"[% IF result.entity.video %] title="[% l("This recording is a video") %]"[% END %]></td>
                 <td>[% link_entity(result.entity) %]</td>
                 <td>[% result.entity.length | format_length %]</td>
                 <td>[% artist_credit(result.entity.artist_credit) %]</td>
@@ -34,7 +32,7 @@
                   [% END %]
                 </td>
               [%- ELSE -%]
-                <td colspan="5">&#xa0;</td>
+                <td colspan="4">&#xa0;</td>
               [%- END -%]
               <td>[%- link_entity(release) -%]</td>
               [%- IF c.try_get_session('tport') -%]
@@ -48,7 +46,6 @@
           [%- END -%]
         [% ELSE %]
           <tr[% ' class="even"' IF linenum % 2 == 0 %] data-score="[% result.score %]">
-            <td class="video c[%- IF result.entity.video %] is-video[%- END -%]"[% IF result.entity.video %] title="[% l("This recording is a video") %]"[% END %]></td>
             <td>[% link_entity(result.entity) %]</td>
             <td>[% result.entity.length | format_length %]</td>
             <td>[% artist_credit(result.entity.artist_credit) %]</td>
@@ -61,7 +58,7 @@
             [%- IF c.try_get_session('tport') -%]
               <td>[% tagger_icon(result.entity) %]</td>
             [%- END -%]
-            <td colspan="5">&#xa0;</td>
+            <td colspan="3">&#xa0;</td>
             [%- linenum = linenum + 1 -%]
           </tr>
         [% END %]

--- a/root/search/lib/inline-results-recording.tt
+++ b/root/search/lib/inline-results-recording.tt
@@ -34,7 +34,7 @@
                   [% END %]
                 </td>
               [%- ELSE -%]
-                <td colspan="6">&#xa0;</td>
+                <td colspan="5">&#xa0;</td>
               [%- END -%]
               <td>[%- link_entity(release) -%]</td>
               [%- IF c.try_get_session('tport') -%]

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -610,10 +610,8 @@ MB.Control.autocomplete_formatters = {
 
         if (item.video)
         {
-            a.append(
-                $('<span class="autocomplete-video"></span>')
-                    .text("(" + i18n.l("video") + ")")
-            );
+            const title = _.escape(i18n.l('This recording is a video'));
+            a.prepend($(`<span class="video" title="${title}"></span>`));
         }
 
         a.append('<br /><span class="autocomplete-comment">by ' +

--- a/root/static/scripts/common/components/EditorLink.js
+++ b/root/static/scripts/common/components/EditorLink.js
@@ -18,11 +18,16 @@ const EditorLink = ({editor, content, avatarSize, subPath}) => {
     avatarSize = 12;
   }
 
-  const gravatar = editor.gravatar + '&s=' + (avatarSize * 2);
+  let gravatar;
+  if (editor.gravatar) {
+    gravatar = editor.gravatar + '&s=' + (avatarSize * 2);
+  }
 
   return (
     <a href={entityHref(editor, subPath)}>
-      <img src={gravatar} height={avatarSize} width={avatarSize} className="gravatar" alt="" />
+      {gravatar ? (
+        <img src={gravatar} height={avatarSize} width={avatarSize} className="gravatar" alt="" />
+      ) : null}
       {isolateText(content)}
     </a>
   );

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -203,6 +203,15 @@ const EntityLink = ({
     }
   }
 
+  if (!subPath && entity.entityType === 'recording' && entity.video) {
+    content = (
+      <Frag>
+        <span className="video" title={l('This recording is a video')} />
+        {content}
+      </Frag>
+    );
+  }
+
   if (!showDisambiguation && !infoLink) {
     return content;
   }

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -22,6 +22,7 @@ const {
     } = require('./immutable-entities');
 const MB = require('./MB');
 const linkTypeInfo = require('./typeInfo').link_type;
+const bracketed = require('./utility/bracketed').default;
 const clean = require('./utility/clean');
 const formatTrackLength = require('./utility/formatTrackLength');
 
@@ -162,6 +163,11 @@ const formatTrackLength = require('./utility/formatTrackLength');
             if (this.artistCredit) {
                 json.artistCredit = ko.unwrap(this.artistCredit);
             }
+
+            if (this.video) {
+                json.videoTooltip = _.escape(i18n.l('This recording is a video'));
+            }
+
             return json;
         }
 
@@ -182,6 +188,7 @@ const formatTrackLength = require('./utility/formatTrackLength');
     }
 
     CoreEntity.prototype.template = _.template(
+        "<% if (data.video) { %><span class=\"video\" title=\"<%- data.videoTooltip %>\"></span> <% } %>" +
         "<% if (data.editsPending) { %><span class=\"mp\"><% } %>" +
         "<% if (data.nameVariation) { %><span class=\"name-variation\" title=\"<%- data.name %>\"><% } %>" +
         "<a href=\"/<%= data.entityType %>/<%- data.gid %>\"" +
@@ -190,8 +197,6 @@ const formatTrackLength = require('./utility/formatTrackLength');
         "<% } %>><bdi><%- data.creditedAs || data.name %></bdi></a>" +
         "<% if (data.comment) { %> " +
         "<span class=\"comment\">(<%- data.comment %>)</span><% } %>" +
-        "<% if (data.video) { %> <span class=\"comment\">" +
-        "(<%- data.videoString %>)</span><% } %>" +
         "<% if (data.nameVariation) { %></span><% } %>" +
         "<% if (data.editsPending) { %></span><% } %>",
         {variable: "data"}
@@ -267,12 +272,6 @@ const formatTrackLength = require('./utility/formatTrackLength');
             if (this._afterRecordingCtor) {
                 this._afterRecordingCtor(data);
             }
-        }
-
-        html(params) {
-            params = params || {};
-            params.videoString = i18n.l("video");
-            return super.html(params);
         }
 
         toJSON() {
@@ -377,18 +376,10 @@ const formatTrackLength = require('./utility/formatTrackLength');
                 return super.html(renderParams);
             }
 
-            return this.template(
-                _.extend(
-                    renderParams || {},
-                    {
-                        entityType: "recording",
-                        gid: recording.gid,
-                        name: this.name,
-                        comment: recording.comment,
-                        editsPending: recording.editsPending
-                    }
-                )
-            );
+            const json = recording.toJSON();
+            json.name = this.name;
+
+            return this.template(_.extend(renderParams || {}, json));
         }
     }
 

--- a/root/static/scripts/tests/entity.js
+++ b/root/static/scripts/tests/entity.js
@@ -21,7 +21,7 @@ test("CoreEntity", function (t) {
 
     t.equal(
         target.html({ "target": "_blank" }),
-        '<a href="/artist/456" target="_blank" title="bar"><bdi>foo</bdi></a>',
+        '<a target="_blank" href="/artist/456" title="bar"><bdi>foo</bdi></a>',
         "artist link"
     );
 });

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -568,6 +568,18 @@ tr.diff-changes {
     margin-left: -5px;
 }
 
+span.video {
+    background-image: data-uri('../images/icons/video.png');
+    background-repeat: no-repeat;
+    display: inline-block;
+    height: 14px;
+    vertical-align: middle;
+    width: 18px;
+}
+
+/* Don't try to add the video icon on the recording overview tab */
+.tabs .video { display: none; }
+
 /* The release information table */
 table.tbl {
     margin-top: 1em;
@@ -655,16 +667,6 @@ table.tbl {
     .rating { width: 50px; }
     .treleases { width: 3em; }
     .t { text-align: right; }
-
-    .video {
-        width: 15px;
-
-        &.is-video {
-            background-repeat: no-repeat;
-            background-position: 50% 2px;
-            background-image: data-uri('../images/icons/video.png');
-        }
-    }
 
     .data-track.icon {
         background: data-uri('../images/icons/page_white_cd.png');

--- a/t/lib/t/TemplateMacros.pm
+++ b/t/lib/t/TemplateMacros.pm
@@ -332,6 +332,22 @@ test all => sub {
             ),
         ],
         [
+            "link_entity(entity)",
+            "React.createElement(EntityLink, {entity: entity})",
+
+            '<span class="video" title="This recording is a video"></span>' .
+            '<a href="/recording/6a77d9f9-1641-4fc9-98a8-9f29552b0d40">' .
+                '<bdi>Foo</bdi>' .
+            '</a>',
+
+            Recording->new(
+                id => 1,
+                gid => '6a77d9f9-1641-4fc9-98a8-9f29552b0d40',
+                name => 'Foo',
+                video => 1,
+            ),
+        ],
+        [
             "link_entity(entity, 'show', 'Bar')",
             "React.createElement(EntityLink, {entity: entity, content: 'Bar'})",
 


### PR DESCRIPTION
Removes the lodash `_.template` code which was used to render links, and plugs in the React components which we've had for a while. It's a bit ugly, but not as bad as before.