### PR TITLE
MBS-9907: Report for places without coordinates

### DIFF
--- a/lib/MusicBrainz/Server/Report/PlaceReport.pm
+++ b/lib/MusicBrainz/Server/Report/PlaceReport.pm
@@ -13,6 +13,8 @@ around inflate_rows => sub {
         map { $_->{place_id} } @$items
     );
 
+    $self->c->model('Area')->load(values %$places);
+
     return [
         map +{
             %$_,

--- a/lib/MusicBrainz/Server/Report/PlacesWithoutCoordinates.pm
+++ b/lib/MusicBrainz/Server/Report/PlacesWithoutCoordinates.pm
@@ -1,0 +1,28 @@
+package MusicBrainz::Server::Report::PlacesWithoutCoordinates;
+use Moose;
+
+with 'MusicBrainz::Server::Report::PlaceReport';
+
+sub query {
+    q{
+      SELECT DISTINCT
+        id AS place_id,
+        row_number() OVER (ORDER BY name, last_updated)
+      FROM place
+      WHERE coordinates IS NULL
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2018 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -58,6 +58,7 @@ use MusicBrainz::Server::PagedReport;
     NoLanguage
     NoScript
     PartOfSetRelationships
+    PlacesWithoutCoordinates
     PossibleCollaborations
     RecordingsWithoutVACredit
     RecordingsWithoutVALink
@@ -133,6 +134,7 @@ use MusicBrainz::Server::Report::MultipleDiscogsLinks;
 use MusicBrainz::Server::Report::NoLanguage;
 use MusicBrainz::Server::Report::NoScript;
 use MusicBrainz::Server::Report::PartOfSetRelationships;
+use MusicBrainz::Server::Report::PlacesWithoutCoordinates;
 use MusicBrainz::Server::Report::PossibleCollaborations;
 use MusicBrainz::Server::Report::RecordingsWithoutVACredit;
 use MusicBrainz::Server::Report::RecordingsWithoutVALink;

--- a/root/report/index.tt
+++ b/root/report/index.tt
@@ -131,6 +131,7 @@
         <ul>
             <li><a href="[% c.uri_for_action('/report/show', 'DeprecatedRelationshipPlaces') %]">[% l('Places with deprecated relationships') %]</a></li>
             <li><a href="[% c.uri_for_action('/report/show', 'AnnotationsPlaces') %]">[% l('Places with annotations') %]</a></li>
+            <li><a href="[% c.uri_for_action('/report/show', 'PlacesWithoutCoordinates') %]">[% l('Places without coordinates') %]</a></li>
         </ul>
 
         <h2>[% l('Series') %]</h2>

--- a/root/report/places_without_coordinates.tt
+++ b/root/report/places_without_coordinates.tt
@@ -9,9 +9,11 @@
     <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
 </ul>
 
-[% BLOCK extra_header_end %]<th>[% l('Address') %]</th><th>[% l('Area') %]</th>[% END %]
+[% BLOCK extra_header_end %]<th>[% l('Address') %]</th><th>[% l('Area') %]</th><th style="width:5em">[% l('Find') %]</th>[% END %]
 [% BLOCK extra_row_end %]
-<td>[% item.place.address %]</td><td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>
+  <td>[% item.place.address %]</td>
+  <td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>
+  <td><input type="button" onclick="window.open('https://www.openstreetmap.org/search?query=[% uri_escape(item.place.name _ ' ' _ item.place.address _ ' ' _ item.place.area.name) %]', '_blank')" value="Search"></td>
 [% END %]
 [%- INCLUDE 'report/place_list.tt' -%]
 

--- a/root/report/places_without_coordinates.tt
+++ b/root/report/places_without_coordinates.tt
@@ -1,0 +1,18 @@
+[%- WRAPPER 'layout.tt' title=l('Places without coordinates') full_width=1 -%]
+
+<h1>[% l('Places without coordinates') %]</h1>
+
+<ul>
+    <li>[% l('This report lists places without coordinates.') -%]
+    </li>
+    <li>[% l('Total places found: {count}', { count => pager.total_entries }) %]</li>
+    <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
+</ul>
+
+[% BLOCK extra_header_end %]<th>[% l('Address') %]</th><th>[% l('Area') %]</th>[% END %]
+[% BLOCK extra_row_end %]
+<td>[% item.place.address %]</td><td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>
+[% END %]
+[%- INCLUDE 'report/place_list.tt' -%]
+
+[%- END -%]


### PR DESCRIPTION
## [MBS-9907](https://tickets.metabrainz.org/browse/MBS-9907): New report: Places without coordinates
This commit adds support for a new daily report, which shows all the places which haven't been assigned coordinates.

https://tickets.metabrainz.org/browse/MBS-9907

I originally did this with an "annotation" column, but seeing as the number of entries with annotations is relatively low, it seemed more of an inconvenience.

The final result looks as follows:

![image](https://user-images.githubusercontent.com/16269580/49371165-7d526000-f6ee-11e8-9434-eb87fac5b88f.png)
