### PR TITLE
MBS-10094: Right-align barcodes in lists

### DIFF
--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -10,7 +10,7 @@
     <td>[% release_countries(release.events) %]</td>
     <td>[% release_label_list(release.labels) %]</td>
     <td>[% release_catno_list(release.labels) %]</td>
-    <td>[% release.barcode.format %]</td>
+    <td class="barcode-cell">[% release.barcode.format %]</td>
     [%- IF c.try_get_session('tport') -%]
       <td>[% tagger_icon(release) %]</td>
     [%- END -%]

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -34,7 +34,7 @@
             <td>[% release_countries(release.events) %]</td>
             <td>[% release_label_list(release.labels) %]</td>
             <td>[% release_catno_list(release.labels) %]</td>
-            <td>[% release.barcode.format %]</td>
+            <td class="barcode-cell">[% release.barcode.format %]</td>
             [% IF c.session.tport %]
             <td>
               [% tagger_icon(release) %]

--- a/root/components/releases-list.tt
+++ b/root/components/releases-list.tt
@@ -59,7 +59,7 @@
               <td>[% release_label_list(release.labels) %]</td>
               <td>[% release_catno_list(release.labels) %]</td>
           [%- END -%]
-          <td>[% release.barcode.format %]</td>
+          <td class="barcode-cell">[% release.barcode.format %]</td>
           [%~ IF show_ratings ~%]
               <td>[% rating_stars(release.release_group) %]</td>
           [%~ END ~%]

--- a/root/edit/details/merge_releases.tt
+++ b/root/edit/details/merge_releases.tt
@@ -8,7 +8,7 @@
     <td>[% release_countries(release.events) %]</td>
     <td>[% release_label_list(release.labels) %]</td>
     <td>[% release_catno_list(release.labels) %]</td>
-    <td>[% release.barcode.format %]</td>
+    <td class="barcode-cell">[% release.barcode.format %]</td>
   </tr>
 [%~ END ~%]
 

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -74,7 +74,7 @@
             [%- END -%]
 
             <input type="hidden" name="url" value="[% c.req.uri %]" />
-            <div class="row no-label" style="text-align: right">
+            <div class="align-right row no-label" >
                 [% form_submit(l('Submit votes &amp; edit notes')) %]
             </div>
         </form>

--- a/root/otherlookup/results-release.tt
+++ b/root/otherlookup/results-release.tt
@@ -35,7 +35,7 @@
           <td>[% release_countries(result.events) %]</td>
           <td>[% release_label_list(result.labels) %]</td>
           <td>[% release_catno_list(result.labels) %]</td>
-          <td>[% result.barcode.format IF result.barcode.format %]</td>
+          <td class="barcode-cell">[% result.barcode.format IF result.barcode.format %]</td>
           <td>
             <abbr title="[% result.language.l_name %]">[% result.language.iso_code_3 %]</abbr>
             [%= '/' IF result.language && result.script =%]

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -293,7 +293,7 @@
           </p>
         </td>
 
-        <td class="icon" style="text-align: right">
+        <td class="align-right icon" >
           <button type="button" class="icon disc-down" title="[% l('Move disc down') %]" data-click="moveMediumDown"></button>
           <button type="button" class="icon disc-up" title="[% l('Move disc up') %]" data-click="moveMediumUp"></button>
           <button type="button" class="icon remove-item" title="[% l('Remove disc') %]" style="margin-left: 16px" data-click="removeMedium"></button>

--- a/root/release/merge.tt
+++ b/root/release/merge.tt
@@ -42,7 +42,7 @@
                       <td>[% release_label_list(release.labels) %]</td>
                       <td>[% release_catno_list(release.labels) %]</td>
                   [%- END -%]
-                  <td>[% release.barcode.format %]</td>
+                  <td class="barcode-cell">[% release.barcode.format %]</td>
               </tr>
               [%- END -%]
             </tbody>

--- a/root/release_group/index.tt
+++ b/root/release_group/index.tt
@@ -56,7 +56,7 @@
                 <td>[% release_countries(release.events) %]</td>
                 <td>[% release_label_list(release.labels) %]</td>
                 <td>[% release_catno_list(release.labels) %]</td>
-                <td>[% release.barcode.format %]</td>
+                <td class="barcode-cell">[% release.barcode.format %]</td>
                 [%- IF c.try_get_session('tport') -%]
                   <td>[% tagger_icon(release) %]</td>
                 [%- END -%]

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -51,7 +51,7 @@ function buildResult(result, index) {
       <td>
         <ReleaseCatnoList labels={release.labels} />
       </td>
-      <td>{formatBarcode(release.barcode)}</td>
+      <td className="barcode-cell">{formatBarcode(release.barcode)}</td>
       <td>
         {release.language ? (
           <abbr title={l_languages(release.language.name)}>

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -66,10 +66,16 @@ function buildResult(result, index) {
         ) : null}
       </td>
       <td>
-        {release.releaseGroup && release.releaseGroup.typeName ? lp_attributes(release.releaseGroup.typeName, 'release_group_primary_type') : null}
+        {release.releaseGroup && release.releaseGroup.typeName
+          ? lp_attributes(
+            release.releaseGroup.typeName,
+            'release_group_primary_type',
+          )
+          : null}
       </td>
       <td>
-        {release.status ? lp_attributes(release.status.name, 'release_status') : null}
+        {release.status
+          ? lp_attributes(release.status.name, 'release_status') : null}
       </td>
       <CatalystContext.Consumer>
         {($c: CatalystContextT) => (

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -91,7 +91,7 @@ const ArtistCreditBubble = ({
           />
         ))}
         <tr>
-          <td colSpan="4" style={{textAlign: 'right'}}>
+          <td className="align-right" colSpan="4" >
             <button type="button" className="add-item with-label" onClick={addName}>
               {l('Add Artist Credit')}
             </button>

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -120,7 +120,7 @@ class ArtistCreditNameEditor extends React.Component {
             type="text"
             value={nonEmpty(name.joinPhrase) ? name.joinPhrase : ''} />
         </td>
-        <td style={{textAlign: 'right'}}>
+        <td className="align-right">
           <button className="icon remove-item remove-artist-credit"
                   onClick={this.props.onRemove}
                   title={l('Remove Artist Credit')}

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -128,6 +128,9 @@ pre code {
 
 .deleted { color: @dark-text; }
 
+/* For general right aligning, and especially for barcodes */
+.align-right, .barcode-cell { text-align: right; }
+
 /*
 ** Header
 */


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10094

IMO it makes no sense to do it like that only on one kind of release list - since I feel it makes sense, I'm making the change in all lists of releases (of which we clearly have way too many).

If you'd rather have a class "barcode-row" or something and then the text-align on CSS, that works for me too.