### PR TITLE
MBS-9766: change worldcat cleanup to https + add tests

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1270,8 +1270,9 @@ const CLEANUPS = {
     clean: function (url) {
       // Standardising ClassicalArchives.com
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?classicalarchives\.com\/(album|artist|composer|ensemble|work)\/([^\/?#]+)(?:.*)?$/, "http://www.classicalarchives.com/$1/$2");
-      // Removing cruft from Worldcat URLs
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, "http://www.worldcat.org/oclc/$1");
+      // Removing cruft from Worldcat URLs and standardising to https
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org/, "https://www.worldcat.org");
+      url = url.replace(/^https:\/\/www\.worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, "https://www.worldcat.org/oclc/$1");
       // Standardising IBDb not to use www
       url = url.replace(/^(https?:\/\/)?(www\.)?ibdb\.com/, "http://ibdb.com");
       // Standardising ESTER to their default parameters
@@ -1460,7 +1461,7 @@ const CLEANUPS = {
           case LINK_TYPES.otherdatabases.work:
             return prefix == 'works/work';
           case LINK_TYPES.otherdatabases.artist:
-            return prefix !== 'works/work';	
+            return prefix !== 'works/work';
         }
       }
       return false;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3260,6 +3260,19 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'discographyentry',
         },
+        // Worldcat
+        {
+                             input_url: 'http://www.worldcat.org/title/sometimes-i-sit-and-think-and-sometimes-i-just-sit/oclc/903606316',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'https://www.worldcat.org/oclc/903606316',
+        },
+        {
+                             input_url: 'http://www.worldcat.org/identities/lccn-no2015052484/',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'otherdatabases',
+                    expected_clean_url: 'https://www.worldcat.org/identities/lccn-no2015052484/',
+        },
         // YouTube
         {
                              input_url: 'http://youtube.com/user/officialpsy/videos',


### PR DESCRIPTION
The ticket mentioned that http and https were not detected as dupes. There seems to be no reason *not* to default to https though, so we might as well. Split the cleanup in two since the "fix cruft" bit only affects some, but not all, of the URLs. While at it, I added a couple tests for this, one per type.