### PR TITLE
MBS-9873: Add autoselect for Discogs compositions

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -24,7 +24,8 @@ const LINK_TYPES = {
     place: "1c140ac8-8dc2-449e-92cb-52c90d525640",
     release: "4a78823c-1c53-4176-a5f3-58026c76f2bc",
     release_group: "99e550f3-5ab4-3110-b5b9-fe01d970b126",
-    series: "338811ef-b1a9-449d-954e-115846f33a44"
+    series: "338811ef-b1a9-449d-954e-115846f33a44",
+    work: "d78b7280-eb9e-4a57-86c3-cedaa1aa2175"
   },
   imdb: {
     artist: "94c8b0cc-4477-4106-932c-da60e63de61c",
@@ -321,14 +322,14 @@ const CLEANUPS = {
     type: LINK_TYPES.discogs,
     clean: function (url) {
       url = url.replace(/\/viewimages\?release=([0-9]*)/, "/release/$1");
-      url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "https://www.discogs.com/$1");
+      url = url.replace(/^https?:\/\/(?:[^.]+\.)?discogs\.com\/(?:.*\/)?(user\/[^\/#?]+|(?:composition\/[^-]+-[^-]+-[^-]+-[^-]+-[^-]+)|(?:artist|release|master(?:\/view)?|label)\/[0-9]+)(?:[\/#?-].*)?$/, "https://www.discogs.com/$1");
       url = url.replace(/^(https:\/\/www\.discogs\.com\/master)\/view\/([0-9]+)$/, "$1/$2");
       return url;
     },
     validate: function (url, id) {
-      var m = /^https:\/\/www\.discogs\.com\/(?:(artist|label|master|release)\/[1-9][0-9]*|(user)\/.+)$/.exec(url);
+      var m = /^https:\/\/www\.discogs\.com\/(?:(artist|label|master|release)\/[1-9][0-9]*|(user)\/.+|(composition)\/(?:[^-]*-){4}[^-]*)$/.exec(url);
       if (m) {
-        var prefix = m[1] || m[2];
+        var prefix = m[1] || m[2] || m[3];
         switch (id) {
           case LINK_TYPES.discogs.artist:
             return prefix === 'artist' || prefix === 'user';
@@ -341,6 +342,8 @@ const CLEANUPS = {
             return prefix === 'master';
           case LINK_TYPES.discogs.release:
             return prefix === 'release';
+          case LINK_TYPES.discogs.work:
+            return prefix === 'composition';
         }
       }
       return false;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1126,6 +1126,12 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'discogs',
                     expected_clean_url: 'https://www.discogs.com/release/5578',
         },
+        {
+                             input_url: 'http://www.discogs.com/composition/27b17569-3e40-40b5-9819-409794c2d5d9-In-The-Hospital',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'discogs',
+                    expected_clean_url: 'https://www.discogs.com/composition/27b17569-3e40-40b5-9819-409794c2d5d9',
+        },
         // DRAM
         {
                              input_url: 'http://www.dramonline.org/composers/buren-john-van',


### PR DESCRIPTION
## [MBS-9873](https://tickets.metabrainz.org/browse/MBS-9873)
Discogs now has support for works (or as they're called on Discogs, 'compositions'). This PR allows these to be recognized.
Unlike all other Discogs entities (apart from users), the IDs aren't numerical, i.e:
* https://www.discogs.com/composition/1b383ed3-7b58-45ff-8f1b-1135c41988d4-In-Verbundenheit
* https://www.discogs.com/composition/d6652f48-35ad-4900-9c42-d0b0f2f84674-Mr-Henri-Rousseaus-Dream
* https://www.discogs.com/composition/27b17569-3e40-40b5-9819-409794c2d5d9-In-The-Hospital

Because of this, I also implemented a new replace statement just for compositions.