### PR TITLE
MBS-9605: Fix converting track length over 1 h

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -133,7 +133,7 @@ class Track {
         if (/^\d+$/.test(length) && (6 - lengthLength) <= 1) {
             var minutes= null, seconds = null, hours = null;
 
-            switch(lengthLength) {
+            switch (lengthLength) {
                 case 3:
                     minutes = length[0];
                     break;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -133,8 +133,10 @@ class Track {
         if (/^\d+$/.test(length) && lengthLength >= 3 && lengthLength <= 6) {
             var minutes = null, seconds = null, hours = null;
 
-            hours = length.slice(0, Math.max(0, lengthLength - 4));
-            minutes = length.slice(Math.max(0, lengthLength - 4), lengthLength - 2);
+            var hoursLength = Math.max(0, lengthLength - 4);
+
+            hours = length.slice(0, hoursLength);
+            minutes = length.slice(hoursLength, lengthLength - 2);
             seconds = length.slice(-2);
 
             if (parseInt(seconds, 10) < 60) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -131,16 +131,23 @@ class Track {
         // Convert stuff like 111 into 1:11
 
         if (/^\d+$/.test(length) && (6 - lengthLength) <= 1) {
-            var minutes, seconds, hours = null;
+            var minutes= null, seconds = null, hours = null;
 
-
-            if (lengthLength === 3) minutes = length[0];
-            if (lengthLength === 4) minutes = length.slice(0, 2);
-            if (lengthLength === 5){ minutes = length.slice(1,3);
-                hours = length.slice(0);
-            }
-            if (lengthLength === 6){ minutes = length.slice(2,4);
-                hours = length.slice(0,2);
+            switch(lengthLength) {
+                case 3:
+                    minutes = length[0];
+                    break;
+                case 4:
+                    minutes = length.slice(0, 2);
+                    break;
+                case 5:
+                    minutes = length.slice(1,3);
+                    hours = length.slice(0);
+                    break;
+                case 6:
+                    minutes = length.slice(2,4);
+                    hours = length.slice(0,2);
+                    break;
             }
 
             if (lengthLength > 6) length = '?:??';

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -157,8 +157,7 @@ class Track {
                     if (lengthLength <= 4) {
                         length = minutes + ":" + seconds;
                         this.formattedLength(length);
-                    }
-                    else if (lengthLength > 4){
+                    } else if (lengthLength > 4) {
                         length = hours + ":" + minutes + ":" + seconds;
                         this.formattedLength(length);
                     }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -152,7 +152,7 @@ class Track {
 
             seconds = length.slice(-2);
 
-            if (seconds < 60){
+            if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {
                     if (lengthLength <= 4){
                     length = minutes + ":" + seconds;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -154,7 +154,7 @@ class Track {
 
             if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {
-                    if (lengthLength <= 4){
+                    if (lengthLength <= 4) {
                     length = minutes + ":" + seconds;
                     this.formattedLength(length);
                     }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -157,7 +157,7 @@ class Track {
                     if (lengthLength <= 4) {
                         length = minutes + ":" + seconds;
                         this.formattedLength(length);
-                    } else if (lengthLength > 4) {
+                    } else {
                         length = hours + ":" + minutes + ":" + seconds;
                         this.formattedLength(length);
                     }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -141,7 +141,7 @@ class Track {
                     minutes = length.slice(0, 2);
                     break;
                 case 5:
-                    minutes = length.slice(1,3);
+                    minutes = length.slice(1, 3);
                     hours = length.slice(0);
                     break;
                 case 6:

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -133,23 +133,8 @@ class Track {
         if (/^\d+$/.test(length) && lengthLength >= 3 && lengthLength <= 6) {
             var minutes = null, seconds = null, hours = null;
 
-            switch (lengthLength) {
-                case 3:
-                    minutes = length[0];
-                    break;
-                case 4:
-                    minutes = length.slice(0, 2);
-                    break;
-                case 5:
-                    minutes = length.slice(1, 3);
-                    hours = length[0];
-                    break;
-                case 6:
-                    hours = length.slice(0, 2);
-                    minutes = length.slice(2, 4);
-                    break;
-            }
-
+            hours = length.slice(0, lengthLength - 4);
+            minutes = length.slice(Math.max(0, lengthLength - 4), lengthLength - 2);
             seconds = length.slice(-2);
 
             if (parseInt(seconds, 10) < 60) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -155,12 +155,12 @@ class Track {
             if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {
                     if (lengthLength <= 4) {
-                    length = minutes + ":" + seconds;
-                    this.formattedLength(length);
+                        length = minutes + ":" + seconds;
+                        this.formattedLength(length);
                     }
                     else if (lengthLength > 4){
-                    length = hours + ":" + minutes + ":" + seconds;
-                    this.formattedLength(length);
+                        length = hours + ":" + minutes + ":" + seconds;
+                        this.formattedLength(length);
                     }
                 }
                 
@@ -170,9 +170,7 @@ class Track {
                     length = hours + ":" + minutes + ":" + seconds;
                     this.formattedLength(length);
                 }
-
             }
-
         }
 
         var oldLength = this.length();

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -169,7 +169,7 @@ class Track {
                     hours = 1;
                     length = hours + ":" + minutes + ":" + seconds;
                     this.formattedLength(length);
-                    }
+                }
 
             }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,16 +130,27 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && (4 - lengthLength) <= 1) {
-            var minutes, seconds;
+        if (/^\d+$/.test(length) && (5 - lengthLength) <= 1) {
+            var minutes, seconds, hours;
+
 
             if (lengthLength === 3) minutes = length[0];
             if (lengthLength === 4) minutes = length.slice(0, 2);
+            if (lengthLength === 5) minutes = length.slice(1,3); {
+                hours = length.slice(0);
+            }
 
             seconds = length.slice(-2);
 
             if (parseInt(minutes, 10) < 60 && parseInt(seconds, 10) < 60) {
-                length = minutes + ":" + seconds;
+                length = hours + ":" + minutes + ":" + seconds;
+                this.formattedLength(length);
+            }
+
+            if (parseInt(minutes, 10) >= 60 )  {
+                minutes = minutes - 60;
+                hours += 1 ;
+                length = hours + ":" + minutes + ":" + seconds;
                 this.formattedLength(length);
             }
         }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -131,7 +131,7 @@ class Track {
         // Convert stuff like 111 into 1:11
 
         if (/^\d+$/.test(length) && (6 - lengthLength) <= 1) {
-            var minutes= null, seconds = null, hours = null;
+            var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {
                 case 3:

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,7 +130,7 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length)) {
+        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) <= -3)) {
             var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {
@@ -139,33 +139,39 @@ class Track {
                     break;
                 case 4:
                     minutes = length.slice(0, 2);
-                    if (parseInt(minutes, 10) >= 60)  {
-                        minutes = minutes - 60;
-                        hours += 1;
-                        length = hours + ":" + minutes + ":" + seconds;
-                        this.formattedLength(length);
-                    }
                     break;
                 case 5:
                     minutes = length.slice(1, 3);
                     hours = length[0];
                     break;
                 case 6:
-                    hours = length.slice(0,2);
-                    minutes = length.slice(2,4);
+                    hours = length.slice(0, 2);
+                    minutes = length.slice(2, 4);
                     break;
             }
 
             seconds = length.slice(-2);
 
-            
+            if (seconds < 60){
+                if (parseInt(minutes, 10) < 60) {
+                    if (lengthLength <= 4){
+                    length = minutes + ":" + seconds;
+                    this.formattedLength(length);
+                    }
+                    else if (lengthLength > 4){
+                    length = hours + ":" + minutes + ":" + seconds;
+                    this.formattedLength(length);
+                    }
+                }
+                
+                if (parseInt(minutes, 10) >= 60 && lengthLength == 4)  {
+                    minutes = minutes - 60;
+                    hours += 1;
+                    length = hours + ":" + minutes + ":" + seconds;
+                    this.formattedLength(length);
+                    }
 
-            if (parseInt(minutes, 10) < 60 && parseInt(seconds, 10) < 60 && lengthLength <= 6) {
-                length = hours + ":" + minutes + ":" + seconds;
-                this.formattedLength(length);
             }
-
-            
 
         }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -146,7 +146,7 @@ class Track {
                     break;
                 case 6:
                     minutes = length.slice(2, 4);
-                    hours = length.slice(0,2);
+                    hours = length.slice(0, 2);
                     break;
             }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -142,7 +142,7 @@ class Track {
                     break;
                 case 5:
                     minutes = length.slice(1, 3);
-                    hours = length.slice(0);
+                    hours = length[0];
                     break;
                 case 6:
                     minutes = length.slice(2, 4);
@@ -150,9 +150,9 @@ class Track {
                     break;
             }
 
-            if (lengthLength > 6) length = '?:??';
-
             seconds = length.slice(-2);
+
+            
 
             if (parseInt(minutes, 10) < 60 && parseInt(seconds, 10) < 60) {
                 length = hours + ":" + minutes + ":" + seconds;
@@ -165,6 +165,8 @@ class Track {
                 length = hours + ":" + minutes + ":" + seconds;
                 this.formattedLength(length);
             }
+
+            if (lengthLength > 6) length = '?:??';
         }
 
         var oldLength = this.length();

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,7 +130,7 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) > -3)) {
+        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) >= -2)) {
             var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -156,9 +156,7 @@ class Track {
                 if (parseInt(minutes, 10) < 60) {
                     length = (hours ? hours + ":" : "") + minutes + ":" + seconds;
                     this.formattedLength(length);
-                }
-                
-                if (parseInt(minutes, 10) >= 60 && lengthLength == 4) {
+                } else if (lengthLength == 4) {
                     minutes = minutes - 60;
                     hours = 1;
                     length = hours + ":" + minutes + ":" + seconds;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,7 +130,7 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && (6 - lengthLength) <= 1) {
+        if (/^\d+$/.test(length)) {
             var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -139,14 +139,20 @@ class Track {
                     break;
                 case 4:
                     minutes = length.slice(0, 2);
+                    if (parseInt(minutes, 10) >= 60)  {
+                        minutes = minutes - 60;
+                        hours += 1;
+                        length = hours + ":" + minutes + ":" + seconds;
+                        this.formattedLength(length);
+                    }
                     break;
                 case 5:
                     minutes = length.slice(1, 3);
                     hours = length[0];
                     break;
                 case 6:
-                    minutes = length.slice(2, 4);
-                    hours = length.slice(0, 2);
+                    hours = length.slice(0,2);
+                    minutes = length.slice(2,4);
                     break;
             }
 
@@ -154,19 +160,13 @@ class Track {
 
             
 
-            if (parseInt(minutes, 10) < 60 && parseInt(seconds, 10) < 60) {
+            if (parseInt(minutes, 10) < 60 && parseInt(seconds, 10) < 60 && lengthLength <= 6) {
                 length = hours + ":" + minutes + ":" + seconds;
                 this.formattedLength(length);
             }
 
-            if (parseInt(minutes, 10) >= 60)  {
-                minutes = minutes - 60;
-                hours += 1;
-                length = hours + ":" + minutes + ":" + seconds;
-                this.formattedLength(length);
-            }
+            
 
-            if (lengthLength > 6) length = '?:??';
         }
 
         var oldLength = this.length();

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -161,7 +161,7 @@ class Track {
 
             if (parseInt(minutes, 10) >= 60)  {
                 minutes = minutes - 60;
-                hours += 1 ;
+                hours += 1;
                 length = hours + ":" + minutes + ":" + seconds;
                 this.formattedLength(length);
             }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -156,11 +156,10 @@ class Track {
                 if (parseInt(minutes, 10) < 60) {
                     if (lengthLength <= 4) {
                         length = minutes + ":" + seconds;
-                        this.formattedLength(length);
                     } else {
                         length = hours + ":" + minutes + ":" + seconds;
-                        this.formattedLength(length);
                     }
+                    this.formattedLength(length);
                 }
                 
                 if (parseInt(minutes, 10) >= 60 && lengthLength == 4) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,14 +130,17 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && (5 - lengthLength) <= 1) {
-            var minutes, seconds, hours;
+        if (/^\d+$/.test(length) && (6 - lengthLength) <= 1) {
+            var minutes, seconds, hours = null;
 
 
             if (lengthLength === 3) minutes = length[0];
             if (lengthLength === 4) minutes = length.slice(0, 2);
             if (lengthLength === 5) minutes = length.slice(1,3); {
                 hours = length.slice(0);
+            }
+            if (lengthLength === 6) minutes = length.slice(2,4);{
+                hours = length.slice(0,2);
             }
 
             seconds = length.slice(-2);

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -166,7 +166,7 @@ class Track {
                 
                 if (parseInt(minutes, 10) >= 60 && lengthLength == 4)  {
                     minutes = minutes - 60;
-                    hours += 1;
+                    hours = 1;
                     length = hours + ":" + minutes + ":" + seconds;
                     this.formattedLength(length);
                     }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -154,11 +154,7 @@ class Track {
 
             if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {
-                    if (!hours) {
-                        length = minutes + ":" + seconds;
-                    } else {
-                        length = hours + ":" + minutes + ":" + seconds;
-                    }
+                    length = (hours ? hours + ":" : "") + minutes + ":" + seconds;
                     this.formattedLength(length);
                 }
                 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -154,7 +154,7 @@ class Track {
 
             if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {
-                    if (lengthLength <= 4) {
+                    if (!hours) {
                         length = minutes + ":" + seconds;
                     } else {
                         length = hours + ":" + minutes + ":" + seconds;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -145,7 +145,7 @@ class Track {
                     hours = length.slice(0);
                     break;
                 case 6:
-                    minutes = length.slice(2,4);
+                    minutes = length.slice(2, 4);
                     hours = length.slice(0,2);
                     break;
             }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -164,7 +164,7 @@ class Track {
                     }
                 }
                 
-                if (parseInt(minutes, 10) >= 60 && lengthLength == 4)  {
+                if (parseInt(minutes, 10) >= 60 && lengthLength == 4) {
                     minutes = minutes - 60;
                     hours = 1;
                     length = hours + ":" + minutes + ":" + seconds;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -136,12 +136,14 @@ class Track {
 
             if (lengthLength === 3) minutes = length[0];
             if (lengthLength === 4) minutes = length.slice(0, 2);
-            if (lengthLength === 5) minutes = length.slice(1,3); {
+            if (lengthLength === 5){ minutes = length.slice(1,3);
                 hours = length.slice(0);
             }
-            if (lengthLength === 6) minutes = length.slice(2,4);{
+            if (lengthLength === 6){ minutes = length.slice(2,4);
                 hours = length.slice(0,2);
             }
+
+            if (lengthLength > 6) length = '?:??';
 
             seconds = length.slice(-2);
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,7 +130,7 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) >= -2)) {
+        if (/^\d+$/.test(length) && lengthLength >= 3 && lengthLength <= 6) {
             var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -133,7 +133,7 @@ class Track {
         if (/^\d+$/.test(length) && lengthLength >= 3 && lengthLength <= 6) {
             var minutes = null, seconds = null, hours = null;
 
-            hours = length.slice(0, lengthLength - 4);
+            hours = length.slice(0, Math.max(0, lengthLength - 4));
             minutes = length.slice(Math.max(0, lengthLength - 4), lengthLength - 2);
             seconds = length.slice(-2);
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -159,7 +159,7 @@ class Track {
                 this.formattedLength(length);
             }
 
-            if (parseInt(minutes, 10) >= 60 )  {
+            if (parseInt(minutes, 10) >= 60)  {
                 minutes = minutes - 60;
                 hours += 1 ;
                 length = hours + ":" + minutes + ":" + seconds;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -130,7 +130,7 @@ class Track {
 
         // Convert stuff like 111 into 1:11
 
-        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) <= -3)) {
+        if (/^\d+$/.test(length) && ((4 - lengthLength) <= 1 || (4 - lengthLength) > -3)) {
             var minutes = null, seconds = null, hours = null;
 
             switch (lengthLength) {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -131,13 +131,11 @@ class Track {
         // Convert stuff like 111 into 1:11
 
         if (/^\d+$/.test(length) && lengthLength >= 3 && lengthLength <= 6) {
-            var minutes = null, seconds = null, hours = null;
-
             var hoursLength = Math.max(0, lengthLength - 4);
 
-            hours = length.slice(0, hoursLength);
-            minutes = length.slice(hoursLength, lengthLength - 2);
-            seconds = length.slice(-2);
+            var hours = length.slice(0, hoursLength);
+            var minutes = length.slice(hoursLength, lengthLength - 2);
+            var seconds = length.slice(-2);
 
             if (parseInt(seconds, 10) < 60) {
                 if (parseInt(minutes, 10) < 60) {

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -215,23 +215,23 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + output[0]);
 
     medium.tracks()[0].formattedLengthChange(lengths[1]);
-    t.equal(medium.tracks()[1].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + output[1]);
+    t.equal(medium.tracks()[0].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + output[1]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[2]);
-    t.equal(medium.tracks()[2].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + output[2]);
+    t.equal(medium.tracks()[0].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + output[2]);
 
     medium.tracks()[0].formattedLengthChange(lengths[3]);
-    t.equal(medium.tracks()[3].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + output[3]);
+    t.equal(medium.tracks()[0].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + output[3]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[4]);
-    t.equal(medium.tracks()[4].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + output[4]);
+    t.equal(medium.tracks()[0].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + output[4]);
 
     medium.tracks()[0].formattedLengthChange(lengths[5]);
-    t.equal(medium.tracks()[5].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + output[5]);
+    t.equal(medium.tracks()[0].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + output[5]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[6]);
-    t.equal(medium.tracks()[6].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
+    t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
 
     medium.tracks()[0].formattedLengthChange(lengths[7]);
-    t.equal(medium.tracks()[7].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);
+    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);googe
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -186,52 +186,22 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
     t.plan(8);
+
+    const tests = [
+        {input: "5", output: "0:05"},
+        {input: "69", output: "1:09"},
+        {input: "174", output: "2:54"},
+        {input: "6000", output: "1:00:00"},
+        {input: "7400", output: "1:14:00"},
+        {input: "10000", output: "1:00:00"},
+        {input: "96900", output: "10:09:00"},
+        {input: "3723494", output: "?:??"}
+    ];
+
+    tests.forEach(({input, output}) => {
+        medium.tracks()[0].formattedLengthChanged(input);
+        t.equal(medium.tracks()[0].formattedLength(), output, "length " + input + " is formatted as " + medium.tracks()[0].formattedLength());
+    });
     
-    var lengths = [
-        "5",
-        "69",
-        "174",
-        "6000",
-        "7400",
-        "10000",
-        "96900",
-        "3723494",
-    ];
-
-    var output = [
-        "0:05",
-        "1:09",
-        "2:54",
-        "1:00:00",
-        "1:14:00",
-        "1:00:00",
-        "10:09:00",
-        "?:??",
-    ];
-
-    var medium = new fields.Medium({ tracks: [ {} ] }, release);
-
-    medium.tracks()[0].formattedLengthChanged(lengths[0]);
-    t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[1]);
-    t.equal(medium.tracks()[0].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[2]);
-    t.equal(medium.tracks()[0].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[3]);
-    t.equal(medium.tracks()[0].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[4]);
-    t.equal(medium.tracks()[0].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[5]);
-    t.equal(medium.tracks()[0].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[6]);
-    t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + medium.tracks()[0].formattedLength());
-
-    medium.tracks()[0].formattedLengthChanged(lengths[7]);
-    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + medium.tracks()[0].formattedLength());
+    
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -212,26 +212,26 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     var medium = new fields.Medium({ tracks: [ {} ] }, release);
 
     medium.tracks()[0].formattedLengthChanged(lengths[0]);
-    t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + output[0]);
+    t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[1]);
-    t.equal(medium.tracks()[0].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + output[1]);
+    t.equal(medium.tracks()[0].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[2]);
-    t.equal(medium.tracks()[0].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + output[2]);
+    t.equal(medium.tracks()[0].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[3]);
-    t.equal(medium.tracks()[0].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + output[3]);
+    t.equal(medium.tracks()[0].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[4]);
-    t.equal(medium.tracks()[0].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + output[4]);
+    t.equal(medium.tracks()[0].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[5]);
-    t.equal(medium.tracks()[0].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + output[5]);
+    t.equal(medium.tracks()[0].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[6]);
-    t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
+    t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + medium.tracks()[0].formattedLength());
 
     medium.tracks()[0].formattedLengthChanged(lengths[7]);
-    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);
+    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + medium.tracks()[0].formattedLength());
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -187,6 +187,8 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
     t.plan(8);
 
+    var medium = new fields.Medium({ tracks: [ {} ] }, release);
+
     const tests = [
         {input: "5", output: "0:05"},
         {input: "69", output: "1:09"},

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -214,24 +214,24 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     medium.tracks()[0].formattedLengthChanged(lengths[0]);
     t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + output[0]);
 
-    medium.tracks()[0].formattedLengthChange(lengths[1]);
+    medium.tracks()[0].formattedLengthChanged(lengths[1]);
     t.equal(medium.tracks()[0].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + output[1]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[2]);
     t.equal(medium.tracks()[0].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + output[2]);
 
-    medium.tracks()[0].formattedLengthChange(lengths[3]);
+    medium.tracks()[0].formattedLengthChanged(lengths[3]);
     t.equal(medium.tracks()[0].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + output[3]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[4]);
     t.equal(medium.tracks()[0].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + output[4]);
 
-    medium.tracks()[0].formattedLengthChange(lengths[5]);
+    medium.tracks()[0].formattedLengthChanged(lengths[5]);
     t.equal(medium.tracks()[0].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + output[5]);
 
     medium.tracks()[0].formattedLengthChanged(lengths[6]);
     t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
 
-    medium.tracks()[0].formattedLengthChange(lengths[7]);
+    medium.tracks()[0].formattedLengthChanged(lengths[7]);
     t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -207,6 +207,4 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
         medium.tracks()[0].formattedLengthChanged(input);
         t.equal(medium.tracks()[0].formattedLength(), output, "length " + input + " is formatted as " + medium.tracks()[0].formattedLength());
     });
-    
-    
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -187,7 +187,7 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
     t.plan(8);
 
-    var medium = new fields.Medium({ tracks: [ {} ] }, release);
+    var medium = new fields.Medium({ tracks: [ ] }, release);
     
     var lengths = [
         {5},

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -205,6 +205,6 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
 
     tests.forEach(({input, output}) => {
         medium.tracks()[0].formattedLengthChanged(input);
-        t.equal(medium.tracks()[0].formattedLength(), output, "length " + input + " is formatted as " + medium.tracks()[0].formattedLength());
+        t.equal(medium.tracks()[0].formattedLength(), output, "length " + input + " is formatted as " + ouput);
     });
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -187,28 +187,28 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
     t.plan(8);
 
-    var medium = new fields.Medium({ tracks: [ ] }, release);
+    var medium = new fields.Medium({ tracks: [ {} ] }, release);
     
     var lengths = [
-        {5},
-        {69},
-        {174},
-        {6000},
-        {7400},
-        {10000},
-        {96900},
-        {3723494},
+        "5",
+        "69",
+        "174",
+        "6000",
+        "7400",
+        "10000",
+        "96900",
+        "3723494",
     ];
 
     var output = [
-        {"0.05"},
-        {"1.09"},
-        {"2:54"},
-        {"1:00:00"},
-        {"1:14:00"},
-        {"1:00:00"},
-        {"10:09:00"},
-        {"?:??"},
+        "0.05",
+        "1.09",
+        "2:54",
+        "1:00:00",
+        "1:14:00",
+        "1:00:00",
+        "10:09:00",
+        "?:??",
     ];
 
     medium.tracks()[0].formattedLengthChanged(lengths[0]);

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -195,9 +195,12 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
         {input: "174", output: "2:54"},
         {input: "6000", output: "1:00:00"},
         {input: "7400", output: "1:14:00"},
+        {input: "7482", output: "2:04:42"},
         {input: "10000", output: "1:00:00"},
-        {input: "96900", output: "10:09:00"},
-        {input: "3723494", output: "?:??"}
+        {input: "96900", output: "26:55:00"},
+        {input: "160000", output: "16:00:00"},
+        {input: "166000", output: "46:06:40"},
+        {input: "3723494", output: "1034:18:14"}
     ];
 
     tests.forEach(({input, output}) => {

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -184,7 +184,7 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
     t.ok(_.last(medium.tracks()).isDataTrack());
 });
 
-fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
+fieldTest("track times entered as integers are converted into HH:MM:SS", function (t, release){
     t.plan(11);
 
     var medium = new fields.Medium({ tracks: [ {} ] }, release);

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -201,8 +201,8 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     ];
 
     var output = [
-        "0.05",
-        "1.09",
+        "0:05",
+        "1:09",
         "2:54",
         "1:00:00",
         "1:14:00",

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -60,9 +60,9 @@ fieldTest("mediums having their \"loaded\" observable set correctly", function (
 
     t.equal(mediums()[0].loaded(), true, "medium without id or tracks is considered loaded");
     t.equal(mediums()[1].loaded(), true, "medium without id but with tracks is considered loaded");
-    t.equal(mediums()[2].loaded(), false, "medium with id but without tracks is considered not loaded")
+    t.equal(mediums()[2].loaded(), false, "medium with id but without tracks is considered not loaded");
     t.equal(mediums()[3].loaded(), false, "medium with originalID but without tracks is considered not loaded");
-    t.equal(mediums()[4].loaded(), true, "medium with id and with tracks is considered loaded")
+    t.equal(mediums()[4].loaded(), true, "medium with id and with tracks is considered loaded");
     t.equal(mediums()[5].loaded(), true, "medium with originalID and with tracks is considered loaded");
 
 });
@@ -186,8 +186,6 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
     t.plan(8);
-
-    var medium = new fields.Medium({ tracks: [ {} ] }, release);
     
     var lengths = [
         "5",
@@ -210,6 +208,8 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
         "10:09:00",
         "?:??",
     ];
+
+    var medium = new fields.Medium({ tracks: [ {} ] }, release);
 
     medium.tracks()[0].formattedLengthChanged(lengths[0]);
     t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + output[0]);

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -200,13 +200,38 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
         {3723494},
     ];
 
+    var output = [
+        {"0.05"},
+        {"1.09"},
+        {"2:54"},
+        {"1:00:00"},
+        {"1:14:00"},
+        {"1:00:00"},
+        {"10:09:00"},
+        {"?:??"},
+    ];
 
-    t.equal(medium.tracks()[0].formattedLengthChanged(lengths[0]), "0:05", );
-    t.equal(medium.tracks()[1].formattedLengthChanged(lengths[1]), "1:09", );
-    t.equal(medium.tracks()[2].formattedLengthChanged(lengths[2]), "2:54", );
-    t.equal(medium.tracks()[3].formattedLengthChanged(lengths[3]), "1:00:00", );
-    t.equal(medium.tracks()[4].formattedLengthChanged(lengths[4]), "1:14:00", );
-    t.equal(medium.tracks()[5].formattedLengthChanged(lengths[5]), "1:00:00", );
-    t.equal(medium.tracks()[6].formattedLengthChanged(lengths[6]), "10:09:00", );
-    t.equal(medium.tracks()[7].formattedLengthChanged(lengths[7]), "?:??", );
+    medium.tracks()[0].formattedLengthChanged(lengths[0]);
+    t.equal(medium.tracks()[0].formattedLength(), output[0], "length " + lengths[0] + " is formatted as " + output[0]);
+
+    medium.tracks()[0].formattedLengthChange(lengths[1]);
+    t.equal(medium.tracks()[1].formattedLength(), output[1], "length " + lengths[1] + " is formatted as " + output[1]);
+
+    medium.tracks()[0].formattedLengthChanged(lengths[2]);
+    t.equal(medium.tracks()[2].formattedLength(), output[2], "length " + lengths[2] + " is formatted as " + output[2]);
+
+    medium.tracks()[0].formattedLengthChange(lengths[3]);
+    t.equal(medium.tracks()[3].formattedLength(), output[3], "length " + lengths[3] + " is formatted as " + output[3]);
+
+    medium.tracks()[0].formattedLengthChanged(lengths[4]);
+    t.equal(medium.tracks()[4].formattedLength(), output[4], "length " + lengths[4] + " is formatted as " + output[4]);
+
+    medium.tracks()[0].formattedLengthChange(lengths[5]);
+    t.equal(medium.tracks()[5].formattedLength(), output[5], "length " + lengths[5] + " is formatted as " + output[5]);
+
+    medium.tracks()[0].formattedLengthChanged(lengths[6]);
+    t.equal(medium.tracks()[6].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
+
+    medium.tracks()[0].formattedLengthChange(lengths[7]);
+    t.equal(medium.tracks()[7].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -60,9 +60,9 @@ fieldTest("mediums having their \"loaded\" observable set correctly", function (
 
     t.equal(mediums()[0].loaded(), true, "medium without id or tracks is considered loaded");
     t.equal(mediums()[1].loaded(), true, "medium without id but with tracks is considered loaded");
-    t.equal(mediums()[2].loaded(), false, "medium with id but without tracks is considered not loaded");
+    t.equal(mediums()[2].loaded(), false, "medium with id but without tracks is considered not loaded")
     t.equal(mediums()[3].loaded(), false, "medium with originalID but without tracks is considered not loaded");
-    t.equal(mediums()[4].loaded(), true, "medium with id and with tracks is considered loaded");
+    t.equal(mediums()[4].loaded(), true, "medium with id and with tracks is considered loaded")
     t.equal(mediums()[5].loaded(), true, "medium with originalID and with tracks is considered loaded");
 
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -185,7 +185,7 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
 });
 
 fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
-    t.plan(8);
+    t.plan(11);
 
     var medium = new fields.Medium({ tracks: [ {} ] }, release);
 

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -183,3 +183,30 @@ fieldTest("tracks are set correctly when the cdtoc is changed", function (t, rel
     );
     t.ok(_.last(medium.tracks()).isDataTrack());
 });
+
+fieldTest("Tracks' time are changed correctly when inputting values in the medium tracklist editing form tab", function (t, release){
+    t.plan(8);
+
+    var medium = new fields.Medium({ tracks: [ {} ] }, release);
+    
+    var lengths = [
+        {5},
+        {69},
+        {174},
+        {6000},
+        {7400},
+        {10000},
+        {96900},
+        {3723494},
+    ];
+
+
+    t.equal(medium.tracks()[0].formattedLengthChange(lengths[0]), "0:05", );
+    t.equal(medium.tracks()[1].formattedLengthChange(lengths[1]), "1:09", );
+    t.equal(medium.tracks()[2].formattedLengthChange(lengths[2]), "2:54", );
+    t.equal(medium.tracks()[3].formattedLengthChange(lengths[3]), "1:00:00", );
+    t.equal(medium.tracks()[4].formattedLengthChange(lengths[4]), "1:14:00", );
+    t.equal(medium.tracks()[5].formattedLengthChange(lengths[5]), "1:00:00", );
+    t.equal(medium.tracks()[6].formattedLengthChange(lengths[6]), "10:09:00", );
+    t.equal(medium.tracks()[7].formattedLengthChange(lengths[7]), "?:??", );
+});

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -201,12 +201,12 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     ];
 
 
-    t.equal(medium.tracks()[0].formattedLengthChange(lengths[0]), "0:05", );
-    t.equal(medium.tracks()[1].formattedLengthChange(lengths[1]), "1:09", );
-    t.equal(medium.tracks()[2].formattedLengthChange(lengths[2]), "2:54", );
-    t.equal(medium.tracks()[3].formattedLengthChange(lengths[3]), "1:00:00", );
-    t.equal(medium.tracks()[4].formattedLengthChange(lengths[4]), "1:14:00", );
-    t.equal(medium.tracks()[5].formattedLengthChange(lengths[5]), "1:00:00", );
-    t.equal(medium.tracks()[6].formattedLengthChange(lengths[6]), "10:09:00", );
-    t.equal(medium.tracks()[7].formattedLengthChange(lengths[7]), "?:??", );
+    t.equal(medium.tracks()[0].formattedLengthChanged(lengths[0]), "0:05", );
+    t.equal(medium.tracks()[1].formattedLengthChanged(lengths[1]), "1:09", );
+    t.equal(medium.tracks()[2].formattedLengthChanged(lengths[2]), "2:54", );
+    t.equal(medium.tracks()[3].formattedLengthChanged(lengths[3]), "1:00:00", );
+    t.equal(medium.tracks()[4].formattedLengthChanged(lengths[4]), "1:14:00", );
+    t.equal(medium.tracks()[5].formattedLengthChanged(lengths[5]), "1:00:00", );
+    t.equal(medium.tracks()[6].formattedLengthChanged(lengths[6]), "10:09:00", );
+    t.equal(medium.tracks()[7].formattedLengthChanged(lengths[7]), "?:??", );
 });

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -233,5 +233,5 @@ fieldTest("Tracks' time are changed correctly when inputting values in the mediu
     t.equal(medium.tracks()[0].formattedLength(), output[6], "length " + lengths[6] + " is formatted as " + output[6]);
 
     medium.tracks()[0].formattedLengthChange(lengths[7]);
-    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);googe
+    t.equal(medium.tracks()[0].formattedLength(), output[7], "length " + lengths[7] + " is formatted as " + output[7]);
 });


### PR DESCRIPTION
### Fix [MBS-9605](https://tickets.metabrainz.org/browse/MBS-9605): Tracklist editor badly converts track length over 1 h

Convert both `7400` and `11400` to `1:14:00`. See added tests for more examples.