### PR TITLE
MBS-9831: Add Bandcamp to the Lyrics Whitelist

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1108,13 +1108,13 @@ const CLEANUPS = {
   },
   bandcamp: {
     match: [new RegExp("^(https?://)?([^/]+)\\.bandcamp\\.com","i")],
-    type: _.defaults({}, LINK_TYPES.bandcamp, LINK_TYPES.review),
+    type: _.defaults({}, LINK_TYPES.bandcamp, LINK_TYPES.review, {work: LINK_TYPES.lyrics.work}),
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com([\/?#].*)?$/, "https://$1.bandcamp.com$2");
+      url = url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com(?:\/([^?#]*))?.*$/, "https://$1.bandcamp.com/$2");
       if (/^https:\/\/daily\.bandcamp\.com/.test(url)) {
-        url = url.replace(/^(?:https?:\/\/)?daily\.bandcamp\.com\/(\d+\/\d+\/\d+\/[\w-]+)(?:[\/?#].*)?$/, "https://daily.bandcamp.com/$1/");
+        url = url.replace(/^https:\/\/daily\.bandcamp\.com\/(\d+\/\d+\/\d+\/[\w-]+)(?:\/.*)?$/, "https://daily.bandcamp.com/$1/");
       } else {
-        url = url.replace(/^(?:https?:\/\/)?([^\/]+)\.bandcamp\.com(?:\/(((album|track)\/([^\/\?]+)))?)?.*$/, "https://$1.bandcamp.com/$2");
+        url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|track)\/[^\/]+))?.*$/, "https://$1.bandcamp.com/$2");
       }
       return url;
     },
@@ -1125,6 +1125,8 @@ const CLEANUPS = {
           return /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url);
         case LINK_TYPES.review.release_group:
           return /^https:\/\/daily\.bandcamp\.com\/\d+\/\d+\/\d+\/[\w-]+-review\/$/.test(url);
+        case LINK_TYPES.lyrics.work:
+          return /^https:\/\/[^\/]+\.bandcamp\.com\/track\/[\w-]+$/.test(url);
       }
       return false;
     }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -401,6 +401,13 @@ const {LINK_TYPES, cleanURL, guessType, validationRules} = require('../../edit/U
                     expected_clean_url: 'https://daily.bandcamp.com/2018/05/30/gnawa-bandcamp-list/',
                only_valid_entity_types: []
         },
+        {
+                             input_url: 'https://davidmandelberg.bandcamp.com/track/maybe-it-s#lyrics',
+                     input_entity_type: 'work',
+            expected_relationship_type: 'lyrics',
+                    expected_clean_url: 'https://davidmandelberg.bandcamp.com/track/maybe-it-s',
+               only_valid_entity_types: ['work']
+        },
         // Bandsintown
         {
                              input_url: "https://m.bandsintown.com/MattDobberteen's50thBirthday?came_from=178",


### PR DESCRIPTION
## [MBS-9831](https://tickets.metabrainz.org/browse/MBS-9831): Add bandcamp.com to lyrics site whitelist

Add auto-select, clean-up, and validation for linking lyrics from Bandcamp track to work.
Add test.