### PR TITLE
Add no-unused-vars rule to eslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -41,6 +41,7 @@ rules:
   no-unreachable: error
   no-unsafe-finally: error
   no-unsafe-negation: error
+  no-unused-vars: error
   use-isnan: error
   valid-typeof: error
 


### PR DESCRIPTION
I keep finding imports we've forgotten, and while there's at least a case I remember seeing when a seemingly unused var was actually needed, I think this makes sense in general.