### PR TITLE
MBS-9883: More clear sidebar name for Wikidata rels

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Wikidata.pm
@@ -21,7 +21,15 @@ sub pretty_name
     return $self->page_name;
 }
 
-sub sidebar_name { shift->pretty_name }
+sub sidebar_name
+{
+    my $self = shift;
+
+    my $name = $self->pretty_name;
+    $name = "Wikidata: $name";
+
+    return $name;
+}
 
 sub url_is_scheme_independent { 1 }
 


### PR DESCRIPTION
Similarly to VIAF, we should show Wikidata: QID for clarity on sidebars, since most people won't recognize the logo. That said, unlike we do with VIAF (why do we do that, actually?), there's no reason showing "Wikidata: QID" elsewhere, since the relationship name is already shown there and there's no confusion. 

https://tickets.metabrainz.org/browse/MBS-9883