### PR TITLE
MBS-9999: Allow custom scheme for redirect URI

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -45,6 +45,9 @@ our %EXPORT_TAGS = (
     email_addresses => [
         qw( $EMAIL_NOREPLY_ADDR_SPEC $EMAIL_NOREPLY_ADDRESS $EMAIL_SUPPORT_ADDRESS )
     ],
+    oauth_redirect_uri_re => [
+        qw( $OAUTH_INSTALLED_APP_REDIRECT_URI_RE $OAUTH_WEB_APP_REDIRECT_URI_RE )
+    ],
 );
 
 our @EXPORT_OK = (
@@ -920,6 +923,9 @@ Readonly our $EDITOR_SANITISED_COLUMNS => join(', ',
 );
 
 Readonly our $PASSPHRASE_BCRYPT_COST => 12;
+
+Readonly our $OAUTH_INSTALLED_APP_REDIRECT_URI_RE => qr/^(?![_-])[\w-]+(?:\.(?![_-])[\w-]+)+:/;
+Readonly our $OAUTH_WEB_APP_REDIRECT_URI_RE => qr/^https?:\/\//;
 
 =head1 NAME
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -310,10 +310,11 @@ sub _check_redirect_uri
 {
     my ($self, $application, $redirect_uri) = @_;
 
-    if ($application->is_server) {
+    if (defined $application->oauth_redirect_uri) {
         return 1 if $redirect_uri eq $application->oauth_redirect_uri;
     }
-    else {
+
+    if (!$application->is_server) {
         return 1 if $redirect_uri eq 'urn:ietf:wg:oauth:2.0:oob';
         return 1 if $redirect_uri =~ /^http:\/\/localhost(:\d+)?(\/.*?)?$/;
     }

--- a/lib/MusicBrainz/Server/Entity/Application.pm
+++ b/lib/MusicBrainz/Server/Entity/Application.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Entity::Application;
 use Moose;
 use namespace::autoclean;
 
+use MusicBrainz::Server::Constants qw( $OAUTH_WEB_APP_REDIRECT_URI_RE );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Types;
 
@@ -41,14 +42,15 @@ sub is_server
 {
     my ($self) = @_;
 
-    return defined $self->oauth_redirect_uri;
+    return defined $self->oauth_redirect_uri
+        && $self->oauth_redirect_uri =~ $OAUTH_WEB_APP_REDIRECT_URI_RE;
 }
 
 sub oauth_type
 {
     my ($self) = @_;
 
-    return defined $self->oauth_redirect_uri ? 'web' : 'installed';
+    return $self->is_server ? 'web' : 'installed';
 }
 
 around TO_JSON => sub {

--- a/lib/MusicBrainz/Server/Form/Application.pm
+++ b/lib/MusicBrainz/Server/Form/Application.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Application;
 
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Constants qw( :oauth_redirect_uri_re );
 use MusicBrainz::Server::Translation qw( l );
 
 extends 'MusicBrainz::Server::Form';
@@ -40,7 +41,21 @@ sub validate
 
     if ($self->field('oauth_type')->value eq 'web') {
         if (!$self->field('oauth_redirect_uri')->value) {
-            $self->field('oauth_redirect_uri')->add_error(l('Redirect URL must be entered for web applications.'));
+            $self->field('oauth_redirect_uri')->add_error(
+                l('Redirect URL must be entered for web applications.')
+            );
+        } elsif ($self->field('oauth_redirect_uri')->value !~ $OAUTH_WEB_APP_REDIRECT_URI_RE) {
+            $self->field('oauth_redirect_uri')->add_error(
+                l('Redirect URL scheme must be either <code>http</code> or ' .
+                  '<code>https</code> for web applications.')
+            );
+        }
+    } elsif ($self->field('oauth_redirect_uri')->value) {
+        if ($self->field('oauth_redirect_uri')->value !~ $OAUTH_INSTALLED_APP_REDIRECT_URI_RE) {
+            $self->field('oauth_redirect_uri')->add_error(
+                l('Redirect URL scheme must be a reverse-DNS string, as in ' .
+                  '<code>org.example.app://auth</code>, for installed applications.')
+            );
         }
     }
 }

--- a/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
@@ -6,8 +6,6 @@ use MusicBrainz::Server::Translation qw( l );
 
 extends 'HTML::FormHandler::Field::Text';
 
-my %ALLOWED_PROTOCOLS = map { $_ => 1 } qw( http https );
-
 sub validate
 {
     my $self = shift;
@@ -16,9 +14,6 @@ sub validate
 
     my $url = $self->value;
     $url = URI->new($url)->canonical;
-
-    return $self->add_error(l('URL protocol must be HTTP or HTTPS'))
-        unless exists $ALLOWED_PROTOCOLS{ lc($url->scheme) };
 
     $self->_set_value($url->as_string);
 }

--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -26,7 +26,7 @@ const buildApplicationRow = (application: ApplicationT, index: number) => (
   <tr className={loopParity(index)} key={application.id}>
     <td>{application.name}</td>
     <td>
-      {application.oauth_redirect_uri ? l('Web Application') : l('Installed Application')}
+      {application.is_server ? l('Web Application') : l('Installed Application')}
     </td>
     <td><code>{application.oauth_id}</code></td>
     <td><code>{application.oauth_secret}</code></td>

--- a/root/static/scripts/account/components/ApplicationForm.js
+++ b/root/static/scripts/account/components/ApplicationForm.js
@@ -8,7 +8,6 @@
  */
 
 import * as React from 'react';
-import noop from 'lodash/noop';
 
 import FormRow from '../../../../components/FormRow';
 import FormRowSelect from '../../../../components/FormRowSelect';
@@ -101,14 +100,22 @@ class ApplicationForm extends React.Component<Props, State> {
           options={oauthTypeOptions}
           required
         />
-        {this.state.form.field.oauth_type.value === 'web' ? (
-          <FormRowURLLong
-            field={this.state.form.field.oauth_redirect_uri}
-            label={addColon(l('Callback URL'))}
-            onChange={this.handleOauthRedirectURIChange}
-            required
-          />
-        ) : null}
+        <FormRowURLLong
+          field={this.state.form.field.oauth_redirect_uri}
+          label={addColon(l('Callback URL'))}
+          onChange={this.handleOauthRedirectURIChange}
+          required={this.state.form.field.oauth_type.value === 'web'}
+        />
+        {this.state.form.field.oauth_type.value === 'web' ? null : (
+          <FormRow hasNoLabel>
+            <span className="input-note">
+              {l(`Callback URI is optional for installed applications.
+                  If set, its scheme must be a custom reverse-DNS string,
+                  as in <code>org.example.app://auth</code>,
+                  for installed applications.`)}
+            </span>
+          </FormRow>
+        )}
         <FormRow hasNoLabel>
           <FormSubmit label={this.props.submitLabel} />
         </FormRow>


### PR DESCRIPTION
### Resolve [MBS-9999](https://tickets.metabrainz.org/browse/MBS-9999) by adding optional redirect URI for “installed applications”

Scheme of such URI must be a reverse-DNS string, e.g. `org.example.app`.