### PR TITLE
MBS-9402: fix multilang display on work merge/sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Work/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Merge.pm
@@ -37,6 +37,7 @@ before build_display_data => sub {
     $self->c->model('Work')->load_recording_artists(@works);
     $self->c->model('WorkAttribute')->load_for_works(@works);
     $self->c->model('ISWC')->load_for_works(grep { $_->all_iswcs == 0 } @works);
+    $self->c->model('Language')->load_for_works(@works);
 };
 
 __PACKAGE__->meta->make_immutable;

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 import LinkSearchableLanguage from '../../../components/LinkSearchableLanguage';
 import {withCatalystContext} from '../../../context';
 import CodeLink from '../../../static/scripts/common/components/CodeLink';
+import commaOnlyList from '../../../static/scripts/common/i18n/commaOnlyList';
 import CommonsImage from '../../../static/scripts/common/components/CommonsImage';
 import {addColon, l} from '../../../static/scripts/common/i18n';
 import {lp_attributes} from '../../../static/scripts/common/i18n/attributes';
@@ -61,13 +62,16 @@ const WorkSidebar = ({$c, work}: Props) => {
 
             {languages.length ? (
               <SidebarProperty className="lyrics-language" label={addColon(l('Lyrics Languages'))}>
-                {languages.map((wl, index) => (
-                  <LinkSearchableLanguage
-                    entityType="work"
-                    key={wl.language.id}
-                    language={wl.language}
-                  />
-                ))}
+                {commaOnlyList(
+                  languages.map((wl, index) => (
+                    <LinkSearchableLanguage
+                      entityType="work"
+                      key={wl.language.id}
+                      language={wl.language}
+                    />
+                  )),
+                  {react: true},
+                )}
               </SidebarProperty>
             ) : null}
 

--- a/root/work/merge.tt
+++ b/root/work/merge.tt
@@ -52,7 +52,13 @@
                       </ul>
                     </td>
                     <td>[% entity.l_type_name %]</td>
-                    <td><abbr title="[% entity.language.l_name %]">[% entity.language.iso_code_3 %]</abbr></td>
+                    <td>
+                      <ul>
+                        [% FOR language=entity.languages %]
+                        <li><abbr title="[% language.language.l_name | html %]">[% language.language.iso_code_3 %]</abbr></li>
+                        [% END %]
+                      </ul>
+                    </td>
                     <td>
                       [% work_attributes_list(entity) %]
                     </td>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9402

Work search was fixed while moving it to React, but work merge (which is still TT) was still broken, and the work merge edit wasn't loading works in the first place. 

Additionally fixed the sidebar to show "English, Japanese" rather than "EnglishJapanese".