### PR TITLE
MBS-9930: Disable CAA images on the homepage for Chrome-based browsers

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -9,7 +9,7 @@ BEGIN { extends 'Catalyst::Controller' }
 use DBDefs;
 use MusicBrainz::Server::Constants qw( $VARTIST_GID $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::SSL qw( ensure_ssl );
-use MusicBrainz::Server::Data::Utils qw( model_to_type );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json model_to_type );
 use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Replication ':replication_type';
 use aliased 'MusicBrainz::Server::Translation';
@@ -55,6 +55,7 @@ sub index : Path Args(0)
         component_props => {
             blogEntries => $c->model('Blog')->get_latest_entries,
             newestReleases => \@newest_releases,
+            withSafeBrowsing => boolean_to_json(($c->req->user_agent // '') =~ /Chrome/),
         },
     );
 }


### PR DESCRIPTION
## [MBS-9930](https://tickets.metabrainz.org/browse/MBS-9930)

Replace each cover art with a message explaining that issue [CAA-116](https://tickets.metabrainz.org/browse/CAA-116) is pending, for every browser with "Chrome" in the user agent string.

See the ticket for motivations.