### PR TITLE
Add ProhibitInterpolationOfLiterals to Critic

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -12,6 +12,7 @@ severity=1
 [TestingAndDebugging::ProhibitNoStrict]
 allow=refs
 
+[ValuesAndExpressions::ProhibitInterpolationOfLiterals]
 [ValuesAndExpressions::ProhibitMismatchedOperators]
 [ValuesAndExpressions::ProhibitMixedBooleanOperators]
 


### PR DESCRIPTION
https://docs.activestate.com/activeperl/5.26/perl/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitInterpolationOfLiterals.html seems like a sensible rule to try to follow, so @yvanzo and I were thinking it might make sense to add it to Critic :)