### PR TITLE
MBS-4469, MBS-4709, MBS-8803: Address some annotation issues

### DIFF
--- a/lib/MusicBrainz/Server/Data/EntityAnnotation.pm
+++ b/lib/MusicBrainz/Server/Data/EntityAnnotation.pm
@@ -2,7 +2,6 @@ package MusicBrainz::Server::Data::EntityAnnotation;
 use Moose;
 use namespace::autoclean;
 
-use HTML::Entities qw( decode_entities );
 use List::MoreUtils qw( uniq );
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT %ENTITIES );
@@ -46,19 +45,6 @@ sub get_history
                 ' WHERE ' . $self->type . ' = ?' .
                 ' ORDER BY created DESC';
     $self->query_to_list_limited($query, [$id], $limit, $offset);
-}
-
-sub _column_mapping {
-    return {
-        id => 'id',
-        text => sub {
-            my $row = shift;
-            $row->{text} && decode_entities($row->{text});
-        },
-        changelog => 'changelog',
-        editor_id => 'editor_id',
-        creation_date => 'creation_date'
-    }
 }
 
 sub get_latest

--- a/root/annotation/edit.tt
+++ b/root/annotation/edit.tt
@@ -50,7 +50,7 @@
     <tr>
       <th>[% l('Lists:') %]</th>
       <td>
-        [%- l("tab or 4 spaces and: * bullets; 1., a., A., i., I. numbered items; spaces alone indent") %]</td>
+        [%- l("tab or 4 spaces and: * bullets or 1., a., A., i., I. numbered items (rendered with 1.)") %]</td>
     </tr>
     <tr>
       <th>[% l('Links:') %]</th>

--- a/root/annotation/edit.tt
+++ b/root/annotation/edit.tt
@@ -55,7 +55,7 @@
     <tr>
       <th>[% l('Links:') %]</th>
       <td>
-        [% l("URL; [URL]; [URL|label]") %]</td>
+        [% l("URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]") %]</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
# Address some annotation issues

1. Fix long-standing regression [MBS-4709](https://tickets.metabrainz.org/browse/MBS-4709): Can't use square brackets in annotations.
    Note: The future Markdown syntax will allow for HTML entities again.
2. Improve embedded documentation about annotation syntax:
    * [MBS-4469](https://tickets.metabrainz.org/browse/MBS-4469): lists syntax only partly working
    * [MBS-8803](https://tickets.metabrainz.org/browse/MBS-8803): `[<entity_type>:<mbid>|<name>]` links