### PR TITLE
MBS-9788: Indicate "series" in series edit lists

### DIFF
--- a/root/series/SeriesHeader.js
+++ b/root/series/SeriesHeader.js
@@ -9,6 +9,7 @@
 
 const React = require('react');
 const {lp} = require('../static/scripts/common/i18n');
+const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
 const EntityHeader = require('../components/EntityHeader');
 
 type Props = {|
@@ -21,7 +22,7 @@ const SeriesHeader = ({series, page}: Props) => (
     entity={series}
     headerClass="seriesheader"
     page={page}
-    subHeading={lp('Series', 'singular')}
+    subHeading={series.typeName ? lp_attributes(series.typeName, 'series_type') : lp('Series', 'singular')}
   />
 );
 


### PR DESCRIPTION
This fixes an issue where, say, a release series just says "Release" in edit lists, making it look like the edit list for a release.

Alternatively, we could keep the code as it is, but rename all the existing types to include "series" when appropriate, as with instruments (e.g. "string instrument"). I'm fine with this if it is the preferred solution.