### PR TITLE
MBS-9909: Change reports to use React (15 - final improvements)

### DIFF
--- a/root/report/AnnotationsArtists.js
+++ b/root/report/AnnotationsArtists.js
@@ -32,8 +32,14 @@ const AnnotationsArtists = ({
       <li>
         {l('This report lists artists with annotations.')}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsLabels.js
+++ b/root/report/AnnotationsLabels.js
@@ -32,8 +32,14 @@ const AnnotationsLabels = ({
       <li>
         {l('This report lists labels with annotations.')}
       </li>
-      <li>{texp.l('Total labels found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total labels found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsPlaces.js
+++ b/root/report/AnnotationsPlaces.js
@@ -32,8 +32,14 @@ const AnnotationsPlaces = ({
       <li>
         {l('This report lists places with annotations.')}
       </li>
-      <li>{texp.l('Total places found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total places found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsRecordings.js
+++ b/root/report/AnnotationsRecordings.js
@@ -32,8 +32,14 @@ const AnnotationsRecordings = ({
       <li>
         {l('This report lists recordings with annotations.')}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsReleaseGroups.js
+++ b/root/report/AnnotationsReleaseGroups.js
@@ -32,8 +32,14 @@ const AnnotationsReleaseGroups = ({
       <li>
         {l('This report lists release groups with annotations.')}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsReleases.js
+++ b/root/report/AnnotationsReleases.js
@@ -32,8 +32,14 @@ const AnnotationsReleases = ({
       <li>
         {l('This report lists releases with annotations.')}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsSeries.js
+++ b/root/report/AnnotationsSeries.js
@@ -32,8 +32,14 @@ const AnnotationsSeries = ({
       <li>
         {l('This report lists series with annotations.')}
       </li>
-      <li>{texp.l('Total series found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total series found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AnnotationsWorks.js
+++ b/root/report/AnnotationsWorks.js
@@ -32,8 +32,14 @@ const AnnotationsWorks = ({
       <li>
         {l('This report lists works with annotations.')}
       </li>
-      <li>{texp.l('Total works found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total works found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ArtistsContainingDisambiguationComments.js
+++ b/root/report/ArtistsContainingDisambiguationComments.js
@@ -25,16 +25,26 @@ const ArtistsContainingDisambiguationComments = ({
   items,
   pager,
 }: ReportDataT<ReportArtistT>) => (
-  <Layout fullWidth title={l('Artists containing disambiguation comments in their name')}>
+  <Layout
+    fullWidth
+    title={l('Artists containing disambiguation comments in their name')}
+  >
     <h1>{l('Artists containing disambiguation comments in their name')}</h1>
 
     <ul>
       <li>
         {l(`This report lists artists that may have disambiguation comments in
-            their name, rather than the actual disambiguation comment field.`)}
+            their name, rather than the actual disambiguation comment
+            field.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ArtistsDisambiguationSameName.js
+++ b/root/report/ArtistsDisambiguationSameName.js
@@ -25,7 +25,10 @@ const ArtistsDisambiguationSameName = ({
   items,
   pager,
 }: ReportDataT<ReportArtistT>) => (
-  <Layout fullWidth title={l('Artists with disambiguation the same as the name')}>
+  <Layout
+    fullWidth
+    title={l('Artists with disambiguation the same as the name')}
+  >
     <h1>{l('Artists with disambiguation the same as the name')}</h1>
 
     <ul>
@@ -34,8 +37,14 @@ const ArtistsDisambiguationSameName = ({
             to be the same as their name. Disambiguation should
             not be filled in this case.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ArtistsThatMayBeGroups.js
+++ b/root/report/ArtistsThatMayBeGroups.js
@@ -37,8 +37,14 @@ const ArtistsThatMayBeGroups = ({
             not, please make sure that the "member of" relationships are
             in the right direction and are correct.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ArtistsThatMayBePersons.js
+++ b/root/report/ArtistsThatMayBePersons.js
@@ -37,8 +37,14 @@ const ArtistsThatMayBePersons = ({
             a person, change its type. If it is not, please make sure that
             all the relationships are correct and make sense.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js
+++ b/root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js
@@ -27,7 +27,10 @@ const ArtistsWithMultipleOccurrencesInArtistCredits = ({
   items,
   pager,
 }: ReportDataT<ReportArtistT>) => (
-  <Layout fullWidth title={l('Artists occurring multiple times in the same artist credit')}>
+  <Layout
+    fullWidth
+    title={l('Artists occurring multiple times in the same artist credit')}
+  >
     <h1>{l('Artists occurring multiple times in the same artist credit')}</h1>
 
     <ul>
@@ -35,8 +38,14 @@ const ArtistsWithMultipleOccurrencesInArtistCredits = ({
         {l(`This report lists artists that appear more than once in different
             positions within the same artist credit.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>
@@ -55,7 +64,11 @@ const ArtistsWithMultipleOccurrencesInArtistCredits = ({
               <td>
                 <EntityLink entity={item.artist} subPath="aliases" />
               </td>
-              <td>{item.artist.typeName ? lp_attributes(item.artist.typeName, 'artist_type') : l('Unknown')}</td>
+              <td>
+                {item.artist.typeName
+                  ? lp_attributes(item.artist.typeName, 'artist_type')
+                  : l('Unknown')}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/root/report/ArtistsWithNoSubscribers.js
+++ b/root/report/ArtistsWithNoSubscribers.js
@@ -34,8 +34,14 @@ const ArtistsWithNoSubscribers = ({
             and whose changes may therefore be under-reviewed. Artists with
             more release groups and more open edits are listed first.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AsinsWithMultipleReleases.js
+++ b/root/report/AsinsWithMultipleReleases.js
@@ -39,10 +39,16 @@ const AsinsWithMultipleReleases = ({
             You might also find some ASINs linked to several discs
             of a multi-disc release: just merge those (see
             {how_to_merge_releases|How to Merge Releases}).`,
-        {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
+               {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/AsinsWithMultipleReleases.js
+++ b/root/report/AsinsWithMultipleReleases.js
@@ -30,16 +30,18 @@ const AsinsWithMultipleReleases = ({
 
     <ul>
       <li>
-        {exp.l(`This report shows Amazon URLs which are linked to multiple
-            releases. In most cases Amazon ASINs should map to MusicBrainz
-            releases 1:1, so only one of the links will be correct. Just
-            check which MusicBrainz release fits the release in Amazon (look
-            at the format, tracklist, etc). If the release has a barcode,
-            you can also search Amazon for it and see which ASIN matches.
-            You might also find some ASINs linked to several discs
-            of a multi-disc release: just merge those (see
-            {how_to_merge_releases|How to Merge Releases}).`,
-               {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
+        {exp.l(
+          `This report shows Amazon URLs which are linked to multiple
+           releases. In most cases Amazon ASINs should map to MusicBrainz
+           releases 1:1, so only one of the links will be correct. Just check
+           which MusicBrainz release fits the release in Amazon (look at the
+           format, tracklist, etc). If the release has a barcode, you can also
+           search Amazon for it and see which ASIN matches.  You might also
+           find some ASINs linked to several discs of a multi-disc release:
+           just merge those (see
+           {how_to_merge_releases|How to Merge Releases}).`,
+          {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+        )}
       </li>
       <li>
         {texp.l('Total releases found: {count}',

--- a/root/report/BadAmazonUrls.js
+++ b/root/report/BadAmazonUrls.js
@@ -40,8 +40,14 @@ const BadAmazonUrls = ({
             archive.org cover links, but in any other case they should
             probably be fixed or removed.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/CatNoLooksLikeAsin.js
+++ b/root/report/CatNoLooksLikeAsin.js
@@ -30,7 +30,10 @@ const CatNoLooksLikeAsin = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseCatNoT>) => (
-  <Layout fullWidth title={l('Releases with catalog numbers that look like ASINs')}>
+  <Layout
+    fullWidth
+    title={l('Releases with catalog numbers that look like ASINs')}
+  >
     <h1>{l('Releases with catalog numbers that look like ASINs')}</h1>
 
     <ul>
@@ -40,8 +43,14 @@ const CatNoLooksLikeAsin = ({
             entries for the releases and should be linked to the release
             with an Amazon URL relationship instead.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/CollaborationRelationships.js
+++ b/root/report/CollaborationRelationships.js
@@ -44,8 +44,14 @@ const CollaborationRelationships = ({
             {how_to_split_artists: '/doc/How_to_Split_Artists'},
           )}
         </li>
-        <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-        <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+        <li>
+          {texp.l('Total artists found: {count}',
+                  {count: pager.total_entries})}
+        </li>
+        <li>
+          {texp.l('Generated on {date}',
+                  {date: formatUserDate($c.user, generated)})}
+        </li>
 
         {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
       </ul>
@@ -64,7 +70,9 @@ const CollaborationRelationships = ({
               currentID = item.id1;
 
               return (
-                <React.Fragment key={item.artist1.gid + '-' + item.artist0.gid}>
+                <React.Fragment
+                  key={item.artist1.gid + '-' + item.artist0.gid}
+                >
                   {lastID === item.id1 ? null : (
                     <tr className="even">
                       <td colSpan="2">

--- a/root/report/CoverArtRelationships.js
+++ b/root/report/CoverArtRelationships.js
@@ -33,8 +33,14 @@ const CoverArtRelationships = ({
         {l(`This report shows releases that still have cover art
             relationships.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipArtists.js
+++ b/root/report/DeprecatedRelationshipArtists.js
@@ -25,11 +25,7 @@ const DeprecatedRelationshipArtists = ({
   items,
   pager,
 }: ReportDataT<ReportArtistRelationshipT>) => (
-  <Layout
-    fullWidth
-    gettext_domains={['relationships']}
-    title={l('Artists with deprecated relationships')}
-  >
+  <Layout fullWidth title={l('Artists with deprecated relationships')}>
     <h1>{l('Artists with deprecated relationships')}</h1>
 
     <ul>

--- a/root/report/DeprecatedRelationshipArtists.js
+++ b/root/report/DeprecatedRelationshipArtists.js
@@ -25,7 +25,11 @@ const DeprecatedRelationshipArtists = ({
   items,
   pager,
 }: ReportDataT<ReportArtistRelationshipT>) => (
-  <Layout fullWidth gettext_domains={['relationships']} title={l('Artists with deprecated relationships')}>
+  <Layout
+    fullWidth
+    gettext_domains={['relationships']}
+    title={l('Artists with deprecated relationships')}
+  >
     <h1>{l('Artists with deprecated relationships')}</h1>
 
     <ul>
@@ -33,8 +37,14 @@ const DeprecatedRelationshipArtists = ({
         {l(`This report lists artists which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipLabels.js
+++ b/root/report/DeprecatedRelationshipLabels.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipLabels = ({
         {l(`This report lists labels which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total labels found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total labels found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipPlaces.js
+++ b/root/report/DeprecatedRelationshipPlaces.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipPlaces = ({
         {l(`This report lists places which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total places found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total places found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipRecordings.js
+++ b/root/report/DeprecatedRelationshipRecordings.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipRecordings = ({
         {l(`This report lists recordings which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipReleaseGroups.js
+++ b/root/report/DeprecatedRelationshipReleaseGroups.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipReleaseGroups = ({
         {l(`This report lists release groups which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipReleases.js
+++ b/root/report/DeprecatedRelationshipReleases.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipReleases = ({
         {l(`This report lists release which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipUrls.js
+++ b/root/report/DeprecatedRelationshipUrls.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipUrls = ({
         {l(`This report lists URLs which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total URLs found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total URLs found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DeprecatedRelationshipWorks.js
+++ b/root/report/DeprecatedRelationshipWorks.js
@@ -33,8 +33,14 @@ const DeprecatedRelationshipWorks = ({
         {l(`This report lists works which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
-      <li>{texp.l('Total works found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total works found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DiscogsLinksWithMultipleArtists.js
+++ b/root/report/DiscogsLinksWithMultipleArtists.js
@@ -33,8 +33,14 @@ const DiscogsLinksWithMultipleArtists = ({
         {l(`This report shows Discogs URLs which are linked
             to multiple artists.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DiscogsLinksWithMultipleLabels.js
+++ b/root/report/DiscogsLinksWithMultipleLabels.js
@@ -33,8 +33,14 @@ const DiscogsLinksWithMultipleLabels = ({
         {l(`This report shows Discogs URLs which are linked
             to multiple labels.`)}
       </li>
-      <li>{texp.l('Total labels found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total labels found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DiscogsLinksWithMultipleReleaseGroups.js
+++ b/root/report/DiscogsLinksWithMultipleReleaseGroups.js
@@ -25,7 +25,10 @@ const DiscogsLinksWithMultipleReleaseGroups = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseGroupUrlT>) => (
-  <Layout fullWidth title={l('Discogs URLs linked to multiple release groups')}>
+  <Layout
+    fullWidth
+    title={l('Discogs URLs linked to multiple release groups')}
+  >
     <h1>{l('Discogs URLs linked to multiple release groups')}</h1>
 
     <ul>
@@ -33,8 +36,14 @@ const DiscogsLinksWithMultipleReleaseGroups = ({
         {l(`This report shows Discogs URLs which are linked
             to multiple release groups.`)}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DiscogsLinksWithMultipleReleases.js
+++ b/root/report/DiscogsLinksWithMultipleReleases.js
@@ -38,10 +38,16 @@ const DiscogsLinksWithMultipleReleases = ({
             some Discogs URLs linked to several discs of a multi-disc release:
             just merge those (see
             {how_to_merge_releases|How to Merge Releases}).`,
-        {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
+               {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DiscogsLinksWithMultipleReleases.js
+++ b/root/report/DiscogsLinksWithMultipleReleases.js
@@ -30,15 +30,16 @@ const DiscogsLinksWithMultipleReleases = ({
 
     <ul>
       <li>
-        {exp.l(`This report shows Discogs URLs which are linked to multiple
-            releases. In most cases Discogs releases should map to MusicBrainz
-            releases 1:1, so only one of the links will be correct. Just check
-            which MusicBrainz release fits the release in Discogs (look at the
-            format, tracklist, release country, etc.). You might also find
-            some Discogs URLs linked to several discs of a multi-disc release:
-            just merge those (see
-            {how_to_merge_releases|How to Merge Releases}).`,
-               {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
+        {exp.l(
+          `This report shows Discogs URLs which are linked to multiple
+           releases. In most cases Discogs releases should map to MusicBrainz
+           releases 1:1, so only one of the links will be correct. Just check
+           which MusicBrainz release fits the release in Discogs (look at the
+           format, tracklist, release country, etc.). You might also find some
+           Discogs URLs linked to several discs of a multi-disc release: just
+           merge those (see {how_to_merge_releases|How to Merge Releases}).`,
+          {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+        )}
       </li>
       <li>
         {texp.l('Total releases found: {count}',

--- a/root/report/DuplicateArtists.js
+++ b/root/report/DuplicateArtists.js
@@ -52,8 +52,14 @@ const DuplicateArtists = ({
             },
           )}
         </li>
-        <li>{texp.l('Total duplicate groups: {count}', {count: pager.total_entries})}</li>
-        <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+        <li>
+          {texp.l('Total duplicate groups: {count}',
+                  {count: pager.total_entries})}
+        </li>
+        <li>
+          {texp.l('Generated on {date}',
+                  {date: formatUserDate($c.user, generated)})}
+        </li>
 
         {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
       </ul>

--- a/root/report/DuplicateEvents.js
+++ b/root/report/DuplicateEvents.js
@@ -35,8 +35,14 @@ const DuplicateEvents = ({
             if there are separate events for headliner and supporting artist)
             please merge them.`)}
       </li>
-      <li>{texp.l('Total events found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total events found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsArtists.js
+++ b/root/report/DuplicateRelationshipsArtists.js
@@ -25,7 +25,10 @@ const DuplicateRelationshipsArtists = ({
   items,
   pager,
 }: ReportDataT<ReportArtistT>) => (
-  <Layout fullWidth title={l('Artists with possible duplicate relationships')}>
+  <Layout
+    fullWidth
+    title={l('Artists with possible duplicate relationships')}
+  >
     <h1>{l('Artists with possible duplicate relationships')}</h1>
 
     <ul>
@@ -35,8 +38,14 @@ const DuplicateRelationshipsArtists = ({
             For multiple relationships to release groups, recordings or works,
             see the reports for those entities.`)}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsLabels.js
+++ b/root/report/DuplicateRelationshipsLabels.js
@@ -33,8 +33,14 @@ const DuplicateRelationshipsLabels = ({
         {l(`This report lists labels which have multiple relationships
             to the same entity using the same relationship type.`)}
       </li>
-      <li>{texp.l('Total labels found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total labels found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsRecordings.js
+++ b/root/report/DuplicateRelationshipsRecordings.js
@@ -25,7 +25,10 @@ const DuplicateRelationshipsRecordings = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings with possible duplicate relationships')}>
+  <Layout
+    fullWidth
+    title={l('Recordings with possible duplicate relationships')}
+  >
     <h1>{l('Recordings with possible duplicate relationships')}</h1>
 
     <ul>
@@ -33,8 +36,14 @@ const DuplicateRelationshipsRecordings = ({
         {l(`This report lists recordings which have multiple relationships
             to the same entity using the same relationship type.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsReleaseGroups.js
+++ b/root/report/DuplicateRelationshipsReleaseGroups.js
@@ -25,7 +25,10 @@ const DuplicateRelationshipsReleaseGroups = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseGroupT>) => (
-  <Layout fullWidth title={l('Release groups with possible duplicate relationships')}>
+  <Layout
+    fullWidth
+    title={l('Release groups with possible duplicate relationships')}
+  >
     <h1>{l('Release groups with possible duplicate relationships')}</h1>
 
     <ul>
@@ -33,8 +36,14 @@ const DuplicateRelationshipsReleaseGroups = ({
         {l(`This report lists release groups which have multiple relationships
             to the same entity using the same relationship type.`)}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsReleases.js
+++ b/root/report/DuplicateRelationshipsReleases.js
@@ -25,7 +25,10 @@ const DuplicateRelationshipsReleases = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases with possible duplicate relationships')}>
+  <Layout
+    fullWidth
+    title={l('Releases with possible duplicate relationships')}
+  >
     <h1>{l('Releases with possible duplicate relationships')}</h1>
 
     <ul>
@@ -33,8 +36,14 @@ const DuplicateRelationshipsReleases = ({
         {l(`This report lists releases which have multiple relationships
             to the same entity using the same relationship type.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateRelationshipsWorks.js
+++ b/root/report/DuplicateRelationshipsWorks.js
@@ -35,8 +35,14 @@ const DuplicateRelationshipsWorks = ({
             This excludes recording-work relationships. See the recording
             version of this report for those.`)}
       </li>
-      <li>{texp.l('Total works found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total works found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/DuplicateReleaseGroups.js
+++ b/root/report/DuplicateReleaseGroups.js
@@ -42,8 +42,14 @@ const DuplicateReleaseGroups = ({
           {url: '/doc/Style/Release_Group'},
         )}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/EventSequenceNotInSeries.js
+++ b/root/report/EventSequenceNotInSeries.js
@@ -25,7 +25,10 @@ const EventSequenceNotInSeries = ({
   items,
   pager,
 }: ReportDataT<ReportEventT>) => (
-  <Layout fullWidth title={l('Events which should be part of series or larger event')}>
+  <Layout
+    fullWidth
+    title={l('Events which should be part of series or larger event')}
+  >
     <h1>{l('Events which should be part of series or larger event')}</h1>
 
     <ul>
@@ -33,8 +36,14 @@ const EventSequenceNotInSeries = ({
         {l(`This report lists events where the event name indicates that it
             may have to be part of a series or a larger event.`)}
       </li>
-      <li>{texp.l('Total events found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total events found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/FeaturingRecordings.js
+++ b/root/report/FeaturingRecordings.js
@@ -25,7 +25,10 @@ const FeaturingRecordings = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings with titles containing featuring artists')}>
+  <Layout
+    fullWidth
+    title={l('Recordings with titles containing featuring artists')}
+  >
     <h1>{l('Recordings with titles containing featuring artists')}</h1>
 
     <ul>
@@ -44,8 +47,14 @@ const FeaturingRecordings = ({
           },
         )}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/FeaturingReleaseGroups.js
+++ b/root/report/FeaturingReleaseGroups.js
@@ -25,7 +25,10 @@ const FeaturingReleaseGroups = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseGroupT>) => (
-  <Layout fullWidth title={l('Release groups with titles containing featuring artists')}>
+  <Layout
+    fullWidth
+    title={l('Release groups with titles containing featuring artists')}
+  >
     <h1>{l('Release groups with titles containing featuring artists')}</h1>
 
     <ul>
@@ -43,8 +46,14 @@ const FeaturingReleaseGroups = ({
           },
         )}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/FeaturingReleases.js
+++ b/root/report/FeaturingReleases.js
@@ -25,23 +25,34 @@ const FeaturingReleases = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases with titles containing featuring artists')}>
+  <Layout
+    fullWidth
+    title={l('Releases with titles containing featuring artists')}
+  >
     <h1>{l('Releases with titles containing featuring artists')}</h1>
 
     <ul>
       <li>
-        {exp.l(`This report shows releases with (feat. Artist) in the title. For
-            classical releases, consult the {CSG|classical style guidelines}.
-            For non-classical releases, this is inherited from an older
-            version of MusicBrainz and should be fixed. Consult the
-            {featured_artists|page about featured artists} to know more.`,
-        {
-          CSG: '/doc/Style/Classical',
-          featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
-        })}
+        {exp.l(
+          `This report shows releases with (feat. Artist) in the title. For
+          classical releases, consult the {CSG|classical style guidelines}.
+          For non-classical releases, this is inherited from an older
+          version of MusicBrainz and should be fixed. Consult the
+          {featured_artists|page about featured artists} to know more.`,
+          {
+            CSG: '/doc/Style/Classical',
+            featured_artists: '/doc/Style/Artist_Credits#Featured_artists',
+          },
+        )}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/FilterLink.js
+++ b/root/report/FilterLink.js
@@ -20,9 +20,13 @@ const FilterLink = (
   return (
     <li>
       {filtered === true ? (
-        <a href={uriWith(reqUri, {filter: 0})}>{l('Show all results.')}</a>
+        <a href={uriWith(reqUri, {filter: 0})}>
+          {l('Show all results.')}
+        </a>
       ) : (
-        <a href={uriWith(reqUri, {filter: 1})}>{l('Show only results that are in my subscribed entities.')}</a>
+        <a href={uriWith(reqUri, {filter: 1})}>
+          {l('Show only results that are in my subscribed entities.')}
+        </a>
       )}
     </li>
   );

--- a/root/report/InstrumentsWithoutAnImage.js
+++ b/root/report/InstrumentsWithoutAnImage.js
@@ -30,8 +30,14 @@ const InstrumentsWithoutAnImage = ({
         {l(`This report shows instruments without image
             relationships nor Wikidata relationships.`)}
       </li>
-      <li>{texp.l('Total instruments found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total instruments found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
     </ul>
 

--- a/root/report/IsrcsWithManyRecordings.js
+++ b/root/report/IsrcsWithManyRecordings.js
@@ -53,8 +53,14 @@ const IsrcsWithManyRecordings = ({
             {isrc: '/doc/ISRC'},
           )}
         </li>
-        <li>{texp.l('Total ISRCs found: {count}', {count: pager.total_entries})}</li>
-        <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+        <li>
+          {texp.l('Total ISRCs found: {count}',
+                  {count: pager.total_entries})}
+        </li>
+        <li>
+          {texp.l('Generated on {date}',
+                  {date: formatUserDate($c.user, generated)})}
+        </li>
 
         {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
       </ul>

--- a/root/report/IswcsWithManyWorks.js
+++ b/root/report/IswcsWithManyWorks.js
@@ -44,8 +44,14 @@ const IswcsWithManyWorks = ({
             {iswc: '/doc/ISWC'},
           )}
         </li>
-        <li>{texp.l('Total ISWCs found: {count}', {count: pager.total_entries})}</li>
-        <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+        <li>
+          {texp.l('Total ISWCs found: {count}',
+                  {count: pager.total_entries})}
+        </li>
+        <li>
+          {texp.l('Generated on {date}',
+                  {date: formatUserDate($c.user, generated)})}
+        </li>
 
         {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
       </ul>

--- a/root/report/LabelsDisambiguationSameName.js
+++ b/root/report/LabelsDisambiguationSameName.js
@@ -25,7 +25,10 @@ const LabelsDisambiguationSameName = ({
   items,
   pager,
 }: ReportDataT<ReportLabelT>) => (
-  <Layout fullWidth title={l('Labels with disambiguation the same as the name')}>
+  <Layout
+    fullWidth
+    title={l('Labels with disambiguation the same as the name')}
+  >
     <h1>{l('Labels with disambiguation the same as the name')}</h1>
 
     <ul>
@@ -34,8 +37,14 @@ const LabelsDisambiguationSameName = ({
             set to be the same as their name.
             Disambiguation should not be filled in this case.`)}
       </li>
-      <li>{texp.l('Total labels found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total labels found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/LimitedEditors.js
+++ b/root/report/LimitedEditors.js
@@ -28,10 +28,16 @@ const LimitedEditors = ({
     <ul>
       <li>
         {exp.l('This report lists {url|beginner/limited editors}.',
-          {url: '/doc/How_to_Create_an_Account'})}
+               {url: '/doc/How_to_Create_an_Account'})}
       </li>
-      <li>{texp.l('Total editors found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total editors found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
     </ul>
 
     {$c.user && $c.user.is_account_admin ? (

--- a/root/report/MediumsWithSequenceIssues.js
+++ b/root/report/MediumsWithSequenceIssues.js
@@ -33,8 +33,14 @@ const MediumsWithSequenceIssues = ({
         {l(`This report lists all releases with gaps in the medium numbers
             (e.g. there is a medium 1 and 3 but no medium 2).`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/MultipleAsins.js
+++ b/root/report/MultipleAsins.js
@@ -37,8 +37,14 @@ const MultipleAsins = ({
             etc). If the release has a barcode, you can search Amazon for it
             and see which ASIN matches.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/MultipleDiscogsLinks.js
+++ b/root/report/MultipleDiscogsLinks.js
@@ -30,14 +30,16 @@ const MultipleDiscogsLinks = ({
 
     <ul>
       <li>
-        {exp.l(`This report shows releases that have more than one link to
-            Discogs. In most cases a MusicBrainz release should have only one
-            equivalent in Discogs, so only one of them will be correct. Just
-            check which ones do not fit the release (because of format,
-            different number of tracks, etc). Any "master" Discogs page
-            belongs at the {release_group|release group level}, not at the
-            release level, and should be removed from releases too.`,
-               {release_group: '/doc/Release_Group'})}
+        {exp.l(
+          `This report shows releases that have more than one link to Discogs.
+           In most cases a MusicBrainz release should have only one equivalent
+           in Discogs, so only one of them will be correct. Just check which
+           ones do not fit the release (because of format, different number of
+           tracks, etc). Any "master" Discogs page belongs at the
+           {release_group|release group level}, not at the release level, and
+           should be removed from releases too.`,
+          {release_group: '/doc/Release_Group'},
+        )}
       </li>
       <li>
         {texp.l('Total releases found: {count}',

--- a/root/report/MultipleDiscogsLinks.js
+++ b/root/report/MultipleDiscogsLinks.js
@@ -37,10 +37,16 @@ const MultipleDiscogsLinks = ({
             different number of tracks, etc). Any "master" Discogs page
             belongs at the {release_group|release group level}, not at the
             release level, and should be removed from releases too.`,
-        {release_group: '/doc/Release_Group'})}
+               {release_group: '/doc/Release_Group'})}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/NoLanguage.js
+++ b/root/report/NoLanguage.js
@@ -35,8 +35,14 @@ const NoLanguage = ({
             pretty sure, don't just guess: not everything written in Cyrillic
             is Russian, for example.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/NoScript.js
+++ b/root/report/NoScript.js
@@ -34,8 +34,14 @@ const NoScript = ({
             recognize the script, just add it! Remember that the script used
             for English (and most other European languages) is Latin.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/PartOfSetRelationships.js
+++ b/root/report/PartOfSetRelationships.js
@@ -30,17 +30,25 @@ const PartOfSetRelationships = ({
 
     <ul>
       <li>
-        {exp.l(`This report shows releases that still have the deprecated "part
-            of set" relationship and should probably be merged. For
-            instructions on how to fix them, please see the documentation
-            about {how_to_merge_releases|how to merge releases}. If the
-            releases are not really part of a set (for example, if they are
-            independently-released volumes in a series) just remove the
-            relationship.`,
-        {how_to_merge_releases: '/doc/How_to_Merge_Releases'})}
+        {exp.l(
+          `This report shows releases that still have the deprecated "part
+          of set" relationship and should probably be merged. For
+          instructions on how to fix them, please see the documentation
+          about {how_to_merge_releases|how to merge releases}. If the
+          releases are not really part of a set (for example, if they are
+          independently-released volumes in a series) just remove the
+          relationship.`,
+          {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
+        )}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/PlacesWithoutCoordinates.js
+++ b/root/report/PlacesWithoutCoordinates.js
@@ -36,8 +36,14 @@ const PlacesWithoutCoordinates = ({
       <li>
         {l('This report lists places without coordinates.')}
       </li>
-      <li>{texp.l('Total places found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total places found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>
@@ -74,7 +80,9 @@ const PlacesWithoutCoordinates = ({
                 <td className="search-links">
                   <span className="no-favicon">
                     <a
-                      href={'https://www.openstreetmap.org/search?query=' + query}
+                      href={
+                        'https://www.openstreetmap.org/search?query=' + query
+                      }
                       rel="noopener noreferrer"
                       target="_blank"
                       title="OpenStreetMap"

--- a/root/report/PossibleCollaborations.js
+++ b/root/report/PossibleCollaborations.js
@@ -41,8 +41,14 @@ const PossibleCollaborations = ({
           {how_to_split_artists: '/doc/How_to_Split_Artists'},
         )}
       </li>
-      <li>{texp.l('Total artists found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total artists found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/RecordingsSameNameDifferentArtistsSameName.js
+++ b/root/report/RecordingsSameNameDifferentArtistsSameName.js
@@ -47,7 +47,7 @@ const RecordingsSameNameDifferentArtistsSameName = ({
       </li>
       <li>
         {exp.l(`These are most likely cases where the {ac|artist credit} is
-            incorrect for at least one of the recordings.`,
+                incorrect for at least one of the recordings.`,
                {ac: '/doc/Artist_Credits'})}
       </li>
       <li>

--- a/root/report/RecordingsSameNameDifferentArtistsSameName.js
+++ b/root/report/RecordingsSameNameDifferentArtistsSameName.js
@@ -30,8 +30,15 @@ const RecordingsSameNameDifferentArtistsSameName = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings with the same name by different artists with the same name')}>
-    <h1>{l('Recordings with the same name by different artists with the same name')}</h1>
+  <Layout
+    fullWidth
+    title={l(`Recordings with the same name by different artists
+              with the same name`)}
+  >
+    <h1>
+      {l(`Recordings with the same name by different artists
+          with the same name`)}
+    </h1>
 
     <ul>
       <li>
@@ -41,14 +48,20 @@ const RecordingsSameNameDifferentArtistsSameName = ({
       <li>
         {exp.l(`These are most likely cases where the {ac|artist credit} is
             incorrect for at least one of the recordings.`,
-        {ac: '/doc/Artist_Credits'})}
+               {ac: '/doc/Artist_Credits'})}
       </li>
       <li>
         {l(`Currently, this report only works with recordings that have
             one artist.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/RecordingsWithEarliestReleaseRelationships.js
+++ b/root/report/RecordingsWithEarliestReleaseRelationships.js
@@ -25,7 +25,10 @@ const RecordingsWithEarliestReleaseRelationships = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings with earliest release relationships')}>
+  <Layout
+    fullWidth
+    title={l('Recordings with earliest release relationships')}
+  >
     <h1>{l('Recordings with earliest release relationships')}</h1>
 
     <ul>
@@ -37,8 +40,14 @@ const RecordingsWithEarliestReleaseRelationships = ({
             the lengths fit, and do not merge recordings with very different
             times!`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/RecordingsWithVaryingTrackLengths.js
+++ b/root/report/RecordingsWithVaryingTrackLengths.js
@@ -33,8 +33,14 @@ const RecordingsWithVaryingTrackLengths = ({
         {l(`This report shows recordings where the linked tracks have times
             that vary by more than 30 seconds.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/RecordingsWithoutVaCredit.js
+++ b/root/report/RecordingsWithoutVaCredit.js
@@ -25,16 +25,27 @@ const RecordingsWithoutVaCredit = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings not credited to "Various Artists" but linked to VA')}>
-    <h1>{l('Recordings not credited to "Various Artists" but linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l('Recordings not credited to "Various Artists" but linked to VA')}
+  >
+    <h1>
+      {l('Recordings not credited to "Various Artists" but linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows recordings linked to the Various Artists entity
             without "Various Artists" as the credited name.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/RecordingsWithoutVaLink.js
+++ b/root/report/RecordingsWithoutVaLink.js
@@ -25,16 +25,27 @@ const RecordingsWithoutVaLink = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings credited to "Various Artists" but not linked to VA')}>
-    <h1>{l('Recordings credited to "Various Artists" but not linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l('Recordings credited to "Various Artists" but not linked to VA')}
+  >
+    <h1>
+      {l('Recordings credited to "Various Artists" but not linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows recordings with "Various Artists" as the
             credited name but not linked to the Various Artists entity.`)}
       </li>
-      <li>{texp.l('Total recordings found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleaseGroupsWithoutVaCredit.js
+++ b/root/report/ReleaseGroupsWithoutVaCredit.js
@@ -25,16 +25,28 @@ const ReleaseGroupsWithoutVaCredit = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseGroupT>) => (
-  <Layout fullWidth title={l('Release groups not credited to "Various Artists" but linked to VA')}>
-    <h1>{l('Release groups not credited to "Various Artists" but linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l(`Release groups not credited to "Various Artists"
+              but linked to VA`)}
+  >
+    <h1>
+      {l('Release groups not credited to "Various Artists" but linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows release groups linked to the Various Artists
             entity without "Various Artists" as the credited name.`)}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleaseGroupsWithoutVaLink.js
+++ b/root/report/ReleaseGroupsWithoutVaLink.js
@@ -25,16 +25,28 @@ const ReleaseGroupsWithoutVaLink = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseGroupT>) => (
-  <Layout fullWidth title={l('Release groups credited to "Various Artists" but not linked to VA')}>
-    <h1>{l('Release groups credited to "Various Artists" but not linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l(`Release groups credited to "Various Artists"
+              but not linked to VA`)}
+  >
+    <h1>
+      {l('Release groups credited to "Various Artists" but not linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows release groups with "Various Artists" as the
             credited name but not linked to the Various Artists entity.`)}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleaseLabelSameArtist.js
+++ b/root/report/ReleaseLabelSameArtist.js
@@ -37,14 +37,15 @@ const ReleaseLabelSameArtist = ({
 
     <ul>
       <li>
-        {exp.l(`This report lists releases where the label name is the same as
-            the artist name. Often this means the release is self-released,
-            and the label
-            {SpecialPurposeLabel|should be "[no label]" instead}.`,
-               {
-                 SpecialPurposeLabel:
+        {exp.l(
+          `This report lists releases where the label name is the same as the
+           artist name. Often this means the release is self-released, and the
+           label {SpecialPurposeLabel|should be "[no label]" instead}.`,
+          {
+            SpecialPurposeLabel:
             '/doc/Style/Unknown_and_untitled/Special_purpose_label',
-               })}
+          }
+        )}
       </li>
       <li>
         {texp.l('Total releases found: {count}',

--- a/root/report/ReleaseLabelSameArtist.js
+++ b/root/report/ReleaseLabelSameArtist.js
@@ -29,7 +29,10 @@ const ReleaseLabelSameArtist = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseLabelT>) => (
-  <Layout fullWidth title={l('Releases where artist name and label name are the same')}>
+  <Layout
+    fullWidth
+    title={l('Releases where artist name and label name are the same')}
+  >
     <h1>{l('Releases where artist name and label name are the same')}</h1>
 
     <ul>
@@ -38,13 +41,19 @@ const ReleaseLabelSameArtist = ({
             the artist name. Often this means the release is self-released,
             and the label
             {SpecialPurposeLabel|should be "[no label]" instead}.`,
-        {
-          SpecialPurposeLabel:
+               {
+                 SpecialPurposeLabel:
             '/doc/Style/Unknown_and_untitled/Special_purpose_label',
-        })}
+               })}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasedTooEarly.js
+++ b/root/report/ReleasedTooEarly.js
@@ -36,8 +36,14 @@ const ReleasedTooEarly = ({
             where a disc ID is attached to a medium whose format does not
             have disc IDs.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesInCaaWithCoverArtRelationships.js
+++ b/root/report/ReleasesInCaaWithCoverArtRelationships.js
@@ -25,8 +25,15 @@ const ReleasesInCaaWithCoverArtRelationships = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases in the Cover Art Archive that still have cover art relationships')}>
-    <h1>{l('Releases in the Cover Art Archive that still have cover art relationships')}</h1>
+  <Layout
+    fullWidth
+    title={l(`Releases in the Cover Art Archive that still have cover art
+              relationships`)}
+  >
+    <h1>
+      {l(`Releases in the Cover Art Archive that still have cover art
+          relationships`)}
+    </h1>
 
     <ul>
       <li>
@@ -34,8 +41,14 @@ const ReleasesInCaaWithCoverArtRelationships = ({
             Archive, but still have a cover art relationship
             (pointing to a URL).`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesMissingDiscIds.js
+++ b/root/report/ReleasesMissingDiscIds.js
@@ -36,7 +36,7 @@ const ReleasesMissingDiscIds = ({
       </li>
       <li>
         {exp.l(`For instructions on how to add one, see the
-            {add_discids|documentation page}.`,
+                {add_discids|documentation page}.`,
                {add_discids: '/doc/How_to_Add_Disc_IDs'})}
       </li>
       <li>

--- a/root/report/ReleasesMissingDiscIds.js
+++ b/root/report/ReleasesMissingDiscIds.js
@@ -37,10 +37,16 @@ const ReleasesMissingDiscIds = ({
       <li>
         {exp.l(`For instructions on how to add one, see the
             {add_discids|documentation page}.`,
-        {add_discids: '/doc/How_to_Add_Disc_IDs'})}
+               {add_discids: '/doc/How_to_Add_Disc_IDs'})}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesToConvert.js
+++ b/root/report/ReleasesToConvert.js
@@ -25,7 +25,10 @@ const ReleasesToConvert = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases which might need converting to "multiple artists"')}>
+  <Layout
+    fullWidth
+    title={l('Releases which might need converting to "multiple artists"')}
+  >
     <h1>{l('Releases which might need converting to "multiple artists"')}</h1>
 
     <ul>
@@ -35,8 +38,14 @@ const ReleasesToConvert = ({
             field, for example). Currently it does this by looking for
             releases where every track contains "/" or "-".`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithCaaNoTypes.js
+++ b/root/report/ReleasesWithCaaNoTypes.js
@@ -25,8 +25,15 @@ const ReleasesWithCaaNoTypes = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases in the Cover Art Archive where no cover art piece has types')}>
-    <h1>{l('Releases in the Cover Art Archive where no cover art piece has types')}</h1>
+  <Layout
+    fullWidth
+    title={l(`Releases in the Cover Art Archive where no cover art piece
+              has types`)}
+  >
+    <h1>
+      {l(`Releases in the Cover Art Archive where no cover art piece
+          has types`)}
+    </h1>
 
     <ul>
       <li>
@@ -34,8 +41,14 @@ const ReleasesWithCaaNoTypes = ({
             Archive, but where none of it has any types set. This often means
             a front cover was added, but not marked as such.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithDownloadRelationships.js
+++ b/root/report/ReleasesWithDownloadRelationships.js
@@ -25,16 +25,27 @@ const ReleasesWithDownloadRelationships = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Non-digital releases with download relationships')}>
-    <h1>{l('Non-digital releases with download relationships')}</h1>
+  <Layout
+    fullWidth
+    title={l('Non-digital releases with download relationships')}
+  >
+    <h1>
+      {l('Non-digital releases with download relationships')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows releases that have download relationships, but
             have media whose format is not "Digital Media".`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithNoMediums.js
+++ b/root/report/ReleasesWithNoMediums.js
@@ -32,8 +32,14 @@ const ReleasesWithNoMediums = ({
       <li>
         {l('This report shows releases without any mediums (no tracklist).')}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithUnlikelyLanguageScript.js
+++ b/root/report/ReleasesWithUnlikelyLanguageScript.js
@@ -33,8 +33,14 @@ const ReleasesWithUnlikelyLanguageScript = ({
         {l(`This report shows releases that have an unlikely combination of
             language and script properties, such as German and Ethiopic.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithoutVaCredit.js
+++ b/root/report/ReleasesWithoutVaCredit.js
@@ -25,16 +25,27 @@ const ReleasesWithoutVaCredit = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases not credited to "Various Artists" but linked to VA')}>
-    <h1>{l('Releases not credited to "Various Artists" but linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l('Releases not credited to "Various Artists" but linked to VA')}
+  >
+    <h1>
+      {l('Releases not credited to "Various Artists" but linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows releases linked to the Various Artists entity
             without "Various Artists" as the credited name.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReleasesWithoutVaLink.js
+++ b/root/report/ReleasesWithoutVaLink.js
@@ -25,16 +25,27 @@ const ReleasesWithoutVaLink = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases credited to "Various Artists" but not linked to VA')}>
-    <h1>{l('Releases credited to "Various Artists" but not linked to VA')}</h1>
+  <Layout
+    fullWidth
+    title={l('Releases credited to "Various Artists" but not linked to VA')}
+  >
+    <h1>
+      {l('Releases credited to "Various Artists" but not linked to VA')}
+    </h1>
 
     <ul>
       <li>
         {l(`This report shows releases with "Various Artists" as the credited
             name but not linked to the Various Artists entity.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/ReportNotAvailable.js
+++ b/root/report/ReportNotAvailable.js
@@ -16,7 +16,10 @@ const ReportNotAvailable = () => (
     <div id="content">
       <h1>{l('Error')}</h1>
 
-      <p>{l('We are sorry, but data for this report is not available right now.')}</p>
+      <p>
+        {l(`We are sorry, but data for this report is not available
+            right now.`)}
+      </p>
     </div>
   </Layout>
 );

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -19,11 +19,11 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
 
       <p>
         {exp.l(
-          `If you'd like to participate in the editing process, but do not know where
-           to start, the following reports should be useful. These reports scour the
-           database looking for data that might require fixing, either to comply with
-           the {style|style guidelines}, or in other cases where administrative
-           "clean up" tasks are required.`,
+          `If you'd like to participate in the editing process, but do not
+           know where to start, the following reports should be useful. These
+           reports scour the database looking for data that might require
+           fixing, either to comply with the {style|style guidelines}, or in
+           other cases where administrative "clean up" tasks are required.`,
           {style: '/doc/Style'},
         )}
       </p>
@@ -207,12 +207,14 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
         </li>
         <li>
           <a href="/report/ReleaseGroupsWithoutVACredit">
-            {l('Release groups not credited to "Various Artists" but linked to VA')}
+            {l(`Release groups not credited to "Various Artists" but linked
+                to VA`)}
           </a>
         </li>
         <li>
           <a href="/report/ReleaseGroupsWithoutVALink">
-            {l('Release groups credited to "Various Artists" but not linked to VA')}
+            {l(`Release groups credited to "Various Artists" but not linked
+                to VA`)}
           </a>
         </li>
       </ul>
@@ -297,7 +299,8 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
         </li>
         <li>
           <a href="/report/SomeFormatsUnset">
-            {l('Releases where some (but not all) mediums have no format set')}
+            {l(`Releases where some (but not all) mediums have
+                no format set`)}
           </a>
         </li>
         <li>
@@ -307,22 +310,26 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
         </li>
         <li>
           <a href="/report/UnlinkedPseudoReleases">
-            {l('Translated/Transliterated Pseudo-Releases not linked to an original version')}
+            {l(`Translated/Transliterated Pseudo-Releases not linked to
+                an original version`)}
           </a>
         </li>
         <li>
           <a href="/report/ReleasesInCAAWithCoverArtRelationships">
-            {l('Releases in the Cover Art Archive that still have cover art relationships')}
+            {l(`Releases in the Cover Art Archive that still have
+                cover art relationships`)}
           </a>
         </li>
         <li>
           <a href="/report/CoverArtRelationships">
-            {l('Releases of any sort that still have cover art relationships')}
+            {l(`Releases of any sort that still have
+                cover art relationships`)}
           </a>
         </li>
         <li>
           <a href="/report/ReleasesWithCAANoTypes">
-            {l('Releases in the Cover Art Archive where no cover art piece has types')}
+            {l(`Releases in the Cover Art Archive where no cover art piece
+                has types`)}
           </a>
         </li>
         <li>
@@ -427,17 +434,20 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
         </li>
         <li>
           <a href="/report/RecordingsWithoutVACredit">
-            {l('Recordings not credited to "Various Artists" but linked to VA')}
+            {l(`Recordings not credited to "Various Artists" but linked
+                to VA`)}
           </a>
         </li>
         <li>
           <a href="/report/RecordingsWithoutVALink">
-            {l('Recordings credited to "Various Artists" but not linked to VA')}
+            {l(`Recordings credited to "Various Artists" but not linked
+                to VA`)}
           </a>
         </li>
         <li>
           <a href="/report/RecordingsSameNameDifferentArtistsSameName">
-            {l('Recordings with the same name by different artists with the same name')}
+            {l(`Recordings with the same name by different artists
+                with the same name`)}
           </a>
         </li>
       </ul>

--- a/root/report/SeparateDiscs.js
+++ b/root/report/SeparateDiscs.js
@@ -36,10 +36,16 @@ const SeparateDiscs = ({
       <li>
         {exp.l('For instructions on how to fix them, please see the documentation\
             about {howto|how to merge releases}.',
-        {howto: '/doc/How_to_Merge_Releases'})}
+               {howto: '/doc/How_to_Merge_Releases'})}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/SetInDifferentRg.js
+++ b/root/report/SetInDifferentRg.js
@@ -41,8 +41,14 @@ const SetInDifferentRg = ({
           {how_to_merge_releases: '/doc/How_to_Merge_Releases'},
         )}
       </li>
-      <li>{texp.l('Total release groups found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total release groups found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/SingleMediumReleasesWithMediumTitles.js
+++ b/root/report/SingleMediumReleasesWithMediumTitles.js
@@ -25,7 +25,10 @@ const SingleMediumReleasesWithMediumTitles = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases with a single medium that has a name')}>
+  <Layout
+    fullWidth
+    title={l('Releases with a single medium that has a name')}
+  >
     <h1>{l('Releases with a single medium that has a name')}</h1>
 
     <ul>
@@ -34,8 +37,14 @@ const SingleMediumReleasesWithMediumTitles = ({
             medium also has a specific name. Usually, this is not necessary
             and is duplicate information which can be removed.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/SomeFormatsUnset.js
+++ b/root/report/SomeFormatsUnset.js
@@ -35,8 +35,14 @@ const SomeFormatsUnset = ({
             find out which the correct formats are (don't just assume that
             they're all CDs because one is though!).`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/SuperfluousDataTracks.js
+++ b/root/report/SuperfluousDataTracks.js
@@ -34,8 +34,14 @@ const SuperfluousDataTracks = ({
             contain data tracks (like videos). A data track should be deleted
             if it is the last track of the CD and there is no disc ID.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/TracksNamedWithSequence.js
+++ b/root/report/TracksNamedWithSequence.js
@@ -25,7 +25,10 @@ const TracksNamedWithSequence = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases where track names start with their track number')}>
+  <Layout
+    fullWidth
+    title={l('Releases where track names start with their track number')}
+  >
     <h1>{l('Releases where track names start with their track number')}</h1>
 
     <ul>
@@ -36,8 +39,14 @@ const TracksNamedWithSequence = ({
              don't automatically assume it is a mistake! If you confirm it
              is a mistake, please correct it.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/TracksWithSequenceIssues.js
+++ b/root/report/TracksWithSequenceIssues.js
@@ -34,8 +34,14 @@ const TracksWithSequenceIssues = ({
             continuous (e.g. there is no "track 2"), or with duplicated
             track numbers (e.g. there are two "track 4"s).`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/TracksWithoutTimes.js
+++ b/root/report/TracksWithoutTimes.js
@@ -33,8 +33,14 @@ const TracksWithoutTimes = ({
         {l(`This report lists all releases where some or all tracks have
             unknown track lengths.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/UnlinkedPseudoReleases.js
+++ b/root/report/UnlinkedPseudoReleases.js
@@ -35,8 +35,14 @@ const UnlinkedPseudoReleases = ({
              original version. This could be because the original version is
              missing, or just because the release status is wrongly set.`)}
       </li>
-      <li>{texp.l('Total releases found: {count}', {count: pager.total_entries})}</li>
-      <li>{texp.l('Generated on {date}', {date: formatUserDate($c.user, generated)})}</li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c.user, generated)})}
+      </li>
 
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>

--- a/root/report/components/ArtistAnnotationList.js
+++ b/root/report/components/ArtistAnnotationList.js
@@ -34,7 +34,11 @@ const ArtistAnnotationList = ({
             <td>
               <EntityLink entity={item.artist} />
             </td>
-            <td>{item.artist.typeName ? lp_attributes(item.artist.typeName, 'artist_type') : l('Unknown')}</td>
+            <td>
+              {item.artist.typeName
+                ? lp_attributes(item.artist.typeName, 'artist_type')
+                : l('Unknown')}
+            </td>
             <td dangerouslySetInnerHTML={{__html: item.text}} />
             <td>{item.created}</td>
           </tr>

--- a/root/report/components/ArtistList.js
+++ b/root/report/components/ArtistList.js
@@ -32,7 +32,11 @@ const ArtistList = ({
             <td>
               <EntityLink entity={item.artist} />
             </td>
-            <td>{item.artist.typeName ? lp_attributes(item.artist.typeName, 'artist_type') : l('Unknown')}</td>
+            <td>
+              {item.artist.typeName
+                ? lp_attributes(item.artist.typeName, 'artist_type')
+                : l('Unknown')}
+            </td>
           </tr>
         ))}
       </tbody>

--- a/root/report/components/ArtistRelationshipList.js
+++ b/root/report/components/ArtistRelationshipList.js
@@ -38,7 +38,11 @@ const ArtistRelationshipList = ({
             <td>
               <EntityLink entity={item.artist} />
             </td>
-            <td>{item.artist.typeName ? lp_attributes(item.artist.typeName, 'artist_type') : l('Unknown')}</td>
+            <td>
+              {item.artist.typeName
+                ? lp_attributes(item.artist.typeName, 'artist_type')
+                : l('Unknown')}
+            </td>
           </tr>
         ))}
       </tbody>

--- a/root/report/components/EditorList.js
+++ b/root/report/components/EditorList.js
@@ -38,7 +38,14 @@ const EditorList = ({
               <td>
                 <EditorLink editor={editor} />
                 {' '}
-                {bracketed(<a href={'/admin/user/delete/' + encodeURIComponent(editor.name)}>{l('delete')}</a>)}
+                {bracketed(
+                  <a
+                    href={'/admin/user/delete/' +
+                    encodeURIComponent(editor.name)}
+                  >
+                    {l('delete')}
+                  </a>,
+                )}
               </td>
               <td>{editor.registration_date}</td>
               <td>{editor.website}</td>
@@ -51,4 +58,5 @@ const EditorList = ({
     </table>
   </PaginatedResults>
 );
+
 export default EditorList;

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -44,7 +44,11 @@ const EventList = ({
                 showEventDate={false}
               />
             </td>
-            <td>{item.event.typeName ? lp_attributes(item.event.typeName, 'event_type') : null}</td>
+            <td>
+              {item.event.typeName
+                ? lp_attributes(item.event.typeName, 'event_type')
+                : null}
+            </td>
             <td>
               <ArtistRoles relations={item.event.performers} />
             </td>

--- a/root/report/components/InstrumentList.js
+++ b/root/report/components/InstrumentList.js
@@ -40,13 +40,18 @@ const InstrumentList = ({
             <td>
               <EntityLink entity={item.instrument} />
             </td>
-            <td>{item.instrument.typeName ? lp_attributes(item.instrument.typeName, 'instrument_type') : l('Unclassified instrument')}</td>
+            <td>
+              {item.instrument.typeName
+                ? lp_attributes(item.instrument.typeName, 'instrument_type')
+                : l('Unclassified instrument')}
+            </td>
             <td>
               {item.instrument.last_updated
                 ? formatUserDate($c.user, item.instrument.last_updated)
                 : null
               }
             </td>
+
           </tr>
         ))}
       </tbody>

--- a/root/report/components/UrlRelationshipList.js
+++ b/root/report/components/UrlRelationshipList.js
@@ -32,7 +32,9 @@ const UrlRelationshipList = ({
         {items.map((item, index) => (
           <tr className={loopParity(index)} key={item.url.gid}>
             <td>
-              <a href={'/relationship/' + item.link_gid}>{l_relationships(item.link_name)}</a>
+              <a href={'/relationship/' + encodeURIComponent(item.link_gid)}>
+                {l_relationships(item.link_name)}
+              </a>
             </td>
             <td>
               <EntityLink entity={item.url} />


### PR DESCRIPTION
To be reviewed and merged after https://github.com/metabrainz/musicbrainz-server/pull/933

After this, https://tickets.metabrainz.org/browse/MBS-9909 should be ready for closing.

Interestingly, eslint didn't detect these lines, even though many were clearly too long. Is there a second rule we can apply for this that will check specifically for too long jsx lines?