### PR TITLE
MBS-9641: Show label-series rels on series page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -16,7 +16,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'series',
     relationships => {
         cardinal => ['edit'],
-        subset => {show => ['artist', 'series', 'url']},
+        subset => {show => ['artist', 'label', 'series', 'url']},
         default => ['url']
     },
 };


### PR DESCRIPTION
By the way: is there a reason we specifically limit what we show here?