### PR TITLE
MBS-9967: Fix typo borking Subscribers tab

### DIFF
--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -43,7 +43,7 @@ function buildTabs(
     tabs.push(buildTab(page, l('Subscriptions'), userPath + '/subscriptions/artist', 'subscriptions'));
   }
 
-  tabs.push(buildTab(page, l('Subscribed'), userPath + '/subscribed', 'subscribed'));
+  tabs.push(buildTab(page, l('Subscribers'), userPath + '/subscribers', 'subscribers'));
   tabs.push(buildTab(page, l('Collections'), userPath + '/collections', 'collections'));
 
   if (showPrivate || user.preferences.public_tags) {


### PR DESCRIPTION
## Fix [MBS-9967](https://tickets.metabrainz.org/browse/MBS-9967): Subscribers tab in user profile is broken

Regression introduced with https://github.com/metabrainz/musicbrainz-server/commit/32cdf4950da69520edb47ffaa776e2383b35c7cb