### PR TITLE
MBS-9846: Fix Beatport URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -597,15 +597,29 @@ const CLEANUPS = {
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:(?:classic|pro|www)\.)?beatport\.com\//, "https://www.beatport.com/");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/0*([0-9]+)\/([\w-]+).*$/, "$1/$2/$4/$3");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/-/$3");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/([\w-]+)\/0*([0-9]+).*$/, "$1/$2/$3/$4");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/\/+0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/-/$3");
-      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/0*([0-9]+)(?:[\/?#].*)?$/, "$1/$2/$3");
+      var m = url.match(/^(https:\/\/www\.beatport\.com)\/[\w-]+\/html\/content\/([\w-]+)\/detail\/0*([0-9]+)\/([^\/?&#]*).*$/);
+      if (m) {
+        const slug = m[4].toLowerCase()
+          .replace(/%21/g, '!')
+          .replace(/%23/g, '-pound-')
+          .replace(/%24/g, '-money-').replace(/\$/g, '-money-')
+          .replace(/%25/g, '-percent-')
+          .replace(/%26/g, '-and-')
+          .replace(/%40/g, '-at-').replace(/@/g, '-at-')
+          .replace(/%[0-9a-f]{2}/g, '-')
+          .replace(/%/g, '-percent-')
+          .replace(/[^a-z0-9!]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '')
+          .replace(/^$/, '---');
+        url = [m[1], m[2], slug, m[3]].join('/');
+      }
+      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/([\w!-]+)\/0*([0-9]+).*$/, "$1/$2/$3/$4");
+      url = url.replace(/^(https:\/\/www\.beatport\.com)\/([\w-]+)\/\/0*([0-9]+)(?![\w!-]|\/[0-9]).*$/, "$1/$2/---/$3");
       return url;
     },
     validate: function (url, id) {
-      var m = /^https:\/\/(?:sounds|www)\.beatport\.com\/([\w-]+)\/[\w-]+\/[1-9][0-9]*$/.exec(url);
+      var m = /^https:\/\/(?:sounds|www)\.beatport\.com\/([\w-]+)\/[\w!-]+\/[1-9][0-9]*$/.exec(url);
       if (m) {
         var prefix = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -445,19 +445,19 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                     expected_clean_url: 'http://www.bbc.co.uk/music/artists/b52dd210-909c-461a-a75d-19e85a522042'
         },
         // Beatport
-        {
+        {                               // Closed in Dec. 2017, replaced with www.beatport.com/chart
                              input_url: 'http://dj.beatport.com/thegoldenboyuk',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
                only_valid_entity_types: []
         },
-        {
+        {                               // Closed in Dec. 2017, replaced with www.beatport.com/best-new-tracks
                              input_url: 'http://mixes.beatport.com/dj/lstunn/450603',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
                only_valid_entity_types: []
         },
-        {
+        {                               // Not supported by MusicBrainz: midi, patches, presets, and so on.
                              input_url: 'http://sounds.beatport.com/publisher/Danyella/34462',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
@@ -470,21 +470,21 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                     expected_clean_url: 'https://www.beatport.com/artist/pryda/10554',
                only_valid_entity_types: ['artist']
         },
-        {
+        {                               // Nowadays display the same content with another UI
                              input_url: 'http://classic.beatport.com/artist/pryda/10554/tracks',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://www.beatport.com/artist/pryda/10554',
                only_valid_entity_types: ['artist']
         },
-        {
+        {                               // Nowadays redirect to www.beatport.com
                              input_url: 'https://pro.beatport.com/artist/pryda/10554#',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://www.beatport.com/artist/pryda/10554',
                only_valid_entity_types: ['artist']
         },
-        {
+        {                               // Used to fool the detection of missing slug (MBS-9743)
                              input_url: 'https://www.beatport.com/artist/4orcedj/208047',
                      input_entity_type: 'artist',
             expected_relationship_type: 'downloadpurchase',
@@ -496,6 +496,41 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                      input_entity_type: 'release',
             expected_relationship_type: 'downloadpurchase',
                     expected_clean_url: 'https://www.beatport.com/release/pryda-10-vol-i/1563118',
+               only_valid_entity_types: ['release']
+        },
+        {                               // Used to fool the detection of missing slug (MBS-9846)
+                             input_url: 'http://classic.beatport.com/release/4/2361374',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/release/4/2361374',
+               only_valid_entity_types: ['release']
+        },
+        {                               // Legacy URL format (real example)
+                             input_url: 'https://www.beatport.com/en-US/html/content/release/detail/161035/Back%20To%20The%20Future',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/release/back-to-the-future/161035',
+               only_valid_entity_types: ['release']
+        },
+        {                               // Legacy URL format (made up to test slug conversion)
+                             input_url: 'https://www.beatport.com/en-US/html/content/release/detail/06130/%40@%26%25%24$%23%22%21!-&tracks#',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/release/at-at-and-percent-money-money-pound-!!/6130',
+               only_valid_entity_types: ['release']
+        },
+        {                               // Legacy URL format missing slug (real example)
+                             input_url: 'https://www.beatport.com/en-US/html/content/release/detail/287442/',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/release/---/287442',
+               only_valid_entity_types: ['release']
+        },
+        {                               // Nowadays erroneous redirect for legacy URL format missing slug (same example)
+                             input_url: 'https://www.beatport.com/release//287442',
+                     input_entity_type: 'release',
+            expected_relationship_type: 'downloadpurchase',
+                    expected_clean_url: 'https://www.beatport.com/release/---/287442',
                only_valid_entity_types: ['release']
         },
         {


### PR DESCRIPTION
## Fix bug [MBS-9846](https://tickets.metabrainz.org/browse/MBS-9846) about broken Beatport URL cleanup

Additionally improve cleanup code to better handle legacy format (documented in [MBS-6130](https://tickets.metabrainz.org/browse/MBS-6130)) and stop handling URL without slug (which may come from Beatport redirect).