### PR TITLE
Remove MB.i18n references from knockout bindings

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -312,7 +312,7 @@
 [%- MACRO area_bubble BLOCK -%]
     <div class="bubble" id="area-bubble">
       <!-- ko with: target() && target().area -->
-        <p data-bind="html: MB.i18n.expand('[% l('You selected {area}.') | js %]', { area: html({ target: '_blank' }) })"></p>
+        <p data-bind="html: $data.selectionMessage()"></p>
       <!-- /ko -->
     </div>
 [%- END -%]

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -29,7 +29,7 @@
 
 <script type="text/html" id="template.dialog-source-entity">
   <tr>
-    <td class="section" data-bind="text: MB.i18n.addColon(MB.i18n.strings.entityName[source.entityType])"></td>
+    <td class="section" data-bind="text: source.entityTypeLabel()"></td>
     <td>
       <span data-bind="html: source.html({ 'target': '_blank', creditedAs: relationship().creditField(source)() })"></span>
       <!-- ko template: {name: "template.dialog-entity-credit", data: {entity: source, relationship: relationship(), role: "source"}} --><!-- /ko -->
@@ -48,7 +48,7 @@
     <div>
       <label>
         <input type="checkbox" data-bind="checked: $parent.changeOtherRelationshipCredits[role]" />
-        <span data-bind="html: MB.i18n.l('Change credits for other {entity} relationships on the page.', {entity: entity.html()})">
+        <span data-bind="html: $parent.changeOtherRelationshipCreditsLabel(entity)">
         </span>
       </label>
     </div>
@@ -62,17 +62,14 @@
       <div>
         <label>
           <input type="radio" value="same-entity-types" data-bind="checked: $parent.selectedRelationshipCredits[role]" />
-          <span data-bind="html: MB.i18n.l('Only relationships to {entity_type} entities.',
-                                           {entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
+          <span data-bind="html: $parent.sameEntityTypesLabel($parent, relationship, entity)">
           </span>
         </label>
       </div>
       <div>
         <label>
           <input type="radio" value="same-relationship-type" data-bind="checked: $parent.selectedRelationshipCredits[role]" />
-          <span data-bind="html: MB.i18n.l('Only “{relationship_type}” relationships to {entity_type} entities.',
-                                           {relationship_type: $parent.linkTypeName(),
-                                            entity_type: MB.i18n.strings.entityName[relationship.target(entity).entityType].toLocaleLowerCase()})">
+          <span data-bind="html: $parent.sameRelationshipTypeLabel($parent, relationship, entity)">
           </span>
         </label>
       </div>
@@ -199,7 +196,7 @@
     </label>
     <!-- /ko -->
     <!-- ko if: attribute.id == 14 -->
-      <!-- ko text: MB.i18n.addColon(attribute.l_name) --><!-- /ko -->
+      <!-- ko text: relationship.attributeLabel(attribute) --><!-- /ko -->
       <div data-bind="instrumentSelect: relationship">
         <!-- ko foreach: instruments -->
           <div class="instrument-selection-credit">
@@ -221,7 +218,7 @@
       </div>
     <!-- /ko -->
     <!-- ko if: attribute.children && max !== 1 && attribute.id != 14 -->
