### PR TITLE
MBS-8062: query for performers and locations when rendering external event search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -318,6 +318,31 @@ sub find_related_entities
     return %map;
 }
 
+=method load_ids
+
+Load internal IDs for event objects that only have GIDs.
+
+=cut
+
+sub load_ids
+{
+    my ($self, @events) = @_;
+
+    my @gids = map { $_->gid } @events;
+    return () unless @gids;
+
+    my $query = "
+        SELECT gid, id FROM event
+        WHERE gid IN (" . placeholders(@gids) . ")
+    ";
+    my %map = map { $_->[0] => $_->[1] }
+        @{ $self->sql->select_list_of_lists($query, @gids) };
+
+    for my $event (@events) {
+        $event->id($map{$event->gid}) if exists $map{$event->gid};
+    }
+}
+
 =method load_performers
 
 This method will load the event's performers based on the event-artist

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -835,6 +835,14 @@ sub external_search
             $self->c->model('Work')->load_recording_artists(@entities);
         }
 
+        if ($type eq 'event')
+        {
+            my @entities = map { $_->entity } @results;
+            $self->c->model('Event')->load_ids(@entities);
+            $self->c->model('Event')->load_related_info(@entities);
+            $self->c->model('Event')->load_areas(@entities);
+        }
+
         my $pager = Data::Page->new;
         $pager->current_page($page);
         $pager->entries_per_page($limit);


### PR DESCRIPTION
Event search was not loading additional (relationship-based) info for external search, only for direct search. Changing it to do so, following the example of works.

load_ids is basically the same method as for works - not sure if we have some way of generalising this that might be good here.