### PR TITLE
MBS-6232: Add report for releases which only have cover art (in CAA) with no types

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithCAANoTypes.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithCAANoTypes.pm
@@ -1,0 +1,40 @@
+package MusicBrainz::Server::Report::ReleasesWithCAANoTypes;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {
+    "
+        SELECT
+            r.id AS release_id,
+            row_number() OVER (ORDER BY musicbrainz_collate(ac.name), musicbrainz_collate(r.name))
+        FROM (
+            SELECT DISTINCT r.*
+            FROM release r
+            WHERE EXISTS (
+            SELECT 1 FROM cover_art_archive.cover_art WHERE cover_art.release = r.id
+            )
+            AND NOT EXISTS (
+            SELECT 1 FROM cover_art_archive.cover_art_type JOIN cover_art_archive.cover_art ON cover_art_type.id = cover_art.id WHERE cover_art.release = r.id
+        )
+        ) r
+        JOIN artist_credit ac ON r.artist_credit = ac.id
+    ";
+}
+
+sub table { 'releases_with_caa_no_types' }
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2018(s) MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -69,6 +69,7 @@ use MusicBrainz::Server::PagedReport;
     ReleaseGroupsWithoutVALink
     ReleasesInCAAWithCoverArtRelationships
     ReleasesToConvert
+    ReleasesWithCAANoTypes
     ReleasesWithDownloadRelationships
     ReleasesWithNoMediums
     ReleasesWithoutVACredit
@@ -144,6 +145,7 @@ use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;
 use MusicBrainz::Server::Report::ReleasesInCAAWithCoverArtRelationships;
 use MusicBrainz::Server::Report::ReleasesToConvert;
+use MusicBrainz::Server::Report::ReleasesWithCAANoTypes;
 use MusicBrainz::Server::Report::ReleasesWithDownloadRelationships;
 use MusicBrainz::Server::Report::ReleasesWithNoMediums;
 use MusicBrainz::Server::Report::ReleasesWithoutVACredit;

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -97,6 +97,8 @@
               [% l('Releases in the Cover Art Archive that still have cover art relationships') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'CoverArtRelationships') %]">
               [% l('Releases of any sort that still have cover art relationships') %]</a></li>
+            <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithCAANoTypes') %]">
+              [% l('Releases in the Cover Art Archive where no cover art piece has types') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'MediumsWithSequenceIssues') %]">[% l('Releases with non-sequential mediums') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithUnlikelyLanguageScript') %]">[% l('Releases with unlikely language/script pairs') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'TracksWithoutTimes') %]">[% l('Releases with unknown track times') %]</a></li>

--- a/root/report/releases_with_caa_no_types.tt
+++ b/root/report/releases_with_caa_no_types.tt
@@ -1,0 +1,14 @@
+[%- WRAPPER 'layout.tt' title=l('Releases in the Cover Art Archive where no cover art piece has types') full_width=1 -%]
+
+<h1>[% l('Releases in the Cover Art Archive where no cover art piece has types') %]</h1>
+
+<ul>
+  <li>[% l('This report shows releases which have cover art in the Cover Art Archive, but where none of it has any types set. This often means a front cover was added, but not marked as such.') %]</li>
+  <li>[% l('Total releases found: {count}', { count => pager.total_entries }) %]</li>
+  <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
+  [%- INCLUDE 'report/filter_link.tt' -%]
+</ul>
+
+[%- INCLUDE 'report/release_list.tt' -%]
+
+[%- END -%]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-6232

The query itself seems fine - I ran it on queen and got the expected results (well, unexpectedly many but they seem correct). I don't have the cover art tables filled locally so I couldn't fully test the report itself but I expect it should be fine.