### PR TITLE
Remove global gc hack

### DIFF
--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -6,7 +6,7 @@
 const i18n = require('../../../common/i18n');
 const getBooleanCookie = require('../../../common/utility/getBooleanCookie');
 const setCookie = require('../../../common/utility/setCookie');
-const global = require('../../../global');
+const gc = require('../GuessCase/Main');
 
 MB.Control.initialize_guess_case = function (type, formPrefix) {
     formPrefix = formPrefix ? (formPrefix + "\\.") : "";
@@ -89,11 +89,11 @@ ko.bindingHandlers.guessCase = {
 
     init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
         if (!guessCaseOptions.modeName.peek()) {
-            guessCaseOptions.modeName(global.gc.modeName);
+            guessCaseOptions.modeName(gc.modeName);
         }
 
         if (!guessCaseOptions.keepUpperCase.peek()) {
-            guessCaseOptions.keepUpperCase(global.gc.CFG_UC_UPPERCASED);
+            guessCaseOptions.keepUpperCase(gc.CFG_UC_UPPERCASED);
         }
 
         if (!guessCaseOptions.upperCaseRoman.peek()) {

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
@@ -27,8 +27,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Area specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Area = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Area = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -30,8 +30,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Artist specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Artist = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Artist = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases of artists

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -33,7 +33,7 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
  * @see GcReleaseHandler
  * @see GcTrackHandler
  */
-MB.GuessCase.Handler.Base = function () {
+MB.GuessCase.Handler.Base = function (gc) {
     var self = {};
 
     // ----------------------------------------------------------------------------

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
@@ -27,8 +27,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Label specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Label = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Label = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases of labels

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
@@ -26,8 +26,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Place specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Place = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Place = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -27,8 +27,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Release specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Release = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Release = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases of releases

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -29,8 +29,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Track specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Track = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Track = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     self.removeBonusInfo = function (is) {
         return is

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
@@ -27,8 +27,8 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 /**
  * Work specific GuessCase functionality
  **/
-MB.GuessCase.Handler.Work = function () {
-    var self = MB.GuessCase.Handler.Base();
+MB.GuessCase.Handler.Work = function (gc) {
+    var self = MB.GuessCase.Handler.Base(gc);
 
     /**
      * Checks special cases of releases

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -28,7 +28,7 @@ MB.GuessCase = MB.GuessCase ? MB.GuessCase : {};
 /**
  * Holds the input variables
  **/
-MB.GuessCase.Input = function () {
+MB.GuessCase.Input = function (gc) {
     var self = {};
 
     // ----------------------------------------------------------------------------
@@ -188,7 +188,7 @@ MB.GuessCase.Input = function () {
     self.capitalizeCurrentWord = function () {
         var w;
         if ((w = self.getCurrentWord()) != null) {
-            var o = utils.titleString(w);
+            var o = utils.titleString(gc, w);
             if (w != o) {
                 self.updateCurrentWord(o);
             }

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -21,7 +21,6 @@
 
 const MB = require('../../../common/MB');
 const getCookie = require('../../../common/utility/getCookie');
-const global = require('../../../global');
 const flags = require('../../flags');
 
 require('./Handler/Base');
@@ -50,8 +49,8 @@ MB.GuessCase = MB.GuessCase || {};
     // ----------------------------------------------------------------------------
     // member variables
     // ----------------------------------------------------------------------------
-    self.i = require('./Input')();
-    self.o = require('./Output')();
+    self.i = require('./Input')(self);
+    self.o = require('./Output')(self);
 
     self.re = {
         // define commonly used RE's
@@ -76,7 +75,7 @@ MB.GuessCase = MB.GuessCase || {};
             // Initialise flags for another run.
             flags.init();
 
-            handler = handler || MB.GuessCase.Handler[handlerName]();
+            handler = handler || MB.GuessCase.Handler[handlerName](self);
 
             // we need to query the handler if the input string is
             // a special case, fetch the correct format, if the
@@ -142,9 +141,6 @@ MB.GuessCase = MB.GuessCase || {};
             return string.toLowerCase();
         }
     };
-
-    /* FIXME: ugly hack, need to get rid of using a global 'gc' everywhere. */
-    global.gc = self;
 
     module.exports = self;
 }());

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -27,7 +27,7 @@ MB.GuessCase = MB.GuessCase ? MB.GuessCase : {};
 /**
  * Holds the output variables
  **/
-MB.GuessCase.Output = function () {
+MB.GuessCase.Output = function (gc) {
     var self = {};
 
     // ----------------------------------------------------------------------------
@@ -176,7 +176,7 @@ MB.GuessCase.Output = function () {
                         pos--;
                     }
                     gc.i.setPos(pos);
-                    o = utils.titleString(w, overrideCaps);
+                    o = utils.titleString(gc, w, overrideCaps);
                     // restore pos pointer on input
                     gc.i.setPos(bef);
                     if (w != o) {

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -133,7 +133,7 @@ exports.trim = function (is) {
 };
 
 // Upper case first letter of word unless it's one of the words in the lowercase words array.
-exports.titleString = function (is, forceCaps) {
+exports.titleString = function (gc, is, forceCaps) {
     if (!is) {
         return '';
     }
@@ -183,7 +183,7 @@ exports.titleString = function (is, forceCaps) {
     } else if (lc.match(/^(o|y)$/i) && exports.isApostrophe(gc.i.getNextWord())) {
         os = uc;
     } else {
-        os = exports.titleStringByMode(lc, forceCaps);
+        os = exports.titleStringByMode(gc, lc, forceCaps);
         lc = gc.mode.toLowerCase(os);
         uc = gc.mode.toUpperCase(os);
 
@@ -204,7 +204,7 @@ exports.titleString = function (is, forceCaps) {
 };
 
 // Capitalize the string, but check if some characters inside the word need to be uppercased as well.
-exports.titleStringByMode = function (is, forceCaps) {
+exports.titleStringByMode = function (gc, is, forceCaps) {
     if (!is) {
         return '';
     }


### PR DESCRIPTION
Removes the global `gc` variable from pages which use guess case.

This is cherry-picked from the Webpack PR (trying to make some PRs smaller).