### PR TITLE
Fix APT package installation failure by refreshing keys

### DIFF
--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -16,6 +16,7 @@ RUN apt-get update && \
         gnupg && \
     apt-key add yarn_pubkey.txt && \
     rm yarn_pubkey.txt && \
+    apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys 'Yarn' && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -sLO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     curl -sLO https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.10.0-1nodesource1_amd64.deb && \

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -3,8 +3,10 @@ m4_divert(-1)
 m4_define(
     `apt_install',
     `m4_dnl
-apt-get update && \
-    apt-get install --no-install-suggests --no-install-recommends -y $1 && \
+apt-get update && ( \
+    apt-get install --no-install-suggests --no-install-recommends -y $1 || ( \
+        apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys && \
+        apt-get install --no-install-suggests --no-install-recommends -y $1 ) ) && \
     rm -rf /var/lib/apt/lists/*')
 
 m4_define(`apt_purge', `apt-get purge --auto-remove -y $1')


### PR DESCRIPTION
**Problem:** Yarn Packaging subkey often changed during the latest months, breaking our build process.
**Solution:** Refresh APT keys when installing yarn package or on package installation failure.