### PR TITLE
Remove explicit calls to _.chain

### DIFF
--- a/root/static/scripts/edit/ExampleRelationships.js
+++ b/root/static/scripts/edit/ExampleRelationships.js
@@ -35,9 +35,9 @@ ERE.init = function (config) {
     });
     ERE.viewModel.selectedEntityType.subscribe(autocomplete.changeEntity);
     ERE.viewModel.availableEntityTypes(
-        _.chain([ type0, type1 ]).uniq().map(function (value) {
+        _.uniq([ type0, type1 ]).map(function (value) {
             return { 'value': value, 'text': ENTITY_NAMES[value]() };
-        }).value());
+        }));
 
     ko.bindingHandlers.checkObject = {
         init: function (element, valueAccessor, all, vm, bindingContext) {


### PR DESCRIPTION
Method chaining is bad because it prevents use from being able to remove unused lodash code.

This commit doesn't remove implicit chaining using `_()`, which is much more common.