### PR TITLE
MBS-8915: Allow editors to choose delimiter in track parser

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -77,6 +77,8 @@
         <label data-bind="visible: useCustomDelimiter">
           [%= l('Custom delimiter') %]
           <input type="text" name="custom-delimiter" data-bind="value: customDelimiter" />
+          (<a href="#" data-bind="click: toggleDelimiterHelp">[% l('help') %]</a>)
+          <div data-bind="visible: delimiterHelpVisible"><i>Enter the delimiter that separates the track name from the artist name (i.e. "," or "\t").</i></div>
         </label>
       </td>
     <tr>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -24,6 +24,12 @@
           [%= l('Use track numbers') %]
         </label>
       </td>
+      <td>
+        <label>
+          [%= l('Custom time delimiter') %]
+          <input type="text" name="time-delimiter" data-bind="value: timeDelimiter" />
+        </label>
+      </td>
     </tr>
     <tr>
       <td style="padding-left: 2em">

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -24,12 +24,6 @@
           [%= l('Use track numbers') %]
         </label>
       </td>
-      <td>
-        <label>
-          [%= l('Custom time delimiter') %]
-          <input type="text" name="time-delimiter" data-bind="value: timeDelimiter" />
-        </label>
-      </td>
     </tr>
     <tr>
       <td style="padding-left: 2em">
@@ -72,6 +66,20 @@
         </label>
       </td>
     </tr>
+    <tr>
+    <td>
+      <label>
+      <input type="checkbox" name="use-custom-delimiter" data-bind="checked: useCustomDelimiter" />
+        [%= l('Use custom artist delimeter') %]
+      </label>
+    </td>
+      <td>
+        <label data-bind="visible: useCustomDelimiter">
+          [%= l('Custom delimiter') %]
+          <input type="text" name="custom-delimiter" data-bind="value: customDelimiter" />
+        </label>
+      </td>
+    <tr>
   </table>
 </script>
 

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -78,7 +78,7 @@
           [%= l('Custom delimiter') %]
           <input type="text" name="custom-delimiter" data-bind="value: customDelimiter" />
           (<a href="#" data-bind="click: toggleDelimiterHelp">[% l('help') %]</a>)
-          <div data-bind="visible: delimiterHelpVisible"><i>Enter the delimiter that separates the track name from the artist name (i.e. "," or "\t").</i></div>
+          <div data-bind="visible: delimiterHelpVisible"><i>{l('Enter the delimiter that separates the track name from the artist name (i.e. "," or "\t").')}</i></div>
         </label>
       </td>
     <tr>

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -39,7 +39,8 @@ releaseEditor.trackParser = {
         hasTrackNumbers: optionCookie("trackparser_tracknumbers", true),
         hasTrackArtists: optionCookie("trackparser_trackartists", true),
         hasVinylNumbers: optionCookie("trackparser_vinylnumbers", false),
-        timeDelimiter: optionCookie("trackparser_timeDelimiter", "", false),
+        customDelimiter: optionCookie("trackparser_customdelimiter", "", false),
+        useCustomDelimiter: optionCookie("trackparser_usecustomdelimiter", false),
         useTrackNumbers: optionCookie("trackparser_usetracknumbers", true),
         useTrackNames: optionCookie("trackparser_usetracknames", true),
         useTrackArtists: optionCookie("trackparser_usetrackartists", true),
@@ -286,12 +287,6 @@ releaseEditor.trackParser = {
         // numbers if the line only contains a time.
 
         // Assume the track time is at the end.
-        if (options.timeDelimiter != "") {
-          //Escape most regex characters
-          options.timeDelimiter = options.timeDelimiter.replace(/[.*?+^$(){}|[\]]/g, '\\$&');
-          this.trackTime = new RegExp("\\(?((?:[0-9０-９]+"+options.timeDelimiter+")?[0-9０-９\\?]+"+options.timeDelimiter+"[0-5０-５\\?][0-9０-９\\?])\\)?$");
-        }
-
         var match = line.match(this.trackTime);
 
         if (match !== null) {
@@ -328,6 +323,13 @@ releaseEditor.trackParser = {
                 data.name = clean(line);
             }
             return data;
+        }
+
+        //Use custom delimeter as separator.
+        if (options.useCustomDelimiter && options.customDelimiter != "") {
+          //Escape most regex characters.
+          options.customDelimiter = options.customDelimiter.replace(/[.*?+^$(){}|[\]]/g, '\\$&');
+          this.separators = new RegExp("("+options.customDelimiter+")");
         }
 
         // Split the string into parts, if there are any.

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -44,7 +44,11 @@ releaseEditor.trackParser = {
         useTrackNumbers: optionCookie("trackparser_usetracknumbers", true),
         useTrackNames: optionCookie("trackparser_usetracknames", true),
         useTrackArtists: optionCookie("trackparser_usetrackartists", true),
-        useTrackLengths: optionCookie("trackparser_tracktimes", true)
+        useTrackLengths: optionCookie("trackparser_tracktimes", true),
+        delimiterHelpVisible: optionCookie("trackparser_delimiterhelpvisible", false),
+        toggleDelimiterHelp: function() {
+          this.delimiterHelpVisible(!this.delimiterHelpVisible());
+        }
     },
 
     parse: function (str, medium) {

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -331,7 +331,7 @@ releaseEditor.trackParser = {
 
         //Use custom delimeter as separator.
         if (options.useCustomDelimiter && options.customDelimiter != "") {
-          //Escape most regex characters.
+            // Escape most regex characters.
           options.customDelimiter = options.customDelimiter.replace(/[.*?+^$(){}|[\]]/g, '\\$&');
           this.separators = new RegExp("("+options.customDelimiter+")");
         }

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -268,13 +268,18 @@ div.changes div.warning { margin: 1em auto; }
         margin-top: 1em;
         border-spacing: 0;
 
-        td:nth-child(1), td:nth-child(2) {
+        td:nth-child(1) {
             padding-right: 0.5em;
             border-right: 1px @medium-grey solid;
         }
 
-        td:nth-child(2), td:nth-child(3) {
+        td:nth-child(2) {
             padding-left: 0.5em;
+        }
+
+        input[type="text"] {
+          height: 1.5em;
+          width: 1.5em;
         }
     }
 

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -268,12 +268,12 @@ div.changes div.warning { margin: 1em auto; }
         margin-top: 1em;
         border-spacing: 0;
 
-        td:nth-child(1) {
+        td:nth-child(1), td:nth-child(2) {
             padding-right: 0.5em;
             border-right: 1px @medium-grey solid;
         }
 
-        td:nth-child(2) {
+        td:nth-child(2), td:nth-child(3) {
             padding-left: 0.5em;
         }
     }


### PR DESCRIPTION
### [MBS-8915](https://tickets.metabrainz.org/browse/MBS-8915)
This PR allows users to choose a custom delimiter, which can also be text like "\t". This also required a change to the CSS to fit the extra option, and a change to the optionCookie function to allow for strings as well as just boolean values.