### PR TITLE
Replace _.assign with Object.assign/spreads

### DIFF
--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -140,7 +140,7 @@
     <td data-bind="foreach: relationship().linkTypeAttributes()">
       <!-- ko template: {
                 name: "template.edit-attribute",
-                data: _.assign({ relationship: $parent.relationship() }, $data)
+                data: Object.assign({ relationship: $parent.relationship() }, $data)
               }
         --><!-- /ko -->
     </td>

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -247,7 +247,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
     let doRequest;
     if (asap) {
       const $ = require('jquery');
-      doRequest = args => $.ajax(_.assign({dataType: 'json'}, args));
+      doRequest = args => $.ajax({...args, dataType: 'json'});
     } else {
       doRequest = require('../utility/request').default;
     }
@@ -356,7 +356,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
   updateVote(index: number, vote: VoteT) {
     const newCount = this.getNewCount(index, vote);
     const tags = this.state.tags.slice(0);
-    tags[index] = _.assign({}, tags[index], {count: newCount, vote: vote});
+    tags[index] = {...tags[index], count: newCount, vote};
     this.setState({tags});
   }
 

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -34,7 +34,7 @@ import formatTrackLength from './utility/formatTrackLength';
     class Entity {
 
         constructor(data) {
-            _.assign(this, data);
+            Object.assign(this, data);
             this.name = this.name || "";
         }
 
@@ -283,7 +283,7 @@ import formatTrackLength from './utility/formatTrackLength';
         }
 
         toJSON() {
-            return _.assign(super.toJSON(), { isrcs: this.isrcs, appearsOn: this.appearsOn });
+            return Object.assign(super.toJSON(), { isrcs: this.isrcs, appearsOn: this.appearsOn });
         }
     }
 
