### PR TITLE
MBS-10032: detect and cleanup iTunes "author" URLs for artists

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1205,7 +1205,10 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?itunes\\.apple\\.com/', 'i')],
     type: LINK_TYPES.downloadpurchase,
     clean: function (url) {
-      return url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://itunes.apple.com/$1$2/id$3');
+      url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|author|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://itunes.apple.com/$1$2/id$3');
+      // Author seems to be a different interface for artist with the same ID
+      url = url.replace(/^(https:\/\/itunes\.apple\.com(?:\/[a-z]{2})?)\/author\//, '$1/artist/');
+      return url;
     },
     validate: function (url, id) {
       const m = /^https:\/\/itunes\.apple\.com\/(?:[a-z]{2}\/)?([a-z-]{3,})\/id[0-9]+$/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1610,6 +1610,13 @@ const testData = [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://itunes.apple.com/us/author/paige-lewis/id348965238#',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'downloadpurchase',
+            expected_clean_url: 'https://itunes.apple.com/us/artist/paige-lewis/id348965238#',
+       only_valid_entity_types: [],
+  },
+  {
                      input_url: 'http://itunes.apple.com/music-video/gangnam-style/id564322420?v0=WWW-NAUS-ITSTOP100-MUSICVIDEOS&ign-mpt=uo%3D2',
              input_entity_type: 'recording',
     expected_relationship_type: 'downloadpurchase',


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10032

Since every artist seems to have an author page automatically (https://itunes.apple.com/us/author/yung-beef/id1090884617 is a rapper with zero books, so it's not even connected to having multiple types of media), and the IDs are the same, I feel it makes sense to just store the links as "artist" (which is specifically about music AFAICT).