### PR TITLE
Merge new linked_entities during the request

### DIFF
--- a/root/server/createServer.js
+++ b/root/server/createServer.js
@@ -71,6 +71,15 @@ const connectionListener = Raven.wrap(function (socket) {
         socket.end();
         socket.destroy();
       } else {
+        // Merge new linked entities into current ones.
+        const current = context.linked_entities;
+        for (let [type, entities] of Object.entries(requestBody.linked_entities)) {
+          if (!current[type]) {
+            current[type] = entities;
+          } else {
+            Object.assign(current[type], entities);
+          }
+        }
         writeResponse(socket, getResponse(requestBody, context));
       }
 


### PR DESCRIPTION
Currently, we only use the `linked_entities` sent when the request begins. If there's a call to `React.embed` later which produces new ones, we had completely ignored them. The change here is to merge them into the existing ones.