### PR TITLE
MBS-10099: Use backwards link phrase when needed on ExternalLinks (+ eslint fixes)

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -105,9 +105,11 @@ export class ExternalLinksEditor
   }
 
   removeLink(index: number) {
-    const newLinks = this.state.links.concat();
-    newLinks.splice(index, 1);
-    this.setState({links: newLinks}, () => {
+    this.setState(prevState => {
+      const newLinks = prevState.links.concat();
+      newLinks.splice(index, 1);
+      return {links: newLinks};
+    }, () => {
       $(ReactDOM.findDOMNode(this))
         .find('tr:gt(' + (index - 1) + ') button.remove:first, ' +
               'tr:lt(' + (index + 1) + ') button.remove:last')

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -584,7 +584,7 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
     const urls = {};
     let match;
 
-    while (match = seededLinkRegex.exec(window.location.search)) {
+    while ((match = seededLinkRegex.exec(window.location.search))) {
       const [/* unused */, index, key, value] = match;
       (urls[index] = urls[index] || {})[key] = decodeURIComponent(value);
     }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -278,6 +278,7 @@ export class ExternalLink extends React.Component<LinkProps> {
     var linkType = props.type ? linkedEntities.link_type[props.type] : null;
     var typeDescription = '';
     var faviconClass: string | void;
+    var backward = linkType && linkType.type1 > 'url';
 
     if (linkType && linkType.description) {
       typeDescription = exp.l('{description} ({url|more documentation})', {
@@ -313,7 +314,11 @@ export class ExternalLink extends React.Component<LinkProps> {
               </LinkTypeSelect>
             : <label>
                 {faviconClass && <span className={'favicon ' + faviconClass + '-favicon'}></span>}
-                {(linkType ? l_relationships(linkType.link_phrase) : null) ||
+                {(linkType ? (
+                  backward
+                    ? l_relationships(linkType.reverse_link_phrase)
+                    : l_relationships(linkType.link_phrase)
+                ) : null) ||
                   (props.isOnlyLink ? l('Add link:') : l('Add another link:'))}
               </label>}
         </td>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -582,8 +582,8 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
     let match;
 
     while (match = seededLinkRegex.exec(window.location.search)) {
-      (urls[match[1]] = urls[match[1]] || {})[match[2]] =
-        decodeURIComponent(match[3]);
+      const [/* unused */, index, key, value] = match;
+      (urls[index] = urls[index] || {})[key] = decodeURIComponent(value);
     }
 
     _.each(urls, function (data) {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -200,6 +200,9 @@ export class ExternalLinksEditor
               ? linkedEntities.link_type[link.type] : {};
             const checker = URLCleanup.validationRules[linkType.gid];
             const oldLink = oldLinks[link.relationship];
+            const isNewLink = !isPositiveInteger(link.relationship);
+            const linkChanged = oldLink && link.url !== oldLink.url;
+            const linkTypeChanged = oldLink && +link.type !== +oldLink.type;
 
             if (isEmpty(link)) {
               error = '';
@@ -213,24 +216,19 @@ export class ExternalLinksEditor
               error = l(`Please select a link type for the URL
                          you’ve entered.`);
             } else if (
-              linkType.deprecated &&
-                (!isPositiveInteger(link.relationship) ||
-                  (oldLink && +link.type !== +oldLink.type))
+              linkType.deprecated && (isNewLink || linkTypeChanged)
             ) {
               error = l(`This relationship type is deprecated 
                          and should not be used.`);
             } else if (
-              (!isPositiveInteger(link.relationship) ||
-                (oldLink && link.url !== oldLink.url)) &&
-                  checker && !checker(link.url)
+              (isNewLink || linkChanged) && checker && !checker(link.url)
             ) {
               error = l(`This URL is not allowed for the selected link type, 
                          or is incorrectly formatted.`);
             } else if (
-              (!isPositiveInteger(link.relationship) ||
-                (oldLink && link.url !== oldLink.url)) &&
-                  /^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/
-                    .test(link.url)
+              (isNewLink || linkChanged) &&
+                /^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/
+                  .test(link.url)
             ) {
               // Kludge for MBS-9515 to be replaced with general MBS-9516
               error = exp.l(

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -354,7 +354,13 @@ export class ExternalLink extends React.Component<LinkProps> {
     if (props.url && !props.errorMessage) {
       typeDescription = (
         <>
-          <a href={props.url} target="_blank">{props.url}</a>
+          <a
+            href={props.url}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {props.url}
+          </a>
           <br />
           <br />
           {typeDescription}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -47,7 +47,8 @@ type LinksEditorState = {
   links: Array<LinkStateT>,
 };
 
-export class ExternalLinksEditor extends React.Component<LinksEditorProps, LinksEditorState> {
+export class ExternalLinksEditor
+  extends React.Component<LinksEditorProps, LinksEditorState> {
   constructor(props: LinksEditorProps) {
     super(props);
     this.state = {links: withOneEmptyLink(props.initialLinks)};
@@ -207,18 +208,51 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
             } else if (isShortened(link.url)) {
               error = l("Please don't use shortened URLs.");
             } else if (!link.type) {
-              error = l('Please select a link type for the URL you’ve entered.');
-            } else if (linkType.deprecated && (!isPositiveInteger(link.relationship) || (oldLink && +link.type !== +oldLink.type))) {
-              error = l('This relationship type is deprecated and should not be used.');
-            } else if ((!isPositiveInteger(link.relationship) || (oldLink && link.url !== oldLink.url)) && checker && !checker(link.url)) {
-              error = l('This URL is not allowed for the selected link type, or is incorrectly formatted.');
-            } else if ((!isPositiveInteger(link.relationship) || (oldLink && link.url !== oldLink.url)) && /^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/.test(link.url)) {
-              // Kludge for MBS-9515 to be replaced with the more general MBS-9516
-              error = exp.l('Links to specific sections of Wikipedia articles are not allowed. Please remove “{fragment}” if still appropriate. See the {url|guidelines}.', {
-                fragment: <span className="url-quote" key="fragment">{link.url.replace(/^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/, '#$1')}</span>,
-                url: {href: '/relationship/' + linkType.gid, target: '_blank'},
-              });
-            } else if ((linksByTypeAndUrl[linkTypeAndUrlString(link)] || []).length > 1) {
+              error = l(`Please select a link type for the URL
+                         you’ve entered.`);
+            } else if (
+              linkType.deprecated &&
+                (!isPositiveInteger(link.relationship) ||
+                  (oldLink && +link.type !== +oldLink.type))
+            ) {
+              error = l(`This relationship type is deprecated 
+                         and should not be used.`);
+            } else if (
+              (!isPositiveInteger(link.relationship) ||
+                (oldLink && link.url !== oldLink.url)) &&
+                  checker && !checker(link.url)
+            ) {
+              error = l(`This URL is not allowed for the selected link type, 
+                         or is incorrectly formatted.`);
+            } else if (
+              (!isPositiveInteger(link.relationship) ||
+                (oldLink && link.url !== oldLink.url)) &&
+                  /^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/
+                    .test(link.url)
+            ) {
+              // Kludge for MBS-9515 to be replaced with general MBS-9516
+              error = exp.l(
+                `Links to specific sections of Wikipedia articles are not 
+                 allowed. Please remove “{fragment}” if still appropriate.
+                 See the {url|guidelines}.`,
+                {
+                  fragment: (
+                    <span className="url-quote" key="fragment">
+                      {link.url.replace(
+                        /^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/,
+                        '#$1',
+                      )}
+                    </span>
+                  ),
+                  url: {
+                    href: '/relationship/' + linkType.gid,
+                    target: '_blank',
+                  },
+                },
+              );
+            } else if (
+              (linksByTypeAndUrl[linkTypeAndUrlString(link)] || []).length > 1
+            ) {
               error = l('This relationship already exists.');
             }
 
@@ -233,14 +267,22 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
                 key={link.relationship}
                 removeCallback={_.bind(this.removeLink, this, index)}
                 type={link.type}
-                typeChangeCallback={_.bind(this.handleTypeChange, this, index)}
+                typeChangeCallback={
+                  _.bind(this.handleTypeChange, this, index)
+                }
                 typeOptions={this.props.typeOptions}
                 url={link.url}
                 urlBlurCallback={_.bind(this.handleUrlBlur, this, index)}
                 urlChangeCallback={_.bind(this.handleUrlChange, this, index)}
-                urlMatchesType={linkType.gid === URLCleanup.guessType(this.props.sourceType, link.url)}
+                urlMatchesType={
+                  linkType.gid === URLCleanup.guessType(
+                    this.props.sourceType, link.url,
+                  )
+                }
                 video={link.video}
-                videoChangeCallback={_.bind(this.handleVideoChange, this, index)}
+                videoChangeCallback={
+                  _.bind(this.handleVideoChange, this, index)
+                }
               />
             );
           })}
@@ -259,7 +301,11 @@ type LinkTypeSelectProps = {
 class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
   render() {
     return (
-      <select className="link-type" onChange={this.props.typeChangeCallback} value={this.props.type || ''}>
+      <select
+        className="link-type"
+        onChange={this.props.typeChangeCallback}
+        value={this.props.type || ''}
+      >
         <option value="">{'\xA0'}</option>
         {this.props.children}
       </select>
@@ -308,9 +354,14 @@ export class ExternalLink extends React.Component<LinkProps> {
       );
     }
 
-    const showTypeSelection = props.errorMessage ? true : !(props.urlMatchesType || isEmpty(props));
+    const showTypeSelection = props.errorMessage
+      ? true
+      : !(props.urlMatchesType || isEmpty(props));
     if (!showTypeSelection && props.urlMatchesType) {
-      faviconClass = _.find(FAVICON_CLASSES, (value: string, key: string) => props.url.indexOf(key) > 0);
+      faviconClass = _.find(
+        FAVICON_CLASSES,
+        (value: string, key: string) => props.url.indexOf(key) > 0,
+      );
     }
 
     return (
@@ -319,17 +370,23 @@ export class ExternalLink extends React.Component<LinkProps> {
           {/* If the URL matches its type or is just empty, display either a
               favicon or a prompt for a new link as appropriate. */
             showTypeSelection
-              ? <LinkTypeSelect type={props.type} typeChangeCallback={props.typeChangeCallback}>
+              ? <LinkTypeSelect
+                type={props.type}
+                typeChangeCallback={props.typeChangeCallback}
+                >
                 {props.typeOptions}
               </LinkTypeSelect>
               : <label>
-                {faviconClass && <span className={'favicon ' + faviconClass + '-favicon'} />}
+                {faviconClass &&
+                  <span className={'favicon ' + faviconClass + '-favicon'} />}
                 {(linkType ? (
                   backward
                     ? l_relationships(linkType.reverse_link_phrase)
                     : l_relationships(linkType.link_phrase)
                 ) : null) ||
-                  (props.isOnlyLink ? l('Add link:') : l('Add another link:'))}
+                  (props.isOnlyLink
+                    ? l('Add link:')
+                    : l('Add another link:'))}
               </label>}
         </td>
         <td>
@@ -340,11 +397,19 @@ export class ExternalLink extends React.Component<LinkProps> {
             type="url"
             value={props.url}
           />
-          {props.errorMessage && <div className="error field-error" data-visible="1">{props.errorMessage}</div>}
-          {linkType && _.has(linkType.attributes, String(VIDEO_ATTRIBUTE_ID)) &&
+          {props.errorMessage &&
+            <div className="error field-error" data-visible="1">
+              {props.errorMessage}
+            </div>}
+          {linkType &&
+            _.has(linkType.attributes, String(VIDEO_ATTRIBUTE_ID)) &&
             <div className="attribute-container">
               <label>
-                <input checked={props.video} onChange={props.videoChangeCallback} type="checkbox" />
+                <input
+                  checked={props.video}
+                  onChange={props.videoChangeCallback}
+                  type="checkbox"
+                />
                 {' '}
                 {l('video')}
               </label>
@@ -352,7 +417,11 @@ export class ExternalLink extends React.Component<LinkProps> {
         </td>
         <td style={{minWidth: '34px'}}>
           {typeDescription && <HelpIcon content={typeDescription} />}
-          {isEmpty(props) || <RemoveButton callback={props.removeCallback} title={l('Remove Link')} />}
+          {isEmpty(props) ||
+            <RemoveButton
+              callback={props.removeCallback}
+              title={l('Remove Link')}
+            />}
         </td>
       </tr>
     );
@@ -402,7 +471,9 @@ function withOneEmptyLink(links, dontRemove) {
 
 const isVideoAttribute = attr => attr.type.gid === VIDEO_ATTRIBUTE_GID;
 
-export function parseRelationships(relationships?: $ReadOnlyArray<RelationshipT>) {
+export function parseRelationships(
+  relationships?: $ReadOnlyArray<RelationshipT>,
+) {
   if (!relationships) {
     return [];
   }
@@ -497,16 +568,22 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
     if (hasSessionStorage) {
       const submittedLinks = window.sessionStorage.getItem('submittedLinks');
       if (submittedLinks) {
-        initialLinks = JSON.parse(submittedLinks).filter(l => !isEmpty(l)).map(newLinkState);
+        initialLinks = JSON.parse(submittedLinks)
+          .filter(l => !isEmpty(l)).map(newLinkState);
       }
     }
   } else {
-    const seededLinkRegex = new RegExp('(?:\\?|&)edit-' + sourceType + '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)', 'g');
+    const seededLinkRegex = new RegExp(
+      '(?:\\?|&)edit-' + sourceType +
+        '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)',
+      'g',
+    );
     const urls = {};
     let match;
 
     while (match = seededLinkRegex.exec(window.location.search)) {
-      (urls[match[1]] = urls[match[1]] || {})[match[2]] = decodeURIComponent(match[3]);
+      (urls[match[1]] = urls[match[1]] || {})[match[2]] =
+        decodeURIComponent(match[3]);
     }
 
     _.each(urls, function (data) {
@@ -522,8 +599,10 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
     const typeA = a.type && linkedEntities.link_type[a.type];
     const typeB = b.type && linkedEntities.link_type[b.type];
 
-    return compare(typeA ? l_relationships(typeA.link_phrase).toLowerCase() : '',
-                   typeB ? l_relationships(typeB.link_phrase).toLowerCase() : '');
+    return compare(
+      typeA ? l_relationships(typeA.link_phrase).toLowerCase() : '',
+      typeB ? l_relationships(typeB.link_phrase).toLowerCase() : '',
+    );
   });
 
   initialLinks = initialLinks.map(function (link) {
@@ -541,11 +620,22 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
   });
 
   const typeOptions = (
-    linkTypeOptions({children: linkedEntities.link_type_tree[entityTypes]}, /^url-/.test(entityTypes))
-      .map((data) => <option disabled={data.disabled} key={data.value} value={data.value}>{data.text}</option>)
+    linkTypeOptions(
+      {children: linkedEntities.link_type_tree[entityTypes]},
+      /^url-/.test(entityTypes),
+    ).map((data) => (
+      <option
+        disabled={data.disabled}
+        key={data.value}
+        value={data.value}
+      >
+        {data.text}
+      </option>
+    ))
   );
 
-  const errorObservable = options.errorObservable || validation.errorField(ko.observable(false));
+  const errorObservable = options.errorObservable ||
+    validation.errorField(ko.observable(false));
 
   return ReactDOM.render(
     <ExternalLinksEditor

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -370,24 +370,27 @@ export class ExternalLink extends React.Component<LinkProps> {
           {/* If the URL matches its type or is just empty, display either a
               favicon or a prompt for a new link as appropriate. */
             showTypeSelection
-              ? <LinkTypeSelect
-                type={props.type}
-                typeChangeCallback={props.typeChangeCallback}
+              ? (
+                <LinkTypeSelect
+                  type={props.type}
+                  typeChangeCallback={props.typeChangeCallback}
                 >
-                {props.typeOptions}
-              </LinkTypeSelect>
-              : <label>
-                {faviconClass &&
+                  {props.typeOptions}
+                </LinkTypeSelect>
+              ) : (
+                <label>
+                  {faviconClass &&
                   <span className={'favicon ' + faviconClass + '-favicon'} />}
-                {(linkType ? (
-                  backward
-                    ? l_relationships(linkType.reverse_link_phrase)
-                    : l_relationships(linkType.link_phrase)
-                ) : null) ||
+                  {(linkType ? (
+                    backward
+                      ? l_relationships(linkType.reverse_link_phrase)
+                      : l_relationships(linkType.link_phrase)
+                  ) : null) ||
                   (props.isOnlyLink
                     ? l('Add link:')
                     : l('Add another link:'))}
-              </label>}
+                </label>)
+          }
         </td>
         <td>
           <input

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1,8 +1,10 @@
-// @flow
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -28,17 +30,17 @@ import * as URLCleanup from './URLCleanup';
 import validation from './validation';
 
 type LinkStateT = {
-  url: string,
-  type: number | null,
   relationship: number | string | null,
+  type: number | null,
+  url: string,
   video: boolean,
 };
 
 type LinksEditorProps = {
+  errorObservable: (boolean) => void,
+  initialLinks: Array<LinkStateT>,
   sourceType: string,
   typeOptions: Array<React.Element<'option'>>,
-  initialLinks: Array<LinkStateT>,
-  errorObservable: (bool) => void,
 };
 
 type LinksEditorState = {
@@ -51,17 +53,19 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
     this.state = {links: withOneEmptyLink(props.initialLinks)};
   }
 
-  setLinkState(index: number,
-               state: $Shape<LinkStateT>,
-               callback?: () => void) {
+  setLinkState(
+    index: number,
+    state: $Shape<LinkStateT>,
+    callback?: () => void,
+  ) {
     const newLinks: Array<LinkStateT> = this.state.links.concat();
     newLinks[index] = Object.assign({}, newLinks[index], state);
     this.setState({links: withOneEmptyLink(newLinks, index)}, callback);
   }
 
   handleUrlChange(index: number, event: SyntheticEvent<HTMLInputElement>) {
-    var url = event.currentTarget.value;
-    var link = this.state.links[index];
+    let url = event.currentTarget.value;
+    const link = this.state.links[index];
 
     // Allow adding spaces while typing, they'll be trimmed on blur
     if (url.trim() !== link.url.trim()) {
@@ -73,7 +77,7 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
 
     this.setLinkState(index, {url: url}, () => {
       if (!link.type) {
-        var type = URLCleanup.guessType(this.props.sourceType, url);
+        const type = URLCleanup.guessType(this.props.sourceType, url);
 
         if (type) {
           this.setLinkState(index, {type: linkedEntities.link_type[type].id});
@@ -83,8 +87,8 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
   }
 
   handleUrlBlur(index: number, event: SyntheticEvent<HTMLInputElement>) {
-    var url = event.currentTarget.value;
-    var trimmed = url.trim();
+    const url = event.currentTarget.value;
+    const trimmed = url.trim();
 
     if (url !== trimmed) {
       this.setLinkState(index, {url: trimmed});
@@ -106,7 +110,8 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
       $(ReactDOM.findDOMNode(this))
         .find('tr:gt(' + (index - 1) + ') button.remove:first, ' +
               'tr:lt(' + (index + 1) + ') button.remove:last')
-        .eq(0).focus();
+        .eq(0)
+        .focus();
     });
   }
 
@@ -118,8 +123,8 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
   }
 
   getEditData() {
-    var oldLinks = this.getOldLinksHash();
-    var newLinks = _.keyBy<
+    const oldLinks = this.getOldLinksHash();
+    const newLinks = _.keyBy<
       LinkStateT,
       $ElementType<LinkStateT, 'relationship'>,
     >(this.state.links, 'relationship');
@@ -127,23 +132,25 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
     return {
       oldLinks: oldLinks,
       newLinks: newLinks,
-      allLinks: _.defaults(_.clone(newLinks), oldLinks)
+      allLinks: _.defaults(_.clone(newLinks), oldLinks),
     };
   }
 
-  getFormData(startingPrefix: string,
-              startingIndex: number,
-              pushInput: (string, string, string) => void) {
-    var index = 0;
-    var backward = this.props.sourceType > 'url';
-    var {oldLinks, newLinks, allLinks} = this.getEditData();
+  getFormData(
+    startingPrefix: string,
+    startingIndex: number,
+    pushInput: (string, string, string) => void,
+  ) {
+    let index = 0;
+    const backward = this.props.sourceType > 'url';
+    const {oldLinks, newLinks, allLinks} = this.getEditData();
 
     _.each(allLinks, function (link, relationship) {
       if (!link.type) {
         return;
       }
 
-      var prefix = startingPrefix + '.' + (startingIndex + (index++));
+      const prefix = startingPrefix + '.' + (startingIndex + (index++));
 
       if (isPositiveInteger(relationship)) {
         pushInput(prefix, 'relationship_id', String(relationship));
@@ -173,20 +180,23 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
   render() {
     this.props.errorObservable(false);
 
-    var oldLinks = this.getOldLinksHash();
-    var linksArray = this.state.links;
+    const oldLinks = this.getOldLinksHash();
+    const linksArray = this.state.links;
 
-    var linksByTypeAndUrl = _(linksArray).concat(this.props.initialLinks)
-          .uniqBy((link) => link.relationship).groupBy(linkTypeAndUrlString).value();
+    const linksByTypeAndUrl = _(linksArray).concat(this.props.initialLinks)
+      .uniqBy((link) => link.relationship)
+      .groupBy(linkTypeAndUrlString)
+      .value();
 
     return (
-      <table id="external-links-editor" className="row-form">
+      <table className="row-form" id="external-links-editor">
         <tbody>
           {linksArray.map((link, index) => {
-            var error;
-            var linkType = link.type ? linkedEntities.link_type[link.type] : {};
-            var checker = URLCleanup.validationRules[linkType.gid];
-            var oldLink = oldLinks[link.relationship];
+            let error;
+            const linkType = link.type
+              ? linkedEntities.link_type[link.type] : {};
+            const checker = URLCleanup.validationRules[linkType.gid];
+            const oldLink = oldLinks[link.relationship];
 
             if (isEmpty(link)) {
               error = '';
@@ -205,8 +215,8 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
             } else if ((!isPositiveInteger(link.relationship) || (oldLink && link.url !== oldLink.url)) && /^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/.test(link.url)) {
               // Kludge for MBS-9515 to be replaced with the more general MBS-9516
               error = exp.l('Links to specific sections of Wikipedia articles are not allowed. Please remove “{fragment}” if still appropriate. See the {url|guidelines}.', {
-                fragment: <span className='url-quote' key='fragment'>{link.url.replace(/^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/, '#$1')}</span>,
-                url: { href: '/relationship/' + linkType.gid, target: '_blank' }
+                fragment: <span className="url-quote" key="fragment">{link.url.replace(/^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/, '#$1')}</span>,
+                url: {href: '/relationship/' + linkType.gid, target: '_blank'},
               });
             } else if ((linksByTypeAndUrl[linkTypeAndUrlString(link)] || []).length > 1) {
               error = l('This relationship already exists.');
@@ -218,19 +228,19 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
 
             return (
               <ExternalLink
-                key={link.relationship}
-                url={link.url}
-                type={link.type}
-                video={link.video}
                 errorMessage={error || ''}
                 isOnlyLink={this.state.links.length === 1}
-                urlMatchesType={linkType.gid === URLCleanup.guessType(this.props.sourceType, link.url)}
+                key={link.relationship}
                 removeCallback={_.bind(this.removeLink, this, index)}
-                urlChangeCallback={_.bind(this.handleUrlChange, this, index)}
-                urlBlurCallback={_.bind(this.handleUrlBlur, this, index)}
+                type={link.type}
                 typeChangeCallback={_.bind(this.handleTypeChange, this, index)}
-                videoChangeCallback={_.bind(this.handleVideoChange, this, index)}
                 typeOptions={this.props.typeOptions}
+                url={link.url}
+                urlBlurCallback={_.bind(this.handleUrlBlur, this, index)}
+                urlChangeCallback={_.bind(this.handleUrlChange, this, index)}
+                urlMatchesType={linkType.gid === URLCleanup.guessType(this.props.sourceType, link.url)}
+                video={link.video}
+                videoChangeCallback={_.bind(this.handleVideoChange, this, index)}
               />
             );
           })}
@@ -242,14 +252,14 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
 
 type LinkTypeSelectProps = {
   children: Array<React.Element<'option'>>,
-  type: number|null,
+  type: number | null,
   typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
 };
 
 class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
   render() {
     return (
-      <select value={this.props.type || ''} onChange={this.props.typeChangeCallback} className="link-type">
+      <select className="link-type" onChange={this.props.typeChangeCallback} value={this.props.type || ''}>
         <option value="">{'\xA0'}</option>
         {this.props.children}
       </select>
@@ -258,32 +268,32 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
 }
 
 type LinkProps = {
-  url: string,
-  type: number|null,
-  video: boolean,
   errorMessage: React.Node,
   isOnlyLink: boolean,
-  urlMatchesType: boolean,
   removeCallback: (number) => void,
-  urlChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
-  urlBlurCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
+  type: number | null,
   typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
-  videoChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
   typeOptions: Array<React.Element<'option'>>,
+  url: string,
+  urlBlurCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
+  urlChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
+  urlMatchesType: boolean,
+  video: boolean,
+  videoChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
 };
 
 export class ExternalLink extends React.Component<LinkProps> {
   render() {
-    var props = this.props;
-    var linkType = props.type ? linkedEntities.link_type[props.type] : null;
-    var typeDescription = '';
-    var faviconClass: string | void;
-    var backward = linkType && linkType.type1 > 'url';
+    const props = this.props;
+    const linkType = props.type ? linkedEntities.link_type[props.type] : null;
+    let typeDescription = '';
+    let faviconClass: string | void;
+    const backward = linkType && linkType.type1 > 'url';
 
     if (linkType && linkType.description) {
       typeDescription = exp.l('{description} ({url|more documentation})', {
         description: l_relationships(linkType.description),
-        url: '/relationship/' + linkType.gid
+        url: '/relationship/' + linkType.gid,
       });
     }
 
@@ -291,14 +301,14 @@ export class ExternalLink extends React.Component<LinkProps> {
       typeDescription = (
         <>
           <a href={props.url} target="_blank">{props.url}</a>
-          <br/>
-          <br/>
+          <br />
+          <br />
           {typeDescription}
         </>
       );
     }
 
-    var showTypeSelection = props.errorMessage ? true : !(props.urlMatchesType || isEmpty(props));
+    const showTypeSelection = props.errorMessage ? true : !(props.urlMatchesType || isEmpty(props));
     if (!showTypeSelection && props.urlMatchesType) {
       faviconClass = _.find(FAVICON_CLASSES, (value: string, key: string) => props.url.indexOf(key) > 0);
     }
@@ -308,12 +318,12 @@ export class ExternalLink extends React.Component<LinkProps> {
         <td>
           {/* If the URL matches its type or is just empty, display either a
               favicon or a prompt for a new link as appropriate. */
-           showTypeSelection
-            ? <LinkTypeSelect type={props.type} typeChangeCallback={props.typeChangeCallback}>
+            showTypeSelection
+              ? <LinkTypeSelect type={props.type} typeChangeCallback={props.typeChangeCallback}>
                 {props.typeOptions}
               </LinkTypeSelect>
-            : <label>
-                {faviconClass && <span className={'favicon ' + faviconClass + '-favicon'}></span>}
+              : <label>
+                {faviconClass && <span className={'favicon ' + faviconClass + '-favicon'} />}
                 {(linkType ? (
                   backward
                     ? l_relationships(linkType.reverse_link_phrase)
@@ -323,22 +333,26 @@ export class ExternalLink extends React.Component<LinkProps> {
               </label>}
         </td>
         <td>
-          <input type="url"
-                 className="value with-button"
-                 value={props.url}
-                 onChange={props.urlChangeCallback}
-                 onBlur={props.urlBlurCallback} />
+          <input
+            className="value with-button"
+            onBlur={props.urlBlurCallback}
+            onChange={props.urlChangeCallback}
+            type="url"
+            value={props.url}
+          />
           {props.errorMessage && <div className="error field-error" data-visible="1">{props.errorMessage}</div>}
           {linkType && _.has(linkType.attributes, String(VIDEO_ATTRIBUTE_ID)) &&
             <div className="attribute-container">
               <label>
-                <input type="checkbox" checked={props.video} onChange={props.videoChangeCallback} /> {l('video')}
+                <input checked={props.video} onChange={props.videoChangeCallback} type="checkbox" />
+                {' '}
+                {l('video')}
               </label>
             </div>}
         </td>
         <td style={{minWidth: '34px'}}>
           {typeDescription && <HelpIcon content={typeDescription} />}
-          {isEmpty(props) || <RemoveButton title={l('Remove Link')} callback={props.removeCallback} />}
+          {isEmpty(props) || <RemoveButton callback={props.removeCallback} title={l('Remove Link')} />}
         </td>
       </tr>
     );
@@ -366,8 +380,8 @@ function isEmpty(link) {
 }
 
 function withOneEmptyLink(links, dontRemove) {
-  var emptyCount = 0;
-  var canRemove = {};
+  let emptyCount = 0;
+  const canRemove = {};
 
   links.forEach(function (link, index) {
     if (isEmpty(link)) {
@@ -382,9 +396,8 @@ function withOneEmptyLink(links, dontRemove) {
     return links.concat(newLinkState({relationship: _.uniqueId('new-')}));
   } else if (emptyCount > 1 && _.size(canRemove)) {
     return links.filter((link, index) => !canRemove[index]);
-  } else {
-    return links;
   }
+  return links;
 }
 
 const isVideoAttribute = attr => attr.type.gid === VIDEO_ATTRIBUTE_GID;
@@ -394,7 +407,7 @@ export function parseRelationships(relationships?: $ReadOnlyArray<RelationshipT>
     return [];
   }
   return relationships.reduce(function (accum, data) {
-    var target = data.target;
+    const target = data.target;
 
     if (target.entityType === 'url') {
       accum.push({
@@ -411,14 +424,14 @@ export function parseRelationships(relationships?: $ReadOnlyArray<RelationshipT>
   }, []);
 }
 
-var protocolRegex = /^(https?|ftp):$/;
-var hostnameRegex = /^(([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])\.)*([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])$/;
+const protocolRegex = /^(https?|ftp):$/;
+const hostnameRegex = /^(([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])\.)*([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])$/;
 
 function isValidURL(url) {
-  var a = document.createElement("a");
+  const a = document.createElement('a');
   a.href = url;
 
-  var hostname = a.hostname;
+  const hostname = a.hostname;
 
   if (url.indexOf(hostname) < 0) {
     return false;
@@ -428,7 +441,7 @@ function isValidURL(url) {
     return false;
   }
 
-  if (hostname.indexOf(".") < 0) {
+  if (hostname.indexOf('.') < 0) {
     return false;
   }
 
@@ -440,29 +453,29 @@ function isValidURL(url) {
 }
 
 const URL_SHORTENERS = [
-  "adf.ly",
-  "bit.ly",
-  "cli.gs",
-  "deck.ly",
-  "fur.ly",
-  "goo.gl",
-  "is.gd",
-  "kl.am",
-  "lnk.co",
-  "mcaf.ee",
-  "moourl.com",
-  "owl.ly",
-  "rubyurl.com",
-  "su.pr",
-  "t.co",
-  "tiny.cc",
-  "tinyurl.com",
-  "u.nu",
-  "yep.it",
-].map(host => new RegExp("^https?://([^/]+\\.)?" + host + "/", "i"));
+  'adf.ly',
+  'bit.ly',
+  'cli.gs',
+  'deck.ly',
+  'fur.ly',
+  'goo.gl',
+  'is.gd',
+  'kl.am',
+  'lnk.co',
+  'mcaf.ee',
+  'moourl.com',
+  'owl.ly',
+  'rubyurl.com',
+  'su.pr',
+  't.co',
+  'tiny.cc',
+  'tinyurl.com',
+  'u.nu',
+  'yep.it',
+].map(host => new RegExp('^https?://([^/]+\\.)?' + host + '/', 'i'));
 
 function isShortened(url) {
-  return URL_SHORTENERS.some(function(shortenerRegex) {
+  return URL_SHORTENERS.some(function (shortenerRegex) {
     return url.match(shortenerRegex) !== null;
   });
 }
@@ -474,23 +487,23 @@ type InitialOptionsT = {
 };
 
 MB.createExternalLinksEditor = function (options: InitialOptionsT) {
-  var sourceData = options.sourceData;
-  var sourceType = sourceData.entityType;
-  var entityTypes = [sourceType, 'url'].sort().join('-');
-  var initialLinks = parseRelationships(sourceData.relationships);
+  const sourceData = options.sourceData;
+  const sourceType = sourceData.entityType;
+  const entityTypes = [sourceType, 'url'].sort().join('-');
+  let initialLinks = parseRelationships(sourceData.relationships);
 
   // Terribly get seeded URLs
   if (MB.formWasPosted) {
     if (hasSessionStorage) {
-      let submittedLinks = window.sessionStorage.getItem('submittedLinks');
+      const submittedLinks = window.sessionStorage.getItem('submittedLinks');
       if (submittedLinks) {
         initialLinks = JSON.parse(submittedLinks).filter(l => !isEmpty(l)).map(newLinkState);
       }
     }
   } else {
-    var seededLinkRegex = new RegExp("(?:\\?|&)edit-" + sourceType + "\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)", "g");
-    var urls = {};
-    var match;
+    const seededLinkRegex = new RegExp('(?:\\?|&)edit-' + sourceType + '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)', 'g');
+    const urls = {};
+    let match;
 
     while (match = seededLinkRegex.exec(window.location.search)) {
       (urls[match[1]] = urls[match[1]] || {})[match[2]] = decodeURIComponent(match[3]);
@@ -498,7 +511,7 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
 
     _.each(urls, function (data) {
       initialLinks.push(newLinkState({
-        url: data.text || "",
+        url: data.text || '',
         type: data.link_type_id,
         relationship: _.uniqueId('new-'),
       }));
@@ -506,16 +519,18 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
   }
 
   initialLinks.sort(function (a, b) {
-    var typeA = a.type && linkedEntities.link_type[a.type];
-    var typeB = b.type && linkedEntities.link_type[b.type];
+    const typeA = a.type && linkedEntities.link_type[a.type];
+    const typeB = b.type && linkedEntities.link_type[b.type];
 
     return compare(typeA ? l_relationships(typeA.link_phrase).toLowerCase() : '',
                    typeB ? l_relationships(typeB.link_phrase).toLowerCase() : '');
   });
 
   initialLinks = initialLinks.map(function (link) {
-    // Only run the URL cleanup on seeded URLs, i.e. URLs that don't have an
-    // existing relationship ID.
+    /*
+     * Only run the URL cleanup on seeded URLs, i.e. URLs that don't have an
+     * existing relationship ID.
+     */
     if (!isPositiveInteger(link.relationship)) {
       return Object.assign({}, link, {
         relationship: _.uniqueId('new-'),
@@ -525,20 +540,21 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
     return link;
   });
 
-  var typeOptions = (
+  const typeOptions = (
     linkTypeOptions({children: linkedEntities.link_type_tree[entityTypes]}, /^url-/.test(entityTypes))
-      .map((data) => <option value={data.value} disabled={data.disabled} key={data.value}>{data.text}</option>)
+      .map((data) => <option disabled={data.disabled} key={data.value} value={data.value}>{data.text}</option>)
   );
 
-  var errorObservable = options.errorObservable || validation.errorField(ko.observable(false));
+  const errorObservable = options.errorObservable || validation.errorField(ko.observable(false));
 
   return ReactDOM.render(
     <ExternalLinksEditor
+      errorObservable={errorObservable}
+      initialLinks={initialLinks}
       sourceType={sourceData.entityType}
       typeOptions={typeOptions}
-      initialLinks={initialLinks}
-      errorObservable={errorObservable} />,
-    options.mountPoint
+    />,
+    options.mountPoint,
   );
 };
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -130,9 +130,9 @@ export class ExternalLinksEditor extends React.Component<LinksEditorProps, Links
     >(this.state.links, 'relationship');
 
     return {
-      oldLinks: oldLinks,
-      newLinks: newLinks,
       allLinks: _.defaults(_.clone(newLinks), oldLinks),
+      newLinks: newLinks,
+      oldLinks: oldLinks,
     };
   }
 
@@ -360,9 +360,9 @@ export class ExternalLink extends React.Component<LinkProps> {
 }
 
 const defaultLinkState: LinkStateT = {
-  url: '',
-  type: null,
   relationship: null,
+  type: null,
+  url: '',
   video: false,
 };
 
@@ -412,8 +412,8 @@ export function parseRelationships(relationships?: $ReadOnlyArray<RelationshipT>
     if (target.entityType === 'url') {
       accum.push({
         relationship: data.id,
-        url: target.name,
         type: data.linkTypeID,
+        url: target.name,
         video: data.attributes
           ? data.attributes.some(isVideoAttribute)
           : false,
@@ -511,9 +511,9 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
 
     _.each(urls, function (data) {
       initialLinks.push(newLinkState({
-        url: data.text || '',
-        type: data.link_type_id,
         relationship: _.uniqueId('new-'),
+        type: data.link_type_id,
+        url: data.text || '',
       }));
     });
   }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -263,6 +263,15 @@ export class ExternalLinksEditor
             return (
               <ExternalLink
                 errorMessage={error || ''}
+                handleUrlBlur={
+                  _.bind(this.handleUrlBlur, this, index)
+                }
+                handleUrlChange={
+                  _.bind(this.handleUrlChange, this, index)
+                }
+                handleVideoChange={
+                  _.bind(this.handleVideoChange, this, index)
+                }
                 isOnlyLink={this.state.links.length === 1}
                 key={link.relationship}
                 removeCallback={_.bind(this.removeLink, this, index)}
@@ -272,17 +281,12 @@ export class ExternalLinksEditor
                 }
                 typeOptions={this.props.typeOptions}
                 url={link.url}
-                urlBlurCallback={_.bind(this.handleUrlBlur, this, index)}
-                urlChangeCallback={_.bind(this.handleUrlChange, this, index)}
                 urlMatchesType={
                   linkType.gid === URLCleanup.guessType(
                     this.props.sourceType, link.url,
                   )
                 }
                 video={link.video}
-                videoChangeCallback={
-                  _.bind(this.handleVideoChange, this, index)
-                }
               />
             );
           })}
@@ -294,8 +298,9 @@ export class ExternalLinksEditor
 
 type LinkTypeSelectProps = {
   children: Array<React.Element<'option'>>,
+  handleTypeChange:
+    (number, SyntheticEvent<HTMLSelectElement>) => void,
   type: number | null,
-  typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
 };
 
 class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
@@ -303,7 +308,7 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
     return (
       <select
         className="link-type"
-        onChange={this.props.typeChangeCallback}
+        onChange={this.props.handleTypeChange}
         value={this.props.type || ''}
       >
         <option value="">{'\xA0'}</option>
@@ -315,17 +320,18 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
 
 type LinkProps = {
   errorMessage: React.Node,
+  handleUrlBlur: (number, SyntheticEvent<HTMLInputElement>) => void,
+  handleUrlChange: (number, SyntheticEvent<HTMLInputElement>) => void,
+  handleVideoChange:
+    (number, SyntheticEvent<HTMLInputElement>) => void,
   isOnlyLink: boolean,
   removeCallback: (number) => void,
   type: number | null,
   typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
   typeOptions: Array<React.Element<'option'>>,
   url: string,
-  urlBlurCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
-  urlChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
   urlMatchesType: boolean,
   video: boolean,
-  videoChangeCallback: (number, SyntheticEvent<HTMLInputElement>) => void,
 };
 
 export class ExternalLink extends React.Component<LinkProps> {
@@ -372,8 +378,8 @@ export class ExternalLink extends React.Component<LinkProps> {
             showTypeSelection
               ? (
                 <LinkTypeSelect
+                  handleTypeChange={props.typeChangeCallback}
                   type={props.type}
-                  typeChangeCallback={props.typeChangeCallback}
                 >
                   {props.typeOptions}
                 </LinkTypeSelect>
@@ -395,8 +401,8 @@ export class ExternalLink extends React.Component<LinkProps> {
         <td>
           <input
             className="value with-button"
-            onBlur={props.urlBlurCallback}
-            onChange={props.urlChangeCallback}
+            onBlur={props.handleUrlBlur}
+            onChange={props.handleUrlChange}
             type="url"
             value={props.url}
           />
@@ -410,7 +416,7 @@ export class ExternalLink extends React.Component<LinkProps> {
               <label>
                 <input
                   checked={props.video}
-                  onChange={props.videoChangeCallback}
+                  onChange={props.handleVideoChange}
                   type="checkbox"
                 />
                 {' '}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10099

It also includes a ton of eslint fixes on the file, moving the amount of failures from like a hundred to 11 warnings. The rest would require a more significant rewrite and/or me understanding refs and callbacks and state stuff which I'm still working on. But it should already be quite an improvement.

Edit: around half the remaining warnings are for react/jsx-no-bind which @mwiencek suggested we might want to stop applying.