### PR TITLE
MBS-10031: Fix schema mapping of entities in relationships

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -591,10 +591,11 @@ sub schema_fixup
 
             my %entity = %{ $rel->{$entity_type} };
 
+            $self->schema_fixup(\%entity, $entity_type);
+
             # The search server returns the MBID in the 'id' attribute, so we
-            # need to rename that.
-            $entity{gid} = delete $entity{id};
-            %entity = %{ $self->schema_fixup_type(\%entity, $entity_type) };
+            # need to delete that. (`schema_fixup` copies it to gid.)
+            delete $entity{id};
 
             my $entity = $self->c->model( type_to_model ($entity_type) )->
                 _entity_class->new(%entity);


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10031

Reason seemed to be the sort-name served by the search result wasn't being turned into sort_name since the fixup didn't run on the relationship entity. This does now load it properly, but I'm not 100% sure this is the best possible way of doing it and won't have any unintended consequences.