### PR TITLE
    MBS-8311: Annotation field in the release editor does not mention liscenses

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -328,6 +328,11 @@
     <p>
       [% l('The purpose of this field is to add information that usually doesn\'t fit into the strict structural data schema of MusicBrainz (be it due to technical limitations that may be addressed later, or because the information in itself has to be free-text).') %]
     </p>
+    <p>
+      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0 </a>) and as such, it should not contain text that you don't have the right to release under that license. 
+      While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
+      {url => "https://creativecommons.org/licenses/by-nc-sa/3.0/"}) %]
+    </p>
   </div>
 
   <div class="bubble" data-bind="bubble: $root.commentBubble">

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -329,7 +329,7 @@
       [% l('The purpose of this field is to add information that usually doesn\'t fit into the strict structural data schema of MusicBrainz (be it due to technical limitations that may be addressed later, or because the information in itself has to be free-text).') %]
     </p>
     <p>
-      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0</a>) and as such, it should not contain text that you don\'t have the right to release under that license. While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
+      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0</a>) and as such, it should not contain text that you don\'t have the right to release under that license. While you can quote a source to support a point you\'re making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
       {url => "https://creativecommons.org/licenses/by-nc-sa/3.0/"}) %]
     </p>
   </div>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -329,7 +329,7 @@
       [% l('The purpose of this field is to add information that usually doesn\'t fit into the strict structural data schema of MusicBrainz (be it due to technical limitations that may be addressed later, or because the information in itself has to be free-text).') %]
     </p>
     <p>
-      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0 </a>) and as such, it should not contain text that you don\'t have the right to release under that license. While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
+      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0</a>) and as such, it should not contain text that you don\'t have the right to release under that license. While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
       {url => "https://creativecommons.org/licenses/by-nc-sa/3.0/"}) %]
     </p>
   </div>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -329,8 +329,7 @@
       [% l('The purpose of this field is to add information that usually doesn\'t fit into the strict structural data schema of MusicBrainz (be it due to technical limitations that may be addressed later, or because the information in itself has to be free-text).') %]
     </p>
     <p>
-      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0 </a>) and as such, it should not contain text that you don't have the right to release under that license. 
-      While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
+      [% l('This annotation will be published under an open license (<a href="{url}" target="_blank">CC BY-NC-SA 3.0 </a>) and as such, it should not contain text that you don\'t have the right to release under that license. While you can quote a source to support a point you're making, you should never enter promotional texts or other artist or label-owned texts into the annotation.',
       {url => "https://creativecommons.org/licenses/by-nc-sa/3.0/"}) %]
     </p>
   </div>


### PR DESCRIPTION
This PR improves of the description of MusicBrainz annotation field in release editor to mention licenses.

https://tickets.metabrainz.org/browse/MBS-8311