### PR TITLE
Improve Label Report from #760

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
@@ -8,6 +8,8 @@ sub query {
     q{
       SELECT DISTINCT
         r.id AS release_id,
+        l.name AS label_name,
+        l.gid AS label_gid,
         row_number() OVER (ORDER BY r.artist_credit, r.name)
       FROM
         release AS r

--- a/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseLabelSameArtist.pm
@@ -7,15 +7,18 @@ with 'MusicBrainz::Server::Report::ReleaseReport',
 sub query {
     q{
       SELECT DISTINCT
-        release.id AS release_id,
-        row_number() OVER (ORDER BY release.artist_credit, release.name)
+        r.id AS release_id,
+        row_number() OVER (ORDER BY r.artist_credit, r.name)
       FROM
-        release
-        INNER JOIN artist ON release.artist_credit=artist.id
-        INNER JOIN release_label ON release_label.release=release.id
-        INNER JOIN label ON release_label.label=label.id
+        release AS r
+        INNER JOIN artist AS a ON a.id = r.artist_credit
+        INNER JOIN artist_credit_name AS acn ON acn.artist_credit = r.artist_credit
+        INNER JOIN release_label AS rl ON rl.release=r.id
+        INNER JOIN label AS l ON rl.label=l.id
       WHERE
-        label.name=artist.name
+        l.name = acn.name
+      OR
+        l.name = a.name
     }
 }
 

--- a/root/report/release_label_same_artist.tt
+++ b/root/report/release_label_same_artist.tt
@@ -11,6 +11,8 @@
     [%- INCLUDE 'report/filter_link.tt' -%]
 </ul>
 
+[% BLOCK extra_header_end %]<th>[% l('Label') %]</th>[% END %]
+[% BLOCK extra_row_end %]<td><a href="[% c.uri_for('/label/' _ item.label_gid) %]">[% item.label_name %]</a></td>[% END %]
 [%- INCLUDE 'report/release_list.tt' -%]
 
 [%- END -%]


### PR DESCRIPTION
This continues on the work from #760.

In [MBS-3685](https://tickets.metabrainz.org/browse/MBS-3685), a new report page was created for artists which have the same label name as artist name. However, this did not include featured artists. This PR compares the artist names from **artist_credit_name** instead of just **artist_credit**,  which means that all featured artists will also be checked.
For example, a release like...
https://musicbrainz.org/release/14bfe5a4-ae36-4642-9ed3-fdadfe83f2e5 
... is now identified.

Before, there were 2964 entities found in the report, but now there are 7026.