### PR TITLE
MBS-9438: Display event dates in inline search

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -15,6 +15,7 @@ const {artistCreditFromArray, reduceArtistCredit} = require('../../immutable-ent
 const MB = require('../../MB');
 const clean = require('../../utility/clean');
 import formatDate from '../../utility/formatDate';
+import formatDatePeriod from '../../utility/formatDatePeriod';
 const formatTrackLength = require('../../utility/formatTrackLength');
 const isBlank = require('../../utility/isBlank');
 import primaryAreaCode from '../../utility/primaryAreaCode';
@@ -897,7 +898,7 @@ MB.Control.autocomplete_formatters = {
 
         if (item.begin_date || item.time)
         {
-            a.append('<br /><span class="autocomplete-comment">' + (item.begin_date ? (item.begin_date + ' ') : '') + (item.time ? item.time : '') + '</span>');
+            a.append('<br /><span class="autocomplete-comment">' + (item.begin_date ? (formatDatePeriod(item) + ' ') : '') + (item.time ? item.time : '') + '</span>');
         }
 
         var entityRenderer = function (prefix, related_entities) {


### PR DESCRIPTION
This was showing as [Object object] which is less than ideal.

I switched from begin date only to date period after a quick check suggested that both dates fit perfectly fine in the inline result list, even with time (and are less misleading than just showing begin date without suggesting it is begin date). In most cases this will *still* show just "Date Time", but on cases where the event span multiple days it will show "Date - Date Time". If this seems undesirable because the time looks weird after the *end* date we can go back to just begin date, or even maybe have its own display function like "Begin Date (Time) - End Date".