### PR TITLE
Replace direct SOLR access with /ws/2 rewrite

### DIFF
--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -427,7 +427,7 @@ sub find_recent_by_artists
         $search_url = sprintf('http://%s/ws/2/recording/?query=title:""',
                               DBDefs->SEARCH_SERVER);
     } else {
-        $search_url = sprintf('http://%s/recording/advanced?q=recording:*&wt=mbxml',
+        $search_url = sprintf('http://%s/ws/2/recording/?query=recording:*&fmt=xml&dismax=false',
                               DBDefs->SEARCH_SERVER);
     }
 

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -732,26 +732,8 @@ sub external_search
     $query = uri_escape_utf8($query);
     $type =~ s/release_group/release-group/;
 
-    my $search_url_string;
-    if (DBDefs->SEARCH_ENGINE eq 'LUCENE') {
-        my $dismax = $adv ? 'false' : 'true';
-        $search_url_string = "http://%s/ws/2/%s/?query=%s&offset=%s&max=%s&fmt=jsonnew&dismax=$dismax&web=1";
-    } else {
-        my $endpoint = "advanced";
-        if (!$adv)
-        {
-            # Solr has a bug where the dismax end point behaves differently
-            # from edismax (advanced) when the query size is 1. This is a fix
-            # for that. See https://issues.apache.org/jira/browse/SOLR-12409
-            if (split(/[\P{Word}_]+/, $query, 2) == 1) {
-                $endpoint = "basic";
-            } else {
-                $endpoint = "select";
-            }
-        }
-        $search_url_string = "http://%s/%s/$endpoint?q=%s&start=%s&rows=%s&wt=mbjson";
-     }
-
+    my $dismax = $adv ? 'false' : 'true';
+    my $search_url_string = "http://%s/ws/2/%s/?query=%s&offset=%s&max=%s&fmt=jsonnew&dismax=$dismax&web=1";
     my $search_url = sprintf($search_url_string,
                                  DBDefs->SEARCH_SERVER,
                                  $type,
@@ -1036,13 +1018,7 @@ sub xml_search
 
     $query = uri_escape_utf8($query);
 
-    my $search_url_string;
-    if ($version eq "1" or DBDefs->SEARCH_ENGINE eq 'LUCENE') {
-        $search_url_string = "http://%s/ws/$version/%s/?query=%s&offset=%s&max=%s&fmt=xml";
-    } else {
-        $search_url_string = "http://%s/%s/advanced?q=%s&start=%s&rows=%s&wt=mbxml";
-    }
-
+    my $search_url_string = "http://%s/ws/$version/%s/?query=%s&offset=%s&max=%s&fmt=xml&dismax=false";
     my $search_url = sprintf($search_url_string,
                                  $version eq "1" ? DBDefs->OLD_SEARCH_SERVER : DBDefs->SEARCH_SERVER,
                                  $type,


### PR DESCRIPTION
NOTE: This is not mergeable until search.mb.org/wstest/2 becomes live at search.mb.org/ws/2, but it needs some more work from Zas first. (The commit message below is written as if it's already been deployed.)

The relevant openresty config is at https://github.com/metabrainz/openresty-gateways/blob/master/files/nginx/includes/search-server_server_http_05.conf

---

We want people with MB mirror servers to continue to be able to use our search servers, as they've always been able to do. But allowing public access to our SOLR cluster is problematic from a security standpoint. We could set up a proxy [1] in front of SOLR to block bad requests, but a better option is to just use the /ws/2 compatibility layer already in place in our openresty config. This layer rewrites "old" API requests understood by our Lucene-based search server into a format expected by SOLR, and performs an internal redirect. There's nothing outdated or impractical about this API, so no reason it needs to be "old."

[1] https://github.com/dergachev/solr-security-proxy