-      <!-- ko text: MB.i18n.addColon(attribute.l_name) --><!-- /ko -->
+      <!-- ko text: relationship.attributeLabel(attribute) --><!-- /ko -->
       <div class="multiselect" data-bind="
               component: {
                 name: 'multiselect',
@@ -236,7 +233,7 @@
     <!-- /ko -->
     <!-- ko if: attribute.freeText -->
     <label>
-      <!-- ko text: MB.i18n.addColon(attribute.l_name) --><!-- /ko -->
+      <!-- ko text: relationship.attributeLabel(attribute) --><!-- /ko -->
       <input type="text" data-bind="textAttribute: { relationship: relationship, typeGID: attribute.gid }
                                     attr: { placeholder: attribute.l_name }" />
     </label>

--- a/root/forms/relationship-editor.tt
+++ b/root/forms/relationship-editor.tt
@@ -19,7 +19,7 @@
       <tr>
         <th>
           <!-- ko if: key -->
-            <label data-bind="text: MB.i18n.addColon(key)"></label>
+            <label data-bind="text: $parent.groupedRelationshipsLabel(key)"></label>
           <!-- /ko -->
           <!-- ko ifnot: key -->
             <label><span class="no-value">[% add_colon(l('no type')) %]</span></label>
@@ -36,7 +36,7 @@
             <!-- ko with: target($root.source) -->
               <!-- ko if: $data.gid -->
                 <!-- ko if: $parent.showLinkOrder($root.source) -->
-                  <span data-bind="html: MB.i18n.expand('[% l('{num}. {relationship}') | js %]', { num: $parent.linkOrder(), relationship: html({ target: '_blank', creditedAs: $parent.creditField($data)() }) }), relationshipStyling: $parent"></span>
+                  <span data-bind="html: $parent.htmlWithLinkOrder($data), relationshipStyling: $parent"></span>
                 <!-- /ko -->
                 <!-- ko ifnot: $parent.showLinkOrder($root.source) -->
                   <span data-bind="html: html({ target: '_blank', creditedAs: $parent.creditField($data)() }), relationshipStyling: $parent"></span>
@@ -67,7 +67,7 @@
       <tr>
         <td></td>
         <td data-bind="with: $parent">
-          <button type="button" class="add-item with-label" data-click="openAddDialog" data-bind="text: MB.i18n.strings.addAnotherEntity[$parent.values.peek()[0].target($data).entityType]"></button>
+          <button type="button" class="add-item with-label" data-click="openAddDialog" data-bind="text: $root.addAnotherEntityLabel($parent, $data)"></button>
         </td>
       </tr>
     </tbody>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -193,7 +193,7 @@
 
       [% table_row_error(
            4, 'showErrorWhenTabIsSwitched: needsLabel',
-           '<!-- ko text: MB.i18n.expand(\'' _ js_escape(l('You haven’t selected a label for “{name}”.')) _ '\', { name: label().name }) --><!-- /ko -->'
+           '<!-- ko text: needsLabelMessage() --><!-- /ko -->'
          )
       %]
 
@@ -264,7 +264,7 @@
 <div class="documentation" data-bind="with: rootField.release">
   <div class="bubble" data-bind="bubble: $root.releaseGroupBubble">
     <!-- ko with: target() && target().releaseGroup -->
-      <p data-bind="html: MB.i18n.expand('[% l('You selected {releasegroup}.') | js %]', { releasegroup: html({ target: '_blank' }) })"></p>
+      <p data-bind="html: $data.selectionMessage()"></p>
     <!-- /ko -->
   </div>
 
@@ -280,7 +280,7 @@
   <div class="bubble" data-bind="bubble: $root.labelBubble">
     <!-- ko with: target() && target().label() -->
       <!-- ko if: $data.gid -->
-        <p data-bind="html: MB.i18n.expand('[% l('You selected {label}.') | js %]', { label: html({ target: '_blank' }) })"></p>
+        <p data-bind="html: $data.selectionMessage()"></p>
       <!-- /ko -->
     <!-- /ko -->
     <!-- ko if: target() && catNoLooksLikeASIN(target().catalogNumber()) -->

--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -29,7 +29,7 @@
     <!-- /ko -->
 
     <!-- ko if: loadError -->
-      <div class="page-error" data-bind="text: MB.i18n.expand('[% l('Error loading release: {error}') | js %]', { error: loadError() })"></div>
+      <div class="page-error" data-bind="text: loadErrorMessage()"></div>
     <!-- /ko -->
 
     <div id="information">

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -96,8 +96,7 @@
   <!-- ko if: totalPages() > 1 -->
   <div style="text-align: center">
     <a href="#" data-click="previousPage">«</a>
-    <!-- ko text: MB.i18n.expand('[% l('Page {page} of {total}') | js %]', { page: currentPage(), total: totalPages() })
-    --><!-- /ko -->
+    <!-- ko text: pageText() --><!-- /ko -->
     <a href="#" data-click="nextPage">»</a>
   </div>
   <!-- /ko -->
@@ -120,14 +119,8 @@
         <span class="ui-icon" data-bind="css: { 'ui-icon-triangle-1-e': !expanded(), 'ui-icon-triangle-1-s': expanded() }">
           [%~ l("Expand") ~%]
         </span>
-        <bdi data-bind="text: name"></bdi>
+        <span data-bind="html: link()"></span>
       </a>
-
-      <!-- ko if: $data.format -->
-        (<!-- ko text: format + ($data.position ? " " + $data.position : "") --><!-- /ko -->)
-      <!-- /ko -->
-
-      <!-- ko text: MB.i18n.expand('[% l('by {artist}') | js %]', { artist: artist }) --><!-- /ko -->
     </div>
 
     <!-- ko if: expanded() && loaded() -->

--- a/root/static/scripts/common/MB.js
+++ b/root/static/scripts/common/MB.js
@@ -35,9 +35,6 @@ const MB: {[string]: *} = {
 
     // Hold constants for knockout templates that depend on globals.
     constants,
-
-    // Deprecated reference needed by knockout templates
-    i18n: require('./i18n')
 };
 
 global.MB = MB;

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -65,6 +65,10 @@ const formatTrackLength = require('./utility/formatTrackLength');
             }
             return isCompleteArtistCredit(ac);
         }
