### PR TITLE
    MBS-9900:  Add information on requesting instruments/genres to their lists

### DIFF
--- a/root/genre/List.js
+++ b/root/genre/List.js
@@ -33,11 +33,11 @@ const GenreList = ({genres}: PropsT) => (
         ))}
       </ul>
       <p>
-        {l('Is a genre missing from the list? Request it by')} + 
-         <a href="https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!">
-         {l(' adding a style ticket ')}
-      </a> + 
-      {l('with the "Genres" component')}
+        {l('Is a genre missing from the list? Request it by {link|adding a style ticket} with the "Genres" component', 
+            {
+             __react: true,
+            MeB: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!'}
+           )}
       </p>
     </div>
   </Layout>

--- a/root/genre/List.js
+++ b/root/genre/List.js
@@ -36,7 +36,7 @@ const GenreList = ({genres}: PropsT) => (
         {l('Is a genre missing from the list? Request it by {link|adding a style ticket} with the "Genres" component', 
             {
              __react: true,
-            MeB: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!'}
+            link: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!'}
            )}
       </p>
     </div>

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -70,11 +70,11 @@ const InstrumentList = ({
           )
           : null}
         <p>
-          {l('Is this list missing an instrument? Request it by going to the')} + 
-          <a href="https://tickets.metabrainz.org/secure/Dashboard.jspa">
-          {l(' ticket tracker, ')}
-          </a> + 
-          {l('creating a new issue and selecting the project type as "Instrument Requests (INST)"')}
+          {l('Is this list missing an instrument? Request it by going to the {link|ticket tracker}, creating a new issue and selecting the project type as "Instrument Requests (INST)"', 
+            {
+             __react: true,
+            link: 'https://tickets.metabrainz.org/secure/Dashboard.jspa'}
+           )}
         </p>
       </div>
     </Layout>

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -70,10 +70,10 @@ const InstrumentList = ({
           )
           : null}
         <p>
-          {l('Is this list missing an instrument? Request it by going to the {link|ticket tracker}, creating a new issue and selecting the project type as "Instrument Requests (INST)"', 
+          {l('Is this list missing an instrument? Request it by following the instructions in {link|this documentation}.', 
             {
              __react: true,
-            link: 'https://tickets.metabrainz.org/secure/Dashboard.jspa'}
+            link: 'https://musicbrainz.org/doc/How_to_Add_Instruments'}
            )}
         </p>
       </div>

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -74,7 +74,7 @@ const InstrumentList = ({
           <a href="https://tickets.metabrainz.org/secure/Dashboard.jspa">
           {l(' ticket tracker, ')}
           </a> + 
-          {l('creating a new issue and selecting the project type as "Instrument Requests (INST)")}
+          {l('creating a new issue and selecting the project type as "Instrument Requests (INST)"')}
         </p>
       </div>
     </Layout>

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -70,7 +70,7 @@ const InstrumentList = ({
           )
           : null}
         <p>
-          {l('Is this list missing an instrument? Request it by following the instructions in {link|this documentation}.', 
+          {l('Is this list missing an instrument? Request it by following {link|these instructions}.', 
             {
              __react: true,
             link: 'https://musicbrainz.org/doc/How_to_Add_Instruments'}


### PR DESCRIPTION
Documentation on how to request a new instrument or a new genre is missing from https://musicbrainz.org/instruments and https://musicbrainz.org/genres. 
This PR has the addition of such documentation. 

https://tickets.metabrainz.org/browse/MBS-9900