### PR TITLE
MBS-9817: Missing i18n in hydrated components

### DIFF
--- a/root/annotation/revision.tt
+++ b/root/annotation/revision.tt
@@ -1,5 +1,5 @@
 [%- WRAPPER "$entity_type/layout.tt" full_width=1 title=l("Annotation") -%]
-    [% React.embed(c, 'components/Annotation', {
+    [% React.embed(c, 'static/scripts/common/components/Annotation', {
         annotation => annotation,
         entity => entity,
         numberOfRevisions => number_of_revisions,

--- a/root/annotation/summary.tt
+++ b/root/annotation/summary.tt
@@ -1,4 +1,4 @@
-[%- React.embed(c, 'components/Annotation', {
+[%- React.embed(c, 'static/scripts/common/components/Annotation', {
         annotation => entity.latest_annotation,
         collapse => 1,
         entity => entity,

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -881,14 +881,14 @@ END ~%]
 [%~ END -%]
 
 [%~ MACRO show_wikipedia_extract BLOCK -%]
-    [%- React.embed(c, 'components/WikipediaExtract.js', {
+    [%- React.embed(c, 'static/scripts/common/components/WikipediaExtract', {
         entity => {entityType => entity.entity_type, gid => entity.gid},
         wikipediaExtract => wikipedia_extract,
     }) -%]
 [%- END -%]
 
 [%~ MACRO show_image BLOCK -%]
-    [%- React.embed(c, 'components/CommonsImage', {
+    [%- React.embed(c, 'static/scripts/common/components/CommonsImage', {
             image => commons_image,
             entity => {entityType => entity.entity_type, gid => entity.gid},
         }) -%]

--- a/root/release_group/index.tt
+++ b/root/release_group/index.tt
@@ -84,10 +84,10 @@
 
     <div id="critiquebrainz-reviews">
       [%~ IF rg.most_recent_review ~%]
-        [% React.embed(c, 'components/CritiqueBrainzReview', {review => rg.most_recent_review, title => l('Most Recent')}) %]
+        [% React.embed(c, 'static/scripts/common/components/CritiqueBrainzReview', {review => rg.most_recent_review, title => l('Most Recent')}) %]
       [%~ END ~%]
       [%~ IF rg.most_popular_review && rg.most_popular_review.id != rg.most_recent_review.id ~%]
-        [% React.embed(c, 'components/CritiqueBrainzReview', {review => rg.most_popular_review, title => l('Most Popular')}) %]
+        [% React.embed(c, 'static/scripts/common/components/CritiqueBrainzReview', {review => rg.most_popular_review, title => l('Most Popular')}) %]
       [%~ END ~%]
     </div>
 

--- a/root/static/scripts/area/index.js
+++ b/root/static/scripts/area/index.js
@@ -7,5 +7,5 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/artist/index.js
+++ b/root/static/scripts/artist/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -21,9 +21,9 @@ window.$ = window.jQuery = require("jquery");
 
 require("../lib/jquery.ui/ui/jquery-ui.custom");
 
-require("../../components/Annotation");
-require("../../components/CommonsImage");
-require("../../components/WikipediaExtract");
+require("./common/components/Annotation");
+require("./common/components/CommonsImage");
+require("./common/components/WikipediaExtract");
 require("./common/i18n");
 require("./common/artworkViewer");
 require("./common/dialogs");

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -9,16 +9,16 @@
 
 import React from 'react';
 
-import {withCatalystContext} from '../context';
-import EditorLink from '../static/scripts/common/components/EditorLink';
-import {l} from '../static/scripts/common/i18n';
-import entityHref from '../static/scripts/common/utility/entityHref';
-import * as lens from '../static/scripts/common/utility/lens';
-import formatUserDate from '../utility/formatUserDate';
-import hydrate from '../utility/hydrate';
-import sanitizedEditor from '../utility/sanitizedEditor';
+import {withCatalystContext} from '../../../../context';
+import formatUserDate from '../../../../utility/formatUserDate';
+import hydrate from '../../../../utility/hydrate';
+import sanitizedEditor from '../../../../utility/sanitizedEditor';
+import {l} from '../i18n';
+import entityHref from '../utility/entityHref';
+import * as lens from '../utility/lens';
 
 import Collapsible from './Collapsible';
+import EditorLink from './EditorLink';
 
 type AnnotatedEntityT =
   | AreaT

--- a/root/static/scripts/common/components/Collapsible.js
+++ b/root/static/scripts/common/components/Collapsible.js
@@ -10,7 +10,7 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 
-import {l} from '../static/scripts/common/i18n';
+import {l} from '../i18n';
 
 type Props = {|
   +className: string,

--- a/root/static/scripts/common/components/CommonsImage.js
+++ b/root/static/scripts/common/components/CommonsImage.js
@@ -10,9 +10,9 @@
 import $ from 'jquery';
 import React from 'react';
 
-import {l} from '../static/scripts/common/i18n';
-import entityHref from '../static/scripts/common/utility/entityHref';
-import hydrate from '../utility/hydrate';
+import hydrate from '../../../../utility/hydrate';
+import {l} from '../i18n';
+import entityHref from '../utility/entityHref';
 
 type Props = {|
   +image: CommonsImageT | null,

--- a/root/static/scripts/common/components/CritiqueBrainzReview.js
+++ b/root/static/scripts/common/components/CritiqueBrainzReview.js
@@ -10,11 +10,11 @@
 import React from 'react';
 import type {ElementRef, Node as ReactNode} from 'react';
 
-import {withCatalystContext} from '../context';
-import DBDefs from '../static/scripts/common/DBDefs';
-import {l} from '../static/scripts/common/i18n';
-import formatUserDate from '../utility/formatUserDate';
-import hydrate from '../utility/hydrate';
+import {withCatalystContext} from '../../../../context';
+import formatUserDate from '../../../../utility/formatUserDate';
+import hydrate from '../../../../utility/hydrate';
+import DBDefs from '../DBDefs';
+import {l} from '../i18n';
 
 import Collapsible from './Collapsible';
 

--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -10,9 +10,9 @@
 import $ from 'jquery';
 import React from 'react';
 
-import {l} from '../static/scripts/common/i18n';
-import entityHref from '../static/scripts/common/utility/entityHref';
-import hydrate from '../utility/hydrate';
+import hydrate from '../../../../utility/hydrate';
+import {l} from '../i18n';
+import entityHref from '../utility/entityHref';
 
 import Collapsible from './Collapsible';
 

--- a/root/static/scripts/event/index.js
+++ b/root/static/scripts/event/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/instrument/index.js
+++ b/root/static/scripts/instrument/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/label/index.js
+++ b/root/static/scripts/label/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/place/index.js
+++ b/root/static/scripts/place/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/release-group/index.js
+++ b/root/static/scripts/release-group/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/WikipediaExtract';
-import '../../../components/CritiqueBrainzReview';
+import '../common/components/Annotation';
+import '../common/components/WikipediaExtract';
+import '../common/components/CritiqueBrainzReview';

--- a/root/static/scripts/series/index.js
+++ b/root/static/scripts/series/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';

--- a/root/static/scripts/work/index.js
+++ b/root/static/scripts/work/index.js
@@ -7,6 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/Annotation';
-import '../../../components/CommonsImage';
-import '../../../components/WikipediaExtract';
+import '../common/components/Annotation';
+import '../common/components/CommonsImage';
+import '../common/components/WikipediaExtract';


### PR DESCRIPTION
The Jed language bundles only contain strings that appear in files under root/static/scripts/. This is to reduce bundle sizes by removing strings only needed on the server. See [root/static/gulpfile.js lines 215 - 223](https://github.com/metabrainz/musicbrainz-server/blob/f94973b0052418679429994a4a62d1f99af136bc/root/static/gulpfile.js#L215-L223).

Thus, components with translated strings used on the client must be placed under root/static/scripts/.

Note that this commit by itself doesn't immediately fix things, because new .pot files have to be generated, and new .po files have to be downloaded based on those; msggrep looks at the .po files in order to filter strings by source path.