### PR TITLE
MBS-9990: Make formatUserDate check it's being passed a valid date

### DIFF
--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -77,7 +77,11 @@ const ElectionDetails = ({election, user}: PropsT) => (
           {election.is_open
             ? (
               lp(election.status_name, 'autoeditor election status', {
-                date: formatUserDate(user, election.open_time),
+                date: (
+                  election.open_time
+                    ? formatUserDate(user, election.open_time)
+                    : null
+                ),
               })
             ) : null}
 

--- a/root/report/components/InstrumentList.js
+++ b/root/report/components/InstrumentList.js
@@ -43,7 +43,12 @@ const InstrumentList = ({
               <EntityLink entity={item.instrument} />
             </td>
             <td>{item.instrument.typeName ? lp_attributes(item.instrument.typeName, 'instrument_type') : l('Unclassified instrument')}</td>
-            <td>{formatUserDate($c.user, item.instrument.last_updated)}</td>
+            <td>
+              {item.instrument.last_updated
+                ? formatUserDate($c.user, item.instrument.last_updated)
+                : null
+              }
+            </td>
           </tr>
         ))}
       </tbody>

--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -11,7 +11,7 @@ import 'moment-timezone';
 
 function formatUserDate(user, dateString, options) {
   let preferences = user ? user.preferences : null;
-  let result = moment(dateString);
+  let result = moment(dateString, moment.defaultFormat, true);
   let format = '%Y-%m-%d %H:%M %Z';
 
   if (preferences) {

--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -1,7 +1,10 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import moment from 'moment';
 import trim from 'lodash/trim';
@@ -9,9 +12,13 @@ import trim from 'lodash/trim';
 import 'moment-strftime';
 import 'moment-timezone';
 
-function formatUserDate(user, dateString, options) {
-  let preferences = user ? user.preferences : null;
-  let result = moment(dateString, moment.defaultFormat, true);
+function formatUserDate(
+  user: ?(CatalystUserT | SanitizedEditorT),
+  dateString: string,
+  options?: {dateOnly?: boolean},
+) {
+  const preferences = user ? user.preferences : null;
+  const result = moment(dateString, moment.defaultFormat, true);
   let format = '%Y-%m-%d %H:%M %Z';
 
   if (preferences) {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9990

https://momentjs.com/guides/#/parsing/strict-mode/ (moment.defaultFormat is YYYY-MM-DDTHH:mm:ssZ, https://momentjs.com/docs/#/displaying/format/)

If not being passed a valid date, it will just say Invalid date. Is there anywhere where we're passing this function anything else than a YYYY-MM-DDTHH:mm:ssZ format? (multiple formats can be allowed, if needed)