+
+        entityTypeLabel() {
+            return i18n.addColon(i18n.strings.entityName[this.entityType]);
+        }
     }
 
     var primitiveTypes = /^(boolean|number|string)$/;
@@ -215,11 +219,19 @@ const formatTrackLength = require('./utility/formatTrackLength');
 
     Instrument.prototype.entityType = 'instrument';
 
-    class Label extends CoreEntity {}
+    class Label extends CoreEntity {
+        selectionMessage() {
+            return i18n.l('You selected {label}.', {label: this.html({target: '_blank'})});
+        }
+    }
 
     Label.prototype.entityType = 'label';
 
-    class Area extends CoreEntity {}
+    class Area extends CoreEntity {
+        selectionMessage() {
+            return i18n.l('You selected {area}.', {area: this.html({ target: '_blank'})});
+        }
+    }
 
     Area.prototype.entityType = 'area';
 
@@ -304,7 +316,13 @@ const formatTrackLength = require('./utility/formatTrackLength');
 
     Release.prototype.entityType = 'release';
 
-    class ReleaseGroup extends CoreEntity {}
+    class ReleaseGroup extends CoreEntity {
+        selectionMessage() {
+            return i18n.l('You selected {releasegroup}.', {
+                releasegroup: this.html({target: '_blank'}),
+            });
+        }
+    }
 
     ReleaseGroup.prototype.entityType = 'release_group';
 

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -509,6 +509,25 @@ const PART_OF_SERIES_LINK_TYPE_GIDS = _.values(PART_OF_SERIES_LINK_TYPES);
                    this.dateError(relationship.end_date) ||
                    this.datePeriodError();
         }
+
+        changeOtherRelationshipCreditsLabel(entity) {
+            return i18n.l('Change credits for other {entity} relationships on the page.', {entity: entity.html()});
+        }
+
+        sameEntityTypesLabel($parent, relationship, entity) {
+            const entityType = relationship.target(entity).entityType;
+            return i18n.l('Only relationships to {entity_type} entities.', {
+                entity_type: i18n.strings.entityName[entityType].toLocaleLowerCase(),
+            });
+        }
+
+        sameRelationshipTypeLabel($parent, relationship, entity) {
+            const entityType = relationship.target(entity).entityType;
+            return i18n.l('Only “{relationship_type}” relationships to {entity_type} entities.', {
+                relationship_type: $parent.linkTypeName(),
+                entity_type: i18n.strings.entityName[entityType].toLocaleLowerCase(),
+            });
+        }
     }
 
     _.assign(Dialog.prototype, {

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -116,6 +116,9 @@ function getDirection(relationship, source) {
                     group.canBeOrdered = ko.observable(false);
 
                     var relationships = group.values.peek();
+                    if (!relationships.length) {
+                        return group;
+                    }
                     var linkType = relationships[0].getLinkType();
 
                     if (linkType && linkType.orderableDirection > 0) {

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 
 require('knockout-arraytransforms');
 
+const {addColon} = require('../../common/i18n');
 const typeInfo = require('../../common/typeInfo');
 const deferFocus = require('../../edit/utility/deferFocus');
 const mergeDates = require('./mergeDates');
@@ -147,6 +148,10 @@ function getDirection(relationship, source) {
                     return group;
                 });
         }),
+
+        groupedRelationshipsLabel: function (key) {
+            return addColon(key);
+        },
 
         // searches this entity's relationships for potential duplicate "rel"
         // if it is a duplicate, remove and merge it

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -308,6 +308,10 @@ const mergeDates = require('./mergeDates');
             return "";
         }
 
