### PR TITLE
MBS-9413: Fix for old 'remove relationship' edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -268,12 +268,12 @@ before restore => sub {
                 type => {
                     root => {
                         id => $_->{root_id},
-                        gid => $_->{root_gid},
+                        $_->{root_gid} ? (gid => $_->{root_gid}) : (),
                         name => $_->{root_name},
                     },
-                    id => $_->{id},
-                    gid => $_->{gid},
-                    name => $_->{name},
+                    id => ($_->{id} // $_->{root_id}),
+                    $_->{gid} ? (gid => $_->{gid}) : (),
+                    name => ($_->{name} // $_->{root_name}),
                 }
             }, @$attributes
         ];


### PR DESCRIPTION
# Fix [MBS-9413](https://tickets.metabrainz.org/browse/MBS-9413): An older edit can't be loaded

Older 'Remove Relationship' edits seem to only have root_id/root_name for attributes, which we can use for the id/name and assume the type is its own root.

Another issue is that attribute gids aren't present in these edits. The LinkAttributesArray type allows these to be optional, but not undef.