### PR TITLE
Unbreak plackup after running Selenium tests

### DIFF
--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -201,6 +201,13 @@ sub GOOGLE_CUSTOM_SEARCH { '' }
 # Cache Settings
 ################################################################################
 
+# A namespace prefix to be applied to all items in all caches, whether for
+# entities or user login sessions. Note that this is used by the default
+# PLUGIN_CACHE_OPTIONS, CACHE_MANAGER_OPTIONS, and DATASTORE_REDIS_ARGS
+# implementations; if you redefine those, CACHE_NAMESPACE will only be used if
+# you use it in your own definitions.
+sub CACHE_NAMESPACE { 'MB:' }
+
 # PLUGIN_CACHE_OPTIONS are the options configured for Plugin::Cache.  $c->cache
 # is provided by Plugin::Cache, and is required for HTTP Digest authentication
 # in the webservice (Catalyst::Authentication::Credential::HTTP).
@@ -209,7 +216,7 @@ sub PLUGIN_CACHE_OPTIONS {
     return {
         class => 'MusicBrainz::Server::CacheWrapper::Redis',
         server => '127.0.0.1:6379',
-        namespace => 'MB:Catalyst:',
+        namespace => $self->CACHE_NAMESPACE . 'Catalyst:',
     };
 }
 
@@ -224,7 +231,7 @@ sub CACHE_MANAGER_OPTIONS {
                 class => 'MusicBrainz::Server::CacheWrapper::Redis',
                 options => {
                     server => '127.0.0.1:6379',
-                    namespace => 'MB:',
+                    namespace => $self->CACHE_NAMESPACE,
                 },
             },
         },
@@ -270,7 +277,7 @@ sub DATASTORE_REDIS_ARGS {
     my $self = shift;
     return {
         database => 0,
-        namespace => 'MB:',
+        namespace => $self->CACHE_NAMESPACE,
         server => '127.0.0.1:6379',
         test_database => 1,
     };

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -338,18 +338,54 @@ around dispatch => sub {
     $c->$orig(@args);
 };
 
-# Use a fresh database connection for every request, and remember to disconnect at the end
+my $ORIG_SEARCH_SERVER = DBDefs->can('SEARCH_SERVER');
+my $ORIG_ENTITY_CACHE_TTL = DBDefs->can('ENTITY_CACHE_TTL');
+my $ORIG_CACHE_NAMESPACE = DBDefs->can('CACHE_NAMESPACE');
+
 before dispatch => sub {
-    shift->model('MB')->context->connector->refresh;
+    my ($self) = @_;
+
+    my $ctx = $self->model('MB')->context;
+
+    # The selenium header is added by the http proxy in t/selenium.js,
+    # and instructs us to use the SELENIUM database instead of
+    # READWRITE. We ignore the header unless USE_SELENIUM_HEADER is
+    # also enabled.
+    if (DBDefs->USE_SELENIUM_HEADER && $self->req->headers->header('selenium')) {
+        no warnings 'redefine';
+        $ctx->database('SELENIUM');
+        $ctx->clear_connector;
+        my $cache_namespace = DBDefs->CACHE_NAMESPACE;
+        *DBDefs::CACHE_NAMESPACE = sub { $cache_namespace . 'Selenium:' };
+        *DBDefs::ENTITY_CACHE_TTL = sub { 1 };
+        *DBDefs::SEARCH_SERVER = sub { '' };
+    } else {
+        # Use a fresh database connection for every request, and
+        # remember to disconnect at the end.
+        $ctx->connector->refresh;
+    }
 };
+
 
 after dispatch => sub {
     my ($self) = @_;
 
-    my $c = $self->model('MB')->context;
-    $c->connector->disconnect;
-    $c->store->disconnect;
-    $c->cache->disconnect;
+    my $ctx = $self->model('MB')->context;
+
+    $ctx->connector->disconnect;
+    $ctx->store->disconnect;
+    $ctx->cache->disconnect;
+
+    if (DBDefs->USE_SELENIUM_HEADER && $self->req->headers->header('selenium')) {
+        no warnings 'redefine';
+        # Clear the connector and database handles, so that we revert
+        # back to the default (READWRITE, or READONLY for slaves).
+        $ctx->clear_connector;
+        $ctx->clear_database;
+        *DBDefs::CACHE_NAMESPACE = $ORIG_SEARCH_SERVER;
+        *DBDefs::ENTITY_CACHE_TTL = $ORIG_ENTITY_CACHE_TTL;
+        *DBDefs::SEARCH_SERVER = $ORIG_SEARCH_SERVER;
+    }
 };
 
 # Timeout long running requests

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -25,7 +25,9 @@ has 'connector' => (
 has 'database' => (
     is => 'rw',
     isa => 'Str',
-    default => sub { DBDefs->REPLICATION_TYPE == RT_SLAVE ? 'READONLY' : 'READWRITE' }
+    default => sub { DBDefs->REPLICATION_TYPE == RT_SLAVE ? 'READONLY' : 'READWRITE' },
+    lazy => 1,
+    clearer => 'clear_database',
 );
 
 has 'fresh_connector' => (

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -202,16 +202,6 @@ sub begin : Private
 
     $c->stats->enable(1) if DBDefs->DEVELOPMENT_SERVER;
 
-    # The selenium header is added by the http proxy in t/selenium.js, and
-    # instructs us to use the SELENIUM database instead of READWRITE. We
-    # ignore the header unless USE_SELENIUM_HEADER is also enabled.
-    if (DBDefs->USE_SELENIUM_HEADER && $c->req->headers->header('selenium')) {
-        $c->model('MB')->context->database('SELENIUM');
-        $c->model('MB')->context->clear_connector;
-        *DBDefs::SEARCH_SERVER = sub { '' };
-        *DBDefs::ENTITY_CACHE_TTL = sub { 1 };
-    }
-
     # Can we automatically login?
     if (!$c->user) {
         $c->forward('/user/cookie_login');


### PR DESCRIPTION
Running Selenium tests against a development server (with `USE_SELENIUM_HEADER` enabled) required a restart of plackup after they were done, due to the database handle still pointing to the `SELENIUM` DB. This sets/resets the handle properly during the request lifecycle (there's now no issue performing `READWRITE` requests concurrently, even).

There were related issues with the DBDefs settings not being reset, and the Redis cache being shared (which could clobber login sessions on the development server). To resolve the DBDefs issue, we save CODE references to the original DBDefs methods and reset them after dispatch. To resolve the cache issue, we introduce a `CACHE_NAMESPACE` setting and modify it to add a 'Selenium:' prefix during Selenium test requests.