+        attributeLabel(attribute) {
+            return i18n.addColon(attribute.l_name);
+        }
+
         _phraseAndExtraAttributes() {
             const linkType = this.getLinkType();
             return linkPhrase.interpolate(linkType, this.attributes());
@@ -430,6 +434,13 @@ const mergeDates = require('./mergeDates');
 
         showLinkOrder(source) {
             return this.linkOrder() > 0 && this.entityCanBeReordered(this.target(source));
+        }
+
+        htmlWithLinkOrder(entity) {
+            return i18n.l('{num}. {relationship}', {
+                num: this.linkOrder(),
+                relationship: entity.html({target: '_blank', creditedAs: this.creditField(entity)()}),
+            });
         }
 
         isDuplicate(other) {

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -7,6 +7,7 @@ const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
 
+const i18n = require('../../common/i18n');
 const MB = require('../../common/MB');
 const typeInfo = require('../../common/typeInfo');
 const parseDate = require('../../common/utility/parseDate');
@@ -95,6 +96,10 @@ const fields = require('./fields');
             return relationships
                 .sortBy(function (r) { return r.lowerCaseTargetName(source) })
                 .sortBy("linkOrder");
+        }
+
+        addAnotherEntityLabel(group, entity) {
+            return i18n.strings.addAnotherEntity[group.values.peek()[0].target(entity).entityType];
         }
     }
 

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -6,9 +6,13 @@
 const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
 
+const Frag = require('../../../components/Frag');
 const i18n = require('../common/i18n');
 const {artistCreditFromArray, reduceArtistCredit} = require('../common/immutable-entities');
+const bracketed = require('../common/utility/bracketed').default;
 const formatTrackLength = require('../common/utility/formatTrackLength');
 const isBlank = require('../common/utility/isBlank');
 const request = require('../common/utility/request');
@@ -124,6 +128,29 @@ class SearchResult {
             track.artistCredit = [{ name: track.artist }];
         }
     }
+
+    link() {
+        let formatString;
+        if (this.format) {
+            formatString = this.format +
+                (this.position ? ' ' + this.position : '');
+        }
+
+        const parts = i18n.l('{entity} by {artist}', {
+            __react: true,
+            entity: (
+                <Frag>
+                    <bdi>{this.name}</bdi>
+                    {formatString ? ' ' + bracketed(formatString) : null}
+                </Frag>
+            ),
+            artist: <bdi>{this.artist}</bdi>,
+        });
+
+        return ReactDOMServer.renderToStaticMarkup(
+            React.createElement(React.Fragment, null, ...parts)
+        );
+    }
 }
 
 
@@ -222,6 +249,13 @@ class SearchTab {
         }
 
         return medium;
+    }
+
+    pageText() {
+        return i18n.l('Page {page} of {total}', {
+            page: this.currentPage(),
+            total: this.totalPages(),
+        });
     }
 }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -661,6 +661,10 @@ class ReleaseLabel {
     labelHTML() {
         return this.label().html({ target: "_blank" });
     }
+
+    needsLabelMessage() {
+        return l('You haven’t selected a label for “{name}”.', {name: this.label().name});
+    }
 }
 
 fields.ReleaseLabel = ReleaseLabel;

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -27,6 +27,9 @@ _.extend(releaseEditor, {
     activeTabID: ko.observable("#information"),
     activeTabIndex: ko.observable(0),
     loadError: ko.observable(""),
+    loadErrorMessage: function () {
+        return i18n.l('Error loading release: {error}', {error: releaseEditor.loadError()});
+    },
     externalLinksEditData: ko.observable({}),
     hasInvalidLinks: validation.errorField(ko.observable(false))
 });


### PR DESCRIPTION
This is a cleanup which improves a few things:

1. Removes the `i18n` reference from the global `MB` object.

2. Removes some ugly hacks where we had to pass strings translated by TT to a JavaScript function (`expand`). Now we can just use `l` directly in the JS.

3. Interpolating raw HTML into a translated string will no longer be possible soon: all raw strings will be HTML-escaped, so you'll have to use JSX to interpolate markup. Moving these instances out of the knockout templates will allow us to easily fix them later.