### PR TITLE
MBS-9340: Improve lyrics language selector

### DIFF
--- a/root/components/FormRowSelectList.js
+++ b/root/components/FormRowSelectList.js
@@ -19,6 +19,7 @@ type Props<S> = {|
   +addId: string,
   +addLabel: string,
   +getSelectField: (S) => FieldT<number | string>,
+  +hideAddButton?: boolean,
   +label: string,
   +onAdd: (event: SyntheticEvent<HTMLButtonElement>) => void,
   +onEdit: (index: number, value: string) => void,
@@ -33,6 +34,7 @@ const FormRowSelectList = <F, S: AnyFieldT<F>>({
   addId,
   addLabel,
   getSelectField,
+  hideAddButton,
   label,
   onAdd,
   onEdit,
@@ -62,16 +64,18 @@ const FormRowSelectList = <F, S: AnyFieldT<F>>({
           <FieldErrors field={getSelectField(subfield)} />
         </div>
       ))}
-      <div className="form-row-add">
-        <button
-          className="with-label add-item"
-          id={addId}
-          onClick={onAdd}
-          type="button"
-        >
-          {addLabel}
-        </button>
-      </div>
+      {hideAddButton ? null : (
+        <div className="form-row-add">
+          <button
+            className="with-label add-item"
+            id={addId}
+            onClick={onAdd}
+            type="button"
+          >
+            {addLabel}
+          </button>
+        </div>
+      )}
     </div>
   </FormRow>
 );

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -286,6 +286,7 @@ function renderWorkLanguages() {
       addId="add-language"
       addLabel={l('Add Language')}
       getSelectField={_.identity}
+      hideAddButton={_.intersection(form.field.languages.field.map(lang => String(lang.value)), ["486", "284"]).length > 0}
       label={l('Lyrics Languages')}
       onAdd={addLanguage}
       onEdit={editLanguage}

--- a/t/selenium/Work_Editor.html
+++ b/t/selenium/Work_Editor.html
@@ -44,6 +44,16 @@
 	<td>label=[No lyrics]</td>
 </tr>
 <tr>
+	<td>assertEval</td>
+	<td>!!window.document.getElementById('add-language')</td>
+	<td>false</td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>name=edit-work.languages.0</td>
+	<td>label=French</td>
+</tr>
+<tr>
 	<td>click</td>
 	<td>css=#add-language</td>
 	<td></td>


### PR DESCRIPTION
## [MBS-9340](https://tickets.metabrainz.org/browse/MBS-9340): Don't allow more languages if [No lyrics] is selected
At the moment, the user can select both "No lyrics", and other languages when editing works' lyrics. This PR aims to prevent this.