### PR TITLE
MBS-9936: Move from CJS style to ES6 (imports, exports) (I)

### DIFF
--- a/root/area/AreaHeader.js
+++ b/root/area/AreaHeader.js
@@ -7,11 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const AreaContainmentLink = require('../static/scripts/common/components/AreaContainmentLink');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import AreaContainmentLink from '../static/scripts/common/components/AreaContainmentLink';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   +area: AreaT,

--- a/root/artist/ArtistHeader.js
+++ b/root/artist/ArtistHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   +artist: ArtistT,
@@ -32,4 +33,4 @@ const ArtistHeader = ({artist, page}: Props) => {
   );
 };
 
-module.exports = ArtistHeader;
+export default ArtistHeader;

--- a/root/event/EventHeader.js
+++ b/root/event/EventHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   +event: EventT,
@@ -26,4 +27,4 @@ const EventHeader = ({event, page}: Props) => (
   />
 );
 
-module.exports = EventHeader;
+export default EventHeader;

--- a/root/instrument/InstrumentHeader.js
+++ b/root/instrument/InstrumentHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   +instrument: InstrumentT,

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -7,13 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
+import React from 'react';
 
-const Layout = require('../layout');
-const EntityLink = require('../static/scripts/common/components/EntityLink');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const {l_instrument_descriptions} = require('../static/scripts/common/i18n/instrument_descriptions');
+import Layout from '../layout';
+import EntityLink from '../static/scripts/common/components/EntityLink';
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import {l_instrument_descriptions} from '../static/scripts/common/i18n/instrument_descriptions';
 
 type PropsT = {|
   +instrument_types: $ReadOnlyArray<InstrumentTypeT>,
@@ -79,4 +79,4 @@ const InstrumentList = ({
   );
 };
 
-module.exports = InstrumentList;
+export default InstrumentList;

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -7,16 +7,16 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
+import React from 'react';
 
-const {withCatalystContext} = require('../context');
-const Layout = require('../layout');
-const ArtistCreditLink = require('../static/scripts/common/components/ArtistCreditLink');
-const CodeLink = require('../static/scripts/common/components/CodeLink');
-const EntityLink = require('../static/scripts/common/components/EntityLink');
-const {l, ln} = require('../static/scripts/common/i18n');
-const {artistCreditFromArray} = require('../static/scripts/common/immutable-entities');
-const formatTrackLength = require('../static/scripts/common/utility/formatTrackLength');
+import {withCatalystContext} from '../context';
+import Layout from '../layout';
+import ArtistCreditLink from '../static/scripts/common/components/ArtistCreditLink';
+import CodeLink from '../static/scripts/common/components/CodeLink';
+import EntityLink from '../static/scripts/common/components/EntityLink';
+import {l, ln} from '../static/scripts/common/i18n';
+import {artistCreditFromArray} from '../static/scripts/common/immutable-entities';
+import formatTrackLength from '../static/scripts/common/utility/formatTrackLength';
 import loopParity from '../utility/loopParity';
 
 type PropsT = {|
@@ -96,4 +96,4 @@ const Index = ({$c, isrcs, recordings}: PropsT) => {
   );
 };
 
-module.exports = withCatalystContext(Index);
+export default withCatalystContext(Index);

--- a/root/label/LabelHeader.js
+++ b/root/label/LabelHeader.js
@@ -7,9 +7,10 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   +label: LabelT,
@@ -25,4 +26,4 @@ const LabelHeader = ({label, page}: Props) => (
   />
 );
 
-module.exports = LabelHeader;
+export default LabelHeader;

--- a/root/place/PlaceHeader.js
+++ b/root/place/PlaceHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   page: string,
@@ -26,4 +27,4 @@ const PlaceHeader = ({place, page}: Props) => (
   />
 );
 
-module.exports = PlaceHeader;
+export default PlaceHeader;

--- a/root/recording/RecordingHeader.js
+++ b/root/recording/RecordingHeader.js
@@ -7,12 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const EntityHeader = require('../components/EntityHeader');
-const ArtistCreditLink = require('../static/scripts/common/components/ArtistCreditLink');
-const TaggerIcon = require('../static/scripts/common/components/TaggerIcon');
-const {artistCreditFromArray} = require('../static/scripts/common/immutable-entities');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import EntityHeader from '../components/EntityHeader';
+import ArtistCreditLink from '../static/scripts/common/components/ArtistCreditLink';
+import TaggerIcon from '../static/scripts/common/components/TaggerIcon';
+import {artistCreditFromArray} from '../static/scripts/common/immutable-entities';
 
 type Props = {|
   +page: string,
@@ -39,4 +40,4 @@ const RecordingHeader = ({recording, page}: Props) => {
   );
 };
 
-module.exports = RecordingHeader;
+export default RecordingHeader;

--- a/root/release_group/ReleaseGroupHeader.js
+++ b/root/release_group/ReleaseGroupHeader.js
@@ -7,11 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const EntityHeader = require('../components/EntityHeader');
-const ArtistCreditLink = require('../static/scripts/common/components/ArtistCreditLink');
-const {artistCreditFromArray} = require('../static/scripts/common/immutable-entities');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import EntityHeader from '../components/EntityHeader';
+import ArtistCreditLink from '../static/scripts/common/components/ArtistCreditLink';
+import {artistCreditFromArray} from '../static/scripts/common/immutable-entities';
 
 type Props = {|
   page: string,
@@ -36,4 +37,4 @@ const ReleaseGroupHeader = ({releaseGroup, page}: Props) => {
   );
 };
 
-module.exports = ReleaseGroupHeader;
+export default ReleaseGroupHeader;

--- a/root/series/SeriesHeader.js
+++ b/root/series/SeriesHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {lp} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {lp} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   page: string,
@@ -26,4 +27,4 @@ const SeriesHeader = ({series, page}: Props) => (
   />
 );
 
-module.exports = SeriesHeader;
+export default SeriesHeader;

--- a/root/url/URLHeader.js
+++ b/root/url/URLHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const EntityHeader = require('../components/EntityHeader');
-const EntityLink = require('../static/scripts/common/components/EntityLink');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import EntityHeader from '../components/EntityHeader';
+import EntityLink from '../static/scripts/common/components/EntityLink';
 
 type Props = {|
   page: string,
@@ -29,4 +30,4 @@ const URLHeader = ({url, page}: Props) => (
   />
 );
 
-module.exports = URLHeader;
+export default URLHeader;

--- a/root/work/WorkHeader.js
+++ b/root/work/WorkHeader.js
@@ -7,10 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const React = require('react');
-const {l} = require('../static/scripts/common/i18n');
-const {lp_attributes} = require('../static/scripts/common/i18n/attributes');
-const EntityHeader = require('../components/EntityHeader');
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {lp_attributes} from '../static/scripts/common/i18n/attributes';
+import EntityHeader from '../components/EntityHeader';
 
 type Props = {|
   page: string,
@@ -26,4 +27,4 @@ const WorkHeader = ({work, page}: Props) => (
   />
 );
 
-module.exports = WorkHeader;
+export default WorkHeader;


### PR DESCRIPTION
Entity headers + instrument list