### PR TITLE
MBS-10095: Meaningful error for editing nonexisting user

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -13,6 +13,10 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves
         unless $c->user->is_account_admin or DBDefs->DB_STAGING_TESTING_FEATURES;
 
     my $user = $c->model('Editor')->get_by_name($user_name);
+
+    if (not defined $user) {
+        $c->detach('/user/not_found')
+    }
     $c->stash->{viewing_own_profile} = $c->user_exists && $c->user->id == $user->id;
 
     my $form = $c->form(

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -150,10 +150,11 @@ sub error_403 : Private
 }
 
 sub error_404 : Private {
-    my ($self, $c) = @_;
+    my ($self, $c, $message) = @_;
 
     $c->response->status(404);
     $c->stash->{current_view} = 'Node';
+    $c->stash->{component_props}{message} = $message;
 }
 
 sub error_500 : Private


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10095

400 seemed appropriate, since the username being requested is incorrect. 404 would work too but it doesn't seem to accept any sort of extra explanatory message, so it seems less ideal. Of course, we could always add an optional extra message to our 404 pages :) 