### PR TITLE
Remove replace_gid

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Details.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Details.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Controller::Role::Details;
 use Moose::Role -traits => 'MooseX::MethodAttributes::Role::Meta::Role';
-use MusicBrainz::Server::Plugin::Canonicalize qw ( replace_gid );
 
 sub details : Chained('load') PathPart {
     my ($self, $c) = @_;
@@ -9,7 +8,6 @@ sub details : Chained('load') PathPart {
 
     if ($entity->entity_type eq 'release_group') {
         my %props = (
-            canonicalURL => MusicBrainz::Server::Plugin::Canonicalize::replace_gid($self, $c, $entity->gid),
             entity       => $entity,
             lastUpdated  => $entity->{last_updated},
         );

--- a/lib/MusicBrainz/Server/Plugin/Canonicalize.pm
+++ b/lib/MusicBrainz/Server/Plugin/Canonicalize.pm
@@ -19,12 +19,4 @@ sub canonicalize
     return $url;
 }
 
-sub replace_gid
-{
-    my ($self, $c, $new_gid) = @_;
-    my $new_captures = [$new_gid];
-    push(@$new_captures, @{ $c->req->captures }[1..scalar(@{ $c->req->captures })-1]);
-    return $c->uri_for_action($c->action->private_path, $new_captures, @{ $c->req->args }, $c->req->query_params);
-}
-
 1;

--- a/root/area/layout.tt
+++ b/root/area/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? area.l_name _ " - ${title}" : area.l_name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? area.l_name _ " - ${title}" : area.l_name ~%]
     <div id="content">
         [%~ React.embed(c, 'area/AreaHeader', { area => area, page => page }) ~%]
         [%~ content ~%]

--- a/root/artist/layout.tt
+++ b/root/artist/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? artist.name _ " - ${title}" : artist.name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? artist.name _ " - ${title}" : artist.name ~%]
     <div id="content">
         [%~ React.embed(c, 'artist/ArtistHeader', { artist => artist, page => page }) ~%]
         [%~ content ~%]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -928,11 +928,6 @@ END -%]
   END %] ([% direction %])
 [%~ END ~%]
 
-[%~ USE Canonicalize ~%]
-[%~ MACRO replace_gid(new_gid) BLOCK ~%]
-  [%~ Canonicalize.replace_gid(c, new_gid) ~%]
-[%~ END ~%]
-
 [%~ MACRO data_track_icon BLOCK ~%]
   <div class="data-track icon img" title="[% l('This track is a data track.') %]"></div>
 [%~ END ~%]

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -19,7 +19,6 @@ import formatUserDate from '../utility/formatUserDate';
 
 type Props = {|
   +$c: CatalystContextT,
-  +canonicalURL: string,
   +entity: CoreEntityT,
   +lastUpdated: string,
 |};
