### PR TITLE
MBS-9966: Fix seeding place to add event

### DIFF
--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -89,7 +89,7 @@ const PlaceSidebar = ({$c, place}: Props) => {
 
       <EditLinks entity={place}>
         <li>
-          <a href={`/event/create?rels.0.target=${gid}?rels.0.type=e2c6f697-07dc-38b1-be0b-83d740165532`}>
+          <a href={`/event/create?rels.0.target=${gid}&rels.0.type=e2c6f697-07dc-38b1-be0b-83d740165532`}>
             {l('Add event')}
           </a>
         </li>


### PR DESCRIPTION
## Fix [MBS-9966](https://tickets.metabrainz.org/browse/MBS-9966): Event creation on place page does not seed
by replacing "?" with "&" for the second query parameter.