### PR TITLE
MBS-10088: Correctly check for cardinality on l_x_x rels

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -135,14 +135,22 @@ sub _load
         my (@cond, @params, $target, $target_id, $source_id, $query);
 
         if ($type eq $type0) {
-            push @cond, "entity0 IN (" . placeholders(@ids) . ")";
+            my $condstring = "entity0 IN (" . placeholders(@ids) . ")";
+            if ($use_cardinality) {
+                $condstring = "($condstring AND entity0_cardinality = 0)";
+            }
+            push @cond, $condstring;
             push @params, @ids;
             $target = $type1;
             $target_id = 'entity1';
             $source_id = 'entity0';
         }
         if ($type eq $type1) {
-            push @cond, "entity1 IN (" . placeholders(@ids) . ")";
+            my $condstring = "entity1 IN (" . placeholders(@ids) . ")";
+            if ($use_cardinality) {
+                $condstring = "($condstring AND entity1_cardinality = 0)";
+            }
+            push @cond, $condstring;
             push @params, @ids;
             $target = $type0;
             $target_id = 'entity0';
@@ -151,8 +159,7 @@ sub _load
 
         # If the source and target types are the same, two possible conditions
         # will have been added above, so join them with an OR.
-        @cond = ("(" . join(" OR ", @cond) . ")");
-        push @cond, "${source_id}_cardinality = 0" if $use_cardinality;
+        @cond = join(" OR ", @cond);
 
         my $select = "l_${type0}_${type1}.* FROM l_${type0}_${type1}
                       JOIN link l ON link = l.id


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10088

The current query used "${source_id}_cardinality = 0" if $use_cardinality; to exclude relationships affected by cardinality.

That works great, except on l_x_x relationships where *both* sides of the relationship need to be checked for cardinality. In that case, only entity1 (the final value of $source_id) was being checked, meaning if entity_1 had cardinality=1 it would always return no results, even if the entity we were looking for was entity0 with cardinality=0.

This changes it so that the condition strings are actually fully built inside the $type checks, which ensures we'll get "WHERE (entity0 IN (?) AND entity0_cardinality = 0) OR (entity1 IN (?) AND entity1_cardinality = 0)" rather than "WHERE (entity0 IN (?) OR entity1 IN (?)) AND entity1_cardinality = 0".