### PR TITLE
MBS-9957: Reindex release cover art on cover art type change

### DIFF
--- a/admin/sql/caa/DropPGQ.sql
+++ b/admin/sql/caa/DropPGQ.sql
@@ -4,6 +4,7 @@ DROP TRIGGER caa_reindex ON musicbrainz.artist;
 DROP TRIGGER caa_reindex ON musicbrainz.release;
 DROP TRIGGER caa_reindex ON musicbrainz.release_label;
 DROP TRIGGER caa_reindex ON cover_art_archive.cover_art;
+DROP TRIGGER caa_reindex ON cover_art_archive.cover_art_type;
 DROP TRIGGER caa_move ON cover_art_archive.cover_art;
 DROP TRIGGER caa_delete ON musicbrainz.release;
 
@@ -11,6 +12,7 @@ DROP FUNCTION cover_art_archive.reindex_release ();
 DROP FUNCTION cover_art_archive.reindex_artist ();
 DROP FUNCTION cover_art_archive.reindex_release_via_catno ();
 DROP FUNCTION cover_art_archive.reindex_caa ();
+DROP FUNCTION cover_art_archive.reindex_caa_type ();
 DROP FUNCTION cover_art_archive.caa_move ();
 DROP FUNCTION cover_art_archive.delete_release ();
 


### PR DESCRIPTION
### Fix [MBS-9957](https://tickets.metabrainz.org/browse/MBS-9957): Cover art image types not updated properly

by triggering a reindex from `cover_art_archive.cover_art_type` table change.