### PR TITLE
Per-database lock file in LoadReplicationChanges

### DIFF
--- a/lib/MusicBrainz/Script/JSONDump/Incremental.pm
+++ b/lib/MusicBrainz/Script/JSONDump/Incremental.pm
@@ -175,6 +175,13 @@ sub run_impl {
                    '--limit', '1'
                 );
 
+                if ($ENV{MUSICBRAINZ_RUNNING_TESTS}) {
+                    push @replicate_args, (
+                        '--lockfile',
+                        '/tmp/.mb-LoadReplicationChanges-' . $self->database,
+                    );
+                }
+
                 my $replication_uri = $self->replication_access_uri;
                 if ($replication_uri) {
                     push @replicate_args, '--base-uri', $replication_uri;

--- a/t/script/ExportAllTables.t
+++ b/t/script/ExportAllTables.t
@@ -110,7 +110,9 @@ EOSQL
 
     system (
         File::Spec->catfile($root, 'admin/replication/LoadReplicationChanges'),
-        '--base-uri', 'file://' . $output_dir, '--database', 'TEST_FULL_EXPORT',
+        '--base-uri', 'file://' . $output_dir,
+        '--database', 'TEST_FULL_EXPORT',
+        '--lockfile', '/tmp/.mb-LoadReplicationChanges-TEST_FULL_EXPORT',
     );
 
     my $c = MusicBrainz::Server::Context->create_script_context(database => 'TEST_FULL_EXPORT');


### PR DESCRIPTION
This is needed because both DumpJSON.t and ExportAllTables.t use LoadReplicationChanges, and they may run concurrently during tests.