### PR TITLE
MBS-9923 (I): Convert URL Layout to React

### DIFF
--- a/root/url/UrlHeader.js
+++ b/root/url/UrlHeader.js
@@ -18,7 +18,7 @@ type Props = {|
   url: UrlT,
 |};
 
-const URLHeader = ({url, page}: Props) => (
+const UrlHeader = ({url, page}: Props) => (
   <EntityHeader
     entity={url}
     headerClass="workheader"
@@ -30,4 +30,4 @@ const URLHeader = ({url, page}: Props) => (
   />
 );
 
-export default URLHeader;
+export default UrlHeader;

--- a/root/url/UrlLayout.js
+++ b/root/url/UrlLayout.js
@@ -1,0 +1,45 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React from 'react';
+import type {Node as ReactNode} from 'react';
+
+import Layout from '../layout';
+import UrlSidebar from '../layout/components/sidebar/UrlSidebar';
+
+import URLHeader from './URLHeader';
+
+type Props = {|
+  +children: ReactNode,
+  +entity: UrlT,
+  +fullWidth?: boolean,
+  +page: string,
+  +title?: string,
+|};
+
+const UrlLayout = ({
+  children,
+  entity: url,
+  fullWidth,
+  page,
+  title,
+}: Props) => (
+  <Layout
+    title={title}
+  >
+    <div id="content">
+      <URLHeader page={page} url={url} />
+      {children}
+    </div>
+    {fullWidth ? null : <UrlSidebar url={url} />}
+  </Layout>
+);
+
+
+export default UrlLayout;

--- a/root/url/UrlLayout.js
+++ b/root/url/UrlLayout.js
@@ -13,7 +13,7 @@ import type {Node as ReactNode} from 'react';
 import Layout from '../layout';
 import UrlSidebar from '../layout/components/sidebar/UrlSidebar';
 
-import URLHeader from './URLHeader';
+import UrlHeader from './UrlHeader';
 
 type Props = {|
   +children: ReactNode,
@@ -34,7 +34,7 @@ const UrlLayout = ({
     title={title}
   >
     <div id="content">
-      <URLHeader page={page} url={url} />
+      <UrlHeader page={page} url={url} />
       {children}
     </div>
     {fullWidth ? null : <UrlSidebar url={url} />}

--- a/root/url/layout.tt
+++ b/root/url/layout.tt
@@ -1,6 +1,6 @@
 [% WRAPPER 'layout.tt' %]
     <div id="content">
-        [%~ React.embed(c, 'url/URLHeader', { url => url, page => page }) ~%]
+        [%~ React.embed(c, 'url/UrlHeader', { url => url, page => page }) ~%]
         [% content %]
     </div>
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9923

Index probably can't be converted until the relationship components are merged, meaning this Layout file is currently unused, but it shouldn't hurt to have it already. Once the relationships component is merged it should be very easy to finish MBS-9923

UrlHeader renamed for consistency on @mwiencek's suggestion.