### PR TITLE
MBS-9208, MBS-9210: Increase bcrypt cost parameter to 12, for all active accounts

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -81,6 +81,7 @@ our @EXPORT_OK = (
         %ENTITIES_WITH_RELATIONSHIP_CREDITS
         %ENTITIES entities_with @RELATABLE_ENTITIES
         $EDITOR_SANITISED_COLUMNS
+        $PASSPHRASE_BCRYPT_COST
     ),
 );
 
@@ -917,6 +918,8 @@ Readonly our $EDITOR_SANITISED_COLUMNS => join(', ',
     "md5(editor.name || ':musicbrainz.org:mb') AS ha1",
     'editor.deleted',
 );
+
+Readonly our $PASSPHRASE_BCRYPT_COST => 10;
 
 =head1 NAME
 

--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -919,7 +919,7 @@ Readonly our $EDITOR_SANITISED_COLUMNS => join(', ',
     'editor.deleted',
 );
 
-Readonly our $PASSPHRASE_BCRYPT_COST => 10;
+Readonly our $PASSPHRASE_BCRYPT_COST => 12;
 
 =head1 NAME
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -90,8 +90,13 @@ sub _perform_login {
             $c->detach;
         }
         else {
-            $c->model('Editor')->update_last_login_date($c->user->id)
-                unless DBDefs->DB_READ_ONLY;
+            unless (DBDefs->DB_READ_ONLY) {
+                if ($c->user->requires_password_rehash) {
+                    $c->model('Editor')->update_password($user_name, $password);
+                } else {
+                    $c->model('Editor')->update_last_login_date($c->user->id);
+                }
+            }
 
             return 1;
         }

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::Data::Utils qw(
     type_to_model
 );
 use MusicBrainz::Server::Constants qw( :edit_status :privileges );
+use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Subscription' => {
@@ -592,8 +593,8 @@ sub hash_password {
     my $password = shift;
     Authen::Passphrase::BlowfishCrypt->new(
         salt_random => 1,
-        cost => 10,
-        passphrase => encode('utf-8', $password)
+        cost => $PASSPHRASE_BCRYPT_COST,
+        passphrase => encode('utf-8', $password),
     )->as_rfc2307
 }
 

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -261,7 +261,7 @@ sub update_password
     my ($self, $editor_name, $password) = @_;
 
     Sql::run_in_transaction(sub {
-        $self->sql->do('UPDATE editor SET password = ?, ha1 = md5(name || \':musicbrainz.org:\' || ?), last_login_date = now() WHERE name = ?',
+        $self->sql->do('UPDATE editor SET password = ?, ha1 = md5(name || \':musicbrainz.org:\' || ?), last_login_date = now() WHERE lower(name) = lower(?)',
                        hash_password($password),
                        $password,
                        $editor_name);

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -6,6 +6,7 @@ use Authen::Passphrase;
 use DateTime;
 use Digest::MD5 qw( md5_hex );
 use Encode;
+use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Preferences;
 use MusicBrainz::Server::Entity::Types qw( Area );
@@ -243,6 +244,14 @@ has ha1 => (
     isa => 'Str',
     is => 'rw',
 );
+
+sub requires_password_rehash {
+    my $self = shift;
+    my $hash = Authen::Passphrase->from_rfc2307($self->password);
+    return blessed($hash)
+        && $hash->isa('Authen::Passphrase::BlowfishCrypt')
+        && $hash->cost < $PASSPHRASE_BCRYPT_COST;
+}
 
 sub match_password {
     my ($self, $password) = @_;


### PR DESCRIPTION
Address two related issues:
- [MBS-9210](https://tickets.metabrainz.org/browse/MBS-9210): Update password hash on login if bcrypt cost parameter increased, so as to gradually rehash password for all active accounts.
- [MBS-9208](https://tickets.metabrainz.org/browse/MBS-9208): Increase bcrypt cost parameter to 12.
