### PR TITLE
MBS-9994: Sitemaps are not rsynced to gateways

### DIFF
--- a/bin/rsync-staticbrainz-files
+++ b/bin/rsync-staticbrainz-files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 
 KEY="$1"
 SOURCE="$2"

--- a/docker/musicbrainz-sitemaps/crontab
+++ b/docker/musicbrainz-sitemaps/crontab
@@ -1,5 +1,5 @@
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 PERL_CARTON_PATH=/home/musicbrainz/carton-local
 SHELL=/bin/bash
-30 * * * * mkdir -p $HOME/log/hourly-sitemaps && cd $HOME/musicbrainz-server && carton exec -- admin/cron/hourly-sitemaps.sh > $HOME/log/hourly-sitemaps/$(date --utc +\%FT\%TZ).log 2>&1
-10 0 * * * mkdir -p $HOME/log/daily-sitemaps && cd $HOME/musicbrainz-server && carton exec -- admin/cron/daily-sitemaps.sh > $HOME/log/daily-sitemaps/$(date --utc +\%FT\%TZ).log 2>&1
+30 * * * * . /etc/container_environment.sh; mkdir -p $HOME/log/hourly-sitemaps && cd $HOME/musicbrainz-server && carton exec -- admin/cron/hourly-sitemaps.sh > $HOME/log/hourly-sitemaps/$(date --utc +\%FT\%TZ).log 2>&1
+10 0 * * * . /etc/container_environment.sh; mkdir -p $HOME/log/daily-sitemaps && cd $HOME/musicbrainz-server && carton exec -- admin/cron/daily-sitemaps.sh > $HOME/log/daily-sitemaps/$(date --utc +\%FT\%TZ).log 2>&1

--- a/docker/templates/Dockerfile.sitemaps.m4
+++ b/docker/templates/Dockerfile.sitemaps.m4
@@ -23,3 +23,5 @@ copy_mb(`docker/templates/DBDefs.pm.ctmpl lib/')
 RUN chown_mb(`/home/musicbrainz/log MBS_ROOT/root/static/sitemaps')
 
 git_info
+
+RUN chmod 644 /etc/container_environment.sh


### PR DESCRIPTION
This failed because `$STATICBRAINZ_SERVERS` (set on the container via `--env`) is unset when bin/rsync-staticbrainz-files runs.

I've made three changes to address this:

 1. Run rsync-staticbrainz-files with `bash -u` so that it errors on unset variables.
 2. Source /etc/container_environment.sh in the crontab so that rsync-staticbrainz-files has access to `$STATICBRAINZ_SERVERS`.
 3. Give the musicbrainz user access to /etc/container_environment.sh by changing permissions in the Dockerfile. This is described in https://github.com/phusion/baseimage-docker#security