### PR TITLE
MBS-9422: Load recordings for CDToc attach

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -212,7 +212,13 @@ sub attach : Local DenyWhenReadonly
             $c->model('Release')->find_for_cdtoc($artist_id, $cdtoc->track_count, shift, shift)
         });
         $c->model('Release')->load_related_info(@$releases);
-        $c->model('Track')->load_for_mediums(map { $_->all_mediums } @$releases);
+
+        my @mediums = map { $_->all_mediums } @$releases;
+        $c->model('Track')->load_for_mediums(@mediums);
+
+        my @tracks = map { $_->all_tracks } @mediums;
+        $c->model('Recording')->load(@tracks);
+
         my @rgs = $c->model('ReleaseGroup')->load(@$releases);
         $c->model('ReleaseGroup')->load_meta(@rgs);
 


### PR DESCRIPTION
# Fix [MBS-9422](https://tickets.metabrainz.org/browse/MBS-9422): Attach CD TOC page shows all tracks in tracklists as deleted

For some reason, this wasn't loading the recordings, meaning all recordings showed as removed.

Also changed the way it works a bit to mirror the one for multi-artist release lists (slightly below). 

In fact, I'd suggest just having the two options be the same thing with different filters when we look into this again for changing the templates into React - I see no reason for the current choice of the one-artist result not showing ACs, which might very well be relevant whether for collaborations or alternate names.