### PR TITLE
MBS-9276: Fix flaky Edit::Instrument::Merge test

### DIFF
--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -198,7 +198,8 @@ sub merge_instrument_attributes {
       GROUP BY link.id, link_type,
                begin_date_year, begin_date_month, begin_date_day,
                end_date_year, end_date_month, end_date_day, ended,
-               entity_type0, entity_type1',
+               entity_type0, entity_type1
+      ORDER BY link.id ASC',
         \@sources);
 
     my %source_attributes = map { $_ => 1 } @sources;


### PR DESCRIPTION
The ORDER BY should make the new link creation order deterministic. Note that if you change ASC to DESC, it'll consistently reproduce the failure given in the description to MBS-9276.