### PR TITLE
MBS-10018: Convert artist/special_purpose.tt to React

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -562,7 +562,14 @@ around $_ => sub {
 
     my $artist = $c->stash->{artist};
     if ($artist->is_special_purpose) {
-        $c->stash( template => 'artist/special_purpose.tt' );
+        my %props = (
+            artist => $artist,
+        );
+        $c->stash(
+            component_path => 'artist/SpecialPurpose.js',
+            component_props => \%props,
+            current_view => 'Node',
+        );
         $c->response->status(HTTP_FORBIDDEN);
         $c->detach;
     }

--- a/root/artist/SpecialPurpose.js
+++ b/root/artist/SpecialPurpose.js
@@ -1,0 +1,31 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+
+import ArtistLayout from './ArtistLayout';
+
+const SpecialPurpose = ({artist}: {artist: ArtistT}) => (
+  <ArtistLayout
+    entity={artist}
+    fullWidth
+    page="special_purpose"
+    title={l('Cannot edit')}
+  >
+    <h2>{l('You may not edit special purpose artists')}</h2>
+    <p>
+      {l(`The artist you are trying to edit is a special purpose artist,
+          and you may not make direct changes to this data.`)}
+    </p>
+  </ArtistLayout>
+);
+
+export default SpecialPurpose;

--- a/root/artist/special_purpose.tt
+++ b/root/artist/special_purpose.tt
@@ -1,5 +1,0 @@
-[% WRAPPER 'layout.tt' title=l('Cannot edit') full_width=1 %]
-    <h2>[% l('You may not edit special purpose artists') %]</h2>
-    <p>[% l('The artist you are trying to edit is a special purpose artist, and you may not make direct
-             changes to this data.') %]</p>
-[% END %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10018

The current implementation does not display any info about the artist being (not) edited. I think that's confusing and it's much better to have the header present (both to show the user *which* artist they're trying to edit, and to allow them more navigation options away from the error) so changed this from the original layout.tt to use ArtistLayout.