### PR TITLE
MBS-9847: Show event collections in reverse by default

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -226,6 +226,7 @@ sub find_by_artist
 
 sub _order_by {
     my ($self, $order) = @_;
+    $order = (($order // "") eq "") ? "-date" : $order;
 
     my $order_by = order_by($order, "date", {
         "date" => sub {


### PR DESCRIPTION
### [MBS-9874](https://tickets.metabrainz.org/browse/MBS-9847): Show event collections in reverse chronological order by default
When viewing a user's event collection, the events were displayed in chronological order. The most relevant results would usually be the most recent ones, so this will reverse the the default $order variable.  

This is cleaner than changing the actual columns passed into **order_by**, since it keeps all of the "DESC" handling within the order_by function itself (found in [Utils.pm](https://github.com/metabrainz/musicbrainz-server/blob/master/lib/MusicBrainz/Server/Data/Utils.pm#L372)).