### PR TITLE
MBS-9941: Load more gettext domains on edit pages

### DIFF
--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -81,6 +81,8 @@ sub GIT_SHA { return }
 
 sub HTML_VALIDATOR { 'http://html5-validator:8888?out=json' }
 
+sub MB_LANGUAGES { qw( de el-gr es-es et fi fr it ja nl en ) }
+
 sub PLUGIN_CACHE_OPTIONS {
     my $self = shift;
     return {

--- a/docker/musicbrainz-tests/run_tests.sh
+++ b/docker/musicbrainz-tests/run_tests.sh
@@ -4,6 +4,9 @@ source /etc/mbs_constants.sh
 
 cd "$MBS_ROOT"
 
+carton exec -- \
+    perl -Ilib /usr/local/bin/install_language_packs.pl
+
 while true; do
     chpst -u musicbrainz:musicbrainz \
         carton exec -- ./script/database_exists SYSTEM > /dev/null 2>&1

--- a/docker/templates/Dockerfile.tests.m4
+++ b/docker/templates/Dockerfile.tests.m4
@@ -2,6 +2,8 @@ m4_include(`server_base.m4')m4_dnl
 
 install_javascript_and_templates()
 
+install_translations()
+
 RUN apt_install(`build-essential libexpat1 libexpat1-dev libxml2 libxml2-dev') && \
     cpanm TAP::Harness::JUnit && \
     apt_purge(`libexpat1-dev libxml2-dev')
@@ -50,7 +52,7 @@ copy_mb(`docker/musicbrainz-tests/DBDefs.pm lib/')
 # Depends on DBDefs.pm.
 RUN sudo_mb(`carton exec -- ./script/compile_resources.sh')
 
-copy_mb(`docker/musicbrainz-tests/run_tests.sh /usr/local/bin/')
+copy_mb(`docker/musicbrainz-tests/run_tests.sh docker/musicbrainz-website/install_language_packs.pl /usr/local/bin/')
 copy_mb(`flow-typed/ flow-typed/')
 copy_mb(`script/ script/')
 copy_mb(`t/ t/')

--- a/root/account/edit.tt
+++ b/root/account/edit.tt
@@ -1,4 +1,4 @@
-[% WRAPPER "user/profile/layout.tt" page="edit_profile" title=l("Edit Profile") %]
+[% WRAPPER "user/profile/layout.tt" page="edit_profile" title=l("Edit Profile") gettext_domains=['attributes', 'countries', 'languages'] %]
     [% script_manifest('edit.js') %]
 
     <h2>[% l("Edit Profile") %]</h2>

--- a/root/area/create.tt
+++ b/root/area/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Area') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Area') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Area') -%]</h1>
         [%- INCLUDE "area/edit_form.tt" -%]

--- a/root/artist/create.tt
+++ b/root/artist/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Artist') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Artist') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Artist') -%]</h1>
         [%- INCLUDE 'artist/edit_form.tt' -%]

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -80,7 +80,7 @@
 <script type="text/html" id="template.dialog-target-entity">
   <tr>
     <td class="section">
-      <select data-bind="disable: disableTypeSelection, value: targetType, options: targetTypeOptions(), optionsValue: 'value', optionsText: 'text'"></select>
+      <select class="entity-type" data-bind="disable: disableTypeSelection, value: targetType, options: targetTypeOptions(), optionsValue: 'value', optionsText: 'text'"></select>
     </td>
     <td>
       <span class="autocomplete">

--- a/root/entity/edit.tt
+++ b/root/entity/edit.tt
@@ -1,3 +1,3 @@
-[%- WRAPPER "$entity_type/layout.tt" title=l('Edit') full_width=1 page='edit' gettext_domains=['attributes'] -%]
+[%- WRAPPER "$entity_type/layout.tt" title=l('Edit') full_width=1 page='edit' gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     [%- INCLUDE "$entity_type/edit_form.tt" -%]
 [%- END -%]

--- a/root/event/create.tt
+++ b/root/event/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Event') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Event') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Event') -%]</h1>
         [%- INCLUDE 'event/edit_form.tt' -%]

--- a/root/forms/dialog.tt
+++ b/root/forms/dialog.tt
@@ -9,10 +9,7 @@
     </head>
   [% ELSE %]
     [%- IF !gettext_domains;
-          SET gettext_domains = [];
-        END;
-        IF dialog_template == "work/edit_form.tt";
-          gettext_domains.push('attributes');
+          SET gettext_domains = ['attributes', 'countries', 'languages', 'relationships'];
         END;
         React.embed(c, 'layout/components/Head', {
             canonical_url => canonical_url,

--- a/root/instrument/create.tt
+++ b/root/instrument/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Instrument') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Instrument') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Instrument') -%]</h1>
         [%- INCLUDE 'instrument/edit_form.tt' new=1 -%]

--- a/root/label/create.tt
+++ b/root/label/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Label') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Label') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Label') -%]</h1>
         [%- INCLUDE 'label/edit_form.tt' -%]

--- a/root/place/create.tt
+++ b/root/place/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Place') full_width=1 -%]
+[%- WRAPPER 'layout.tt' title=l('Add Place') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Place') -%]</h1>
         [%- INCLUDE 'place/edit_form.tt' -%]

--- a/root/recording/create.tt
+++ b/root/recording/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=lp('Add Standalone Recording', 'header') full_width=1 %]
+[% WRAPPER 'layout.tt' title=lp('Add Standalone Recording', 'header') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] %]
     <div id="content">
         <h1>[%- lp('Add Standalone Recording', 'header') -%]</h1>
         [% INCLUDE 'recording/edit_form.tt' %]

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) -%]
+[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     [% script_manifest('edit.js') %]
 
     [% PROCESS 'components/relationship-editor.tt' %]

--- a/root/release_group/create.tt
+++ b/root/release_group/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=l('Add Release Group') full_width=1 %]
+[% WRAPPER 'layout.tt' title=l('Add Release Group') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] %]
     <div id="content">
         <h1>[%- lp('Add Release Group', 'header') -%]</h1>
         [%~ javascript_required() ~%]

--- a/root/series/create.tt
+++ b/root/series/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Series') full_width=1 gettext_domains=['attributes'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Series') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
     <div id="content">
         <h1>[%- l('Add Series') -%]</h1>
         [%- INCLUDE 'series/edit_form.tt' new=1 -%]

--- a/root/work/create.tt
+++ b/root/work/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=lp('Add Work', 'header') full_width=1 gettext_domains=['attributes'] %]
+[% WRAPPER 'layout.tt' title=lp('Add Work', 'header') full_width=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] %]
    <h1>[%- lp('Add Work', 'header') -%]</h1>
 
    [% INCLUDE 'work/edit_form.tt' %]

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -411,6 +411,7 @@ const seleniumTests = [
   {name: 'Create_Account.html'},
   {name: 'MBS-7456.html', login: true},
   {name: 'MBS-9548.html'},
+  {name: 'MBS-9941.html', login: true},
   {name: 'Artist_Credit_Editor.html', login: true},
   {name: 'External_Links_Editor.html', login: true, timeout: 90000},
   {name: 'Work_Editor.html', login: true},

--- a/t/selenium/MBS-9941.html
+++ b/t/selenium/MBS-9941.html
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost:5000" />
+<title>MBS-9941</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">MBS-9941</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/set-language/de</td>
+	<td></td>
+</tr>
+<tr>
+	<td>open</td>
+	<td>/artist/create</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=id-edit-artist.area.name</td>
+	<td>France</td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>1000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>xpath=//li[contains(@class, 'ui-menu-item')][contains(., 'direkten Suche')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>1000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>xpath=//li[contains(@class, 'ui-menu-item')][contains(., 'France')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=area-bubble</td>
+	<td>Du hast Frankreich ausgewählt.</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>xpath=//button[contains(text(), 'Beziehung hinzufügen')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>css=select.entity-type</td>
+	<td>label=Werk</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>css=#dialog input.name</td>
+	<td>Starman</td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>1000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>xpath=//li[contains(@class, 'ui-menu-item')][contains(., 'direkten Suche')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>1000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>xpath=//li[contains(@class, 'ui-menu-item')][contains(., 'Starman')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#dialog button.positive</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>document.querySelector('.relationship-list a').textContent</td>
+	<td>Starman</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>document.querySelector('.relationship-list a').href</td>
+	<td>http://localhost:5000/work/4491f749-d06a-348c-aa58-a288d2eafa5f</td>
+</tr>
+<tr>
+	<td>open</td>
+	<td>/set-language/en</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -140,6 +140,7 @@ INSERT INTO l_release_url (id, link, entity0, entity1, edits_pending, last_updat
     (2036111, 6330, 2154808, 4948549, 0, '2018-04-11 10:09:59.527876+00', 0, '', '');
 
 INSERT INTO work (id, gid, name, type, comment, edits_pending, last_updated) VALUES
+    (346907, '4491f749-d06a-348c-aa58-a288d2eafa5f', 'Starman', 17, '', 0, '2017-04-01 20:00:18.388559+00'),
     (12610030, '69cd3461-089e-4138-adc2-f3a1907a5013', 'The Night Is Over', 17, '', 0, '2013-04-17 11:06:22.012835+00');
 
 INSERT INTO work_gid_redirect (gid, new_id, created) VALUES


### PR DESCRIPTION
This fixes the inline search for works in the relationship editor, and the area selection bubbles, when using a non-English translation.

The attributes domain isn't currently needed, AFAICT, but it will be once we fix all the untranslated strings in Autocomplete.js.