### PR TITLE
Do not start a template renderer in t/tests.t

### DIFF
--- a/t/tests.t
+++ b/t/tests.t
@@ -5,7 +5,6 @@ use Module::Pluggable::Object;
 use lib 't/lib';
 use Test::More;
 use Test::Routine::Util;
-use Try::Tiny;
 
 use MusicBrainz::Server::Test qw( commandline_override );
 
@@ -22,8 +21,6 @@ my @classes = (
 );
 
 MusicBrainz::Server::Test->prepare_test_server;
-my $renderer_pid = `./script/start_renderer.pl --daemonize`;
-$renderer_pid =~ s/[^0-9]//g;
 
 @classes = commandline_override("t::MusicBrainz::Server::", @classes);
 
@@ -31,11 +28,4 @@ $renderer_pid =~ s/[^0-9]//g;
 @classes = grep { $_ !~ /WatchArtist/ } @classes;
 
 plan tests => scalar(@classes);
-
-try {
-    run_tests($_ => $_) for @classes;
-} catch {
-    die $_;
-} finally {
-    kill -9, $renderer_pid;
-};
+run_tests($_ => $_) for @classes;


### PR DESCRIPTION
The tests container already has one running in the background. Someone running the tests on their own will almost definitely already have one running, too.