### PR TITLE
MBS-9872: change leftover bracketed macro calls to bracketedWithSpace

### DIFF
--- a/root/edit/details/add_remove_alias.tt
+++ b/root/edit/details/add_remove_alias.tt
@@ -4,7 +4,7 @@
         <td>
             [%~ descriptive_link(edit.display_data.${edit.display_data.entity_type}) ~%]
             [%~ IF entity_exists(edit.display_data.${edit.display_data.entity_type}) ~%]
-                [%~ bracketed(link_entity(edit.display_data.${edit.display_data.entity_type}, 'aliases', l('view all aliases'))) ~%]
+                [%~ bracketedWithSpace(link_entity(edit.display_data.${edit.display_data.entity_type}, 'aliases', l('view all aliases'))) ~%]
             [%~ END ~%]
         </td>
     </tr>

--- a/root/edit/details/edit_alias.tt
+++ b/root/edit/details/edit_alias.tt
@@ -8,7 +8,7 @@
         <th>[%~ entity_label(edit.display_data.entity_type) ~%]</th>
         <td colspan="2">
             [%~ descriptive_link(edit.display_data.${edit.display_data.entity_type}) ~%]
-            [%~ bracketed(link_entity(edit.display_data.${edit.display_data.entity_type}, 'aliases', l('view all aliases')))
+            [%~ bracketedWithSpace(link_entity(edit.display_data.${edit.display_data.entity_type}, 'aliases', l('view all aliases')))
                 IF entity_exists(edit.display_data.${edit.display_data.entity_type}) ~%]
         </td>
     </tr>
@@ -21,7 +21,7 @@
                 <span class='deleted'>[%~ l('[removed]') ~%]</span>
             [%~ ELSE ~%]
                 [%~ isolate_text(edit.alias.name) =%]
-                [%~ bracketed(edit.alias.primary_for_locale ?
+                [%~ bracketedWithSpace(edit.alias.primary_for_locale ?
                         l('primary for {locale}', { locale => show_locale(edit.alias.locale) }) :
                         show_locale(edit.alias.locale)) ~%]
             [%~ END ~%]

--- a/root/edit/details/macros.tt
+++ b/root/edit/details/macros.tt
@@ -58,7 +58,7 @@
      ELSIF !relationship.link.end_date.is_empty;
        l('until {date}', { date => relationship.link.end_date.format });
      ELSIF relationship.link.ended;
-       bracketed(l('ended'));
+       bracketedWithSpace(l('ended'));
      END;
    END; -%]
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9872

The rename in https://github.com/metabrainz/musicbrainz-server/commit/5cb19e7248bc838d5124559fa36d1d39b67413ef left three files using "bracketed" behind, which broke the ended flag (as reported) plus some alias edit displays.