### PR TITLE
Use separate DB for sitemaps tests

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -183,7 +183,7 @@ These are a bit more involved to set up:
    Just make sure the connection options match what you're using for the
    `TEST` database.
 
- * Set USE_SELENIUM_HEADER to 1 in lib/DBDefs.pm.
+ * Set USE_SET_DATABASE_HEADER to 1 in lib/DBDefs.pm.
 
  * Run ./script/create_test_db.sh and ./script/compile_resources.sh again.
 

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -106,6 +106,6 @@ sub PLUGIN_CACHE_OPTIONS {
     };
 }
 
-sub USE_SELENIUM_HEADER { 1 }
+sub USE_SET_DATABASE_HEADER { 1 }
 
 1;

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -47,6 +47,13 @@ MusicBrainz::Server::DatabaseConnectionFactory->register_databases(
         port        => 5432,
         username    => 'musicbrainz',
     },
+    TEST_SITEMAPS => {
+        database    => 'musicbrainz_test_sitemaps',
+        host        => 'musicbrainz-test-database',
+        password    => '',
+        port        => 5432,
+        username    => 'musicbrainz',
+    },
 );
 
 sub CACHE_MANAGER_OPTIONS {

--- a/docker/musicbrainz-tests/run_tests.sh
+++ b/docker/musicbrainz-tests/run_tests.sh
@@ -36,6 +36,7 @@ clone_test_db() {
 
 clone_test_db 'musicbrainz_test_json_dump'
 clone_test_db 'musicbrainz_test_full_export'
+clone_test_db 'musicbrainz_test_sitemaps'
 clone_test_db 'musicbrainz_test_template'
 
 exec sudo -E -H -u musicbrainz carton exec -- prove \

--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -410,6 +410,10 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # sub HTML_VALIDATOR { 'http://validator.w3.org/nu/?out=json' }
 # local use example: sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
 
+# Set to 1 if you're a developer and plan to run tests locally. Never
+# enable in production.
+# sub USE_SET_DATABASE_HEADER { 0 }
+
 ################################################################################
 # Profiling
 ################################################################################

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -427,10 +427,15 @@ sub DISCOURSE_API_USERNAME { '' }
 # See https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045
 sub DISCOURSE_SSO_SECRET { '' }
 
-# When enabled, if Catalyst receives a request with the 'Selenium' header set
-# to 1, database queries will go to SELENIUM instead of READWRITE, as defined
-# in the `DatabaseConnectionFactory->register_databases` section of DBDefs.pm.
-# This is only useful if you're running Selenium tests locally.
+# When enabled, if Catalyst receives a request with an `mb-set-database`
+# header, all database queries will go to the specified database instead of
+# READWRITE, as defined in the DatabaseConnectionFactory->register_databases
+# section of DBDefs.pm. This is only useful if you're running Selenium or
+# Sitemaps tests locally.
+#
+# This defaults to the deprecated `USE_SELENIUM_HEADER` for backwards-
+# compatibility.
+sub USE_SET_DATABASE_HEADER { shift->USE_SELENIUM_HEADER }
 sub USE_SELENIUM_HEADER { 0 }
 
 sub WIKIMEDIA_COMMONS_IMAGES_ENABLED { 1 }

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -344,16 +344,20 @@ before dispatch => sub {
 
     my $ctx = $self->model('MB')->context;
 
-    # The selenium header is added by the http proxy in t/selenium.js,
-    # and instructs us to use the SELENIUM database instead of
-    # READWRITE. We ignore the header unless USE_SELENIUM_HEADER is
-    # also enabled.
-    if (DBDefs->USE_SELENIUM_HEADER && $self->req->headers->header('selenium')) {
+    # The mb-set-database header is added by:
+    #  1) the http proxy in t/selenium.js
+    #  2) make_jsonld_request in
+    #     lib/MusicBrainz/Server/Sitemap/Incremental.pm
+    # and instructs us to use the specified database instead of
+    # READWRITE. We ignore the header unless USE_SET_DATABASE_HEADER
+    # is also enabled.
+    my $database = $self->req->headers->header('mb-set-database');
+    if (DBDefs->USE_SET_DATABASE_HEADER && $database) {
         no warnings 'redefine';
-        $ctx->database('SELENIUM');
+        $ctx->database($database);
         $ctx->clear_connector;
         my $cache_namespace = DBDefs->CACHE_NAMESPACE;
-        *DBDefs::CACHE_NAMESPACE = sub { $cache_namespace . 'Selenium:' };
+        *DBDefs::CACHE_NAMESPACE = sub { $cache_namespace . $database . ':' };
         *DBDefs::ENTITY_CACHE_TTL = sub { 1 };
         *DBDefs::SEARCH_SERVER = sub { '' };
     } else {
@@ -373,7 +377,8 @@ after dispatch => sub {
     $ctx->store->disconnect;
     $ctx->cache->disconnect;
 
-    if (DBDefs->USE_SELENIUM_HEADER && $self->req->headers->header('selenium')) {
+    my $database = $self->req->headers->header('mb-set-database');
+    if (DBDefs->USE_SET_DATABASE_HEADER && $database) {
         no warnings 'redefine';
         # Clear the connector and database handles, so that we revert
         # back to the default (READWRITE, or READONLY for slaves).

--- a/lib/MusicBrainz/Server/Sitemap/Incremental.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Incremental.pm
@@ -28,27 +28,14 @@ my %INDEXABLE_ENTITIES = map { $_ => 1 } entities_with(['mbid', 'indexable']);
 my @LASTMOD_ENTITIES = grep { exists $INDEXABLE_ENTITIES{$_} }
                        entities_with('sitemaps_lastmod_table');
 
-BEGIN {
+sub make_jsonld_request {
+    my ($c, $url) = @_;
+
+    my %extra_headers;
     if ($ENV{MUSICBRAINZ_RUNNING_TESTS}) {
-        use Catalyst::Test 'MusicBrainz::Server';
-        use HTTP::Headers;
-        use HTTP::Request;
-
-        *make_jsonld_request = sub {
-            my ($c, $url) = @_;
-
-            request(HTTP::Request->new(
-                GET => $url,
-                HTTP::Headers->new(Accept => 'application/ld+json'),
-            ));
-        };
-    } else {
-        *make_jsonld_request = sub {
-            my ($c, $url) = @_;
-
-            $c->lwp->get($url, Accept => 'application/ld+json');
-        };
+        $extra_headers{'mb-set-database'} = 'TEST';
     }
+    $c->lwp->get($url, Accept => 'application/ld+json', %extra_headers);
 }
 
 sub dump_schema { 'sitemaps' }

--- a/lib/MusicBrainz/Server/Sitemap/Incremental.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Incremental.pm
@@ -33,7 +33,7 @@ sub make_jsonld_request {
 
     my %extra_headers;
     if ($ENV{MUSICBRAINZ_RUNNING_TESTS}) {
-        $extra_headers{'mb-set-database'} = 'TEST';
+        $extra_headers{'mb-set-database'} = 'TEST_SITEMAPS';
     }
     $c->lwp->get($url, Accept => 'application/ld+json', %extra_headers);
 }

--- a/t/script/BuildSitemaps.t
+++ b/t/script/BuildSitemaps.t
@@ -1,5 +1,3 @@
-package t::MusicBrainz::Server::Sitemap;
-
 use DBDefs;
 use File::Spec;
 use File::Temp qw( tempdir );
@@ -7,9 +5,12 @@ use List::UtilsBy qw( sort_by );
 use String::ShellQuote;
 use Test::Deep qw( cmp_deeply );
 use Test::Routine;
+use Test::Routine::Util;
 use Test::More;
 use WWW::Sitemap::XML;
 use WWW::SitemapIndex::XML;
+
+$ENV{MUSICBRAINZ_RUNNING_TESTS} = 1;
 
 test 'Sitemap build scripts' => sub {
     # Because this test invokes external scripts that rely on certain test data
@@ -22,7 +23,7 @@ test 'Sitemap build scripts' => sub {
     my $exec_sql = sub {
         my $sql = shell_quote(shift);
 
-        system 'sh', '-c' => "echo $sql | $psql TEST";
+        system 'sh', '-c' => "echo $sql | $psql TEST_SITEMAPS";
     };
 
     $exec_sql->(<<EOSQL);
@@ -40,7 +41,7 @@ EOSQL
         system (
             File::Spec->catfile($root, 'admin/BuildSitemaps.pl'),
             '--nocompress',
-            '--database' => 'TEST',
+            '--database' => 'TEST_SITEMAPS',
             '--output-dir' => $output_dir,
             '--current-time' => $current_time,
         );
@@ -52,7 +53,7 @@ EOSQL
         system (
             File::Spec->catfile($root, 'admin/BuildIncrementalSitemaps.pl'),
             '--nocompress',
-            '--database' => 'TEST',
+            '--database' => 'TEST_SITEMAPS',
             '--output-dir' => $output_dir,
             '--replication-access-uri' => "file://$tmp",
             '--current-time' => $current_time,
@@ -539,4 +540,5 @@ TRUNCATE sitemaps.tmp_checked_entities;
 EOSQL
 };
 
-1;
+run_me;
+done_testing;

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -95,8 +95,8 @@ const proxy = httpProxy.createProxyServer({});
 const customProxyServer = http.createServer(function (req, res) {
   const host = req.headers.host;
   if (host === DBDefs.WEB_SERVER) {
-    req.headers['Selenium'] = '1';
-    req.rawHeaders['Selenium'] = '1';
+    req.headers['mb-set-database'] = 'SELENIUM';
+    req.rawHeaders['mb-set-database'] = 'SELENIUM';
   }
   proxy.web(req, res, {target: 'http://' + host});
 });


### PR DESCRIPTION
Similar to what was done for the DumpJSON and ExportAllTables tests, create a separate musicbrainz_test_sitemaps DB to allow running it concurrently in a safe manner.

In order to use this DB for requests made during the incremental sitemaps tests, I've adapted the `selenium` header into a more generic `mb-set-database` header to allow selecting any database for the duration of the request.