### PR TITLE
Refer to mmd-schema git tag v-2019-01-07

### DIFF
--- a/docker/templates/Dockerfile.tests.m4
+++ b/docker/templates/Dockerfile.tests.m4
@@ -24,7 +24,7 @@ RUN cd /tmp && \
 RUN cd /home/musicbrainz && \
     git clone https://github.com/metabrainz/mmd-schema && \
     cd mmd-schema && \
-    git reset --hard MMD_SCHEMA_COMMIT && \
+    git reset --hard MMD_SCHEMA_TAG && \
     cd ../
 
 ENV MMDSCHEMA /home/musicbrainz/mmd-schema

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -17,7 +17,7 @@ m4_define(`CHROME_DRIVER', `chromedriver_linux64.zip')
 
 m4_define(`NODEJS_DEB', `nodejs_10.10.0-1nodesource1_amd64.deb')
 
-m4_define(`MMD_SCHEMA_COMMIT', `ac9a0bdd209091a61c97915d8419180002e87931')
+m4_define(`MMD_SCHEMA_TAG', `v-2019-01-07')
 
 m4_define(
     `install_javascript',


### PR DESCRIPTION
instead of git commit ac9a0bdd209091a61c97915d8419180002e87931

The content is the same, the reference only changes.

Note: Tag [v-2019-01-07](https://github.com/metabrainz/mmd-schema/releases/tag/v-2019-01-07) is on `production` branch, whereas commit was from `master` branch.