### PR TITLE
MBS-9765: Do not display event dates twice in search results

### DIFF
--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -14,6 +14,7 @@ import {l} from '../../static/scripts/common/i18n';
 import {lp_attributes} from '../../static/scripts/common/i18n/attributes';
 import ArtistRoles from '../../static/scripts/common/components/ArtistRoles';
 import DescriptiveLink from '../../static/scripts/common/components/DescriptiveLink';
+import EntityLink from '../../static/scripts/common/components/EntityLink';
 import formatDatePeriod from '../../static/scripts/common/utility/formatDatePeriod';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsT} from '../types';
@@ -28,8 +29,10 @@ function buildResult(result, index) {
   return (
     <tr className={loopParity(index)} data-score={score} key={event.id}>
       <td>
-        <DescriptiveLink entity={event} />
+        <EntityLink entity={event} showDisambiguation showEventDate={false} />
       </td>
+      <td>{formatDatePeriod(event)}</td>
+      <td>{event.time}</td>
       <td>{event.typeName ? lp_attributes(event.typeName, 'event_type') : null}</td>
       <td>
         <ArtistRoles relations={event.performers} />
@@ -48,8 +51,6 @@ function buildResult(result, index) {
           ))}
         </ul>
       </td>
-      <td>{formatDatePeriod(event)}</td>
-      <td>{event.time}</td>
     </tr>
   );
 }
@@ -68,11 +69,11 @@ const EventResults = ({
       columns={
         <>
           <th>{l('Name')}</th>
+          <th>{l('Date')}</th>
+          <th>{l('Time')}</th>
           <th>{l('Type')}</th>
           <th>{l('Artists')}</th>
           <th>{l('Location')}</th>
-          <th>{l('Date')}</th>
-          <th>{l('Time')}</th>
         </>
       }
       pager={pager}

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -41,14 +41,14 @@ const Comment = ({className, comment}: {|+className: string, +comment: string|})
   </>
 );
 
-const EventDisambiguation = ({event}: {|+event: EventT|}) => {
+const EventDisambiguation = ({event, showDate}: {|+event: EventT, +showDate: boolean|}) => {
   const dates = formatDatePeriod(event);
-  if (!dates && !event.cancelled) {
+  if ((!dates || !showDate) && !event.cancelled) {
     return null;
   }
   return (
     <>
-      {dates ? ' ' + bracketed(dates) : null}
+      {dates && showDate ? ' ' + bracketed(dates) : null}
       {event.cancelled
         ? <Comment className="cancelled" comment={l('cancelled')} />
         : null}
@@ -93,6 +93,7 @@ type EntityLinkProps = {
   +content?: React.Node,
   +entity: CoreEntityT | CollectionT,
   +hover?: string,
+  +showEventDate?: boolean,
   +showDeleted?: boolean,
   +showDisambiguation?: boolean,
   +subPath?: string,
@@ -109,6 +110,7 @@ const EntityLink = ({
   content,
   entity,
   hover,
+  showEventDate = true,
   showDeleted = true,
   showDisambiguation,
   subPath,
@@ -219,7 +221,7 @@ const EntityLink = ({
 
   if (showDisambiguation) {
     if (entity.entityType === 'event') {
-      parts.push(<EventDisambiguation event={entity} key="eventdisambig" />);
+      parts.push(<EventDisambiguation event={entity} showDate={showEventDate} key="eventdisambig" />);
     }
     if (comment) {
       parts.push(


### PR DESCRIPTION
### [MBS-9765](https://tickets.metabrainz.org/browse/MBS-9765):

> Event dates are displayed:
>1. in parenthesis right after the name in the column “Name”,
>2. in the column “Date”.
>
> Example: https://musicbrainz.org/search?query=test&type=event
> It is redundant and unnecessarily widens the event results page.

I also merged the date & time columns, since otherwise they were on the other side of the screen (or taking too much space next to eachother as seperate columns).
<br/>
Before:
![image](https://user-images.githubusercontent.com/16269580/48194980-66665b00-e346-11e8-8b98-14ecae0d4eeb.png)

After:
![image](https://user-images.githubusercontent.com/16269580/48195060-931a7280-e346-11e8-8744-c526d79c9250.png)