@@ -46,7 +45,6 @@ const XMLLink = ({
 
 const Details = ({
   $c,
-  canonicalURL,
   entity,
   lastUpdated,
 }: Props) => {
@@ -59,7 +57,7 @@ const Details = ({
   const LayoutComponent = chooseLayoutComponent(entityType);
 
   return (
-    <LayoutComponent canonicalURL={canonicalURL} page="details" releaseGroup={entity} title={l('Details')}>
+    <LayoutComponent page="details" releaseGroup={entity} title={l('Details')}>
       <h2>{l('Details')}</h2>
       <table className="details">
         <tr>

--- a/root/event/layout.tt
+++ b/root/event/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? event.name _ " - ${title}" : event.name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? event.name _ " - ${title}" : event.name ~%]
     <div id="content">
         [%~ React.embed(c, 'event/EventHeader', { event => event, page => page }) ~%]
         [%~ content ~%]

--- a/root/forms/dialog.tt
+++ b/root/forms/dialog.tt
@@ -12,7 +12,6 @@
           SET gettext_domains = ['attributes', 'countries', 'languages', 'relationships'];
         END;
         React.embed(c, 'layout/components/Head', {
-            canonical_url => canonical_url,
             gettext_domains => gettext_domains,
             homepage => homepage,
             no_icons => no_icons,

--- a/root/instrument/layout.tt
+++ b/root/instrument/layout.tt
@@ -2,7 +2,7 @@
         type => instrument.l_type_name or l('Instrument'),
         instrument => instrument.l_name
 }) ~%]
-[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]
     <div id="content">
         [%~ React.embed(c, 'instrument/InstrumentHeader', { instrument => instrument, page => page }) ~%]
         [%~ content ~%]

--- a/root/label/layout.tt
+++ b/root/label/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? label.name _ " - ${title}" : label.name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? label.name _ " - ${title}" : label.name ~%]
     <div id="content">
         [%~ React.embed(c, 'label/LabelHeader', { label => label, page => page }) ~%]
         [%~ content ~%]

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -1,7 +1,6 @@
 [% set_header() %]
     [%- DEFAULT no_icons = homepage -%]
     [%- React.embed(c, 'layout/components/Head', {
-            canonical_url => canonical_url,
             homepage => homepage,
             no_icons => no_icons,
             pager => pager,

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -39,8 +39,8 @@ function getTitle(props) {
   return title;
 }
 
-const CanonicalLink = ({href, requestUri}) => {
-  const canonUri = canonicalize(href || requestUri);
+const CanonicalLink = ({requestUri}) => {
+  const canonUri = canonicalize(requestUri);
   if (requestUri !== canonUri) {
     return <link rel="canonical" href={canonUri} />;
   }
@@ -56,7 +56,7 @@ const Head = ({$c, ...props}) => (
 
     <title>{getTitle(props)}</title>
 
-    <CanonicalLink href={props.canonical_url} requestUri={$c.req.uri} />
+    <CanonicalLink requestUri={$c.req.uri} />
 
     {manifest.css('common')}
 

--- a/root/place/layout.tt
+++ b/root/place/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? place.name _ " - ${title}" : place.name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? place.name _ " - ${title}" : place.name ~%]
     <div id="content">
         [%~ React.embed(c, 'place/PlaceHeader', { place => place, page => page }) ~%]
         [%~ content ~%]

--- a/root/recording/layout.tt
+++ b/root/recording/layout.tt
@@ -1,7 +1,7 @@
 [%~ title_args = { artist => artist_credit(recording.artist_credit, plain => 1), name => recording.name } ~%]
 
 [%~ main_title = recording.video ? l('Video “{name}” by {artist}', title_args) : l('Recording “{name}” by {artist}', title_args) ~%]
-[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]
     <div id="content">
         [%~ React.embed(c, 'recording/RecordingHeader', { recording => recording, page => page }) ~%]
         [%~ content ~%]

--- a/root/release/layout.tt
+++ b/root/release/layout.tt
@@ -2,7 +2,7 @@
         artist => artist_credit(release.artist_credit, plain => 1),
         name => release.name
 }) ~%]
-[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]
     <div id="content">
         [%~ INCLUDE "release/header.tt" ~%]
         [%~ content ~%]

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -18,7 +18,6 @@ import {artistCreditFromArray, reduceArtistCredit} from '../static/scripts/commo
 import ReleaseGroupHeader from './ReleaseGroupHeader';
 
 type Props = {|
-  +canonicalURL: string,
   +children: ReactNode,
   +fullWidth?: boolean,
   +page: string,
@@ -27,7 +26,6 @@ type Props = {|
 |};
 
 const ReleaseGroupLayout = ({
-  canonicalURL,
   children,
   fullWidth,
   page,
@@ -39,7 +37,7 @@ const ReleaseGroupLayout = ({
     name: releaseGroup.name,
   });
   return (
-    <Layout canonical_url={canonicalURL} title={title ? hyphenateTitle(mainTitle, title) : mainTitle}>
+    <Layout title={title ? hyphenateTitle(mainTitle, title) : mainTitle}>
       <div id="content">
         <ReleaseGroupHeader page={page} releaseGroup={releaseGroup} />
         {children}

--- a/root/release_group/layout.tt
+++ b/root/release_group/layout.tt
@@ -2,7 +2,7 @@
     artist => artist_credit(rg.artist_credit, plain => 1),
     name => rg.name
 }) %]
-[%- WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title canonical_url=replace_gid(entity.gid) -%]
+[%- WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title -%]
     <div id="content">
         [%~ React.embed(c, 'release_group/ReleaseGroupHeader', { releaseGroup => rg, page => page }) ~%]
         [%- content -%]

--- a/root/series/layout.tt
+++ b/root/series/layout.tt
@@ -1,4 +1,4 @@
-[%~ WRAPPER "layout.tt" title=title ? series.name _ " - ${title}" : series.name canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? series.name _ " - ${title}" : series.name ~%]
     <div id="content">
         [%~ React.embed(c, 'series/SeriesHeader', { series => series, page => page }) ~%]
         [%~ content ~%]

--- a/root/url/layout.tt
+++ b/root/url/layout.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' canonical_url=replace_gid(entity.gid) %]
+[% WRAPPER 'layout.tt' %]
     <div id="content">
         [%~ React.embed(c, 'url/URLHeader', { url => url, page => page }) ~%]
         [% content %]

--- a/root/work/layout.tt
+++ b/root/work/layout.tt
@@ -2,7 +2,7 @@
         type => work.l_type_name or l('Work'),
         work => work.name
 }) ~%]
-[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title canonical_url=replace_gid(entity.gid) ~%]
+[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]
     <div id="content">
         [%~ React.embed(c, 'work/WorkHeader', { work => work, page => page }) ~%]
         [%~ content ~%]


### PR DESCRIPTION
This doesn't seem to be needed anymore now that we perform a 301 redirect for merged MBIDs. The MBID in the URL should always be the same as the main entity gid in that case.