@@ -357,7 +357,7 @@ import formatTrackLength from './utility/formatTrackLength';
         }
 
         toJSON() {
-            return _.assign(super.toJSON(), {
+            return Object.assign(super.toJSON(), {
                 type: this.type(),
                 typeID: this.typeID,
                 orderingTypeID: this.orderingTypeID
@@ -408,7 +408,7 @@ import formatTrackLength from './utility/formatTrackLength';
 
     class Work extends CoreEntity {
         toJSON() {
-            return _.assign(super.toJSON(), { artists: this.artists });
+            return Object.assign(super.toJSON(), { artists: this.artists });
         }
     }
 

--- a/root/static/scripts/common/utility/lens.js
+++ b/root/static/scripts/common/utility/lens.js
@@ -28,8 +28,6 @@
  * https://github.com/gcanti/monocle-ts/tree/d1ebe6b with heavy modifications.
  */
 
-import assign from 'lodash/assign';
-
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 type MapT = {+[string]: *};
@@ -117,7 +115,7 @@ export function update<S: *, A>(lens: Lens<S, A>, f: (a: A) => A, s: S): S {
 }
 
 function _merge<T: MapT>(a: T, b: T): T {
-  return ((assign({}, a, b): any): T);
+  return ((Object.assign({}, a, b): any): T);
 }
 
 export function merge<S: *, A: MapT>(lens: Lens<S, A>, values: A, s: S): S {

--- a/root/static/scripts/common/utility/request.js
+++ b/root/static/scripts/common/utility/request.js
@@ -11,7 +11,7 @@ var previousDeferred = null;
 var timeout = 1000;
 
 function makeRequest(args, context, deferred) {
-    deferred.jqXHR = $.ajax(_.extend({ dataType: "json" }, args))
+    deferred.jqXHR = $.ajax({...args, dataType: "json"})
         .done(function () {
             if (!deferred.aborted) {
                 deferred.resolveWith(context, arguments);

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -277,7 +277,7 @@ import request from '../../common/utility/request';
 
     function editConstructor(type, callback) {
         return function (args, ...rest) {
-            args = _.extend({ edit_type: type }, args);
+            args = {...args, edit_type: type};
 
             callback && callback.apply(null, [args].concat(rest));
             args.hash = editHash(args);

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -39,21 +39,21 @@ function setAutoJoinPhrases(ac) {
   if (size > 0) {
     const name0 = ac[size - 1];
     if (name0 && name0.automaticJoinPhrase !== false) {
-      ac[size - 1] = _.assign({}, name0, {joinPhrase: ''});
+      ac[size - 1] = {...name0, joinPhrase: ''};
     }
   }
 
   if (size > 1) {
     const name1 = ac[size - 2];
     if (name1 && name1.automaticJoinPhrase !== false && auto.test(name1.joinPhrase)) {
-      ac[size - 2] = _.assign({}, name1, {joinPhrase: ' & '});
+      ac[size - 2] = {...name1, joinPhrase: ' & '};
     }
   }
 
   if (size > 2) {
     const name2 = ac[size - 3];
     if (name2 && name2.automaticJoinPhrase !== false && auto.test(name2.joinPhrase)) {
-      ac[size - 3] = _.assign({}, name2, {joinPhrase: ', '});
+      ac[size - 3] = {...name2, joinPhrase: ', '};
     }
   }
 

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -157,7 +157,7 @@ function expandCredit(fullName, artists, isProbablyClassical) {
         .map(function (pair) {
             var name = cleanCredit(pair[0], isProbablyClassical);
 
-            return _.assign(
+            return Object.assign(
                 {similarity: -1, artist: null, name: name, joinPhrase: fixJoinPhrase(pair[1])},
                 bestArtistMatch(artists, name, isProbablyClassical) || {}
             );
@@ -197,7 +197,7 @@ export default function (entity) {
 MB.Control.initGuessFeatButton = function (formName) {
     var nameInput = document.getElementById('id-' + formName + '.name');
 
-    var augmentedEntity = _.assign(
+    var augmentedEntity = Object.assign(
         Object.create(MB.sourceRelationshipEditor.source),
         {
             // Emulate an observable that just reads/writes to the name input directly.

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -105,7 +105,7 @@ ko.bindingHandlers.guessCase = {
             guessCaseOptions.upperCaseRoman(getBooleanCookie('guesscase_roman'));
         }
 
-        var bindings = _.assign({}, guessCaseOptions);
+        var bindings = {...guessCaseOptions};
         bindings.guessCase = _.bind(valueAccessor(), bindings);
 
         var context = bindingContext.createChildContext(bindings);

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -536,7 +536,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         }
     }
 
-    _.assign(Dialog.prototype, {
+    Object.assign(Dialog.prototype, {
         loading: ko.observable(false),
         showAttributesHelp: ko.observable(false),
         showLinkTypeHelp: ko.observable(false),
@@ -555,7 +555,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             var widget = $dialog.data("ui-dialog");
             widget.uiDialog.find(".ui-dialog-titlebar").remove();
 
-            _.assign(Dialog.prototype, {$dialog, widget});
+            Object.assign(Dialog.prototype, {$dialog, widget});
             ko.applyBindings(this.viewModel, $dialog[0]);
         }),
     });
@@ -600,7 +600,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         }
     }
 
-    _.assign(AddDialog.prototype, {
+    Object.assign(AddDialog.prototype, {
         dialogTemplate: "template.relationship-dialog",
         disableTypeSelection: false,
     });
@@ -641,7 +641,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         }
     }
 
-    _.assign(EditDialog.prototype, {
+    Object.assign(EditDialog.prototype, {
         dialogTemplate: "template.relationship-dialog",
         disableTypeSelection: true,
     });
@@ -674,7 +674,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         }
     }
 
-    _.assign(BatchRelationshipDialog.prototype, {
+    Object.assign(BatchRelationshipDialog.prototype, {
         dialogTemplate: "template.batch-relationship-dialog",
         disableTypeSelection: false,
     });
@@ -682,7 +682,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
     export class BatchCreateWorksDialog extends BatchRelationshipDialog {
 
         constructor(options) {
-            super(_.assign(options, { target: new MB.entity.Work({}) }));
+            super(Object.assign(options, { target: new MB.entity.Work({}) }));
             this.error = ko.observable(false);
         }
 
@@ -726,7 +726,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         targetEntityError() { return "" }
     }
 
-    _.assign(BatchCreateWorksDialog.prototype, {
+    Object.assign(BatchCreateWorksDialog.prototype, {
         dialogTemplate: "template.batch-create-works-dialog",
         workType: ko.observable(null),
         workLanguage: ko.observable(null),

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -39,7 +39,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         this.relationshipElements = {};
     };
 
-    _.assign(coreEntityPrototype, {
+    Object.assign(coreEntityPrototype, {
 
         parseRelationships: function (relationships) {
             var self = this;

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -118,7 +118,7 @@ export class ViewModel {
         }
     }
 
-    _.assign(ViewModel.prototype, {
+    Object.assign(ViewModel.prototype, {
         relationshipClass: fields.Relationship,
         activeDialog: ko.observable(),
     });

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -308,6 +308,6 @@ const actions = {
     copyTrackArtistsToRecordings: ko.observable(false)
 };
 
-_.extend(releaseEditor, actions);
+Object.assign(releaseEditor, actions);
 
 export default actions;

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -12,7 +12,7 @@ import releaseEditor from './viewModel';
 
 function bubbleDoc(options) {
     var bubble = new MB.Control.BubbleDoc("Information");
-    _.assign(bubble, options);
+    Object.assign(bubble, options);
     return bubble;
 }
 

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -34,7 +34,7 @@ class Dialog {
 
 export const trackParserDialog = releaseEditor.trackParserDialog = new Dialog();
 
-_.assign(trackParserDialog, {
+Object.assign(trackParserDialog, {
     element: "#track-parser-dialog",
     title: l("Track Parser"),
 
@@ -73,7 +73,7 @@ _.assign(trackParserDialog, {
 class SearchResult {
 
     constructor(tab, data) {
-        _.extend(this, data);
+        Object.assign(this, data);
 
         this.tab = tab;
         this.loaded = ko.observable(false);
@@ -109,7 +109,7 @@ class SearchResult {
 
     requestDone(data) {
         _.each(data.tracks, (track, index) => this.parseTrack(track, index));
-        _.extend(this, utils.reuseExistingMediumData(data));
+        Object.assign(this, utils.reuseExistingMediumData(data));
 
         this.loaded(true);
     }
@@ -260,7 +260,7 @@ SearchTab.prototype.tracksRequestData = {};
 
 export const mediumSearchTab = releaseEditor.mediumSearchTab = new SearchTab();
 
-_.assign(mediumSearchTab, {
+Object.assign(mediumSearchTab, {
     endpoint: "/ws/js/medium",
 
     tracksRequestData: { inc: "recordings" },
@@ -278,7 +278,7 @@ _.assign(mediumSearchTab, {
 
 var cdstubSearchTab = new SearchTab();
 
-_.assign(cdstubSearchTab, {
+Object.assign(cdstubSearchTab, {
     endpoint: "/ws/js/cdstub",
 
     tracksRequestURL: function (result) {
@@ -289,7 +289,7 @@ _.assign(cdstubSearchTab, {
 
 export const addDiscDialog = releaseEditor.addDiscDialog = new Dialog();
 
-_.assign(addDiscDialog, {
+Object.assign(addDiscDialog, {
     element: "#add-disc-dialog",
     title: l("Add Medium"),
 

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -78,7 +78,7 @@ releaseEditor.edits = {
             edits.push(MB.edit.releaseCreate(newData));
         }
         else if (!_.isEqual(newData, oldData)) {
-            newData = _.extend(_.clone(newData), { to_edit: release.gid() });
+            newData = {...newData, to_edit: release.gid()};
             edits.push(MB.edit.releaseEdit(newData, oldData));
         }
         return edits;

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -291,7 +291,7 @@ class Track {
     }
 }
 
-_.assign(Track.prototype, {
+Object.assign(Track.prototype, {
     entityType: 'track',
     renderArtistCredit: MB_entity.Entity.prototype.renderArtistCredit,
     isCompleteArtistCredit: MB_entity.Entity.prototype.isCompleteArtistCredit,

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -24,7 +24,7 @@ import recordingAssociation from './recordingAssociation';
 import utils from './utils';
 import releaseEditor from './viewModel';
 
-_.extend(releaseEditor, {
+Object.assign(releaseEditor, {
     activeTabID: ko.observable("#information"),
     activeTabIndex: ko.observable(0),
     loadError: ko.observable(""),

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -360,7 +360,7 @@ relationshipEditorTest("dialog backwardness", function (t) {
     ];
 
     _.each(tests, function (test) {
-        var options = _.assign({ viewModel: vm }, test.input);
+        var options = {...test.input, viewModel: vm};
         var dialog = new AddDialog(options);
 
         t.equal(dialog.backward(), test.expected.backward)
@@ -946,7 +946,7 @@ relationshipEditorTest('relationships with different link orders are not duplica
     var relationship = vm.source.relationships()[0];
 
     var newRelationship = vm.getRelationship(
-        _.assign(_.clone(sourceData.relationships[0]), { linkOrder: 1 }),
+        {...sourceData.relationships[0], linkOrder: 1},
         vm.source
     );
 

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -126,7 +126,7 @@ dialogTest("adding a new medium does not cause reorder edits (MBS-7412)", functi
 
     release.mediums([
         new fields.Medium(
-            _.assign(_.omit(common.testMedium, "id"), { position: 1 })
+            Object.assign(_.omit(common.testMedium, "id"), { position: 1 })
         )
     ]);
 

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -31,7 +31,7 @@ function parserTest(name, callback) {
 parserTest("track numbers", function (t) {
     t.plan(1);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         hasVinylNumbers: true,
         useTrackNumbers: true,
@@ -64,7 +64,7 @@ parserTest("track numbers", function (t) {
 parserTest("parsing track durations with trailing whitespace (MBS-1284)", function (t) {
     t.plan(1);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true,
@@ -90,7 +90,7 @@ parserTest("parsing track durations with trailing whitespace (MBS-1284)", functi
 parserTest("numbers at the end of track names being wrongly interpreted as durations (MBS-2511, MBS-2902)", function (t) {
     t.plan(1);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true,
@@ -112,7 +112,7 @@ parserTest("numbers at the end of track names being wrongly interpreted as durat
 parserTest("ignoring lines that don't start with a number when the option is set (MBS-2540)", function (t) {
     t.plan(1);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true,
@@ -137,7 +137,7 @@ parserTest("ignoring lines that don't start with a number when the option is set
 parserTest("XX:XX:XX track times (MBS-3353)", function (t) {
     t.plan(1);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true,
@@ -154,7 +154,7 @@ parserTest("XX:XX:XX track times (MBS-3353)", function (t) {
 parserTest("internal track positions are updated appropriately after being reused", function (t) {
     t.plan(2);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNames: true,
         useTrackLengths: true
@@ -212,7 +212,7 @@ parserTest("MBS-7451: track parser can clear TOC track lengths", function (t) {
 parserTest("can parse only numbers, titles, artists, or lengths (MBS-3730, MBS-3732)", function (t) {
     t.plan(16);
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         hasVinylNumbers: true,
         hasTrackArtists: true,
@@ -243,7 +243,7 @@ parserTest("can parse only numbers, titles, artists, or lengths (MBS-3730, MBS-3
     t.equal(track.formattedLength(), "3:00", "length was not used");
 
     // Parse only titles
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         useTrackNumbers: false,
         useTrackNames: true
     });
@@ -257,7 +257,7 @@ parserTest("can parse only numbers, titles, artists, or lengths (MBS-3730, MBS-3
     t.equal(track.formattedLength(), "3:00", "length was not used");
 
     // Parse only artists
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         useTrackNames: false,
         useTrackArtists: true
     });
@@ -271,7 +271,7 @@ parserTest("can parse only numbers, titles, artists, or lengths (MBS-3730, MBS-3
     t.equal(track.formattedLength(), "3:00", "length was not used");
 
     // Parse only lengths
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         useTrackArtists: false,
         useTrackLengths: true
     });
@@ -290,7 +290,7 @@ parserTest("Does not lose previous recordings (MBS-7719)", function (t) {
 
     var trackParser = releaseEditor.trackParser;
 
-    _.assign(trackParser.options, {
+    Object.assign(trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true
@@ -368,7 +368,7 @@ parserTest("Does not lose previous recordings (MBS-7719)", function (t) {
 parserTest("parsing fullwidth numbers", function (t) {
     t.plan(1);
 
-    _.assign(releaseEditor.trackParser.options, {
+    Object.assign(releaseEditor.trackParser.options, {
         hasTrackNumbers: true,
         useTrackNumbers: true,
         useTrackNames: true,
@@ -386,7 +386,7 @@ parserTest("parses track times for data tracks if there's a disc ID (MBS-8409)",
     t.plan(2);
 
     var trackParser = releaseEditor.trackParser;
-    _.assign(trackParser.options, {useTrackLengths: true});
+    Object.assign(trackParser.options, {useTrackLengths: true});
 
     var release = new fields.Release({
         id: 1,


### PR DESCRIPTION
Removing unnecessary uses of lodash. This doesn't help with our bundle sizes yet (we'll have to kill lodash chaining first).

`_.extend` differs in that it enumerates over inherited properties, but there was no case where we needed or wanted that.

Note: We already have an `Object.assign` polyfill for IE.