### PR TITLE
Relationship editor test: "guitars" has been renamed

### DIFF
--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -198,7 +198,7 @@ relationshipEditorTest("link phrase interpolation", function (t) {
             linkTypeID: 154,
             attributes: ids2attrs([1, 69, 75, 109, 302]),
             expected: "contains additional samples by",
-            expectedExtra: "strings, guitars, lyre, plucked string instruments"
+            expectedExtra: "strings, guitar family, lyre, plucked string instruments"
         },
         // MBS-6129
         {


### PR DESCRIPTION
Was getting this failure even on master. Not entirely sure how this hasn't been an issue before? 