### PR TITLE
Workaround for MBS-9865

### DIFF
--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -38,8 +38,8 @@ const ArtistCreditBubble = ({
   done,
   entity,
   extraButtons,
-  extraContent,
   hide,
+  initialArtistText,
   onNameChange,
   pasteArtistCredit,
   removeName,
@@ -98,7 +98,16 @@ const ArtistCreditBubble = ({
         </tr>
       </tbody>
     </table>
-    {extraContent ? extraContent : null}
+    {(initialArtistText && entity.entityType === 'track') ? (
+      <div>
+        <label>
+          <input id="change-matching-artists" type="checkbox" />
+          {l('Change all artists on this release that match “{name}”', {
+            name: initialArtistText,
+          })}
+        </label>
+      </div>
+    ) : null}
     <div className="buttons">
       <button type="button" style={{float: 'left'}} onClick={copyArtistCredit}>{l('Copy Credits')}</button>
       <button type="button" style={{float: 'left'}} onClick={pasteArtistCredit}>{l('Paste Credits')}</button>

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -187,7 +187,7 @@ class ArtistCreditEditor extends React.Component {
       .position(position);
   }
 
-  updateBubble(show = false) {
+  updateBubble(show = false, callback = null) {
     this.createBubble();
 
     const $bubble = $('#artist-credit-bubble');
@@ -232,6 +232,11 @@ class ArtistCreditEditor extends React.Component {
 
         if (!bubbleWasVisible) {
           $bubble.find(':input:eq(0)').focus();
+          $('#change-matching-artists').prop('checked', false);
+        }
+
+        if (callback) {
+          callback();
         }
       }) : null,
     );

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -76,6 +76,7 @@ class ArtistCreditEditor extends React.Component {
       artistCredit: ko.unwrap(this.props.entity.artistCredit)
     };
 
+    this.initialArtistText = '';
     this.addName = this.addName.bind(this);
     this.copyArtistCredit = this.copyArtistCredit.bind(this);
     this.done = this.done.bind(this);
@@ -174,8 +175,6 @@ class ArtistCreditEditor extends React.Component {
 
     $bubble
       .css('max-width', maxWidth)
-      .data('target', this.props.entity)
-      .data('componentInst', this)
       .find('.bubble')
         .removeClass('left-tail right-tail')
         .addClass(tailClass)
@@ -206,22 +205,26 @@ class ArtistCreditEditor extends React.Component {
       return;
     }
 
-    const props = this.props;
-    if (show && props.beforeShow) {
-      props.beforeShow(props, this.state);
+    if (show) {
+      this.initialArtistText = reduceArtistCredit(this.state.artistCredit);
     }
+
+    $bubble
+      .data('target', this.props.entity)
+      .data('componentInst', this);
 
     ReactDOM.render(
       <ArtistCreditBubble
         addName={this.addName}
         artistCredit={this.state.artistCredit}
+        initialArtistText={this.initialArtistText}
         copyArtistCredit={this.copyArtistCredit}
         done={this.done}
         hide={this.hide}
         onNameChange={this.onNameChange}
         pasteArtistCredit={this.pasteArtistCredit}
         removeName={this.removeName}
-        {...props}
+        {...this.props}
       />,
       $bubble[0],
       show ? (() => {
@@ -247,7 +250,8 @@ class ArtistCreditEditor extends React.Component {
 
   done(stealFocus = true, nextTrack = false) {
     if (this.props.doneCallback) {
-      this.props.doneCallback();
+      this.props.doneCallback(this.initialArtistText);
+      this.initialArtistText = '';
     }
 
     // XXX The release editor still uses knockout.

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -253,11 +253,15 @@ class ArtistCreditEditor extends React.Component {
     });
   }
 
-  done(stealFocus = true, nextTrack = false) {
+  runDoneCallback() {
     if (this.props.doneCallback) {
       this.props.doneCallback(this.initialArtistText);
       this.initialArtistText = '';
     }
+  }
+
+  done(stealFocus = true, nextTrack = false) {
+    this.runDoneCallback();
 
     // XXX The release editor still uses knockout.
     if (nextTrack) {

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -42,11 +42,18 @@ ko.bindingHandlers.artistCreditEditor = {
         return $('#artist-credit-bubble').data('target');
     },
 
+    uncheckChangeMatchingArtists: function () {
+        const input = document.getElementById('change-matching-artists');
+        if (input) {
+            input.checked = false;
+        }
+    },
+
     previousTrack: function () {
         const entity = this.currentTarget();
         const prev = entity.medium.tracks()[entity.position() - 2];
         if (prev) {
-            prev.artistCreditEditorInst.updateBubble(true);
+            prev.artistCreditEditorInst.updateBubble(true, this.uncheckChangeMatchingArtists);
         }
     },
 
@@ -54,7 +61,7 @@ ko.bindingHandlers.artistCreditEditor = {
         const entity = this.currentTarget();
         const next = entity.medium.tracks()[entity.position()];
         if (next) {
-            next.artistCreditEditorInst.updateBubble(true);
+            next.artistCreditEditorInst.updateBubble(true, this.uncheckChangeMatchingArtists);
         }
     },
 
@@ -107,5 +114,6 @@ _.bindAll(
     'doneCallback',
     'nextTrack',
     'previousTrack',
+    'uncheckChangeMatchingArtists',
     'update',
 );


### PR DESCRIPTION
I suggest trying to test/break this locally to see if it works and ignoring my useless commit message, since I got frustrated trying to fix this and could barely remember why things worked afterward. 😆

---

This works around the issue while we wait for the release editor to be converted to React, and for the artist credit editor/bubble code to be implemented properly.

The main fix is in setting the `target` and `componentInst` data values on the bubble div before rendering it, *not* after. I don't remember why that works, exactly, after half an hour in the Chrome debugger, but it's not important or interesting since this code is going in the scrap heap.

Fixing this then revealed that the "change matching artists" option was broken, because someone (me) thought mixing knockout and React was a good idea to begin with. The solution there is to (handwavy) bring some codey bits closer to React.