### PR TITLE
MBS-7192: Show work types in inline search

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
@@ -33,6 +33,7 @@ sub search : Chained('root') PathPart('work')
 after _load_entities => sub {
     my ($self, $c, @entities) = @_;
     $c->model('Language')->load_for_works(@entities);
+    $c->model('WorkType')->load(@entities);
 };
 
 around _format_output => sub {

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -12,6 +12,7 @@ const MB_entity = require('../../entity');
 const i18n = require('../../i18n');
 const commaOnlyList = require('../../i18n/commaOnlyList');
 import {l_languages} from '../../i18n/languages';
+import {lp_attributes} from '../../i18n/attributes';
 const {artistCreditFromArray, reduceArtistCredit} = require('../../immutable-entities');
 const MB = require('../../MB');
 const clean = require('../../utility/clean');
@@ -762,6 +763,11 @@ MB.Control.autocomplete_formatters = {
         {
             a.append(' <span class="autocomplete-comment">(' +
                      _.escape(commaOnlyList(comment)) + ')</span>');
+        }
+
+        if (item.typeName)
+        {
+            a.append('<br /><span class="autocomplete-comment">' + _.escape(i18n.addColon(i18n.l('Type')) + ' ' + lp_attributes(item.typeName, 'work_type')) + '</span>');
         }
 
         var artistRenderer = function (prefix, artists) {


### PR DESCRIPTION
Chose to use the same way as we do with artists and writers because the more consistent / usual way (parentheses after the name) was blocked by the way we do work languages. Alternatively, we could do the usual with types *and* move languages to a "Languages: X, Y" line like writers / artists.