### PR TITLE
Fix QUALITY_NAMES to use N_l

### DIFF
--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -15,11 +15,11 @@ import {
   EDIT_STATUS_TOBEDELETED,
 } from '../../constants';
 import {withCatalystContext} from '../../context';
+import SidebarDataQuality from '../../layout/components/sidebar/SidebarDataQuality';
 import {
   SidebarProperties,
   SidebarProperty,
 } from '../../layout/components/sidebar/SidebarProperties';
-import {QUALITY_NAMES} from '../../static/scripts/common/constants';
 import {addColon, l, ln, lp} from '../../static/scripts/common/i18n';
 import {
   getEditExpireAction,
@@ -64,9 +64,7 @@ const EditSidebar = ({$c, edit}: Props) => (
         </SidebarProperty>
       )}
 
-      <SidebarProperty className="" label={l('Data Quality:')}>
-        {QUALITY_NAMES.get(edit.quality) || ''}
-      </SidebarProperty>
+      <SidebarDataQuality quality={edit.quality} />
 
       <SidebarProperty className="" label={l('Requires:')}>
         {ln(

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -14,7 +14,6 @@ import * as React from 'react';
 import {QUALITY_UNKNOWN} from '../../../constants';
 import {withCatalystContext} from '../../../context';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
-import {QUALITY_NAMES} from '../../../static/scripts/common/constants';
 import {l, lp} from '../../../static/scripts/common/i18n';
 import {l_attributes} from '../../../static/scripts/common/i18n/attributes';
 import {l_languages} from '../../../static/scripts/common/i18n/languages';
@@ -37,6 +36,7 @@ import EditLinks from './EditLinks';
 import LastUpdated from './LastUpdated';
 import MergeLink from './MergeLink';
 import RemoveLink from './RemoveLink';
+import SidebarDataQuality from './SidebarDataQuality';
 import SidebarLicenses from './SidebarLicenses';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties';
 import SidebarRating from './SidebarRating';
@@ -185,9 +185,7 @@ const ReleaseSidebar = ({$c, release}: Props) => {
         ) : null}
 
         {release.quality === QUALITY_UNKNOWN ? null : (
-          <SidebarProperty className="data-quality" label={l('Data Quality:')}>
-            {QUALITY_NAMES.get(release.quality) || ''}
-          </SidebarProperty>
+          <SidebarDataQuality quality={release.quality} />
         )}
       </SidebarProperties>
 

--- a/root/layout/components/sidebar/SidebarDataQuality.js
+++ b/root/layout/components/sidebar/SidebarDataQuality.js
@@ -1,0 +1,30 @@
+/*
+ * @flow
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {QUALITY_NAMES} from '../../../static/scripts/common/constants';
+import {addColon, l} from '../../../static/scripts/common/i18n';
+
+import {SidebarProperty} from './SidebarProperties';
+
+type Props = {|
+  +quality: QualityT,
+|};
+
+const SidebarDataQuality = ({quality}: Props) => {
+  const name = QUALITY_NAMES.get(quality);
+  return name ? (
+    <SidebarProperty className="data-quality" label={addColon(l('Data Quality'))}>
+      {name.toString()}
+    </SidebarProperty>
+  ) : null;
+};
+
+export default SidebarDataQuality;

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -7,7 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import {l, N_l, N_lp} from './i18n';
+import {N_l, N_lp} from './i18n';
+import NopArgs from './i18n/NopArgs';
 
 export const ENTITIES = require('../../../../entities');
 
@@ -219,9 +220,9 @@ export const ENTITIES_WITH_RELATIONSHIP_CREDITS: {[string]: boolean} = {
   place: true,
 };
 
-export const QUALITY_NAMES: Map<QualityT, string> = new Map([
-  [0, l('Low')],
-  [-1, l('Normal')],
-  [1, l('Normal')],
-  [2, l('High')],
+export const QUALITY_NAMES: Map<QualityT, NopArgs> = new Map([
+  [0, N_l('Low')],
+  [-1, N_l('Normal')],
+  [1, N_l('Normal')],
+  [2, N_l('High')],
 ]);


### PR DESCRIPTION
These should not be cached at the module-level, otherwise they won't change when the language changes. (`DEVELOPMENT_SERVER` must be disabled to observe this.)

I added a `SidebarDataQuality` component to hold code used by both the release and edit sidebars.