### PR TITLE
MBS-8803: Fix entity link syntax doc for annotation

### DIFF
--- a/root/annotation/edit.tt
+++ b/root/annotation/edit.tt
@@ -55,7 +55,7 @@
     <tr>
       <th>[% l('Links:') %]</th>
       <td>
-        [% l("URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]") %]</td>
+        [% l("URL; [URL]; [URL|label]; [entity-type:MBID|label]") %]</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
# [MBS-8803](https://tickets.metabrainz.org/browse/MBS-8803): Fix entity link syntax doc in annotation editor page

Issue was angle quotes were not escaped.

- Remove angle quotes to follow other link syntax
- Switch entity-type to kebab-case like release-group
- Write MBID all caps since it is an acronym like URL
- Replace name with label not to confuse wwith entity name

Fix commit 44128de8a3ae822cac6f25cd17e3149371bfae0e

Change-Id: I6a4984c73d97ca5588d9681f2575d7a1270fd7e3