### PR TITLE
Un-genericize wrapGettext

### DIFF
--- a/root/static/scripts/common/i18n.js
+++ b/root/static/scripts/common/i18n.js
@@ -7,11 +7,11 @@
  */
 
 import NopArgs from './i18n/NopArgs';
-import wrapGettext from './i18n/wrapGettext';
+import * as wrapGettext from './i18n/wrapGettext';
 
-export const l = wrapGettext('dgettext', 'mb_server');
-export const ln = wrapGettext('dngettext', 'mb_server');
-export const lp = wrapGettext('dpgettext', 'mb_server');
+export const l = wrapGettext.dgettext('mb_server');
+export const ln = wrapGettext.dngettext('mb_server');
+export const lp = wrapGettext.dpgettext('mb_server');
 
 function noop(func) {
   return (...args) => new NopArgs(func, args);

--- a/root/static/scripts/common/i18n/attributes.js
+++ b/root/static/scripts/common/i18n/attributes.js
@@ -6,6 +6,6 @@
 
 const wrapGettext = require('./wrapGettext');
 
-exports.l_attributes = wrapGettext('dgettext', 'attributes');
-exports.ln_attributes = wrapGettext('dngettext', 'attributes');
-exports.lp_attributes = wrapGettext('dpgettext', 'attributes');
+exports.l_attributes = wrapGettext.dgettext('attributes');
+exports.ln_attributes = wrapGettext.dngettext('attributes');
+exports.lp_attributes = wrapGettext.dpgettext('attributes');

--- a/root/static/scripts/common/i18n/countries.js
+++ b/root/static/scripts/common/i18n/countries.js
@@ -7,11 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_countries = wrapGettext('dgettext', 'countries');
-const ln_countries = wrapGettext('dngettext', 'countries');
-const lp_countries = wrapGettext('dpgettext', 'countries');
+const l_countries = wrapGettext.dgettext('countries');
+const ln_countries = wrapGettext.dngettext('countries');
+const lp_countries = wrapGettext.dpgettext('countries');
 
 export {
   l_countries,

--- a/root/static/scripts/common/i18n/instrument_descriptions.js
+++ b/root/static/scripts/common/i18n/instrument_descriptions.js
@@ -7,6 +7,6 @@
 
 const wrapGettext = require('./wrapGettext');
 
-exports.l_instrument_descriptions = wrapGettext('dgettext', 'instrument_descriptions');
-exports.ln_instrument_descriptions = wrapGettext('dngettext', 'instrument_descriptions');
-exports.lp_instrument_descriptions = wrapGettext('dpgettext', 'instrument_descriptions');
+exports.l_instrument_descriptions = wrapGettext.dgettext('instrument_descriptions');
+exports.ln_instrument_descriptions = wrapGettext.dngettext('instrument_descriptions');
+exports.lp_instrument_descriptions = wrapGettext.dpgettext('instrument_descriptions');

--- a/root/static/scripts/common/i18n/instruments.js
+++ b/root/static/scripts/common/i18n/instruments.js
@@ -7,11 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_instruments = wrapGettext('dgettext', 'instruments');
-const ln_instruments = wrapGettext('dngettext', 'instruments');
-const lp_instruments = wrapGettext('dpgettext', 'instruments');
+const l_instruments = wrapGettext.dgettext('instruments');
+const ln_instruments = wrapGettext.dngettext('instruments');
+const lp_instruments = wrapGettext.dpgettext('instruments');
 
 export {
   l_instruments,

--- a/root/static/scripts/common/i18n/languages.js
+++ b/root/static/scripts/common/i18n/languages.js
@@ -7,11 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_languages = wrapGettext('dgettext', 'languages');
-const ln_languages = wrapGettext('dngettext', 'languages');
-const lp_languages = wrapGettext('dpgettext', 'languages');
+const l_languages = wrapGettext.dgettext('languages');
+const ln_languages = wrapGettext.dngettext('languages');
+const lp_languages = wrapGettext.dpgettext('languages');
 
 export {
   l_languages,

--- a/root/static/scripts/common/i18n/relationships.js
+++ b/root/static/scripts/common/i18n/relationships.js
@@ -7,11 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_relationships = wrapGettext('dgettext', 'relationships');
-const ln_relationships = wrapGettext('dngettext', 'relationships');
-const lp_relationships = wrapGettext('dpgettext', 'relationships');
+const l_relationships = wrapGettext.dgettext('relationships');
+const ln_relationships = wrapGettext.dngettext('relationships');
+const lp_relationships = wrapGettext.dpgettext('relationships');
 
 export {
   l_relationships,

--- a/root/static/scripts/common/i18n/scripts.js
+++ b/root/static/scripts/common/i18n/scripts.js
@@ -7,11 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_scripts = wrapGettext('dgettext', 'scripts');
-const ln_scripts = wrapGettext('dngettext', 'scripts');
-const lp_scripts = wrapGettext('dpgettext', 'scripts');
+const l_scripts = wrapGettext.dgettext('scripts');
+const ln_scripts = wrapGettext.dngettext('scripts');
+const lp_scripts = wrapGettext.dpgettext('scripts');
 
 export {
   l_scripts,

--- a/root/static/scripts/common/i18n/statistics.js
+++ b/root/static/scripts/common/i18n/statistics.js
@@ -6,11 +6,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import wrapGettext from './wrapGettext';
+import * as wrapGettext from './wrapGettext';
 
-const l_statistics = wrapGettext('dgettext', 'statistics');
-const ln_statistics = wrapGettext('dngettext', 'statistics');
-const lp_statistics = wrapGettext('dpgettext', 'statistics');
+const l_statistics = wrapGettext.dgettext('statistics');
+const ln_statistics = wrapGettext.dngettext('statistics');
+const lp_statistics = wrapGettext.dpgettext('statistics');
 
 export {
   l_statistics,


### PR DESCRIPTION
Before this commit, wrapGettext was a single function that handled all three of dgettext, dngettext, and dpgettext. This required some hacks due to the different argument orders these functions have; the code is much clearer by just having separate exports. Additionally, we can more easily define sound Flow types this way.

This is cherry-picked from #801.