### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
           MMD_SCHEMA_TAG: v-2019-01-07
           PERL_CARTON_PATH: &carton /home/musicbrainz/carton-local
           PERL_CPANM_OPT: --notest --no-interactive
-        image: metabrainz/musicbrainz-tests:v-2019-02
+        image: metabrainz/musicbrainz-tests:v-2019-05
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 

--- a/bin/rsync-staticbrainz-files
+++ b/bin/rsync-staticbrainz-files
@@ -5,7 +5,9 @@ SOURCE="$2"
 DESTINATION="$3"
 RSYNC_OPTIONS="$4"
 
-source /etc/mbs_constants.sh
+MBS_HOME=/home/musicbrainz
+MBS_ROOT=$MBS_HOME/musicbrainz-server
+
 source "$MBS_ROOT/script/functions.sh"
 
 for server in $STATICBRAINZ_SERVERS; do

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -78,8 +78,9 @@ RUN apt-get update && \
 RUN wget -q -O - https://cpanmin.us | perl - App::cpanminus && \
     cpanm Carton JSON::XS
 
-RUN curl -sLO http://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip && \
+RUN curl -sLO https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/chromedriver && \
     rm chromedriver_linux64.zip
 
 RUN curl -sLO https://github.com/validator/validator/releases/download/18.11.5/vnu.jar_18.11.5.zip && \

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -16,7 +16,7 @@ RUN apt-get update && \
         gnupg && \
     apt-key add yarn_pubkey.txt && \
     rm yarn_pubkey.txt && \
-    apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys 'Yarn' && \
+    apt-key adv --keyserver keyserver.ubuntu.com --refresh-keys 'Yarn' && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -sLO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     curl -sLO https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.10.0-1nodesource1_amd64.deb && \

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -29,7 +29,6 @@ RUN apt-get update && \
         ./nodejs_10.10.0-1nodesource1_amd64.deb \
         build-essential \
         bzip2 \
-        carton \
         default-jre \
         gcc \
         gettext \
@@ -75,6 +74,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm google-chrome-stable_current_amd64.deb && \
     rm nodejs_10.10.0-1nodesource1_amd64.deb
+
+RUN wget -q -O - https://cpanmin.us | perl - App::cpanminus && \
+    cpanm Carton
 
 RUN curl -sLO http://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/local/bin && \

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -76,7 +76,7 @@ RUN apt-get update && \
     rm nodejs_10.10.0-1nodesource1_amd64.deb
 
 RUN wget -q -O - https://cpanmin.us | perl - App::cpanminus && \
-    cpanm Carton
+    cpanm Carton JSON::XS
 
 RUN curl -sLO http://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/local/bin && \

--- a/docker/musicbrainz-website/deploy_static_resources.sh
+++ b/docker/musicbrainz-website/deploy_static_resources.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-source /etc/mbs_constants.sh
+MBS_HOME=/home/musicbrainz
+MBS_ROOT=$MBS_HOME/musicbrainz-server
+
 source "$MBS_ROOT/script/functions.sh"
 
 BUILD_DIR=$MBS_ROOT/root/static/build

--- a/docker/musicbrainz-website/start_musicbrainz_website.sh
+++ b/docker/musicbrainz-website/start_musicbrainz_website.sh
@@ -12,6 +12,10 @@ cd $MBS_ROOT
 deploy_static_resources.sh &
 trap_jobs
 
+sudo -E -H -u musicbrainz \
+    carton exec -- ./script/compile_resources.sh server &
+trap_jobs
+
 sv start template-renderer
 
 exec start_musicbrainz_server.sh

--- a/docker/musicbrainz-website/start_musicbrainz_website.sh
+++ b/docker/musicbrainz-website/start_musicbrainz_website.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-source /etc/mbs_constants.sh
+MBS_HOME=/home/musicbrainz
+MBS_ROOT=$MBS_HOME/musicbrainz-server
+
 source "$MBS_ROOT/script/functions.sh"
 
 cd $MBS_ROOT

--- a/docker/scripts/mbs_constants.sh
+++ b/docker/scripts/mbs_constants.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-MBS_HOME=/home/musicbrainz
-MBS_ROOT=$MBS_HOME/musicbrainz-server

--- a/docker/scripts/start_template_renderer.sh
+++ b/docker/scripts/start_template_renderer.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-source /etc/mbs_constants.sh
+MBS_HOME=/home/musicbrainz
+MBS_ROOT=$MBS_HOME/musicbrainz-server
 
 cd "$MBS_ROOT"
 

--- a/docker/scripts/start_template_renderer.sh
+++ b/docker/scripts/start_template_renderer.sh
@@ -7,7 +7,4 @@ MBS_ROOT=$MBS_HOME/musicbrainz-server
 
 cd "$MBS_ROOT"
 
-sudo -E -H -u musicbrainz \
-    carton exec -- ./script/compile_resources.sh server
-
 exec sudo -E -H -u musicbrainz node root/server.js

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -5,7 +5,7 @@ m4_define(
     `m4_dnl
 apt-get update && ( \
     apt-get install --no-install-suggests --no-install-recommends -y $1 || ( \
-        apt-key adv --keyserver hkps.pool.sks-keyservers.net --refresh-keys && \
+        apt-key adv --keyserver keyserver.ubuntu.com --refresh-keys && \
         apt-get install --no-install-suggests --no-install-recommends -y $1 ) ) && \
     rm -rf /var/lib/apt/lists/*')
 

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -133,7 +133,6 @@ m4_define(
 copy_mb(``admin/ admin/'')
 copy_mb(``app.psgi entities.json ./'')
 copy_mb(``bin/ bin/'')
-copy_mb(``docker/scripts/mbs_constants.sh /etc/'')
 copy_mb(``docker/scripts/consul-template-dedup-prefix /usr/local/bin/'')
 copy_mb(``lib/ lib/'')
 copy_mb(``script/functions.sh script/git_info script/'')')


### PR DESCRIPTION
It completes the previous pull request https://github.com/metabrainz/musicbrainz-server/pull/915, more particularly the commit https://github.com/metabrainz/musicbrainz-server/pull/915/commits/43ee7e757bcb8246108606c7e73609bfbd54be73, that fixed building docker images but musicbrainz-tests docker image which is used by CircleCI.