### PR TITLE
Standardize i18n domain file formatting

### DIFF
--- a/root/static/scripts/common/i18n/attributes.js
+++ b/root/static/scripts/common/i18n/attributes.js
@@ -1,11 +1,14 @@
-// Copyright (C) 2018 MetaBrainz Foundation
-//
-// This file is part of MusicBrainz, the open internet music database,
-// and is licensed under the GPL version 2, or (at your option) any
-// later version: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
-const wrapGettext = require('./wrapGettext');
+import * as wrapGettext from './wrapGettext';
 
-exports.l_attributes = wrapGettext.dgettext('attributes');
-exports.ln_attributes = wrapGettext.dngettext('attributes');
-exports.lp_attributes = wrapGettext.dpgettext('attributes');
+export const l_attributes = wrapGettext.dgettext('attributes');
+export const ln_attributes = wrapGettext.dngettext('attributes');
+export const lp_attributes = wrapGettext.dpgettext('attributes');

--- a/root/static/scripts/common/i18n/countries.js
+++ b/root/static/scripts/common/i18n/countries.js
@@ -9,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_countries = wrapGettext.dgettext('countries');
-const ln_countries = wrapGettext.dngettext('countries');
-const lp_countries = wrapGettext.dpgettext('countries');
-
-export {
-  l_countries,
-  ln_countries,
-  lp_countries,
-};
+export const l_countries = wrapGettext.dgettext('countries');
+export const ln_countries = wrapGettext.dngettext('countries');
+export const lp_countries = wrapGettext.dpgettext('countries');

--- a/root/static/scripts/common/i18n/instrument_descriptions.js
+++ b/root/static/scripts/common/i18n/instrument_descriptions.js
@@ -1,12 +1,14 @@
-/* Copyright (C) 2018 MetaBrainz Foundation
+/*
+ * @flow
+ * Copyright (C) 2018 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
  * and is licensed under the GPL version 2, or (at your option) any
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const wrapGettext = require('./wrapGettext');
+import * as wrapGettext from './wrapGettext';
 
-exports.l_instrument_descriptions = wrapGettext.dgettext('instrument_descriptions');
-exports.ln_instrument_descriptions = wrapGettext.dngettext('instrument_descriptions');
-exports.lp_instrument_descriptions = wrapGettext.dpgettext('instrument_descriptions');
+export const l_instrument_descriptions = wrapGettext.dgettext('instrument_descriptions');
+export const ln_instrument_descriptions = wrapGettext.dngettext('instrument_descriptions');
+export const lp_instrument_descriptions = wrapGettext.dpgettext('instrument_descriptions');

--- a/root/static/scripts/common/i18n/instruments.js
+++ b/root/static/scripts/common/i18n/instruments.js
@@ -9,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_instruments = wrapGettext.dgettext('instruments');
-const ln_instruments = wrapGettext.dngettext('instruments');
-const lp_instruments = wrapGettext.dpgettext('instruments');
-
-export {
-  l_instruments,
-  ln_instruments,
-  lp_instruments,
-};
+export const l_instruments = wrapGettext.dgettext('instruments');
+export const ln_instruments = wrapGettext.dngettext('instruments');
+export const lp_instruments = wrapGettext.dpgettext('instruments');

--- a/root/static/scripts/common/i18n/languages.js
+++ b/root/static/scripts/common/i18n/languages.js
@@ -9,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_languages = wrapGettext.dgettext('languages');
-const ln_languages = wrapGettext.dngettext('languages');
-const lp_languages = wrapGettext.dpgettext('languages');
-
-export {
-  l_languages,
-  ln_languages,
-  lp_languages,
-};
+export const l_languages = wrapGettext.dgettext('languages');
+export const ln_languages = wrapGettext.dngettext('languages');
+export const lp_languages = wrapGettext.dpgettext('languages');

--- a/root/static/scripts/common/i18n/relationships.js
+++ b/root/static/scripts/common/i18n/relationships.js
@@ -9,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_relationships = wrapGettext.dgettext('relationships');
-const ln_relationships = wrapGettext.dngettext('relationships');
-const lp_relationships = wrapGettext.dpgettext('relationships');
-
-export {
-  l_relationships,
-  ln_relationships,
-  lp_relationships,
-};
+export const l_relationships = wrapGettext.dgettext('relationships');
+export const ln_relationships = wrapGettext.dngettext('relationships');
+export const lp_relationships = wrapGettext.dpgettext('relationships');

--- a/root/static/scripts/common/i18n/scripts.js
+++ b/root/static/scripts/common/i18n/scripts.js
@@ -9,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_scripts = wrapGettext.dgettext('scripts');
-const ln_scripts = wrapGettext.dngettext('scripts');
-const lp_scripts = wrapGettext.dpgettext('scripts');
-
-export {
-  l_scripts,
-  ln_scripts,
-  lp_scripts,
-};
+export const l_scripts = wrapGettext.dgettext('scripts');
+export const ln_scripts = wrapGettext.dngettext('scripts');
+export const lp_scripts = wrapGettext.dpgettext('scripts');

--- a/root/static/scripts/common/i18n/statistics.js
+++ b/root/static/scripts/common/i18n/statistics.js
@@ -1,4 +1,5 @@
 /*
+ * @flow
  * Copyright (C) 2018 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -8,12 +9,6 @@
 
 import * as wrapGettext from './wrapGettext';
 
-const l_statistics = wrapGettext.dgettext('statistics');
-const ln_statistics = wrapGettext.dngettext('statistics');
-const lp_statistics = wrapGettext.dpgettext('statistics');
-
-export {
-  l_statistics,
-  ln_statistics,
-  lp_statistics,
-};
+export const l_statistics = wrapGettext.dgettext('statistics');
+export const ln_statistics = wrapGettext.dngettext('statistics');
+export const lp_statistics = wrapGettext.dpgettext('statistics');


### PR DESCRIPTION
These all used different export styles for some reason. Some were missing `@flow` too.