### PR TITLE
MBS-9975: Add release/track sortname guess-case (for aliases)

### DIFF
--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -80,5 +80,10 @@ MB.GuessCase.Handler.Release = function (gc) {
         return null;
     };
 
+    /**
+     * Guesses the sortname for releases (for aliases)
+     **/
+    self.guessSortName = self.moveArticleToEnd;
+
     return self;
 };

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -136,5 +136,10 @@ MB.GuessCase.Handler.Track = function (gc) {
         return null;
     };
 
+    /**
+     * Guesses the sortname for recordings (for aliases)
+     **/
+    self.guessSortName = self.moveArticleToEnd;
+
     return self;
 };

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -113,14 +113,16 @@ MB.GuessCase = MB.GuessCase || {};
     };
 
     MB.GuessCase.release = {
-        guess: guess("Release", "process")
+        guess: guess("Release", "process"),
+        sortname: guess("Release", "guessSortName")
     };
 
     MB.GuessCase["release_group"] = MB.GuessCase.release;
     MB.GuessCase["release-group"] = MB.GuessCase.release;
 
     MB.GuessCase.track = {
-        guess: guess("Track", "process")
+        guess: guess("Track", "process"),
+        sortname: guess("Track", "guessSortName")
     };
 
     MB.GuessCase.recording = MB.GuessCase.track;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9975

Release (and RG) and Track (so, Recording) have no sort name methods, because they don't have sort names. Which is great... but their aliases have, so those break. This just adds the simplest possible sort name method (copied from Work) which is, IMO, all they need.