### PR TITLE
MBS-9905: Tipeee Broken URL validation

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2025,7 +2025,7 @@ const CLEANUPS = {
       new RegExp("^(https?://)?(www\\.)?flattr\\.com/profile/[^/?#]", "i"),
       new RegExp("^(https?://)?(www\\.)?patreon\\.com/[^/?#]", "i"),
       new RegExp("^(https?://)?(www\\.)?paypal\\.me/[^/?#]", "i"),
-      new RegExp("^(https?://)?(www\\.)?tipeee\\.com/[^/?#]", "i"),
+      new RegExp("^(https?://)?(?:[^/]+\\.)?tipeee\\.com/[^/?#]", "i"),
       new RegExp("^(https?://)?(www\\.)?d\\.rip/[^/?#]", "i"),
       new RegExp("^(https?://)?(www\\.)?drip\\.kickstarter.com/[^/?#]", "i"),
     ],
@@ -2037,7 +2037,7 @@ const CLEANUPS = {
       url = url.replace(/^((?:https?:\/\/)?(?:www\.)?patreon\.com\/user)\/(?:community|posts)(\?u=.*)$/, "$1$2");
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?patreon\.com\/((?:user\?u=)?[^\/?&#]+)(?:.*)?$/, "https://www.patreon.com/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?paypal\.me\/([^\/?#]+)(?:.*)?$/, "https://www.paypal.me/$1");
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?tipeee\.com\/([^\/?#]+)(?:.*)?$/, "https://www.tipeee.com/$1");
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?tipeee\.com\/([^\/?#]+)(?:.*)?$/, "https://www.tipeee.com/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?d\.rip\/([^\/?#]+)(?:.*)?$/, "https://d.rip/$1");
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?drip\.kickstarter.com\/([^\/?#]+)(?:.*)?$/, "https://d.rip/$1");
       return url;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2818,6 +2818,12 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
             expected_relationship_type: 'patronage',
                     expected_clean_url: 'https://www.tipeee.com/example',
         },
+        {
+                             input_url: 'http://fr.tipeee.com/example/news',
+                     input_entity_type: 'artist',
+            expected_relationship_type: 'patronage',
+                    expected_clean_url: 'https://www.tipeee.com/example',
+        },
         // triple j Unearthed
         {
                              input_url: 'https://www.triplejunearthed.com/artist/sampa-great',


### PR DESCRIPTION
## [MBS-9905](https://tickets.metabrainz.org/browse/MBS-9905)
When inputting a Tipeee URL that begins with a language-related subdomain, i.e...

https://en.tipeee.com/borisdalstein

...the URL is not recognised as tipeee. This is the case with all 5 languages that the Tipeee website supports: **en**, **it**, **fr**, **de** & **es**.

An example of a _working_ URL would be:
https://www.tipeee.com/borisdalstein

----

![image](https://user-images.githubusercontent.com/16269580/48716564-8e3fa380-ec0f-11e8-8030-47237e2985eb.png)
