### PR TITLE
URLCleanup fixes: split grouped cleanups for clarity

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -437,6 +437,14 @@ const CLEANUPS = {
       return id === LINK_TYPES.lyrics.work && /^http:\/\/animationsong\.com\/archives\/\d+\.html$/.test(url);
     },
   },
+  'animenewsnetwork': {
+    match: [new RegExp('^(https?://)?(www\\.)?animenewsnetwork\\.com', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?animenewsnetwork\.com\/encyclopedia\/(people|company).php\?id=([0-9]+).*$/, 'https://www.animenewsnetwork.com/encyclopedia/$1.php?id=$2');
+      return url;
+    },
+  },
   'anisongeneration': {
     match: [new RegExp('^(?:https?://)?anison\\.info/', 'i')],
     type: LINK_TYPES.otherdatabases,
@@ -804,17 +812,23 @@ const CLEANUPS = {
       return url;
     },
   },
-  'crowdfunding': {
+  'changetip': {
     match: [
-      new RegExp('^(https?://)?(www\\.)?indiegogo\\.com/(individuals|projects)/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?kickstarter\\.com/(profile|projects)/', 'i'),
+      new RegExp('^(https?://)?(www\\.)?changetip\\.com/tipme/[^/?#]', 'i'),
+      new RegExp('^(https?://)?[^/?#]+\\.tip.me([/?#].*)?$', 'i'),
     ],
-    type: LINK_TYPES.crowdfunding,
+    type: LINK_TYPES.patronage,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?indiegogo\.com\/individuals\/(\d+)(?:[\/?#].*)?$/, 'https://www.indiegogo.com/individuals/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?indiegogo\.com\/projects\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.indiegogo.com/projects/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?kickstarter\.com\/profile\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.kickstarter.com/profile/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?kickstarter\.com\/projects\/(\d+)\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.kickstarter.com/projects/$1/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?changetip\.com\/tipme\/([^\/?#]+)(?:.*)?$/, 'https://www.changetip.com/tipme/$1');
+      url = url.replace(/^(?:https?:\/\/)?([^\/?#]+)\.tip\.me(?:[\/?#].*)?$/, 'https://www.changetip.com/tipme/$1');
+      return url;
+    },
+  },
+  'classicalarchives': {
+    match: [new RegExp('^(https?://)?(www\\.)?classicalarchives\\.com/(album|artist|composer|ensemble|work)/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?classicalarchives\.com\/(album|artist|composer|ensemble|work)\/([^\/?#]+)(?:.*)?$/, 'https://www.classicalarchives.com/$1/$2');
       return url;
     },
   },
@@ -876,6 +890,14 @@ const CLEANUPS = {
         }
       }
       return false;
+    },
+  },
+  'dhhu': {
+    match: [new RegExp('^(https?://)?(www\\.)?dhhu\\.dk', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(www\.)?dhhu\.dk\/w\/(.*)+$/, 'http://www.dhhu.dk/w/$2');
+      return url;
     },
   },
   'discographyentry': {
@@ -964,6 +986,26 @@ const CLEANUPS = {
       return false;
     },
   },
+  'drip': {
+    match: [
+      new RegExp('^(https?://)?(www\\.)?d\\.rip/[^/?#]', 'i'),
+      new RegExp('^(https?://)?(www\\.)?drip\\.kickstarter.com/[^/?#]', 'i'),
+    ],
+    type: LINK_TYPES.patronage,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?d\.rip\/([^\/?#]+)(?:.*)?$/, 'https://d.rip/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?drip\.kickstarter.com\/([^\/?#]+)(?:.*)?$/, 'https://d.rip/$1');
+      return url;
+    },
+  },
+  'ester': {
+    match: [new RegExp('^(https?://)?(www\\.)?ester\\.ee/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ester\.ee\/record=([^~]+)(?:.*)?$/, 'http://www.ester.ee/record=$1~S1*est');
+      return url;
+    },
+  },
   'facebook': {
     match: [new RegExp('^(https?://)?([\\w.-]*\\.)?(facebook|fb)\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
@@ -991,6 +1033,14 @@ const CLEANUPS = {
         return /\/pages\/[^\/?#]+\/\d+/.test(url);
       }
       return true;
+    },
+  },
+  'flattr': {
+    match: [new RegExp('^(https?://)?(www\\.)?flattr\\.com/profile/[^/?#]', 'i')],
+    type: LINK_TYPES.patronage,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?flattr\.com\/profile\/([^\/?#]+)(?:.*)?$/, 'https://flattr.com/profile/$1');
+      return url;
     },
   },
   'generasia': {
@@ -1056,6 +1106,14 @@ const CLEANUPS = {
       return false;
     },
   },
+  'ibdb': {
+    match: [new RegExp('^(https?://)?(www\\.)?ibdb\\.com/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(https?:\/\/)?(www\.)?ibdb\.com/, 'https://www.ibdb.com');
+      return url;
+    },
+  },
   'imdb': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?imdb\\.', 'i')],
     type: LINK_TYPES.imdb,
@@ -1085,6 +1143,15 @@ const CLEANUPS = {
   'imslp': {
     match: [new RegExp('^(https?://)?(www\\.)?imslp\\.org/', 'i')],
     type: _.defaults({}, LINK_TYPES.imslp, LINK_TYPES.score),
+  },
+  'indiegogo': {
+    match: [new RegExp('^(https?://)?(www\\.)?indiegogo\\.com/(individuals|projects)/', 'i')],
+    type: LINK_TYPES.crowdfunding,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?indiegogo\.com\/individuals\/(\d+)(?:[\/?#].*)?$/, 'https://www.indiegogo.com/individuals/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?indiegogo\.com\/projects\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.indiegogo.com/projects/$1');
+      return url;
+    },
   },
   'instagram': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?instagram\\.com/', 'i')],
@@ -1217,6 +1284,23 @@ const CLEANUPS = {
         }
       }
       return false;
+    },
+  },
+  'kickstarter': {
+    match: [new RegExp('^(https?://)?(www\\.)?kickstarter\\.com/(profile|projects)/', 'i')],
+    type: LINK_TYPES.crowdfunding,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?kickstarter\.com\/profile\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.kickstarter.com/profile/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?kickstarter\.com\/projects\/(\d+)\/([\w\-]+)(?:[\/?#].*)?$/, 'https://www.kickstarter.com/projects/$1/$2');
+      return url;
+    },
+  },
+  'kofi': {
+    match: [new RegExp('^(https?://)?(www\\.)?ko-fi.com/[^/?#]', 'i')],
+    type: LINK_TYPES.patronage,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ko-fi\.com\/([^\/?#]+)(?:.*)?$/, 'https://ko-fi.com/$1');
+      return url;
     },
   },
   'lastfm': {
@@ -1355,6 +1439,14 @@ const CLEANUPS = {
       return false;
     },
   },
+  'musiksammler': {
+    match: [new RegExp('^(https?://)?(www\\.)?musik-sammler\\.de/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/(album|artist|media)\/([0-9a-z-]+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/$1/$2/');
+      return url;
+    },
+  },
   'musixmatch': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?musixmatch\\.com/', 'i')],
     type: LINK_TYPES.lyrics,
@@ -1447,6 +1539,14 @@ const CLEANUPS = {
       return url;
     },
   },
+  'openlibrary': {
+    match: [new RegExp('^(https?://)?(www\\.)?openlibrary\\.org', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, 'https://openlibrary.org/$2/$3');
+      return url;
+    },
+  },
   'operabase': {
     match: [new RegExp('^(https?://)?(www\\.)?operabase\\.com', 'i')],
     type: LINK_TYPES.otherdatabases,
@@ -1459,13 +1559,9 @@ const CLEANUPS = {
   },
   'otherdatabases': {
     match: [
-      new RegExp('^(https?://)?(www\\.)?classicalarchives\\.com/(album|artist|composer|ensemble|work)/', 'i'),
       new RegExp('^(https?://)?(www\\.)?rateyourmusic\\.com/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?worldcat\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?musicmoz\\.org/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?musik-sammler\\.de/', 'i'),
       new RegExp('^(https?://)?(www\\.)?discografia\\.dds\\.it/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?ester\\.ee/', 'i'),
       new RegExp('^(https?://)?(www\\.)?encyclopedisque\\.fr/', 'i'),
       new RegExp('^(https?://)?(www\\.)?discosdobrasil\\.com\\.br/', 'i'),
       new RegExp('^(https?://)?(www\\.)?isrc\\.ncl\\.edu\\.tw/', 'i'),
@@ -1473,17 +1569,9 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?psydb\\.net/', 'i'),
       new RegExp('^(https?://)?(www\\.)?metal-archives\\.com/(bands?|albums|artists|labels)', 'i'),
       new RegExp('^(https?://)?(www\\.)?spirit-of-metal\\.com/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?ibdb\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?lortel\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?theatricalia\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?(trove\\.)?nla\\.gov\\.au/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?rockensdanmarkskort\\.dk', 'i'),
-      new RegExp('^(https?://)?((www|wiki)\\.)?rockinchina\\.com', 'i'),
-      new RegExp('^(https?://)?(www\\.)?dhhu\\.dk', 'i'),
-      new RegExp('^(https?://)?(www\\.)?openlibrary\\.org', 'i'),
-      new RegExp('^(https?://)?(www\\.)?animenewsnetwork\\.com', 'i'),
-      new RegExp('^(https?://)?(www\\.)?rockipedia\\.no', 'i'),
       new RegExp('^(https?://)?(www\\.)?whosampled\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?maniadb\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?imvdb\\.com', 'i'),
@@ -1515,65 +1603,25 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?triplejunearthed\\.com', 'i'),
     ],
     type: LINK_TYPES.otherdatabases,
-    clean: function (url) {
-      // Standardising ClassicalArchives.com
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?classicalarchives\.com\/(album|artist|composer|ensemble|work)\/([^\/?#]+)(?:.*)?$/, 'https://www.classicalarchives.com/$1/$2');
-      // Removing cruft from Worldcat URLs and standardising to https
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org/, 'https://www.worldcat.org');
-      url = url.replace(/^https:\/\/www\.worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, 'https://www.worldcat.org/oclc/$1');
-      // Standardising IBDb not to use www
-      url = url.replace(/^(https?:\/\/)?(www\.)?ibdb\.com/, 'https://www.ibdb.com');
-      // Standardising ESTER to their default parameters
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ester\.ee\/record=([^~]+)(?:.*)?$/, 'http://www.ester.ee/record=$1~S1*est');
-      // Standardising Trove
-      url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/work\/([^\/?#]+)(?:.*)?$/, 'https://trove.nla.gov.au/work/$1');
-      url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/people\/([^\/?#]+)(?:.*)?$/, 'https://nla.gov.au/nla.party-$1');
-      url = url.replace(/^(?:https?:\/\/)?nla\.gov\.au\/(nla\.party-|anbd\.bib-an)([^\/?#]+)(?:.*)?$/, 'https://nla.gov.au/$1$2');
-      // Standardising Musik-Sammler.de
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/(album|artist|media)\/([0-9a-z-]+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/$1/$2/');
-      // Standardising Rockens Danmarkskort
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockensdanmarkskort\.dk\/steder\/(.*)+$/, 'http://www.rockensdanmarkskort.dk/steder/$1');
-      // Standardising RIC
-      url = url.replace(/^(?:https?:\/\/)?(wiki|www)\.rockinchina\.com\/w\/(.*)+$/, 'http://www.rockinchina.com/w/$2');
-      // Standardising Rockipedia
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockipedia\.no\/(utgivelser|artister|plateselskap)\/(.+)\/.*$/, 'https://www.rockipedia.no/$1/$2/');
-      // Standardising DHHU
-      url = url.replace(/^(?:https?:\/\/)?(www\.)?dhhu\.dk\/w\/(.*)+$/, 'http://www.dhhu.dk/w/$2');
-      // Standardising Open Library
-      url = url.replace(/^(?:https?:\/\/)?(www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, 'https://openlibrary.org/$2/$3');
-      // Standardising Anime News Network
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?animenewsnetwork\.com\/encyclopedia\/(people|company).php\?id=([0-9]+).*$/, 'https://www.animenewsnetwork.com/encyclopedia/$1.php?id=$2');
-      return url;
-    },
   },
   'ozonru': {
     match: [new RegExp('^(https?://)?(www\\.)?ozon\\.ru/context/detail/id/', 'i')],
     type: LINK_TYPES.mailorder,
   },
-  'patronage': {
-    match: [
-      new RegExp('^(https?://)?(www\\.)?changetip\\.com/tipme/[^/?#]', 'i'),
-      new RegExp('^(https?://)?[^/?#]+\\.tip.me([/?#].*)?$', 'i'),
-      new RegExp('^(https?://)?(www\\.)?flattr\\.com/profile/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(www\\.)?patreon\\.com/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(www\\.)?paypal\\.me/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(?:[^/]+\\.)?tipeee\\.com/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(www\\.)?d\\.rip/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(www\\.)?drip\\.kickstarter.com/[^/?#]', 'i'),
-      new RegExp('^(https?://)?(www\\.)?ko-fi.com/[^/?#]', 'i'),
-    ],
+  'patreon': {
+    match: [new RegExp('^(https?://)?(www\\.)?patreon\\.com/[^/?#]', 'i')],
     type: LINK_TYPES.patronage,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?changetip\.com\/tipme\/([^\/?#]+)(?:.*)?$/, 'https://www.changetip.com/tipme/$1');
-      url = url.replace(/^(?:https?:\/\/)?([^\/?#]+)\.tip\.me(?:[\/?#].*)?$/, 'https://www.changetip.com/tipme/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?flattr\.com\/profile\/([^\/?#]+)(?:.*)?$/, 'https://flattr.com/profile/$1');
       url = url.replace(/^((?:https?:\/\/)?(?:www\.)?patreon\.com\/user)\/(?:community|posts)(\?u=.*)$/, '$1$2');
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?patreon\.com\/((?:user\?u=)?[^\/?&#]+)(?:.*)?$/, 'https://www.patreon.com/$1');
+      return url;
+    },
+  },
+  'paypal': {
+    match: [new RegExp('^(https?://)?(www\\.)?paypal\\.me/[^/?#]', 'i')],
+    type: LINK_TYPES.patronage,
+    clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?paypal\.me\/([^\/?#]+)(?:.*)?$/, 'https://www.paypal.me/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?tipeee\.com\/([^\/?#]+)(?:.*)?$/, 'https://www.tipeee.com/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?d\.rip\/([^\/?#]+)(?:.*)?$/, 'https://d.rip/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?drip\.kickstarter.com\/([^\/?#]+)(?:.*)?$/, 'https://d.rip/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ko-fi\.com\/([^\/?#]+)(?:.*)?$/, 'https://ko-fi.com/$1');
       return url;
     },
   },
@@ -1695,6 +1743,30 @@ const CLEANUPS = {
         }
       }
       return false;
+    },
+  },
+  'rockensdanmarkskort': {
+    match: [new RegExp('^(https?://)?(www\\.)?rockensdanmarkskort\\.dk', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockensdanmarkskort\.dk\/steder\/(.*)+$/, 'http://www.rockensdanmarkskort.dk/steder/$1');
+      return url;
+    },
+  },
+  'rockinchina': {
+    match: [new RegExp('^(https?://)?((www|wiki)\\.)?rockinchina\\.com', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(wiki|www)\.rockinchina\.com\/w\/(.*)+$/, 'http://www.rockinchina.com/w/$2');
+      return url;
+    },
+  },
+  'rockipedia': {
+    match: [new RegExp('^(https?://)?(www\\.)?rockipedia\\.no', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?rockipedia\.no\/(utgivelser|artister|plateselskap)\/(.+)\/.*$/, 'https://www.rockipedia.no/$1/$2/');
+      return url;
     },
   },
   'runeberg': {
@@ -1923,6 +1995,24 @@ const CLEANUPS = {
       return false;
     },
   },
+  'tipeee': {
+    match: [new RegExp('^(https?://)?(?:[^/]+\\.)?tipeee\\.com/[^/?#]', 'i')],
+    type: LINK_TYPES.patronage,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?tipeee\.com\/([^\/?#]+)(?:.*)?$/, 'https://www.tipeee.com/$1');
+      return url;
+    },
+  },
+  'trove': {
+    match: [new RegExp('^(https?://)?(www\\.)?(trove\\.)?nla\\.gov\\.au/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/work\/([^\/?#]+)(?:.*)?$/, 'https://trove.nla.gov.au/work/$1');
+      url = url.replace(/^(?:https?:\/\/)?trove\.nla\.gov\.au\/people\/([^\/?#]+)(?:.*)?$/, 'https://nla.gov.au/nla.party-$1');
+      url = url.replace(/^(?:https?:\/\/)?nla\.gov\.au\/(nla\.party-|anbd\.bib-an)([^\/?#]+)(?:.*)?$/, 'https://nla.gov.au/$1$2');
+      return url;
+    },
+  },
   'twitch': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?(twitch\\.tv/)', 'i')],
     type: _.defaults({}, LINK_TYPES.videochannel, LINK_TYPES.streamingmusic),
@@ -2119,6 +2209,15 @@ const CLEANUPS = {
     },
     validate: function (url, id) {
       return /^https:\/\/(?:[a-z-]+\.)?wikisource\.org\/wiki\//.test(url);
+    },
+  },
+  'worldcat': {
+    match: [new RegExp('^(https?://)?(www\\.)?worldcat\\.org/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org/, 'https://www.worldcat.org');
+      url = url.replace(/^https:\/\/www\.worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, 'https://www.worldcat.org/oclc/$1');
+      return url;
     },
   },
   'youtube': {


### PR DESCRIPTION
This just separates things that have their own match + cleanup but were before grouped into a huge ball of per-relationship-type cleanup. I feel it's much easier now to follow stuff. I left together under otherdatabases the ones that are only matched, but not cleaned up in any other way - I'd suggest to split those only if we start also cleaning them up.