### PR TITLE
Small tweaks to PR #752 (MBS-9900)

### DIFF
--- a/root/genre/List.js
+++ b/root/genre/List.js
@@ -33,11 +33,10 @@ const GenreList = ({genres}: PropsT) => (
         ))}
       </ul>
       <p>
-        {l('Is a genre missing from the list? Request it by {link|adding a style ticket} with the "Genres" component', 
-            {
-             __react: true,
-            link: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!'}
-           )}
+        {l('Is a genre missing from the list? Request it by {link|adding a style ticket}.', {
+          __react: true,
+          link: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!&components=10699',
+        })}
       </p>
     </div>
   </Layout>

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -70,11 +70,10 @@ const InstrumentList = ({
           )
           : null}
         <p>
-          {l('Is this list missing an instrument? Request it by following {link|these instructions}.', 
-            {
-             __react: true,
-            link: 'https://musicbrainz.org/doc/How_to_Add_Instruments'}
-           )}
+          {l('Is this list missing an instrument? Request it by following {link|these instructions}.', {
+            __react: true,
+            link: '/doc/How_to_Add_Instruments',
+          })}
         </p>
       </div>
     </Layout>


### PR DESCRIPTION
I made a few small tweaks to the original PR:

 * In the STYLE ticket creation link, added `&components=10699` to auto-select the genres component and removed that instruction from the text. Also added punctuation at the end.
 * Switched the instrument /doc/ link to a relative one.
 * Fixed indentation/whitespace issues reported by eslint.