### PR TITLE
Remove some apparently unused TT filters

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -52,13 +52,10 @@ __PACKAGE__->config(
             comma_only_list
         )],
         FILTERS => {
-            'release_date' => \&MusicBrainz::Server::Filters::release_date,
             'format_length' => \&MusicBrainz::Server::Filters::format_length,
-            'format_distance' => \&MusicBrainz::Server::Filters::format_distance,
             'format_wikitext' => \&MusicBrainz::Server::Filters::format_wikitext,
             'format_editnote' => \&MusicBrainz::Server::Filters::format_editnote,
             'format_setlist' => \&MusicBrainz::Server::Filters::format_setlist,
-            'language' => \&MusicBrainz::Server::Filters::language,
             'locale' => \&MusicBrainz::Server::Filters::locale,
             'gravatar' => \&MusicBrainz::Server::Filters::gravatar,
             'coverart_https' => \&MusicBrainz::Server::Filters::coverart_https

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -7,7 +7,6 @@ use warnings;
 
 use Digest::MD5 qw( md5_hex );
 use Encode;
-use Locale::Language;
 use MusicBrainz::Server::Track;
 use MusicBrainz::Server::Validation qw( encode_entities );
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );
@@ -20,32 +19,9 @@ use Sub::Exporter -setup => {
     exports => [qw( format_editnote format_setlist format_wikitext )]
 };
 
-sub release_date
-{
-    my $date = shift;
-
-    my ($y, $m, $d) = split /-/, $date;
-
-    my $str = "";
-
-    $str .= $y     if ($y && 0 + $y);
-    $str .= "-".$m if ($m && 0 + $m);
-    $str .= "-".$d if ($d && 0 + $d);
-
-    return $str;
-
-}
-
 sub format_length
 {
     my $ms = shift;
-    return MusicBrainz::Server::Track::FormatTrackLength($ms);
-}
-
-sub format_distance
-{
-    my $ms = shift;
-    return "0 s" if (!$ms);
     return MusicBrainz::Server::Track::FormatTrackLength($ms);
 }
 
@@ -232,11 +208,6 @@ sub format_editnote
     $html =~ s/(\015\012|\012\015|\012|\015)/<br\/>/g;
 
     return $html;
-}
-
-sub language
-{
-    return code2language(shift);
 }
 
 sub locale


### PR DESCRIPTION
Removing the `language` filter and its dependency on `Locale::Language` resolves a warning on plackup startup (in Perl 5.28) that this module is being removed.