### PR TITLE
Allow % replacements to be React nodes

### DIFF
--- a/root/static/scripts/tests/i18n/expand2.js
+++ b/root/static/scripts/tests/i18n/expand2.js
@@ -4,7 +4,7 @@ import React from 'react';
 import expand2, {expand2html} from '../../common/i18n/expand2';
 
 test('expand2', function (t) {
-  t.plan(54);
+  t.plan(55);
 
   let error = '';
   const consoleError = console.error;
@@ -118,6 +118,7 @@ test('expand2', function (t) {
   expandText('{x:%|}', {x: ''}, '');
   expandText('{x:%|}', {x: '%'}, '%');
   expandText('{x:%|}', {x: '&percnt;'}, '&percnt;');
+  expandHtml('{x:%|}', {x: <p>hi</p>}, '<p>hi</p>');
   expandText('{x:a%c|}', {x: 'b'}, 'abc');
   expandText('{x:a&percnt;c|}', {x: 'b'}, 'a%c');
 


### PR DESCRIPTION
This is needed for instrument links in relationship link phrases. For example, in 'performed {instrument:%|instruments} on', we will want to substitute the '%' with a link to the actual instrument page, as our Perl-based expand code currently does.