### PR TITLE
MBS-9863: License links are ignored if https

### DIFF
--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -151,18 +151,18 @@ my %URL_SPECIALIZATIONS = (
     'Yunisan'             => qr{^https?://(?:www22\.)?big\.or\.jp/}i,
 
     # License links
-    'CCBY'              => qr{^http://creativecommons\.org/licenses/by/}i,
-    'CCBYND'            => qr{^http://creativecommons\.org/licenses/by-nd/}i,
-    'CCBYNC'            => qr{^http://creativecommons\.org/licenses/by-nc/}i,
-    'CCBYNCND'          => qr{^http://creativecommons\.org/licenses/by-nc-nd/}i,
-    'CCBYNCSA'          => qr{^http://creativecommons\.org/licenses/by-nc-sa/}i,
-    'CCBYSA'            => qr{^http://creativecommons\.org/licenses/by-sa/}i,
-    'CC0'               => qr{^http://creativecommons\.org/publicdomain/zero/}i,
-    'CCPD'              => qr{^http://creativecommons\.org/licenses/publicdomain/}i,
-    'CCSampling'        => qr{^http://creativecommons\.org/licenses/sampling/}i,
-    'CCNCSamplingPlus'  => qr{^http://creativecommons\.org/licenses/nc-sampling\+/}i,
-    'CCSamplingPlus'    => qr{^http://creativecommons\.org/licenses/sampling\+/}i,
-    'ArtLibre'          => qr{^http://artlibre\.org/licence/lal}i,
+    'CCBY'              => qr{^https?://creativecommons\.org/licenses/by/}i,
+    'CCBYND'            => qr{^https?://creativecommons\.org/licenses/by-nd/}i,
+    'CCBYNC'            => qr{^https?://creativecommons\.org/licenses/by-nc/}i,
+    'CCBYNCND'          => qr{^https?://creativecommons\.org/licenses/by-nc-nd/}i,
+    'CCBYNCSA'          => qr{^https?://creativecommons\.org/licenses/by-nc-sa/}i,
+    'CCBYSA'            => qr{^https?://creativecommons\.org/licenses/by-sa/}i,
+    'CC0'               => qr{^https?://creativecommons\.org/publicdomain/zero/}i,
+    'CCPD'              => qr{^https?://creativecommons\.org/licenses/publicdomain/}i,
+    'CCSampling'        => qr{^https?://creativecommons\.org/licenses/sampling/}i,
+    'CCNCSamplingPlus'  => qr{^https?://creativecommons\.org/licenses/nc-sampling\+/}i,
+    'CCSamplingPlus'    => qr{^https?://creativecommons\.org/licenses/sampling\+/}i,
+    'ArtLibre'          => qr{^https?://artlibre\.org/licence/lal}i,
 
 );
 


### PR DESCRIPTION
### [MBS-9863](https://tickets.metabrainz.org/browse/MBS-9863)
**Problem**  
Creative  commons licenses only match if links are HTTP, while most will probably be HTTPS.  
  
**Solution**  
Replace "http" regex with "https?", as "?" matches 0 or 1 for the previous character.  
  
Made for [GCI](https://codein.withgoogle.com/tasks/5620778444783616/?sp-organization=5353072260808704).
