### PR TITLE
MBS-3685: Report for releases where label name = artist name

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
@@ -1,0 +1,34 @@
+package MusicBrainz::Server::Report::ReleaseLabelSameArtist;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {
+    q{
+      SELECT DISTINCT
+        release.id AS release_id,
+        row_number() OVER (ORDER BY release.artist_credit, release.name)
+      FROM
+        release
+        INNER JOIN artist ON release.artist_credit=artist.id
+        INNER JOIN release_label ON release_label.release=release.id
+        INNER JOIN label ON release_label.label=label.id
+      WHERE
+        label.name=artist.name
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2018 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -68,6 +68,7 @@ use MusicBrainz::Server::PagedReport;
     ReleaseGroupsWithoutVACredit
     ReleaseGroupsWithoutVALink
     ReleasesInCAAWithCoverArtRelationships
+    ReleaseLabelSameArtist
     ReleasesToConvert
     ReleasesWithDownloadRelationships
     ReleasesWithNoMediums
@@ -143,6 +144,7 @@ use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;
 use MusicBrainz::Server::Report::ReleasesInCAAWithCoverArtRelationships;
+use MusicBrainz::Server::Report::ReleaseLabelSameArtist;
 use MusicBrainz::Server::Report::ReleasesToConvert;
 use MusicBrainz::Server::Report::ReleasesWithDownloadRelationships;
 use MusicBrainz::Server::Report::ReleasesWithNoMediums;

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -109,6 +109,7 @@
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVACredit') %]">[% l('Releases not credited to "Various Artists" but linked to VA') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVALink') %]">[% l('Releases credited to "Various Artists" but not linked to VA') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesMissingDiscIDs') %]">[% l('Releases missing disc IDs') %]</a></li>
+            <li><a href="[% c.uri_for_action('/report/show', 'ReleaseLabelSameArtist') %]">[% l('Releases with label the same as the artist') %]</a></li>
         </ul>
 
         <h2>[% l('Recordings') %]</h2>

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -109,7 +109,7 @@
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVACredit') %]">[% l('Releases not credited to "Various Artists" but linked to VA') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesWithoutVALink') %]">[% l('Releases credited to "Various Artists" but not linked to VA') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'ReleasesMissingDiscIDs') %]">[% l('Releases missing disc IDs') %]</a></li>
-            <li><a href="[% c.uri_for_action('/report/show', 'ReleaseLabelSameArtist') %]">[% l('Releases with label the same as the artist') %]</a></li>
+            <li><a href="[% c.uri_for_action('/report/show', 'ReleaseLabelSameArtist') %]">[% l('Releases where artist name and label name are the same') %]</a></li>
         </ul>
 
         <h2>[% l('Recordings') %]</h2>

--- a/root/report/release_label_same_artist.tt
+++ b/root/report/release_label_same_artist.tt
@@ -1,10 +1,11 @@
-[%- WRAPPER 'layout.tt' title=l('Releases with label the same as the artist') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Releases where artist name and label name are the same') full_width=1 -%]
 
-<h1>[% l('Releases with label the same as the artist') %]</h1>
+<h1>[% l('Releases where artist name and label name are the same') %]</h1>
 
 <ul>
-    <li>[% l('This report lists releases that have their label set to be the same
-              as their artist.') %]</li>
+    <li>[% l('This report lists releases where the label name is the same as the artist name.
+              Often this means the release is self-released, and the label {SpecialPurposeLabel|should be "[no label]" instead}.',
+            { SpecialPurposeLabel => '/doc/Style/Unknown_and_untitled/Special_purpose_label' }) %]</li>
     <li>[% l('Total releases found: {count}', { count => pager.total_entries }) %]</li>
     <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
     [%- INCLUDE 'report/filter_link.tt' -%]

--- a/root/report/release_label_same_artist.tt
+++ b/root/report/release_label_same_artist.tt
@@ -1,0 +1,15 @@
+[%- WRAPPER 'layout.tt' title=l('Releases with label the same as the artist') full_width=1 -%]
+
+<h1>[% l('Releases with label the same as the artist') %]</h1>
+
+<ul>
+    <li>[% l('This report lists releases that have their label set to be the same
+              as their artist.') %]</li>
+    <li>[% l('Total releases found: {count}', { count => pager.total_entries }) %]</li>
+    <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
+    [%- INCLUDE 'report/filter_link.tt' -%]
+</ul>
+
+[%- INCLUDE 'report/release_list.tt' -%]
+
+[%- END -%]


### PR DESCRIPTION
## [MBS-3685](https://tickets.metabrainz.org/browse/MBS-3685): Report: releases with label name = artist name
This commit adds support for a new daily report, which shows all releases which have label names that are identical to their artist names.

If "ReleaseLabelSameArtist" is too ambiguous, please don't hesitate to suggest an alternative name.

https://tickets.metabrainz.org/browse/MBS-3685