### PR TITLE
Add missing imports

### DIFF
--- a/root/static/scripts/common/MB/Control/EditList.js
+++ b/root/static/scripts/common/MB/Control/EditList.js
@@ -3,7 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const {l} = require('../../i18n');
+const MB = require('../../MB');
 
 var SELECTED_CLASS = {
     '1':  'vote-yes',

--- a/root/static/scripts/common/MB/Control/EditSummary.js
+++ b/root/static/scripts/common/MB/Control/EditSummary.js
@@ -3,7 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const {l} = require('../../i18n');
+const MB = require('../../MB');
 
 MB.Control.EditSummary = function (container) {
     var self = {};

--- a/root/static/scripts/common/MB/Control/Filter.js
+++ b/root/static/scripts/common/MB/Control/Filter.js
@@ -18,7 +18,10 @@
 
 */
 
+const $ = require('jquery');
+
 const getBooleanCookie = require('../../utility/getBooleanCookie');
+const MB = require('../../MB');
 const setCookie = require('../../utility/setCookie');
 
 MB.Control.FilterButton = function () {

--- a/root/static/scripts/common/MB/Control/Menu.js
+++ b/root/static/scripts/common/MB/Control/Menu.js
@@ -18,6 +18,10 @@
 
 */
 
+const $ = require('jquery');
+
+const MB = require('../../MB');
+
 MB.Control.HeaderMenu = function () {
     var self = {};
 

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -18,6 +18,10 @@
 
 */
 
+const $ = require('jquery');
+
+const MB = require('../../MB');
+
 MB.Control.SelectAll = function (table) {
     var self = {};
 

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -1,3 +1,7 @@
+const $ = require('jquery');
+
+const MB = require('../MB');
+
 $(function () {
 
     var cardinalityMap = {

--- a/root/static/scripts/common/MB/release.js
+++ b/root/static/scripts/common/MB/release.js
@@ -3,6 +3,8 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const i18n = require('../i18n');
 const getBooleanCookie = require('../utility/getBooleanCookie');
 const setCookie = require('../utility/setCookie');

--- a/root/static/scripts/common/artworkViewer.js
+++ b/root/static/scripts/common/artworkViewer.js
@@ -3,6 +3,9 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+
 const {l} = require('./i18n');
 
 $.widget("mb.artworkViewer", $.ui.dialog, {

--- a/root/static/scripts/common/coverart.js
+++ b/root/static/scripts/common/coverart.js
@@ -3,6 +3,8 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 $(function () {
     $(".cover-art-image").each(function () {
         var $e = $(this);

--- a/root/static/scripts/common/dialogs.js
+++ b/root/static/scripts/common/dialogs.js
@@ -3,9 +3,11 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
-const {l, strings} = require('./i18n');
+const $ = require('jquery');
+const _ = require('lodash');
 
-(function (MB) {
+const {l, strings} = require('./i18n');
+const MB = require('./MB');
 
     $.widget("mb.iframeDialog", $.ui.dialog, {
 
@@ -118,5 +120,3 @@ const {l, strings} = require('./i18n');
             event.stopPropagation();
         });
     });
-
-}(MB = MB || {}));

--- a/root/static/scripts/common/ratings.js
+++ b/root/static/scripts/common/ratings.js
@@ -3,6 +3,8 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const ratingTooltip = require('../../../utility/ratingTooltip');
 
 $(document).on("click", "span.star-rating a", function () {

--- a/root/static/scripts/common/tagger.js
+++ b/root/static/scripts/common/tagger.js
@@ -1,3 +1,5 @@
+const $ = require('jquery');
+
 $(function () {
     $('a.tagger-icon').click(function (event) {
         event.preventDefault();

--- a/root/static/scripts/edit/ExampleRelationships.js
+++ b/root/static/scripts/edit/ExampleRelationships.js
@@ -1,4 +1,9 @@
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
 const i18n = require('../common/i18n');
+const MB = require('../common/MB');
 const request = require('../common/utility/request');
 
 MB.ExampleRelationshipsEditor = (function (ERE) {

--- a/root/static/scripts/edit/MB/Control/Area.js
+++ b/root/static/scripts/edit/MB/Control/Area.js
@@ -3,6 +3,12 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
+const MB = require('../../../common/MB');
+
 MB.Control.Area = function () {
     var bubble = new MB.Control.BubbleDoc();
 

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -3,7 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const i18n = require('../../../common/i18n');
+const MB = require('../../../common/MB');
 
 MB.Control.ArtistEdit = function () {
     var self = {};

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -2,6 +2,11 @@
 // Copyright (C) 2013 MetaBrainz Foundation
 // Released under the GPLv2 license: http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
+const MB = require('../../../common/MB');
 const deferFocus = require('../../utility/deferFocus');
 
 class BubbleBase {

--- a/root/static/scripts/edit/MB/TextList.js
+++ b/root/static/scripts/edit/MB/TextList.js
@@ -18,6 +18,10 @@
 
 */
 
+const $ = require('jquery');
+
+const MB = require('../../common/MB');
+
 MB.Form = (MB.Form) ? MB.Form : {};
 
 MB.Form.TextList = function (input) {

--- a/root/static/scripts/edit/MB/reltypeslist.js
+++ b/root/static/scripts/edit/MB/reltypeslist.js
@@ -1,3 +1,5 @@
+const $ = require('jquery');
+
 $(function () {
 
     $(".reldetails").hide();

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -3,12 +3,14 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
 const {l} = require('../common/i18n');
+const MB = require('../common/MB');
 const clean = require('../common/utility/clean');
 const isBlank = require('../common/utility/isBlank');
 const request = require('../common/utility/request');

--- a/root/static/scripts/edit/common.js
+++ b/root/static/scripts/edit/common.js
@@ -3,6 +3,7 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const ko = require('knockout');
 
 // Supports loading a component template from a <script type="text/html">
 ko.components.loaders.unshift({

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -20,6 +20,7 @@ const {
     isComplexArtistCredit,
     reduceArtistCredit,
   } = require('../../common/immutable-entities');
+const MB = require('../../common/MB');
 const {
   compose2,
   deleteIndex,

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -8,6 +8,7 @@ const ReactDOM = require('react-dom');
 
 const {l} = require('../../common/i18n');
 const {artistCreditFromArray} = require('../../common/immutable-entities');
+const MB = require('../../common/MB');
 const ArtistCreditEditor = require('./ArtistCreditEditor');
 import FieldErrors from '../../../../components/FieldErrors';
 import FormRow from '../../../../components/FormRow';

--- a/root/static/scripts/edit/confirmNavigationFallback.js
+++ b/root/static/scripts/edit/confirmNavigationFallback.js
@@ -4,6 +4,7 @@
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
 const {l} = require('../common/i18n');
+const MB = require('../common/MB');
 
 MB.confirmNavigationFallback = function () {
     /* Every major browser supports onbeforeunload expect Opera. (This says

--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -3,6 +3,7 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
 

--- a/root/static/scripts/edit/notes-received.js
+++ b/root/static/scripts/edit/notes-received.js
@@ -3,6 +3,8 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
 const setCookie = require('../common/utility/setCookie');
 
 $('#alert-new-edit-notes')

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -3,6 +3,7 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const balanced = require('balanced-match');
 const _ = require('lodash');
 

--- a/root/static/scripts/edit/utility/toggleEnded.js
+++ b/root/static/scripts/edit/utility/toggleEnded.js
@@ -3,6 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+
+const MB = require('../../common/MB');
+
 MB.initializeToggleEnded = function (formID) {
     $(function () {
         const endYear = '#' + formID + '\\.period\\.end_date\\.year';

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -3,7 +3,12 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
 const i18n = require('../../../common/i18n');
+const MB = require('../../../common/MB');
 const getBooleanCookie = require('../../../common/utility/getBooleanCookie');
 const setCookie = require('../../../common/utility/setCookie');
 const gc = require('../GuessCase/Main');

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
@@ -18,6 +18,7 @@
 
 */
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 const utils = require('../../../utils');
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -21,6 +21,7 @@
 
 const _ = require('lodash');
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 const utils = require('../../../utils');
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -19,6 +19,7 @@
 
 */
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 const utils = require('../../../utils');
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
@@ -19,6 +19,7 @@
 
 */
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
@@ -18,6 +18,7 @@
 
 */
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -19,6 +19,9 @@
 
 */
 
+const _ = require('lodash');
+
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -21,6 +21,7 @@
 
 const _ = require('lodash');
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
@@ -19,6 +19,7 @@
 
 */
 
+const MB = require('../../../../common/MB');
 const flags = require('../../../flags');
 
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -21,6 +21,7 @@
 
 const _ = require('lodash');
 
+const MB = require('../../../common/MB');
 const utils = require('../../utils');
 
 MB.GuessCase = MB.GuessCase ? MB.GuessCase : {};

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -19,6 +19,7 @@
 
 */
 
+const MB = require('../../../common/MB');
 const flags = require('../../flags');
 const utils = require('../../utils');
 

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -3,6 +3,7 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const L = require('leaflet/dist/leaflet-src');
 const ko = require('knockout');
 const _ = require('lodash');

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -13,6 +13,7 @@ require('../../../lib/jquery-ui');
 const {PART_OF_SERIES_LINK_TYPES} = require('../../common/constants');
 const i18n = require('../../common/i18n');
 import {l_relationships} from '../../common/i18n/relationships';
+const MB = require('../../common/MB');
 const linkTypeInfo = require('../../common/typeInfo').link_type;
 const URLCleanup = require('../../edit/URLCleanup');
 const dates = require('../../edit/utility/dates');

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 require('knockout-arraytransforms');
 
 const {addColon} = require('../../common/i18n');
+const MB = require('../../common/MB');
 const typeInfo = require('../../common/typeInfo');
 const deferFocus = require('../../edit/utility/deferFocus');
 const mergeDates = require('./mergeDates');

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -3,8 +3,11 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
 const ko = require('knockout');
 
+const MB = require('../../common/MB');
 const typeInfo = require('../../common/typeInfo');
 const clean = require('../../common/utility/clean');
 const deferFocus = require('../../edit/utility/deferFocus');

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -8,6 +8,7 @@ const ko = require('knockout');
 const _ = require('lodash');
 
 const i18n = require('../common/i18n');
+const MB = require('../common/MB');
 const request = require('../common/utility/request');
 const {ViewModel} = require('./common/viewModel');
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -14,6 +14,7 @@ const {
         isComplexArtistCredit,
         reduceArtistCredit,
     } = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const deferFocus = require('../edit/utility/deferFocus');
 const guessFeat = require('../edit/utility/guessFeat');
 const fields = require('./fields');

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -4,7 +4,9 @@
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
 const _ = require('lodash');
+const ko = require('knockout');
 
+const MB = require('../common/MB');
 const releaseEditor = require('./viewModel');
 
 function bubbleDoc(options) {

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -3,11 +3,17 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
 const {isCompleteArtistCredit} = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const debounce = require('../common/utility/debounce');
 const request = require('../common/utility/request');
 const releaseEditor = require('./viewModel');
 const utils = require('./utils');
+
 
 var releaseGroupReleases = ko.observableArray([]);
 

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -3,11 +3,13 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const ko = require('knockout');
 const _ = require('lodash');
 
 const {VIDEO_ATTRIBUTE_GID} = require('../common/constants');
 const {reduceArtistCredit} = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const clean = require('../common/utility/clean');
 const debounce = require('../common/utility/debounce');
 const isPositiveInteger = require('../edit/utility/isPositiveInteger');

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -17,6 +17,7 @@ const {
         isCompleteArtistCredit,
         reduceArtistCredit,
     } = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const clean = require('../common/utility/clean');
 const formatTrackLength = require('../common/utility/formatTrackLength');
 import releaseLabelKey from '../common/utility/releaseLabelKey';

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -14,6 +14,7 @@ const {
         hasVariousArtists,
         reduceArtistCredit,
     } = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const clean = require('../common/utility/clean');
 const request = require('../common/utility/request');
 const externalLinks = require('../edit/externalLinks');

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -12,6 +12,7 @@ const {
         isCompleteArtistCredit,
         reduceArtistCredit,
     } = require('../common/immutable-entities');
+const MB = require('../common/MB');
 const debounce = require('../common/utility/debounce');
 const releaseEditor = require('./viewModel');
 const utils = require('./utils');

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -3,6 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
+const _ = require('lodash');
+const ko = require('knockout');
+
 const i18n = require('../common/i18n');
 const releaseEditor = require('./viewModel');
 const utils = require('./utils');

--- a/root/static/scripts/series.js
+++ b/root/static/scripts/series.js
@@ -1,8 +1,10 @@
+const $ = require('jquery');
 const _ = require('lodash');
 const ko = require('knockout');
 
 const {SERIES_ORDERING_TYPE_AUTOMATIC} = require('./common/constants');
 const {lp_attributes} = require('./common/i18n/attributes');
+const MB = require('./common/MB');
 const initializeDuplicateChecker = require('./edit/check-duplicates');
 
 $(function () {

--- a/root/static/scripts/statistics.js
+++ b/root/static/scripts/statistics.js
@@ -1,3 +1,4 @@
+const $ = require('jquery');
 const tablesorter = require('tablesorter');
 
 tablesorter.addWidget({

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -6,6 +6,7 @@
 import _ from 'lodash';
 import test from 'tape';
 
+import MB from '../common/MB';
 import setCookie from '../common/utility/setCookie';
 import gc from '../guess-case/MB/GuessCase/Main';
 import * as modes from '../guess-case/modes';

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -10,6 +10,7 @@ import ko from 'knockout';
 import _ from 'lodash';
 import test from 'tape';
 
+import MB from '../common/MB';
 import typeInfo from '../common/typeInfo';
 import {LinkAttribute, Relationship} from '../relationship-editor/common/fields';
 import {

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -12,6 +12,7 @@ import test from 'tape';
 import ReactTestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
 
+import MB from '../../common/MB';
 import validation from '../../edit/validation';
 import fields from '../../release-editor/fields';
 import {triggerChange, triggerClick, addURL} from '../external-links-editor/utils';

--- a/root/static/scripts/url.js
+++ b/root/static/scripts/url.js
@@ -1,6 +1,7 @@
 const $ = require('jquery');
 const ko = require('knockout');
 
+const MB = require('./common/MB');
 const {registerEvents} = require('./edit/URLCleanup');
 
 $(function () {

--- a/root/static/scripts/voting.js
+++ b/root/static/scripts/voting.js
@@ -3,8 +3,10 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+const $ = require('jquery');
 const querystring = require('querystring');
 
+const MB = require('./common/MB');
 require('./common/MB/Control/EditList');
 require('./common/MB/Control/EditSummary');
 


### PR DESCRIPTION
This fixes all of the undef variables eslint found in our own code (but not in external libraries, e.g. the ones under root/static/lib/).

The command I used to find them is:

```sh
./node_modules/.bin/eslint \
  --no-eslintrc \
  --env 'browser,es6,node' \
  --parser babel-eslint \
  --plugin react \
  --plugin flowtype \
  --rule 'no-undef: [error]' \
  --rule 'flowtype/define-flow-type: warn' \
  root/static/scripts/
```

This is a prerequisite to Webpack.