### PR TITLE
MBS-10090: Escape id before passing to MediaWiki

### DIFF
--- a/lib/MusicBrainz/Server/Data/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Data/WikiDoc.pm
@@ -7,7 +7,7 @@ use Readonly;
 use HTML::TreeBuilder::XPath;
 use MusicBrainz::Server::Entity::WikiDocPage;
 use MusicBrainz::Server::ExternalUtils qw( get_chunked_with_retry );
-use URI::Escape qw( uri_unescape );
+use URI::Escape qw( uri_escape uri_unescape );
 use Encode qw( decode );
 
 with 'MusicBrainz::Server::Data::Role::Context';
@@ -122,7 +122,7 @@ sub _load_page
     return MusicBrainz::Server::Entity::WikiDocPage->new({ canonical => "MusicBrainz_Documentation" })
         if ($id eq "");
 
-    my $doc_url = sprintf "http://%s/%s?action=render&redirect=no", DBDefs->WIKITRANS_SERVER, $id;
+    my $doc_url = sprintf "http://%s/%s?action=render&redirect=no", DBDefs->WIKITRANS_SERVER, uri_escape($id);
     if (defined $version) {
         $doc_url .= "&oldid=$version";
     }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10090

This avoids a situation where a '%3F' in the docpage URL is taken by MediaWiki to be an actual ? and breaks the "?action=render&redirect=no" part of the page, causing it to return the entire html content of the wiki page inc. headers and UI sections.

(in case you're wondering, yes, this is what came out of me being like "oh I wonder what will happen if I add a question mark to the URL")