### PR TITLE
MBS-10022: Event tab for areas

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -16,7 +16,7 @@
             "id": 1
         },
         "collections": true,
-        "custom_tabs": ["artists", "labels", "releases", "places", "users"],
+        "custom_tabs": ["artists", "events", "labels", "releases", "places", "users"],
         "date_period": true,
         "disambiguation": true,
         "edit_table": true,

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -123,6 +123,9 @@ sub events : Chained('load')
         $c->model('Event')->find_by_area($c->stash->{area}->id, shift, shift);
     });
     $c->model('Event')->load_related_info(@$events);
+    $c->model('Area')->load(map { $_->{entity} } map { $_->all_places } @$events);
+    $c->model('Area')->load_containment(map { (map { $_->{entity} } $_->all_areas),
+                                              (map { $_->{entity}->area } $_->all_places) } @$events);
     $c->model('Event')->rating->load_user_ratings($c->user->id, @$events) if $c->user_exists;
 
     my %props = (

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -5,8 +5,13 @@ BEGIN { extends 'MusicBrainz::Server::Controller'; }
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Area',
-    relationships   => { all => ['show'], cardinal => ['edit'], default => ['url'] },
-};
+    relationships   => {
+        cardinal    => ['edit'],
+        default     => ['url'],
+        subset      => {
+            show => [qw( area artist label place url work series instrument release release_group recording work url )],
+        }
+    },};
 with 'MusicBrainz::Server::Controller::Role::LoadWithRowID';
 with 'MusicBrainz::Server::Controller::Role::Annotation';
 with 'MusicBrainz::Server::Controller::Role::Alias';
@@ -103,6 +108,34 @@ sub artists : Chained('load')
         $c->model('Artist')->rating->load_user_ratings($c->user->id, @$artists);
     }
     $c->stash( artists => $artists );
+}
+
+=head2 events
+
+Shows all events for an area.
+
+=cut
+
+sub events : Chained('load')
+{
+    my ($self, $c) = @_;
+    my $events = $self->_load_paged($c, sub {
+        $c->model('Event')->find_by_area($c->stash->{area}->id, shift, shift);
+    });
+    $c->model('Event')->load_related_info(@$events);
+    $c->model('Event')->rating->load_user_ratings($c->user->id, @$events) if $c->user_exists;
+
+    my %props = (
+        area       => $c->stash->{area},
+        events      => $events,
+        pager       => serialize_pager($c->stash->{pager}),
+    );
+
+    $c->stash(
+        component_path  => 'area/AreaEvents.js',
+        component_props => \%props,
+        current_view    => 'Node',
+    );
 }
 
 =head2 labels

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -1,0 +1,62 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React from 'react';
+
+import {l} from '../static/scripts/common/i18n';
+import {withCatalystContext} from '../context';
+import EventsList from '../components/EventsList';
+import PaginatedResults from '../components/PaginatedResults';
+
+import AreaLayout from './AreaLayout';
+
+type Props = {|
+  +$c: CatalystContextT,
+  +area: AreaT,
+  +events: $ReadOnlyArray<EventT>,
+  +pager: PagerT,
+|};
+
+const AreaEvents = ({
+  $c,
+  area,
+  events,
+  pager,
+}: Props) => (
+  <AreaLayout entity={area} page="events" title={l('Events')}>
+    <h2>{l('Events')}</h2>
+
+    {events.length > 0 ? (
+      <form action="/event/merge_queue" method="post">
+        <PaginatedResults pager={pager}>
+          <EventsList
+            checkboxes="add-to-merge"
+            events={events}
+            noLocation
+          />
+        </PaginatedResults>
+        {$c.user_exists ? (
+          <div className="row">
+            <span className="buttons">
+              <button type="submit">
+                {l('Add selected events for merging')}
+              </button>
+            </span>
+          </div>
+        ) : null}
+      </form>
+    ) : (
+      <p>
+        {l('This area is not currently associated with any events.')}
+      </p>
+    )}
+  </AreaLayout>
+);
+
+export default withCatalystContext(AreaEvents);

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -38,7 +38,6 @@ const AreaEvents = ({
           <EventsList
             checkboxes="add-to-merge"
             events={events}
-            noLocation
           />
         </PaginatedResults>
         {$c.user_exists ? (

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -28,6 +28,7 @@ module.exports = {
   'account/ResetPasswordStatus': require('../account/ResetPasswordStatus'),
   'account/sso/DiscourseRegistered': require('../account/sso/DiscourseRegistered'),
   'account/sso/DiscourseUnconfirmedEmailAddress': require('../account/sso/DiscourseUnconfirmedEmailAddress'),
+  'area/AreaEvents': require('../area/AreaEvents'),
   'area/AreaLabels': require('../area/AreaLabels'),
   'area/NotFound': require('../area/NotFound'),
   'artist/ArtistEvents': require('../artist/ArtistEvents'),


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10022

I don't see any real reason not to add this, and in fact it should at least help lower the amount of stuff cluttering the Overview page of areas. Given some take a minute to load, this should be a slight improvement. Plus, places have this tab and we use place and area as effectively equivalent everywhere else for events.