### PR TITLE
MBS-10033: Missing space after Wikipedia blurb

### DIFF
--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -51,6 +51,7 @@ class WikipediaExtract extends React.Component<Props, State> {
         <a href={wikipediaExtract.url}>
           {l('Continue reading at Wikipedia...')}
         </a>
+        {' '}
         <small>
           {l('Wikipedia content provided under the terms of the {license_link|Creative Commons BY-SA license}',
             {license_link: 'https://creativecommons.org/licenses/by-sa/3.0/'})}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10033