### PR TITLE
MBS-10103: Strip language code from Bandsintown

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -536,7 +536,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?((m|www)\\.)?bandsintown\\.com', 'i')],
     type: LINK_TYPES.bandsintown,
     clean: function (url) {
-      let m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(a(?=rtist|\/)|e(?=vent|\/)|v(?=enue|\/))[a-z]*\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
+      let m = url.match(/^(?:https?:\/\/)?(?:(?:m|www)\.)?bandsintown\.com\/(?:[a-z]{2}\/)?(a(?=rtist|\/)|e(?=vent|\/)|v(?=enue|\/))[a-z]*\/0*([1-9][0-9]*)(?:[^0-9].*)?$/);
       if (m) {
         const prefix = m[1];
         const number = m[2];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -427,6 +427,13 @@ const testData = [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://www.bandsintown.com/en/a/12625251-wormwitch',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'bandsintown',
+            expected_clean_url: 'https://www.bandsintown.com/a/12625251',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://bandsintown.com/a/159526#',
              input_entity_type: 'artist',
     expected_relationship_type: 'bandsintown',


### PR DESCRIPTION
### Resolve [MBS-10103](https://tickets.metabrainz.org/browse/MBS-10103): Update Bandsintown URL cleanup to strip languages

Bandsintown URLs can now have a language code for website UI.
(Note: Tested, this was likely not the case with old URL format.)

This patch recognizes such language code and strips it of URLs.