### PR TITLE
Add no-unneeded-ternary eslint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -58,6 +58,7 @@ rules:
   no-eq-null: error
   no-floating-decimal: warn
   no-multi-spaces: [error, {ignoreEOLComments: true}]
+  no-unneeded-ternary: warn
   radix: warn
   wrap-iife: warn
 


### PR DESCRIPTION
https://eslint.org/docs/rules/no-unneeded-ternary

There's no good reason to have (x ? x : 1) when we can have (x || 1). This will just ensure we are reminded of it.