### PR TITLE
Prepare for SOLR access via search.mb.org (MBH-502)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -345,7 +345,8 @@ The server by itself doesn't rate limit any request it handles. If you're
 receiving 503s, then you're likely performing
 [search queries](https://musicbrainz.org/doc/Search_Server) without having set
 up a local instance of the
-[search server](https://github.com/metabrainz/search-server). By default,
+[search server](https://github.com/metabrainz/mb-solr) along with the
+[search index rebuilder](https://github.com/metabrainz/sir). By default,
 search queries are sent to search.musicbrainz.org and are rate limited.
 
 Once you set up your own instance, change `SEARCH_SERVER` in lib/DBDefs.pm to

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -170,7 +170,7 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # Relevant only if SSL redirects are enabled
 # sub WEB_SERVER_SSL            { "localhost" }
 # sub SEARCH_SERVER             { "search.musicbrainz.org" }
-# sub SEARCH_ENGINE             { "LUCENE" }
+# sub SEARCH_ENGINE             { "SOLR" }
 # Used, for example, to have emails sent from the beta server list the
 # main server
 # sub WEB_SERVER_USED_IN_EMAIL  { my $self = shift; $self->WEB_SERVER }

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -103,7 +103,7 @@ sub WEB_SERVER                { "localhost:5000" }
 # Relevant only if SSL redirects are enabled
 sub WEB_SERVER_SSL            { "localhost" }
 sub SEARCH_SERVER             { "search.musicbrainz.org" }
-sub SEARCH_ENGINE             { "LUCENE" }
+sub SEARCH_ENGINE             { "SOLR" }
 # Whether to use x-accel-redirect for webservice searches,
 # using /internal/search as the internal redirect
 sub SEARCH_X_ACCEL_REDIRECT   { 0 }

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -794,7 +794,7 @@ sub external_search
     $type =~ s/release_group/release-group/;
 
     my $search_url_string;
-    if (DBDefs->SEARCH_ENGINE eq 'LUCENE') {
+    if (DBDefs->SEARCH_ENGINE eq 'LUCENE' || DBDefs->SEARCH_SERVER eq DBDefs::Default->SEARCH_SERVER) {
         my $dismax = $adv ? 'false' : 'true';
         $search_url_string = "http://%s/ws/2/%s/?query=%s&offset=%s&max=%s&fmt=jsonnew&dismax=$dismax&web=1";
     } else {

--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -211,7 +211,7 @@ sub xml_search
     }
 
     my $url_ext;
-    if (DBDefs->SEARCH_ENGINE eq 'LUCENE') {
+    if (DBDefs->SEARCH_ENGINE eq 'LUCENE' || DBDefs->SEARCH_SERVER eq DBDefs::Default->SEARCH_SERVER) {
         my $format = ($args->{fmt} // "") eq "json" ? "jsonnew" : "xml";
         $url_ext = "/ws/2/$resource/?" .
            "max=$limit&type=$resource&fmt=$format&offset=$offset" .


### PR DESCRIPTION
NOTE: This is not mergeable until search.mb.org/wstest/2 becomes live at search.mb.org/ws/2, but it needs some more work from Zas first.

The relevant openresty config is at https://github.com/metabrainz/openresty-gateways/blob/master/files/nginx/includes/search-server_server_http_05.conf

Edit: this change is now in production, as 2020-05-26

---

 * WS1 is removed.
 * The default `SEARCH_ENGINE` setting is changed to 'SOLR'. If 'SOLR' is in use and `SEARCH_SERVER` is set to the default public search server (search.musicbrainz.org), it uses the compatibility API described in MBH-502. This is the very same code used if `SEARCH_ENGINE` is set to 'LUCENE' (which I assume the VM still needs?). Otherwise it assumes direct SOLR access (so, production or someone setting up their own instance).
 * The endpoint /ws/js/last-updated-recordings is removed (it was only a workaround for search indexing delays).