### PR TITLE
Fix link to profile from preferences saved dialog

### DIFF
--- a/root/account/PreferencesSaved.js
+++ b/root/account/PreferencesSaved.js
@@ -21,7 +21,7 @@ const PreferencesSaved = ({$c}: Props) => (
   <StatusPage title={l('Preferences')}>
     <p>
       {l('Your preferences have been saved. Click {link|here} to continue to your user page.',
-        {__react: true, link: $c.user ? '/user/profile/' + $c.user.name : '/register'})}
+        {__react: true, link: $c.user ? '/user/' + encodeURIComponent($c.user.name) : '/register'})}
     </p>
   </StatusPage>
 );


### PR DESCRIPTION
"profile/" here led to a non-working link, that also caused a situation where someone registering the "profile" username would get seen every time someone changed their prefs. I've also removed the malicious "profile" user, but this fixes it so that the link will actually go to the appropriate user profile.