### PR TITLE
Improvements to PR #762 (MBS-9907)

### DIFF
--- a/root/report/places_without_coordinates.tt
+++ b/root/report/places_without_coordinates.tt
@@ -13,7 +13,17 @@
 [% BLOCK extra_row_end %]
   <td>[% item.place.address %]</td>
   <td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>
-  <td><input type="button" onclick="window.open('https://www.openstreetmap.org/search?query=[% uri_escape(item.place.name _ ' ' _ item.place.address _ ' ' _ item.place.area.name) %]', '_blank')" value="Search"></td>
+  <td class="search-links">
+      <span class="no-favicon"><a
+            href="https://www.openstreetmap.org/search?query=[%
+                uri_escape(item.place.name
+                   _ ' ' _ item.place.address
+                   _ ' ' _ item.place.area.name) %]"
+            target="_blank"
+            title="OpenStreetMap">
+        OSM
+      </a></span>
+  </td>
 [% END %]
 [%- INCLUDE 'report/place_list.tt' -%]
 

--- a/root/report/places_without_coordinates.tt
+++ b/root/report/places_without_coordinates.tt
@@ -9,7 +9,7 @@
     <li>[% l('Generated on {date}', { date => UserDate.format(generated) }) %]</li>
 </ul>
 
-[% BLOCK extra_header_end %]<th>[% l('Address') %]</th><th>[% l('Area') %]</th><th style="width:5em">[% l('Find') %]</th>[% END %]
+[% BLOCK extra_header_end %]<th>[% l('Address') %]</th><th>[% l('Area') %]</th><th>[% l('Search for coordinates') %]</th>[% END %]
 [% BLOCK extra_row_end %]
   <td>[% item.place.address %]</td>
   <td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>

--- a/root/report/places_without_coordinates.tt
+++ b/root/report/places_without_coordinates.tt
@@ -14,14 +14,35 @@
   <td>[% item.place.address %]</td>
   <td>[% IF item.place.area %][% descriptive_link(item.place.area) %][% END %]</td>
   <td class="search-links">
+      [% q = uri_escape(item.place.name
+                _ ' ' _ item.place.address
+                _ ' ' _ item.place.area.name) %]
       <span class="no-favicon"><a
-            href="https://www.openstreetmap.org/search?query=[%
-                uri_escape(item.place.name
-                   _ ' ' _ item.place.address
-                   _ ' ' _ item.place.area.name) %]"
+            href="https://www.openstreetmap.org/search?query=[% q %]"
             target="_blank"
             title="OpenStreetMap">
         OSM
+      </a></span>
+      |
+      <span><a
+            href="https://www.qwant.com/local/?q=[% q %]"
+            target="_blank"
+            title="Qwant Local">
+        QL
+      </a></span>
+      |
+      <span><a
+            href="https://www.mapquest.com/search/results/?query=[% q %]"
+            target="_blank"
+            title="MapQuest">
+        MQ
+      </a></span>
+      |
+      <span><a
+            href="https://www.google.com/maps/search/[% q %]"
+            target="_blank"
+            title="Google Maps">
+        GM
       </a></span>
   </td>
 [% END %]

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -400,7 +400,7 @@ div.warning img.warning {
     word-break: break-all;
 }
 
-#sidebar ul.external_links li {
+#sidebar ul.external_links li, td.search-links span.no-favicon {
     background-position: 0 2px;
     background-repeat: no-repeat;
     margin-bottom: 2px;


### PR DESCRIPTION
### Improve PR #762 on [MBS-9907](https://tickets.metabrainz.org/browse/MBS-9907): New report: Places without coordinates

As requested in comment to this ticket, link to Google Maps to search for place's coordinates.
Plus, link to MapQuest and Qwant Maps ([open source](https://github.com/QwantResearch/qwantmaps)) which both use OpenStreetMap data.
Finally, make small UI changes, displaying _external link_ favicon ahead of this set of links.
