### PR TITLE
Wait for net requests between Selenium commands

### DIFF
--- a/root/static/scripts/common/utility/debounce.js
+++ b/root/static/scripts/common/utility/debounce.js
@@ -9,6 +9,9 @@ function debounce(value, delay) {
     if (!ko.isObservable(value)) {
         value = ko.computed(value);
     }
+    if (process.env.MUSICBRAINZ_RUNNING_TESTS) {
+        return value;
+    }
     return value.extend({
         rateLimit: { method: "notifyWhenChangesStop", timeout: delay || 500 }
     });


### PR DESCRIPTION
I think this will help solve sporadic issues waiting for edit previews in the release editor.

The debounce change is to make sure edit previews start generating immediately (meaning a request will initiate before the next command starts, and we'll wait for it). The EnvironmentPlugin for webpack should replace `MUSICBRAINZ_RUNNING_TESTS` with `false` for production builds and eliminate that block as dead code.