### PR TITLE
MBS-10008: Generalize CPDL sidebar name

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/CPDL.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/CPDL.pm
@@ -1,15 +1,12 @@
 package MusicBrainz::Server::Entity::URL::CPDL;
 
 use Moose;
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
-sub sidebar_name {
-    my $self = shift;
-
-    return "Score at CPDL";
-}
+sub sidebar_name { l('Score(s) at CPDL') }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10008

Since the URLs can't be differentiated, the best we can do is generalize this to "Score(s)" or "Scores", sadly.