### PR TITLE
Gracefully handle null, undefined in expand2

### DIFF
--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -359,7 +359,11 @@ function parseRoot() {
  * substitution syntax. In order to display a character reserved by
  * either syntax, HTML character entities must be used.
  */
-export default function expand(source: string, args?: ?VarArgs): React.Node {
+export default function expand(source: ?string, args?: ?VarArgs): React.Node {
+  if (!source) {
+    return '';
+  }
+
   // Reset the global state.
   state.args = args;
   state.match = '';

--- a/root/static/scripts/tests/i18n/expand2.js
+++ b/root/static/scripts/tests/i18n/expand2.js
@@ -3,7 +3,7 @@ import React from 'react';
 import expand2, {expand2html} from '../../common/i18n/expand2';
 
 test('expand2', function (t) {
-  t.plan(47);
+  t.plan(50);
 
   let error;
   const consoleError = console.error;
@@ -19,6 +19,9 @@ test('expand2', function (t) {
     t.equal(expand2html(input, args), output);
   }
 
+  expandText('', null, '');
+  expandText(null, null, '');
+  expandText(undefined, null, '');
   expandText('Some plain text', null, 'Some plain text');
   expandText('Some &quot;plain&quot; text', null, 'Some "plain" text');
   expandText('An {apple_fruit}', null, 'An {apple_fruit}');


### PR DESCRIPTION
I don't have a specific line of code where this is needed, but in addition to being a small ergonomic benefit, it provides some additional safety where we call this function via untyped files and don't know where null/undefined values are lurking.

Cherry-picked from #801