### PR TITLE
Change user to entity on UserAccountLayout for use with chooseLayoutComponent

### DIFF
--- a/root/account/Donation.js
+++ b/root/account/Donation.js
@@ -24,11 +24,16 @@ const Donation = ({days, nag}: Props) => (
       ? (
         <>
           <p>
-            {l('We have not received a donation from you recently. If you have just made a PayPal donation, then we have not received a notification from PayPal yet. Please wait a few minutes and reload this page to check again.')}
+            {l(`We have not received a donation from you recently. If you have
+                just made a PayPal donation, then we have not received a
+                notification from PayPal yet. Please wait a few minutes and
+                reload this page to check again.`)}
           </p>
           <p>
-            {l('If you would like to make a donation, {donate|you can do that here}. If you have donated, but you are still being nagged, please {contact|contact us}.',
-              {contact: CONTACT_URL, donate: DONATE_URL})}
+            {l(`If you would like to make a donation, {donate|you can do that
+                here}. If you have donated, but you are still being nagged,
+                please {contact|contact us}.`,
+               {contact: CONTACT_URL, donate: DONATE_URL})}
           </p>
         </>
       ) : (
@@ -39,7 +44,10 @@ const Donation = ({days, nag}: Props) => (
           {days > 0
             ? (
               <p>
-                {l('You will not be nagged for another {days} days.', {days: days})}
+                {l(
+                  'You will not be nagged for another {days} days.',
+                  {days: days},
+                )}
               </p>
             ) : (
               <p>

--- a/root/account/EmailVerificationStatus.js
+++ b/root/account/EmailVerificationStatus.js
@@ -21,7 +21,8 @@ const EmailVerificationStatus = ({message}: Props) => (
     <p>
       {message
         ? message
-        : l('Thank you, your email address has now been verified! If you still can\'t edit, please try to log out and log in again.')
+        : l(`Thank you, your email address has now been verified! If you still
+             can't edit, please try to log out and log in again.`)
       }
     </p>
   </StatusPage>

--- a/root/account/LostPassword.js
+++ b/root/account/LostPassword.js
@@ -29,8 +29,10 @@ const LostPassword = (props: Props) => (
   <Layout fullWidth title={l('Lost Password')}>
     <h1>{l('Lost Password')}</h1>
     <p>
-      {l('Enter your username and email below. We will send you an email with a link to reset your password. If you have forgotten your username, {link|retrieve it} first and then reset your password.',
-        {link: '/account/lost-username'})}
+      {l(`Enter your username and email below. We will send you an email with
+          a link to reset your password. If you have forgotten your username,
+          {link|retrieve it} first and then reset your password.`,
+         {link: '/account/lost-username'})}
     </p>
     <form method="post">
       <FormRowText

--- a/root/account/LostPasswordSent.js
+++ b/root/account/LostPasswordSent.js
@@ -16,8 +16,10 @@ import StatusPage from '../components/StatusPage';
 const LostPasswordSent = () => (
   <StatusPage title={hyphenateTitle(l('Lost Password'), l('Email Sent!'))}>
     <p>
-      {l('We\'ve sent you instructions on how to reset your password. If you don\'t receive this email or still have problems logging in, please {link|contact us}.',
-        {link: CONTACT_URL})}
+      {l(`We've sent you instructions on how to reset your password. If you
+          don't receive this email or still have problems logging in,
+          please {link|contact us}.`,
+         {link: CONTACT_URL})}
     </p>
   </StatusPage>
 );

--- a/root/account/LostUsername.js
+++ b/root/account/LostUsername.js
@@ -27,7 +27,8 @@ const LostUsername = (props: Props) => (
   <Layout fullWidth title={l('Lost Username')}>
     <h1>{l('Lost Username')}</h1>
     <p>
-      {l('Enter your email address below and we will send you an email with your MusicBrainz account information.')}
+      {l(`Enter your email address below and we will send you an email with
+          your MusicBrainz account information.`)}
     </p>
     <form method="post">
       <FormRowEmailLong

--- a/root/account/LostUsernameSent.js
+++ b/root/account/LostUsernameSent.js
@@ -16,8 +16,10 @@ import StatusPage from '../components/StatusPage';
 const LostUsernameSent = () => (
   <StatusPage title={hyphenateTitle(l('Lost Username'), l('Email Sent!'))}>
     <p>
-      {l('We\'ve sent you information about your MusicBrainz account. If you don\'t receive this email or still have problems logging in, please {link|contact us}.',
-        {link: CONTACT_URL})}
+      {l(`We've sent you information about your MusicBrainz account. If you
+          don't receive this email or still have problems logging in,
+          please {link|contact us}.`,
+         {link: CONTACT_URL})}
     </p>
   </StatusPage>
 );

--- a/root/account/Preferences.js
+++ b/root/account/Preferences.js
@@ -11,8 +11,10 @@ import * as React from 'react';
 
 import UserAccountLayout from '../components/UserAccountLayout';
 import {withCatalystContext} from '../context';
-import PreferencesForm from '../static/scripts/account/components/PreferencesForm';
-import type {PreferencesFormPropsT} from '../static/scripts/account/components/PreferencesForm';
+import PreferencesForm
+  from '../static/scripts/account/components/PreferencesForm';
+import type {PreferencesFormPropsT}
+  from '../static/scripts/account/components/PreferencesForm';
 import {l} from '../static/scripts/common/i18n';
 import * as manifest from '../static/manifest';
 

--- a/root/account/Preferences.js
+++ b/root/account/Preferences.js
@@ -17,11 +17,11 @@ import {l} from '../static/scripts/common/i18n';
 import * as manifest from '../static/manifest';
 
 type Props = {|
-  +$c: CatalystContextT,
+  +$c: {user: EditorT} & CatalystContextT,
   ...PreferencesFormPropsT,
 |};
 
-const Preferences = withCatalystContext(({$c, ...props}) => (
+const Preferences = withCatalystContext(({$c, ...props}: Props) => (
   <UserAccountLayout
     entity={$c.user}
     page="preferences"

--- a/root/account/Preferences.js
+++ b/root/account/Preferences.js
@@ -23,9 +23,9 @@ type Props = {|
 
 const Preferences = withCatalystContext(({$c, ...props}) => (
   <UserAccountLayout
+    entity={$c.user}
     page="preferences"
     title={l('Preferences')}
-    user={$c.user}
   >
     <PreferencesForm {...props} />
     {manifest.js('account/preferences')}

--- a/root/account/PreferencesSaved.js
+++ b/root/account/PreferencesSaved.js
@@ -20,8 +20,13 @@ type Props = {|
 const PreferencesSaved = ({$c}: Props) => (
   <StatusPage title={l('Preferences')}>
     <p>
-      {l('Your preferences have been saved. Click {link|here} to continue to your user page.',
-        {link: $c.user ? '/user/' + encodeURIComponent($c.user.name) : '/register'})}
+      {l(`Your preferences have been saved. Click {link|here} to continue
+          to your user page.`,
+         {
+           link: $c.user
+             ? '/user/' + encodeURIComponent($c.user.name)
+             : '/register',
+         })}
     </p>
   </StatusPage>
 );

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -18,15 +18,15 @@ import UserAccountTabs from './UserAccountTabs';
 
 type Props = {|
   +children: React.Node,
+  +entity: EditorT,
   +page: string,
   +title?: string,
-  +user: EditorT,
 |};
 
 const UserAccountLayout = ({
   children,
+  entity: user,
   page,
-  user,
   title,
   ...layoutProps
 }: Props) => (

--- a/root/utility/chooseLayoutComponent.js
+++ b/root/utility/chooseLayoutComponent.js
@@ -18,12 +18,14 @@ import RecordingLayout from '../recording/RecordingLayout';
 import ReleaseGroupLayout from '../release_group/ReleaseGroupLayout';
 import ReleaseLayout from '../release/ReleaseLayout';
 import SeriesLayout from '../series/SeriesLayout';
+import UserAccountLayout from '../components/UserAccountLayout';
 import WorkLayout from '../work/WorkLayout';
 
 const layoutPicker = {
   area: AreaLayout,
   artist: ArtistLayout,
   collection: CollectionLayout,
+  editor: UserAccountLayout,
   event: EventLayout,
   instrument: InstrumentLayout,
   label: LabelLayout,


### PR DESCRIPTION
CatCat caught this one on test - we weren't actually using UserAccountLayout in chooseLayoutComponent, but we were using it for entity/Subscribers, so the user subscriber page broke. In order to use it on cLC, it needs to take "entity" rather than "user", like all other entity layouts, so changed that.