### PR TITLE
MBS-9971: Link ISNI code to isni.org

### DIFF
--- a/lib/MusicBrainz/Server/Entity/ISNI.pm
+++ b/lib/MusicBrainz/Server/Entity/ISNI.pm
@@ -11,7 +11,7 @@ has 'isni' => (
 
 sub url {
     my ($self) = @_;
-    return "http://isni-url.oclc.nl/isni/" . $self->isni;
+    return "http://www.isni.org/" . $self->isni;
 }
 
 sub TO_JSON {

--- a/root/layout/components/sidebar/SidebarIsnis.js
+++ b/root/layout/components/sidebar/SidebarIsnis.js
@@ -14,13 +14,17 @@ import formatIsni from '../../../utility/formatIsni';
 
 import {SidebarProperty} from './SidebarProperties';
 
+const isniUrl = 'http://www.isni.org/';
+
 const buildSidebarIsni = (isni, index) => (
   <SidebarProperty
     className="isni-code"
     key={'isni-code-' + isni.isni}
     label={l('ISNI code:')}
   >
-    {formatIsni(isni.isni)}
+    <a href={isniUrl + isni.isni}>
+      {formatIsni(isni.isni)}
+    </a>
   </SidebarProperty>
 );
 


### PR DESCRIPTION
# Fix [MBS-9971](https://tickets.metabrainz.org/browse/MBS-9971)

- Fix a regression introduced during sidebar rewrite to React
- Move from `isni-url.oclc.nl` to `isni.org`