### PR TITLE
MBS-10084: Allow percent encoding in CD Baby URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -811,18 +811,18 @@ const CLEANUPS = {
       if (m) {
         url = 'https://store.cdbaby.com/cd/' + m[1].toLowerCase();
       }
-      url = url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.com\/Images\/Album\/(\w+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
-      return url.replace(/(?:https?:\/\/)?(?:images\.)?cdbaby\.name\/.\/.\/(\w+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
+      url = url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.com\/Images\/Album\/([\w%]+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
+      return url.replace(/(?:https?:\/\/)?(?:images\.)?cdbaby\.name\/.\/.\/([\w%]+)(?:_small)?\.jpg/, 'https://store.cdbaby.com/cd/$1');
     },
   },
   'cdbaby_artist': {
     match: [new RegExp('^(https?://)?((store|www)\\.)?cdbaby\\.(com|name)/Artist/', 'i')],
     type: LINK_TYPES.cdbaby,
     clean: function (url) {
-      return url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.(?:com|name)\/Artist\/(\w+).*$/i, 'https://store.cdbaby.com/Artist/$1');
+      return url.replace(/(?:https?:\/\/)?(?:(?:store|www)\.)?cdbaby\.(?:com|name)\/Artist\/([\w%]+).*$/i, 'https://store.cdbaby.com/Artist/$1');
     },
     validate: function (url, id) {
-      return /^https:\/\/store.cdbaby\.com\/Artist\/\w+$/.test(url) && id === LINK_TYPES.cdbaby.artist;
+      return /^https:\/\/store.cdbaby\.com\/Artist\/[\w%]+$/.test(url) && id === LINK_TYPES.cdbaby.artist;
     },
   },
   'cdjapan': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -816,17 +816,17 @@ const testData = [
   },
   // CD Baby
   {
-                     input_url: 'www.cdbaby.name/artist/JohnDoe1#',
+                     input_url: 'www.cdbaby.name/artist/Johnn%c3%afDoe1#',
              input_entity_type: 'artist',
     expected_relationship_type: 'cdbaby',
-            expected_clean_url: 'https://store.cdbaby.com/Artist/JohnDoe1',
+            expected_clean_url: 'https://store.cdbaby.com/Artist/Johnn%c3%afDoe1',
        only_valid_entity_types: ['artist'],
   },
   {
-                     input_url: 'http://cdbaby.com/cd/John003',
+                     input_url: 'http://cdbaby.com/cd/Johnn%c3%af003',
              input_entity_type: 'release',
     expected_relationship_type: undefined,
-            expected_clean_url: 'https://store.cdbaby.com/cd/john003',
+            expected_clean_url: 'https://store.cdbaby.com/cd/johnn%c3%af003',
   },
   // CB (Cape Breton) Fiddle Recordings
   {


### PR DESCRIPTION
# Resolves [MBS-10084](https://tickets.metabrainz.org/browse/MBS-10084): Unable to add CDBaby URL containing "ï"

Allow % for CD Baby both artist and release. Update related tests.
Real example: https://store.cdbaby.com/artist/ka%c3%afssa