### PR TITLE
Disable t/critic.t

### DIFF
--- a/docker/musicbrainz-tests/run_tests.sh
+++ b/docker/musicbrainz-tests/run_tests.sh
@@ -47,7 +47,6 @@ exec sudo -E -H -u musicbrainz carton exec -- prove \
     --source pgTAP \
     -I lib \
     -j 9 \
-    t/critic.t \
     t/flow.sh \
     t/js.t \
     t/web.js \


### PR DESCRIPTION
We don't add a ton of new Perl code these days, so I think this is of limited utility to have run on *every* build (even ones where no Perl is touched). I don't remember the last time it reported an issue, either. It takes around a minute to run this locally, so I think it could save a good chunk of time if we disable it. If someone does add a lot of Perl code in some PR, it can still easily be run locally.