### PR TITLE
Add support for template literals to xgettext.js

### DIFF
--- a/script/xgettext.js
+++ b/script/xgettext.js
@@ -60,6 +60,12 @@ function extractStringLiteral(node) {
     case 'StringLiteral':
       return node.value;
 
+    case 'TemplateLiteral':
+      if (node.expressions.length) {
+        throw new Error('Error: Template literals are not allowed to contain expressions');
+      }
+      return node.quasis[0].value.cooked;
+
     // Handle string concatenation
     case 'BinaryExpression':
       if (node.operator !== '+') {


### PR DESCRIPTION
Detecting whether the literal contains `${}` turned out to be simple. There's no issue if a translation contains `${}`.