### PR TITLE
MBS-10029: Include editor on page title of Edits by Editor

### DIFF
--- a/root/user/edits.tt
+++ b/root/user/edits.tt
@@ -5,23 +5,23 @@
             page_title = l('Votes by {name}', title_param);
             page_heading = l('Votes by {name}', heading_param);
         CASE 'open';
-            page_title = l('Open Edits by {name}', title_param);
-            page_heading = l('Open Edits by {name}', heading_param);
+            page_title = l('Open edits by {name}', title_param);
+            page_heading = l('Open edits by {name}', heading_param);
         CASE 'cancelled';
-            page_title = l('Cancelled Edits by {name}', title_param);
-            page_heading = l('Cancelled Edits by {name}', heading_param);
+            page_title = l('Cancelled edits by {name}', title_param);
+            page_heading = l('Cancelled edits by {name}', heading_param);
         CASE 'accepted';
-            page_title = l('Accepted Edits by {name}', title_param);
-            page_heading = l('Accepted Edits by {name}', heading_param);
+            page_title = l('Accepted edits by {name}', title_param);
+            page_heading = l('Accepted edits by {name}', heading_param);
         CASE 'failed';
-            page_title = l('Failed Edits by {name}', title_param);
-            page_heading = l('Failed Edits by {name}', heading_param);
+            page_title = l('Failed edits by {name}', title_param);
+            page_heading = l('Failed edits by {name}', heading_param);
         CASE 'rejected';
-            page_title = l('Rejected Edits by {name}', title_param)
-            page_heading = l('Rejected Edits by {name}', heading_param);
+            page_title = l('Rejected edits by {name}', title_param)
+            page_heading = l('Rejected edits by {name}', heading_param);
         CASE 'autoedits';
-            page_title = l('Auto-Edits by {name}', title_param);
-            page_heading = l('Auto-Edits by {name}', heading_param);
+            page_title = l('Auto-edits by {name}', title_param);
+            page_heading = l('Auto-edits by {name}', heading_param);
         CASE DEFAULT;
             page_title = l('Edits by {name}', title_param);
             page_heading = l('Edits by {name}', heading_param);

--- a/root/user/edits.tt
+++ b/root/user/edits.tt
@@ -1,29 +1,30 @@
-[%- param = { name => link_editor(user) };
+[%- title_param = { name => user.name };
+    heading_param = { name => link_editor(user) };
     SWITCH c.action.name;
         CASE 'votes';
-            page_title = l('Votes');
-            page_heading = l('Votes by {name}', param);
+            page_title = l('Votes by {name}', title_param);
+            page_heading = l('Votes by {name}', heading_param);
         CASE 'open';
-            page_title = l('Open Edits');
-            page_heading = l('Open Edits by {name}', param);
+            page_title = l('Open Edits by {name}', title_param);
+            page_heading = l('Open Edits by {name}', heading_param);
         CASE 'cancelled';
-            page_title = l('Cancelled Edits');
-            page_heading = l('Cancelled Edits by {name}', param);
+            page_title = l('Cancelled Edits by {name}', title_param);
+            page_heading = l('Cancelled Edits by {name}', heading_param);
         CASE 'accepted';
-            page_title = l('Accepted Edits');
-            page_heading = l('Accepted Edits by {name}', param);
+            page_title = l('Accepted Edits by {name}', title_param);
+            page_heading = l('Accepted Edits by {name}', heading_param);
         CASE 'failed';
-            page_title = l('Failed Edits');
-            page_heading = l('Failed Edits by {name}', param);
+            page_title = l('Failed Edits by {name}', title_param);
+            page_heading = l('Failed Edits by {name}', heading_param);
         CASE 'rejected';
-            page_title = l('Rejected Edits');
-            page_heading = l('Rejected Edits by {name}', param);
+            page_title = l('Rejected Edits by {name}', title_param)
+            page_heading = l('Rejected Edits by {name}', heading_param);
         CASE 'autoedits';
-            page_title = l('Auto-Edits');
-            page_heading = l('Auto-Edits by {name}', param);
+            page_title = l('Auto-Edits by {name}', title_param);
+            page_heading = l('Auto-Edits by {name}', heading_param);
         CASE DEFAULT;
-            page_title = l('Edits');
-            page_heading = l('Edits by {name}', param);
+            page_title = l('Edits by {name}', title_param);
+            page_heading = l('Edits by {name}', heading_param);
     END ~%]
 
 [% WRAPPER 'layout.tt' title=page_title %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10029

I'm not happy with the capitalization (we use "Release group X by Y" for example, so I'd want "Open edits" rather than "Open Edits") so changing that on a second commit but I can drop that one if it's a problem.