### PR TITLE
Fix messages changed since v-2019-01-22 and update localization files

### DIFF
--- a/po/attributes.es.po
+++ b/po/attributes.es.po
@@ -15,6 +15,7 @@
 # Héctor Arroyo <email address hidden>, 2012,2015
 # Héctor Arroyo <email address hidden>, 2012
 # Ismael Olea <email address hidden>, 2013-2015
+# Jaime Marquínez Ferrándiz, 2019
 # Jeremias Brown <email address hidden>, 2018
 # Juan Acuña <email address hidden>, 2016
 # Kevin Doncam Demian López Brante <email address hidden>, 2016
@@ -34,8 +35,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-05 00:22+0000\n"
-"Last-Translator: Robert Schneider <email address hidden>\n"
+"PO-Revision-Date: 2019-01-29 16:24+0000\n"
+"Last-Translator: Jaime Marquínez Ferrándiz\n"
 "Language-Team: Spanish (http://www.transifex.com/musicbrainz/musicbrainz/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2442,6 +2443,13 @@ msgctxt "medium_format"
 msgid "Floppy Disk"
 msgstr "Disquete"
 
+#: DB:gender/description:4
+msgctxt "gender"
+msgid ""
+"For cases where gender just doesn't apply at all (like companies entered as "
+"artists)."
+msgstr "Para casos en los que el género no es aplicable de ningún modo (por ejemplo compañías introducidas como artistas)."
+
 #: DB:work_attribute_type/name:16
 msgctxt "work_attribute_type"
 msgid "Form (Ottoman, Turkish)"
@@ -4675,6 +4683,11 @@ msgstr "Nişabureyn"
 msgctxt "release_packaging"
 msgid "None"
 msgstr "Ninguno"
+
+#: DB:gender/name:4
+msgctxt "gender"
+msgid "Not applicable"
+msgstr "No aplicable"
 
 #: DB:work_attribute_type_allowed_value/value:491
 msgctxt "work_attribute_type_allowed_value"

--- a/po/attributes.it.po
+++ b/po/attributes.it.po
@@ -6,13 +6,13 @@
 # Gioele  <email address hidden>, 2012
 # Gioele <email address hidden>, 2012
 # leofiore <email address hidden>, 2012
-# Luca Salini <email address hidden>, 2016-2018
+# Luca Salini <email address hidden>, 2016-2019
 # Luca Salini <email address hidden>, 2013-2015
 # Luca Salini <email address hidden>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2018-12-22 14:21+0000\n"
+"PO-Revision-Date: 2019-02-21 20:10+0000\n"
 "Last-Translator: Luca Salini <email address hidden>\n"
 "Language-Team: Italian (http://www.transifex.com/musicbrainz/musicbrainz/language/it/)\n"
 "MIME-Version: 1.0\n"
@@ -2420,6 +2420,13 @@ msgctxt "medium_format"
 msgid "Floppy Disk"
 msgstr "Floppy disk"
 
+#: DB:gender/description:4
+msgctxt "gender"
+msgid ""
+"For cases where gender just doesn't apply at all (like companies entered as "
+"artists)."
+msgstr "Per i casi in cui il genere non è applicabile (per esempio, società inserite come artisti)."
+
 #: DB:work_attribute_type/name:16
 msgctxt "work_attribute_type"
 msgid "Form (Ottoman, Turkish)"
@@ -4653,6 +4660,11 @@ msgstr "Nişabureyn"
 msgctxt "release_packaging"
 msgid "None"
 msgstr "Nessuno"
+
+#: DB:gender/name:4
+msgctxt "gender"
+msgid "Not applicable"
+msgstr "Non applicabile"
 
 #: DB:work_attribute_type_allowed_value/value:491
 msgctxt "work_attribute_type_allowed_value"

--- a/po/attributes.nl.po
+++ b/po/attributes.nl.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-04 12:09+0000\n"
+"PO-Revision-Date: 2019-01-23 08:10+0000\n"
 "Last-Translator: Maurits Meulenbelt <email address hidden>\n"
 "Language-Team: Dutch (http://www.transifex.com/musicbrainz/musicbrainz/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -2418,6 +2418,13 @@ msgctxt "medium_format"
 msgid "Floppy Disk"
 msgstr "Floppy"
 
+#: DB:gender/description:4
+msgctxt "gender"
+msgid ""
+"For cases where gender just doesn't apply at all (like companies entered as "
+"artists)."
+msgstr "Bedoeld voor gevallen waarbij het geslacht helemaal niet van toepassing is (zoals bedrijven die als artiest worden toegevoegd)."
+
 #: DB:work_attribute_type/name:16
 msgctxt "work_attribute_type"
 msgid "Form (Ottoman, Turkish)"
@@ -4651,6 +4658,11 @@ msgstr "Nişabureyn"
 msgctxt "release_packaging"
 msgid "None"
 msgstr "Geen"
+
+#: DB:gender/name:4
+msgctxt "gender"
+msgid "Not applicable"
+msgstr "Niet van toepassing"
 
 #: DB:work_attribute_type_allowed_value/value:491
 msgctxt "work_attribute_type_allowed_value"

--- a/po/attributes.pot
+++ b/po/attributes.pot
@@ -6122,6 +6122,13 @@ msgid ""
 "medium."
 msgstr ""
 
+#: DB:medium_format/description:82
+msgctxt "medium_format"
+msgid ""
+"The CD side of a vinyl + CD VinylDisc. The vinyl side should be added as a "
+"separate medium."
+msgstr ""
+
 #: DB:medium_format/description:60
 msgctxt "medium_format"
 msgid ""
@@ -6152,6 +6159,13 @@ msgid ""
 "separate medium."
 msgstr ""
 
+#: DB:medium_format/description:80
+msgctxt "medium_format"
+msgid ""
+"The DVD side of a vinyl + DVD VinylDisc. The vinyl side should be added as a "
+"separate medium."
+msgstr ""
+
 #: DB:medium_format/description:64
 msgctxt "medium_format"
 msgid ""
@@ -6177,6 +6191,13 @@ msgstr ""
 #: DB:release_packaging/description:1
 msgctxt "release_packaging"
 msgid "The traditional CD case, made of hard, brittle plastic."
+msgstr ""
+
+#: DB:medium_format/description:81
+msgctxt "medium_format"
+msgid ""
+"The vinyl side of a VinylDisc. The CD or DVD side should be added as a "
+"separate medium."
 msgstr ""
 
 #: DB:work_type/description:23
@@ -6474,6 +6495,21 @@ msgstr ""
 #: DB:medium_format/name:48
 msgctxt "medium_format"
 msgid "VinylDisc"
+msgstr ""
+
+#: DB:medium_format/name:82
+msgctxt "medium_format"
+msgid "VinylDisc (CD side)"
+msgstr ""
+
+#: DB:medium_format/name:80
+msgctxt "medium_format"
+msgid "VinylDisc (DVD side)"
+msgstr ""
+
+#: DB:medium_format/name:81
+msgctxt "medium_format"
+msgid "VinylDisc (Vinyl side)"
 msgstr ""
 
 #: DB:work_attribute_type_allowed_value/value:259

--- a/po/instrument_descriptions.fr.po
+++ b/po/instrument_descriptions.fr.po
@@ -3,6 +3,7 @@
 # AO <email address hidden>, 2013
 # Benjamin Sonntag <email address hidden>, 2011-2012
 # Benjamin Sonntag <email address hidden>, 2011
+# Idlusen <email address hidden>, 2019
 # Dibou <email address hidden>, 2012,2016
 # Dorian Soergel <email address hidden>, 2018
 # Frédéric Da Vitoria <email address hidden>, 2014
@@ -22,8 +23,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"PO-Revision-Date: 2019-02-27 12:54+0000\n"
+"Last-Translator: Idlusen <email address hidden>\n"
 "Language-Team: French (http://www.transifex.com/musicbrainz/musicbrainz/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -347,7 +348,7 @@ msgid ""
 "truncated cone resting on a triangular base."
 msgstr "Une trompette marine est un instrument triangulaire à corde frottée, utilisé dans l’Europe médiévale et de la Renaissance, comprenant un corps et un manche en forme de cône tronqué et reposant sur une base triangulaire."
 
-#. name:marxophone
+#. name:Marxophone
 #: DB:instrument/description:442
 msgid "A type of fretless zither."
 msgstr "Un type de cithare sans frette."
@@ -734,6 +735,14 @@ msgstr ""
 #: DB:instrument/description:411
 msgid "Davul, turkish drum"
 msgstr "Le davul, un tambour turc"
+
+#. name:setar
+#: DB:instrument/description:630
+msgid ""
+"Derived from the Indian tritantri veena by the Persian poet Amir Khusro "
+"sometime in 13th century, it had 3 (now 4) strings and a long neck. It later"
+" gave name to the Indian sitar."
+msgstr ""
 
 #. name:tenora
 #: DB:instrument/description:869
@@ -1395,6 +1404,15 @@ msgid ""
 " townspeople."
 msgstr ""
 
+#. name:tritantri veena
+#: DB:instrument/description:945
+msgid ""
+"Originally played in court, it consists of a 1m long piece of wood with a "
+"small intricately carved soundbox. It has 16 frets and 3 metal strings. "
+"Legend has it, the Persian Ameer Khusrau made some alterations and created "
+"the Persian sehtara (setar)."
+msgstr ""
+
 #. name:renaissance rackett
 #: DB:instrument/description:896
 msgid ""
@@ -1533,7 +1551,7 @@ msgstr ""
 #. name:ngɔni
 #: DB:instrument/description:729
 msgid "Plucked string instrument made of wood or gourd from West Africa."
-msgstr ""
+msgstr "Instrument à cordes pincées d’Afrique occidentale fait de bois ou d’une coque de calebasse."
 
 #. name:melodica
 #: DB:instrument/description:44
@@ -1721,7 +1739,7 @@ msgstr "Type de fifre utilisé dans la musique traditionnelle ukrainienne."
 msgid ""
 "Sound chip in various video game consoles used for music, chiefly in bit-"
 "tunes and chip-tunes"
-msgstr ""
+msgstr "Puce audio de console de jeu vidéo utilisée pour la musique, principalement dans le genre chiptune."
 
 #. name:struck idiophone
 #: DB:instrument/description:675
@@ -3072,13 +3090,6 @@ msgstr "Le saz est luth à manche long avec frettes. (<a href=\"http://fr.wikipe
 msgid "The segunda is a bass garifuna drum."
 msgstr "Tambour basse garifuna."
 
-#. name:setar
-#: DB:instrument/description:630
-msgid ""
-"The setar is a long-necked three-stringed lute found in Iran and Central "
-"Asia."
-msgstr "Le setâr est un luth à long manche et à trois cordes trouvé en Iran et en Asie centrale."
-
 #. name:shakuhachi
 #: DB:instrument/description:173
 msgid "The shakuhachi is a Japanese end-blown flute."
@@ -4193,7 +4204,7 @@ msgid ""
 "made of clay with two layers of goat skin, it is used as a rhythmic "
 "accompaniment to shehnai players and is one of the instruments of the Baul "
 "community."
-msgstr ""
+msgstr "fait de terre cuite avec deux peaux de chèvre tendues, il est utilisé en accompagnement rythmique des joueurs de shehnai et fait partie des instruments de la communauté Baul."
 
 #. name:pūrerehua
 #: DB:instrument/description:791
@@ -4287,8 +4298,8 @@ msgid ""
 " of mandolin, it is tuned like it and the violin."
 msgstr ""
 
-#. name:saó ôi flute
-#: DB:instrument/description:310
+#. name:sáo meò
+#: DB:instrument/description:316
 msgid "saó ôi (flute of the Muong)"
 msgstr "flûte saó ôi, utilisée par les Muong"
 

--- a/po/instrument_descriptions.nl.po
+++ b/po/instrument_descriptions.nl.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-10 11:41+0000\n"
+"PO-Revision-Date: 2019-02-11 13:34+0000\n"
 "Last-Translator: Maurits Meulenbelt <email address hidden>\n"
 "Language-Team: Dutch (http://www.transifex.com/musicbrainz/musicbrainz/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -322,7 +322,7 @@ msgstr "Een tenorbanjo is een viersnarige banjo die als tenor is gestemd, meesta
 msgid ""
 "A tom-tom (or just tom) is a cylindrical drum with no snare, commonly found "
 "in a standard drum set."
-msgstr "Een tom-tom (of gewoon tom) is een cilindrische trommel zonder snaar. Standaard onderdeel van een drumstel."
+msgstr "Een tom-tom (of gewoon tom) is een cilindrische trommel zonder snaar. Standaardonderdeel van een drumstel."
 
 #. name:tromba marina
 #: DB:instrument/description:698
@@ -332,7 +332,7 @@ msgid ""
 "truncated cone resting on a triangular base."
 msgstr "Een tromba marina of marinetrompet is een driehoekig strijkinstrument met één snaar dat vooral werd bespeeld in Europa tijdens de Middeleeuwen en de Renaissance. De naam komt van het feit dat de klank lijkt op die van een trompet."
 
-#. name:marxophone
+#. name:Marxophone
 #: DB:instrument/description:442
 msgid "A type of fretless zither."
 msgstr "Een soort fretloze citer."
@@ -675,7 +675,7 @@ msgid ""
 "ritual and meditation, North Indian raga and Dhrupad music. It has two dried"
 " gourd resonators and a body of bamboo with 24 wooden frets and 4 main, 2-3 "
 "secondary and one drone string."
-msgstr "De ruda veena wordt als de stamvader van alle Indiase snaarinstrumenten (veena) beschouwd. Het werd gebruikt bij rituelen en meditatie, Noord-Indiase raga en dhrupadmuziek. Het heeft twee resonatoren van gedroogde kalebas en een klankkast van bamboe, 24 houten fretten, 4 hoofdsnaren, 2 tot 3 secundaire snaren en een bourdonsnaar."
+msgstr "De rudra-vina wordt als de stamvader van alle Indiase snaarinstrumenten (vina) beschouwd. Het werd gebruikt bij rituelen en meditatie, Noord-Indiase raga en dhrupadmuziek. Het heeft twee resonatoren van gedroogde kalebas en een klankkast van bamboe, 24 houten fretten, 4 hoofdsnaren, 2 tot 3 secundaire snaren en een bourdonsnaar."
 
 #. name:whip / slapstick
 #: DB:instrument/description:107
@@ -719,6 +719,14 @@ msgstr "Bellen zijn klok- of schaalvormige instrumenten die worden geschud of aa
 #: DB:instrument/description:411
 msgid "Davul, turkish drum"
 msgstr "Davul, Turkse trommel"
+
+#. name:setar
+#: DB:instrument/description:630
+msgid ""
+"Derived from the Indian tritantri veena by the Persian poet Amir Khusro "
+"sometime in 13th century, it had 3 (now 4) strings and a long neck. It later"
+" gave name to the Indian sitar."
+msgstr "De setar werd in de 13e eeuw door de Perzische dichter Amīr Khusrow ontwikkeld uit de Indiase tritantri-vina. Het had drie (tegenwoordig vier) snaren en een lange hals. Het gaf ook de naam aan de Indiase sitar."
 
 #. name:tenora
 #: DB:instrument/description:869
@@ -1380,6 +1388,15 @@ msgid ""
 " townspeople."
 msgstr "De jootsjin werd vanuit China in Mongolië geïntroduceerd. Het heeft 13 dubbele snaren en een zwartgelakt houten klankbord. Het werd oorspronkelijk alleen door dorpsbewoners bespeeld."
 
+#. name:tritantri veena
+#: DB:instrument/description:945
+msgid ""
+"Originally played in court, it consists of a 1m long piece of wood with a "
+"small intricately carved soundbox. It has 16 frets and 3 metal strings. "
+"Legend has it, the Persian Ameer Khusrau made some alterations and created "
+"the Persian sehtara (setar)."
+msgstr "De tritantri-vina werd oorspronkelijk aan het hof bespeeld. Het bestaat uit een stuk hout van een meter lang met een kleine klankkast die met fijn houtsnijwerk is versierd. Het instrument heeft 16 fretten en drie metalen snaren. Volgens de legende maakte Amīr Khusrow wat aanpassingen en ontwikkelde zo de Perzische setar."
+
 #. name:renaissance rackett
 #: DB:instrument/description:896
 msgid ""
@@ -1534,7 +1551,7 @@ msgid ""
 "Popular in the fifteenth century, it was a combination of a pipe organ and "
 "harpsichord, often with two keyboards, one for the strings and one for the "
 "pipes mounted underneath."
-msgstr "Het Klaviorganum is een combinatie van een klavecimbel en een pijporgel, vaak met twee klavieren, één voor de snaren en één voor de pijpen. Het was in de 15e eeuw een populair instrument."
+msgstr "Het klaviorganum is een combinatie van een klavecimbel en een pijporgel, vaak met twee klavieren, één voor de snaren en één voor de pijpen. Het was in de 15e eeuw een populair instrument."
 
 #. name:regal
 #: DB:instrument/description:918
@@ -3057,13 +3074,6 @@ msgstr "Saz is een familie van snaarinstrumenten waaronder de bağlama valt. De 
 msgid "The segunda is a bass garifuna drum."
 msgstr "Een segunda is een basgarifunatrommel."
 
-#. name:setar
-#: DB:instrument/description:630
-msgid ""
-"The setar is a long-necked three-stringed lute found in Iran and Central "
-"Asia."
-msgstr "Een setar is een driesnarige luit met een lange hals uit Iran en Centraal-Azië."
-
 #. name:shakuhachi
 #: DB:instrument/description:173
 msgid "The shakuhachi is a Japanese end-blown flute."
@@ -4272,8 +4282,8 @@ msgid ""
 " of mandolin, it is tuned like it and the violin."
 msgstr "De banjoline is meerdere keren in verschillende landen uitgevonden. Het is een combinatie van de klankkast van een banjo en de hals van een mandoline, en is gestemd als een viool."
 
-#. name:saó ôi flute
-#: DB:instrument/description:310
+#. name:sáo meò
+#: DB:instrument/description:316
 msgid "saó ôi (flute of the Muong)"
 msgstr "Fluit van de Muong uit Vietnam"
 

--- a/po/instrument_descriptions.pot
+++ b/po/instrument_descriptions.pot
@@ -61,13 +61,6 @@ msgid ""
 "inverted metal bowls."
 msgstr ""
 
-#. name:bullroarer 
-#: DB:instrument/description:153
-msgid ""
-"A bullroarer consists of a piece of wood attached to a long cord which is "
-"then swung in a circle."
-msgstr ""
-
 #. name:chamber organ 
 #: DB:instrument/description:471
 msgid "A chamber organ is a small pipe organ."
@@ -115,13 +108,6 @@ msgstr ""
 #. name:five-string banjo 
 #: DB:instrument/description:523
 msgid "A five-string banjo is a banjo with five strings."
-msgstr ""
-
-#. name:flute 
-#: DB:instrument/description:13
-msgid ""
-"A flute is an aerophone or reedless wind instrument that produces its sound "
-"from the flow of air across an opening."
 msgstr ""
 
 #. name:four-string banjo 
@@ -183,13 +169,6 @@ msgid ""
 "guitar"
 msgstr ""
 
-#. name:lithophone 
-#: DB:instrument/description:702
-msgid ""
-"A lithophone is a musical instrument consisting of a rock or pieces of rock "
-"which are struck to produce musical notes."
-msgstr ""
-
 #. name:pōrutu 
 #: DB:instrument/description:787
 msgid ""
@@ -225,13 +204,6 @@ msgstr ""
 msgid ""
 "A mouth organ is a generic term for free reed aerophone with one or more air "
 "chambers fitted with a free reed."
-msgstr ""
-
-#. name:musical saw 
-#: DB:instrument/description:145
-msgid ""
-"A musical saw is a hand saw used as a musical instrument. It is usually "
-"played by bowing the non-serrated edge."
 msgstr ""
 
 #. name:bowed piano 
@@ -328,11 +300,6 @@ msgstr ""
 msgid "A type of fretless zither."
 msgstr ""
 
-#. name:typewriter 
-#: DB:instrument/description:526
-msgid "A typewriter, used for percussion (either keys or bells)"
-msgstr ""
-
 #. name:vessel flute 
 #: DB:instrument/description:650
 msgid ""
@@ -345,13 +312,6 @@ msgstr ""
 msgid ""
 "A wooden double-reed instrument with a conical bore from the 16th and 17th "
 "centuries"
-msgstr ""
-
-#. name:wooden fish 
-#: DB:instrument/description:267
-msgid ""
-"A wooden fish is an idiophone often used during Buddhist rituals in East "
-"Asia."
 msgstr ""
 
 #. name:acoustic fretless guitar 
@@ -388,13 +348,6 @@ msgid ""
 "bars"
 msgstr ""
 
-#. name:calabash 
-#: DB:instrument/description:777
-msgid ""
-"An African percussion instrument, made of a dried gourd plant. Struck with "
-"hands or objects."
-msgstr ""
-
 #. name:Irish harp / clàrsach 
 #: DB:instrument/description:355
 msgid "An Irish/Scottish harp."
@@ -419,14 +372,6 @@ msgstr ""
 msgid ""
 "An electric keyboard slung over the shoulder by a strap like a guitar, it "
 "has soundcontrols placed on the neck"
-msgstr ""
-
-#. name:electric piano 
-#: DB:instrument/description:259
-msgid ""
-"An electric piano is an electro-mechanical musical instrument. Depending on "
-"the type of electric piano, the tones may be produced by strings, reeds or "
-"tuning forks."
 msgstr ""
 
 #. name:Pianet 
@@ -491,17 +436,25 @@ msgid ""
 "often combined with tabor drums."
 msgstr ""
 
-#. name:membranophone 
-#: DB:instrument/description:100
-msgid "Any kind of idiophone with membranes, variously sized drums."
+#. name:khlui 
+#: DB:instrument/description:666
+msgid "Ancient reedless fipple flute made of bamboo."
 msgstr ""
 
-#. name:drum 
+#. name:membranophone 
+#: DB:instrument/description:100
+msgid "Any kind of instrument with membranes, usually variously sized drums."
+msgstr ""
+
+#. name:unspecified drum 
 #: DB:instrument/description:933
 msgid ""
-"Any kind of idiophone with membranes, variously sized drums. For the "
-"instrument commonly known as \"drums\" use <a href=\"https://beta."
-"musicbrainz.org/instrument/12092505-6ee1-46af-a15a-b5b468b6b155\">drumset</a>"
+"Any kind of unspecified percussion with membranes, variously sized drums. "
+"For the instrument commonly known as \"drums\" use <a href=\"https://"
+"musicbrainz.org/instrument/12092505-6ee1-46af-a15a-b5b468b6b155\">drums "
+"(drum set)</a>. For programmed or \"drum-loops\" use <a href=\"https://"
+"musicbrainz.org/instrument/ce0eed13-58d8-4744-8ad0-b7d6182a2d0f\">drum "
+"machine</a>."
 msgstr ""
 
 #. name:flumpet 
@@ -581,6 +534,11 @@ msgstr ""
 #. name:bendir 
 #: DB:instrument/description:343
 msgid "Bendir, frame drum from North Africa, doesn't have jingles"
+msgstr ""
+
+#. name:typewriter 
+#: DB:instrument/description:526
+msgid "Besides being used for writing, it has also been used in percussion."
 msgstr ""
 
 #. name:cajón 
@@ -667,6 +625,16 @@ msgid ""
 "secondary and one drone string."
 msgstr ""
 
+#. name:metallophone 
+#: DB:instrument/description:349
+msgid ""
+"Consisting of tuned metal bars, slates or keys struck with mallets and "
+"arranged (often on resonators of sonorous material) in various scales. "
+"Compare <a href=\"https://musicbrainz.org/instrument/"
+"db95a035-6a3d-44b4-8694-74ff71b61768\">xylophone</a> for the wooden bar "
+"equivalent."
+msgstr ""
+
 #. name:whip / slapstick 
 #: DB:instrument/description:107
 msgid ""
@@ -700,9 +668,9 @@ msgstr ""
 msgid "Crumhorn used in the 14th to 17th centuries in Europe"
 msgstr ""
 
-#. name:bells 
+#. name:bell 
 #: DB:instrument/description:116
-msgid "Cup or bellshaped bells, these are shuk or struck."
+msgid "Cup or bellshaped bells, these are shook or struck."
 msgstr ""
 
 #. name:davul 
@@ -813,6 +781,20 @@ msgid ""
 "and mellower than the trumpet which it resembles."
 msgstr ""
 
+#. name:đing buốt 
+#: DB:instrument/description:306
+msgid "Ede traditional flute, four finger holes, blowing reed"
+msgstr ""
+
+#. name:surbahar 
+#: DB:instrument/description:946
+msgid ""
+"Effectively a bass sitar, it has 4 main, 3-4 chikari(drone) and 10-11 "
+"resonance strings strung over a wide wooden neck. Made of flat-cut gourd "
+"with a possible secondary resonator (tumba) it was invented in 1825 by sitar-"
+"player Ghulam Mohammed who wanted a deeper sound."
+msgstr ""
+
 #. name:harpejji 
 #: DB:instrument/description:894
 msgid ""
@@ -868,6 +850,19 @@ msgstr ""
 msgid "Fipple flute that became a symbol for the Basque folk revival."
 msgstr ""
 
+#. name:fipple flute 
+#: DB:instrument/description:194
+msgid ""
+"Fipple or duct flutes have a mouthpiece that is breathed into, but no reeds"
+msgstr ""
+
+#. name:oboe da caccia 
+#: DB:instrument/description:572
+msgid ""
+"First referred to in 1722, this transposing double-reed has a curved tube "
+"and a flared (brass) bell."
+msgstr ""
+
 #. name:poi 
 #: DB:instrument/description:866
 msgid ""
@@ -903,9 +898,30 @@ msgid ""
 "ensemble with zhu."
 msgstr ""
 
+#. name:gendèr 
+#: DB:instrument/description:961
+msgid ""
+"From the Bali and Java use in gamelan, it has 12-14 tuned bronze keys "
+"suspended over metal or bamboo resonators."
+msgstr ""
+
 #. name:gankogui 
 #: DB:instrument/description:383
 msgid "Gankogui, iron bell"
+msgstr ""
+
+#. name:percussion idiophone 
+#: DB:instrument/description:959
+msgid ""
+"Generally consists of one to very many plates, sticks, or other objects hit "
+"with (or against) various types of mallets."
+msgstr ""
+
+#. name:concussion idiophone 
+#: DB:instrument/description:958
+msgid ""
+"Generally consists of two completely equal or somewhat unsymmetrical sticks, "
+"plates, shells or similar hit together."
 msgstr ""
 
 #. name:German harp 
@@ -991,6 +1007,16 @@ msgid ""
 "end of the 18th century."
 msgstr ""
 
+#. name:guban 
+#: DB:instrument/description:956
+msgid ""
+"Important in Yue, Kunkqu and Peking opera, it consists of the drum <a href="
+"\"https://musicbrainz.org/instrument/42349583-c10d-4c6e-"
+"b553-28d916113856\">bangu</a> and the clapper <a href=\"https://beta."
+"musicbrainz.org/instrument/c641bccc-2060-4871-9c12-e2df2523e53c\">paiban</"
+"a>. Drum is played by one hand and clapper with the other."
+msgstr ""
+
 #. name:morin khuur 
 #: DB:instrument/description:224
 msgid ""
@@ -1064,6 +1090,15 @@ msgid ""
 "lute\""
 msgstr ""
 
+#. name:slentho 
+#: DB:instrument/description:964
+msgid ""
+"It has seven bossed keys hit with the tabuh mallet and is nailed to a wooden "
+"frame. Largely replaced by the <a href=\"https://musicbrainz.org/"
+"instrument/73173277-b7ef-4d5e-83b2-205cd2f12488\">slethem</a> in gamelan, it "
+"is the lowest member of the saron family."
+msgstr ""
+
 #. name:yangqin 
 #: DB:instrument/description:254
 msgid ""
@@ -1133,7 +1168,7 @@ msgid ""
 "rhythmic component of Gnawa music."
 msgstr ""
 
-#. name:lamellophone 
+#. name:lamellaphone 
 #: DB:instrument/description:632
 msgid ""
 "Lamellophones are a family of musical instruments which have one or more "
@@ -1199,11 +1234,24 @@ msgid ""
 "rhythmic accompaniment in Yakshagana."
 msgstr ""
 
+#. name:suling 
+#: DB:instrument/description:725
+msgid ""
+"Made of bamboo, it has from 4 to 6 finger-holes and a small wedge-shaped "
+"fipple. There are many varieties all around Southeast Asia, it is also used "
+"in gamelan."
+msgstr ""
+
 #. name:bones 
 #: DB:instrument/description:357
 msgid ""
 "Made of bone or wood, these are paired sticks of sonorous material used in "
 "folk music."
+msgstr ""
+
+#. name:calabash 
+#: DB:instrument/description:777
+msgid "Made of dried gourd. Struck with hands or objects."
 msgstr ""
 
 #. name:njarka 
@@ -1236,6 +1284,14 @@ msgid ""
 "hardwood, this ancient instrument was used for rhythm during chanting."
 msgstr ""
 
+#. name:paiban 
+#: DB:instrument/description:957
+msgid ""
+"Made of sandalwood or bamboo, 2 blocks are tied together with a string, a "
+"third with a ribbon. Part of the drum and clapper ensemble guban, but "
+"confusingly, the clapper alone can also be called guban."
+msgstr ""
+
 #. name:tungso 
 #: DB:instrument/description:887
 msgid ""
@@ -1249,6 +1305,13 @@ msgid ""
 "Made of tubing with holes that may have everything from none to two reeds, "
 "water instead of air comes out of the holes. Sound is produced by covering "
 "the holes with fingers, altering the flow of water through the holes."
+msgstr ""
+
+#. name:krap 
+#: DB:instrument/description:949
+msgid ""
+"Made of various materials, clappers are struck together to keep rhythm and "
+"time for use in ceremonies and rituals and to accompany dancing and singing."
 msgstr ""
 
 #. name:pūtōrino 
@@ -1287,12 +1350,11 @@ msgstr ""
 msgid "Mexican vihuela, used by mariachi bands"
 msgstr ""
 
-#. name:mirliton 
-#: DB:instrument/description:591
+#. name:kachva sitar 
+#: DB:instrument/description:947
 msgid ""
-"Mirliton is a generic term for membranophones played by a performer speaking "
-"or singing into them, and which alter the sound of the voice by means of a "
-"vibrating membrane."
+"More common in the 19th century, it was made of flat-cut gourd and had 16 "
+"frets, In the 1820s it was used by Ghulam Mohammed to develop the surbahar."
 msgstr ""
 
 #. name:bass viol 
@@ -1344,6 +1406,15 @@ msgstr ""
 #. name:oboe d'amore 
 #: DB:instrument/description:473
 msgid "Oboe d'amore / Oboe d'amour (mezzo-soprano)"
+msgstr ""
+
+#. name:boomwhacker 
+#: DB:instrument/description:948
+msgid ""
+"Often used in group musical education and by street musicians, it consists "
+"of individual colourful hollow plastic tubes of various widths that are "
+"struck on various surfaces to produce sound, tubes can also be arranged and "
+"hit by mallets."
 msgstr ""
 
 #. name:kanklės 
@@ -1444,6 +1515,22 @@ msgstr ""
 #. name:pardessus de viole 
 #: DB:instrument/description:924
 msgid "Pardessus or sopranino member of the viol family"
+msgstr ""
+
+#. name:slenthem 
+#: DB:instrument/description:962
+msgid ""
+"Part of central Javanese gamelan, the 6(slendro)-7(pelog) bronze keys beat "
+"by a disk mallet(tabuh) are suspended above individual tube metal/bamboo "
+"resonators set in a 75 cm long wooden frame."
+msgstr ""
+
+#. name:saron 
+#: DB:instrument/description:597
+msgid ""
+"Part of the Javanese gamelan, these can have from six up to nine thick "
+"bronze or iron slabs resting on wooden resonator (rancak) and are hit with "
+"wooden mallets or buffalo horn."
 msgstr ""
 
 #. name:body percussion 
@@ -1568,6 +1655,11 @@ msgid ""
 "India and \"cimbalon\" in Europe."
 msgstr ""
 
+#. name:flute 
+#: DB:instrument/description:13
+msgid "Reedless Aerophone, usually a tube"
+msgstr ""
+
 #. name:rubab 
 #: DB:instrument/description:883
 msgid ""
@@ -1594,12 +1686,26 @@ msgstr ""
 msgid "Santur, Middle Eastern"
 msgstr ""
 
+#. name:arrabel 
+#: DB:instrument/description:960
+msgid ""
+"Scraper made of bones tied together with rope scraped with a conch-shell, in "
+"Catalonia it's scraped with a castanet. Ginebra is a variant made of cane."
+msgstr ""
+
 #. name:drums (drum set) 
 #: DB:instrument/description:101
 msgid ""
 "Set of drums developed from the 1930's onward, it is used in Jazz, Swing, "
 "Rock and Pop music. It consists of snare drum, tom-toms, hi-hats, cymbals "
 "and bass drum."
+msgstr ""
+
+#. name:shaken idiophone 
+#: DB:instrument/description:954
+msgid ""
+"Shaken idiophone or rattle. Sound is produced by holding or containing "
+"usually small concussing parts."
 msgstr ""
 
 #. name:Otamatone 
@@ -1624,6 +1730,13 @@ msgstr ""
 msgid ""
 "Side drum, often with one or more snares, worn by one person and beaten by "
 "one hand, it is often combined with tabor pipes."
+msgstr ""
+
+#. name:mirliton 
+#: DB:instrument/description:591
+msgid ""
+"Simultaneously a woodwind and membranophone, sound is produced by singing or "
+"speaking into a thin buzzing membrane."
 msgstr ""
 
 #. name:donso ngɔni 
@@ -1710,6 +1823,16 @@ msgstr ""
 msgid ""
 "Sound chip in various video game consoles used for music, chiefly in bit-"
 "tunes and chip-tunes"
+msgstr ""
+
+#. name:sitar 
+#: DB:instrument/description:88
+msgid ""
+"Soundbox made of gourd, it has 18-21 (6-7 on frets and 11-15 sympathetic "
+"under the frets) metal strings, two bridges and a long wooden neck where the "
+"tuning pegs of the sympathetic strings are attached. Used in India since "
+"ancient times, it flourished during the 16-17th before arriving at it's "
+"current form in the 18th century. It became popular worldwide in the 1950-60"
 msgstr ""
 
 #. name:struck idiophone 
@@ -1952,15 +2075,6 @@ msgstr ""
 msgid ""
 "The bandoneón is a type of bisonoric concertina popular in parts of South "
 "America and in Lithuania."
-msgstr ""
-
-#. name:bangu 
-#: DB:instrument/description:581
-msgid ""
-"The bangu or danpigu is a Chinese frame drum, struck by two bamboo sticks. "
-"It is usually played along with the clappers ban (Chinese: 板, bǎn) and both "
-"instruments are known collectively as <a href=\"http://en.wikipedia.org/wiki/"
-"Guban_(instrument)\">guban</a> (Chinese: 鼓板, gǔbǎn)."
 msgstr ""
 
 #. name:banhu 
@@ -2395,13 +2509,6 @@ msgid ""
 "family."
 msgstr ""
 
-#. name:gramorimba 
-#: DB:instrument/description:748
-msgid ""
-"The gramorimba is a lithophone, similar to a xylophone whose bars are made "
-"of stone."
-msgstr ""
-
 #. name:guan 
 #: DB:instrument/description:683
 msgid ""
@@ -2558,13 +2665,6 @@ msgid ""
 "used by some ethnic minority groups in Vietnam. It typically consists of 14 "
 "bamboo pipes arranged into two rows which are connected to a small, hollowed-"
 "out hardwood windchest."
-msgstr ""
-
-#. name:khlui 
-#: DB:instrument/description:666
-msgid ""
-"The khlui is a vertical duct flute from Thailand which is generally made of "
-"bamboo."
 msgstr ""
 
 #. name:khong wong 
@@ -2795,14 +2895,6 @@ msgstr ""
 msgid "The nyckelharpa is a traditional Swedish string instrument."
 msgstr ""
 
-#. name:oboe da caccia 
-#: DB:instrument/description:572
-msgid ""
-"The oboe da caccia is a double reed woodwind instrument in the oboe family, "
-"pitched a fifth below the oboe and used primarily in the Baroque period of "
-"European classical music."
-msgstr ""
-
 #. name:ocarina 
 #: DB:instrument/description:15
 msgid ""
@@ -2816,13 +2908,6 @@ msgid ""
 "The octave mandolin is a fretted string instrument with four pairs of "
 "strings tuned in fifths, G, D, A, E (low to high), an octave below a "
 "mandolin."
-msgstr ""
-
-#. name:pakhavaj 
-#: DB:instrument/description:502
-msgid ""
-"The pakhavaj is an Indian barrel-shaped, two-headed drum used in Hindustani "
-"music."
 msgstr ""
 
 #. name:pedal piano 
@@ -3000,13 +3085,6 @@ msgid ""
 "Pakistan."
 msgstr ""
 
-#. name:saron 
-#: DB:instrument/description:597
-msgid ""
-"The saron is an Indonesian musical instrument which is used in the gamelan. "
-"It normally has seven bronze bars placed on top of a resonating frame."
-msgstr ""
-
 #. name:sarrusophone 
 #: DB:instrument/description:749
 msgid ""
@@ -3133,14 +3211,6 @@ msgstr ""
 msgid "The sistrum is a metal rattle associated with ancient Iraq and Egypt."
 msgstr ""
 
-#. name:sitar 
-#: DB:instrument/description:88
-msgid ""
-"The sitar is a plucked stringed instrument used mainly in Hindustani music "
-"and Indian classical music which is descended from a similar but simpler "
-"Persian instrument called the setar."
-msgstr ""
-
 #. name:song loan 
 #: DB:instrument/description:284
 msgid ""
@@ -3166,11 +3236,6 @@ msgstr ""
 #. name:suka 
 #: DB:instrument/description:730
 msgid "The suka is a once-extinct fiddle from Poland."
-msgstr ""
-
-#. name:suling 
-#: DB:instrument/description:725
-msgid "The suling is a bamboo flute from Southeast Asia."
 msgstr ""
 
 #. name:suona 
@@ -3675,6 +3740,14 @@ msgid ""
 "It was for signalling, but also ceremonial and ritual use."
 msgstr ""
 
+#. name:shakers 
+#: DB:instrument/description:340
+msgid ""
+"Tube made of metal or bamboo, it is filled with seeds, pebbles or sand. "
+"Especially used in Latin American music, it is shaken rhythmically to "
+"produce sound."
+msgstr ""
+
 #. name:soprano violin 
 #: DB:instrument/description:210
 msgid ""
@@ -3740,6 +3813,13 @@ msgid ""
 "announcements like war, welcoming people and kumara planting."
 msgstr ""
 
+#. name:clapstick 
+#: DB:instrument/description:955
+msgid ""
+"Used by Australian Aboriginals to maintain rhythm in chants and "
+"traditionally to accompany didgeridoo. There are also Boomerang clapsticks."
+msgstr ""
+
 #. name:harmonica 
 #: DB:instrument/description:43
 msgid ""
@@ -3754,6 +3834,13 @@ msgid ""
 "Used in Carnatic tradition, named after goddess of art and music Saraswati, "
 "it is known since ancient times. Lute with a gourd sound resonator, it has "
 "24 fixed frets, 7 steel strings (4 main & 3 drone)"
+msgstr ""
+
+#. name:pakhawaj 
+#: DB:instrument/description:502
+msgid ""
+"Used in Hindustani dhrupad, this two-headed barrel-drum is tuned like its "
+"descendant the tabla."
 msgstr ""
 
 #. name:octavilla 
@@ -3773,9 +3860,31 @@ msgid ""
 "was derived from the Chinese xiao in the 19th century."
 msgstr ""
 
+#. name:krap khū 
+#: DB:instrument/description:950
+msgid ""
+"Used in folk music, bamboo is split into a pair of 40 cm long sticks which "
+"are hit together."
+msgstr ""
+
 #. name:viola caipira 
 #: DB:instrument/description:660
 msgid "Used in folk-music, It has ten steel strings in five courses."
+msgstr ""
+
+#. name:krap phuang 
+#: DB:instrument/description:951
+msgid ""
+"Used in royal ceremonies, played by striking against the palm, it is made of "
+"several pieces of wood, ivory and sheets of brass between two larger pieces "
+"of wood tied together by a string at one end."
+msgstr ""
+
+#. name:krap sēphā 
+#: DB:instrument/description:952
+msgid ""
+"Used in the chant, sēphā, a pair of squared bevelled rosewood sticks around "
+"21 cm long and 3-4 cm thick."
 msgstr ""
 
 #. name:hyoshigi 
@@ -3814,8 +3923,8 @@ msgid ""
 "tubing into the instrument."
 msgstr ""
 
-#. name:não bạt / chập chõa 
-#: DB:instrument/description:272
+#. name:cymbal 
+#: DB:instrument/description:271
 msgid "Various types of cymbal. Also called chũm chọe"
 msgstr ""
 
@@ -3845,10 +3954,10 @@ msgid ""
 "commonly referred to as just \"flute\"."
 msgstr ""
 
-#. name:English horn 
+#. name:cor anglais 
 #: DB:instrument/description:7
 msgid ""
-"While also known as Cor anglais, it is neither a horn nor English, but a "
+"While also known as English horn, it is neither a horn nor English, but a "
 "transposing member of the oboe family, pitched at F"
 msgstr ""
 
@@ -3872,6 +3981,14 @@ msgstr ""
 msgid ""
 "Widely used in Korea, it has a wood soundbox and a rod neck with two silk-"
 "strings, heldt on the knee while played with a bow"
+msgstr ""
+
+#. name:bangu 
+#: DB:instrument/description:581
+msgid ""
+"Widely used in folk music, opera and music ensembles, it can be round or "
+"cone-shaped with cow/pigskin nailed to the larger convex end which has a "
+"small hole (guxin)."
 msgstr ""
 
 #. name:wind chime 
@@ -4062,11 +4179,6 @@ msgid ""
 "do not confuse with: Serb-Croat \"tamburica\" ensemble. Persian/Turkish "
 "ancient things evolved/came from \"tanbur\". unrelated Indian drone \"tanpura"
 "\" related Indian \"pandour\""
-msgstr ""
-
-#. name:đing buốt 
-#: DB:instrument/description:306
-msgid "edo village traditional flute, four finger holes, blowing reed"
 msgstr ""
 
 #. name:tubon 

--- a/po/instruments.fr.po
+++ b/po/instruments.fr.po
@@ -2,6 +2,7 @@
 # Translators:
 # nikki, 2014
 # AO <email address hidden>, 2013
+# Idlusen <email address hidden>, 2019
 # AO <email address hidden>, 2013,2015
 # Laurent Hosch <email address hidden>, 2017
 # Yanuut, 2018
@@ -21,8 +22,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"PO-Revision-Date: 2019-02-27 13:17+0000\n"
+"Last-Translator: Idlusen <email address hidden>\n"
 "Language-Team: French (http://www.transifex.com/musicbrainz/musicbrainz/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -168,6 +169,10 @@ msgstr "harpe celtique"
 #: DB:instrument/name:561
 msgid "Lyricon"
 msgstr "Lyricon"
+
+#: DB:instrument/name:442
+msgid "Marxophone"
+msgstr ""
 
 #: DB:instrument/name:92
 msgid "Mexican vihuela"
@@ -514,7 +519,7 @@ msgstr "saxophone baryton"
 
 #: DB:instrument/name:917
 msgid "baroque guitar"
-msgstr ""
+msgstr "guitare baroque"
 
 #: DB:instrument/name:897
 msgctxt "Conical bored compact double reed"
@@ -811,7 +816,7 @@ msgstr "carillon"
 #: DB:instrument/name:109
 msgctxt "Pair of concave shells"
 msgid "castanets"
-msgstr ""
+msgstr "castagnettes"
 
 #: DB:instrument/name:524
 msgid "cavaquinho"
@@ -1494,7 +1499,7 @@ msgstr "gadoulka"
 #: DB:instrument/name:365
 msgctxt "Indonesian traditional ensemble"
 msgid "gamelan"
-msgstr ""
+msgstr "gamelan"
 
 #: DB:instrument/name:383
 msgid "gankogui"
@@ -1816,7 +1821,7 @@ msgstr "janggo"
 #: DB:instrument/name:854
 msgctxt "West African four-stringed grigot lute"
 msgid "jeli ngɔni"
-msgstr ""
+msgstr "djéli n’goni"
 
 #: DB:instrument/name:80
 msgid "jew's harp"
@@ -2196,10 +2201,6 @@ msgstr "Marimba Lumina"
 #: DB:instrument/name:637
 msgid "mark tree"
 msgstr "rivière"
-
-#: DB:instrument/name:442
-msgid "marxophone"
-msgstr "marxophone"
 
 #: DB:instrument/name:633
 msgid "marímbula"
@@ -2911,10 +2912,6 @@ msgstr ""
 msgid "saz"
 msgstr "saz"
 
-#: DB:instrument/name:310
-msgid "saó ôi flute"
-msgstr "flûte saó ôi"
-
 #: DB:instrument/name:757
 msgid "segunda"
 msgstr "segunda"
@@ -2924,6 +2921,7 @@ msgid "serpent"
 msgstr "serpent"
 
 #: DB:instrument/name:630
+msgctxt "Persian three-stringed long-necked lute"
 msgid "setar"
 msgstr "setâr"
 
@@ -3098,7 +3096,7 @@ msgstr ""
 #: DB:instrument/name:915
 msgctxt "ensemble of violin, viola and cello"
 msgid "string trio"
-msgstr ""
+msgstr "Trio à cordes"
 
 #: DB:instrument/name:46
 msgid "strings"
@@ -3464,6 +3462,11 @@ msgstr "triangle"
 msgctxt "Basque button accordion"
 msgid "trikiti"
 msgstr "trikitixa"
+
+#: DB:instrument/name:945
+msgctxt "Indian three-stringed long-necked lute"
+msgid "tritantri veena"
+msgstr ""
 
 #: DB:instrument/name:698
 msgid "tromba marina"

--- a/po/instruments.ja.po
+++ b/po/instruments.ja.po
@@ -8,11 +8,12 @@
 # Osamu Takahashi, 2014
 # Shunsuke Shimizu <email address hidden>, 2016
 # th1rtyf0ur, 2013
+# wa2c <email address hidden>, 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: Shunsuke Shimizu <email address hidden>\n"
+"PO-Revision-Date: 2019-03-19 15:29+0000\n"
+"Last-Translator: wa2c <email address hidden>\n"
 "Language-Team: Japanese (http://www.transifex.com/musicbrainz/musicbrainz/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,12 +27,12 @@ msgstr "12弦ギター"
 
 #: DB:instrument/name:516
 msgid "17-string bass koto"
-msgstr ""
+msgstr "十七弦箏"
 
 #: DB:instrument/name:839
 msgctxt "historical hybrid between English and German style concertinas"
 msgid "Anglo concertina"
-msgstr ""
+msgstr "アングロ コンサー ティーナ"
 
 #: DB:instrument/name:66
 msgid "Appalachian dulcimer"
@@ -49,12 +50,12 @@ msgstr "バタドラム"
 #: DB:instrument/name:852
 msgctxt "long metal bar with strings"
 msgid "Blaster Beam"
-msgstr ""
+msgstr "ブラスタービーム"
 
 #: DB:instrument/name:794
 msgctxt "an electric piano with reeds"
 msgid "Cembalet"
-msgstr ""
+msgstr "チェンバレット"
 
 #: DB:instrument/name:183
 msgid "Chapman stick"
@@ -62,7 +63,7 @@ msgstr "チャップマン・スティック"
 
 #: DB:instrument/name:175
 msgid "Clavinet"
-msgstr ""
+msgstr "クラビネット"
 
 #: DB:instrument/name:482
 msgid "Cretan lyra"
@@ -70,7 +71,7 @@ msgstr "クレタン・リラ"
 
 #: DB:instrument/name:736
 msgid "Cristal Baschet"
-msgstr ""
+msgstr "クリスタルバシェ"
 
 #: DB:instrument/name:118
 msgid "Denis d'or"
@@ -91,12 +92,12 @@ msgstr "ＥＷＩ"
 #: DB:instrument/name:837
 msgctxt "unisonoric concertina"
 msgid "English concertina"
-msgstr ""
+msgstr "イングリッシュ・コンサーティーナ"
 
 #: DB:instrument/name:844
 msgctxt "English \"improved\" flageolet"
 msgid "English flageolet"
-msgstr ""
+msgstr "イングリッシュ・フラジオレット"
 
 #: DB:instrument/name:7
 msgctxt "Transposing oboe"
@@ -110,7 +111,7 @@ msgstr "フレンチホルン"
 #: DB:instrument/name:838
 msgctxt "bisonoric concertina"
 msgid "German concertina"
-msgstr ""
+msgstr "ジャーマン・コンサーティーナ"
 
 #: DB:instrument/name:356
 msgid "German harp"
@@ -119,7 +120,7 @@ msgstr "ジャーマンハープ"
 #: DB:instrument/name:901
 msgctxt "Modern 24-stringed stainless steel kora"
 msgid "Gravikord"
-msgstr ""
+msgstr "クラヴィコード"
 
 #: DB:instrument/name:236
 msgid "Greek baglama"
@@ -149,7 +150,7 @@ msgstr "アイリッシュ・ブズーキ"
 #: DB:instrument/name:878
 msgctxt "19th century transverse flute"
 msgid "Irish flute"
-msgstr ""
+msgstr "アイリッシュ・フルート"
 
 #: DB:instrument/name:355
 msgid "Irish harp / clàrsach"
@@ -158,6 +159,10 @@ msgstr "アイリッシュハープ"
 #: DB:instrument/name:561
 msgid "Lyricon"
 msgstr "リリコン"
+
+#: DB:instrument/name:442
+msgid "Marxophone"
+msgstr "マーキソフォン"
 
 #: DB:instrument/name:92
 msgid "Mexican vihuela"
@@ -178,7 +183,7 @@ msgstr "ノーサンブリアン・パイプ"
 #: DB:instrument/name:890
 msgctxt "Toy synthesizer"
 msgid "Otamatone"
-msgstr ""
+msgstr "オタマトーン"
 
 #: DB:instrument/name:664
 msgid "Paraguayan harp"
@@ -187,7 +192,7 @@ msgstr "アルパ"
 #: DB:instrument/name:793
 msgctxt "an electromechanical piano"
 msgid "Pianet"
-msgstr ""
+msgstr "プラネット"
 
 #: DB:instrument/name:647
 msgid "Portuguese guitar"
@@ -204,7 +209,7 @@ msgstr "ローズ・ピアノ"
 #: DB:instrument/name:476
 msgctxt "Ancient Carnatic veena lute"
 msgid "Saraswati veena"
-msgstr ""
+msgstr "サラスヴァティー・ヴィーナ"
 
 #: DB:instrument/name:679
 msgid "Schwyzerörgeli"
@@ -242,7 +247,7 @@ msgstr "チベット・ウォーター・ドラム"
 #: DB:instrument/name:846
 msgctxt "plastic fipple flute"
 msgid "Tonette"
-msgstr ""
+msgstr "トネット"
 
 #: DB:instrument/name:235
 msgid "Turkish baglama"
@@ -316,7 +321,7 @@ msgstr "牙箏（アジェン）"
 #: DB:instrument/name:747
 msgctxt "set of Nyabinghi drums"
 msgid "akete"
-msgstr ""
+msgstr "アケテ"
 
 #: DB:instrument/name:718
 msgid "alfaia"
@@ -345,12 +350,12 @@ msgstr "アルト・サクソフォン"
 #: DB:instrument/name:923
 msgctxt "Alto member of the viol family"
 msgid "alto viol"
-msgstr ""
+msgstr "アルト・ヴァイオル"
 
 #: DB:instrument/name:174
 msgctxt "Alto or vertical violin, for French \"alto\" credits, choose viola"
 msgid "alto violin"
-msgstr ""
+msgstr "アルト・ヴァイオリン"
 
 #: DB:instrument/name:363
 msgid "amadinda"
@@ -364,7 +369,7 @@ msgstr ""
 #: DB:instrument/name:813
 msgctxt "uses analogue circuits to produce sound"
 msgid "analog synthesizer"
-msgstr ""
+msgstr "アナログ・シンセサイザー"
 
 #: DB:instrument/name:373
 msgid "ankle rattlers"
@@ -474,12 +479,12 @@ msgstr "バンジョー"
 #: DB:instrument/name:832
 msgctxt "banjo ukulele hybrid"
 msgid "banjo-ukulele"
-msgstr ""
+msgstr "バンジョー・ウクレレ"
 
 #: DB:instrument/name:831
 msgctxt "banjo and mandolin/violin hybrid"
 msgid "banjolin"
-msgstr ""
+msgstr "バンジョリン"
 
 #: DB:instrument/name:190
 msgid "bansuri"
@@ -488,7 +493,7 @@ msgstr "バーンスリー"
 #: DB:instrument/name:819
 msgctxt "ancient asian/persian lute"
 msgid "barbat"
-msgstr ""
+msgstr "バルバット"
 
 #: DB:instrument/name:301
 msgid "baritone guitar"
@@ -504,12 +509,12 @@ msgstr "バリトン・サクソフォン"
 
 #: DB:instrument/name:917
 msgid "baroque guitar"
-msgstr ""
+msgstr "バロック・ギター"
 
 #: DB:instrument/name:897
 msgctxt "Conical bored compact double reed"
 msgid "baroque rackett"
-msgstr ""
+msgstr "バロック・ラケット"
 
 #: DB:instrument/name:521
 msgctxt "20th century reinvented natural trumpet"
@@ -584,12 +589,12 @@ msgstr "バス・トランペット"
 #: DB:instrument/name:916
 msgctxt "Bass member of the viol family"
 msgid "bass viol"
-msgstr ""
+msgstr "バス・ヴァイオル"
 
 #: DB:instrument/name:900
 msgctxt "Sixteenth century precursor of the (violon)cello"
 msgid "bass violin"
-msgstr ""
+msgstr "バス・バイオリン"
 
 #: DB:instrument/name:404
 msgid "basset clarinet"
@@ -2131,7 +2136,7 @@ msgstr "リュテアル"
 #: DB:instrument/name:925
 msgctxt "Small bass viol"
 msgid "lyra viol"
-msgstr ""
+msgstr "リラ・ヴァイオル"
 
 #: DB:instrument/name:84
 msgid "lyre"
@@ -2186,10 +2191,6 @@ msgstr "marimba lumina"
 #: DB:instrument/name:637
 msgid "mark tree"
 msgstr ""
-
-#: DB:instrument/name:442
-msgid "marxophone"
-msgstr "マーキソフォン"
 
 #: DB:instrument/name:633
 msgid "marímbula"
@@ -2901,10 +2902,6 @@ msgstr ""
 msgid "saz"
 msgstr "サズ"
 
-#: DB:instrument/name:310
-msgid "saó ôi flute"
-msgstr ""
-
 #: DB:instrument/name:757
 msgid "segunda"
 msgstr "セグンダ"
@@ -2914,6 +2911,7 @@ msgid "serpent"
 msgstr "セルパン"
 
 #: DB:instrument/name:630
+msgctxt "Persian three-stringed long-necked lute"
 msgid "setar"
 msgstr "セタール"
 
@@ -3321,7 +3319,7 @@ msgstr "テナー・トロンボーン"
 #: DB:instrument/name:922
 msgctxt "Tenor member of the viol family"
 msgid "tenor viol"
-msgstr ""
+msgstr "テナー・ヴァイオル"
 
 #: DB:instrument/name:615
 msgid "tenor violin"
@@ -3435,12 +3433,12 @@ msgstr "アルト・リコーダー"
 #: DB:instrument/name:921
 msgctxt "Treble/descant member of the viol family"
 msgid "treble viol"
-msgstr ""
+msgstr "トレブル・ヴァイオル"
 
 #: DB:instrument/name:209
 msgctxt "Smallest member of the new violin family"
 msgid "treble violin"
-msgstr ""
+msgstr "トレブル・ヴァイオリン"
 
 #: DB:instrument/name:90
 msgid "tres"
@@ -3453,6 +3451,11 @@ msgstr "バウロン"
 #: DB:instrument/name:847
 msgctxt "Basque button accordion"
 msgid "trikiti"
+msgstr ""
+
+#: DB:instrument/name:945
+msgctxt "Indian three-stringed long-necked lute"
+msgid "tritantri veena"
 msgstr ""
 
 #: DB:instrument/name:698
@@ -3646,7 +3649,7 @@ msgstr ""
 #: DB:instrument/name:899
 msgctxt "Viola de gamba family"
 msgid "viol family"
-msgstr ""
+msgstr "ヴァイオル・ファミリー"
 
 #: DB:instrument/name:63
 msgid "viola"
@@ -3678,12 +3681,12 @@ msgstr "ヴァイオリン"
 #: DB:instrument/name:59
 msgctxt "Modern violin family"
 msgid "violin family"
-msgstr ""
+msgstr "ヴァイオリン・ファミリー"
 
 #: DB:instrument/name:898
 msgctxt "New modern streamlined family of violins"
 msgid "violin octet"
-msgstr ""
+msgstr "ヴァイオリン・オクテット"
 
 #: DB:instrument/name:661
 msgid "violino piccolo"
@@ -3692,7 +3695,7 @@ msgstr "ヴァイオリーノ・ピッコロ"
 #: DB:instrument/name:834
 msgctxt "cretan lyra / violin hybrid"
 msgid "viololyra"
-msgstr ""
+msgstr "ヴィオロリラ"
 
 #: DB:instrument/name:693
 msgctxt "for violoncello use \"cello\""
@@ -3702,7 +3705,7 @@ msgstr "ヴィオロンチェロ・ピッコロ"
 #: DB:instrument/name:420
 msgctxt "Contra/double-bass member of the viol family"
 msgid "violone"
-msgstr ""
+msgstr "ヴィオローネ"
 
 #: DB:instrument/name:95
 msgid "violotta"

--- a/po/instruments.nl.po
+++ b/po/instruments.nl.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-09 21:32+0000\n"
+"PO-Revision-Date: 2019-01-23 08:19+0000\n"
 "Last-Translator: Maurits Meulenbelt <email address hidden>\n"
 "Language-Team: Dutch (http://www.transifex.com/musicbrainz/musicbrainz/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -155,6 +155,10 @@ msgstr "Keltische harp"
 #: DB:instrument/name:561
 msgid "Lyricon"
 msgstr "Lyricon"
+
+#: DB:instrument/name:442
+msgid "Marxophone"
+msgstr "Marxophone"
 
 #: DB:instrument/name:92
 msgid "Mexican vihuela"
@@ -2184,10 +2188,6 @@ msgstr "marimba lumina"
 msgid "mark tree"
 msgstr "bellenboom"
 
-#: DB:instrument/name:442
-msgid "marxophone"
-msgstr "marxofoon"
-
 #: DB:instrument/name:633
 msgid "marímbula"
 msgstr "marímbula"
@@ -2898,10 +2898,6 @@ msgstr "saxofoonkwartet"
 msgid "saz"
 msgstr "saz"
 
-#: DB:instrument/name:310
-msgid "saó ôi flute"
-msgstr "saó ôi fluit"
-
 #: DB:instrument/name:757
 msgid "segunda"
 msgstr "segunda"
@@ -2911,6 +2907,7 @@ msgid "serpent"
 msgstr "serpent"
 
 #: DB:instrument/name:630
+msgctxt "Persian three-stringed long-necked lute"
 msgid "setar"
 msgstr "setar"
 
@@ -3451,6 +3448,11 @@ msgstr "triangel"
 msgctxt "Basque button accordion"
 msgid "trikiti"
 msgstr "trikiti"
+
+#: DB:instrument/name:945
+msgctxt "Indian three-stringed long-necked lute"
+msgid "tritantri veena"
+msgstr "tritantri-vina"
 
 #: DB:instrument/name:698
 msgid "tromba marina"

--- a/po/instruments.pot
+++ b/po/instruments.pot
@@ -16,6 +16,10 @@ msgstr ""
 msgid "17-string bass koto"
 msgstr ""
 
+#: DB:instrument/name:108
+msgid "Afuche/Cabasa"
+msgstr ""
+
 #: DB:instrument/name:839
 msgctxt "historical hybrid between English and German style concertinas"
 msgid "Anglo concertina"
@@ -84,11 +88,6 @@ msgstr ""
 #: DB:instrument/name:844
 msgctxt "English \"improved\" flageolet"
 msgid "English flageolet"
-msgstr ""
-
-#: DB:instrument/name:7
-msgctxt "Transposing oboe"
-msgid "English horn"
 msgstr ""
 
 #: DB:instrument/name:30
@@ -293,10 +292,6 @@ msgstr ""
 msgid "afoxé"
 msgstr ""
 
-#: DB:instrument/name:108
-msgid "afuche / cabasa"
-msgstr ""
-
 #: DB:instrument/name:487
 msgid "agogô"
 msgstr ""
@@ -383,6 +378,11 @@ msgctxt "bass viol with guitar frets and tuning"
 msgid "arpeggione"
 msgstr ""
 
+#: DB:instrument/name:960
+msgctxt "Spanish bone scraper"
+msgid "arrabel"
+msgstr ""
+
 #: DB:instrument/name:812
 msgctxt "cone shaped west african frame-drum"
 msgid "ashiko"
@@ -447,6 +447,7 @@ msgid "bandurria"
 msgstr ""
 
 #: DB:instrument/name:581
+msgctxt "Traditional Chinese frame drum"
 msgid "bangu"
 msgstr ""
 
@@ -607,16 +608,16 @@ msgstr ""
 msgid "bazooka"
 msgstr ""
 
+#: DB:instrument/name:116
+msgid "bell"
+msgstr ""
+
 #: DB:instrument/name:479
 msgid "bell tree"
 msgstr ""
 
 #: DB:instrument/name:428
 msgid "bellow-blown bagpipes"
-msgstr ""
-
-#: DB:instrument/name:116
-msgid "bells"
 msgstr ""
 
 #: DB:instrument/name:343
@@ -695,6 +696,11 @@ msgstr ""
 #: DB:instrument/name:874
 msgctxt "arrangement of bamboo tube-drums"
 msgid "boobam"
+msgstr ""
+
+#: DB:instrument/name:948
+msgctxt "Tuned hollow plastic tubes"
+msgid "boomwhacker"
 msgstr ""
 
 #: DB:instrument/name:833
@@ -929,6 +935,11 @@ msgctxt "egyptian ancient clappers"
 msgid "clapper"
 msgstr ""
 
+#: DB:instrument/name:955
+msgctxt "Ancient Aboriginal rhythm stick"
+msgid "clapstick"
+msgstr ""
+
 #: DB:instrument/name:9
 msgid "clarinet"
 msgstr ""
@@ -980,6 +991,10 @@ msgstr ""
 msgid "conch"
 msgstr ""
 
+#: DB:instrument/name:958
+msgid "concussion idiophone"
+msgstr ""
+
 #: DB:instrument/name:102
 msgid "congas"
 msgstr ""
@@ -1006,6 +1021,11 @@ msgstr ""
 
 #: DB:instrument/name:6
 msgid "contrabassoon"
+msgstr ""
+
+#: DB:instrument/name:7
+msgctxt "Curved bulb belled transposing oboe"
+msgid "cor anglais"
 msgstr ""
 
 #: DB:instrument/name:510
@@ -1199,11 +1219,6 @@ msgstr ""
 
 #: DB:instrument/name:689
 msgid "dramyin"
-msgstr ""
-
-#: DB:instrument/name:933
-msgctxt "Generic drums of any kind."
-msgid "drum"
 msgstr ""
 
 #: DB:instrument/name:120
@@ -1409,6 +1424,7 @@ msgid "flumpet"
 msgstr ""
 
 #: DB:instrument/name:13
+msgctxt "Reedless aerophone"
 msgid "flute"
 msgstr ""
 
@@ -1513,6 +1529,11 @@ msgctxt "Medieval chamois or goat horn"
 msgid "gemshorn"
 msgstr ""
 
+#: DB:instrument/name:961
+msgctxt "Family of Indonesian metallophones"
+msgid "gendèr"
+msgstr ""
+
 #: DB:instrument/name:76
 msgid "geomungo"
 msgstr ""
@@ -1585,6 +1606,11 @@ msgstr ""
 
 #: DB:instrument/name:683
 msgid "guan"
+msgstr ""
+
+#: DB:instrument/name:956
+msgctxt "Traditional chinese drum and clapper."
+msgid "guban"
 msgstr ""
 
 #: DB:instrument/name:230
@@ -1836,6 +1862,11 @@ msgctxt "Vietnamese Air Xylophone"
 msgid "k'lông pút"
 msgstr ""
 
+#: DB:instrument/name:947
+msgctxt "Flat-cut gourd sitar"
+msgid "kachva sitar"
+msgstr ""
+
 #: DB:instrument/name:849
 msgctxt "bamboo transverse flute"
 msgid "kagurabue"
@@ -1924,6 +1955,7 @@ msgid "khim"
 msgstr ""
 
 #: DB:instrument/name:666
+msgctxt "Vertical bamboo duct flute"
 msgid "khlui"
 msgstr ""
 
@@ -2014,6 +2046,26 @@ msgstr ""
 msgid "krakebs"
 msgstr ""
 
+#: DB:instrument/name:949
+msgctxt "Group of thai concussion idiophones"
+msgid "krap"
+msgstr ""
+
+#: DB:instrument/name:950
+msgctxt "Thai bamboo concussion sticks"
+msgid "krap khū"
+msgstr ""
+
+#: DB:instrument/name:951
+msgctxt "Thai wood/brass clappers"
+msgid "krap phuang"
+msgstr ""
+
+#: DB:instrument/name:952
+msgctxt "Thai bevelled wood rhythm-sticks"
+msgid "krap sēphā"
+msgstr ""
+
 #: DB:instrument/name:734
 msgid "krar"
 msgstr ""
@@ -2045,7 +2097,7 @@ msgid "kōauau ponga ihu"
 msgstr ""
 
 #: DB:instrument/name:632
-msgid "lamellophone"
+msgid "lamellaphone"
 msgstr ""
 
 #: DB:instrument/name:249
@@ -2099,7 +2151,8 @@ msgstr ""
 msgid "lirone"
 msgstr ""
 
-#: DB:instrument/name:702
+#: DB:instrument/name:963
+msgctxt "Arrangement of struck tuned stone bars."
 msgid "lithophone"
 msgstr ""
 
@@ -2202,7 +2255,6 @@ msgid "melodica"
 msgstr ""
 
 #: DB:instrument/name:100
-msgctxt "generic drums of any kind"
 msgid "membranophone"
 msgstr ""
 
@@ -2215,6 +2267,7 @@ msgid "metal angklung"
 msgstr ""
 
 #: DB:instrument/name:349
+msgctxt "Arrangements of struck tuned metal bars."
 msgid "metallophone"
 msgstr ""
 
@@ -2351,10 +2404,6 @@ msgctxt "nylon-stringed acoustic guitar"
 msgid "nylon guitar"
 msgstr ""
 
-#: DB:instrument/name:272
-msgid "não bạt / chập chõa"
-msgstr ""
-
 #: DB:instrument/name:8
 msgid "oboe"
 msgstr ""
@@ -2364,6 +2413,7 @@ msgid "oboe d'amore"
 msgstr ""
 
 #: DB:instrument/name:572
+msgctxt "Baroque curved flared bell transposing oboe"
 msgid "oboe da caccia"
 msgstr ""
 
@@ -2461,8 +2511,14 @@ msgctxt "Māori taonga pūoro gong made of jade and bone"
 msgid "pahū pounamu"
 msgstr ""
 
+#: DB:instrument/name:957
+msgctxt "Ancient Chinese clapper"
+msgid "paiban"
+msgstr ""
+
 #: DB:instrument/name:502
-msgid "pakhavaj"
+msgctxt "Dhrupad wooden two-headed barrel-drum"
+msgid "pakhawaj"
 msgstr ""
 
 #: DB:instrument/name:16
@@ -2488,6 +2544,10 @@ msgstr ""
 
 #: DB:instrument/name:99
 msgid "percussion"
+msgstr ""
+
+#: DB:instrument/name:959
+msgid "percussion idiophone"
 msgstr ""
 
 #: DB:instrument/name:302
@@ -2693,10 +2753,6 @@ msgstr ""
 msgid "ratchet"
 msgstr ""
 
-#: DB:instrument/name:334
-msgid "rattle"
-msgstr ""
-
 #: DB:instrument/name:595
 msgid "rauschpfeife"
 msgstr ""
@@ -2849,6 +2905,7 @@ msgid "sarod"
 msgstr ""
 
 #: DB:instrument/name:597
+msgctxt "Javanese wooden trough metallophone family"
 msgid "saron"
 msgstr ""
 
@@ -2889,6 +2946,10 @@ msgstr ""
 msgid "saz"
 msgstr ""
 
+#: DB:instrument/name:953
+msgid "scraped idiophone"
+msgstr ""
+
 #: DB:instrument/name:757
 msgid "segunda"
 msgstr ""
@@ -2902,7 +2963,12 @@ msgctxt "Persian three-stringed long-necked lute"
 msgid "setar"
 msgstr ""
 
+#: DB:instrument/name:954
+msgid "shaken idiophone"
+msgstr ""
+
 #: DB:instrument/name:340
+msgctxt "Latin-American tube rattle"
 msgid "shakers"
 msgstr ""
 
@@ -2976,7 +3042,18 @@ msgid "sistrum"
 msgstr ""
 
 #: DB:instrument/name:88
+msgctxt "Indian long-necked lute"
 msgid "sitar"
+msgstr ""
+
+#: DB:instrument/name:962
+msgctxt "Central Javanese single octave metallophone"
+msgid "slenthem"
+msgstr ""
+
+#: DB:instrument/name:964
+msgctxt "Largely obsolete Central Javan metallophone."
+msgid "slentho"
 msgstr ""
 
 #: DB:instrument/name:202
@@ -3100,11 +3177,17 @@ msgid "suka"
 msgstr ""
 
 #: DB:instrument/name:725
+msgctxt "Southeast asian bamboo fipple flute"
 msgid "suling"
 msgstr ""
 
 #: DB:instrument/name:548
 msgid "suona"
+msgstr ""
+
+#: DB:instrument/name:946
+msgctxt "Bass sitar"
+msgid "surbahar"
 msgstr ""
 
 #: DB:instrument/name:379
@@ -3513,12 +3596,8 @@ msgid "tumbi"
 msgstr ""
 
 #: DB:instrument/name:863
-msgctxt "Māori taonga pūoro ancient struck percussion"
+msgctxt "Māori taonga pūoro ancient struck idiophone"
 msgid "tumutumu"
-msgstr ""
-
-#: DB:instrument/name:115
-msgid "tuned percussion"
 msgstr ""
 
 #: DB:instrument/name:887
@@ -3567,6 +3646,14 @@ msgstr ""
 
 #: DB:instrument/name:89
 msgid "ukulele"
+msgstr ""
+
+#: DB:instrument/name:933
+msgctxt ""
+"Drums not specified. For rock \"drums\" credits, you generally want \"drums "
+"(drum set)\". For \"programmed\" drums you generally want drum machine. ONLY "
+"USE IF THERE'S NO BETTER ALTERNATIVE"
+msgid "unspecified drum"
 msgstr ""
 
 #: DB:instrument/name:140
@@ -3796,6 +3883,7 @@ msgid "xun"
 msgstr ""
 
 #: DB:instrument/name:170
+msgctxt "Arrangement of struck tuned wooden bars."
 msgid "xylophone"
 msgstr ""
 

--- a/po/languages.pot
+++ b/po/languages.pot
@@ -2448,6 +2448,11 @@ msgstr ""
 msgid "Umbundu"
 msgstr ""
 
+#. frequency:1 iso_code_3:sju 
+#: DB:language/name:5995
+msgid "Ume Sami"
+msgstr ""
+
 #. frequency:0 iso_code_3:mis 
 #: DB:language/name:273
 msgid "Uncoded languages"

--- a/po/languages_notrim.pot
+++ b/po/languages_notrim.pot
@@ -35633,7 +35633,7 @@ msgstr ""
 msgid "Umbuygamu"
 msgstr ""
 
-#. frequency:0 iso_code_3:sju 
+#. frequency:1 iso_code_3:sju 
 #: DB:language/name:5995
 msgid "Ume Sami"
 msgstr ""

--- a/po/mb_server.de.po
+++ b/po/mb_server.de.po
@@ -9,6 +9,7 @@
 # nikki2 <email address hidden>, 2012
 # Beat Jörg <email address hidden>, 2016
 # Beat Jörg <email address hidden>, 2016
+# Christan Weller <email address hidden>, 2019
 # Daniel Schury <email address hidden>, 2011
 # Daniel Schury <email address hidden>, 2011
 # Dirk Hoffmann <email address hidden>, 2019
@@ -40,7 +41,7 @@
 # nikki, 2013
 # nikki, 2012-2013
 # Philipp Wolfer <email address hidden>, 2012
-# Philipp Wolfer <email address hidden>, 2014-2015
+# Philipp Wolfer <email address hidden>, 2014-2015,2019
 # Philipp Wolfer <email address hidden>, 2012
 # Philipp Wolfer <email address hidden>, 2012
 # S.Brandt <email address hidden>, 2014-2015
@@ -65,9 +66,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-13 09:09+0000\n"
-"Last-Translator: Dirk Hoffmann <email address hidden>\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-02-23 20:24+0000\n"
+"Last-Translator: Christan Weller <email address hidden>\n"
 "Language-Team: German (http://www.transifex.com/musicbrainz/musicbrainz/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -226,6 +227,7 @@ msgstr "(keine)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
@@ -432,9 +434,9 @@ msgstr "Kontoadministratoren"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Kontoadministratoren können Benutzerkonten bearbeiten und löschen."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
-msgstr ""
+msgstr "AcousticBrainz-Eintrag:"
 
 #: ../root/admin/attributes/index.tt:36
 #: ../root/admin/attributes/language.tt:15
@@ -442,7 +444,7 @@ msgstr ""
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -627,10 +629,6 @@ msgstr "Mit Werk verbinden"
 msgid "Add relationship"
 msgstr "Beziehung hinzufügen"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Ausgewählte Künstler zum Vereinen hinzufügen"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Ausgewählte Veranstaltungen zum Vereinen hinzufügen"
@@ -703,7 +701,7 @@ msgstr "Alter:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -723,9 +721,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Aliasse"
 
@@ -773,26 +772,21 @@ msgstr "Tritt auch auf als"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "Amazon-URLs, die mit mehreren Veröffentlichungen verbunden sind"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "Amazon-URLs, die mit mehreren Veröffentlichungen verbunden sind"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Ein Alias ist ein alternativer Name für ein Objekt. Er enthält typischerweise häufig auftretende Falschschreibungen oder Variationen des Namens und wird auch zur Verbesserung der Suche verwendet. Weitere Informationen findest du in der {doc|Alias-Dokumentation}."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Ein anonymer Benutzer"
 msgstr[1] "{n} anonyme Benutzer"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -814,8 +808,7 @@ msgstr "Ein Fehler trat auf: "
 msgid "An error occurred while creating the works."
 msgstr "Beim Erstellen der Werke ist ein Fehler aufgetreten."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -824,8 +817,9 @@ msgstr "Beim Erstellen der Werke ist ein Fehler aufgetreten."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Anmerkung"
@@ -959,11 +953,11 @@ msgstr "Bist du sicher, dass du die Serie {series} aus MusicBrainz entfernen mö
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -1014,24 +1008,27 @@ msgstr "Gebiete"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1077,11 +1074,6 @@ msgstr "Künstler MBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Künstlerabonnements"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Künstleranmerkungen"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1129,7 +1121,7 @@ msgstr "Künstler {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Künstler:"
 
@@ -1137,81 +1129,15 @@ msgstr "Künstler:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Künstler"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Künstler mit Unterscheidungskommentaren im Namen"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Künstler, die mehrfach in der gleichen Künstlernennung vorkommen"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Künstler, die Zusammenarbeiten sein könnten"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Künstler, die Gruppen sein könnten"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Künstler, die Personen sein könnten"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Künstler, die Zusammenarbeitsbeziehungen haben"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Künstler, die wie Zusammenarbeiten aussehen"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Künstler mit Zusammenarbeitsbeziehungen"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Künstler mit Anmerkungen"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Künstler mit veralteten Beziehungen"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Künstler, deren Unterscheidungsmerkmal gleich ihrem Namen ist"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Künstler ohne Abonnenten"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Künstler mit möglicherweise duplizierten Beziehungen"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1376,9 +1302,8 @@ msgstr "Beziehung zu mehreren Werken auf einmal hinzufügen"
 msgid "Batch-create new works"
 msgstr "Mehrere Werke auf einmal erstellen"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Sei der Erste! {sub|Abonnieren}?"
 
@@ -1434,12 +1359,7 @@ msgstr "Anfangsdatum:"
 
 #: ../root/user/profile.tt:58
 msgid "Beginner"
-msgstr ""
-
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr ""
+msgstr "Anfänger"
 
 #: ../root/search/error/internal-error.tt:6
 msgid ""
@@ -1447,10 +1367,6 @@ msgid ""
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Unten befinden sich die Fehlerinformationen. Wenn du einen Fehlerbericht einreichen möchten, kannst du das in {bugs|unserem Bug-Tracker} tun. Die folgenden Informationen werden helfen, gib sie daher bitte mit an!"
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Über mich"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1461,12 +1377,12 @@ msgstr "Über mich:"
 msgid "Birth date:"
 msgstr "Geburtsdatum:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blog"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Geboren:"
 
@@ -1478,13 +1394,13 @@ msgstr "Bot"
 msgid "Bots"
 msgstr "Bots"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "Bereitgestellt von der {MeB|MetaBrainz-Stiftung} und unseren {spon|Sponsoren} und {supp|Unterstützern}. Cover-Art zur Verfügung gestellt vom {caa|Cover-Art-Archiv}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Bug-Tracker"
@@ -1629,7 +1545,7 @@ msgstr "Katalognr."
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Passwort ändern"
 
@@ -1708,14 +1624,6 @@ msgstr "Geschlossen"
 msgid "Code"
 msgstr "Code"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Zusammenarbeit"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Zusammenarbeiter"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Medium zuklappen"
@@ -1744,7 +1652,7 @@ msgstr "Sammlung „{collection}“"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Sammlungen"
@@ -1822,7 +1730,7 @@ msgid "Country:"
 msgstr "Land:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Cover-Art"
 
@@ -1954,7 +1862,7 @@ msgstr "Das Datum ist im Format JJJJ-MM-TT. Unvollständige Daten wie JJJJ-MM od
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Konto löschen"
 
@@ -2006,13 +1914,14 @@ msgstr "Beschreibung:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Details"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Gestorben:"
 
@@ -2022,7 +1931,7 @@ msgstr "Vergleich"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Direkte Datenbanksuche"
 
@@ -2079,7 +1988,7 @@ msgid "Disc ID:"
 msgstr "Disc-ID:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "Disc-IDs"
 
@@ -2099,11 +2008,6 @@ msgstr "Mediumstitel:"
 msgid "Discography"
 msgstr "Diskografie"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "Discogs-URLs, die mit mehreren Künstlern verbunden sind"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2119,32 +2023,12 @@ msgstr "Discogs-URLs, die mit mehreren Veröffentlichungsgruppen verbunden sind"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "Discogs-URLs, die mit mehreren Veröffentlichungen verbunden sind"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "Discogs-URLs, die mit mehreren Künstlern verbunden sind"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "Discogs-URLs, die mit mehreren Labels verbunden sind"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "Discogs-URLs, die mit mehreren Veröffentlichungsgruppen verbunden sind"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "Discogs-URLs, die mit mehreren Veröffentlichungen verbunden sind"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Medien als getrennte Veröffentlichungen"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Medien, die als getrennte Veröffentlichungen eingegeben wurden"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Aufgelöst:"
 
@@ -2162,7 +2046,7 @@ msgstr "Dokumentation:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Hast du noch kein Benutzerkonto? {uri|Erstell einfach eins}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Spenden"
 
@@ -2193,9 +2077,9 @@ msgstr "Jeder Titel in MusicBrainz muss mit einer Aufnahme verbunden sein. Wähl
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -2248,7 +2132,7 @@ msgid "Edit Note Author"
 msgstr "Verfasser der Bearbeitungsbemerkung"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
@@ -2323,10 +2207,10 @@ msgid "Editing/voting disabled"
 msgstr "Kann nicht bearbeiten/abstimmen"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Bearbeiter"
 
@@ -2342,10 +2226,6 @@ msgstr "Bearbeiterabonnements"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Bearbeiter „{user}“"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr ""
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2374,12 +2254,6 @@ msgstr "Bearbeitungen an {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Bearbeitungen geladen für die Seite:"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "E-Mail"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2439,7 +2313,7 @@ msgstr "Beendet"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Beendet:"
 
@@ -2482,11 +2356,6 @@ msgstr "Objekttyp"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Objekttypen:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Fehler"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2536,8 +2405,8 @@ msgstr "Es hilft schon viel, wenn du nur ein oder zwei Links angibst!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2564,13 +2433,14 @@ msgstr "Veranstaltung:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Veranstaltungen"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr ""
 
@@ -2651,7 +2521,7 @@ msgid "Find Relationships"
 msgstr "Beziehungen finden"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Fingerabdrücke"
 
@@ -2700,7 +2570,7 @@ msgstr "Weitere Informationen findest du in der {doc_doc|Dokumentation} und den 
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Weitere Informationen findest du in der {doc_doc|Dokumentation}."
 
@@ -2732,7 +2602,7 @@ msgstr "Format"
 msgid "Format:"
 msgstr "Format:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Foren"
@@ -2788,7 +2658,7 @@ msgstr[1] "{n} Ergebnisse für „{q}“ gefunden"
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Gegründet:"
 
@@ -2844,7 +2714,6 @@ msgstr "Geschlecht:"
 msgid "General Information"
 msgstr "Allgemeine Informationen"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2852,17 +2721,9 @@ msgstr "Allgemeine Informationen"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2870,13 +2731,10 @@ msgstr "Allgemeine Informationen"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2891,13 +2749,11 @@ msgstr "Allgemeine Informationen"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2928,13 +2784,27 @@ msgstr "Allgemeine Informationen"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Erzeugt am {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Genres"
 
@@ -3133,13 +3003,15 @@ msgstr "ISRC {isrc} an {recording}"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRCs"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRCs mit mehreren Aufnahmen"
 
@@ -3163,12 +3035,8 @@ msgstr "ISWC {iswc} an {work}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWCs"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "ISWCs mit mehreren Werken"
 
@@ -3240,15 +3108,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Wenn du denkst, dass dies ein Fehler ist, kontaktiere bitte <code>support@musicbrainz.org</code> und gib deinen Kontonamen an."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Falls du am Bearbeitungsprozess teilnehmen willst, aber nicht so recht weißt, wo du anfangen sollst, könnten die folgenden Reporte einen guten Einstieg bilden. Diese Reporte durchstreifen die Datenbank nach Daten, die möglicherweise korrigiert werden müssen, entweder um mit den {style|Stilrichtlinien} übereinzustimmen, oder in anderen Fällen, wo administrative „Aufräumarbeiten“ nötig sind."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3286,11 +3145,11 @@ msgstr "Falscher Benutzername oder Passwort"
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Indexierte Suche"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Indexierte Suche mit {doc|erweiterter Abfragesyntax}"
 
@@ -3301,7 +3160,7 @@ msgstr "Indexierte Suche mit {doc|erweiterter Abfragesyntax}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3326,13 +3185,14 @@ msgstr "Instrumentendetails"
 msgid "Instrument:"
 msgstr "Instrument:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Instrumente"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Instrumente ohne Bild"
 
@@ -3398,9 +3258,9 @@ msgstr "Eingeloggt bleiben"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3461,31 +3321,28 @@ msgstr "Label:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Labels"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Labels mit Anmerkungen"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Labels mit veralteten Beziehungen"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Label, deren Unterscheidungsmerkmal gleich ihrem Namen ist"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Label mit möglicherweise duplizierten Beziehungen"
 
@@ -3526,7 +3383,6 @@ msgstr "Letzte 24 Stunden"
 msgid "Last 28 days"
 msgstr "In den letzten 28 Tagen"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3534,6 +3390,7 @@ msgstr "In den letzten 28 Tagen"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Zuletzt bearbeitet"
 
@@ -3541,7 +3398,7 @@ msgstr "Zuletzt bearbeitet"
 msgid "Last login:"
 msgstr "Letzter Login:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Letztes Replikations-Paket erhalten am {datetime}"
 
@@ -3549,7 +3406,7 @@ msgstr "Letztes Replikations-Paket erhalten am {datetime}"
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Zuletzt aktualisiert:"
 
@@ -3619,14 +3476,14 @@ msgid "Loading edit previews..."
 msgstr "Lade Bearbeitungsvorschauen …"
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Lade …"
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Sprachumgebung"
 
@@ -3636,6 +3493,7 @@ msgstr "Sprachumgebung:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Ort"
 
@@ -3708,7 +3566,7 @@ msgstr "Niedrig"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Liedtextsprachen"
 
@@ -3743,7 +3601,7 @@ msgid "Many relationships"
 msgstr "Viele Beziehungen"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Karte"
 
@@ -3804,10 +3662,6 @@ msgstr "Medium:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Medien:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Mitglied seit"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3919,7 +3773,7 @@ msgstr "Beliebteste"
 msgid "Most Recent"
 msgstr "Jüngste"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Verschieben"
 
@@ -4048,7 +3902,7 @@ msgstr "Name"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Name:"
 
@@ -4150,7 +4004,7 @@ msgstr "Neue Version:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Weiter"
@@ -4226,7 +4080,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Keine Veröffentlichungen haben Cover-Art, das als „Vorderseite“ markiert ist; kann Cover-Art nicht festlegen."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Keine Ergebnisse"
 
@@ -4240,7 +4094,7 @@ msgstr "Keine Ergebnisse gefunden."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Keine Ergebnisse gefunden. Versuche es doch mit einer veränderten Suchanfrage noch einmal."
 
@@ -4265,13 +4119,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "Niemand hat in den letzten drei Monaten Bemerkungen zu einer deiner Bearbeitungen hinterlassen."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Niemand hat dies bereits getaggt."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Nicht-digitale Veröffentlichungen mit Download-Beziehungen"
 
@@ -4281,7 +4135,7 @@ msgid "None"
 msgstr "Keine"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr ""
@@ -4490,18 +4344,18 @@ msgid "Other lookups"
 msgstr "Andere Dinge nachschlagen"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
-msgstr ""
+msgstr "Andere Tags"
 
 #: ../root/user/profile.tt:232
 msgid "Overall"
 msgstr "Insgesamt"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Übersicht"
@@ -4578,11 +4432,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Führe die obigen Schritte durch, wenn ich die Anwendung nicht benutze"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Aufführungen"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Permanenter Link:"
 
@@ -4594,8 +4448,8 @@ msgstr "Phrase:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4621,25 +4475,22 @@ msgstr "Örtlichkeit:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Örtlichkeiten"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Örtlichkeiten mit Anmerkungen"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Örtlichkeiten mit veralteten Beziehungen"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
-msgstr ""
+msgstr "Örtlichkeiten ohne Koordinaten"
 
 #: ../root/main/500.tt:31
 msgid ""
@@ -4760,22 +4611,14 @@ msgid "Possible duplicate events"
 msgstr "Möglicherweise doppelte Veranstaltungen"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Möglicherweise doppelte Veröffentlichungsgruppen"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Mögliche Werte:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Möglicherweise doppelte Künstler"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Möglicherweise doppelte Veranstaltungen"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4793,7 +4636,7 @@ msgstr "Vorschau:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Vorheriges"
@@ -4845,7 +4688,7 @@ msgid "Public collection by {owner}"
 msgstr "Öffentliche Sammlung von {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Suchtext:"
 
@@ -4870,7 +4713,7 @@ msgstr "Bewertung"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Bewertungen"
 
@@ -4900,7 +4743,7 @@ msgstr "Bemerkungen, die kürzlich zu deinen Bearbeitungen hinterlassen wurden"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4943,21 +4786,22 @@ msgstr "Aufnahme:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Aufnahmen"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
@@ -4971,40 +4815,28 @@ msgstr "Aufnahmen mit „früheste Veröffentlichung“-Beziehungen"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Aufnahmen mit unterschiedlichen Titellängen"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Aufnahmen mit Anmerkungen"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Aufnahmen mit veralteten Beziehungen"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Aufnahmen mit „früheste Veröffentlichung“-Beziehungen"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Aufnahmen mit möglicherweise doppelten Beziehungen"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr ""
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Aufnahmen, deren Titel „featuring“ Künstler enthalten"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Aufnahmen mit unterschiedlichen Titellängen"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5040,7 +4872,7 @@ msgstr "Verbundene Objekte:"
 
 #: ../root/components/relationships.tt:45
 msgid "Related series"
-msgstr ""
+msgstr "Verbundene Serien"
 
 #: ../root/components/relationships.tt:37
 msgid "Related works"
@@ -5062,7 +4894,6 @@ msgid "Relationship Editor"
 msgstr "Beziehungsbearbeiter"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5070,6 +4901,7 @@ msgstr "Beziehungsbearbeiter"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Beziehungstyp"
 
@@ -5119,7 +4951,7 @@ msgstr "Beziehung:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Beziehungen"
 
@@ -5151,7 +4983,7 @@ msgstr "Beziehungen:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5183,7 +5015,7 @@ msgstr "Veröffentlichungsereignisse:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Veröffentlichungsgruppe"
@@ -5219,7 +5051,7 @@ msgstr "Veröffentlichungsgruppen"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Veröffentlichungsgruppen mit veralteten Beziehungen"
 
@@ -5278,6 +5110,7 @@ msgid "Release group ratings"
 msgstr "Veröffentlichungsgruppenbewertungen"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Veröffentlichungsgruppe „{name}“ von {artist}"
 
@@ -5289,38 +5122,27 @@ msgstr "Veröffentlichungsgruppe „{name}“ von {artist}"
 msgid "Release group:"
 msgstr "Veröffentlichungsgruppe:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Veröffentlichungsgruppen"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Veröffentlichungsgruppen, die eventuell vereint werden müssen"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Veröffentlichungsgruppen mit Anmerkungen"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Veröffentlichungsgruppen mit möglicherweise doppelten Beziehungen"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Veröffentlichungsgruppen, deren Titel „featuring“ Künstler enthalten"
 
@@ -5363,8 +5185,8 @@ msgstr "Veröffentlichung:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Veröffentlichungen"
@@ -5398,67 +5220,43 @@ msgstr "Veröffentlichungen mit mehreren Discogs-Links"
 msgid "Releases With Some Formats Unset"
 msgstr "Veröffentlichungen, bei denen einige Formate nicht gesetzt sind"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Veröffentlichungen im Cover-Art-Archiv, die noch Cover-Art-Beziehungen haben"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr ""
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr ""
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Veröffentlichungen jeglicher Art, die noch Cover-Art-Beziehungen haben"
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Zu früh veröffentlichte Veröffentlichungen"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr ""
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Veröffentlichungen, wo bei einigen (aber nicht allen) Medien kein Format angegeben ist"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Veröffentlichungen mit mehreren ASINs"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Veröffentlichungen mit mehreren Discogs-Links"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Veröffentlichungen mit Teil-eines-Sets-Beziehungen"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Veröffentlichungen mit unerwarteten Amazon-URLs"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Veröffentlichungen, die möglicherweise in „mehrere Künstler“ umgewandelt werden müssen"
 
@@ -5467,23 +5265,15 @@ msgstr "Veröffentlichungen, die möglicherweise in „mehrere Künstler“ umge
 msgid "Releases with Cover Art relationships"
 msgstr "Veröffentlichungen mit Cover-Art-Beziehungen"
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Veröffentlichungen mit nur einem Medium, das einen Namen hat"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Veröffentlichungen mit Anmerkungen"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Veröffentlichungen mit Katalognummern, die wie ASINs aussehen"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Veröffentlichungen mit veralteten Beziehungen"
 
@@ -5492,31 +5282,25 @@ msgstr "Veröffentlichungen mit veralteten Beziehungen"
 msgid "Releases with medium number issues"
 msgstr "Veröffentlichungen mit Mediumsnummer-Problemen"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Veröffentlichungen ohne Medien"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Veröffentlichungen mit nicht-sequentiellen Medien"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Veröffentlichungen mit nicht-sequentiellen Titelnummern"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Veröffentlichungen mit möglicherweise doppelten Beziehungen"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Veröffentlichungen mit überflüssigen Datentracks"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Veröffentlichungen, deren Titel „featuring“ Künstler enthalten"
 
@@ -5525,24 +5309,26 @@ msgstr "Veröffentlichungen, deren Titel „featuring“ Künstler enthalten"
 msgid "Releases with track number issues"
 msgstr "Veröffentlichungen mit Titelnummer-Problemen"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Veröffentlichungen mit unbekannten Titellängen"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Veröffentlichungen mit unwahrscheinlichen Sprach-Schrift-Kombinationen"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Veröffentlichungen ohne Sprache"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Veröffentlichungen ohne Schrift"
 
@@ -5568,7 +5354,7 @@ msgstr "Veröffentlichungen:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5580,7 +5366,7 @@ msgstr "Veröffentlichungen:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Entfernen"
@@ -5720,11 +5506,6 @@ msgstr "Benutzer melden"
 msgid "Report this user for bad behavior"
 msgstr "Fehlverhalten dieses Benutzers melden"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Reporte"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Zeitüberschreitung bei Anfrage"
@@ -5747,7 +5528,7 @@ msgstr "Passwort zurücksetzen"
 msgid "Reset track numbers"
 msgstr "Titelnummern zurücksetzen"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Ergebnisse pro Seite:"
 
@@ -5787,7 +5568,7 @@ msgstr "Lies unsere {url|documentation} zum Release Editor Seeding und stell sic
 msgid "Role"
 msgstr "Rolle"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Serverversion: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5830,7 +5611,7 @@ msgstr "Schrift:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5867,7 +5648,7 @@ msgstr "Künstler suchen"
 
 #: ../root/report/places_without_coordinates.tt:12
 msgid "Search for coordinates"
-msgstr ""
+msgstr "Nach Koordinaten suchen"
 
 #: ../root/edit/list_header.tt:8
 msgid "Search for edits"
@@ -5877,7 +5658,7 @@ msgstr "Bearbeitungen suchen"
 msgid "Search for the target URL."
 msgstr "Suche nach der Ziel-URL."
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Suchmethode:"
 
@@ -5966,7 +5747,7 @@ msgstr "Eine Kopie an meine eigene E-Mail-Adresse senden"
 msgid "Sentence"
 msgstr "Satz"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Serien"
@@ -5981,8 +5762,8 @@ msgstr "Serien"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -6005,10 +5786,6 @@ msgstr "Serienabonnements"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "Serienanmerkungen"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "Serien mit Anmerkungen"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -6037,7 +5814,7 @@ msgstr "Setze ein neues Passwort für dein MusicBrainz-Benutzerkonto."
 msgid "Set cover art"
 msgstr "Cover-Art festlegen"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Titellängen setzen"
 
@@ -6050,10 +5827,6 @@ msgstr "Setliste"
 msgid "Setlist:"
 msgstr "Setliste:"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Zeige alle Ergebnisse."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "Benachrichtige mich immer, wenn ich eine neue Bearbeitungsbemerkung erhalte."
@@ -6063,10 +5836,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Zeige mir {autoedit_select_block}, auf die {and_vs_or_block} der folgenden Bedingungen {match_or_negation_block}, {sort_select_block}:"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Zeige nur Ergebnisse, die zu meinen abonnierten Objekten gehören."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6202,7 +5971,7 @@ msgstr "Tut uns leid, die Seite, die du sehen möchtest, ist auf einem Spiegelse
 msgid "Sorry, there was a problem with your request."
 msgstr "Entschuldigung, es gab ein Problem mit deiner Anfrage."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Tut uns leid, aber du bist nicht berechtigt, diese Seite anzusehen."
 
@@ -6226,8 +5995,8 @@ msgstr "Tut uns leid, „{id}“ ist keine gültige Dokumentationsseite."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Sortiername"
 
@@ -6281,7 +6050,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Status:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Beta-Seite nicht mehr benutzen"
 
@@ -6335,12 +6104,10 @@ msgstr "Abonnierende Bearbeiter"
 msgid "Subscribed entities"
 msgstr "Abonnierte Objekte"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6388,8 +6155,8 @@ msgid "Tagger"
 msgstr "Tagger"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6460,7 +6227,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Die Daten in dieser Bearbeitung kamen ursprünglich aus einer älteren Version dieser Bearbeitung und werden möglicherweise nicht korrekt dargestellt"
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6471,7 +6238,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "Die Daten, die du platziert hast, enthielten die folgenden Fehler:"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "Das von dir eingegebene Datum ist ungültig"
 
@@ -6570,7 +6337,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Der Suchserver konnte deine Anfrage aufgrund eines internen Fehlers nicht ausführen. Dies ist üblicherweise nur ein temporärer Fehler, versuche es bitte also später nochmal."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "Der Server ist wegen Wartungsarbeiten an der Datenbank vorübergehend im Nur-lese-Modus."
 
@@ -6609,21 +6376,9 @@ msgstr "Derzeit abonnieren keine Benutzer deine Bearbeitungen."
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Derzeit abonnieren keine Benutzer die Bearbeitungen von {user}."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Derzeit abonnieren keine Benutzer den Künstler {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "Derzeit abonnieren keine Benutzer die Sammlung {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Derzeit gibt es keine Benutzer, die {label} abonnieren."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "Derzeit gibt es keine Benutzer, die {series} abonnieren."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6632,12 +6387,12 @@ msgid ""
 msgstr "An dieser Veröffentlichung hängen keine Disc-IDs. Um mehr darüber zu erfahren, wie man eine hinzufügt, siehe {doc|Wie man Disc-IDs hinzufügt}."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr ""
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr ""
 
@@ -6663,29 +6418,11 @@ msgid_plural ""
 msgstr[0] "Derzeit gibt es einen Benutzer, der die Bearbeitungen von {user} abonniert:"
 msgstr[1] "Derzeit gibt es {num} Benutzer, die die Bearbeitungen von {user} abonnieren:"
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Derzeit gibt es einen Benutzer, der {artist} abonniert:"
-msgstr[1] "Derzeit gibt es {num} Benutzer, die {artist} abonnieren:"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "Derzeit gibt es einen Benutzer, der {collection} abonniert:"
 msgstr[1] "Derzeit gibt es {num} Benutzer, der {collection} abonniert:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Derzeit gibt es einen Benutzer, der {label} abonniert:"
-msgstr[1] "Derzeit gibt es {num} Benutzer, die {label} abonnieren:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "Derzeit abonniert ein Benutzer {series}:"
-msgstr[1] "Derzeit gibt es {num} Benutzer, die {series} abonnieren:"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6793,7 +6530,7 @@ msgid ""
 msgstr ""
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Dieser Künstler ist beendet."
 
@@ -6843,7 +6580,7 @@ msgstr "Dieser Künstler hat nur inoffizielle Veröffentlichungsgruppen."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Dieser Eigenschaftstyp wird nur zur Gruppierung verwendet, bitte wähle einen Untertyp"
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Dieser Beta-Testserver ermöglicht das Testen von neuen Features mit der Live-Datenbank."
@@ -6950,11 +6687,11 @@ msgid ""
 "attributed to it."
 msgstr "Dieses Instrument kann nicht entfernt werden, weil es noch Teil von Beziehungen ist."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Dies ist ein MusicBrainz-Entwicklungsserver."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7074,7 +6811,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Diese Aufnahme hat keine verbundenen AcoustIDs"
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "Diese Aufnahme ist ein Video"
@@ -7108,7 +6845,7 @@ msgstr "Dieser Beziehungstyp kann keine Attribute haben."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "Dieser Beziehungstyp ist veraltet und sollte nicht verwendet werden."
 
@@ -7142,16 +6879,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "Dieser Veröffentlichungsstatus sollte für inoffizielle Übersetzungen und Umschreibungen von Titellisten und Veröffentlichungstiteln verwendet werden und stellt keine eigenständige, echte Veröffentlichung dar. Er sollte nicht für Bootlegs, Mixtape-/Street-Alben, Demos oder digitale Alben verwendet werden. Verlinke bitte auch die entsprechende echte Veröffentlichung mittels der {url|Übersetzungs-/Umschreibungs-Beziehung}."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Dieser Report hat das Ziel, Künstler mit sehr ähnlichen Namen zu identifizieren. Wenn es sich bei zwei Künstlern eigentlich um den gleichen handelt, vereine sie bitte (denk daran, {how_to_write_edit_notes|eine Bearbeitungsbemerkung zu schreiben} und deinen Nachweis mit anzugeben). Sind sie jedoch unterschiedlich, so gib ihnen {disambiguation_comment|Unterscheidungskommentare} (und sobald eine Gruppe von ähnlich benannten Künstlern Unterscheidungskommentare hat, werden sie hier nicht mehr auftauchen)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7193,85 +6920,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr "Dieser Report listet alle Veröffentlichungen auf, bei denen die Medien nicht durchgehend nummeriert sind (z.&nbsp;B. wenn es ein \"Medium 1\" und \"Medium 3\" gibt, aber kein „Medium 2“)"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "Dieser Report listet Künstler auf, die mehr als einmal an verschiedenen Stellen innerhalb der selben Künstlernennung auftauchen."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "Dieser Report listet Künstler auf, die kein Bearbeiter abonniert hat und deren Änderungen daher nicht zur Genüge überprüft werden. Künstler mit mehr Veröffentlichungsgruppen und mehr offenen Bearbeitungen werden zuerst aufgelistet."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "Dieser Report listet alle Künstler auf, deren Typ auf etwas anderes als <em>Gruppe</em> gesetzt ist, die aber <em>Gruppen</em> sein könnten, da sie andere Künstler als Mitglieder eingetragen haben. Wenn ein hier aufgelisteter Künstler wirklich eine Gruppe ist, ändere ihren Typ. Wenn nicht, stelle bitte sicher, dass alle „Mitglied von“-Beziehungen in die richtige Richtung zeigen und korrekt sind."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "Dieser Report listet alle Künstler auf, deren Typ auf etwas anderes als <em>Person</em> gesetzt ist, die aber ihren Beziehungen nach <em>Personen</em> sein könnten. Ein Künstler wird zum Beispiel hier aufgelistet, wenn er als Mitglied eines anderen eingetragen ist. Wenn ein hier aufgelisteter Künstler wirklich eine Person ist, ändere ihren Typ. Wenn nicht, stelle bitte sicher, dass alle Beziehungen richtig sind und Sinn ergeben."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Dieser Report listet alle Künstler auf, die eventuell Unterscheidungskommentare in ihren Namen haben, statt im eigentlichen Feld für Unterscheidungskommentare."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Dieser Report listet alle Künstler auf, deren Name ein „&“ enthält, die aber keine Mitglieds- oder Zusammenarbeitsbeziehungen haben. Wenn der Künstler überlicherweise als eine richtige Gruppe angesehen wird, sollten Mitgliedsbeziehungen hinzugefügt werden. Wenn es sich um eine kurzzeitige Zusammenarbeit handelt, sollte er nach Möglichkeit aufgeteilt werden (see {how_to_split_artists|Wie man Künstler aufteilt}). Wenn es eine Zusammenarbeit mit eigenem Namen ist und nicht aufgeteilt werden kann, sollten Zusammenarbeitsbeziehungen hinzugefügt werden."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Dieser Report listet Künstler auf, die Zusammenarbeitsbeziehungen haben, aber keine URL-Beziehungen. Wenn diese Zusammenarbeit ihren eigenen unabhängigen Namen hat, unternimm nichts weiter. Wenn der Name in der Form „X mit Y“ oder „X & Y“ ist, solltest du ihn wahrscheinlich aufteilen. Siehe {how_to_split_artists|Wie man Künstler aufteilt}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "Dieser Report listet Künstler auf, die mehrere Beziehungen zum gleichen Künstler, Label oder einer URL haben und dabei den gleichen Beziehungstyp verwenden. Zu mehreren Beziehungen zu Veröffentlichungsgruppen, Aufnahmen oder Werken, siehe die Berichte für diese Objekte."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "Dieser Report listet Künstler auf, die Beziehungen haben, die veraltete und nur zum Gruppieren gedachte Beziehungstypen verwenden"
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "Dieser Report listet Künstler auf, die Anmerkungen haben."
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7433,10 +7081,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "Dieser Report listet {iswc|ISWCs} auf, die mit mehr als einem Werk verbunden sind. Wenn die Werke die gleichen sind, bedeutet das in der Regel, dass sie vereint werden sollten."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr ""
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7447,10 +7091,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Dieser Report zeigt Amazon-URLs, die mit mehreren Veröffentlichungen verbunden sind. In den meisten Fällen sollten Amazon-ASINs 1:1 mit MusicBrainz-Veröffentlichungen korrespondieren, daher dürfte nur einer der Links richtig sein. Überprüfe einfach, welche MusicBrainz-Veröffentlichung auf die Veröffentlichung in Amazon passt (indem du das Format, die Titelliste etc. vergleichst). Wenn die Veröffentlichung einen Strichcode hat, kannst du Amazon auch danach durchsuchen und herausfinden, welche ASIN passt. Eventuell findest du auch ASINs, die mit mehren CDs einer Multi-CD-Veröffentlichung verbunden sind: Diese kannst du einfach zu einer Veröffentlichung vereinen (siehe {how_to_merge_releases|Wie man Veröffentlichungen vereint})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Dieser Report zeigt Discogs-URLs, die mit mehreren Künstlern verlinkt sind."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7730,7 +7370,7 @@ msgstr "Diese Serie ist derzeit leer."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Diese Tabelle zeigt eine Zusammenfassung der Stimmabgaben dieses Bearbeiters."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "Dieser Titel ist eine Datenspur."
 
@@ -7856,29 +7496,6 @@ msgstr "Gefundene ISWCs insgesamt: {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Gefundene URLs insgesamt: {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Gefundene Künstler insgesamt: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Doppelte Gruppen insgesamt: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr ""
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -8038,7 +7655,7 @@ msgstr "Titel:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Titelliste"
 
@@ -8056,10 +7673,6 @@ msgstr "Titelliste:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Titel"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Titel, deren Namen ihre Sequenznummer enthalten"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8088,16 +7701,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Transklusionsbearbeiter sind Benutzer, die Einträge in die {uri|WikiDocs} Transklusionstabelle hinzufügen oder vorhandene warten."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Übersetzte/transliterierte Pseudo-Veröffentlichungen, die nicht mit einer Originalversion verbunden sind"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8113,15 +7721,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8135,7 +7746,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Typ"
 
@@ -8163,7 +7774,7 @@ msgstr "Typ"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Typ:"
 
@@ -8179,14 +7790,15 @@ msgstr "Typ: {type}, Status: {status}"
 msgid "Types:"
 msgstr "Typen:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8206,17 +7818,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URLs"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "URLs mit veralteten Beziehungen"
 
@@ -8238,8 +7850,12 @@ msgstr "Unerlaubte Anfrage"
 msgid "Unclassified instrument"
 msgstr "Unklassifiziertes Instrument"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -8266,9 +7882,9 @@ msgstr "Abbestellen"
 msgid "Untrusted"
 msgstr "Nicht vertrauenswürdig"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Bis zu {n}"
 
@@ -8301,7 +7917,7 @@ msgstr "Bild wird hochgeladen ..."
 msgid "Uppercase roman numerals"
 msgstr "Großgeschriebene römische Zahlen"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Beta-Seite benutzen"
 
@@ -8357,7 +7973,7 @@ msgid "Username:"
 msgstr "Benutzername:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Benutzer"
 
@@ -8489,10 +8105,6 @@ msgstr "Warnung: Diese Beziehung hat ausstehende Bearbeitungen. {show|Klicke hie
 msgid "Watched Artists"
 msgstr "Beobachtete Künstler"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Tut uns leid, aber zur Zeit stehen für diesen Report keine Daten zur Verfügung."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "Wir können für dieses Cover-Art keine Historie anzeigen."
@@ -8538,10 +8150,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Es tut uns fürchterlich keid, dass dieses Problem aufgetreten ist! Bitte warte ein paar Minuten und wiederhole deine Anfrage – das Problem löst sich dann vielleicht einfach von selbst."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Website"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Website:"
@@ -8554,7 +8162,7 @@ msgid ""
 "and following the merge link."
 msgstr "Wenn du so weit bist, diese zu vereinen, klicke einfach auf den Vereinen-Button. Du kannst aber auch mehr zu dieser Vereinigungsliste hinzufügen, indem du einfach zu den Seiten der Objekte gehst und dort den Vereinen-Link benutzt."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8576,10 +8184,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Werk"
 
@@ -8618,35 +8226,32 @@ msgstr "Werk:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Werke"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Werke mit Anmerkungen"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Werke mit veralteten Beziehungen"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Werke mit möglicherweise doppelten Beziehungen"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Autoren"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8759,9 +8364,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Du bist im Begriff, die folgenden Werke in einem einzigen aufgehen zu lassen. Bitte wähle das Werk, in das die anderen Werke integriert werden sollen:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Du bist derzeit Abonnent. {unsub|Nicht mehr abonnieren}?"
 
@@ -8777,9 +8381,8 @@ msgstr "Du kannst derzeit keine Bemerkungen zu dieser Bearbeitung abgegeben. ({u
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Du kannst derzeit nicht über diese Bearbeitung abstimmen. ({url|Details})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Du bist derzeit nicht Abonnent. {sub|Abonnieren}?"
 
@@ -8856,10 +8459,10 @@ msgstr "Du hast den {valink|Diverse-Interpreten}-Spezialkünstler auf dieser Auf
 
 #: ../root/release/edit/information.tt:30
 msgid "You haven’t entered a complete artist credit."
-msgstr ""
+msgstr "Du hast noch keine vollständige Künstlernennung eingetragen."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Du hast keine Veränderungen durchgeführt!"
 
@@ -8884,7 +8487,7 @@ msgstr ""
 msgid "You must be logged in to vote on edits"
 msgstr "Zum Abstimmen über Bearbeitungen musst du eingeloggt sein."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Du musst einen Unterscheidungskommentar für dieses Objekt eingeben."
 
@@ -8966,7 +8569,7 @@ msgstr "Deine Suche dauerte zu lange und wurde abgebrochen. Es kann helfen, gena
 msgid "Your username will be publicly visible."
 msgstr "Dein Benutzername wird öffentlich sichtbar sein."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8975,7 +8578,7 @@ msgstr "Du bist momentan nicht berechtigt, Bearbeitungen vorzunehmen oder abzust
 
 #: ../root/edit/cannot_vote.tt:3
 msgid "You’re not currently allowed to vote, please read the banner."
-msgstr ""
+msgstr "Du kannst derzeit nicht abstimmen, bitte lese das Banner."
 
 #: ../root/release/edit/tracklist.tt:258
 msgid ""
@@ -9008,10 +8611,6 @@ msgstr "[unbekannt]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "nach"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "Alias:"
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9074,10 +8673,6 @@ msgstr "abgesagt"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "genannt als"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr "löschen"
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9296,9 +8891,7 @@ msgstr "Original"
 msgid "places"
 msgstr "Örtlichkeiten"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "plus ein weiterer anonymer Benutzer"
@@ -9521,7 +9114,7 @@ msgstr[1] "{entity} wurde zu {num} Sammlungen hinzugefügt:"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} wurde zu keiner Sammlung hinzugefügt."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9535,7 +9128,7 @@ msgstr "{link} hat keine Bewertungen."
 msgid "{link} has no relationships."
 msgstr "{link} hat keine Beziehungen."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainz Identifikator\">MBID</abbr>}:"
 
@@ -9648,7 +9241,7 @@ msgstr "{type} „{instrument}“"
 msgid "{type} “{work}”"
 msgstr "{type} „{work}“"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Zurück zu musicbrainz.org}."
 
@@ -9855,34 +9448,34 @@ msgstr "„{id}“ ist keine gültige Wahl-ID"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Der erforderliche TOC-Parameter war ungültig oder nicht vorhanden"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Gib bitte eine Medium-ID an"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Medium konnte nicht gefunden werden"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "Die angegebene CD-TOC ist ungültig"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "Die angegebene Mediums-ID ist ungültig"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Diese CD-TOC ist bereits mit diesem Medium verbunden"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Das ausgewählte Medium kann keine Disc-IDs haben"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "Die angegebene Künstler-ID ist nicht gültig"
 
@@ -10264,7 +9857,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Veröffentlichung in mehrere Künstler umwandeln (historisch)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Titellängen setzen"
 
@@ -10565,6 +10158,12 @@ msgstr "Durch Abstimmung fehlgeschlagen"
 msgid "Failed dependency"
 msgstr "Durch Abhängigkeit fehlgeschlagen"
 
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Fehler"
+
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
 msgstr "Durch Vorbedingungen fehlgeschlagen"
@@ -10778,7 +10377,7 @@ msgstr "{role} (als {credited_name})"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Gutenberg.pm:9
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Projekt Gutenberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/IMSLP.pm:31
 msgid "Score at IMSLP"
@@ -10893,7 +10492,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Diese Koordinaten konnten nicht erkannt werden"
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "Das Enddatum kann nicht vor dem Anfangsdatum liegen."
 
@@ -10997,13 +10596,13 @@ msgstr "Du musst eine Bearbeitungsbemerkung angeben"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "CD-Stub"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Tag"
@@ -11011,7 +10610,7 @@ msgstr "Tag"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Dokumentation"
 
@@ -11271,7 +10870,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Spendencheck"
 
@@ -11322,6 +10921,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr ""
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "E-Mail"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11353,7 +10958,7 @@ msgid ""
 msgstr "Wir haben dir Informationen zu deinem MusicBrainz-Konto geschickt. Wenn du diese Nachricht nicht erhältst oder immer noch Probleme beim Einloggen hast, so {link|kontaktiere uns} bitte."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -11489,7 +11094,7 @@ msgstr ""
 msgid "Unconfirmed Email Address"
 msgstr "Unbestätigte E-Mail-Adresse"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} in {parent_areas}"
 
@@ -11529,32 +11134,32 @@ msgid ""
 msgstr "Tut uns leid, wir konnten keinen Künstler mit dieser MusicBrainz-ID finden. Vielleicht möchtest du stattdessen versuchen, {search_url|danach zu suchen}?"
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Geboren in:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Gegründet in:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Anfangsgebiet:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Gestorben in:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Aufgelöst in:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Endgebiet:"
 
@@ -11574,25 +11179,25 @@ msgstr "Sammlung nicht gefunden"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Tut uns leid, wir konnten keine Sammlung zu dieser MusicBrainz-ID finden."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Anfangsdatum"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Enddatum"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr ""
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} hat keine Aliasse."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
-msgstr ""
+msgstr "Einen neuen Alias hinzufügen"
 
 #: ../root/components/ConfirmLayout.js:38
 msgid "Yes, I am sure"
@@ -11632,19 +11237,19 @@ msgstr[1] "Läuft in <span class=\"tooltip\" title=\"{exactdate}\">{num} Minuten
 msgid "Already expired"
 msgstr "Schon abgelaufen"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profil"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Benutzer bearbeiten"
 
@@ -11706,7 +11311,7 @@ msgid "For more information:"
 msgstr "Weitere Informationen:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Bemerkung hinzufügen"
 
@@ -11885,6 +11490,22 @@ msgstr "Abstimmung"
 msgid "Votes cast"
 msgstr "Abgegebene Stimmen"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] "Derzeit gibt es {num} Benutzer, der {entity} abonniert:"
+msgstr[1] "Derzeit gibt es {num} Benutzer, die {entity} abonnieren:"
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] "Plus {n} weiterer anonymer Benutzer"
+msgstr[1] "Plus {n} weitere anonyme Benutzer"
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr "Derzeit gibt es keine Benutzer, die {entity} abonnieren."
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Veranstaltung nicht gefunden"
@@ -11898,7 +11519,7 @@ msgstr "Tut uns leid, wir konnten keine Veranstaltung mit dieser MusicBrainz-ID 
 #: ../root/genre/List.js:22 ../root/genre/List.js:24
 #: ../root/layout/components/BottomMenu.js:276
 msgid "Genre List"
-msgstr ""
+msgstr "Genres"
 
 #: ../root/genre/List.js:26
 msgid ""
@@ -11911,7 +11532,7 @@ msgid ""
 "ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "Instrument"
 
@@ -12153,6 +11774,11 @@ msgstr "Ereignis hinzufügen"
 msgid "Vote on Edits"
 msgstr "Über Bearbeitungen abstimmen"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Reporte"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Leitfaden für Anfänger"
@@ -12193,23 +11819,23 @@ msgstr "Alle Beziehungen ansehen"
 msgid "Running: {git_details}"
 msgstr "Serverversion: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Seite {n}"
 
-#: ../root/layout/components/Head.js:64
-msgid "MusicBrainz: Artist"
-msgstr ""
-
 #: ../root/layout/components/Head.js:65
+msgid "MusicBrainz: Artist"
+msgstr "MusicBrainz: Künstler"
+
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Label"
 
-#: ../root/layout/components/Head.js:66
-msgid "MusicBrainz: Release"
-msgstr ""
-
 #: ../root/layout/components/Head.js:67
+msgid "MusicBrainz: Release"
+msgstr "MusicBrainz: Veröffentlichung"
+
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Titel"
 
@@ -12444,9 +12070,13 @@ msgstr "Instrumenteninformationen"
 msgid "Label information"
 msgstr "Labelinformationen"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Zuletzt aktualisiert am {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr ""
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12471,11 +12101,11 @@ msgstr "Cover-Art von {cover|Amazon}"
 
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:96
 msgid "Cover art from {cover|{host}}"
-msgstr ""
+msgstr "Cover-Art von {cover|{host}}"
 
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:107
 msgid "No front cover image available."
-msgstr ""
+msgstr "Kein vorderes Cover-Bild verfügbar."
 
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:110
 msgid "View all artwork"
@@ -12522,20 +12152,20 @@ msgid "see all ratings"
 msgstr "alle Bewertungen ansehen"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(keine)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(keine)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
-msgstr ""
+msgstr "Alle Tags anzeigen"
 
 #: ../root/layout/components/sidebar/WorkSidebar.js:57
 msgid "Work information"
@@ -12702,11 +12332,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Tut uns leid, wir konnten keine Aufnahme mit dieser MusicBrainz-ID finden. Vielleicht möchtest du stattdessen versuchen, {search_url|danach zu suchen}?"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "Video von {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Aufnahme von {artist}"
 
@@ -12735,9 +12365,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Tut uns leid, wir konnten keine Veröffentlichungsgruppe mit dieser MusicBrainz-ID finden. Vielleicht möchtest du stattdessen versuchen, {search_url|danach zu suchen}?"
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Veröffentlichungsgruppe von {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Künstleranmerkungen"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "Dieser Report listet Künstler auf, die Anmerkungen haben."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Gefundene Künstler insgesamt: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Künstler mit Unterscheidungskommentaren im Namen"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Dieser Report listet alle Künstler auf, die eventuell Unterscheidungskommentare in ihren Namen haben, statt im eigentlichen Feld für Unterscheidungskommentare."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Künstler, deren Unterscheidungsmerkmal gleich ihrem Namen ist"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Künstler, die Gruppen sein könnten"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Künstler, die Personen sein könnten"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "Dieser Report listet Künstler auf, die mehr als einmal an verschiedenen Stellen innerhalb der selben Künstlernennung auftauchen."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Künstler ohne Abonnenten"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "Dieser Report listet Künstler auf, die kein Bearbeiter abonniert hat und deren Änderungen daher nicht zur Genüge überprüft werden. Künstler mit mehr Veröffentlichungsgruppen und mehr offenen Bearbeitungen werden zuerst aufgelistet."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr "Künstler mit Zusammenarbeitsbeziehungen"
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Dieser Report listet Künstler auf, die Zusammenarbeitsbeziehungen haben, aber keine URL-Beziehungen. Wenn diese Zusammenarbeit ihren eigenen unabhängigen Namen hat, unternimm nichts weiter. Wenn der Name in der Form „X mit Y“ oder „X & Y“ ist, solltest du ihn wahrscheinlich aufteilen. Siehe {how_to_split_artists|Wie man Künstler aufteilt}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Zusammenarbeit"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Zusammenarbeiter"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Künstler mit veralteten Beziehungen"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "Dieser Report listet Künstler auf, die Beziehungen haben, die veraltete und nur zum Gruppieren gedachte Beziehungstypen verwenden"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "Discogs-URLs, die mit mehreren Künstlern verbunden sind"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Dieser Report zeigt Discogs-URLs, die mit mehreren Künstlern verlinkt sind."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Möglicherweise doppelte Künstler"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Dieser Report hat das Ziel, Künstler mit sehr ähnlichen Namen zu identifizieren. Wenn es sich bei zwei Künstlern eigentlich um den gleichen handelt, vereine sie bitte (denk daran, {how_to_write_edit_notes|eine Bearbeitungsbemerkung zu schreiben} und deinen Nachweis mit anzugeben). Sind sie jedoch unterschiedlich, so gib ihnen {disambiguation_comment|Unterscheidungskommentare} (und sobald eine Gruppe von ähnlich benannten Künstlern Unterscheidungskommentare hat, werden sie hier nicht mehr auftauchen)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Doppelte Gruppen insgesamt: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "Alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Ausgewählte Künstler zum Vereinen hinzufügen"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Künstler mit möglicherweise duplizierten Beziehungen"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "Dieser Report listet Künstler auf, die mehrere Beziehungen zum gleichen Künstler, Label oder einer URL haben und dabei den gleichen Beziehungstyp verwenden. Zu mehreren Beziehungen zu Veröffentlichungsgruppen, Aufnahmen oder Werken, siehe die Berichte für diese Objekte."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Zeige alle Ergebnisse."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Zeige nur Ergebnisse, die zu meinen abonnierten Objekten gehören."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr ""
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Künstler, die Zusammenarbeiten sein könnten"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Dieser Report listet alle Künstler auf, deren Name ein „&“ enthält, die aber keine Mitglieds- oder Zusammenarbeitsbeziehungen haben. Wenn der Künstler überlicherweise als eine richtige Gruppe angesehen wird, sollten Mitgliedsbeziehungen hinzugefügt werden. Wenn es sich um eine kurzzeitige Zusammenarbeit handelt, sollte er nach Möglichkeit aufgeteilt werden (see {how_to_split_artists|Wie man Künstler aufteilt}). Wenn es eine Zusammenarbeit mit eigenem Namen ist und nicht aufgeteilt werden kann, sollten Zusammenarbeitsbeziehungen hinzugefügt werden."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Tut uns leid, aber zur Zeit stehen für diesen Report keine Daten zur Verfügung."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Falls du am Bearbeitungsprozess teilnehmen willst, aber nicht so recht weißt, wo du anfangen sollst, könnten die folgenden Reporte einen guten Einstieg bilden. Diese Reporte durchstreifen die Datenbank nach Daten, die möglicherweise korrigiert werden müssen, entweder um mit den {style|Stilrichtlinien} übereinzustimmen, oder in anderen Fällen, wo administrative „Aufräumarbeiten“ nötig sind."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Künstler, die Zusammenarbeitsbeziehungen haben"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Künstler, die wie Zusammenarbeiten aussehen"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Künstler mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Möglicherweise doppelte Veranstaltungen"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "Discogs-URLs, die mit mehreren Labels verbunden sind"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Labels mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Veröffentlichungsgruppen"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Veröffentlichungsgruppen, die eventuell vereint werden müssen"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "Discogs-URLs, die mit mehreren Veröffentlichungsgruppen verbunden sind"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Veröffentlichungsgruppen mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Veröffentlichungen mit unerwarteten Amazon-URLs"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Veröffentlichungen mit mehreren ASINs"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Veröffentlichungen mit mehreren Discogs-Links"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "Amazon-URLs, die mit mehreren Veröffentlichungen verbunden sind"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "Discogs-URLs, die mit mehreren Veröffentlichungen verbunden sind"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Veröffentlichungen mit Teil-eines-Sets-Beziehungen"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Medien, die als getrennte Veröffentlichungen eingegeben wurden"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Veröffentlichungen mit nicht-sequentiellen Titelnummern"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Veröffentlichungen, wo bei einigen (aber nicht allen) Medien kein Format angegeben ist"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Veröffentlichungen mit Katalognummern, die wie ASINs aussehen"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Übersetzte/transliterierte Pseudo-Veröffentlichungen, die nicht mit einer Originalversion verbunden sind"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Veröffentlichungen jeglicher Art, die noch Cover-Art-Beziehungen haben"
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Veröffentlichungen mit nicht-sequentiellen Medien"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Veröffentlichungen mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Aufnahmen mit „früheste Veröffentlichung“-Beziehungen"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Titel, deren Namen ihre Sequenznummer enthalten"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Aufnahmen mit unterschiedlichen Titellängen"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Aufnahmen mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Örtlichkeiten mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Serien mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Werke mit Anmerkungen"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWCs"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Mitglied seit"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Website"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Über mich"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "löschen"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12888,66 +12907,82 @@ msgstr[1] "… und {place_count} andere"
 
 #: ../root/static/scripts/area/places-map.js:90
 msgid "No type"
-msgstr ""
+msgstr "Kein Typ"
 
 #: ../root/static/scripts/area/places-map.js:101
 msgid "{place_type}: {place_link}"
 msgstr "{place_type}: {place_link}"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Während der Suche ist ein Fehler aufgetreten. Klicke hier, um es erneut zu versuchen."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Versuch’s nochmal mit der direkten Suche."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Versuch’s nochmal mit der indexierten Suche."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Suchbegriff eingeben oder MBID einfügen"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Letzte Elemente löschen"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Zeige mehr …"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Nichts gefunden? Versuch’s nochmal mit der direkten Suche."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Zu langsam? Verwende wieder die indexierte Suche."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr "erscheint auf"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr "alleinstehende Aufnahme"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr "{release_group_type} von {artist}"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr "Interpreten"
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Über alle Bearbeitungen abstimmen:"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Bemerkung entfernen"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Beziehungen unten anzeigen"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Beziehungen inline anzeigen"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Laden des Mediums fehlgeschlagen."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Bild {current} von {total}"
 
@@ -12969,7 +13004,7 @@ msgstr "Anmerkung zuletzt geändert am {date}."
 msgid "Show less..."
 msgstr "Zeige weniger …"
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Bild von Wikimedia Commons"
 
@@ -12984,69 +13019,86 @@ msgstr ""
 
 #: ../root/static/scripts/common/components/EditorLink.js:20
 msgid "[missing editor]"
-msgstr ""
+msgstr "[fehlender Bearbeiter]"
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
-msgstr ""
+msgstr "Stimme zurückziehen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Zustimmung"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Du hast diesem Tag zugestimmt."
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Ablehnung"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Du hast dieses Tag abgelehnt."
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "Tags mit einer Bewertung von 0 oder weniger sowie Tags, die du abgelehnt hast, sind versteckt."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "Tags mit einer Bewertung von 0 oder weniger sind versteckt."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Alle Tags anzeigen."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Alle Tags werden angezeigt."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr "Vestecke Tags mit einer Bewertung von 0 oder weniger."
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Tags hinzufügen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Du kannst unten deine eigenen {tagdocs|Tags} hinzufügen. Benutze Kommas zur Trennung verschiedener Tags."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Tags abschicken"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
-msgstr ""
+msgstr "alle Tags anzeigen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Tag"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Auf Wikipedia weiterlesen ..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13066,7 +13118,7 @@ msgstr "Du hast {releasegroup} ausgewählt."
 
 #: ../root/static/scripts/common/i18n.js:47
 msgid "{title} - {subtitle}"
-msgstr ""
+msgstr "{title} - {subtitle}"
 
 #: ../root/static/scripts/common/i18n.js:68
 msgid "Add a new artist"
@@ -13164,21 +13216,21 @@ msgstr "{begin_date} – ????"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Begann:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Diese Person ist verstorben."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Diese Gruppe hat sich aufgelöst."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Erforderliches Feld"
 
@@ -13238,9 +13290,9 @@ msgid ""
 "entity from the others."
 msgstr ""
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Alle deine Änderungen gehen verloren, wenn du diese Seite verlässt."
 
@@ -13253,7 +13305,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Wähle bitte einen Linktyp für die von dir eingegebene URL aus."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13270,7 +13322,7 @@ msgid "This relationship already exists."
 msgstr "Diese Beziehung besteht bereits,"
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|more documentation})"
 
@@ -13290,7 +13342,7 @@ msgstr "Video"
 msgid "Remove Link"
 msgstr "Link entfernen"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Einstellungen Groß-/Kleinschreibung"
 
@@ -13323,45 +13375,45 @@ msgid ""
 "language guidelines}. "
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "Die von dir ausgewählte Serie ist für Aufnahmen."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "Die von dir ausgewählte Serie ist für Veröffentlichungen."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "Die von dir ausgewählte Serie ist für Veröffentlichungsgruppen."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "Die von dir ausgewählte Serie ist für Werke."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Bitte einen Beziehungstyp auswählen"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Bitte wähle einen Untertyp des derzeit ausgewählten Beziehungstyps aus. Der ausgewählte Beziehungstyp ist nur zum Gruppieren von Untertypen gedacht."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Objekte in einer Beziehung dürfen nicht identisch sein."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
-msgstr ""
+msgstr "Nur Beziehungen zu {entity_type} Objekten."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
@@ -13369,19 +13421,19 @@ msgstr ""
 msgid "This attribute is required."
 msgstr "Dieses Attribut ist erforderlich."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "Eine Aufnahme ausgewählt"
 msgstr[1] "{n} Aufnahmen ausgewählt"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "Ein Werk ausgewählt"
 msgstr[1] "{n} Werke ausgewählt"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13398,64 +13450,64 @@ msgstr "Dieses Medium hat eine oder mehrere Disc-IDs, die verhindern, dass diese
 msgid "Page {page} of {total}"
 msgstr "Seite {page} von {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Medium {position}: {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Medium {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Du hast kein Label für „{name}“ ausgewählt."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Fehler beim Laden der Veröffentlichung: {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Veröffentlichung hinzufügen"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Veröffentlichung bearbeiten"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "Die Prüfziffer ist {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Bitte überprüfe den Strichcode auf der Veröffentlichung nochmal genau."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Der von dir eingegebene Barcode scheint ein UPC mit fehlender Prüfziffer zu sein."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Der von dir eingegebene Strichcode ist ein gültiger UPC."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Der Strichcode, den du eingegeben hast, ist entweder ein ungültiger UPC oder eine EAN mit fehlender Prüfziffer."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Der von dir eingegebene Strichcode ist eine gültige EAN."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Der Strichcode, den du eingegeben hast, ist keine gültige EAN."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Der Strichcode, den du eingegeben hast, ist kein gültiger UPC und keine gültige EAN."
 
@@ -13463,7 +13515,7 @@ msgstr "Der Strichcode, den du eingegeben hast, ist kein gültiger UPC und keine
 msgid "Add Language"
 msgstr "Sprache hinzufügen"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Sprache entfernen"
 

--- a/po/mb_server.el.po
+++ b/po/mb_server.el.po
@@ -22,8 +22,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-01-24 08:45+0000\n"
 "Last-Translator: yvanz\n"
 "Language-Team: Greek (http://www.transifex.com/musicbrainz/musicbrainz/language/el/)\n"
 "MIME-Version: 1.0\n"
@@ -183,6 +183,7 @@ msgstr "(κανένα)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(άγνωστο)"
 
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Account administrators can edit and delete user accounts."
 msgstr ""
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr ""
 
@@ -399,7 +400,7 @@ msgstr ""
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Ενέργειες"
 
@@ -584,10 +585,6 @@ msgstr ""
 msgid "Add relationship"
 msgstr "Προσθήκη σχέσης"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Προσθήκη επιλεγμένων καλλιτεχνών προς συγχώνευση"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr ""
@@ -660,7 +657,7 @@ msgstr "Ηλικία:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Ψευδώνυμο"
 
@@ -680,9 +677,10 @@ msgstr "Ψευδώνυμο:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Ψευδώνυμα"
 
@@ -730,26 +728,21 @@ msgstr ""
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "Amazon URLs Συνδεδεμένα με πολλαπλές κυκλοφορίες"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "Amazon URLs συνδεδεμένα με πολλαπλές κυκλοφορίες"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr ""
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Ένας ανώνυμος χρήστης"
 msgstr[1] "{n} ανώνυμοι χρήστες"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -771,8 +764,7 @@ msgstr "Προέκυψε ένα σφάλμα: "
 msgid "An error occurred while creating the works."
 msgstr ""
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -781,8 +773,9 @@ msgstr ""
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Σχόλιο"
@@ -916,11 +909,11 @@ msgstr ""
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -971,24 +964,27 @@ msgstr ""
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1034,11 +1030,6 @@ msgstr ""
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Παρακολουθήσεις καλλιτεχνών"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr ""
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1086,7 +1077,7 @@ msgstr "Καλλιτέχνης {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Καλλιτέχνης:"
 
@@ -1094,81 +1085,15 @@ msgstr "Καλλιτέχνης:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Καλλιτέχνες"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Καλλιτέχνες που περιέχουν αμφιλεγόμενα σχόλια στο όνομά τους"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr ""
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Καλλιτέχνες που μπορεί να είναι συνεργασίες"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Καλλιτέχνες που μπορεί να είναι συγκροτήματα"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Καλλιτέχνες που μπορεί να είναι άτομα"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Καλλιτέχνες οι οποίοι έχουν σχέσεις συνεργασίας"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Καλλιτέχνες που μοιάζουν με συνεργασίες"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Καλλιτέχνες με σχέσεις συνεργασίας"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr ""
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr ""
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr ""
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1333,9 +1258,8 @@ msgstr ""
 msgid "Batch-create new works"
 msgstr ""
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Γίνε ο πρώτος! {sub|Παρακολούθηση};"
 
@@ -1393,20 +1317,11 @@ msgstr "Ημερομηνία έναρξης:"
 msgid "Beginner"
 msgstr ""
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr ""
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
-msgstr ""
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
 msgstr ""
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
@@ -1418,12 +1333,12 @@ msgstr ""
 msgid "Birth date:"
 msgstr "Ημερομηνία γέννησης:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr ""
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Γεννήθηκε:"
 
@@ -1435,13 +1350,13 @@ msgstr "Bot"
 msgid "Bots"
 msgstr "Bots"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr ""
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr ""
@@ -1586,7 +1501,7 @@ msgstr "# κατάλογου"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Αλλαγή κωδικού πρόσβασης"
 
@@ -1665,14 +1580,6 @@ msgstr "Έκλεισε"
 msgid "Code"
 msgstr "Κώδικας"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Συνεργασία"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Συνεργάτης"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Σύμπτυξη Δίσκου"
@@ -1701,7 +1608,7 @@ msgstr "Συλλογή “{collection}”"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Συλλογές"
@@ -1779,7 +1686,7 @@ msgid "Country:"
 msgstr "Χώρα:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Εξώφυλλο"
 
@@ -1911,7 +1818,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Διαγραφή λογαριασμού"
 
@@ -1963,13 +1870,14 @@ msgstr "Περιγραφή:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Λεπτομέρειες"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Πέθανε:"
 
@@ -1979,7 +1887,7 @@ msgstr ""
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Απευθείας αναζήτηση βάσης δεδομένων"
 
@@ -2036,7 +1944,7 @@ msgid "Disc ID:"
 msgstr "Disc ID:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "Disc IDs"
 
@@ -2056,11 +1964,6 @@ msgstr ""
 msgid "Discography"
 msgstr "Δισκογραφία"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "Discogs URLs συνδεδεμένα με πολλαπλούς χρήστες"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2076,32 +1979,12 @@ msgstr "Discogs URLs συνδεδεμένα με πολλαπλές ομάδες
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "Discogs URLs συνδεδεμένα με πολλαπλές κυκλοφορίες"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "Discogs URLs συνδεδεμένα με πολλαπλούς καλλιτέχνες"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "Discogs URLs συνδεδεμένα με πολλαπλές δισκογραφικές εταιρείες"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "Discogs URLs συνδεδεμένα με πολλαπλές ομάδες κυκλοφοριών"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "Discogs URLs συνδεδεμένα με πολλαπλές κυκλοφορίες"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Δίσκοι ως ξεχωριστές κυκλοφορίες"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Δίσκοι καταχωρημένοι ως ξεχωριστές κυκλοφορίες"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Διαλύθηκε:"
 
@@ -2119,7 +2002,7 @@ msgstr ""
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Δεν έχετε λογαριασμό; {uri|Δημιουργήστε έναν τώρα}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Δωρεά"
 
@@ -2150,9 +2033,9 @@ msgstr "Κάθε κομμάτι στη βάση δεδομένων του MusicB
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Επεξεργασία"
 
@@ -2205,7 +2088,7 @@ msgid "Edit Note Author"
 msgstr ""
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Επεξεργασία προφίλ"
 
@@ -2280,10 +2163,10 @@ msgid "Editing/voting disabled"
 msgstr ""
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Χρήστης"
 
@@ -2299,10 +2182,6 @@ msgstr "Παρακολουθήσεις χρηστών"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Χρήστης “{user}”"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr ""
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2331,12 +2210,6 @@ msgstr "Τροποποιήσεις για {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr ""
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "Email"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2396,7 +2269,7 @@ msgstr ""
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Έληξε:"
 
@@ -2439,11 +2312,6 @@ msgstr ""
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr ""
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Σφάλμα"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2493,8 +2361,8 @@ msgstr "Ακόμα και η προσθήκη ενός ή δύο URL είναι 
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2521,13 +2389,14 @@ msgstr ""
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr ""
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr ""
 
@@ -2608,7 +2477,7 @@ msgid "Find Relationships"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Αποτυπώματα"
 
@@ -2657,7 +2526,7 @@ msgstr ""
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr ""
 
@@ -2689,7 +2558,7 @@ msgstr "Μορφή"
 msgid "Format:"
 msgstr "Μορφή:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr ""
@@ -2745,7 +2614,7 @@ msgstr[1] "Βρέθηκαν {n} αποτελέσματα για \"{q}\""
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Ιδρύθηκε:"
 
@@ -2801,7 +2670,6 @@ msgstr "Φύλο:"
 msgid "General Information"
 msgstr "Γενικές πληροφορίες"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2809,17 +2677,9 @@ msgstr "Γενικές πληροφορίες"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2827,13 +2687,10 @@ msgstr "Γενικές πληροφορίες"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2848,13 +2705,11 @@ msgstr "Γενικές πληροφορίες"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2885,13 +2740,27 @@ msgstr "Γενικές πληροφορίες"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Δημιουργήθηκε στις {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr ""
 
@@ -3090,13 +2959,15 @@ msgstr "ISRC {isrc} στο {recording}"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRCs"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRCs με πολλαπλές ηχογραφήσεις"
 
@@ -3120,12 +2991,8 @@ msgstr "ISWC {iswc} στο {work}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr ""
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr ""
 
@@ -3197,15 +3064,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Αν θεωρείτε ότι έχει συμβεί κάποιο λάθος, παρακαλούμε επικοινωνήστε μαζί μας στο <code>support@musicbrainz.org</code> με το όνομα χρήστη του λογαριασμού σας."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr ""
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3243,11 +3101,11 @@ msgstr "Εσφαλμένο όνομα χρήστη ή κωδικός πρόσβ�
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr ""
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr ""
 
@@ -3258,7 +3116,7 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3283,13 +3141,14 @@ msgstr ""
 msgid "Instrument:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr ""
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr ""
 
@@ -3355,9 +3214,9 @@ msgstr "Να παραμείνω συνδεδεμένος"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3418,31 +3277,28 @@ msgstr "Δισκογαφική εταιρεία:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Δισκογραφικές εταιρείες"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr ""
 
@@ -3483,7 +3339,6 @@ msgstr ""
 msgid "Last 28 days"
 msgstr "Τελευταίες 28 μέρες"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3491,6 +3346,7 @@ msgstr "Τελευταίες 28 μέρες"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr ""
 
@@ -3498,7 +3354,7 @@ msgstr ""
 msgid "Last login:"
 msgstr ""
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr ""
 
@@ -3506,7 +3362,7 @@ msgstr ""
 msgid "Last updated"
 msgstr ""
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Τελευταία ενημέρωση:"
 
@@ -3576,14 +3432,14 @@ msgid "Loading edit previews..."
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Τοπικότητα"
 
@@ -3593,6 +3449,7 @@ msgstr "Τοπικότητα:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr ""
 
@@ -3665,7 +3522,7 @@ msgstr "Χαμηλή"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr ""
 
@@ -3700,7 +3557,7 @@ msgid "Many relationships"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr ""
 
@@ -3761,10 +3618,6 @@ msgstr "Μέσο:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Μέσα:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr ""
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3876,7 +3729,7 @@ msgstr ""
 msgid "Most Recent"
 msgstr ""
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Μετακίνηση"
 
@@ -4005,7 +3858,7 @@ msgstr "Όνομα"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Όνομα:"
 
@@ -4107,7 +3960,7 @@ msgstr "Νέα έκδοση:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Επόμενο"
@@ -4183,7 +4036,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr ""
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Κανένα αποτέλεσμα"
 
@@ -4197,7 +4050,7 @@ msgstr "Δε βρέθηκαν αποτελέσματα."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Δε βρέθηκαν αποτελέσματα. Δοκιμάστε να επαναπροσδιορίσετε το ερώτημα αναζήτησής σας"
 
@@ -4222,13 +4075,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr ""
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr ""
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr ""
 
@@ -4238,7 +4091,7 @@ msgid "None"
 msgstr "Κανένα"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr ""
@@ -4447,9 +4300,9 @@ msgid "Other lookups"
 msgstr "Άλλες αναζητήσεις"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr ""
 
@@ -4458,7 +4311,7 @@ msgid "Overall"
 msgstr "Συνολικά"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Επισκόπηση"
@@ -4535,11 +4388,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr ""
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Μόνιμος σύνδεσμος:"
 
@@ -4551,8 +4404,8 @@ msgstr "Φράση:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4578,23 +4431,20 @@ msgstr ""
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr ""
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr ""
 
@@ -4717,22 +4567,14 @@ msgid "Possible duplicate events"
 msgstr ""
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr ""
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Πιθανές τιμές:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Πιθανές διπλοεγγραφές καλλιτεχνών"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr ""
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4750,7 +4592,7 @@ msgstr "Προεπισκόπηση:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Προηγούμενο"
@@ -4802,7 +4644,7 @@ msgid "Public collection by {owner}"
 msgstr "Δημόσια συλλογή από {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Ερώτημα:"
 
@@ -4827,7 +4669,7 @@ msgstr "Βαθμολογία"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Βαθμολογίες"
 
@@ -4857,7 +4699,7 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4900,21 +4742,22 @@ msgstr "Ηχογράφηση:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Ηχογραφήσεις"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
@@ -4928,40 +4771,28 @@ msgstr ""
 msgid "Recordings with Varying Track Lengths"
 msgstr ""
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
-msgstr ""
-
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr ""
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr ""
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Ηχογραφήσεις με τίτλους που περιέχουν τους καλλιτέχνες που συμμετέχουν"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr ""
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5019,7 +4850,6 @@ msgid "Relationship Editor"
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5027,6 +4857,7 @@ msgstr ""
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Τύπος σχέσης"
 
@@ -5076,7 +4907,7 @@ msgstr "Σχέση:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Σχέσεις"
 
@@ -5108,7 +4939,7 @@ msgstr "Σχέσεις:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5140,7 +4971,7 @@ msgstr "Γεγονότα κυκλοφορίας:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Ομάδα κυκλοφοριών"
@@ -5176,7 +5007,7 @@ msgstr "Ομάδες κυκλοφοριών"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr ""
 
@@ -5235,6 +5066,7 @@ msgid "Release group ratings"
 msgstr "Βαθμολογίες ομάδας κυκλοφοριών"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Ομάδα κυκλοφοριών “{name}” από {artist}"
 
@@ -5246,38 +5078,27 @@ msgstr "Ομάδα κυκλοφοριών “{name}” από {artist}"
 msgid "Release group:"
 msgstr "Ομάδα κυκλοφοριών:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Ομάδες κυκλοφοριών"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
-msgstr ""
-
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Ομάδες κυκλοφοριών που ίσως χρειάζονται συγχώνευση"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr ""
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Ομάδες κυκλοφοριών με τίτλους που περιέχουν τους καλλιτέχνες που συμμετέχουν"
 
@@ -5320,8 +5141,8 @@ msgstr "Κυκλοφορία:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Κυκλοφορίες"
@@ -5355,67 +5176,43 @@ msgstr "Κυκλοφορίες με πολλαπλούς συνδέσμους Di
 msgid "Releases With Some Formats Unset"
 msgstr "Κυκλοφορίες με κάποιες μορφές που δεν έχουν ρυθμιστεί"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Κυκλοφορίες στο Cover Art Archive που εξακκολουθούν να έχουν σχέσεις εξωφύλλου"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr ""
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr ""
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr ""
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr ""
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr ""
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr ""
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Κυκλοφορίες με πολλαπλά ASINs"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Κυκλοφορίες με πολλαπλούς συνδέσμους Discogs"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr ""
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Κυκλοφορίες με απροσδόκητα Amazon URLs"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Κυκλοφορίες που ίσως πρέπει να μετατραπούν σε \"πολλαπλών καλλιτεχνών\""
 
@@ -5424,23 +5221,15 @@ msgstr "Κυκλοφορίες που ίσως πρέπει να μετατρα�
 msgid "Releases with Cover Art relationships"
 msgstr ""
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr ""
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr ""
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Κυκλοφορίες με αριθμούς καταλόγου που μοιάζουν με ASINs"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr ""
 
@@ -5449,31 +5238,25 @@ msgstr ""
 msgid "Releases with medium number issues"
 msgstr ""
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr ""
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr ""
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Κυκλοφορίες με μη συνεχείς αριθμούς κομματιών"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr ""
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Κυκλοφορίες με περιττά κομμάτια δεδομένων"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Κυκλοφορίες με τίτλους που περιέχουν τους καλλιτέχνες που συμμετέχουν"
 
@@ -5482,24 +5265,26 @@ msgstr "Κυκλοφορίες με τίτλους που περιέχουν τ�
 msgid "Releases with track number issues"
 msgstr "Κυκλοφορίες με θέματα στους αριθμούς κομματιών"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr ""
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Κυκλοφορίες με όχι πιθανά ζεύγη γλώσσας/γραφής"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Κυκλοφορίες χωρίς γλώσσα"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Κυκλοφορίες χωρίς γραφή"
 
@@ -5525,7 +5310,7 @@ msgstr "Κυκλοφορίες:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5537,7 +5322,7 @@ msgstr "Κυκλοφορίες:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Κατάργηση"
@@ -5677,11 +5462,6 @@ msgstr ""
 msgid "Report this user for bad behavior"
 msgstr ""
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Αναφορές"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr ""
@@ -5704,7 +5484,7 @@ msgstr "Επαναφορά κωδικού πρόσβασης"
 msgid "Reset track numbers"
 msgstr ""
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Αποτελέσματα ανά σελίδα:"
 
@@ -5744,7 +5524,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Εκτελείται: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5787,7 +5567,7 @@ msgstr "Γραφή:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5834,7 +5614,7 @@ msgstr "Αναζήτηση για τροποποιήσεις"
 msgid "Search for the target URL."
 msgstr ""
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Μέθοδος αναζήτησης:"
 
@@ -5923,7 +5703,7 @@ msgstr "Στείλε ένα αντίγραφο και στη δική μου δ�
 msgid "Sentence"
 msgstr ""
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr ""
@@ -5938,8 +5718,8 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5961,10 +5741,6 @@ msgstr ""
 #: ../root/report/annotations_series.tt:1
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
-msgstr ""
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
 msgstr ""
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
@@ -5994,7 +5770,7 @@ msgstr "Ορίστε ένα νέο κωδικό πρόσβασης για το �
 msgid "Set cover art"
 msgstr ""
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Ορισμός διάρκειας κομματιών"
 
@@ -6007,10 +5783,6 @@ msgstr ""
 msgid "Setlist:"
 msgstr ""
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Εμφάνιση όλων των αποτελεσμάτων."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr ""
@@ -6020,10 +5792,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr ""
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Εμφάνιση μόνο τα αποτελέσματα που βρίσκονται στα στοιχεία που παρακολουθώ."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6159,7 +5927,7 @@ msgstr ""
 msgid "Sorry, there was a problem with your request."
 msgstr "Λυπούμαστε, υπήρξε ένα πρόβλημα με το αίτημά σας."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Λυπούμαστε, δεν έχετε πρόσβαση σε αυτή τη σελίδα."
 
@@ -6183,8 +5951,8 @@ msgstr "Λυπούμαστε, το “{id}” δεν είναι έγκυρη σ�
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Όνομα ταξινόμησης"
 
@@ -6238,7 +6006,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr ""
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr ""
 
@@ -6292,12 +6060,10 @@ msgstr "Χρήστες που παρακολουθώ"
 msgid "Subscribed entities"
 msgstr "Στοιχεία που παρακολουθώ"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6345,8 +6111,8 @@ msgid "Tagger"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6417,7 +6183,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Αυτά τα δεδομένα αρχικά ήρθαν από μία παλιότερη έκδοση αυτής της επεξεργασίας, και για αυτό μπορεί να μην εμφανίζονται σωστά"
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6428,7 +6194,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr ""
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr ""
 
@@ -6527,7 +6293,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Ο εξυπηρετητής αναζήτησης δεν μπόρεσε να εκπληρώσει το αίτημά σας λόγω ενός εσωτερικού σφάλματος. Αυτό συνήθως είναι προσωρινό, οπότε ξαναδοκιμάστε αργότερα."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr ""
 
@@ -6566,20 +6332,8 @@ msgstr "Δεν υπάρχουν χρήστες που να παρακολουθ�
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Δεν υπάρχουν χρήστες που να παρακολουθούν τις τροποποιήσεις του χρήστη {user}."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Δεν υπάρχουν χρήστες που να παρακολουθούν τον καλλιτέχνη {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
-msgstr ""
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Δεν υπάρχουν χρήστες που να παρακολουθούν την δισκογραφική εταιρεία {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
 msgstr ""
 
 #: ../root/release/discids.tt:49
@@ -6589,12 +6343,12 @@ msgid ""
 msgstr ""
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr ""
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr ""
 
@@ -6620,27 +6374,9 @@ msgid_plural ""
 msgstr[0] "Τις επεξεργασίες του χρήστη {user} παρακολουθεί {num} χρήστης:"
 msgstr[1] "Τις επεξεργασίες του χρήστη {user} παρακολουθούν {num} χρήστες:"
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Τον καλλιτέχνη {artist} παρακολουθεί {num} χρήστης:"
-msgstr[1] "Τον καλλιτέχνη {artist} παρακολουθούν {num} χρήστες:"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Τη δισκογραφική εταιρεία {label} παρακολουθεί {num} χρήστης:"
-msgstr[1] "Τη δισκογραφική εταιρεία {label} παρακολουθούν {num} χρήστες:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6750,7 +6486,7 @@ msgid ""
 msgstr ""
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Αυτός ο καλλιτέχνης έληξε."
 
@@ -6800,7 +6536,7 @@ msgstr ""
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr ""
@@ -6907,11 +6643,11 @@ msgid ""
 "attributed to it."
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Αυτός είναι ένας εξυπηρετητής ανάπτυξης του MusicBrainz."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7031,7 +6767,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Αυτή η ηχογράφηση δεν έχει συνδεδεμένα AcoustIDs"
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr ""
@@ -7065,7 +6801,7 @@ msgstr ""
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr ""
 
@@ -7099,16 +6835,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr ""
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Αυτή η αναφορά έχει ως στόχο να εντοπιστούν καλλιτέχνες με παρόμοια ονόματα. Αν δύο καλλιτέχνες στην πραγματικότητα είναι ο ίδιος, παρακαλούμε συγχωνεύστε τους (θυμηθείτε να {how_to_write_edit_notes|γράψετε μία σημείωση επεξεργασίας} και να δώσετε τα αποδεικτικά σας στοιχεία). Αν είναι διαφορετικοί, προσθέστε {disambiguation_comment|σχόλια αποσαφήνισης} σε αυτούς (και μόλις μία ομάδα καλλιτεχνών με παρόμοια ονόματα έχουν σχόλια αποσαφήνισης, θα σταματήσουν να εμφανίζονται εδώ)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7149,85 +6875,6 @@ msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με ό�
 msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
-msgstr ""
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr ""
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr ""
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr ""
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με καλλιτέχνες οι οποίοι μπορεί να έχουν σχόλια αποσαφήνισης στο όνομά τους, και όχι στο πραγματικό πεδίο σχολίων αποσαφήνισης."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με τους καλλιτέχνες που έχουν το \"&\" στα ονόματά τους αλλά είναι χωρίς σχέσεις μελών ή συνεργασίας. Αν ο καλλιτέχνης αντιμετωπίζεται ως ένα πραγματικό συγκρότημα, πρέπει να προστεθούν σχέσεις μελών. Αν είναι συνεργασία μικρής διάρκειας, πρέπει να διαχωριστεί (δείτε {how_to_split_artists|Πως να διαχωρίζετε καλλιτέχνες}). Αν είναι συνεργασία με το δικό της όνομα και δεν μπορεί να διαχωριστεί, πρέπει να προστεθούν σχέσεις συνεργασίας."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με τους καλλιτέχνες που έχουν σχέσεις συνεργασίας αλλά όχι σχέσεις URL. Αν η συνεργασία έχει το δικό της ανεξάρτητο όνομα, μην κάνετε τίποτα. Αν είναι της μορφής \"X με Y\" ή \"X & Y\", πιθανώς να πρέπει να τους διαχωρίσετε. Δείτε {how_to_split_artists|Πως να διαχωρίζετε καλλιτέχνες}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
 msgstr ""
 
 #: ../root/report/duplicate_events.tt:6
@@ -7390,10 +7037,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr ""
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr ""
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7404,10 +7047,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Αυτή η λίστα εμφανίζει τα Amazon URLs τα οποία έχουν συνδεθεί με πολλαπλές κυκλοφορίες. Στις περισσότερες περιπτώσεις τα Amazon ASINs πρέπει να αντιστοιχούν στις κυκλοφορίες του MusicBrainz ένα προς ένα, οπότε μόνο ένας από τους συνδέσμους είναι σωστός. Απλώς ελέγξτε αν η κυκλοφορία του MusicBrainz ταιριάζει με την κυκλοφορία στο Amazon (ψάξτε για τη μορφή, λίστα κομματιών, κτλ). Αν η κυκλοφορία έχει barcode, μπορείτε επίσης να ψάξετε το Amazon με αυτό και να δείτε ποια ASIN ταιριάζουν. Επίσης μπορεί να βρείτε κάποια ASINs να συνδέονται με πολλούς δίσκους μίας κυκλοφορίας πολλών δίσκων: απλά συγχωνεύστε τες (δείτε {how_to_merge_releases|Πως να συγχωνεύετε κυκλοφορίες})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Αυτή η αναφορά εμφανίζει Discogs URLs τα οποία είναι συνδεδεμένα με πολλούς καλλιτέχνες."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7687,7 +7326,7 @@ msgstr ""
 msgid "This table shows a summary of votes cast by this editor."
 msgstr ""
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr ""
 
@@ -7812,29 +7451,6 @@ msgstr ""
 
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Σύνολο καλλιτεχνών: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Σύνολο διπλοεγγεγραμμένων συγκροτημάτων: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
 msgstr ""
 
 #: ../root/report/duplicate_events.tt:10
@@ -7995,7 +7611,7 @@ msgstr "Κομμάτι:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Λίστα κομματιών"
 
@@ -8013,10 +7629,6 @@ msgstr "Λίστα κομματιών:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Κομμάτια"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr ""
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8045,16 +7657,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr ""
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Μεταφρασμένες/Μεταγλωττισμένες Ψευδο-κυκλοφορίες που δεν έχουν συνδεθεί με την πρωτότυπη έκδοση"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr ""
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8070,15 +7677,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8092,7 +7702,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Τύπος"
 
@@ -8120,7 +7730,7 @@ msgstr "Τύπος"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Τύπος:"
 
@@ -8136,14 +7746,15 @@ msgstr "Τύπος: {type}, κατάσταση: {status}"
 msgid "Types:"
 msgstr "Τύποι:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8163,17 +7774,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr ""
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr ""
 
@@ -8195,8 +7806,12 @@ msgstr "Μη επιτρεπόμενο αίτημα"
 msgid "Unclassified instrument"
 msgstr ""
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Άγνωστο"
 
@@ -8223,9 +7838,9 @@ msgstr "Μη παρακολούθηση"
 msgid "Untrusted"
 msgstr "Μη έμπιστο"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Μέχρι {n}"
 
@@ -8258,7 +7873,7 @@ msgstr ""
 msgid "Uppercase roman numerals"
 msgstr ""
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr ""
 
@@ -8314,7 +7929,7 @@ msgid "Username:"
 msgstr "Όνομα χρήστη:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr ""
 
@@ -8446,10 +8061,6 @@ msgstr ""
 msgid "Watched Artists"
 msgstr "Καλλιτέχνες που παρακολουθώ"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Λυπούμαστε, αλλά τα δεδομένα για αυτή την αναφορά δεν είναι διαθέσιμα αυτή τη στιγμή."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr ""
@@ -8495,10 +8106,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Λυπούμαστε πραγματικά για αυτό το πρόβλημα. Παρακαλούμε περιμένετε μερικά λεπτά και επαναλάβετε το αίτημά σας &#x2014; το πρόβλημα μπορεί να εξαφανιστεί."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr ""
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Ιστοσελίδα:"
@@ -8511,7 +8118,7 @@ msgid ""
 "and following the merge link."
 msgstr "Όταν είστε έτοιμοι για να τα συγχωνεύσετε, πατήστε το κουμπί \"Συγχώνευση\". Έπειτα μπορείτε να προσθέσετε περισσότερα στοιχεία προς συγχώνευση πηγαίνοντας στη σελίδα τους και ακολουθώντας εκεί το σύνδεσμο συγχώνευσης."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8533,10 +8140,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Έργο"
 
@@ -8575,35 +8182,32 @@ msgstr "Έργο:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Έργα"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr ""
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Συγγραφείς"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8716,9 +8320,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Πρόκειται να συγχωνεύσετε το ακόλουθο έργο σε ένα μοναδικό έργο. Παρακαλούμε επιλέξτε το έργο στο οποίο θέλετε να συγχωνευτούν τα άλλα έργα:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Αυτή τη στιγμή παρακολουθείτε αυτό το στοιχείο. {unsub|Μη παρακολούθηση};"
 
@@ -8734,9 +8337,8 @@ msgstr "Δεν μπορείτε να προσθέσετε σημειώσεις �
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Δεν μπορείτε να ψηφίσετε για αυτή την επεξεργασία αυτή τη στιγμή. ({url|Λεπτομέρειες})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Αυτή τη στιγμή δεν παρακολουθείτε αυτό το στοιχείο. {sub|Παρακολούθηση};"
 
@@ -8816,7 +8418,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr ""
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr ""
 
@@ -8841,7 +8443,7 @@ msgstr ""
 msgid "You must be logged in to vote on edits"
 msgstr "Πρέπει να είστε συνδεδεμένοι για να ψηφίσετε για τροποποιήσεις"
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr ""
 
@@ -8923,7 +8525,7 @@ msgstr ""
 msgid "Your username will be publicly visible."
 msgstr "Το όνομα χρήστη σας θα είναι ορατό δημόσια."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8965,10 +8567,6 @@ msgstr "[άγνωστο]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "μετά από"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr ""
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9030,10 +8628,6 @@ msgstr ""
 #: ../root/components/relationship-editor.tt:208
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
-msgstr ""
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
 msgstr ""
 
 #: ../root/admin/wikidoc/index.tt:53
@@ -9253,9 +8847,7 @@ msgstr ""
 msgid "places"
 msgstr ""
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "συν άλλος {n} ανώνυμος χρήστης"
@@ -9478,7 +9070,7 @@ msgstr[1] ""
 msgid "{entity} has not been added to any collections."
 msgstr ""
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9492,7 +9084,7 @@ msgstr "{link} δεν έχει βαθμολογίες."
 msgid "{link} has no relationships."
 msgstr "{link} δεν έχει σχέσεις."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 
@@ -9605,7 +9197,7 @@ msgstr ""
 msgid "{type} “{work}”"
 msgstr "{type} “{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr ""
 
@@ -9812,34 +9404,34 @@ msgstr "Το '{id}' δεν είναι έγκυρο ID ψηφοφορίας"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Η απαιτούμενη παράμετρος TOC δεν ήταν έγκυρη ή δεν υπήρχε"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "Το παρεχόμενο CD TOC δεν είναι έγκυρο"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "Το παρεχόμενο id μέσου δεν είναι έγκυρο"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Αυτό το CDTOC είναι πλήρως συνδεδεμένο με αυτό το μέσο"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Το επιλεγμένο μέσο δεν μπορεί να έχει disc IDs"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "Το παρεχόμενο id καλλιτέχνη δεν είναι έγκυρο"
 
@@ -10221,7 +9813,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Μετατροπή κυκλοφορίας σε πολλαπλών καλλιτεχνών (ιστορικό)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Ρύθμιση διάρκειας κομματιών"
 
@@ -10521,6 +10113,12 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
 msgid "Failed dependency"
 msgstr ""
+
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Σφάλμα"
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
@@ -10850,7 +10448,7 @@ msgid "These coordinates could not be parsed"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr ""
 
@@ -10954,13 +10552,13 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "CD Stub"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr ""
@@ -10968,7 +10566,7 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Τεκμηρίωση"
 
@@ -11228,7 +10826,7 @@ msgstr ""
 msgid "{last_list_item}"
 msgstr ""
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Έλεγχος δωρεάς"
 
@@ -11279,6 +10877,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr ""
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "Email"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11310,7 +10914,7 @@ msgid ""
 msgstr "Σας έχουμε στείλει πληροφορίες σχετικά με το λογαριασμό σας στο MusicBrainz. Εάν δεν έχετε λάβει αυτό το email ή έχετε ακόμα προβλήματα κατά τη σύνδεσή σας, παρακαλώ {link|επικοινωνήστε μαζί μας}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
@@ -11446,7 +11050,7 @@ msgstr ""
 msgid "Unconfirmed Email Address"
 msgstr ""
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr ""
 
@@ -11486,32 +11090,32 @@ msgid ""
 msgstr "Λυπούμαστε, δεν μπορέσαμε να βρούμε καλλιτέχνη με αυτό το MusicBrainz ID. Ίσως θέλετε να κάνετε {search_url|αναζήτηση} για αυτόν."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr ""
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr ""
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr ""
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr ""
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr ""
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr ""
 
@@ -11531,23 +11135,23 @@ msgstr "Δε βρέθηκε συλλογή"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Λυπούμαστε, δεν μπορέσαμε να βρούμε συλλογή με αυτό το MusicBrainz ID."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Ημερομηνία έναρξης"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Ημερομηνία λήξης"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr ""
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} δεν έχει ψευδώνυμα."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr ""
 
@@ -11589,19 +11193,19 @@ msgstr[1] ""
 msgid "Already expired"
 msgstr "Έληξε ήδη"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Προφίλ"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Λίστα παρακολουθήσεων"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Επεξεργασία χρήστη"
 
@@ -11663,7 +11267,7 @@ msgid "For more information:"
 msgstr "Για περισσότερες πληροφορίες:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Προσθήκη σημείωσης"
 
@@ -11842,6 +11446,22 @@ msgstr "Ψηφοφορία"
 msgid "Votes cast"
 msgstr "Ψήφοι που ρίχτηκαν"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr ""
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr ""
@@ -11868,7 +11488,7 @@ msgid ""
 "ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr ""
 
@@ -12110,6 +11730,11 @@ msgstr ""
 msgid "Vote on Edits"
 msgstr "Ψήφος στις τροποποιήσεις"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Αναφορές"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Οδηγός για αρχάριους"
@@ -12150,23 +11775,23 @@ msgstr "Προβολή όλων των σχέσεων"
 msgid "Running: {git_details}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr ""
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Δισκογραφική εταιρεία"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr ""
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Κομμάτι"
 
@@ -12401,9 +12026,13 @@ msgstr ""
 msgid "Label information"
 msgstr "Πληροφορίες δισκογραφικής εταιρείας"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Τελευταία ενημέρωση στις {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr ""
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12479,18 +12108,18 @@ msgid "see all ratings"
 msgstr "δείτε όλες τις βαθμολογίες"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(κανένα)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(κανένα)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr ""
 
@@ -12659,11 +12288,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Λυπούμαστε, δεν μπορέσαμε να βρούμε ηχογράφηση με αυτό το MusicBrainz ID. Ίσως θέλετε να κάνετε {search_url|αναζήτηση} για αυτήν."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr ""
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Ηχογράφηση από {artist}"
 
@@ -12692,9 +12321,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Λυπούμαστε, δεν μπορέσαμε να βρούμε ομάδα κυκλοφοριών με αυτό το MusicBrainz ID. Ίσως θέλετε να κάνετε {search_url|αναζήτηση} για αυτήν."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Ομάδα κυκλοφοριών από {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Σύνολο καλλιτεχνών: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Καλλιτέχνες που περιέχουν αμφιλεγόμενα σχόλια στο όνομά τους"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με καλλιτέχνες οι οποίοι μπορεί να έχουν σχόλια αποσαφήνισης στο όνομά τους, και όχι στο πραγματικό πεδίο σχολίων αποσαφήνισης."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr ""
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Καλλιτέχνες που μπορεί να είναι συγκροτήματα"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Καλλιτέχνες που μπορεί να είναι άτομα"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr ""
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr ""
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με τους καλλιτέχνες που έχουν σχέσεις συνεργασίας αλλά όχι σχέσεις URL. Αν η συνεργασία έχει το δικό της ανεξάρτητο όνομα, μην κάνετε τίποτα. Αν είναι της μορφής \"X με Y\" ή \"X & Y\", πιθανώς να πρέπει να τους διαχωρίσετε. Δείτε {how_to_split_artists|Πως να διαχωρίζετε καλλιτέχνες}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Συνεργασία"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Συνεργάτης"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "Discogs URLs συνδεδεμένα με πολλαπλούς καλλιτέχνες"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Αυτή η αναφορά εμφανίζει Discogs URLs τα οποία είναι συνδεδεμένα με πολλούς καλλιτέχνες."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Πιθανές διπλοεγγραφές καλλιτεχνών"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Αυτή η αναφορά έχει ως στόχο να εντοπιστούν καλλιτέχνες με παρόμοια ονόματα. Αν δύο καλλιτέχνες στην πραγματικότητα είναι ο ίδιος, παρακαλούμε συγχωνεύστε τους (θυμηθείτε να {how_to_write_edit_notes|γράψετε μία σημείωση επεξεργασίας} και να δώσετε τα αποδεικτικά σας στοιχεία). Αν είναι διαφορετικοί, προσθέστε {disambiguation_comment|σχόλια αποσαφήνισης} σε αυτούς (και μόλις μία ομάδα καλλιτεχνών με παρόμοια ονόματα έχουν σχόλια αποσαφήνισης, θα σταματήσουν να εμφανίζονται εδώ)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Σύνολο διπλοεγγεγραμμένων συγκροτημάτων: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr ""
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Προσθήκη επιλεγμένων καλλιτεχνών προς συγχώνευση"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr ""
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Εμφάνιση όλων των αποτελεσμάτων."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Εμφάνιση μόνο τα αποτελέσματα που βρίσκονται στα στοιχεία που παρακολουθώ."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr ""
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Καλλιτέχνες που μπορεί να είναι συνεργασίες"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Αυτή η αναφορά εμφανίζει μια λίστα με τους καλλιτέχνες που έχουν το \"&\" στα ονόματά τους αλλά είναι χωρίς σχέσεις μελών ή συνεργασίας. Αν ο καλλιτέχνης αντιμετωπίζεται ως ένα πραγματικό συγκρότημα, πρέπει να προστεθούν σχέσεις μελών. Αν είναι συνεργασία μικρής διάρκειας, πρέπει να διαχωριστεί (δείτε {how_to_split_artists|Πως να διαχωρίζετε καλλιτέχνες}). Αν είναι συνεργασία με το δικό της όνομα και δεν μπορεί να διαχωριστεί, πρέπει να προστεθούν σχέσεις συνεργασίας."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Λυπούμαστε, αλλά τα δεδομένα για αυτή την αναφορά δεν είναι διαθέσιμα αυτή τη στιγμή."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Καλλιτέχνες οι οποίοι έχουν σχέσεις συνεργασίας"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Καλλιτέχνες που μοιάζουν με συνεργασίες"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "Discogs URLs συνδεδεμένα με πολλαπλές δισκογραφικές εταιρείες"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Ομάδες κυκλοφοριών"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Ομάδες κυκλοφοριών που ίσως χρειάζονται συγχώνευση"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "Discogs URLs συνδεδεμένα με πολλαπλές ομάδες κυκλοφοριών"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Κυκλοφορίες με απροσδόκητα Amazon URLs"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Κυκλοφορίες με πολλαπλά ASINs"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Κυκλοφορίες με πολλαπλούς συνδέσμους Discogs"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "Amazon URLs συνδεδεμένα με πολλαπλές κυκλοφορίες"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "Discogs URLs συνδεδεμένα με πολλαπλές κυκλοφορίες"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Δίσκοι καταχωρημένοι ως ξεχωριστές κυκλοφορίες"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Κυκλοφορίες με μη συνεχείς αριθμούς κομματιών"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Κυκλοφορίες με αριθμούς καταλόγου που μοιάζουν με ASINs"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Μεταφρασμένες/Μεταγλωττισμένες Ψευδο-κυκλοφορίες που δεν έχουν συνδεθεί με την πρωτότυπη έκδοση"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr ""
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12851,60 +12869,76 @@ msgstr ""
 msgid "{place_type}: {place_link}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Εμφάνιση περισσότερων..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Δε βρέθηκε; Δοκιμάστε ξανά με απευθείας αναζήτηση."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr ""
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr ""
 
@@ -12926,7 +12960,7 @@ msgstr "Τελευταία τροποποίηση σχολίου στις {date}
 msgid "Show less..."
 msgstr "Εμφάνιση λιγότερων..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr ""
 
@@ -12943,67 +12977,84 @@ msgstr ""
 msgid "[missing editor]"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Ετικέτα"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr ""
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr ""
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13121,21 +13172,21 @@ msgstr ""
 msgid "{begin_date} –"
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Ξεκίνησε:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Αυτό το άτομο απεβίωσε."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Αυτό το συγκρότημα διαλύθηκε."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr ""
 
@@ -13195,9 +13246,9 @@ msgid ""
 "entity from the others."
 msgstr ""
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr ""
 
@@ -13210,7 +13261,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr ""
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13227,7 +13278,7 @@ msgid "This relationship already exists."
 msgstr ""
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr ""
 
@@ -13247,7 +13298,7 @@ msgstr ""
 msgid "Remove Link"
 msgstr ""
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr ""
 
@@ -13280,45 +13331,45 @@ msgid ""
 "language guidelines}. "
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Παρακαλούμε επιλέξτε ένα τύπο σχέσης."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Παρακαλούμε επιλέξτε έναν επιμέρους τύπο του τρέχοντος επιλεγμένου τύπου σχέσης. Ο επιλεγμένος τύπος σχέσης χρησιμοποιείται μόνο για την ομαδοποίηση των επιμέρους τύπων"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
@@ -13326,19 +13377,19 @@ msgstr ""
 msgid "This attribute is required."
 msgstr "Αυτό το γνώρισμα απαιτείται."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13355,64 +13406,64 @@ msgstr ""
 msgid "Page {page} of {total}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Προσθήκη κυκλοφορίας"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Παρακαλούμε ελέγξτε το barcode σε αυτήν την κυκλοφορία."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Το barcode που έχετε εισάγει μοιάζει με κωδικό UPC του οποίου λείπει το ψηφίο ελέγχου."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Το barcode που έχετε εισάγει δεν είναι έγκυρος κωδικός UPC."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Το barcode που έχετε εισάγει είναι είτε μη έγκυρος κωδικός UPC ή ένας EAN κωδικός του οποίου λείπει το ψηφίο ελέγχου."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Το barcode που έχετε εισάγει είναι έγκυρος κωδικός EAN."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Το barcode που έχετε εισάγει δεν είναι έγκυρος κωδικός EAN."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Το barcode που έχετε εισάγει δεν είναι έγκυρος κωδικός UPC ή EAN."
 
@@ -13420,7 +13471,7 @@ msgstr "Το barcode που έχετε εισάγει δεν είναι έγκυ
 msgid "Add Language"
 msgstr ""
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr ""
 

--- a/po/mb_server.es.po
+++ b/po/mb_server.es.po
@@ -16,10 +16,12 @@
 # Héctor Arroyo <email address hidden>, 2012
 # Jaime Marquínez Ferrándiz, 2018
 # Jaime Marquínez Ferrándiz, 2018
+# Jaime Marquínez Ferrándiz, 2019
 # Juan González <email address hidden>, 2016
 # Juan González <email address hidden>, 2016
 # Kevin Doncam Demian López Brante <email address hidden>, 2012
-# Nicolás Tamargo <email address hidden>, 2011-2013,2015-2016,2018
+# Michael Wiencek <email address hidden>, 2019
+# Nicolás Tamargo <email address hidden>, 2011-2013,2015-2016,2018-2019
 # nikki, 2012
 # nikki, 2012
 # nikki, 2012
@@ -42,9 +44,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-04-01 18:17+0000\n"
+"Last-Translator: Nicolás Tamargo <email address hidden>\n"
 "Language-Team: Spanish (http://www.transifex.com/musicbrainz/musicbrainz/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -203,6 +205,7 @@ msgstr "(ninguno)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(desconocido)"
 
@@ -409,7 +412,7 @@ msgstr "Administradores de cuenta"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Los administradores de cuenta pueden modificar o eliminar cuentas de usuario."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "Entrada de AcousticBrainz:"
 
@@ -419,7 +422,7 @@ msgstr "Entrada de AcousticBrainz:"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Acciones"
 
@@ -604,10 +607,6 @@ msgstr "Añadir obra relacionada"
 msgid "Add relationship"
 msgstr "Añadir relación"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Agregar artistas seleccionados para fusionar"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Añadir eventos seleccionados para la fusión"
@@ -680,7 +679,7 @@ msgstr "Edad:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -700,9 +699,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Alias"
 
@@ -750,26 +750,21 @@ msgstr "También actúa como"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "URLs de Amazon asociadas a más de una publicación"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "URLs de Amazon asociadas a más de una publicación"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Un alias es un nombre alternativo para una entidad. Por lo general, contienen errores ortográficos comunes o variaciones del nombre y también se utilizan para mejorar los resultados de búsqueda. Vea la {doc|documentación de alias} para más detalles."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Un usuario anónimo"
 msgstr[1] "{n} usuarios anónimos"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -791,8 +786,7 @@ msgstr "Ha ocurrido un error: "
 msgid "An error occurred while creating the works."
 msgstr "Se ha producido un error al crear las obras."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -801,8 +795,9 @@ msgstr "Se ha producido un error al crear las obras."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Anotación"
@@ -936,11 +931,11 @@ msgstr "¿Estás seguro de que deseas eliminar la serie {series} de MusicBrainz?
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -991,24 +986,27 @@ msgstr "Áreas"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1054,11 +1052,6 @@ msgstr "Artista MBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Suscripciones al artista"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Anotaciones del Artista"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1106,7 +1099,7 @@ msgstr "Artista {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artista:"
 
@@ -1114,81 +1107,15 @@ msgstr "Artista:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artistas"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artistas cuyo nombre contiene disambiguación"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artistas que ocurren varias veces en el mismo crédito de artista"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artistas que podrían ser colaboraciones"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artistas que podrían ser grupos"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artistas que podrían ser personas"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artistas que tienen relaciones de colaboración"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artistas que parecen colaboraciones"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artistas con relaciones de colaboración"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Artistas con anotaciones"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artistas con relaciones en desuso"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artistas con desambiguación igual que el nombre."
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artistas con ningún suscriptor"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artistas con posibles relaciones duplicadas"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1353,9 +1280,8 @@ msgstr "Añadir relación a múltiples obras"
 msgid "Batch-create new works"
 msgstr "Crear múltiples obras nuevas"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "¿Por qué no cambiarlo? {sub|¡Suscríbete!}"
 
@@ -1413,21 +1339,12 @@ msgstr "Fecha de inicio:"
 msgid "Beginner"
 msgstr "Principiante"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Principiantes / editores limitados"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Abajo está la información del error. Si usted desea presentar un informe de fallo, lo puede hacer en {bugs | nuestro localizador de fallas}. La siguiente información ayudará, así que por favor asegúrese de incluirlo."
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Biografía"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1438,12 +1355,12 @@ msgstr "Biografía:"
 msgid "Birth date:"
 msgstr "Fecha de nacimiento:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blog"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Nacido:"
 
@@ -1455,13 +1372,13 @@ msgstr "Bot"
 msgid "Bots"
 msgstr "Bots"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
-msgstr "Traído a usted por {MeB | La Fundación MetaBrainz} y {spon | patrocinadores} y {Supl. | partidarios}. Imagenes proporcionadas por {caa | Cover Art Archive.}"
+msgstr "Sostenido por {MeB|La Fundación MetaBrainz} con la ayuda de {spon|patrocinadores} y {supp|simpatizantes}. Imágenes proporcionadas por el {caa|Cover Art Archive}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Seg. de fallos"
@@ -1606,7 +1523,7 @@ msgstr "Nº de catálogo"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Cambiar contraseña"
 
@@ -1634,7 +1551,7 @@ msgstr "Cambios"
 
 #: ../root/admin/attributes/form.tt:54 ../root/admin/attributes/index.tt:20
 msgid "Child order"
-msgstr ""
+msgstr "Orden de hijos"
 
 #: ../root/doc/relationship_type.tt:32
 #: ../root/edit/details/add_relationship_attribute.tt:11
@@ -1685,14 +1602,6 @@ msgstr "Cerrada"
 msgid "Code"
 msgstr "Código"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Colaboración"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Colaborador"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Contraer disco"
@@ -1721,7 +1630,7 @@ msgstr "Colección “{collection}”"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Colecciones"
@@ -1799,7 +1708,7 @@ msgid "Country:"
 msgstr "País:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Imagen"
 
@@ -1841,7 +1750,7 @@ msgstr "Creada"
 
 #: ../root/release/add_cover_art.tt:61
 msgid "Creating edit..."
-msgstr ""
+msgstr "Creando edición..."
 
 #: ../root/components/relationships-table.tt:22
 msgid "Credited As"
@@ -1931,7 +1840,7 @@ msgstr "El formato de fecha es AAAA-MM-DD. Puedes usar fechas parciales, como AA
 msgid "Delete"
 msgstr "Eliminar"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Eliminar cuenta"
 
@@ -1983,13 +1892,14 @@ msgstr "Descripción:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Detalles"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Muerto:"
 
@@ -1999,7 +1909,7 @@ msgstr "Diff"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Búsqueda directa en la base de datos"
 
@@ -2056,13 +1966,13 @@ msgid "Disc ID:"
 msgstr "ID de disco:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "IDs de disco"
 
 #: ../root/admin/attributes/index.tt:25
 msgid "Disc IDs allowed"
-msgstr ""
+msgstr "IDs de disco permitidas"
 
 #: ../root/report/superfluous_data_tracks.tt:1
 msgid "Disc IDs with superfluous data tracks"
@@ -2075,11 +1985,6 @@ msgstr "Título del disco:"
 #: ../root/artist/index.tt:31
 msgid "Discography"
 msgstr "Discografía"
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "URLs de Discogs asociadas a más de un artista"
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
@@ -2096,32 +2001,12 @@ msgstr "URLs de Discogs asociadas a más de un grupo de publicaciones"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "URLs de Discogs asociadas a más de una publicación"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "URLs de Discogs asociadas a más de un artista"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "URLs de Discogs asociadas a más de una discográfica"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "URLs de Discogs asociadas a más de un grupo de publicaciones"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "URLs de Discogs asociadas a más de una publicación"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Discos como publicaciones independientes"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Discos introducidos como publicaciones independientes"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Separación:"
 
@@ -2139,7 +2024,7 @@ msgstr "Documentación:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "¿No tienes una cuenta? {uri|¡Créala ahora!}"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Donaciones"
 
@@ -2170,9 +2055,9 @@ msgstr "Cada pista en la base de datos de MusicBrainz debe estar asociada a una 
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Editar"
 
@@ -2222,10 +2107,10 @@ msgstr "Nota"
 
 #: ../root/edit/search_macros.tt:360
 msgid "Edit Note Author"
-msgstr ""
+msgstr "Autor de las notas"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Editar perfil"
 
@@ -2297,13 +2182,13 @@ msgstr "FAQ de ediciones"
 
 #: ../root/admin/edit_user.tt:12
 msgid "Editing/voting disabled"
-msgstr ""
+msgstr "Edición/votación deshabilitadas"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Editor"
 
@@ -2319,10 +2204,6 @@ msgstr "Suscripciones al editor"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Editor \"{user}\""
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Editores"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2351,12 +2232,6 @@ msgstr "Ediciones de {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr ""
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "Correo electrónico"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2416,7 +2291,7 @@ msgstr "Finalizado"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Fin:"
 
@@ -2460,11 +2335,6 @@ msgstr "Tipo de entidad"
 msgid "Entity types:"
 msgstr "Tipos de entidad"
 
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Error"
-
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
 msgid "Error Approving Edit"
@@ -2494,7 +2364,7 @@ msgstr[1] "Errores:"
 
 #: ../root/components/entity-tabs.tt:1
 msgid "Error: Unknown Tab Type"
-msgstr ""
+msgstr "Error: tipo de pestaña desconocido"
 
 #: ../root/components/common-macros.tt:121
 msgid "Error: Unknown Type"
@@ -2513,8 +2383,8 @@ msgstr "¡Incluso un enlace o dos son de gran ayuda!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2541,13 +2411,14 @@ msgstr "Evento"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Eventos"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr ""
 
@@ -2603,7 +2474,7 @@ msgstr "Ediciones Fallidas"
 
 #: ../root/user/edits.tt:1
 msgid "Failed Edits by {name}"
-msgstr ""
+msgstr "Ediciones fallidas de {name}"
 
 #: ../root/components/common-macros.tt:918
 msgid "Few relationships"
@@ -2628,7 +2499,7 @@ msgid "Find Relationships"
 msgstr "Encontrar relaciones"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Huellas digitales"
 
@@ -2677,7 +2548,7 @@ msgstr ""
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr ""
 
@@ -2709,7 +2580,7 @@ msgstr "Formato"
 msgid "Format:"
 msgstr "Formato:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Foros"
@@ -2765,7 +2636,7 @@ msgstr[1] "Se encontraron {n} resultados para \"{q}\""
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Fundación:"
 
@@ -2821,7 +2692,6 @@ msgstr "Género:"
 msgid "General Information"
 msgstr "Información general:"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2829,17 +2699,9 @@ msgstr "Información general:"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2847,13 +2709,10 @@ msgstr "Información general:"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2868,13 +2727,11 @@ msgstr "Información general:"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2905,13 +2762,27 @@ msgstr "Información general:"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Generado el {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Géneros"
 
@@ -2956,7 +2827,7 @@ msgstr ""
 
 #: ../root/doc/relationship_type.tt:72
 msgid "Guidelines"
-msgstr ""
+msgstr "Convenciones"
 
 #: ../root/components/forms.tt:116
 msgid "HH:MM"
@@ -3110,13 +2981,15 @@ msgstr "ISRC {isrc} a {recording}"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRCs"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRCs con múltiples grabaciones"
 
@@ -3140,14 +3013,10 @@ msgstr "ISWC {iswc} a {work}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWCs"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
-msgstr ""
+msgstr "ISWCs con múltiples piezas"
 
 #: ../root/work/edit_form.tt:17
 #: ../root/layout/components/MetaDescription.js:160
@@ -3178,7 +3047,7 @@ msgstr "Si no encuentras lo que estás buscando, puedes añadir una nueva public
 
 #: ../root/account/edit.tt:19
 msgid "If you change your email address, you will be required to verify it."
-msgstr ""
+msgstr "Si cambia su dirección de correo electrónico, tendrá que verificarla."
 
 #: ../root/release/edit/information.tt:320
 msgid ""
@@ -3217,15 +3086,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Si crees que es un error, contacta con <code>support@musicbrainz.org</code> indicando el nombre de tu cuenta."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Si te gustaría editar MusicBrainz, pero no sabes por dónde empezar, estos informes pueden resultar útiles. Para crearlos se analiza la base de datos en busca de información que quizá deba ser modificada, ya sea para seguir las {style|convenciones de estilo} o por otras razones de organización."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3263,11 +3123,11 @@ msgstr "Nombre de usuario o contraseña incorrectos."
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Búsqueda indexada"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Búsqueda indexada con {doc|sintaxis avanzada}"
 
@@ -3278,7 +3138,7 @@ msgstr "Búsqueda indexada con {doc|sintaxis avanzada}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3286,7 +3146,7 @@ msgstr "instrumento"
 
 #: ../root/user/collections.tt:2
 msgid "Instrument Collections"
-msgstr ""
+msgstr "Colecciones de instrumentos"
 
 #: ../root/components/recordings-list.tt:31
 #: ../root/components/releases-list.tt:26
@@ -3295,7 +3155,7 @@ msgstr ""
 
 #: ../root/instrument/edit_form.tt:9
 msgid "Instrument Details"
-msgstr ""
+msgstr "Detalles del instrumento"
 
 #: ../root/components/common-macros.tt:570
 #: ../root/edit/details/add_instrument.tt:3
@@ -3303,15 +3163,16 @@ msgstr ""
 msgid "Instrument:"
 msgstr "instrumento"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Instrumentos"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
-msgstr ""
+msgstr "Instrumentos sin imagen"
 
 #: ../root/main/info/environment.tt:13
 msgid "Interface language:"
@@ -3375,9 +3236,9 @@ msgstr "Mantenedme conectado"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3438,31 +3299,28 @@ msgstr "Discográfica:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Discográficas"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr ""
 
@@ -3503,7 +3361,6 @@ msgstr "Últimas 24 horas"
 msgid "Last 28 days"
 msgstr "Últimos 28 días"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3511,14 +3368,15 @@ msgstr "Últimos 28 días"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Última edición"
 
 #: ../root/user/profile.tt:96
 msgid "Last login:"
-msgstr ""
+msgstr "Último inicio de sesión:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr ""
 
@@ -3526,7 +3384,7 @@ msgstr ""
 msgid "Last updated"
 msgstr "Última actualización:"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Última actualización:"
 
@@ -3596,14 +3454,14 @@ msgid "Loading edit previews..."
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Cargando..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Idioma"
 
@@ -3613,6 +3471,7 @@ msgstr "Idioma:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Ubicación"
 
@@ -3685,7 +3544,7 @@ msgstr "Baja"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Idiomas de la letra"
 
@@ -3702,7 +3561,7 @@ msgstr "MM"
 #: ../root/components/forms.tt:15 ../root/components/forms.tt:20
 #: ../root/components/EnterEdit.js:32
 msgid "Make all edits votable."
-msgstr ""
+msgstr "Permitir votar todas las ediciones."
 
 #: ../root/release/merge.tt:112
 msgid ""
@@ -3720,7 +3579,7 @@ msgid "Many relationships"
 msgstr "Muchas relaciones"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Mapa"
 
@@ -3781,10 +3640,6 @@ msgstr "Medio:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Medios:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Miembro desde"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3896,7 +3751,7 @@ msgstr "Más Polular"
 msgid "Most Recent"
 msgstr "Más Reciente"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Mover"
 
@@ -3914,11 +3769,11 @@ msgstr "Mover el disco hacia arriba"
 
 #: ../root/forms/relationship-editor.tt:33
 msgid "Move entity down"
-msgstr ""
+msgstr "Mover entidad hacia abajo"
 
 #: ../root/forms/relationship-editor.tt:34
 msgid "Move entity up"
-msgstr ""
+msgstr "Mover entidad hacia arriba"
 
 #: ../root/release/add_cover_art.tt:47
 msgid "Move file down"
@@ -4025,7 +3880,7 @@ msgstr "Nombre"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Nombre:"
 
@@ -4051,7 +3906,7 @@ msgstr "Nueva imagen aquí"
 
 #: ../root/edit/details/reorder_relationships.tt:10
 msgid "New Order"
-msgstr ""
+msgstr "Nuevo orden"
 
 #: ../root/relationship/linkattributetype/create.tt:1
 #: ../root/relationship/linkattributetype/create.tt:3
@@ -4127,7 +3982,7 @@ msgstr "Nueva versión:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Siguiente"
@@ -4203,7 +4058,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Ningún de los lanzamientos tiene imágenes marcadas como 'Frente', no se puede establecer la Imagen."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "No hay resultados."
 
@@ -4217,7 +4072,7 @@ msgstr "No se encontraron resultados."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "No se encontraron resultados. Intenta perfeccionar tu búsqueda."
 
@@ -4242,13 +4097,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr ""
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr ""
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr ""
 
@@ -4258,7 +4113,7 @@ msgid "None"
 msgstr "Ninguno"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr ""
@@ -4325,7 +4180,7 @@ msgstr "Artista anterior"
 
 #: ../root/edit/details/reorder_relationships.tt:7
 msgid "Old Order"
-msgstr ""
+msgstr "Antiguo orden"
 
 #: ../root/edit/details/edit_medium.tt:45
 msgid "Old Tracklist"
@@ -4411,11 +4266,11 @@ msgstr "Ediciones pendientes"
 
 #: ../root/user/edits.tt:1
 msgid "Open Edits by {name}"
-msgstr ""
+msgstr "Ediciones abiertas de {name}"
 
 #: ../root/entity/edits.tt:1
 msgid "Open Edits for {name}"
-msgstr ""
+msgstr "Ediciones abiertas para {name}"
 
 #: ../root/edit/list_header.tt:16
 #: ../root/layout/components/sidebar/CollectionSidebar.js:53
@@ -4467,18 +4322,18 @@ msgid "Other lookups"
 msgstr "Otras búsquedas"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
-msgstr ""
+msgstr "Otras etiquetas"
 
 #: ../root/user/profile.tt:232
 msgid "Overall"
 msgstr "Total"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Resumen"
@@ -4527,7 +4382,7 @@ msgstr "Padre"
 
 #: ../root/admin/attributes/index.tt:21
 msgid "Parent ID"
-msgstr ""
+msgstr "ID del padre"
 
 #: ../root/edit/details/add_relationship_attribute.tt:15
 #: ../root/edit/details/edit_relationship_attribute.tt:14
@@ -4555,11 +4410,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Llevar a cabo las operaciones anteriores cuando no estoy usando la aplicación"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
-msgstr ""
+msgstr "Interpretaciones"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Enlace permanente:"
 
@@ -4571,8 +4426,8 @@ msgstr "Frase:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4580,7 +4435,7 @@ msgstr "Lugar"
 
 #: ../root/user/collections.tt:2
 msgid "Place Collections"
-msgstr ""
+msgstr "Colecciones de lugares"
 
 #: ../root/place/edit_form.tt:11
 msgid "Place Details"
@@ -4598,23 +4453,20 @@ msgstr "Lugar:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Lugares"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr ""
 
@@ -4737,22 +4589,14 @@ msgid "Possible duplicate events"
 msgstr "Eventos que quizás estén duplicados"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr ""
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Valores posibles:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Artistas que podrían ser duplicados"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Eventos que quizás estén duplicados"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4770,7 +4614,7 @@ msgstr "Previsualización:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Anterior"
@@ -4822,7 +4666,7 @@ msgid "Public collection by {owner}"
 msgstr "Colección pública de {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Consulta:"
 
@@ -4847,7 +4691,7 @@ msgstr "Valoración"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Valoraciones"
 
@@ -4877,7 +4721,7 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4885,7 +4729,7 @@ msgstr "Grabación"
 
 #: ../root/user/collections.tt:2
 msgid "Recording Collections"
-msgstr ""
+msgstr "Colecciones de grabaciones"
 
 #: ../root/recording/edit_form.tt:24
 msgid "Recording Details"
@@ -4898,7 +4742,7 @@ msgstr ""
 #: ../root/report/annotations_recordings.tt:1
 #: ../root/report/annotations_recordings.tt:3
 msgid "Recording annotations"
-msgstr ""
+msgstr "Anotaciones de la grabación"
 
 #: ../root/user/ratings_summary.tt:3 ../root/user/ratings.tt:2
 msgid "Recording ratings"
@@ -4920,21 +4764,22 @@ msgstr "Grabación:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Grabaciones"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
@@ -4948,40 +4793,28 @@ msgstr "Grabaciones con la relación \"primera publicación\""
 msgid "Recordings with Varying Track Lengths"
 msgstr ""
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Grabaciones con la relación \"primera publicación\""
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr ""
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr ""
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Grabaciones que contienen \"feat.\" en el título"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr ""
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5001,11 +4834,11 @@ msgstr "Rechazar edición"
 
 #: ../root/user/edits.tt:1
 msgid "Rejected Edits"
-msgstr ""
+msgstr "Ediciones rechazadas"
 
 #: ../root/user/edits.tt:1
 msgid "Rejected Edits by {name}"
-msgstr ""
+msgstr "Ediciones rechazadas de {name}"
 
 #: ../root/release/edit_relationships.tt:55
 msgid "Related Works"
@@ -5013,11 +4846,11 @@ msgstr "Obras relacionadas"
 
 #: ../root/edit/data.tt:15
 msgid "Related entities:"
-msgstr ""
+msgstr "Entidades relacionadas:"
 
 #: ../root/components/relationships.tt:45
 msgid "Related series"
-msgstr ""
+msgstr "Series relacionadas"
 
 #: ../root/components/relationships.tt:37
 msgid "Related works"
@@ -5036,10 +4869,9 @@ msgstr "Atributos de relación"
 
 #: ../root/edit/search_macros.tt:339
 msgid "Relationship Editor"
-msgstr ""
+msgstr "Editor de relaciones"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5047,6 +4879,7 @@ msgstr ""
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Tipo de relación"
 
@@ -5096,7 +4929,7 @@ msgstr "Relación:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Relaciones"
 
@@ -5128,7 +4961,7 @@ msgstr "Relaciones:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5141,7 +4974,7 @@ msgstr "Artista de la publicación"
 
 #: ../root/user/collections.tt:2
 msgid "Release Collections"
-msgstr ""
+msgstr "Colecciones de lanzamientos"
 
 #: ../root/edit/search_macros.tt:360
 msgid "Release Country"
@@ -5160,7 +4993,7 @@ msgstr "Eventos de lanzamiento:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Grupo de publicaciones"
@@ -5196,7 +5029,7 @@ msgstr "Grupos de publicaciones"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr ""
 
@@ -5237,7 +5070,7 @@ msgstr "Evento de lanzamiento"
 #: ../root/edit/details/edit_release_label.tt:50
 #: ../root/edit/details/edit_release.tt:65
 msgid "Release events:"
-msgstr ""
+msgstr "Eventos de lanzamiento:"
 
 #: ../root/report/release_group_url_list.tt:6
 #: ../lib/MusicBrainz/Server/Edit/ReleaseGroup.pm:7
@@ -5255,6 +5088,7 @@ msgid "Release group ratings"
 msgstr "Valoraciones del grupo de publicaciones"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Grupo de publicaciones “{name}” de {artist}"
 
@@ -5266,38 +5100,27 @@ msgstr "Grupo de publicaciones “{name}” de {artist}"
 msgid "Release group:"
 msgstr "Grupo de publicaciones:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Grupos de publicaciones"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
-msgstr ""
-
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Grupos de publicaciones que quizá necesiten ser fusionados"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr ""
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Grupos de publicaciones que contienen \"feat.\" en el título"
 
@@ -5340,8 +5163,8 @@ msgstr "Publicación:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Publicaciones"
@@ -5375,67 +5198,43 @@ msgstr "Publicaciones con varios enlaces de Discogs"
 msgid "Releases With Some Formats Unset"
 msgstr "Publicaciones con algunos formatos sin indicar"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Publicaciones en el archivo de imágenes que aún tienen relaciones de \"imagen de portada\"."
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr ""
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr ""
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr ""
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Lanzamientos publicados demasiado pronto"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr ""
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Publicaciones en las que algunos medios (pero no todos) no tienen formato"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Publicaciones con varios ASINs"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Publicaciones con varios enlaces de Discogs"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Publicaciones que tienen relaciones de \"parte de conjunto\""
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Publicaciones con URLs de Amazon inesperadas"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Publicaciones que quizá deban estar atribuidas a múltiples artistas"
 
@@ -5444,23 +5243,15 @@ msgstr "Publicaciones que quizá deban estar atribuidas a múltiples artistas"
 msgid "Releases with Cover Art relationships"
 msgstr ""
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr ""
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr ""
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Publicaciones con números de catálogo que parecen ASINs"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr ""
 
@@ -5469,31 +5260,25 @@ msgstr ""
 msgid "Releases with medium number issues"
 msgstr "Publicaciones con problemas en la posición de los medios"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr ""
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Publicaciones con números de medio discontinuos"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Publicaciones con números de pista discontinuos"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr ""
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Publicaciones con pistas de datos superfluas"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Publicaciones que contienen \"feat.\" en el título "
 
@@ -5502,24 +5287,26 @@ msgstr "Publicaciones que contienen \"feat.\" en el título "
 msgid "Releases with track number issues"
 msgstr "Publicaciones con problemas en la posición de las pistas"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr ""
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Publicaciones con combinaciones extrañas idioma/alfabeto"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Publicaciones sin idioma"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Publicaciones sin alfabeto"
 
@@ -5545,7 +5332,7 @@ msgstr "Publicaciones:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5557,7 +5344,7 @@ msgstr "Publicaciones:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Eliminar"
@@ -5568,11 +5355,11 @@ msgstr ""
 
 #: ../root/area/delete.tt:2
 msgid "Remove Area"
-msgstr ""
+msgstr "Eliminar área"
 
 #: ../root/admin/attributes/delete.tt:1 ../root/admin/attributes/delete.tt:3
 msgid "Remove Attribute"
-msgstr ""
+msgstr "Eliminar atributo"
 
 #: ../root/release/remove_cover_art.tt:1 ../root/release/remove_cover_art.tt:2
 msgid "Remove Cover Art"
@@ -5584,11 +5371,11 @@ msgstr "Eliminar ID de disco"
 
 #: ../root/relationship/linktype/form.tt:81
 msgid "Remove Example"
-msgstr ""
+msgstr "Eliminar ejemplo"
 
 #: ../root/instrument/delete.tt:1 ../root/instrument/delete.tt:2
 msgid "Remove Instrument"
-msgstr ""
+msgstr "Eliminar instrumento"
 
 #: ../root/label/delete.tt:2 ../root/release/edit/information.tt:190
 msgid "Remove Label"
@@ -5630,7 +5417,7 @@ msgstr "Eliminar grupo de publicaciones"
 
 #: ../root/series/delete.tt:2
 msgid "Remove Series"
-msgstr ""
+msgstr "Eliminar serie"
 
 #: ../root/entity/alias/delete.tt:2
 msgid "Remove alias"
@@ -5638,7 +5425,7 @@ msgstr ""
 
 #: ../root/work/edit_form.tt:61
 msgid "Remove attribute"
-msgstr ""
+msgstr "Eliminar atributo"
 
 #: ../root/collection/delete.tt:2 ../root/collection/delete.tt:7
 msgid "Remove collection"
@@ -5691,16 +5478,11 @@ msgstr "Ordenar imágenes"
 
 #: ../root/user/report.tt:1 ../root/user/report.tt:2
 msgid "Report User"
-msgstr ""
+msgstr "Reportar usuario"
 
 #: ../root/user/profile.tt:275
 msgid "Report this user for bad behavior"
 msgstr ""
-
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Informes"
 
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
@@ -5724,7 +5506,7 @@ msgstr "Restablecer contraseña"
 msgid "Reset track numbers"
 msgstr "Restablecer núm. de pista"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Resultados por página:"
 
@@ -5737,7 +5519,7 @@ msgstr "Resultados:"
 
 #: ../root/release/edit/recordings.tt:7
 msgid "Reuse previous recordings"
-msgstr ""
+msgstr "Reutilizar grabaciones previas"
 
 #: ../root/user/contact.tt:16 ../root/user/report.tt:23
 msgid "Reveal my email address"
@@ -5764,7 +5546,7 @@ msgstr ""
 msgid "Role"
 msgstr "Rol"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Ejecutando: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5777,7 +5559,7 @@ msgstr "Guardar"
 
 #: ../root/admin/attributes/script.tt:1 ../root/admin/attributes/script.tt:3
 msgid "Script"
-msgstr ""
+msgstr "Alfabeto"
 
 #: ../root/edit/details/add_release.tt:53
 #: ../root/edit/details/edit_release.tt:37
@@ -5807,7 +5589,7 @@ msgstr "Alfabeto:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5854,7 +5636,7 @@ msgstr "Buscar ediciones"
 msgid "Search for the target URL."
 msgstr ""
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Método de búsqueda:"
 
@@ -5943,7 +5725,7 @@ msgstr "Enviar una copia a mi propia dirección de correo"
 msgid "Sentence"
 msgstr ""
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Series"
@@ -5958,8 +5740,8 @@ msgstr "Series"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5981,10 +5763,6 @@ msgstr ""
 #: ../root/report/annotations_series.tt:1
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
-msgstr ""
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
 msgstr ""
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
@@ -6014,7 +5792,7 @@ msgstr "Establecer una nueva contraseña para tu cuenta de MusicBrainz"
 msgid "Set cover art"
 msgstr "Escoger imagen"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Establecer la duración de pista"
 
@@ -6027,10 +5805,6 @@ msgstr ""
 msgid "Setlist:"
 msgstr ""
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Ver todos los resultados."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr ""
@@ -6040,10 +5814,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Mostrar {autoedit_select_block} que {match_or_negation_block} {and_vs_or_block} las siguientes condiciones (orden: {sort_select_block} ):"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Ver solo resultados en mis suscripciones."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6132,7 +5902,7 @@ msgstr "Publicaciones similares"
 
 #: ../root/admin/edit_user.tt:37
 msgid "Skip verification"
-msgstr ""
+msgstr "Saltar verificación"
 
 #: ../root/release/edit/editnote.tt:4
 msgid ""
@@ -6179,7 +5949,7 @@ msgstr "Lo sentimos, la página que buscas no está disponible en un servidor es
 msgid "Sorry, there was a problem with your request."
 msgstr "Lo sentimos, hubo un problema con tu petición."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Lo sentimos, no tienes permiso para ver esta página."
 
@@ -6203,8 +5973,8 @@ msgstr "“{id}” no es una página de documentación válida."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Nombre de ordenación"
 
@@ -6258,7 +6028,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Estatus:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Dejar de usar la versión beta"
 
@@ -6302,7 +6072,7 @@ msgstr ""
 
 #: ../root/user/collections.tt:48
 msgid "Subscribed"
-msgstr ""
+msgstr "Suscrito"
 
 #: ../root/edit/list_header.tt:20
 msgid "Subscribed editors"
@@ -6312,12 +6082,10 @@ msgstr "Suscripciones a editores"
 msgid "Subscribed entities"
 msgstr "Suscripciones a entidades"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6338,7 +6106,7 @@ msgstr ""
 #: ../root/edit/details/add_annotation.tt:21
 #: ../root/edit/details/historic/add_release_annotation.tt:25
 msgid "Summary"
-msgstr ""
+msgstr "Resumen"
 
 #: ../root/release/edit/tracklist.tt:400
 msgid "Swap track titles with artist credits"
@@ -6365,8 +6133,8 @@ msgid "Tagger"
 msgstr "Etiquetador"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6374,7 +6142,7 @@ msgstr "Etiquetas"
 
 #: ../root/main/400.tt:20 ../root/main/timeout.tt:9
 msgid "Technical Information"
-msgstr ""
+msgstr "Información técnica"
 
 #: ../root/admin/edit_user.tt:14
 msgid "Technical flags"
@@ -6387,7 +6155,7 @@ msgstr "Características de prueba"
 #: ../root/edit/details/add_annotation.tt:10
 #: ../root/edit/details/historic/add_release_annotation.tt:14
 msgid "Text"
-msgstr ""
+msgstr "Texto"
 
 #: ../root/release/caa_darkened.tt:3 ../root/release/cover_art.tt:59
 msgid ""
@@ -6437,7 +6205,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Los datos de esta edición provienen originalmente de una versión anterior y puede que no se muestren correctamente"
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6448,7 +6216,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr ""
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "La fecha indicada no es válida."
 
@@ -6547,7 +6315,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "El servidor de búsqueda no ha podido procesar tu solicitud debido a un error interno. Normalmente estos errores son temporales, por favor reintenta tu búsqueda más tarde."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr ""
 
@@ -6586,21 +6354,9 @@ msgstr "No hay usuarios suscritos a tus ediciones."
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "No hay usuarios suscritos a las ediciones realizadas por {user}."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "No hay usuarios suscritos a {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "No hay ningún usuario suscrito a {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "No hay usuarios suscritos a {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr ""
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6609,12 +6365,12 @@ msgid ""
 msgstr ""
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr ""
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr ""
 
@@ -6640,29 +6396,11 @@ msgid_plural ""
 msgstr[0] "Hay {num} usuario suscrito a las ediciones realizadas por {user}."
 msgstr[1] "Hay {num} usuarios suscritos a las ediciones realizadas por {user}."
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Hay {num} usuario suscrito a {artist}."
-msgstr[1] "Hay {num} usuarios suscritos a {artist}."
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "Hay {num} usuario suscrito a {collection}:"
 msgstr[1] "Hay {num} usuarios suscritos a {collection}:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Hay {num} usuario suscrito a {label}."
-msgstr[1] "Hay {num} usuarios suscritos a {label}."
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] ""
-msgstr[1] ""
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6770,7 +6508,7 @@ msgid ""
 msgstr ""
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Este artista ya no está activo."
 
@@ -6820,7 +6558,7 @@ msgstr ""
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Este servidor beta permite probar mejoras y nuevas herramientas en la base de datos real."
@@ -6927,11 +6665,11 @@ msgid ""
 "attributed to it."
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Este es un servidor de desarrollo de MusicBrainz."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7051,7 +6789,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Esta grabación no está asociada a ningúna AcoustID."
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr ""
@@ -7085,7 +6823,7 @@ msgstr ""
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr ""
 
@@ -7119,16 +6857,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr ""
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Este informe muestra artistas con nombres muy similares. Si dos de ellos son realmente el mismo, fusiónalos (no olvides {how_to_write_edit_notes|dejar una nota} con las pruebas que tengas). Si son diferentes, añade {disambiguation_comment|comentarios de disambiguación}; cuando todos los artistas con el mismo nombre tengan comentarios de disambiguación, dejarán de aparecer en este informe."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7169,85 +6897,6 @@ msgstr "Este informe muestra todas las publicaciones en las que la lista de pist
 msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
-msgstr ""
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr ""
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr ""
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "Este informe muestra artistas cuyo tipo actual no es <em>grupo</em>, pero parecen ser <em>grupos</em> ya que tienen otros artistas asociados como miembros. Si uno de ellos es, efectivamente, un grupo, cambia el tipo. Si no lo es, asegúrate de que las relaciones con sus miembros son correctas y están en el orden adecuado."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "Este informe muestra artistas cuyo tipo actual no es <em>persona</em>, pero según sus relaciones, parecen ser <em>personas</em> (por ejemplo, porque están asociados como miembros de un grupo). Si uno de ellos es, efectivamente, una persona, cambia el tipo. Si no lo es, asegúrate de que todas las relaciones son correctas y están en el orden adecuado."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Este informe muestra artistas que parecen tener comentarios de disambiguación como parte del nombre, en vez de en el campo de disambiguación."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Este informe muestra artistas que tienen \"&\" en su nombre, pero no están asociados a miembros ni colaboradores. Si el artista suele considerarse un grupo propiamente dicho, añade relaciones con sus miembros. Si es una colaboración breve, sepárala si es posible: consulta {how_to_split_artists|cómo separar artistas (en inglés)}. Si es una colaboración que tiene un nombre específico y no es posible separarla, añade relaciones con sus colaboradores."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Este informe muestra artistas que tienen relaciones de colaboración, pero ninguna URL. Si una colaboración tiene un nombre específico, no hagas nada, pero si su nombre es del estilo \"X con Y\" o \"X & Y\", es probable que necesite ser separado en varios artistas. Consulta {how_to_split_artists|cómo separar artistas (en inglés)}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
 msgstr ""
 
 #: ../root/report/duplicate_events.tt:6
@@ -7410,10 +7059,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr ""
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr ""
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7424,10 +7069,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Este informe muestra URLs de Amazon asociadas a más de una publicación. En la mayoría de los casos una ASIN de Amazon equivale a una y solo una publicación de MusicBrainz, así que solo uno de los enlaces será correcto. Comprueba cuál de las publicaciones en MusicBrainz coincide con la de Amazon (en formato, pistas, país, etc.).  Si la publicación tiene un código de barras, puedes buscarlo en Amazon y ver cuál de las ASINs corresponde a dicho código. Es posible que encuentres algunas ASINs asociada a varios discos de una publicación con múltiples discos; en ese caso, fusiónalos. Consulta {how_to_merge_releases|cómo fusionar publicaciones (en inglés)}."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Este informe muestra URLs de Discogs asociadas a más de un artista."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7707,7 +7348,7 @@ msgstr ""
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Esta tabla muestra un resumen de los votos de este editor."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr ""
 
@@ -7832,29 +7473,6 @@ msgstr ""
 
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Artistas encontrados: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Total de grupos duplicados: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
 msgstr ""
 
 #: ../root/report/duplicate_events.tt:10
@@ -8015,7 +7633,7 @@ msgstr "Pistas:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Lista de pistas"
 
@@ -8033,10 +7651,6 @@ msgstr "Lista de pistas:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Pistas"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Pistas cuyos títulos incluyen su número de pista"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8065,16 +7679,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Los editores de transclusión añaden y mantienen las entradas en la tabla de transclusión de {uri|WikiDocs}."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Pseudo-lanzamientos traducidos/transliterados no enlazados con una versión original"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Turco"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8090,15 +7699,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8112,7 +7724,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Tipo"
 
@@ -8140,7 +7752,7 @@ msgstr "Tipo"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Tipo:"
 
@@ -8156,14 +7768,15 @@ msgstr "Tipo: {type}, estatus: {status}"
 msgid "Types:"
 msgstr "Tipos:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8183,17 +7796,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr ""
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr ""
 
@@ -8215,8 +7828,12 @@ msgstr "Solicitud no autorizada"
 msgid "Unclassified instrument"
 msgstr ""
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -8243,9 +7860,9 @@ msgstr "Desuscribirse"
 msgid "Untrusted"
 msgstr "No confiable"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Hasta {n}"
 
@@ -8272,13 +7889,13 @@ msgstr ""
 
 #: ../root/release/add_cover_art.tt:60
 msgid "Uploading image..."
-msgstr ""
+msgstr "Subiendo imagen..."
 
 #: ../root/components/forms.tt:266 ../root/components/forms.tt:290
 msgid "Uppercase roman numerals"
 msgstr "Poner en mayúsculas los números romanos"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Usar la versión beta"
 
@@ -8334,7 +7951,7 @@ msgid "Username:"
 msgstr "Nombre de usuario:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Usuarios"
 
@@ -8374,7 +7991,7 @@ msgstr ""
 #: ../root/edit/details/add_standalone_recording.tt:34
 #: ../root/edit/details/edit_recording.tt:26
 msgid "Video:"
-msgstr ""
+msgstr "Vídeo:"
 
 #: ../root/user/ratings_summary.tt:26
 msgid "View all ratings"
@@ -8443,7 +8060,7 @@ msgstr "Período de votación (días)"
 
 #: ../root/components/common-macros.tt:701
 msgid "Warning"
-msgstr ""
+msgstr "Advertencia"
 
 #: ../root/release/edit/information.tt:273
 msgid ""
@@ -8465,10 +8082,6 @@ msgstr ""
 #: ../root/watch/list.tt:1 ../root/watch/list.tt:2
 msgid "Watched Artists"
 msgstr "Artistas seguidos"
-
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Lo sentimos, pero los datos de este informe no están disponibles en este momento."
 
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
@@ -8515,10 +8128,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Sentimos mucho este problema. Espera unos minutos y vuelve a intentarlo; quizá se haya solucionado."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr ""
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Página web:"
@@ -8531,7 +8140,7 @@ msgid ""
 "and following the merge link."
 msgstr "Cuando estés listo para unir éstos elementos haz click en el botón de unir. Puedes añadir más elementos a la cola de unión accediendo a las páginas de las entidades y haciendo click en el enlace de unir."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8553,10 +8162,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Obra"
 
@@ -8595,35 +8204,32 @@ msgstr "Obra:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Obras"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr ""
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr ""
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Autores"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8736,9 +8342,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Vas a fusionar las siguientes obras en una. Elige la obra con la que quieres fusionar a las demás:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Estás suscrito/a, ¿{unsub|quieres desuscribirte}?"
 
@@ -8754,9 +8359,8 @@ msgstr "No puedes añadir notas a esta edición. ({url|¿Por qué?})"
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "En estos momentos no puedes votar en esta edición. ({url|Detalles})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "No estás suscrito/a, ¿{sub|quieres suscribirte}?"
 
@@ -8836,7 +8440,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr ""
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr ""
 
@@ -8861,7 +8465,7 @@ msgstr ""
 msgid "You must be logged in to vote on edits"
 msgstr "Debes estar conectado para votar."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr ""
 
@@ -8943,7 +8547,7 @@ msgstr ""
 msgid "Your username will be publicly visible."
 msgstr "Tu nombre de usuario será público."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8986,10 +8590,6 @@ msgstr "[desconocido]"
 msgid "after"
 msgstr "después de"
 
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr ""
-
 #: ../root/edit/search_macros.tt:28
 msgid "all"
 msgstr "todas"
@@ -9008,7 +8608,7 @@ msgstr "aparece en:"
 
 #: ../root/components/common-macros.tt:121
 msgid "areas"
-msgstr ""
+msgstr "áreas"
 
 #: ../root/components/common-macros.tt:121
 msgid "artists"
@@ -9050,10 +8650,6 @@ msgstr ""
 #: ../root/components/relationship-editor.tt:208
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
-msgstr ""
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
 msgstr ""
 
 #: ../root/admin/wikidoc/index.tt:53
@@ -9100,7 +8696,7 @@ msgstr ""
 
 #: ../root/components/common-macros.tt:121
 msgid "events"
-msgstr ""
+msgstr "eventos"
 
 #: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
 msgid "from {begin_date} until {end_date}"
@@ -9190,7 +8786,7 @@ msgstr "menor que"
 
 #: ../root/edit/search_macros.tt:245 ../root/edit/search_macros.tt:320
 msgid "is me"
-msgstr ""
+msgstr "soy yo"
 
 #: ../root/edit/search_macros.tt:139
 msgid "is more than"
@@ -9207,7 +8803,7 @@ msgstr "no es"
 
 #: ../root/edit/search_macros.tt:245 ../root/edit/search_macros.tt:320
 msgid "is not me"
-msgstr ""
+msgstr "no soy yo"
 
 #: ../root/components/common-macros.tt:121
 msgid "labels"
@@ -9271,11 +8867,9 @@ msgstr "original"
 
 #: ../root/components/common-macros.tt:121
 msgid "places"
-msgstr ""
+msgstr "lugares"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "más {n} usuario anónimo"
@@ -9344,7 +8938,7 @@ msgstr "lista de pistas"
 
 #: ../root/doc/relationship_type.tt:62
 msgid "start date"
-msgstr ""
+msgstr "fecha de inicio"
 
 #: ../root/user/profile.tt:131
 msgid "subscribe"
@@ -9498,7 +9092,7 @@ msgstr[1] ""
 msgid "{entity} has not been added to any collections."
 msgstr ""
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9512,7 +9106,7 @@ msgstr "{link} no tiene valoraciones"
 msgid "{link} has no relationships."
 msgstr "{link} no tiene relaciones."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"ID de MusicBrainz\">MBID</abbr>}:"
 
@@ -9625,7 +9219,7 @@ msgstr ""
 msgid "{type} “{work}”"
 msgstr "{type} “{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr ""
 
@@ -9672,7 +9266,7 @@ msgstr "« Anterior"
 #: ../root/components/paginator.tt:39 ../root/components/Paginator.js:69
 #: ../root/components/Paginator.js:89 ../root/components/Paginator.js:103
 msgid "…"
-msgstr ""
+msgstr "…"
 
 #: ../lib/MusicBrainz/Server/Controller.pm:32
 #, perl-brace-format
@@ -9796,7 +9390,7 @@ msgstr "Hemos enviado un correo de verificación a <code>{email}</code>. Comprue
 
 #: ../lib/MusicBrainz/Server/Controller/Account.pm:433
 msgid "Your password has been changed."
-msgstr ""
+msgstr "Su contraseña se ha cambiado."
 
 #: ../lib/MusicBrainz/Server/Controller/Account.pm:650
 msgid ""
@@ -9832,34 +9426,34 @@ msgstr "'{id}' no es una ID de elección válida"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "El parámetro requerido TOC faltaba o no era válido"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "El CD TOC proporcionado no es válido"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "La ID de medio suministrada no es válida"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Este CD TOC ya está asociado a este medio"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "El medio seleccionado no puede tener IDs de disco"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "La ID de artista indicada no es válida"
 
@@ -9996,7 +9590,7 @@ msgstr "Ya hay un esbozo de CD con esta ID de disco"
 #: ../lib/MusicBrainz/Server/Data/Language.pm:61
 #: ../lib/MusicBrainz/Server/Form/Utils.pm:44
 msgid "[No lyrics]"
-msgstr ""
+msgstr "[Sin letra]"
 
 #: ../lib/MusicBrainz/Server/Data/LinkType.pm:156
 #, perl-brace-format
@@ -10032,11 +9626,11 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Area/Create.pm:20
 msgid "Add area"
-msgstr ""
+msgstr "Añadir área"
 
 #: ../lib/MusicBrainz/Server/Edit/Area/Delete.pm:10
 msgid "Remove area"
-msgstr ""
+msgstr "Eliminar área"
 
 #: ../lib/MusicBrainz/Server/Edit/Area/DeleteAlias.pm:14
 msgid "Remove area alias"
@@ -10044,7 +9638,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Area/Edit.pm:31
 msgid "Edit area"
-msgstr ""
+msgstr "Editar área"
 
 #: ../lib/MusicBrainz/Server/Edit/Area/EditAlias.pm:12
 msgid "Edit area alias"
@@ -10122,7 +9716,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Event/Merge.pm:11
 msgid "Merge events"
-msgstr ""
+msgstr "Fusionar eventos"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/AddDiscID.pm:11
 #: ../lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm:10
@@ -10241,7 +9835,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Convertir en publicación de múltiples artistas (histórico)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Aplicar a duraciones de pistas"
 
@@ -10275,7 +9869,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Instrument/Merge.pm:11
 msgid "Merge instruments"
-msgstr ""
+msgstr "Fusionar instrumentos"
 
 #: ../lib/MusicBrainz/Server/Edit/Label/AddAlias.pm:11
 msgid "Add label alias"
@@ -10351,7 +9945,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Place/Merge.pm:11
 msgid "Merge places"
-msgstr ""
+msgstr "Combinar lugares"
 
 #: ../lib/MusicBrainz/Server/Edit/Recording/AddAlias.pm:11
 msgid "Add recording alias"
@@ -10541,6 +10135,12 @@ msgstr "Rechazada"
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
 msgid "Failed dependency"
 msgstr "Error de dependencia"
+
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Error"
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
@@ -10755,7 +10355,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Gutenberg.pm:9
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Proyecto Gutenberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/IMSLP.pm:31
 msgid "Score at IMSLP"
@@ -10763,7 +10363,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/URL/NicoNicoVideo.pm:9
 msgid "Niconico"
-msgstr ""
+msgstr "Niconico"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Runeberg.pm:13
 msgid "Project Runeberg"
@@ -10797,7 +10397,7 @@ msgstr "Este alias solo puede ser un alias primario si hay un locale (idioma y r
 
 #: ../lib/MusicBrainz/Server/Form/Alias.pm:118
 msgid "This alias already exists."
-msgstr ""
+msgstr "Este alias ya existe."
 
 #: ../lib/MusicBrainz/Server/Form/Application.pm:43
 msgid "Redirect URL must be entered for web applications."
@@ -10805,7 +10405,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Area.pm:85
 msgid "An area already exists with this ISO code"
-msgstr ""
+msgstr "Ya existe un área con este código ISO"
 
 #: ../lib/MusicBrainz/Server/Form/Artist.pm:72
 msgid "Group artists cannot have a gender."
@@ -10813,11 +10413,11 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Artist.pm:79
 msgid "Orchestras cannot have a gender."
-msgstr ""
+msgstr "Las orquestas no pueden tener género."
 
 #: ../lib/MusicBrainz/Server/Form/Artist.pm:86
 msgid "Choirs cannot have a gender."
-msgstr ""
+msgstr "Los coros no pueden tener género."
 
 #: ../lib/MusicBrainz/Server/Form/CDStub.pm:38
 msgid "You must provide at least one track"
@@ -10867,12 +10467,12 @@ msgstr "Es necesario rellenar el campo \"créditos de artista\""
 
 #: ../lib/MusicBrainz/Server/Form/Field/Coordinates.pm:55
 msgid "These coordinates could not be parsed"
-msgstr ""
+msgstr "Estas coordenadas no se pueden interpretar."
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
-msgstr ""
+msgstr "La fecha de fin no puede ser anterior a la de inicio."
 
 #: ../lib/MusicBrainz/Server/Form/Field/DiscID.pm:12
 msgid "This is not a valid disc ID"
@@ -10888,23 +10488,23 @@ msgstr "Esta MBID no es válida"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISO_3166_1.pm:12
 msgid "This is not a valid ISO 3166-1 code"
-msgstr ""
+msgstr "Este no es un código ISO 3166-1 válido"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISO_3166_2.pm:12
 msgid "This is not a valid ISO 3166-2 code"
-msgstr ""
+msgstr "Este no es un código ISO 3166-2 válido"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISO_3166_3.pm:12
 msgid "This is not a valid ISO 3166-3 code"
-msgstr ""
+msgstr "Este no es un código ISO 3166-3 válido"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISRC.pm:14
 msgid "This is not a valid ISRC"
-msgstr ""
+msgstr "Este no es un ISRC válido"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISRC.pm:18
 msgid "This is not a valid ISRC."
-msgstr ""
+msgstr "Este no es un ISRC válido."
 
 #: ../lib/MusicBrainz/Server/Form/Field/ISWC.pm:12
 #: ../lib/MusicBrainz/Server/Form/Field/ISWC.pm:16
@@ -10974,13 +10574,13 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "Esbozo de CD"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Etiqueta"
@@ -10988,7 +10588,7 @@ msgstr "Etiqueta"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Documentación"
 
@@ -11248,7 +10848,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Comprobar donación"
 
@@ -11279,7 +10879,7 @@ msgstr "¡No volveremos a pedirte que dones!"
 
 #: ../root/account/EmailVerificationStatus.js:20
 msgid "Email Verification"
-msgstr ""
+msgstr "Verificación de la dirección de correo"
 
 #: ../root/account/EmailVerificationStatus.js:24
 msgid ""
@@ -11298,6 +10898,12 @@ msgid ""
 "to reset your password. If you have forgotten your username, {link|retrieve "
 "it} first and then reset your password."
 msgstr ""
+
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "Correo electrónico"
 
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
@@ -11330,7 +10936,7 @@ msgid ""
 msgstr "Te hemos enviado la información sobre tu cuenta de MusicBrainz. Si no recibes el correo o sigues teniendo problemas para conectarte, {link|avísanos}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -11393,7 +10999,7 @@ msgstr "Acceso"
 
 #: ../root/account/applications/Index.js:92
 msgid "You have not authorized any applications."
-msgstr ""
+msgstr "No ha autorizado ningún aplicación."
 
 #: ../root/account/applications/Index.js:95
 msgid "Developer Applications"
@@ -11464,9 +11070,9 @@ msgstr ""
 #: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:16
 #: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:17
 msgid "Unconfirmed Email Address"
-msgstr ""
+msgstr "Dirección de correo no confirmada"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr ""
 
@@ -11506,32 +11112,32 @@ msgid ""
 msgstr "No hemos encontrado un artista con esa ID de MusicBrainz. Puedes probar a {search_url|usar la búsqueda}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Nacido en:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Fundado en:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr ""
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Muerto en:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
-msgstr ""
+msgstr "Separación en:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr ""
 
@@ -11551,23 +11157,23 @@ msgstr "Colección no encontrada"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "No hemos encontrado una colección con esa ID de MusicBrainz."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Fecha de inicio"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Fecha de fin"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr ""
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} no tiene ningún alias."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr ""
 
@@ -11609,19 +11215,19 @@ msgstr[1] "Expira en <span class=\"tooltip\" title=\"{exactdate}\">{num} minutos
 msgid "Already expired"
 msgstr "Ya caducado"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Suscripciones"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Editar usuario"
 
@@ -11683,7 +11289,7 @@ msgid "For more information:"
 msgstr "Para saber más:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Añadir nota"
 
@@ -11756,11 +11362,11 @@ msgstr ""
 
 #: ../root/elections/ElectionTable/index.js:31
 msgid "Votes for"
-msgstr ""
+msgstr "Votos a favor"
 
 #: ../root/elections/ElectionTable/index.js:32
 msgid "Votes against"
-msgstr ""
+msgstr "Votos en contra"
 
 #: ../root/elections/ElectionVotes.js:27
 msgid "Vote"
@@ -11862,6 +11468,22 @@ msgstr "Votar"
 msgid "Votes cast"
 msgstr "Votos totales"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr ""
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr ""
@@ -11888,7 +11510,7 @@ msgid ""
 "ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr ""
 
@@ -11989,7 +11611,7 @@ msgstr "Equipo"
 
 #: ../root/layout/components/BottomMenu.js:105
 msgid "Shop"
-msgstr ""
+msgstr "Tienda"
 
 #: ../root/layout/components/BottomMenu.js:108
 msgid "Contact Us"
@@ -12130,6 +11752,11 @@ msgstr "Agregar evento"
 msgid "Vote on Edits"
 msgstr "Votar ediciones"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Informes"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Guía para principiantes"
@@ -12170,33 +11797,33 @@ msgstr "Ver todas las relaciones"
 msgid "Running: {git_details}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Página {n}"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr ""
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Discográfica"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr ""
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Pista"
 
 #: ../root/layout/components/MetaDescription.js:60
 msgid "Start:"
-msgstr ""
+msgstr "Inicio:"
 
 #: ../root/layout/components/MetaDescription.js:63
 msgid "End:"
-msgstr ""
+msgstr "Fin:"
 
 #: ../root/layout/components/MetaDescription.js:84
 msgid "Label Code:"
@@ -12213,7 +11840,7 @@ msgstr "Año:"
 
 #: ../root/layout/components/MetaDescription.js:131
 msgid "Labels:"
-msgstr ""
+msgstr "Discográficas:"
 
 #: ../root/layout/components/MetaDescription.js:154
 msgid "Writers:"
@@ -12296,7 +11923,7 @@ msgstr "Ver historial de la anotación"
 
 #: ../root/layout/components/sidebar/AreaSidebar.js:48
 msgid "Area information"
-msgstr ""
+msgstr "Información del área"
 
 #: ../root/layout/components/sidebar/ArtistSidebar.js:61
 msgid "Artist information"
@@ -12403,15 +12030,15 @@ msgstr "Suscribirse"
 
 #: ../root/layout/components/sidebar/EventSidebar.js:49
 msgid "Event information"
-msgstr ""
+msgstr "Información del evento"
 
 #: ../root/layout/components/sidebar/EventSidebar.js:60
 msgid "Start Date:"
-msgstr ""
+msgstr "Fecha de inicio:"
 
 #: ../root/layout/components/sidebar/EventSidebar.js:61
 msgid "End Date:"
-msgstr ""
+msgstr "Fecha de fin:"
 
 #: ../root/layout/components/sidebar/InstrumentSidebar.js:45
 msgid "Instrument information"
@@ -12421,13 +12048,17 @@ msgstr "Información del instrumento"
 msgid "Label information"
 msgstr "Información de la discográfica"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Última actualización el {date}"
 
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr ""
+
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
-msgstr ""
+msgstr "Información del lugar"
 
 #: ../root/layout/components/sidebar/RecordingSidebar.js:41
 msgid "Recording information"
@@ -12499,20 +12130,20 @@ msgid "see all ratings"
 msgstr "ver todas las valoraciones"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(ninguno)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
-msgstr ""
+msgstr "Ver todas las etiquetas"
 
 #: ../root/layout/components/sidebar/WorkSidebar.js:57
 msgid "Work information"
@@ -12616,7 +12247,7 @@ msgstr "Comunidad"
 
 #: ../root/main/index.js:141
 msgid "How to Contribute"
-msgstr ""
+msgstr "Cómo contribuir"
 
 #: ../root/main/index.js:151
 msgid ""
@@ -12679,11 +12310,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "No hemos encontrado una grabación con esa ID de MusicBrainz. Puedes probar a {search_url|usar la búsqueda}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr ""
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Grabación de {artist}"
 
@@ -12712,9 +12343,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "No hemos encontrado un grupo de publicaciones con esa ID de MusicBrainz. Puedes probar a {search_url|usar la búsqueda}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Grupo de publicaciones de {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Anotaciones del Artista"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Artistas encontrados: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artistas cuyo nombre contiene disambiguación"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Este informe muestra artistas que parecen tener comentarios de disambiguación como parte del nombre, en vez de en el campo de disambiguación."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artistas con desambiguación igual que el nombre."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artistas que podrían ser grupos"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artistas que podrían ser personas"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr ""
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artistas con ningún suscriptor"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Este informe muestra artistas que tienen relaciones de colaboración, pero ninguna URL. Si una colaboración tiene un nombre específico, no hagas nada, pero si su nombre es del estilo \"X con Y\" o \"X & Y\", es probable que necesite ser separado en varios artistas. Consulta {how_to_split_artists|cómo separar artistas (en inglés)}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Colaboración"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Colaborador"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artistas con relaciones en desuso"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "URLs de Discogs asociadas a más de un artista"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Este informe muestra URLs de Discogs asociadas a más de un artista."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Artistas que podrían ser duplicados"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Este informe muestra artistas con nombres muy similares. Si dos de ellos son realmente el mismo, fusiónalos (no olvides {how_to_write_edit_notes|dejar una nota} con las pruebas que tengas). Si son diferentes, añade {disambiguation_comment|comentarios de disambiguación}; cuando todos los artistas con el mismo nombre tengan comentarios de disambiguación, dejarán de aparecer en este informe."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Total de grupos duplicados: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Agregar artistas seleccionados para fusionar"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artistas con posibles relaciones duplicadas"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr ""
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Ver todos los resultados."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Ver solo resultados en mis suscripciones."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Principiantes / editores limitados"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr ""
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artistas que podrían ser colaboraciones"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Este informe muestra artistas que tienen \"&\" en su nombre, pero no están asociados a miembros ni colaboradores. Si el artista suele considerarse un grupo propiamente dicho, añade relaciones con sus miembros. Si es una colaboración breve, sepárala si es posible: consulta {how_to_split_artists|cómo separar artistas (en inglés)}. Si es una colaboración que tiene un nombre específico y no es posible separarla, añade relaciones con sus colaboradores."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Lo sentimos, pero los datos de este informe no están disponibles en este momento."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Si te gustaría editar MusicBrainz, pero no sabes por dónde empezar, estos informes pueden resultar útiles. Para crearlos se analiza la base de datos en busca de información que quizá deba ser modificada, ya sea para seguir las {style|convenciones de estilo} o por otras razones de organización."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artistas que tienen relaciones de colaboración"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artistas que parecen colaboraciones"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Artistas con anotaciones"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Editores"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Eventos que quizás estén duplicados"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "URLs de Discogs asociadas a más de una discográfica"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Sellos con anotaciones"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Grupos de publicaciones"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Grupos de publicaciones que quizá necesiten ser fusionados"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "URLs de Discogs asociadas a más de un grupo de publicaciones"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Publicaciones con URLs de Amazon inesperadas"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Publicaciones con varios ASINs"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Publicaciones con varios enlaces de Discogs"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "URLs de Amazon asociadas a más de una publicación"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "URLs de Discogs asociadas a más de una publicación"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Publicaciones que tienen relaciones de \"parte de conjunto\""
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Discos introducidos como publicaciones independientes"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Publicaciones con números de pista discontinuos"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Publicaciones en las que algunos medios (pero no todos) no tienen formato"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Publicaciones con números de catálogo que parecen ASINs"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Pseudo-lanzamientos traducidos/transliterados no enlazados con una versión original"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Publicaciones con números de medio discontinuos"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Grabaciones con la relación \"primera publicación\""
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Pistas cuyos títulos incluyen su número de pista"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Grabaciones con distintas duraciones de la pista"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Grabaciones con anotaciones"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Lugares con anotaciones"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Piezas con anotaciones"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWCs"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Miembro desde"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Página web"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Biografía"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "eliminar"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12860,8 +12880,8 @@ msgstr ""
 #: ../root/static/scripts/area/places-map.js:78
 msgid "… and {place_count} other"
 msgid_plural "… and {place_count} others"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "… y {place_count} más"
+msgstr[1] "… y {place_count} más"
 
 #: ../root/static/scripts/area/places-map.js:90
 msgid "No type"
@@ -12871,62 +12891,78 @@ msgstr "Sin tipo"
 msgid "{place_type}: {place_link}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Mostrar más..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "¿No encuentras lo que estás buscando? Prueba de nuevo con la búsqueda directa."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "¿Lento? Vuelve a la búsqueda indexada."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr "Intérpretes"
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Votar en todas las ediciones."
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Eliminar nota"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Mostrar créditos bajo la publicación"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Mostrar créditos en cada pista"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr ""
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
-msgstr ""
+msgstr "Imagen {current} de {total}"
 
 #: ../root/static/scripts/common/components/Annotation.js:84
 msgid "Annotation last modified by {user} on {date}."
@@ -12946,7 +12982,7 @@ msgstr "Última edición: {date}"
 msgid "Show less..."
 msgstr "Mostrar menos..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Imagen de Wikimedia Commons"
 
@@ -12963,67 +12999,84 @@ msgstr ""
 msgid "[missing editor]"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr "Retirar voto"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Votar a favor"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Tu has votado a favor de esta etiqueta"
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Votar en contra"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Tu has votado en contra de esta etiqueta"
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "Las etiquetas con una puntuación de cero o menor están ocultas."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Mostrar todas las etiquetas."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Se están mostrando todas las etiquetas."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Añadir etiquetas"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
-msgstr ""
+msgstr "Enviar etiquetas"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "ver todas las etiquetas"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Etiquetar"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Lee más en Wikipedia..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13035,7 +13088,7 @@ msgstr "Has seleccionado {label}."
 
 #: ../root/static/scripts/common/entity.js:245
 msgid "You selected {area}."
-msgstr ""
+msgstr "Ha seleccionado {area}."
 
 #: ../root/static/scripts/common/entity.js:330
 msgid "You selected {releasegroup}."
@@ -13043,7 +13096,7 @@ msgstr "Has seleccionado {releasegroup}."
 
 #: ../root/static/scripts/common/i18n.js:47
 msgid "{title} - {subtitle}"
-msgstr ""
+msgstr "{title} - {subtitle}"
 
 #: ../root/static/scripts/common/i18n.js:68
 msgid "Add a new artist"
@@ -13055,7 +13108,7 @@ msgstr "Agregar un nuevo evento"
 
 #: ../root/static/scripts/common/i18n.js:70
 msgid "Add a new label"
-msgstr ""
+msgstr "Añadir nuevo sello"
 
 #: ../root/static/scripts/common/i18n.js:71
 msgid "Add a new place"
@@ -13087,7 +13140,7 @@ msgstr "Agregar otro evento"
 
 #: ../root/static/scripts/common/i18n.js:83
 msgid "Add another label"
-msgstr ""
+msgstr "Añadir otro sello"
 
 #: ../root/static/scripts/common/i18n.js:84
 msgid "Add another place"
@@ -13095,7 +13148,7 @@ msgstr "Agregar otro lugar"
 
 #: ../root/static/scripts/common/i18n.js:85
 msgid "Add another recording"
-msgstr ""
+msgstr "Añadir otra grabación"
 
 #: ../root/static/scripts/common/i18n.js:86
 msgid "Add another release"
@@ -13111,15 +13164,15 @@ msgstr "Agregar otra serie"
 
 #: ../root/static/scripts/common/i18n.js:89
 msgid "Add another work"
-msgstr ""
+msgstr "Añadir otra pieza"
 
 #: ../root/static/scripts/common/utility/bracketed.js:24
 msgid "[{text}]"
-msgstr "[{texto}]"
+msgstr "[{text}]"
 
 #: ../root/static/scripts/common/utility/bracketed.js:27
 msgid "({text})"
-msgstr "({texto})"
+msgstr "({text})"
 
 #: ../root/static/scripts/common/utility/formatDatePeriod.js:19
 msgid " – ????"
@@ -13141,21 +13194,21 @@ msgstr ""
 msgid "{begin_date} –"
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Inicio:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Esta persona ha fallecido."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Este grupo se ha separado."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Campo obligatorio."
 
@@ -13215,9 +13268,9 @@ msgid ""
 "entity from the others."
 msgstr ""
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Todos tus cambios se perderán si sales de esta página."
 
@@ -13230,7 +13283,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr ""
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13247,7 +13300,7 @@ msgid "This relationship already exists."
 msgstr "Esta relación ya existe."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr ""
 
@@ -13267,7 +13320,7 @@ msgstr "vídeo"
 msgid "Remove Link"
 msgstr "Eliminar enlace"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr ""
 
@@ -13300,45 +13353,45 @@ msgid ""
 "language guidelines}. "
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
-msgid "The series you’ve selected is for recordings."
-msgstr ""
-
 #: ../root/static/scripts/relationship-editor/common/dialog.js:31
+msgid "The series you’ve selected is for recordings."
+msgstr "La serie seleccionada es para grabaciones."
+
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
-msgstr ""
+msgstr "La serie seleccionada es para piezas."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Selecciona un tipo de relación."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Selecciona un subtipo del tipo seleccionado. Este tipo de relación solo se usa como cabecera de otros."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Las entidades en una relación deben ser distintas."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
@@ -13346,19 +13399,19 @@ msgstr ""
 msgid "This attribute is required."
 msgstr "Este atributo es necesario."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} grabación seleccionada"
 msgstr[1] "{n} grabaciones seleccionadas"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} obra seleccionada"
 msgstr[1] "{n} obras seleccionadas"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13375,64 +13428,64 @@ msgstr "Este medio tiene una o más IDs de disco que impiden que se pueda modifi
 msgid "Page {page} of {total}"
 msgstr "Página {page} de {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Medio {posición}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Añadir publicación"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Editar Lanzamiento"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Por favor, comprueba el código de barras de la publicación."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "El código de barras introducido parece un UPC sin el dígito de control."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Este código de barras es un código UPC válido."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Este código de barras es un código UPC no válido, o un código EAN sin el dígito de control."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Este código de barras es un código EAN válido."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Este código de barras no es un código EAN válido."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "El código de barras introducido no es un UPC o EAN válido."
 
@@ -13440,15 +13493,15 @@ msgstr "El código de barras introducido no es un UPC o EAN válido."
 msgid "Add Language"
 msgstr "Añadir idioma"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Eliminar idioma"
 
 #: ../root/tag/EntityList.js:19
 msgid "{num} area found"
 msgid_plural "{num} areas found"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Encontrada {num} área"
+msgstr[1] "Encontradas {num} áreas"
 
 #: ../root/tag/EntityList.js:20
 msgid "{num} artist found"
@@ -13459,14 +13512,14 @@ msgstr[1] "Encontrados {num} artistas"
 #: ../root/tag/EntityList.js:21
 msgid "{num} event found"
 msgid_plural "{num} events found"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Encontrado {num} evento"
+msgstr[1] "Encontrados {num} eventos"
 
 #: ../root/tag/EntityList.js:22
 msgid "{num} instrument found"
 msgid_plural "{num} instruments found"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Encontrado {num} instrumento"
+msgstr[1] "Encontrados {num} instrumentos"
 
 #: ../root/tag/EntityList.js:23
 msgid "{num} label found"
@@ -13477,8 +13530,8 @@ msgstr[1] "Encontradas {num} discográficas"
 #: ../root/tag/EntityList.js:24
 msgid "{num} place found"
 msgid_plural "{num} places found"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Encontrado {num} lugar"
+msgstr[1] "Encontrados {num} lugares"
 
 #: ../root/tag/EntityList.js:25
 msgid "{num} recording found"
@@ -13653,7 +13706,7 @@ msgstr "Duración"
 
 #: ../root/taglookup/Form.js:45
 msgid "Filename"
-msgstr ""
+msgstr "Nombre de archivo"
 
 #: ../root/taglookup/Index.js:20 ../root/taglookup/Index.js:22
 msgid "Tag Lookup"

--- a/po/mb_server.et.po
+++ b/po/mb_server.et.po
@@ -20,8 +20,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-01-24 08:45+0000\n"
 "Last-Translator: yvanz\n"
 "Language-Team: Estonian (http://www.transifex.com/musicbrainz/musicbrainz/language/et/)\n"
 "MIME-Version: 1.0\n"
@@ -181,6 +181,7 @@ msgstr "(pole)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(teadmata)"
 
@@ -387,7 +388,7 @@ msgstr "Kontoadministraatorid"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Kontoadministraatorid saavad muuta ja kustutada kasutajakontosid."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "AcousticBrainzi kirje:"
 
@@ -397,7 +398,7 @@ msgstr "AcousticBrainzi kirje:"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Toimingud"
 
@@ -582,10 +583,6 @@ msgstr "Lisa seotud teos"
 msgid "Add relationship"
 msgstr "Lisa seos"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Vali märgitud artistid mestimiseks"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Vali märgitud sündmused mestimiseks"
@@ -658,7 +655,7 @@ msgstr "Vanus:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -678,9 +675,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Aliased"
 
@@ -728,26 +726,21 @@ msgstr "Tegutseb ka kui"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "Mitme väljalaskega lingitud Amazoni URL-id"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "Mitme väljalaskega lingitud Amazoni URL-id"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Alias on kellegi või millegi alternatiivne nimi või pealkiri. Tüüpiliselt on aliasteks teistes keeltes kasutatavad nimevariandid, samuti sagedased vead. Lisateabe saamiseks vaata {doc|aliaste dokumentatsiooni}."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Üks anonüümne kasutaja"
 msgstr[1] "{n} anonüümset kasutajat"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -769,8 +762,7 @@ msgstr "Ilmnes viga:"
 msgid "An error occurred while creating the works."
 msgstr "Teoste loomisel ilmnes viga."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -779,8 +771,9 @@ msgstr "Teoste loomisel ilmnes viga."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Annotatsioon"
@@ -914,11 +907,11 @@ msgstr "Kas oled kindel, et soovid seeria „{series}” MusicBrainzist eemaldad
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -969,24 +962,27 @@ msgstr "Piirkonnad"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1032,11 +1028,6 @@ msgstr "Artisti MBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Jälgitavad artistid"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Artistiannotatsioonid"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1084,7 +1075,7 @@ msgstr "Artist {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artist:"
 
@@ -1092,81 +1083,15 @@ msgstr "Artist:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artistid"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artistid, kelle nimes on täpsustav märkus"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artistid, keda on samal artistiteabe väljal mainitud mitu korda"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artistid, kes võivad olla koostööd"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artistid, kes võivad olla grupid"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artistid, kes võivad olla isikud"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artistid koostöö-seostega"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artistid, kes näevad välja nagu koostööd"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artistid koostöö-seostega"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Annotatsiooniga artistid"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artistid iganenud seostega"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artistid, kelle täpsustav märkus on sama nagu nimi"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artistid ilma ühegi jälgijata"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artistid võimalike topeltseostega"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1331,9 +1256,8 @@ msgstr "Sama seose lisamine korraga mitmele teosele"
 msgid "Batch-create new works"
 msgstr "Korraga mitme uue teose lisamine"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Võid olla esimene! {sub|Jälgid?}"
 
@@ -1391,21 +1315,12 @@ msgstr "Alguskuupäev:"
 msgid "Beginner"
 msgstr "algaja"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Algajad / piiratud õigustega toimetajad"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Allpool on teave vea kohta. Kui soovid veast teada anda, siis tee seda meie {bugs|veahaldussüsteemis}. Allolev teave aitab viga parandada, nii et lisa see kindlasti kirjeldusse!"
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Enesetutvustus"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1416,12 +1331,12 @@ msgstr "Enesetutvustus:"
 msgid "Birth date:"
 msgstr "Sünnikuupäev:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blogi"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Sündinud:"
 
@@ -1433,13 +1348,13 @@ msgstr "Bot"
 msgid "Bots"
 msgstr "Botid"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "MusicBrainzi taga seisavad {MeB|MetaBrainz Foundation} ning {spon|sponsorid} ja {supp|toetajad}. Kaanepiltidega varustab {caa|Kaanepildiarhiiv}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Veahaldus"
@@ -1584,7 +1499,7 @@ msgstr "Kat-nr"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Parooli muutmine"
 
@@ -1663,14 +1578,6 @@ msgstr "Suletud"
 msgid "Code"
 msgstr "Kood"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Koostöö"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Koostööline"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Peida plaadi sisu"
@@ -1699,7 +1606,7 @@ msgstr "Kogu „{collection}”"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Kogud"
@@ -1777,7 +1684,7 @@ msgid "Country:"
 msgstr "Maa:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Kaanepilt"
 
@@ -1909,7 +1816,7 @@ msgstr "Kuupäevade vorming on AAAA-KK-PP. Sobivad ka osalised kuupäevad nagu A
 msgid "Delete"
 msgstr "Kustuta"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Konto kustutamine"
 
@@ -1961,13 +1868,14 @@ msgstr "Kirjeldus:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Üksikasjad"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Surnud:"
 
@@ -1977,7 +1885,7 @@ msgstr "Erinevus"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Otsing otse andmebaasist"
 
@@ -2034,7 +1942,7 @@ msgid "Disc ID:"
 msgstr "Plaadi-ID:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "Plaadi-ID-d"
 
@@ -2054,11 +1962,6 @@ msgstr "Plaadi pealkiri:"
 msgid "Discography"
 msgstr "Diskograafia"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "Mitme artistiga lingitud Discogsi URL-id"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2074,32 +1977,12 @@ msgstr "Mitme väljalaskerühmaga lingitud Discogsi URL-id"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "Mitme väljalaskega lingitud Discogsi URL-id"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "Mitme artistiga lingitud Discogsi URL-id"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "Mitme plaadifirmaga lingitud Discogsi URL-id"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "Mitme väljalaskerühmaga lingitud Discogsi URL-id"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "Mitme väljalaskega lingitud Discogsi URL-id"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Plaadid eraldi väljalasetena"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Eraldi väljalasetena sisestatud plaadid"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Laiali läinud:"
 
@@ -2117,7 +2000,7 @@ msgstr "Dokumentatsioon:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Pole kontot? {uri|Loo kasvõi kohe}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Anneta"
 
@@ -2148,9 +2031,9 @@ msgstr "Iga lugu MusicBrainzi andmebaasis peab olema lingitud salvestisega. Vali
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Toimetamine"
 
@@ -2203,7 +2086,7 @@ msgid "Edit Note Author"
 msgstr "Toimetusmärke autor"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Profiili muutmine"
 
@@ -2278,10 +2161,10 @@ msgid "Editing/voting disabled"
 msgstr "Toimetamine/hääletamine keelatud"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Toimetaja"
 
@@ -2297,10 +2180,6 @@ msgstr "Jälgitavad toimetajad"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Toimetaja {user}"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Toimetajad"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2329,12 +2208,6 @@ msgstr "Toimetused: {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Leheküljele laaditud toimetuste arv:"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "E-post"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2394,7 +2267,7 @@ msgstr "Pole enam aktiivselt kasutusel"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Lõpp:"
 
@@ -2437,11 +2310,6 @@ msgstr "Olemitüüp"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Olemitüübid:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Viga"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2491,8 +2359,8 @@ msgstr "Isegi lihtsalt üks-kaks internetiaadressi on abiks!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2519,13 +2387,14 @@ msgstr "Sündmus:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Sündmused"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr "Sündmused, mis peaks olema osa seeriast või suuremast sündmusest"
 
@@ -2606,7 +2475,7 @@ msgid "Find Relationships"
 msgstr "Otsi seoseid"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Sõrmejäljed"
 
@@ -2655,7 +2524,7 @@ msgstr "Lisateabe saamiseks vaata {doc_doc|dokumentatsiooni} ja {doc_styleguide|
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Lisateabe saamiseks vaata {doc_doc|dokumentatsiooni}."
 
@@ -2687,7 +2556,7 @@ msgstr "Formaat"
 msgid "Format:"
 msgstr "Formaat:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Foorumid"
@@ -2743,7 +2612,7 @@ msgstr[1] "Päringule „{q}” leiti {n} vastet."
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Loodud:"
 
@@ -2799,7 +2668,6 @@ msgstr "Sugu:"
 msgid "General Information"
 msgstr "Üldinfo"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2807,17 +2675,9 @@ msgstr "Üldinfo"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2825,13 +2685,10 @@ msgstr "Üldinfo"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2846,13 +2703,11 @@ msgstr "Üldinfo"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2883,13 +2738,27 @@ msgstr "Üldinfo"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Genereeritud {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Muusikastiilid"
 
@@ -3088,13 +2957,15 @@ msgstr "ISRC „{isrc}” salvestisele „{recording}”"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC-d"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "Mitme salvestisega ISRC-d"
 
@@ -3118,12 +2989,8 @@ msgstr "ISWC „{iswc}” teosele „{work}”"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC-d"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "Mitme teosega ISWC-d"
 
@@ -3195,15 +3062,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Kui arvad, et see on viga, siis saada palun oma konto nimega (ingliskeelne) kiri aadressile <code>support@musicbrainz.org</code>."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Kui soovid toimetamises osaleda, aga ei tea, millest alustada, siis peaks järgnev loetelu kasulik olema. Linkide taga on andmebaasist automaatselt leitud andmed, mis võivad vajada parandamist, kas siis {style|stiilijuhistega} vastavusse viimiseks või muude „puhastustööde” korras."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3241,11 +3099,11 @@ msgstr "Kasutajanimi või parool on vale."
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Indekseeritud otsing"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Indekseeritud otsing {doc|laiendatud päringusüntaksiga}"
 
@@ -3256,7 +3114,7 @@ msgstr "Indekseeritud otsing {doc|laiendatud päringusüntaksiga}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3281,13 +3139,14 @@ msgstr "Instrumendi üksikasjad"
 msgid "Instrument:"
 msgstr "Instrument:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Instrumendid"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Ilma pildita instrumendid"
 
@@ -3353,9 +3212,9 @@ msgstr "Hoitakse sisselogituna"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3416,31 +3275,28 @@ msgstr "Plaadifirma:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Plaadifirmad"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Annotatsiooniga plaadifirmad"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Plaadifirmad iganenud seostega"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Plaadifirmad, mille täpsustav märkus on sama nagu nimi"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Plaadifirmad võimalike topeltseostega"
 
@@ -3481,7 +3337,6 @@ msgstr "Viimase 24 tunni jooksul"
 msgid "Last 28 days"
 msgstr "Viimase 28 päeva jooksul"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3489,6 +3344,7 @@ msgstr "Viimase 28 päeva jooksul"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Viimati muudetud"
 
@@ -3496,7 +3352,7 @@ msgstr "Viimati muudetud"
 msgid "Last login:"
 msgstr "Viimati sisse loginud:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Viimane replikatsioonipakett saadud {datetime}"
 
@@ -3504,7 +3360,7 @@ msgstr "Viimane replikatsioonipakett saadud {datetime}"
 msgid "Last updated"
 msgstr "Viimati uuendatud"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Viimati uuendatud:"
 
@@ -3574,14 +3430,14 @@ msgid "Loading edit previews..."
 msgstr "Toimetuste eelvaate laadimine..."
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Laadimine..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Lokaat"
 
@@ -3591,6 +3447,7 @@ msgstr "Lokaat:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Asukoht"
 
@@ -3663,7 +3520,7 @@ msgstr "madal"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Sõnade keeled"
 
@@ -3698,7 +3555,7 @@ msgid "Many relationships"
 msgstr "Palju seoseid"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Kaart"
 
@@ -3759,10 +3616,6 @@ msgstr "Helikandja:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Helikandjad:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Liitunud"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3874,7 +3727,7 @@ msgstr "Populaarseim"
 msgid "Most Recent"
 msgstr "Uusim"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Teisalda"
 
@@ -4003,7 +3856,7 @@ msgstr "Nimi"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Nimi:"
 
@@ -4105,7 +3958,7 @@ msgstr "Uus versioon:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Järgmine"
@@ -4181,7 +4034,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Ühelgi väljalaskel pole esikaanepilti, seega ei saa siin kaanepilti määrata."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Tulemusi pole"
 
@@ -4195,7 +4048,7 @@ msgstr "Tulemusi ei leitud."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Tulemusi ei leitud. Proovi otsingupäringut täpsustada."
 
@@ -4220,13 +4073,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "Keegi pole viimase kolme kuu jooksul sinu toimetustele märkeid jätnud."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Keegi pole seda veel sildistanud."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Mittedigitaalsed väljalasked, millel on allalaadimisseos"
 
@@ -4236,7 +4089,7 @@ msgid "None"
 msgstr "Puudub"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr "Ükski omistatud plaadi-ID-dest ei luba sellise pikkusega pregap-rada."
@@ -4445,9 +4298,9 @@ msgid "Other lookups"
 msgstr "Muud päringud"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr "Muud sildid"
 
@@ -4456,7 +4309,7 @@ msgid "Overall"
 msgstr "Üldse"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Ülevaade"
@@ -4533,11 +4386,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Teha eelnimetatud toiminguid, kui ma parajasti rakendust ei kasuta"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Salvestised"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Püsilink:"
 
@@ -4549,8 +4402,8 @@ msgstr "Fraas:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4576,23 +4429,20 @@ msgstr "Koht:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Kohad"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Annotatsiooniga kohad"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Kohad iganenud seostega"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr "Ilma koordinaatideta kohad"
 
@@ -4715,22 +4565,14 @@ msgid "Possible duplicate events"
 msgstr "Võimalikud duplikaatsündmused"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Võimalikud duplikaatväljalaskerühmad"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Võimalikud väärtused:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Võimalikud duplikaatartistid"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Võimalikud duplikaatsündmused"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4748,7 +4590,7 @@ msgstr "Eelvaade:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Eelmine"
@@ -4800,7 +4642,7 @@ msgid "Public collection by {owner}"
 msgstr "Avalik kogu ~ {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Päring:"
 
@@ -4825,7 +4667,7 @@ msgstr "Hinne"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Hinded"
 
@@ -4855,7 +4697,7 @@ msgstr "Hiljutised märked minu toimetustele"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4898,21 +4740,22 @@ msgstr "Salvestis:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Salvestised"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
@@ -4926,40 +4769,28 @@ msgstr "Salvestised, millel on „varaseima väljalaske” seoseid"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Varieeruvate loopikkustega salvestised"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Annotatsiooniga salvestised"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Salvestised iganenud seostega"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Salvestised, millel on „varaseima väljalaske” seoseid"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Salvestised võimalike topeltseostega"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr "Erinevate, aga samanimeliste artistide sama pealkirjaga salvestised"
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Salvestised, millel on pealkirjas kaasa tegevad artistid"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Varieeruvate loopikkustega salvestised"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5017,7 +4848,6 @@ msgid "Relationship Editor"
 msgstr "Seosetoimetaja"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5025,6 +4855,7 @@ msgstr "Seosetoimetaja"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Seose tüüp"
 
@@ -5074,7 +4905,7 @@ msgstr "Seos:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Seosed"
 
@@ -5106,7 +4937,7 @@ msgstr "Seosed:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5138,7 +4969,7 @@ msgstr "Väljalaskesündmused:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Väljalaskerühm"
@@ -5174,7 +5005,7 @@ msgstr "Väljalaskerühmad"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Väljalaskerühmad iganenud seostega"
 
@@ -5233,6 +5064,7 @@ msgid "Release group ratings"
 msgstr "Hinded väljalaskerühmadele"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Väljalaskerühm „{name}” - {artist}"
 
@@ -5244,38 +5076,27 @@ msgstr "Väljalaskerühm „{name}” - {artist}"
 msgid "Release group:"
 msgstr "Väljalaskerühm:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Väljalaskerühmad"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Väljalaskerühmad, mis võivad vajada mestimist"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Annotatsiooniga väljalaskerühmad"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Väljalaskerühmad võimalike topeltseostega"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Väljalaskerühmad, millel on pealkirjas kaasa tegevad artistid"
 
@@ -5318,8 +5139,8 @@ msgstr "Väljalase:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Väljalasked"
@@ -5353,67 +5174,43 @@ msgstr "Väljalasked mitme Discogsi-lingiga"
 msgid "Releases With Some Formats Unset"
 msgstr "Väljalasked osaliselt määramata formaatidega"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Kaanepildiarhiivis leiduvad väljalasked, millel on ikka veel kaanepildiseos"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr ""
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr "Väljalasked ilma ühegi plaadi-ID-ta"
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Igasugused väljalasked, millel on ikka veel kaanepildiseoseid"
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Liiga vara avaldatud väljalasked"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr "Väljalasked, millel artisti nimi on sama nagu plaadifirma oma"
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Väljalasked, kus ainult osade helikandjate formaat on määratud"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Väljalasked, millel on mitu ASIN-i"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Väljalasked, millel on mitu Discogsi-linki"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Väljalasked, millel on „osa komplektist” seoseid"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Väljalasked, millel on ootamatuid Amazoni URL-e"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Väljalasked, mis võivad vajada teisendamist mitme artisti alla"
 
@@ -5422,23 +5219,15 @@ msgstr "Väljalasked, mis võivad vajada teisendamist mitme artisti alla"
 msgid "Releases with Cover Art relationships"
 msgstr "Väljalasked, millel on kaanepildiseoseid"
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Väljalasked, mille ainsal helikandjal on pealkiri"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Annotatsiooniga väljalasked"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Väljalasked, mille katalooginumbrid näevad välja nagu ASIN-id"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Väljalasked iganenud seostega"
 
@@ -5447,31 +5236,25 @@ msgstr "Väljalasked iganenud seostega"
 msgid "Releases with medium number issues"
 msgstr "Väljalasked, millel on probleeme helikandjanumbritega"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Ilma helikandjateta väljalasked"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Mittejärjestikuste helikandjatega väljalasked"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Mittejärjestikuste loonumbritega väljalasked"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Väljalasked võimalike topeltseostega"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Liigsete andmeradadega väljalasked"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Väljalasked, millel on pealkirjas kaasa tegevad artistid"
 
@@ -5480,24 +5263,26 @@ msgstr "Väljalasked, millel on pealkirjas kaasa tegevad artistid"
 msgid "Releases with track number issues"
 msgstr "Väljalasked, millel on probleeme loonumbritega"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Sisestamata loopikkustega väljalasked"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Ebatõenäolise keele ja kirja kombinatsiooniga väljalasked"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Määramata keelega väljalasked"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Määramata kirjasüsteemiga väljalasked"
 
@@ -5523,7 +5308,7 @@ msgstr "Väljalasked:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5535,7 +5320,7 @@ msgstr "Väljalasked:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Eemalda"
@@ -5675,11 +5460,6 @@ msgstr ""
 msgid "Report this user for bad behavior"
 msgstr ""
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Võimalike vigade aruanded"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Päring aegus"
@@ -5702,7 +5482,7 @@ msgstr "Lähtesta parool"
 msgid "Reset track numbers"
 msgstr "Lähtesta loonumbrid"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Tulemusi lehel:"
 
@@ -5742,7 +5522,7 @@ msgstr "Vaata üle väljalasketoimetile andmete söötmise {url|dokumentatsioon}
 msgid "Role"
 msgstr "Roll"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Haru: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5785,7 +5565,7 @@ msgstr "Kirjasüsteem:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5832,7 +5612,7 @@ msgstr "Toimetuste otsing"
 msgid "Search for the target URL."
 msgstr "Otsi siht-URL-i"
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Otsingumeetod:"
 
@@ -5921,7 +5701,7 @@ msgstr "Koopia mu enda e-posti aadressile"
 msgid "Sentence"
 msgstr "Lause"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Seeriad"
@@ -5936,8 +5716,8 @@ msgstr "Seeriad"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5960,10 +5740,6 @@ msgstr "Jälgitavad seeriad"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "Seeriaannotatsioonid"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "Annotatsiooniga seeriad"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -5992,7 +5768,7 @@ msgstr "Sisesta uus parool oma MusicBrainzi konto jaoks."
 msgid "Set cover art"
 msgstr "Määra kaanepilt"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Määra loopikkused"
 
@@ -6005,10 +5781,6 @@ msgstr "Esitatud lood"
 msgid "Setlist:"
 msgstr "Esitatud lood:"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Näita kõiki tulemusi"
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "Uute toimetusmärgete peale näidatakse märguannet"
@@ -6018,10 +5790,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Näidatakse {sort_select_block} {autoedit_select_block}, mis {match_or_negation_block} {and_vs_or_block} järgnevatest tingimustest:"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Näita ainult mind huvitavaid tulemusi"
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6157,7 +5925,7 @@ msgstr "Vabandust, otsitud leht pole peegelserverist saadaval."
 msgid "Sorry, there was a problem with your request."
 msgstr "Vabandust, su päringuga oli midagi valesti."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Vabandust, sul pole lubatud sellele lehele pääseda."
 
@@ -6181,8 +5949,8 @@ msgstr "Vabandust, „{id}” pole kehtiv dokumentatsioonileht."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Nimi sortimisel"
 
@@ -6236,7 +6004,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Staatus:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Lõpeta beetasaidi kasutamine"
 
@@ -6290,12 +6058,10 @@ msgstr "Jälgitavad toimetajad"
 msgid "Subscribed entities"
 msgstr "Jälgitav sisu"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6343,8 +6109,8 @@ msgid "Tagger"
 msgstr "Sildistaja"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6415,7 +6181,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Selle toimetuse andmed pärinevad algselt selle toimetuse vanemast versioonist ning nende näitamisel võib esineda vigu."
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6426,7 +6192,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "Söödetud andmetes oli vigu:"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "Sisestatud kuupäev ei ole korrektne."
 
@@ -6525,7 +6291,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Otsinguserveril ei õnnestunud sisemise vea tõttu päringut täita. Tavaliselt on viga ajutine, nii et proovi hiljem uuesti."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "Server on hooldustööde tarvis ajutiselt kirjutuskaitstud režiimis."
 
@@ -6564,21 +6330,9 @@ msgstr "Sinu toimetusi ei jälgi hetkel ükski kasutaja."
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Üksi kasutaja ei jälgi hetkel toimetusi, mida {user} teeb."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "{artist} pole hetkel ühegi kasutaja jälgimisloendis."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "{collection} pole hetkel ühegi kasutaja jälgimisloendis."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "{label} pole hetkel ühegi kasutaja jälgimisloendis."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "„{series}” pole hetkel ühegi kasutaja jälgimisloendis."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6587,12 +6341,12 @@ msgid ""
 msgstr "Sellele väljalaskele pole plaadi-ID-sid omistatud. Soovi korral vaata, {doc|kuidas plaadi-ID-d lisada}."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr "Pole ühtki muusikastiili, mida näidata."
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr "Pole muid silte, mida näidata."
 
@@ -6618,29 +6372,11 @@ msgid_plural ""
 msgstr[0] "Hetkel on {num} kasutaja, kes jälgib toimetusi, mida {user} teeb:"
 msgstr[1] "Hetkel on {num} kasutajat, kes jälgivad toimetusi, mida {user} teeb:"
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "{artist} on hetkel {num} kasutaja jälgimisloendis:"
-msgstr[1] "{artist} on hetkel {num} kasutaja jälgimisloendis:"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "{collection} on hetkel {num} kasutaja jälgimisloendis:"
 msgstr[1] "{collection} on hetkel {num} kasutaja jälgimisloendis:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "{label} on hetkel {num} kasutaja jälgimisloendis:"
-msgstr[1] "{label} on hetkel {num} kasutaja jälgimisloendis:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "„{series}” on hetkel {num} kasutaja jälgimisloendis:"
-msgstr[1] "„{series}” on hetkel {num} kasutaja jälgimisloendis:"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6748,7 +6484,7 @@ msgid ""
 msgstr "Sel artistil pole väljalaskerühmi eri esitajate hulgas. {show_non_va|Näita selle artisti nimel väljalaskerühmi}"
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "See artist ei tegutse enam"
 
@@ -6798,7 +6534,7 @@ msgstr "Sel artistil on ainult mitteametlikke väljalaskerühmi."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Seda atribuuditüüpi kasutatakse ainult teiste rühmitamiseks — palun vali mõni alltüüp."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Selles beetatestimisserveris saab katsetada uusi funktsioone pärisandmebaasiga."
@@ -6905,11 +6641,11 @@ msgid ""
 "attributed to it."
 msgstr "Seda instrumenti ei saa eemaldada, kuna sel on ikka veel seoseid."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "See on MusicBrainzi arendusserver."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7029,7 +6765,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Sel salvestisel pole seostatud AcoustID-sid."
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "See salvestis on video"
@@ -7063,7 +6799,7 @@ msgstr "See seosetüüp ei luba ühtegi atribuuti."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "See seosetüüp on iganenud ja seda ei tohiks enam kasutada."
 
@@ -7097,16 +6833,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "See väljalaskestaatus on mõeldud kasutamiseks loo- ja väljalaskepealkirjade mitteametlike tõlgete ja translitereeringute jaoks. See ei tähista reaalselt ilmunud väljalaset ja seda ei tohiks kasutada piraattoodangu, miksilintide/tänavaalbumite, demode või digitaalkujul albumite märkimiseks. Kindlasti tuleb lisada {url|tõlke/translitereeringu seos} vastava reaalse väljalaskega."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Selle aruande eesmärk on tuvastada väga sarnaste nimedega artistid. Kui kaks artisti on tegelikult üks ja sama, siis palun mesti need (ära unusta {how_to_write_edit_notes|toimetusmärget} tõendusmaterjaliga). Kui nad on erinevad, siis {disambiguation_comment|lisa neile täpsustus} (kui kõik sarnaste nimedega artistid on omale täpsustusmärke saanud, neid siin enam ei näidata)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7148,85 +6874,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr "See aruanne loetleb kõik väljalasked, kus helikandjanumbrid pole järjestikused (nt puudub helikandja nr 2, kuigi 1 ja 3 on olemas)."
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "See aruanne loetleb artistid, kelle nimi esineb ühel ja samal artistiteabe väljal mitu korda."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "See aruanne loetleb artistid, keda ei jälgi ükski toimetaja ja kelle suhtes tehtud muudatused võivad seega olla ülevaatamata. Esimesena näidatakse artiste, kellel on väljalaskerühmi ja lahtisi toimetusi rohkem."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr "See aruanne loetleb artistid, kelle täpsustusmärge on sama nagu nende nimi. Täpsustusväli peaks nende puhul tühi olema."
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "See aruanne loetleb artistid, kelle tüübiks on määratud midagi muud kui „grupp”, aga kes võivad olla grupid, kuna neil on liikmed. Kui leiad, et mõni siin loetletud artist on tõepoolest grupp, siis muuda tema tüüp vastavaks. Kui mõni kindlasti pole grupp, siis vaata, et liikmeseosed osutaks õiges suunas ja oleks muidu korrektsed."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "See aruanne loetleb artistid, kelle tüübiks on määratud midagi muud kui „isik”, aga kes seoste järgi otsustades võivad olla isikud, nt on nad märgitud mõne grupi liikmeks. Kui leiad, et mõni siin loetletud artist on tõepoolest isik, siis muuda tema tüüp vastavaks. Kui mõni kindlasti pole isik, siis vaata, et kõik seosed oleks korrektsed ja mõistuspärased."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "See aruanne loetleb artistid, kellel võib täpsustusmärge olla nimes, mitte selleks ette nähtud täpsustusväljal."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "See aruanne loetleb artistid, kelle nimes on „&”, aga kellel pole liikme- või koostööseoseid. Kui artisti peetakse valdavalt püsivaks grupiks, tuleks lisada liikmeseosed. Kui tegu on lühiajalise koostööga, tuleks see võimaluse korral vastavateks artistideks eraldada (vaata, {how_to_split_artists|kuidas see käib}). Kui tegu on koostööga, millel on omaenda nimi (mistõttu seda ei saa mitmeks artistiks eraldada), siis tuleks lisada koostööseosed."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "See aruanne loetleb artistid, kellel on koostööseosed, aga eiühtki seost URL-idega. Kui koostööl on omaenda nimi, ära tee midagi. Kui nimi on kujul „X koos Y-iga” või „X & Y”, tuleks see tõenäoliselt vastavateks artistideks eraldada (vaata, {how_to_split_artists|kuidas see käib})."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "See aruanne loetleb artistid, millel on mitu sama tüüpi seost ühe ja sama artisti, plaadifirma või URL-iga. Välja on jäetud topeltseosed väljalaskerühmade, salvestiste ja teostega — need on loetletud nende vastavates aruannetes."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "See aruanne loetleb artistid, kellel on aegunud või teiste seoste rühmitamiseks mõeldud seosetüüpe."
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "See aruanne loetleb annotatsiooniga artistid."
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7388,10 +7035,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "See aruanne loetleb {iswc|ISWC-d}, mis on omistatud rohkem kui ühele teosele. Kui need teosed on tegelikult üks ja sama, tuleks nad mestida."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr "See aruanne loetleb {url|algajad / piiratud õigustega toimetajad}."
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7402,10 +7045,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "See aruanne loetleb Amazoni URL-id, mis on lingitud mitme väljalaskega. Üldjuhul peaks Amazoni ASIN-id üksüheselt MusicBrainzi väljalasetele vastama, nii et ainult üks link saab õige olla. Kontrolli, milline MusicBrainzi väljalase sobib Amazoni oma vasteks (vaata formaati, loonimekirja jm). Kui väljalaskel on vöötkood, võid selle Amazoni otsingusse pista ja vaadata, mis ASIN selle peale leitakse. Võid leida ka ASIN-e, mis on lingitud mitmeplaadilise väljalaske eri plaatidele — nood tuleks lihtsalt üheks väljalaskeks mestida (vaata, {how_to_merge_releases|kuidas see käib})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "See aruanne loetleb Discogsi URL-id, mis on lingitud mitme artistiga."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7685,7 +7324,7 @@ msgstr "See seeria on hetkel tühi."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "See tabel näitab selle toimetaja antud häälte kokkuvõtet."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "See on andmerada."
 
@@ -7811,29 +7450,6 @@ msgstr "Leitud ISWC-sid: {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Leitud URL-e: {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Leitud artiste: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Leitud duplikaate: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr "Leitud toimetajaid: {count}"
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -7993,7 +7609,7 @@ msgstr "Lugu:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Lugude nimekiri"
 
@@ -8011,10 +7627,6 @@ msgstr "Lugude nimekiri:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Lood"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Lood, mille nimed sisaldavad nende järjekorranumbrit"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8043,16 +7655,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Transklusioonitoimetajad on kasutajad, kes lisavad ja hooldavad kirjeid {uri|WikiDocs}i transklusioonitabelis."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Tõlgitud/translitereeritud pseudoväljalasked, mis pole originaaliga lingitud"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Türgi"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8068,15 +7675,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8090,7 +7700,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Tüüp"
 
@@ -8118,7 +7728,7 @@ msgstr "Tüüp"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Tüüp:"
 
@@ -8134,14 +7744,15 @@ msgstr "Tüüp: {type}, staatus: {status}"
 msgid "Types:"
 msgstr "Tüüp:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8161,17 +7772,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URL-id"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "URL-id iganenud seostega"
 
@@ -8193,8 +7804,12 @@ msgstr "Autoriseerimata päring"
 msgid "Unclassified instrument"
 msgstr "Klassifitseerimata instrument"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Teadmata"
 
@@ -8221,9 +7836,9 @@ msgstr "Lõpeta jälgimine"
 msgid "Untrusted"
 msgstr "Mitteusaldatav"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "kuni {n}"
 
@@ -8256,7 +7871,7 @@ msgstr "Pildi üleslaadimine..."
 msgid "Uppercase roman numerals"
 msgstr "Rooma numbrid suurtähtedega"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Kasuta beetasaiti"
 
@@ -8312,7 +7927,7 @@ msgid "Username:"
 msgstr "Kasutajanimi:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Kasutajad"
 
@@ -8444,10 +8059,6 @@ msgstr "Hoiatus: sel seosel on ootel toimetusi. Nende nägemiseks {show|klõpsa 
 msgid "Watched Artists"
 msgstr "Artistid, kelle plaati ootad"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Vabandust, kuid selle aruande andmed pole hetkel saadaval."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "Selle kaanepildi ajalugu pole võimalik näidata."
@@ -8493,10 +8104,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Meil on selle probleemi pärast kohutavalt kahju. Palun oota paar minutit ja proovi siis uuesti — probleem võib olla lahenenud."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Veebisait"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Veebisait:"
@@ -8509,7 +8116,7 @@ msgid ""
 "and following the merge link."
 msgstr "Kui oled valmis neid mestima, klõpsa lihtsalt „Mesti”. Rohkemate mestitavate lisamiseks liigu nende lehele ja klõpsa linki „Mesti”."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8531,10 +8138,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Teos"
 
@@ -8573,35 +8180,32 @@ msgstr "Teos:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Teosed"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Annotatsiooniga teosed"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Teosed iganenud seostega"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Teosed võimalike topeltseostega"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Autorid"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8714,9 +8318,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Asusid järgnevaid teoseid üheks mestima. Palun vali teos, millesse ülejäänud mestida:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Hetkel oled sa jälgijate hulgas. {unsub|Lõpetad jälgimise?}"
 
@@ -8732,9 +8335,8 @@ msgstr "Hetkel ei saa sa sellele toimetusele märget lisada. ({url|Üksikasjad})
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Hetkel ei saa sa seda toimetust hääletada. ({url|Üksikasjad})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Hetkel pole sa jälgijate hulgas. {sub|Hakkad jälgima}?"
 
@@ -8814,7 +8416,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr "Täielikku artistiteavet pole sisestatud."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Midagi pole muudetud."
 
@@ -8839,7 +8441,7 @@ msgstr ""
 msgid "You must be logged in to vote on edits"
 msgstr "Toimetuste hääletamiseks logi palun sisse."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Sellele olemile tuleb lisada täpsustusmärge."
 
@@ -8921,7 +8523,7 @@ msgstr "Otsing võttis liiga kaua aega ja tühistati. Võid uuesti proovida või
 msgid "Your username will be publicly visible."
 msgstr "Sinu kasutajanimi saab avalikult nähtavaks."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8963,10 +8565,6 @@ msgstr "[teadmata]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "pärast"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "alias:"
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9029,10 +8627,6 @@ msgstr "tühistatud"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "täpne nimetus"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr ""
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9251,9 +8845,7 @@ msgstr "algne"
 msgid "places"
 msgstr "kohtade"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "ja veel {n} anonüümne toimetaja"
@@ -9476,7 +9068,7 @@ msgstr[1] "{entity} on lisatud {num} kogusse:"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} ei ole ühtegi kogusse lisatud."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9490,7 +9082,7 @@ msgstr "{link} on ilma hinneteta."
 msgid "{link} has no relationships."
 msgstr "{link} on ilma seosteta."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainzi identifikaator\">MBID</abbr>}:"
 
@@ -9603,7 +9195,7 @@ msgstr "{type} „{instrument}”"
 msgid "{type} “{work}”"
 msgstr "{type} „{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Tagasi musicbrainz.org-i}."
 
@@ -9810,34 +9402,34 @@ msgstr "„{id}” ei ole kehtiv valimiste ID"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Kohustuslik sisukorra parameeter oli kas sobimatul kujul või puudu"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Palun sisesta helikandja ID"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Helikandjat ei leitud"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "Antud CD-sisukord pole korrektne"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "Antud helikandja-ID pole korrektne"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "See CD-sisukord on sellele helikandjale juba omistatud"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Valitud helikandjal ei saa plaadi-ID-d olla"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "Antud artisti-ID pole korrektne"
 
@@ -10219,7 +9811,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Väljalaske teisendamine mitme artisti nime alla (ajalooline)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Loopikkuste määramine"
 
@@ -10519,6 +10111,12 @@ msgstr "ei läbinud hääletust"
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
 msgid "Failed dependency"
 msgstr "ei rahuldanud sõltuvust"
+
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Viga"
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
@@ -10848,7 +10446,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Antud koordinaate polnud võimalik parsida."
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "Lõppkuupäev ei saa olla enne alguskuupäeva."
 
@@ -10952,13 +10550,13 @@ msgstr "Pead sisestama ka toimetusmärke."
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "CD-mustand"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Silt"
@@ -10966,7 +10564,7 @@ msgstr "Silt"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Dokumentatsioon"
 
@@ -11226,7 +10824,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Annetuse kontroll"
 
@@ -11277,6 +10875,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr "Sisesta allpool oma kasutajanimi ja e-post. Saadame sulle e-kirja koos lingiga oma salasõna lähtestamiseks. Kui oled oma kasutajanime ära unustanud, lase esmalt see {link|välja otsida} ja siis lähtesta oma salasõna."
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "E-post"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11308,7 +10912,7 @@ msgid ""
 msgstr "Saatsime sulle sinu MusicBrainzi konto kohta kirja. Kui see kohale ei jõua või kui sisselogimine endiselt ei õnnestu, siis {link|võta ühendust}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Eelistused"
 
@@ -11444,7 +11048,7 @@ msgstr "E-kiri saadeti aadressil {addr}. Palun vaata oma postkasti ning klõpsa 
 msgid "Unconfirmed Email Address"
 msgstr "Kinnitamata e-posti aadress"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} ~ {parent_areas}"
 
@@ -11484,32 +11088,32 @@ msgid ""
 msgstr "Vabandust, selle MusicBrainzi ID-ga artisti ei leitud. Võid proovida {search_url|seda otsida}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Sünnikoht:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Loomiskoht:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Alguspiirkond:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Surmakoht:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Laialiminekukoht:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Lõpp-piirkond:"
 
@@ -11529,23 +11133,23 @@ msgstr "Kogu ei leitud"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Vabandust, selle MusicBrainzi ID-ga kogu ei leitud."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Alguskuupäev"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Lõppkuupäev"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr "esmane"
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} on ilma aliasteta."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr "Lisa uus alias"
 
@@ -11587,19 +11191,19 @@ msgstr[1] "Aegub <span class=\"tooltip\" title=\"{exactdate}\">{num} minuti pär
 msgid "Already expired"
 msgstr "Juba aegunud"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profiil"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Jälgimisloend"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Kasutaja muutmine"
 
@@ -11661,7 +11265,7 @@ msgid "For more information:"
 msgstr "Lisateave:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Lisa märge"
 
@@ -11840,6 +11444,22 @@ msgstr "Hääletamine"
 msgid "Votes cast"
 msgstr "Antud hääled"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr ""
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Sündmust ei leitud"
@@ -11866,7 +11486,7 @@ msgid ""
 "ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "instrument"
 
@@ -12108,6 +11728,11 @@ msgstr "Lisa sündmus"
 msgid "Vote on Edits"
 msgstr "Hääleta toimetusi"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Võimalike vigade aruanded"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Alustusjuhend"
@@ -12148,23 +11773,23 @@ msgstr "Vaata kõiki seoseid"
 msgid "Running: {git_details}"
 msgstr "Haru: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "{n}. lk"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr "MusicBrainz: artist"
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: plaadifirma"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr "MusicBrainz: väljalase"
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: lugu"
 
@@ -12399,9 +12024,13 @@ msgstr "Instrumendi teave"
 msgid "Label information"
 msgstr "Plaadifirma teave"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Viimati uuendatud {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr ""
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12477,18 +12106,18 @@ msgid "see all ratings"
 msgstr "vaata kõiki"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(pole)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(pole)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr "Näita kõiki silte"
 
@@ -12657,11 +12286,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Vabandust, selle MusicBrainzi ID-ga salvestist ei leitud. Võid proovida {search_url|seda otsida}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "video ~ {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "salvestis ~ {artist}"
 
@@ -12690,9 +12319,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Vabandust, selle MusicBrainzi ID-ga väljalaskerühma ei leitud. Võid proovida {search_url|seda otsida}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "väljalaskerühm ~ {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Artistiannotatsioonid"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "See aruanne loetleb annotatsiooniga artistid."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Leitud artiste: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artistid, kelle nimes on täpsustav märkus"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "See aruanne loetleb artistid, kellel võib täpsustusmärge olla nimes, mitte selleks ette nähtud täpsustusväljal."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artistid, kelle täpsustav märkus on sama nagu nimi"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr "See aruanne loetleb artistid, kelle täpsustusmärge on sama nagu nende nimi. Täpsustusväli peaks nende puhul tühi olema."
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artistid, kes võivad olla grupid"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artistid, kes võivad olla isikud"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "See aruanne loetleb artistid, kelle nimi esineb ühel ja samal artistiteabe väljal mitu korda."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artistid ilma ühegi jälgijata"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "See aruanne loetleb artistid, keda ei jälgi ükski toimetaja ja kelle suhtes tehtud muudatused võivad seega olla ülevaatamata. Esimesena näidatakse artiste, kellel on väljalaskerühmi ja lahtisi toimetusi rohkem."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "See aruanne loetleb artistid, kellel on koostööseosed, aga eiühtki seost URL-idega. Kui koostööl on omaenda nimi, ära tee midagi. Kui nimi on kujul „X koos Y-iga” või „X & Y”, tuleks see tõenäoliselt vastavateks artistideks eraldada (vaata, {how_to_split_artists|kuidas see käib})."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Koostöö"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Koostööline"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artistid iganenud seostega"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "See aruanne loetleb artistid, kellel on aegunud või teiste seoste rühmitamiseks mõeldud seosetüüpe."
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "Mitme artistiga lingitud Discogsi URL-id"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "See aruanne loetleb Discogsi URL-id, mis on lingitud mitme artistiga."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Võimalikud duplikaatartistid"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Selle aruande eesmärk on tuvastada väga sarnaste nimedega artistid. Kui kaks artisti on tegelikult üks ja sama, siis palun mesti need (ära unusta {how_to_write_edit_notes|toimetusmärget} tõendusmaterjaliga). Kui nad on erinevad, siis {disambiguation_comment|lisa neile täpsustus} (kui kõik sarnaste nimedega artistid on omale täpsustusmärke saanud, neid siin enam ei näidata)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Leitud duplikaate: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Vali märgitud artistid mestimiseks"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artistid võimalike topeltseostega"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "See aruanne loetleb artistid, millel on mitu sama tüüpi seost ühe ja sama artisti, plaadifirma või URL-iga. Välja on jäetud topeltseosed väljalaskerühmade, salvestiste ja teostega — need on loetletud nende vastavates aruannetes."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Näita kõiki tulemusi"
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Näita ainult mind huvitavaid tulemusi"
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Algajad / piiratud õigustega toimetajad"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr "See aruanne loetleb {url|algajad / piiratud õigustega toimetajad}."
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr "Leitud toimetajaid: {count}"
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artistid, kes võivad olla koostööd"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "See aruanne loetleb artistid, kelle nimes on „&”, aga kellel pole liikme- või koostööseoseid. Kui artisti peetakse valdavalt püsivaks grupiks, tuleks lisada liikmeseosed. Kui tegu on lühiajalise koostööga, tuleks see võimaluse korral vastavateks artistideks eraldada (vaata, {how_to_split_artists|kuidas see käib}). Kui tegu on koostööga, millel on omaenda nimi (mistõttu seda ei saa mitmeks artistiks eraldada), siis tuleks lisada koostööseosed."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Vabandust, kuid selle aruande andmed pole hetkel saadaval."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Kui soovid toimetamises osaleda, aga ei tea, millest alustada, siis peaks järgnev loetelu kasulik olema. Linkide taga on andmebaasist automaatselt leitud andmed, mis võivad vajada parandamist, kas siis {style|stiilijuhistega} vastavusse viimiseks või muude „puhastustööde” korras."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artistid koostöö-seostega"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artistid, kes näevad välja nagu koostööd"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Annotatsiooniga artistid"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Toimetajad"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Võimalikud duplikaatsündmused"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "Mitme plaadifirmaga lingitud Discogsi URL-id"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Annotatsiooniga plaadifirmad"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Väljalaskerühmad"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Väljalaskerühmad, mis võivad vajada mestimist"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "Mitme väljalaskerühmaga lingitud Discogsi URL-id"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Annotatsiooniga väljalaskerühmad"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Väljalasked, millel on ootamatuid Amazoni URL-e"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Väljalasked, millel on mitu ASIN-i"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Väljalasked, millel on mitu Discogsi-linki"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "Mitme väljalaskega lingitud Amazoni URL-id"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "Mitme väljalaskega lingitud Discogsi URL-id"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Väljalasked, millel on „osa komplektist” seoseid"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Eraldi väljalasetena sisestatud plaadid"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Mittejärjestikuste loonumbritega väljalasked"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Väljalasked, kus ainult osade helikandjate formaat on määratud"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Väljalasked, mille katalooginumbrid näevad välja nagu ASIN-id"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Tõlgitud/translitereeritud pseudoväljalasked, mis pole originaaliga lingitud"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Igasugused väljalasked, millel on ikka veel kaanepildiseoseid"
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Mittejärjestikuste helikandjatega väljalasked"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Annotatsiooniga väljalasked"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr "Väljalasked ilma ühegi plaadi-ID-ta"
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Salvestised, millel on „varaseima väljalaske” seoseid"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Lood, mille nimed sisaldavad nende järjekorranumbrit"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Varieeruvate loopikkustega salvestised"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Annotatsiooniga salvestised"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Annotatsiooniga kohad"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Annotatsiooniga seeriad"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Annotatsiooniga teosed"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC-d"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Liitunud"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Veebisait"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Enesetutvustus"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr ""
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12849,60 +12867,76 @@ msgstr ""
 msgid "{place_type}: {place_link}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Otsimisel ilmnes viga. Uuestiproovimiseks klõpsa siin."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Proovi selle asemel otsese otsinguga."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Proovi selle asemel indekseeritud otsinguga."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Kirjuta otsitav sõna või kopeeri MBID"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Puhasta loend"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Näita rohkem..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Tulemusteta? Proovi otsese otsinguga."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Aeglane? Lülita tagasi indekseeritud otsingule."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Hääl kõigil avatud toimetustel:"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Kustuta märge"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Näita artistiteavet lehe lõpus"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Näita artistiteavet iga loo all"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Helikandja laadimine ei õnnestunud."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Pilt {current} / {total}"
 
@@ -12924,7 +12958,7 @@ msgstr "Annotatsiooni muudeti viimati {date}."
 msgid "Show less..."
 msgstr "Näita vähem..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Pilt on pärit Wikimedia Commonsist"
 
@@ -12941,67 +12975,84 @@ msgstr ""
 msgid "[missing editor]"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr "Võta hääl tagasi"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Hääleta poolt"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Oled sellele sildile oma poolthääle andnud"
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Hääleta vastu"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Oled sellele sildile oma vastuhääle andnud"
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "Negatiivse või nullskooriga sildid on peidetud, samuti need, mille vastu oled hääletanud."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Näita kõiki silte"
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Siltide lisamine"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Allolevasse kasti saad lisada oma {tagdocs|sildid}. Nende eraldamiseks kasuta koma."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Sildista"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "vaata kõiki"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Sildista"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Loe Wikipedias edasi..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13119,21 +13170,21 @@ msgstr "{begin_date} – ?"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Algus:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "See isik on surnud (aga surmakuupäeva ei tea)"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "See grupp on laiali läinud"
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Kohustuslik väli"
 
@@ -13193,9 +13244,9 @@ msgid ""
 "entity from the others."
 msgstr "Palun sisesta {doc_disambiguation|täpsustus}, et aidata seda olemit teistest eristada."
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Sellelt lehelt lahkudes lähevad kõik tehtud muudatused kaotsi."
 
@@ -13208,7 +13259,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Palun vali sisestatud URL-ile lingitüüp."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13225,7 +13276,7 @@ msgid "This relationship already exists."
 msgstr "See seos on juba olemas."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|Veel dokumentatsiooni})"
 
@@ -13245,7 +13296,7 @@ msgstr "video"
 msgid "Remove Link"
 msgstr "Eemalda link"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Suurtähestuse oletamise seaded"
 
@@ -13278,45 +13329,45 @@ msgid ""
 "language guidelines}. "
 msgstr "See režiim tegeleb türgi „i” („İ”) ja „ı” („I”) suurtähestusega. Mõned sõnad tuleb võibolla käsitsi {url|türgi keele reeglitega} vastavusse viia."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "Valitud seeria on salvestiste jaoks."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "Valitud seeria on väljalasete jaoks."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "Valitud seeria on väljalaskerühmade jaoks."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "Valitud seeria on teoste jaoks."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Palun vali seosetüüp."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Palun vali praeguse seosetüübi asemel sobiv alltüüp. Valitud seosetüüpi kasutatakse ainult teiste seoste rühmitamiseks."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Iseendaga ei saa midagi seostada."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr "Muudatus kehtib kõigile olemi {entity} seostele sel lehel"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
@@ -13324,19 +13375,19 @@ msgstr ""
 msgid "This attribute is required."
 msgstr "See on kohustuslik atribuut."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} salvestis valitud"
 msgstr[1] "{n} salvestist valitud"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} teos valitud"
 msgstr[1] "{n} teost valitud"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13353,64 +13404,64 @@ msgstr "Sellele helikandjale on omistatud plaadi-ID, mistõttu ei saa seda teave
 msgid "Page {page} of {total}"
 msgstr "Lk {page} / {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Helikandja {position}: „{title}”"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Helikandja {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Plaadifirmat pole valitud ({name})."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Viga väljalaske laadimisel: {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Väljalaske lisamine"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Väljalaske toimetamine"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "Kontrollnumber on {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Palun kontrolli see väljalaskelt hoolikalt üle."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Sisestatud vöötkood näeb välja nagu puuduva kontrollnumbriga UPC-kood."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Sisestatud vöötkood on korrektne UPC-kood."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Sisestatud vöötkood on kas ebakorrektne UPC-kood või puuduva kontrollnumbriga EAN-kood."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Sisestatud vöötkood on korrektne EAN-kood."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Sisestatud vöötkood ei ole korrektne EAN-kood."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Sisestatud vöötkood ei ole korrektne UPC- ega EAN-kood."
 
@@ -13418,7 +13469,7 @@ msgstr "Sisestatud vöötkood ei ole korrektne UPC- ega EAN-kood."
 msgid "Add Language"
 msgstr "Lisa keel"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Eemalda keel"
 

--- a/po/mb_server.fi.po
+++ b/po/mb_server.fi.po
@@ -8,7 +8,7 @@
 # <email address hidden>, 2012
 #   <email address hidden>, 2012
 # Jaakko Perttilä <email address hidden>, 2012,2014
-# Jaakko Perttilä <email address hidden>, 2012,2014,2018
+# Jaakko Perttilä <email address hidden>, 2012,2014,2018-2019
 # jozo, 2014
 # jozo, 2014
 # ListMyCDs.com Martikainen <>, 2012
@@ -30,9 +30,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-01-24 14:51+0000\n"
+"Last-Translator: Jaakko Perttilä <email address hidden>\n"
 "Language-Team: Finnish (http://www.transifex.com/musicbrainz/musicbrainz/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,6 +191,7 @@ msgstr "(ei mitään)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(tuntematon)"
 
@@ -397,7 +398,7 @@ msgstr "Käyttäjätunnusten ylläpitäjät"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Käyttäjätunnusten ylläpitäjät voivat muokata ja poistaa käyttäjätunnuksia."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "AcousticBrainz merkintä:"
 
@@ -407,7 +408,7 @@ msgstr "AcousticBrainz merkintä:"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Toiminnot"
 
@@ -592,10 +593,6 @@ msgstr "Lisää yhteys teokseen"
 msgid "Add relationship"
 msgstr "Lisää yhteys"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Lisää valitut artistit sulautettaviksi"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Lisää valitut tapahtumat sulautettaviksi"
@@ -668,7 +665,7 @@ msgstr "Ikä:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -688,9 +685,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Aliakset"
 
@@ -738,26 +736,21 @@ msgstr "Esiintyy myös nimellä "
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "Amazon web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "Amazon web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Alias on toinen nimi entiteetille. Aliakset ovat yleensä tavanomaisia kirjoitusvirheitä, tai nimen kirjoitusmuotoja. Niitä käytetään myös parantamaan hakutuloksia. Lisää tietoa {doc|dokumentaatiossa aliaksista}."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
-msgstr[0] "Anonyymi käyttäjä."
+msgstr[0] "Nimetön käyttäjä."
 msgstr[1] "{n} anonyymiä käyttäjää"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -779,8 +772,7 @@ msgstr "Virhe: "
 msgid "An error occurred while creating the works."
 msgstr "Virhe kesken teoksen luonnin."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -789,8 +781,9 @@ msgstr "Virhe kesken teoksen luonnin."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Lisätiedot"
@@ -924,11 +917,11 @@ msgstr "Haluatko varmasti poistaa sarjan {series} MusicBrainzista?"
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -979,24 +972,27 @@ msgstr "Alueet"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1042,11 +1038,6 @@ msgstr "Artistin MBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Seuratut artistit"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Artistin lisätietokenttiä"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1094,7 +1085,7 @@ msgstr "Aristi {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artisti:"
 
@@ -1102,81 +1093,15 @@ msgstr "Artisti:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artistit"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artistit, joiden nimissä on täsmennyskommentit"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artistit, jotka on merkitty useamman kerran samaan tekijänimeen"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artistit, jotka voivat olla yhteistöitä"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artistit, jotka saattavat olla ryhmiä"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artistit, jotka saattavat olla yksityishenkilöitä"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artistit, joilla on yhteistyö-yhteyksiä"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artistit, jotka voivat olla yhteistöitä"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artistit, joilla on yhteistyö-yhteyksiä"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Artistit, joilla lisätietokenttä"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artistit, joilla vanhentuneita yhteyksiä"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artistit, joiden täsmennyskommentti on sama kuin nimi"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artistit, joita kukaan ei seuraa"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artistit, joilla mahdollisesti yhteyksien kaksoiskappaleita"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1341,9 +1266,8 @@ msgstr "Lisää yhteys kaikkiin valittuihin teoksiin"
 msgid "Batch-create new works"
 msgstr "Luo uusi teos kaikille valituille äänitteille"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Ole ensimmäinen! {sub|Seuraa muutoksia}?"
 
@@ -1401,21 +1325,12 @@ msgstr "Alkanut:"
 msgid "Beginner"
 msgstr "Aloittelija"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Aloittelevat/rajoitetut editorit"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Alta löydät tietoja virheestä. Voit halutessasi lisätä virheraportin {bugs|virheidenseurantaamme}. Alta löytyvä tieto helpottaa vian paikallistamista, joten muistathan sisällyttää sen raporttiisi!"
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Elämäkerta"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1426,12 +1341,12 @@ msgstr "Elämäkerta:"
 msgid "Birth date:"
 msgstr "Syntymäpäivä:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blogi"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Syntymäaika:"
 
@@ -1443,13 +1358,13 @@ msgstr "Botti"
 msgid "Bots"
 msgstr "Botit"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "Palvelun mahdollistaa {MeB|MetaBrainz-säätiö} ja {spon|sponsorimme} sekä {supp|tukijamme}. Kansitaiteen tarjoaa {caa|Cover Art Archive}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Virheiden seuranta"
@@ -1495,7 +1410,7 @@ msgid ""
 "CD stubs are a feature to allow anonymous users to submit data to "
 "MusicBrainz. For more information, see {cdstub|the documentation on CD "
 "stubs}."
-msgstr "CD-tynkä on ominaisuus, joka sallii anonyymien käyttäjien lähettää tietoa MusicBrainziin. Saadaksesi lisätietoja, tutustu {cdstub|dokumentaatioon CD-tyngästä}."
+msgstr "CD-tynkä on ominaisuus, joka sallii nimettömien käyttäjien lähettää tietoa MusicBrainziin. Saadaksesi lisätietoja, tutustu {cdstub|dokumentaatioon CD-tyngästä}."
 
 #: ../root/doc/edit_type.tt:42
 msgid "Can be approved"
@@ -1594,7 +1509,7 @@ msgstr "Luettelonumero"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Vaihda salasana"
 
@@ -1673,14 +1588,6 @@ msgstr "Suljettu"
 msgid "Code"
 msgstr "Koodi"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Yhteistyö"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Yhteistyökumppani"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Supista levy"
@@ -1709,7 +1616,7 @@ msgstr "Kokoelma \"{collection}\""
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Kokoelmat"
@@ -1787,7 +1694,7 @@ msgid "Country:"
 msgstr "Maa:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Kansitaide"
 
@@ -1919,7 +1826,7 @@ msgstr "Päiväykset ovat muotoa VVVV-KK-PP. Osittaiset päiväykset kuten VVVV-
 msgid "Delete"
 msgstr "Poista"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Poista käyttäjätunnus"
 
@@ -1971,13 +1878,14 @@ msgstr "Kuvaus:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Lisätietoja"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Kuolinaika:"
 
@@ -1987,7 +1895,7 @@ msgstr "Eroavaisuudet"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Suora tietokantahaku"
 
@@ -2044,7 +1952,7 @@ msgid "Disc ID:"
 msgstr "Levyn tunniste:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "Levyjen tunnisteet"
 
@@ -2064,11 +1972,6 @@ msgstr "Levyn nimi:"
 msgid "Discography"
 msgstr "Diskografia"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin artisteihin"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2084,32 +1987,12 @@ msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuryhmiin"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin artisteihin"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin levymerkkeihin"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuryhmiin"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Levyt ovat erillisiä julkaisuja"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Erillisinä julkaisuina syötetyt levyt"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Lopetettu:"
 
@@ -2127,7 +2010,7 @@ msgstr "Dokumentaatio:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Puuttuuko sinulta käyttäjätunnus? {uri|Luo käyttäjätunnus heti}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Lahjoita"
 
@@ -2158,9 +2041,9 @@ msgstr "MusicBrainz-tietokannassa kunkin kappaleen tulee olla yhdistettynä ää
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -2213,7 +2096,7 @@ msgid "Edit Note Author"
 msgstr "Muokkausmerkinnän tekijä"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Muokkaa profiilia"
 
@@ -2288,10 +2171,10 @@ msgid "Editing/voting disabled"
 msgstr "Muokkaaminen/äänestäminen pois käytöstä"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Käyttäjä"
 
@@ -2307,10 +2190,6 @@ msgstr "Seuratut käyttäjät"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Käyttäjä \"{user}\""
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Käyttäjät"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2339,12 +2218,6 @@ msgstr "Muokkaukset kohteelle {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Sivulle ladatut muokkaukset:"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "Sähköposti"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2404,7 +2277,7 @@ msgstr "Päättynyt"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Päättynyt:"
 
@@ -2447,11 +2320,6 @@ msgstr "Entiteettityyppi"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Entiteettityypit:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Virhe"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2501,8 +2369,8 @@ msgstr "Pelkän web-osoitteen antaminenkin auttaa!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2529,15 +2397,16 @@ msgstr "Tapahtuma:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Tapahtumat"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
-msgstr ""
+msgstr "Tapahtumat, joiden tulisi olla osana suurempaa tapahtumaa"
 
 #: ../root/doc/relationship_type.tt:85
 #: ../root/relationship/linktype/form.tt:71
@@ -2616,7 +2485,7 @@ msgid "Find Relationships"
 msgstr "Etsi yhteydet"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Äänitunnisteet"
 
@@ -2665,7 +2534,7 @@ msgstr "Lisätietoja saat {doc_doc|dokumentaatiosta} ja {doc_styleguide|tyyliohj
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Lisätietoja saat {doc_doc|dokumentaatiosta}."
 
@@ -2697,7 +2566,7 @@ msgstr "Tallenteen muoto"
 msgid "Format:"
 msgstr "Tallenteen muoto:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Keskustelufoorumi"
@@ -2753,7 +2622,7 @@ msgstr[1] "Löytyi {n} tulosta kyselylle  \"{q}\""
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Perustettu:"
 
@@ -2809,7 +2678,6 @@ msgstr "Sukupuoli:"
 msgid "General Information"
 msgstr "Yleistä tietoa"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2817,17 +2685,9 @@ msgstr "Yleistä tietoa"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2835,13 +2695,10 @@ msgstr "Yleistä tietoa"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2856,13 +2713,11 @@ msgstr "Yleistä tietoa"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2893,13 +2748,27 @@ msgstr "Yleistä tietoa"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Luotu {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Tyylilajit"
 
@@ -3098,13 +2967,15 @@ msgstr "ISRC-koodi {isrc} äänitteelle {recording}"
 msgid "ISRC:"
 msgstr "ISRC-koodi:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC-koodit"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRC-koodeja, joista kukin liittyy useampaan äänitteeseen"
 
@@ -3128,12 +2999,8 @@ msgstr "ISWC-koodi{iswc} teokselle {work}"
 msgid "ISWC:"
 msgstr "ISWC-koodi:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC-koodit"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "ISWC-koodit, jotka viittaavat useaan teokseen"
 
@@ -3205,15 +3072,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Jos tämä on mielestäsi erehdys, ota yhteyttä osoitteeseen <code>support@musicbrainz.org</code> ja mainitse käyttäjänimesi."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Jos haluaisit osallistua muokkaamiseen, mutta et tiedä mistä aloittaisit, näistä raporteista saattaa olla apua. Nämä raportit listaavat tietokannasta poimittuja kohteita, jotka saattavat tarvita korjaamista. Osa vaatiinee muokkausta noudattaakseen {style|tyyliohjeita}, ja joissakin tapauksissa saatetaan tarvita hallinnollista \"siivoamista\"."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3251,11 +3109,11 @@ msgstr "Virheellinen käyttäjänimi tai salasana."
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Indeksoitu haku"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Indeksoitu haku {doc|kehittyneemmällä hakusyntaksilla}"
 
@@ -3266,7 +3124,7 @@ msgstr "Indeksoitu haku {doc|kehittyneemmällä hakusyntaksilla}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3291,13 +3149,14 @@ msgstr "Lisätietoja soittimesta"
 msgid "Instrument:"
 msgstr "Soitin:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Soittimet"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Soittimet, joilla ei kuvia"
 
@@ -3363,9 +3222,9 @@ msgstr "Pidä minut sisäänkirjautuneena."
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3426,31 +3285,28 @@ msgstr "Levymerkki:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Levymerkit"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Levymerkit, joilla lisätietokenttä"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Levymerkit, joilla vanhentuneita yhteyksiä"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Levymerkit, joiden täsmennyskommentti on sama kuin nimi"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Levymerkit, joilla mahdollisesti yhteyksien kaksoiskappaleita"
 
@@ -3491,7 +3347,6 @@ msgstr "Viimeiset 24 tuntia"
 msgid "Last 28 days"
 msgstr "Viimeiset 28 päivää"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3499,6 +3354,7 @@ msgstr "Viimeiset 28 päivää"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Viimeksi muokattu"
 
@@ -3506,7 +3362,7 @@ msgstr "Viimeksi muokattu"
 msgid "Last login:"
 msgstr "Viimeksi sisäänkirjauduttu:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Viimeisin kopiointipaketti vastaanotettu {datetime}"
 
@@ -3514,7 +3370,7 @@ msgstr "Viimeisin kopiointipaketti vastaanotettu {datetime}"
 msgid "Last updated"
 msgstr "Viimeksi päivitetty"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Viimeksi päivitetty:"
 
@@ -3584,14 +3440,14 @@ msgid "Loading edit previews..."
 msgstr "Ladataan muokkauksien esikatselua..."
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Ladataan..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Lokaali"
 
@@ -3601,6 +3457,7 @@ msgstr "Lokaali:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Sijainti"
 
@@ -3673,7 +3530,7 @@ msgstr "Matala"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Sanoituksen kielet"
 
@@ -3708,7 +3565,7 @@ msgid "Many relationships"
 msgstr "Useita yhteyksiä"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Kartta"
 
@@ -3769,10 +3626,6 @@ msgstr "Tallenne:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Tallenteet:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Liittynyt"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3884,7 +3737,7 @@ msgstr "Suosituin"
 msgid "Most Recent"
 msgstr "Uusin"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Siirrä"
 
@@ -4013,7 +3866,7 @@ msgstr "Nimi"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Nimi:"
 
@@ -4115,7 +3968,7 @@ msgstr "Uusi versio"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Seuraava"
@@ -4191,7 +4044,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Yhdelläkään julkaisulla ei ole kansikuvaksi merkattua kansitaidetta, joten kansikuvaa ei voida asettaa."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Ei tuloksia"
 
@@ -4205,7 +4058,7 @@ msgstr "Tuloksia ei löytynyt."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Ei hakutuloksia. Yritä uudelleenmäärittää hakukyselysi. "
 
@@ -4230,13 +4083,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "Et ole saanut muokkausmerkintäviestejä viimeiseen kolmeen kuukauteen."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Kukaan ei ole vielä luokitellut tätä."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Ei digitaaliset julkaisut, joissa lataus-yhteys"
 
@@ -4246,7 +4099,7 @@ msgid "None"
 msgstr "Ei mitään"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr "Yksikään yhdistetyistä levyn tunnisteista ei pysty sisältämään tämän pituista pregap-raitaa."
@@ -4455,9 +4308,9 @@ msgid "Other lookups"
 msgstr "Muut haut"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr "Muut luokitukset"
 
@@ -4466,7 +4319,7 @@ msgid "Overall"
 msgstr "Yhteensä"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Yleiskatsaus"
@@ -4543,11 +4396,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Suorita yllämainitut tehtävät kun ohjelmaa ei käytetä"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Esitykset"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Pysyvä linkki:"
 
@@ -4559,8 +4412,8 @@ msgstr "Fraasi:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4586,25 +4439,22 @@ msgstr "Paikka:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Paikat"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Paikat, joilla lisätietokenttä"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Paikat, joilla vanhentuneita yhteyksiä"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
-msgstr ""
+msgstr "Paikat ilman koordinaatteja"
 
 #: ../root/main/500.tt:31
 msgid ""
@@ -4725,22 +4575,14 @@ msgid "Possible duplicate events"
 msgstr "Mahdollisia kaksoiskappaleita tapahtumista"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Mahdollisia kaksoiskappaleita julkaisuryhmistä"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Mahdolliset arvot:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Mahdollisia kaksoiskappaleita artisteista"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Mahdollisia kaksoiskappaleita tapahtumista"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4758,7 +4600,7 @@ msgstr "Esikatselu:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Aiempi"
@@ -4810,7 +4652,7 @@ msgid "Public collection by {owner}"
 msgstr "Käyttäjän {owner} julkinen kokoelma"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Kysely:"
 
@@ -4835,7 +4677,7 @@ msgstr "Arvostelu"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Arvostelut"
 
@@ -4865,7 +4707,7 @@ msgstr "Viimeaikaisia muokkausmerkintäviestejä muokkauksissasi"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4908,21 +4750,22 @@ msgstr "Äänite:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Äänitteet"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr "Äänitteet, joiden tekijänimenä on \"Eri esittäjiä\", mutta joita ei ole yhdistetty eri esittäjiin"
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr "Äänitteet, joiden tekijänimenä ei ole \"Eri esittäjiä\", mutta jotka on yhdistetty eri esittäjiin"
 
@@ -4936,40 +4779,28 @@ msgstr "Äänitteet, joissa aiempi julkaisu -yhteys"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Äänitteitä, joissa eripituisia kappaleita"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Äänitteet, joilla lisätietokenttä"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Äänitteet, joilla vanhentuneita yhteyksiä"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Äänitteet, joissa aiempi julkaisu -yhteys"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Äänitteet, joilla mahdollisesti yhteyksien kaksoiskappaleita"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr "Äänitteet, joilla on sama nimi ja eri artistit joilla on samat nimet"
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Äänitteet, joiden nimi sisältää vierailevan artistin "
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Äänitteitä, joissa eripituisia kappaleita"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5027,7 +4858,6 @@ msgid "Relationship Editor"
 msgstr "Yhteys-editori"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5035,6 +4865,7 @@ msgstr "Yhteys-editori"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Yhteyden tyyppi"
 
@@ -5084,7 +4915,7 @@ msgstr "Yhteys:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Yhteydet"
 
@@ -5116,7 +4947,7 @@ msgstr "Yhteydet:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5148,7 +4979,7 @@ msgstr "Julkaisutapahtumia:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Julkaisuryhmä"
@@ -5184,7 +5015,7 @@ msgstr "Julkaisuryhmät"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Julkaisuryhmät, joilla vanhentuneita yhteyksiä"
 
@@ -5243,6 +5074,7 @@ msgid "Release group ratings"
 msgstr "Julkaisuryhmien arvostelut"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Julkaisuryhmä “{name}” artistilta {artist}"
 
@@ -5254,38 +5086,27 @@ msgstr "Julkaisuryhmä “{name}” artistilta {artist}"
 msgid "Release group:"
 msgstr "Julkaisuryhmä:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Julkaisuryhmät"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr "Julkaisuryhmät, joiden tekijänimenä on \"Eri esittäjiä\", mutta joita ei ole yhdistetty eri esittäjiin"
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr "Julkaisuryhmät, joiden tekijänimenä ei ole \"Eri esittäjiä\", mutta jotka on yhdistetty eri esittäjiin"
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Julkaisuryhmät, jotka saattavat vaatia sulauttamisen"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Julkaisuryhmät, joilla lisätietokenttä"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Julkaisuryhmät, joilla mahdollisesti yhteyksien kaksoiskappaleita"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Julkaisuryhmät, joiden nimissä on vieraileva artisti"
 
@@ -5328,8 +5149,8 @@ msgstr "Julkaisu:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Julkaisut"
@@ -5363,67 +5184,43 @@ msgstr "Julkaisut, joihin liittyy monia Discogs-linkkejä"
 msgid "Releases With Some Formats Unset"
 msgstr "Julkaisut, joissa jonkin tallenteen muoto asettamatta"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr "Julkaisut, joiden tekijänimenä on \"Eri esittäjiä\", mutta joita ei ole yhdistetty eri esittäjiin"
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Julkaisut Cover Art Archivessa, joilla on yhä kansitaide-yhteyksiä"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
-msgstr ""
+msgstr "Julkaisut Cover Art Archivessa, joiden kansitaiteille ei ole määritelty tyyppejä"
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr "Julkaisut, joilta puuttuu levyn tunniste"
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr "Julkaisut, joiden tekijänimenä ei ole \"Eri esittäjiä\", mutta jotka on yhdistetty eri esittäjiin"
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Kaikenlaiset julkaisut, joilla on yhä kansitaide-yhteyksiä"
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Julkaisut, joiden julkaisuajankohta on liian aikainen"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
-msgstr ""
+msgstr "Julkaisut, joissa artistin ja levymerkin nimet ovat samat"
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Julkaisut, joissa joidenkin (mutta ei kaikkien) tallenteiden muoto asettamatta"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Julkaisut, joissa useita ASIN-koodeja"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Julkaisut, joissa useita Discogs-linkkejä"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Julkaisut, joissa osana joukkoa -yhteyksiä"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Julkaisut, joissa odottamattomia Amazon web-osoitteita"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Julkaisut, jotka saattavat vaatia muunnoksen usean artistin julkaisuksi"
 
@@ -5432,23 +5229,15 @@ msgstr "Julkaisut, jotka saattavat vaatia muunnoksen usean artistin julkaisuksi"
 msgid "Releases with Cover Art relationships"
 msgstr "Julkaisut, joissa kansitaide-yhteyksiä"
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Julkaisut, joissa ainoalla tallenteella nimi"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Julkaisut, joilla lisätietokenttä"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Julkaisut, joissa luettelonumero näyttää Amazon ASIN-tunnisteilta"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Julkaisut, joissa vanhentuneita yhteyksiä"
 
@@ -5457,31 +5246,25 @@ msgstr "Julkaisut, joissa vanhentuneita yhteyksiä"
 msgid "Releases with medium number issues"
 msgstr "Julkaisut, joissa epäselvyyksiä tallenteiden numeroinnissa"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Julkaisut, joissa ei ole tallenteita"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Julkaisut, joissa ei peräkkäisiä tallenteita"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Julkaisut, joissa ei peräkkäistä kappalenumerointia"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Julkaisut, joissa mahdollisesti yhteyksien kaksoiskappaleita"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Julkaisut, joissa tarpeettomia data-raitoja"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Julkaisut, joiden nimi sisältää vierailevan artistin"
 
@@ -5490,24 +5273,26 @@ msgstr "Julkaisut, joiden nimi sisältää vierailevan artistin"
 msgid "Releases with track number issues"
 msgstr "Julkaisut, joissa epäselvyyksiä kappalenumeroinnissa"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Julkaisut, joissa tuntemattomia kappaleiden kestoja"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Julkaisut, joissa epätodennäköisiä kieli- ja merkistöpareja"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Julkaisut ilman määritettyä kieltä"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Julkaisut ilman määritettyä merkistöä"
 
@@ -5533,7 +5318,7 @@ msgstr "Julkaisut:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5545,7 +5330,7 @@ msgstr "Julkaisut:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Poista"
@@ -5685,11 +5470,6 @@ msgstr "Ilmoita käyttäjästä"
 msgid "Report this user for bad behavior"
 msgstr "Ilmoita käyttäjästä huonon käytöksen takia"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Raportit"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Pyyntö aikakatkaistiin"
@@ -5712,7 +5492,7 @@ msgstr "Salasanan vaihtaminen"
 msgid "Reset track numbers"
 msgstr "Nollaa kappalenumerot"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Tuloksia per sivu:"
 
@@ -5752,7 +5532,7 @@ msgstr "Tarkastele {url|dokumentaatiota} julkaisumuokkaimen alustamisesta ja var
 msgid "Role"
 msgstr "Rooli"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Ajossa: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5795,7 +5575,7 @@ msgstr "Merkistö:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5832,7 +5612,7 @@ msgstr "Etsi artistia"
 
 #: ../root/report/places_without_coordinates.tt:12
 msgid "Search for coordinates"
-msgstr ""
+msgstr "Etsi koordinaatteja"
 
 #: ../root/edit/list_header.tt:8
 msgid "Search for edits"
@@ -5842,7 +5622,7 @@ msgstr "Etsi muokkauksia"
 msgid "Search for the target URL."
 msgstr "Etsi kohteena olevaa web-osoitetta."
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Hakumetodi:"
 
@@ -5931,7 +5711,7 @@ msgstr "Lähetä kopio sähköpostiini"
 msgid "Sentence"
 msgstr "lause"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Sarjat"
@@ -5946,8 +5726,8 @@ msgstr "Sarjat"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5970,10 +5750,6 @@ msgstr "Seuratut sarjat"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "Sarjojen lisätietokenttiä"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "Sarjat, joilla lisätietokenttä"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -6002,7 +5778,7 @@ msgstr "Aseta uusi salasana MusicBrainz-käyttäjätunnuksellesi."
 msgid "Set cover art"
 msgstr "Aseta kansitaide"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Aseta kappaleiden kestot"
 
@@ -6015,10 +5791,6 @@ msgstr "Soittolista"
 msgid "Setlist:"
 msgstr "Soittolista:"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Näytä kaikki tulokset."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "Näytä ilmoitus kun saan uuden muokkausmerkinnän."
@@ -6028,10 +5800,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Näytä {autoedit_select_block} järjestettynä {sort_select_block} siten, että nämä {match_or_negation_block} {and_vs_or_block} seuraaviin ehtoihin:"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Näytä kaikki tulokset liittyen tilauksiini."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6167,7 +5935,7 @@ msgstr "Hakemasi sivu ei ole saatavilla peilipalvelimelta."
 msgid "Sorry, there was a problem with your request."
 msgstr "Pyyntö sisälsi ongelmia."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Valtuutesi eivät riitä näkemään tätä sivua."
 
@@ -6191,8 +5959,8 @@ msgstr "\"{id}\" ei ole kelvollinen dokumentaatiosivu."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Lajittelunimi"
 
@@ -6246,7 +6014,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Tila:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Lopeta beta-sivuston käyttö"
 
@@ -6300,12 +6068,10 @@ msgstr "Seuratut käyttäjät"
 msgid "Subscribed entities"
 msgstr "Seuratut kohteet"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6353,8 +6119,8 @@ msgid "Tagger"
 msgstr "Luokittelija"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6425,7 +6191,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Muokkauksen tiedot ovat alunperin tämän muokkauksen vanhemmasta versiosta ja eivätkä välttämättä näy oikein"
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6436,7 +6202,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "Alustamiseen käytetyssä syötteessä oli seuraavat virheet:"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "Syöttämäsi päiväys on virheellinen."
 
@@ -6535,7 +6301,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Hakupalvelin ei voinut toteuttaa pyyntöäsi sisäisen virheen vuoksi. Tämä on yleensä vain väliaikaista, joten yritä hakuasi myöhemmin uudelleen."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "Palvelin on tilapäisesti vain-luku tilassa tietokantahuoltotoimenpiteiden vuoksi."
 
@@ -6574,21 +6340,9 @@ msgstr "Yksikään käyttäjä ei seuraa tekemiäsi muutoksia."
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Yksikään käyttäjä ei seuraa käyttäjän {user} tekemiä muutoksia."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Yksikään käyttäjä ei tällä hetkellä seuraa artistia {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "Yksikään käyttäjä ei tällä hetkellä seuraa kokoelmaa {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Yksikään käyttäjä ei tällä hetkellä seuraa levy-yhtiötä {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "Yksikään käyttäjä ei tällä hetkellä seuraa sarjaa {series}."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6597,12 +6351,12 @@ msgid ""
 msgstr "Yhtäkään levyn tunnistetta ei ole liitetty julkaisuun. Lue{doc|kuinka liittää levyn tunniste}."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr "Ei muita näytettäviä tyylilajeja."
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr "Ei muita näytettäviä luokituksia."
 
@@ -6625,32 +6379,14 @@ msgstr[1] "Tällä alueella on juuri nyt {num} käyttäjää."
 msgid "There is currently {num} user subscribed to edits that {user} makes:"
 msgid_plural ""
 "There are currently {num} users subscribed to edits that {user} makes:"
-msgstr[0] "Käyttäjän {user} muokkauksia seuraa tällä hetkellä {num} käyttäjä:"
+msgstr[0] "Käyttäjän {user} muokkauksilla on tällä hetkellä {num} seuraajaa:"
 msgstr[1] "Käyttäjän {user} muokkauksia seuraa tällä hetkellä {num} käyttäjää:"
-
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Artistia {artist} seuraa tällä hetkellä {num} käyttäjä:"
-msgstr[1] "Artistia {artist} seuraa tällä hetkellä {num} käyttäjää:"
 
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
-msgstr[0] "Kokoelmaa {collection} seuraa tällä hetkellä {num} käyttäjä:"
+msgstr[0] "Kokoelmalla {collection} on tällä hetkellä {num} seuraajaa:"
 msgstr[1] "Kokoelmaa {collection} seuraa tällä hetkellä {num} käyttäjää:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Levy-yhtiötä {label} seuraa tällä hetkellä {num} käyttäjä:"
-msgstr[1] "Levy-yhtiötä {label} seuraa tällä hetkellä {num} käyttäjää:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "Sarjaa {series} seuraa tällä hetkellä {num} käyttäjä:"
-msgstr[1] "Sarjaa {series} seuraa tällä hetkellä {num} käyttäjää:"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6715,7 +6451,7 @@ msgid ""
 "text that you don't have the right to release under that license. While you "
 "can quote a source to support a point you're making, you should never enter "
 "promotional texts or other artist or label-owned texts into the annotation."
-msgstr ""
+msgstr "Tämä lisätieto tullaan julkaisemaan avoimella lisenssillä (<a href=\"{url}\" target=\"_blank\">CC BY-NC-SA 3.0</a>), joten sen ei tule sisältää tekstiä, johon sinulla ei ole oikeutta julkaista kyseisellä lisenssillä. Voit viitata lähteeseen, mutta et saa lisätä mainostavia tekstejä tai muita artistin tai levy-yhtiön omistamia tekstejä lisätietokenttään."
 
 #: ../root/area/delete.tt:14
 msgid ""
@@ -6758,7 +6494,7 @@ msgid ""
 msgstr "Tällä artistilla ei ole yhtään eri esittäjien julkaisuryhmää. {show_non_va|Näytä artistin julkaisuryhmät}."
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Tämä artisti on lopettanut esiintymisen."
 
@@ -6808,7 +6544,7 @@ msgstr "Tällä artistilla on vain epävirallisia julkaisuryhmiä."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Tämä määritetyyppi on tarkoitettu vain ryhmittelyyn, valitse alatyyppi"
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Tämä betatestaus-palvelin mahdollistaa uusien ominaisuuksien testaamisen live-tietokannalla. "
@@ -6915,11 +6651,11 @@ msgid ""
 "attributed to it."
 msgstr "Tätä soitinta ei voida poistaa, koska sille on vielä määriteltynä yhteyksiä."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Tämä on MusicBrainzin ohjelmistokehitykseen tarkoitettu testipalvelin."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7039,7 +6775,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Tällä äänitteellä ei ole yhteenkuuluvia AcoustID-äänitunnisteita"
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "Tämä äänite on video"
@@ -7073,7 +6809,7 @@ msgstr "Tämä yhteystyyppi ei salli määritteitä."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "Tämä yhteystyyppi on vanhentunut eikä sitä tulisi käyttää. "
 
@@ -7107,16 +6843,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "Tätä julkaisun tilaa tulisi käyttää vain epävirallisissa käännöksissä ja translitteroinneissa kappalelistoista ja julkaisujen nimistä. Tämä ei merkitse erillistä oikeaa julkaisua. Tätä ei tule käyttää merkitsemään bootleg-, mixtape/street-, demo- tai digitaalisia julkaisuja. Muista luoda yhteys vastaavaan oikeaan julkaisuun {url|käännös/translitterointi-yhteydellä}."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Tämä raportti pyrkii tunnistamaan artistit, joilla on hyvin samankaltainen nimi. Jos kaksi artistia on oikeasti samoja, niin sulauta ne (muista {how_to_write_edit_notes|muokkausmerkintä} ja todistelu). Jos artistit ovat eri artisteja, niin lisää {disambiguation_comment|täsmennyskommentit} niille (sitten kun samannimisillä artisteilla on täsmennyskommentit, ne eivät päädy enää tähän raporttiin)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7159,85 +6885,6 @@ msgid ""
 "is a medium 1 and 3 but no medium 2)."
 msgstr "Tämä raportti listaa julkaisut, joissa on rakoja tallenteiden numeroissa (esimerkiksi tallenteet 1 ja 3 mutta ei tallennetta 2)."
 
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "Tämä raportti listaa artistit, jotka ovat merkittynä useamman kerran, eri kohdissa, samassa tekijätiedossa."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "Tämä raportti listaa artistit, joilla ei ole editoreja seuraamassa muutoksia, ja joihin tehdyt muutokset saattavat jäädä tarkistamatta. Artistit, joilla on enemmän julkaisuryhmiä ja enemmän avoimia muokkauksia listataan ensin."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr "Tämä raportti listaa artistit, joiden täsmennyskommentti on sama kuin nimi. Täsmennyskommenttia ei pitäisi olla tässä tapauksessa."
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "Tämä raportti listaa artistit, joiden tyyppi on muuta kuin <em>ryhmä</em>, mutta saattavat olla <em>ryhmiä</em>, sillä niiden jäseniksi on yhdistetty muita artisteja. Jos huomaat, että tässä listattu artisti onkin ryhmä, muuta sen tyyppiä. Jos se ei ole, tarkista että jäsenenä-yhteys on oikeaan suuntaan ja oikeellinen."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "Tämä raportti listaa artistit, joiden tyyppi on muuta kuin <em>henkilö</em>, mutta saattavat olla <em>henkilöitä</em> yhteyksiensä perusteella. Esimerkiksi, artisti päätyy tälle listalle, jos se on merkitty toisen jäseneksi. Jos huomaat, että tässä listattu artisti on oikeasti henkilö, muuta sen tyyppiä. Jos se ei ole, tarkista että kaikki sen yhteydet ovat oikein ja järkeviä."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Tämä raportti listaa artistit, joiden nimessä saattaa olla täsmennyskommentti täsmennyskommenttikentän sijaan."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Tämä raportti listaa artistit, joiden nimessä on \"&\", mutta niillä ei ole jäseniä tai yhteystyöyhteyksiä. Jos artistia pidetään yleisesti oikeana ryhmänä, jäsenten yhteydet tulisi lisätä. Jos se taas on lyhytaikainen yhteistyö, se tulisi jakaa, mikäli mahdollista (katso {how_to_split_artists|kuinka jakaa artisti}). Jos se on yhteistyö omalla nimellään, eikä sitä voida jakaa, siihen tulee lisätä yhteistyöyhteydet."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Tämä raportti listaa artistit, joilla on yhteistyöyhteys, mutta ei URL-yhteyksiä. Jos yhteistyöllä on oma erillinen nimensä, älä tee mitään. Jos nimi on muotoa \"X sekä Y\" tai \"X & Y\", se tulisi ehkä jakaa. Katso, {how_to_split_artists|kuinka artisti jaetaan}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "Tämä raportti listaa artistit, joilla on useita yhteyksiä samaan artistiin, levymerkkiin tai URL-osoitteeseen samalla yhteystyypillä. Yhteyksistä useisiin julkaisuryhmiin, äänitteisiin ja teoksiin on omat raporttinsa."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "Tämä raportti listaa artistit, joilla on vanhentuneita ja vain ryhmittämiseen tarkoitettuja yhteystyyppejä."
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "Tämä raportti listaa artistit, joilla lisätietokenttä."
-
 #: ../root/report/duplicate_events.tt:6
 msgid ""
 "This report lists events happening at the same place on the same date. If "
@@ -7249,7 +6896,7 @@ msgstr "Tämä raportti listaa tapahtumat samassa paikassa samana päivänä. Jo
 msgid ""
 "This report lists events where the event name indicates that it may have to "
 "be part of a series or a larger event."
-msgstr ""
+msgstr "Tämä raportti listaa tapahtumat, joiden mahdollisesti tulisi olla nimensä perusteella osana sarjaa tai suurempaa tapahtumaa."
 
 #: ../root/report/labels_disambiguation_same_name.tt:6
 msgid ""
@@ -7285,7 +6932,7 @@ msgstr "Tämä raportti listaa paikat, joilla lisätietokenttä."
 
 #: ../root/report/places_without_coordinates.tt:6
 msgid "This report lists places without coordinates."
-msgstr ""
+msgstr "Tämä raportti listaa paikat ilman koordinaatteja."
 
 #: ../root/report/duplicate_relationships_recordings.tt:6
 msgid ""
@@ -7335,7 +6982,7 @@ msgid ""
 "This report lists releases where the label name is the same as the artist "
 "name. Often this means the release is self-released, and the label "
 "{SpecialPurposeLabel|should be \"[no label]\" instead}."
-msgstr ""
+msgstr "Tämä raportti listaa julkaisut, joissa levymerkin nimi on sama kuin artistin. Tämä yleensä tarkoittaa sitä, että julkaisu on omakustanne ja levymerkkinä {SpecialPurposeLabel|tulisi olla \"[no label]\" sen sijaan}."
 
 #: ../root/report/duplicate_relationships_releases.tt:6
 msgid ""
@@ -7398,10 +7045,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "Tämä raportti listaa {iswc|ISWC-koodit}, jotka ovat liitettyinä useampaan kuin yhteen teokseen. Jos teokset ovat samat, ne tulisi yleensä sulauttaa."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr "Tämä raportti listaa {url|beginner/limited editors}."
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7412,10 +7055,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Tämä raportti näyttää Amazon web-osoitteet, jotka ovat yhdistetty useisiin julkaisuihin. Yleensä Amazon ASIN-koodin tulisi vastata yksi yhteen MusicBrainzin julkaisun kanssa, joten vain yksi linkeistä on oikein. Tarkista mikä MusicBrainzin julkaisu sopii Amazonin julkaisuun (julkaisumuoto, kappalelista jne). Jos julkaisussa on viivakoodi, voit etsiä sillä Amazonista ja katsoa mikä ASIN vastaa sitä. Jotkut ASIN-koodit saattavat olla yhdistettynä myös useisiin saman julkaisun eri levyihin. Ne tulee sulauttaa (katso {how_to_merge_releases|kuinka sulauttaa julkaisut})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Tämä raportti näyttää Discogs web-osoitteet, jotka on yhdistetty useisiin artisteihin."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7630,7 +7269,7 @@ msgid ""
 "This report shows releases which have cover art in the Cover Art Archive, "
 "but where none of it has any types set. This often means a front cover was "
 "added, but not marked as such."
-msgstr ""
+msgstr "Tämä raportti näyttää julkaisut, joilla on kansitaidetta Cover Art Archivessa, mutta yhdellekään ei ole merkitty tyyppiä. Tämä yleensä tarkoittaa, että etukansitaide on lisätty, mutta sitä ei ole merkitty sellaiseksi."
 
 #: ../root/report/released_too_early.tt:6
 msgid ""
@@ -7695,7 +7334,7 @@ msgstr "Tämä sarja on tällä hetkellä tyhjä."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Taulukko näyttää yhteenvedon tämän editorin antamista äänistä."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "Tämä kappale on dataraita."
 
@@ -7821,29 +7460,6 @@ msgstr "ISWC-koodeja löytyi yhteensä: {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Web-osoitteita löytyi yhteensä: {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Artisteja löytyi yhteensä: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Samannimisiä yhtyeitä yhteensä: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr "Editoreja yhteensä: {count}"
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -8003,7 +7619,7 @@ msgstr "Kappale:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Kappalelista"
 
@@ -8021,10 +7637,6 @@ msgstr "Kappalelista:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Kappaleet"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Kappaleet, joiden nimet sisältävät niiden järjestysnumeroita"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8053,16 +7665,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Sisällyttäjä-editorit ovat käyttäjiä, jotka lisäävät ja ylläpitävät merkintöjä {uri|WikiDocsin} sisällyttämistaulukkoon."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Käännetyt/translitteroidut valejulkaisut, joita ei ole yhdistetty alkuperäiseen versioon"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Turkki"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8078,15 +7685,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8100,7 +7710,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Tyyppi"
 
@@ -8128,7 +7738,7 @@ msgstr "Tyyppi"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Tyyppi:"
 
@@ -8144,14 +7754,15 @@ msgstr "Tyyppi: {type}, tila: {status}"
 msgid "Types:"
 msgstr "Tyypit:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "Web-osoite"
 
@@ -8171,17 +7782,17 @@ msgid "URL:"
 msgstr "Web-osoite:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
-msgstr ""
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
+msgstr "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "Web-osoitteet"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "Web-osoitteet, joilla on vanhentuneita yhteyksiä"
 
@@ -8203,8 +7814,12 @@ msgstr "Valtuuttamaton pyyntö"
 msgid "Unclassified instrument"
 msgstr "Määrittelemätön soitin"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -8231,9 +7846,9 @@ msgstr "Lopeta seuraaminen"
 msgid "Untrusted"
 msgstr "Epäluotettava"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Enintään {n}"
 
@@ -8266,7 +7881,7 @@ msgstr "Lähetetään kuvaa..."
 msgid "Uppercase roman numerals"
 msgstr "Roomalaiset numerot isoin kirjaimin "
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Käytä beta-sivustoa"
 
@@ -8322,7 +7937,7 @@ msgid "Username:"
 msgstr "Käyttäjänimi:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Käyttäjät"
 
@@ -8454,10 +8069,6 @@ msgstr "Varoitus: Tällä yhteydellä on avoimia muokkauksia. {show|Näytä} avo
 msgid "Watched Artists"
 msgstr "Seuratut artistit"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Tämän raportin tiedot eivät ole juuri nyt saatavilla."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "Tämän kansitaiteen aiempaa tilannetta ei voida esittää. "
@@ -8503,10 +8114,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Olemme pahoillamme tästä virhetilanteesta. Kokeile muutaman minuutin kuluttua uudelleen &#x2014; ongelma saattaa korjaantua itsekseen."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Verkkosivu"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Kotisivu:"
@@ -8519,7 +8126,7 @@ msgid ""
 "and following the merge link."
 msgstr "Kun olet valmis sulauttamaan nämä, paina Sulauta-nappulaa. Voit yhä lisätä tähän jonoon enemmän kohteita menemällä niiden sivuille ja seuraamalla sulauta-linkkiä."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8541,10 +8148,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Teos"
 
@@ -8583,35 +8190,32 @@ msgstr "Teos:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Teokset"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Teokset, joilla lisätietokenttä"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Teokset, joilla vanhentuneita yhteyksiä"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Teokset, joilla mahdollisesti yhteyksien kaksoiskappaleita"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Tekijät"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8724,9 +8328,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Olet sulauttamassa seuraavia teoksia yhdeksi. Valitse se, johon muut tulisi sulauttaa:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Seuraat muutoksia. {unsub|Lopeta seuraaminen}?"
 
@@ -8742,9 +8345,8 @@ msgstr "Et voi lisätä tällä hetkellä merkintöjä tähän muokkaukseen. ({u
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Et voi tällä hetkellä äänestää tästä muokkauksesta. ({url|Lisätietoja})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Et seuraa muutoksia. {sub|Aloita seuraaminen}?"
 
@@ -8824,7 +8426,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr "Et ole syöttänyt täydellisiä artistin tekijätietoja."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Et ole tehnyt muutoksia!"
 
@@ -8849,7 +8451,7 @@ msgstr "Voit poistaa henkilökohtaiset tietosi palvelusta koska vain poistamalla
 msgid "You must be logged in to vote on edits"
 msgstr "Sinun tulee olla sisäänkirjautunut äänestääksesi muokkauksista."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Aseta täsmennyskommentti tälle entiteetille."
 
@@ -8931,7 +8533,7 @@ msgstr "Hakusi kesti liian kauan ja se peruutettiin. Voit yrittää uudelleen ta
 msgid "Your username will be publicly visible."
 msgstr "Käyttäjänimesi on julkisesti esillä."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8973,10 +8575,6 @@ msgstr "[tuntematon]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "jälkeen"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "alias:"
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9039,10 +8637,6 @@ msgstr "peruutettu"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "nimellä"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr "poista"
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9261,13 +8855,11 @@ msgstr "alkuperäinen"
 msgid "places"
 msgstr "paikat"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
-msgstr[0] "lisäksi {n} muu anonyymi käyttäjä"
-msgstr[1] "lisäksi {n} muuta anonyymiä käyttäjää"
+msgstr[0] "lisäksi {n} nimetön käyttäjä"
+msgstr[1] "Lisäksi {n} nimetöntä käyttäjää"
 
 #: ../root/entity/collections.tt:15
 msgid "plus {n} other private collection"
@@ -9342,7 +8934,7 @@ msgstr "Seuraa muutoksia"
 msgid ""
 "tab or 4 spaces and: * bullets or 1., a., A., i., I. numbered items "
 "(rendered with 1.)"
-msgstr ""
+msgstr "sarkain tai 4 välilyöntiä ja: * luettelomerkki tai 1., a., A., i., I. numeroituna (alkaen 1.)"
 
 #: ../root/release/edit/recordings.tt:22
 msgid "track"
@@ -9486,7 +9078,7 @@ msgstr[1] "{entity} on lisätty {num} kokoelmaan:"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} ei ole yhdessäkään kokoelmassa."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9500,7 +9092,7 @@ msgstr "Kohdetta {link} ei ole arvosteltu."
 msgid "{link} has no relationships."
 msgstr "Ei yhteyksiä kohteelle {link}."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainz-tunniste\">MBID</abbr>}:"
 
@@ -9613,7 +9205,7 @@ msgstr "{type} “{instrument}”"
 msgid "{type} “{work}”"
 msgstr "{type} “{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Palaa musicbrainz.org -sivulle}."
 
@@ -9820,34 +9412,34 @@ msgstr "'{id}' ei ole kelvollinen äänestyksen tunniste"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Sisällysluettelossa vaadittu parametri oli kelpaamaton tai se puuttui"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Anna tallenteen ID"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Tallennetta ei löydy"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "Annettu CD:n sisällysluettelo ei ole kelvollinen"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "Annettu tallenteen tunniste ei ole kelvollinen"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Tämä CD-levyn sisällysluettelo on jo liitetty tähän tallenteeseen."
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Valittu tallenne ei voi sisältää levyjen tunnisteita"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "Annettu artistin tunniste ei ole kelvollinen"
 
@@ -10229,7 +9821,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Muokkaa julkaisu usealle artistille (historiallinen)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Määritä kappaleiden kestot"
 
@@ -10530,6 +10122,12 @@ msgstr "Epäonnistunut äänestys"
 msgid "Failed dependency"
 msgstr "Epäonnistunut riippuvuus"
 
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Virhe"
+
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
 msgstr "Epäonnistunut edellytys"
@@ -10743,7 +10341,7 @@ msgstr "{role} (nimellä {credited_name})"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Gutenberg.pm:9
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Project Gutenberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/IMSLP.pm:31
 msgid "Score at IMSLP"
@@ -10751,15 +10349,15 @@ msgstr "Nuotit sivustolla IMSLP"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/NicoNicoVideo.pm:9
 msgid "Niconico"
-msgstr ""
+msgstr "Niconico"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Runeberg.pm:13
 msgid "Project Runeberg"
-msgstr ""
+msgstr "Project Runeberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Wikisource.pm:9
 msgid "Wikisource"
-msgstr ""
+msgstr "Wikisource"
 
 #: ../lib/MusicBrainz/Server/FilterUtils.pm:22
 msgid "Filter release groups"
@@ -10858,7 +10456,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Näitä koordinaatteja ei voitu jäsentää"
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "Päättymisajankohta ei voi olla ennen alkamisajankohtaa."
 
@@ -10962,13 +10560,13 @@ msgstr "Muokkausmerkintä vaaditaan."
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "CD-tynkä"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Luokitus"
@@ -10976,7 +10574,7 @@ msgstr "Luokitus"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Dokumentaatio"
 
@@ -11236,7 +10834,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Tarkista lahjoitukset"
 
@@ -11285,7 +10883,13 @@ msgid ""
 "Enter your username and email below. We will send you an email with a link "
 "to reset your password. If you have forgotten your username, {link|retrieve "
 "it} first and then reset your password."
-msgstr ""
+msgstr "Syötä alle käyttäjänimesi ja sähköpostiosoitteesi. Saat sähköpostiviestin, joka sisältää linkin josta voit asettaa salasanasi. Jos olet unohtanut käyttäjänimesi {link|selvitä se} ensin ja sitten vaihda salasanasi."
+
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "Sähköposti"
 
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
@@ -11318,7 +10922,7 @@ msgid ""
 msgstr "Olemme lähettäneet sinulle tietoja MusicBrainz käyttäjätunnuksestasi. Jos et vastaanota tätä sähköpostia tai sisäänkirjautumisongelmat jatkuvat, voit {link|ottaa meihin yhteyttä}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Asetukset"
 
@@ -11454,7 +11058,7 @@ msgstr "Sähköposti lähetettiin osoitteeseen {addr}. Tarkista sähköpostisi j
 msgid "Unconfirmed Email Address"
 msgstr "Vahvistamaton sähköpostiosoite"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} alueella {parent_areas}"
 
@@ -11494,32 +11098,32 @@ msgid ""
 msgstr "Tällä MusicBrainz-tunnisteella ei löydy artistia. Saatat haluta kokeilla {search_url|etsiä sitä}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Syntymäpaikka:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Perustamispaikka:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Aloitusalue:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Kuolinpaikka:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Lopetuspaikka:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Lopetusalue:"
 
@@ -11539,25 +11143,25 @@ msgstr "Kokoelmaa ei löytynyt"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Tällä MusicBrainz-tunnisteella ei löydy kokoelmaa."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Alkanut"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Päättymisajankohta"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr "ensisijainen"
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "Entiteetillä {entity} ei ole aliaksia."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
-msgstr ""
+msgstr "Lisää alias"
 
 #: ../root/components/ConfirmLayout.js:38
 msgid "Yes, I am sure"
@@ -11597,19 +11201,19 @@ msgstr[1] "Vanhenee <span class=\"tooltip\" title=\"{exactdate}\">{num} minuutis
 msgid "Already expired"
 msgstr "Jo vanhentunut"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profiili"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Seuratut kohteet"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Muokkaa käyttäjää"
 
@@ -11671,7 +11275,7 @@ msgid "For more information:"
 msgstr "Lisätietojen saamiseksi:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Lisää merkintä"
 
@@ -11850,6 +11454,22 @@ msgstr "Äänestys"
 msgid "Votes cast"
 msgstr "Annetut äänet"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] "Entiteettillä {entity} on tällä hetkellä {num} seuraaja:"
+msgstr[1] "Entiteettillä {entity} on tällä hetkellä {num} seuraajaa:"
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] "Lisäksi {n} nimetön käyttäjä"
+msgstr[1] "Lisäksi {n} nimetöntä käyttäjää"
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr "Entiteettillä {entity} ei ole tällä hetkellä yhtään seuraajaa."
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Tapahtumaa ei löytynyt"
@@ -11874,9 +11494,9 @@ msgstr "Tässä on kaikki luokitukset, jotka luokitusjärjestelmä tunnistaa tyy
 msgid ""
 "Is a genre missing from the list? Request it by {link|adding a style "
 "ticket}."
-msgstr ""
+msgstr "Puuttuuko tyylilaji listalta? {link|Pyydä sen lisäämistä}."
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "soitin"
 
@@ -11889,7 +11509,7 @@ msgstr "Soitinlista"
 msgid ""
 "Is this list missing an instrument? Request it by following {link|these "
 "instructions}."
-msgstr ""
+msgstr "Puuttuuko soitin listalta? {link|Pyydä sen lisäämistä}."
 
 #: ../root/instrument/NotFound.js:16
 msgid "Instrument Not Found"
@@ -12118,6 +11738,11 @@ msgstr "Lisää tapahtuma"
 msgid "Vote on Edits"
 msgstr "Äänestä muokkauksista"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Raportit"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Aloittelijan opas"
@@ -12158,23 +11783,23 @@ msgstr "Näytä kaikki yhteydet"
 msgid "Running: {git_details}"
 msgstr "Suoritetaan: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Sivu {n}"
 
-#: ../root/layout/components/Head.js:64
-msgid "MusicBrainz: Artist"
-msgstr ""
-
 #: ../root/layout/components/Head.js:65
+msgid "MusicBrainz: Artist"
+msgstr "MusicBrainz: Artisti"
+
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Levymerkki"
 
-#: ../root/layout/components/Head.js:66
-msgid "MusicBrainz: Release"
-msgstr ""
-
 #: ../root/layout/components/Head.js:67
+msgid "MusicBrainz: Release"
+msgstr "MusicBrainz: Julkaisu"
+
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Kappale"
 
@@ -12409,9 +12034,13 @@ msgstr "Tietoja soittimesta"
 msgid "Label information"
 msgstr "Tietoja levymerkistä"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Viimeksi päivitetty {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr "Viimeksi päivitetty tietoa ei ole"
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12487,18 +12116,18 @@ msgid "see all ratings"
 msgstr "katso kaikki arvostelut"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(ei mitään)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(ei mitään)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr "Näytä kaikki tunnisteet"
 
@@ -12635,7 +12264,7 @@ msgid ""
 " may show up on any other page with cover art. You are encouraged to "
 "{report_link|report errors to Google Safe Browsing}. Sorry for the "
 "inconvenience!"
-msgstr ""
+msgstr "Kansitaide on poistettu käytöstä pääsivulta Chrome-pohjaisissa selaimissa, jotka virheellisesti ilmoittavat kalasteluvaroituksen 11.11.2018 jälkeen (Lisää tietoa: {ticket_link|tiketti CAA-116}).<br/>Kalasteluvaroitus saattaa tulla millä tahansa sivulla, jolla on kansitaidetta. Suosittelemme että {report_link|ilmoitat virheistä Googlen Safe Browsing palveluun}. Pahoittelemme haittaa!"
 
 #: ../root/otherlookup/NotFound.js:16
 msgid "Entity Not Found"
@@ -12667,11 +12296,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Tällä MusicBrainz-tunnisteella ei löydy äänitettä. Saatat haluta kokeilla {search_url|etsiä sitä}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "Video artistilta {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Äänite artistilta {artist}"
 
@@ -12700,9 +12329,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Tällä MusicBrainz-tunnisteella ei löydy julkaisuryhmää. Saatat haluta kokeilla {search_url|etsiä sitä}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Julkaisuryhmä artistilta {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Artistin lisätietokenttiä"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "Tämä raportti listaa artistit, joilla lisätietokenttä."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Artisteja löytyi yhteensä: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artistit, joiden nimissä on täsmennyskommentit"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Tämä raportti listaa artistit, joiden nimessä saattaa olla täsmennyskommentti täsmennyskommenttikentän sijaan."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artistit, joiden täsmennyskommentti on sama kuin nimi"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr "Tämä raportti listaa artistit, joiden täsmennyskommentti on sama kuin nimi. Täsmennyskommenttia ei pitäisi olla tässä tapauksessa."
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artistit, jotka saattavat olla ryhmiä"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr "Tämä raportti listaa artistit, joiden tyyppi on muuta kuin ryhmä (tai ryhmän alatyyppi), mutta saattavat olla ryhmiä, sillä niiden jäseniksi on yhdistetty muita artisteja. Jos huomaat, että tässä listattu artisti onkin ryhmä, muuta sen tyyppiä. Jos se ei ole, tarkista että jäsenenä-yhteys on oikeaan suuntaan ja oikeellinen."
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artistit, jotka saattavat olla yksityishenkilöitä"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr "Tämä raportti listaa artistit, joiden tyyppi on muuta kuin henkilö, mutta saattavat olla henkilöitä yhteyksiensä perusteella. Esimerkiksi, artisti päätyy tälle listalle, jos se on merkitty toisen jäseneksi. Jos huomaat, että tässä listattu artisti on oikeasti henkilö, muuta sen tyyppiä. Jos se ei ole, tarkista että kaikki sen yhteydet ovat oikein ja järkeviä."
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr "Artistit, jotka on merkitty useamman kerran samaan tekijänimeen"
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "Tämä raportti listaa artistit, jotka ovat merkittynä useamman kerran, eri kohdissa, samassa tekijätiedossa."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artistit, joita kukaan ei seuraa"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "Tämä raportti listaa artistit, joilla ei ole editoreja seuraamassa muutoksia, ja joihin tehdyt muutokset saattavat jäädä tarkistamatta. Artistit, joilla on enemmän julkaisuryhmiä ja enemmän avoimia muokkauksia listataan ensin."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr "Artistit, joilla on yhteistyö-yhteyksiä"
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Tämä raportti listaa artistit, joilla on yhteistyöyhteys, mutta ei URL-yhteyksiä. Jos yhteistyöllä on oma erillinen nimensä, älä tee mitään. Jos nimi on muotoa \"X sekä Y\" tai \"X & Y\", se tulisi ehkä jakaa. Katso, {how_to_split_artists|kuinka artisti jaetaan}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Yhteistyö"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Yhteistyökumppani"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artistit, joilla vanhentuneita yhteyksiä"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "Tämä raportti listaa artistit, joilla on vanhentuneita ja vain ryhmittämiseen tarkoitettuja yhteystyyppejä."
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin artisteihin"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Tämä raportti näyttää Discogs web-osoitteet, jotka on yhdistetty useisiin artisteihin."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Mahdollisia kaksoiskappaleita artisteista"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Tämä raportti pyrkii tunnistamaan artistit, joilla on hyvin samankaltainen nimi. Jos kaksi artistia on oikeasti samoja, niin sulauta ne (muista {how_to_write_edit_notes|muokkausmerkintä} ja todistelu). Jos artistit ovat eri artisteja, niin lisää {disambiguation_comment|täsmennyskommentit} niille (sitten kun samannimisillä artisteilla on täsmennyskommentit, ne eivät päädy enää tähän raporttiin)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Samannimisiä yhtyeitä yhteensä: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Lisää valitut artistit sulautettaviksi"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artistit, joilla mahdollisesti yhteyksien kaksoiskappaleita"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "Tämä raportti listaa artistit, joilla on useita yhteyksiä samaan artistiin, levymerkkiin tai URL-osoitteeseen samalla yhteystyypillä. Yhteyksistä useisiin julkaisuryhmiin, äänitteisiin ja teoksiin on omat raporttinsa."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Näytä kaikki tulokset."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Näytä kaikki tulokset liittyen tilauksiini."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Aloittelevat/rajoitetut editorit"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr "Tämä raportti listaa {url|beginner/limited editors}."
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr "Editoreja yhteensä: {count}"
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artistit, jotka voivat olla yhteistöitä"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Tämä raportti listaa artistit, joiden nimessä on \"&\", mutta niillä ei ole jäseniä tai yhteystyöyhteyksiä. Jos artistia pidetään yleisesti oikeana ryhmänä, jäsenten yhteydet tulisi lisätä. Jos se taas on lyhytaikainen yhteistyö, se tulisi jakaa, mikäli mahdollista (katso {how_to_split_artists|kuinka jakaa artisti}). Jos se on yhteistyö omalla nimellään, eikä sitä voida jakaa, siihen tulee lisätä yhteistyöyhteydet."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Tämän raportin tiedot eivät ole juuri nyt saatavilla."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Jos haluaisit osallistua muokkaamiseen, mutta et tiedä mistä aloittaisit, näistä raporteista saattaa olla apua. Nämä raportit listaavat tietokannasta poimittuja kohteita, jotka saattavat tarvita korjaamista. Osa vaatiinee muokkausta noudattaakseen {style|tyyliohjeita}, ja joissakin tapauksissa saatetaan tarvita hallinnollista \"siivoamista\"."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artistit, joilla on yhteistyö-yhteyksiä"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artistit, jotka voivat olla yhteistöitä"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Artistit, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Käyttäjät"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Mahdollisia kaksoiskappaleita tapahtumista"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin levymerkkeihin"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Levymerkit, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Julkaisuryhmät"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Julkaisuryhmät, jotka saattavat vaatia sulauttamisen"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuryhmiin"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Julkaisuryhmät, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Julkaisut, joissa odottamattomia Amazon web-osoitteita"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Julkaisut, joissa useita ASIN-koodeja"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Julkaisut, joissa useita Discogs-linkkejä"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "Amazon web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "Discogs web-osoitteet, jotka on yhdistetty useisiin julkaisuihin"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Julkaisut, joissa osana joukkoa -yhteyksiä"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Erillisinä julkaisuina syötetyt levyt"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Julkaisut, joissa ei peräkkäistä kappalenumerointia"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Julkaisut, joissa joidenkin (mutta ei kaikkien) tallenteiden muoto asettamatta"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Julkaisut, joissa luettelonumero näyttää Amazon ASIN-tunnisteilta"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Käännetyt/translitteroidut valejulkaisut, joita ei ole yhdistetty alkuperäiseen versioon"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Kaikenlaiset julkaisut, joilla on yhä kansitaide-yhteyksiä"
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Julkaisut, joissa ei peräkkäisiä tallenteita"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Julkaisut, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr "Julkaisut, joilta puuttuu levyn tunniste"
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Äänitteet, joissa aiempi julkaisu -yhteys"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Kappaleet, joiden nimet sisältävät niiden järjestysnumeroita"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Äänitteitä, joissa eripituisia kappaleita"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Äänitteet, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Paikat, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Sarjat, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Teokset, joilla lisätietokenttä"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC-koodit"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Liittynyt"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Verkkosivu"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Elämäkerta"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "poista"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12789,7 +12807,7 @@ msgstr "Maakohtaiset asetukset"
 
 #: ../root/static/scripts/account/components/PreferencesForm.js:177
 msgid "Guess timezone"
-msgstr ""
+msgstr "Arvaa aikavyöhyke"
 
 #: ../root/static/scripts/account/components/PreferencesForm.js:182
 msgid "Timezone:"
@@ -12859,60 +12877,76 @@ msgstr "Ei tyyppiä"
 msgid "{place_type}: {place_link}"
 msgstr "{place_type}: {place_link}"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Virhe kesken haun. Paina tästä yrittääksesi uudelleen."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Kokeile suoralla haulla sen sijaan."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Kokeile indeksoidulla haulla sen sijaan."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Kirjoita etsiäksesi, tai liitä MBID-tunniste"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Tyhjennä viimeaikaiset"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Näytä lisää..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Ei löytynyt? Kokeile uudelleen suoralla haulla."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Hidasta? Vaihda takaisin indeksoituun hakuun."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr "julkaisulla"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr "yksittäinen äänite"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr "{release_group_type} artistilta {artist}"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr "Esiintyjät"
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Äänestä kaikista muokkauksista:"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Poista merkintä"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Näytä tiedot alhaalla"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Näytä tiedot upotettuna"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Tallenteen lataaminen epäonnistui."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Kuva {current} / {total}"
 
@@ -12934,7 +12968,7 @@ msgstr "Muokattu viimeksi {date}."
 msgid "Show less..."
 msgstr "Näytä vähemmän..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "kuva Wikimedia Commonsista"
 
@@ -12945,73 +12979,90 @@ msgstr "{author} {review_link|arvosteli} {date}"
 #: ../root/static/scripts/common/components/EditorLink.js:19
 msgid ""
 "This editor is missing from this server, and cannot be displayed correctly."
-msgstr ""
+msgstr "Tämä käyttäjä puuttuu palvelimelta, joten sitä ei voida näyttää kunnolla."
 
 #: ../root/static/scripts/common/components/EditorLink.js:20
 msgid "[missing editor]"
-msgstr ""
+msgstr "[puuttuva käyttäjä]"
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
-msgstr ""
+msgstr "Vedä ääni pois"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Puolesta"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Olet äänestänyt tämän tunnisteen puolesta"
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Vastaan"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Olet äänestänyt tätä tunnistetta vastaan"
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "Tunnisteet joiden arvo on nolla tai pienempi, ja tunnisteet, joita vastaan olet äänestänyt piilotetaan."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "Tunnisteet joiden arvo on nolla tai pienempi piilotetaan."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Näytä kaikki tunnisteet."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Kaikki tunnisteet näytetään."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr "Piilota tunnisteet, joiden arvo on nolla tai pienempi, sekä tunnisteet joita vastaan olet äänestänyt."
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr "Piilota tunnisteet, joiden arvo on nolla tai pienempi."
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Lisää tunnisteita"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Voit lisätä omia {tagdocs|tunnisteita} alapuolella. Erottele pilkulla useat tunnisteet."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Lähetä tunnisteet"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "näytä kaikki tunnisteet"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Luokitus"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Jatka lukemista Wikipediassa..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13129,21 +13180,21 @@ msgstr "{begin_date} – ????"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Alkoi:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Tämä henkilö on kuollut."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Tämä yhtye on hajonnut."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Pakollinen kenttä."
 
@@ -13203,9 +13254,9 @@ msgid ""
 "entity from the others."
 msgstr "Aseta {doc_disambiguation|täsmennyskommentti} erottamaan tämä entiteetti muista."
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Kaikki muutokset menetetään, jos jätät tämän sivun."
 
@@ -13218,7 +13269,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Valitse linkin tyyppi kirjoittamallesi web-osoitteelle."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13235,7 +13286,7 @@ msgid "This relationship already exists."
 msgstr "Tämä yhteys on jo olemassa."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|lisää dokumentaatiota})"
 
@@ -13255,7 +13306,7 @@ msgstr "video"
 msgid "Remove Link"
 msgstr "Poista linkki"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Kirjoitusasun tunnistuksen asetukset"
 
@@ -13288,45 +13339,45 @@ msgid ""
 "language guidelines}. "
 msgstr "Tämä tapa käsittelee turkin kielen kirjoitusasun 'i' ('İ') and 'ı' ('I'). Jotkin sanat saatetaan joutua korjaamaan käsin noudattamaan {url|turkin kielen tyyliohjeistusta}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "Valitsemasi sarja on äänitteille."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "Valitsemasi sarja on julkaisuille."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "Valitsemasi sarja on julkaisuryhmille."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "Valitsemasi sarja on teoksille."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Valitse yhteyden tyyppi."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Valitse jokin yhteystyyppi tämän alta. Tämä yhteystyyppi ryhmittää vain muita yhteystyyppejä."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Yhteyden kohteet eivät voi olla samat."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr "Muuta tekijätiedot muille {entity} -yhteyksille tällä sivulla."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr "Vain yhteydet {entity_type} -entiteeteille."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr "Vain “{relationship_type}” -yhteydet {entity_type} -entiteetteihin."
 
@@ -13334,19 +13385,19 @@ msgstr "Vain “{relationship_type}” -yhteydet {entity_type} -entiteetteihin."
 msgid "This attribute is required."
 msgstr "Tämä määrite vaaditaan."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} valittu äänite "
 msgstr[1] "{n} valittua äänitettä"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} valittu teos"
 msgstr[1] "{n} valittua teosta"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13363,64 +13414,64 @@ msgstr "Tallenteella on yksi tai useampia levytunnisteita, jotka estävät täm�
 msgid "Page {page} of {total}"
 msgstr "Sivu {page} / {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Tallenne {position}: {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Tallenne {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Et ole valinnut levymerkkiä kohteelle “{name}”."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Virhe ladattaessa julkaisua: {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Lisää julkaisu"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Muokkaa julkaisua"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "Tarkistusluku on {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Tarkista varmuuden vuoksi julkaisun viivakoodi uudelleen."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Syöttämäsi viivakoodi näyttää UPC-koodilta, jonka tarkistusluku puuttuu."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Syöttämäsi viivakoodi on kelvollinen UPC-koodi."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Syöttämäsi viivakoodi on joko kelpaamaton UPC-koodi, tai EAN-koodi, jonka tarkistusluku puuttuu."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Syöttämäsi viivakoodi on kelvollinen EAN-koodi."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Syöttämäsi viivakoodi ei ole kelvollinen EAN-koodi."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Syöttämäsi viivakoodi ei ole kelvollinen UPC- tai EAN-koodi."
 
@@ -13428,7 +13479,7 @@ msgstr "Syöttämäsi viivakoodi ei ole kelvollinen UPC- tai EAN-koodi."
 msgid "Add Language"
 msgstr "Lisää kieli"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Poista kieli"
 

--- a/po/mb_server.fr.po
+++ b/po/mb_server.fr.po
@@ -10,6 +10,7 @@
 # Benjamin <email address hidden>, 2011
 # Benjamin Sonntag <email address hidden>, 2011
 # Benjamin Sonntag <email address hidden>, 2011
+# Idlusen <email address hidden>, 2019
 # Dibou <email address hidden>, 2012
 # Dibou <email address hidden>, 2012
 # Dibou  <email address hidden>, 2012
@@ -41,6 +42,7 @@
 # Nikolai Prokoschenko <email address hidden>, 2011
 # Nikolai Prokoschenko <email address hidden>, 2011
 # nikki, 2013
+# PATATE12 ★, 2019
 # Paul Tremberth <email address hidden>, 2013
 # Paul Tremberth <email address hidden>, 2013
 # Raphaël Fery <email address hidden>, 2017
@@ -60,9 +62,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-14 14:59+0000\n"
-"Last-Translator: yvanz\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-03-13 16:16+0000\n"
+"Last-Translator: PATATE12 ★\n"
 "Language-Team: French (http://www.transifex.com/musicbrainz/musicbrainz/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -221,6 +223,7 @@ msgstr "(aucun)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(inconnu)"
 
@@ -427,7 +430,7 @@ msgstr "Administrateurs de compte"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Les administrateurs de compte peuvent modifier et supprimer les comptes d’utilisateurs."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "Entrée AcousticBrainz :"
 
@@ -437,7 +440,7 @@ msgstr "Entrée AcousticBrainz :"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Actions"
 
@@ -622,10 +625,6 @@ msgstr "Ajouter une œuvre connexe"
 msgid "Add relationship"
 msgstr "Ajouter une relation"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Ajouter les artistes choisis pour la fusion"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Ajouter les événements choisis pour la fusion"
@@ -698,7 +697,7 @@ msgstr "Âge :"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -718,9 +717,10 @@ msgstr "Alias :"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Alias"
 
@@ -768,26 +768,21 @@ msgstr "Se produit aussi comme"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "URLs d’Amazon reliées à plusieurs parutions"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "URLs d’Amazon reliées à plusieurs parutions"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Un alias est un nom alternatif pour une entité. Il contient habituellement des erreurs d’orthographe ou des variations du nom. Il est aussi utilisé pour améliorer les résultats de recherche. Consultez la {doc|documentation sur les alias} pour plus de détails."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Un utilisateur anonyme"
 msgstr[1] "{n} utilisateurs anonymes"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -809,8 +804,7 @@ msgstr "Une erreur est survenue : "
 msgid "An error occurred while creating the works."
 msgstr "Une erreur est survenue durant la création des œuvres."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -819,8 +813,9 @@ msgstr "Une erreur est survenue durant la création des œuvres."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Annotation"
@@ -954,11 +949,11 @@ msgstr "Êtes-vous certain de vouloir supprimer la série {series} de MusicBrain
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -1009,24 +1004,27 @@ msgstr "Régions"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1072,11 +1070,6 @@ msgstr "MBID de l’artiste"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Abonnements à des artistes"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Annotations sur les artistes"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1124,7 +1117,7 @@ msgstr "Artiste {n} :"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artiste :"
 
@@ -1132,81 +1125,15 @@ msgstr "Artiste :"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artistes"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artistes contenant des commentaires de désambiguïsation dans leur nom"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artistes apparaissant plusieurs fois dans le même crédit d’artiste"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artistes qui sont peut-être des collaborations"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artistes pouvant être des groupes"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artistes pouvant être des personnes"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artistes ayant des relations de collaboration"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artistes qui ressemblent à des collaborations"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artistes ayant des relations de collaboration"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Artistes avec des annotations"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artistes avec des relations obsolètes"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artistes contenant des commentaires de désambiguïsation identiques à leur nom"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artistes sans abonné"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artistes avec relations probablement en double"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1371,9 +1298,8 @@ msgstr "Ajout par lot de relations aux œuvres"
 msgid "Batch-create new works"
 msgstr "Création par lot de nouvelles œuvres"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Soyez le premier ! {sub|Abonnez-vous} ?"
 
@@ -1431,21 +1357,12 @@ msgstr "Début (date) :"
 msgid "Beginner"
 msgstr "Débutant"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Éditeurs débutants / restreints"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Voici ci-dessous des informations sur l’erreur. Si vous désirez remplir un rapport de bogue, vous pouvez le faire avec {bugs|notre gestionnaire de bogues}. Les informations ci-dessous nous aiderons, veuillez donc vous assurer de les inclure."
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Bio"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1456,12 +1373,12 @@ msgstr "Bio :"
 msgid "Birth date:"
 msgstr "Date de naissance :"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blogue"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Date de naissance :"
 
@@ -1473,13 +1390,13 @@ msgstr "Robot"
 msgid "Bots"
 msgstr "Robots"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "Délivré pour vous par la {MeB|fondation MetaBrainz} et ses {spon|sponsors} et {supp|supporters}. Illustrations servies par la {caa|Cover Art Archive}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Gestionnaire  de bogues"
@@ -1624,7 +1541,7 @@ msgstr "No dans le catalogue "
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Changer de mot de passe"
 
@@ -1703,14 +1620,6 @@ msgstr "Fermé"
 msgid "Code"
 msgstr "Code"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Collaboration"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Collaborateur"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Réduire le disque"
@@ -1739,7 +1648,7 @@ msgstr "Collection « {collection} »"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Collections"
@@ -1817,7 +1726,7 @@ msgid "Country:"
 msgstr "Pays : "
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Illustration"
 
@@ -1949,7 +1858,7 @@ msgstr "Les dates sont au format AAAA-MM-JJ. Des dates partielles comme AAAA-MM 
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Supprimer le compte"
 
@@ -2001,13 +1910,14 @@ msgstr "Description :"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Détails"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Date de décès : "
 
@@ -2017,7 +1927,7 @@ msgstr "Diff"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Recherche directe dans la base de données"
 
@@ -2074,7 +1984,7 @@ msgid "Disc ID:"
 msgstr "ID de disque :"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "ID de disque"
 
@@ -2094,11 +2004,6 @@ msgstr "Titre du disque :"
 msgid "Discography"
 msgstr "Discographie"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "URLs Discogs reliées vers plusieurs artistes"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2114,32 +2019,12 @@ msgstr "URL Discogs reliée à plusieurs groupes de parution"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "URL Discogs reliée à plusieurs parutions"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "URLs Discogs reliées vers plusieurs artistes"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "URLs Discogs reliées à plusieurs labels"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "URL Discogs reliée à plusieurs groupes de parution"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "URL Discogs reliée à plusieurs parutions"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Disques sous forme de parutions séparées"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Disques entrés sous forme de parutions séparées"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Dissous : "
 
@@ -2157,7 +2042,7 @@ msgstr "Documentation :"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Vous n’avez pas de compte ? {uri|Créez en un maintenant} !"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Faites un don"
 
@@ -2188,9 +2073,9 @@ msgstr "Chaque piste de la base de données de MusicBrainz doit être reliée à
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Modifier"
 
@@ -2243,7 +2128,7 @@ msgid "Edit Note Author"
 msgstr "Auteur de la note de modification"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Modifier le profil"
 
@@ -2318,10 +2203,10 @@ msgid "Editing/voting disabled"
 msgstr "Édition / vote désactivés"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Éditeur"
 
@@ -2337,10 +2222,6 @@ msgstr "Abonnements à des éditeurs"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Éditeur « {user} »"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Éditeurs"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2369,12 +2250,6 @@ msgstr "Modifications de {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Modifications chargées pour la page :"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "Courriel"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2434,7 +2309,7 @@ msgstr "Fin"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Terminé le : "
 
@@ -2460,7 +2335,7 @@ msgstr "Saisir les coordonnées manuellement ou glisser le marqueur pour obtenir
 #: ../root/release/edit/layout.tt:67 ../root/release/edit_relationships.tt:103
 #: ../root/components/EnterEdit.js:38
 msgid "Enter edit"
-msgstr "Saisir une modification"
+msgstr "Soumettre la modification"
 
 #: ../root/components/forms.tt:30
 msgid ""
@@ -2477,11 +2352,6 @@ msgstr "Type d’entité"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Types d’entités :"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Erreur"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2531,8 +2401,8 @@ msgstr "Même nous fournir une URL ou deux est utile !"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2559,13 +2429,14 @@ msgstr "Événement :"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Événements"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr "Événements qui devraient faire partie d’une série ou d’un événement plus grand"
 
@@ -2646,7 +2517,7 @@ msgid "Find Relationships"
 msgstr "Trouver les relations"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Empreintes"
 
@@ -2695,7 +2566,7 @@ msgstr "Pour plus d’informations, consultez la {doc_doc|documentation} et les 
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Pour plus d’informations, consultez la {doc_doc|documentation}."
 
@@ -2727,7 +2598,7 @@ msgstr "Format"
 msgid "Format:"
 msgstr "Format : "
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Forums"
@@ -2783,7 +2654,7 @@ msgstr[1] "Trouvé {n} résultats pour « {q} »"
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Fondé le :"
 
@@ -2839,7 +2710,6 @@ msgstr "Genre :"
 msgid "General Information"
 msgstr "Information Générale"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2847,17 +2717,9 @@ msgstr "Information Générale"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2865,13 +2727,10 @@ msgstr "Information Générale"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2886,13 +2745,11 @@ msgstr "Information Générale"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2923,13 +2780,27 @@ msgstr "Information Générale"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Généré le {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Genres"
 
@@ -3128,13 +2999,15 @@ msgstr "ISRC {isrc} pour {recording}"
 msgid "ISRC:"
 msgstr "ISRC :"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRC avec plusieurs enregistrements"
 
@@ -3158,12 +3031,8 @@ msgstr "Code ISWC {iswc} pour {work}"
 msgid "ISWC:"
 msgstr "ISWC :"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "ISWC à plusieurs œuvres "
 
@@ -3235,15 +3104,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Si vous pensez que ceci est une erreur, veuillez contacter <code>support@musicbrainz.org</code> avec le nom de votre compte."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Si vous souhaitez participer au processus d’édition mais que vous ne savez pas par où commencer, les rapports ci-dessous pourraient vous être utiles. Ces rapports fouille la base de données à la recherche de données qui devraient peut-être être corrigées soit pour correspondre au {style|directives de style}, ou pour toute autre tache de « nettoyage administratif »."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3281,11 +3141,11 @@ msgstr "Nom d’utilisateur ou mot de passe incorrect"
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Recherche indexée"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Recherche indexée avec {doc|la syntaxe de requête approfondie}"
 
@@ -3296,7 +3156,7 @@ msgstr "Recherche indexée avec {doc|la syntaxe de requête approfondie}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3321,13 +3181,14 @@ msgstr "Détails sur l’instrument"
 msgid "Instrument:"
 msgstr "Instrument :"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Instruments"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Instruments sans image"
 
@@ -3393,9 +3254,9 @@ msgstr "Je souhaite rester connecté"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3456,31 +3317,28 @@ msgstr "Label :"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Labels"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Labels avec des annotations"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Labels avec des relations obsolètes"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Labels contenant des commentaires de désambiguïsation identiques au nom du label"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Labels avec relations probablement en double"
 
@@ -3521,7 +3379,6 @@ msgstr "Les dernières 24 heures"
 msgid "Last 28 days"
 msgstr "Les 28 derniers jours"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3529,6 +3386,7 @@ msgstr "Les 28 derniers jours"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Dernière modification"
 
@@ -3536,7 +3394,7 @@ msgstr "Dernière modification"
 msgid "Last login:"
 msgstr "Dernière connexion :"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Dernier paquet de réplication reçu à {datetime}"
 
@@ -3544,7 +3402,7 @@ msgstr "Dernier paquet de réplication reçu à {datetime}"
 msgid "Last updated"
 msgstr "Dernière mise à jour"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Dernière mise à jour :"
 
@@ -3614,14 +3472,14 @@ msgid "Loading edit previews..."
 msgstr "Chargements des prévisualisations des modifications..."
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Chargement en cours..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Locale"
 
@@ -3631,6 +3489,7 @@ msgstr "Locale : "
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Lieu"
 
@@ -3703,7 +3562,7 @@ msgstr "Bas"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Langues des paroles"
 
@@ -3738,7 +3597,7 @@ msgid "Many relationships"
 msgstr "Beaucoup de relations"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Carte"
 
@@ -3799,10 +3658,6 @@ msgstr "Support :"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Supports :"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Membre depuis"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3914,7 +3769,7 @@ msgstr "Les plus populaires"
 msgid "Most Recent"
 msgstr "Les plus récentes"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Déplacement "
 
@@ -4043,7 +3898,7 @@ msgstr "Nom"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Nom : "
 
@@ -4145,7 +4000,7 @@ msgstr "Nouvelle version : "
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Suivant "
@@ -4221,7 +4076,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Aucune parution n’a d’illustration indiquée comme « Face avant », l’illustration ne peut être assignée. "
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -4235,7 +4090,7 @@ msgstr "Aucun résultat."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Aucun résultat de trouvé. Essayez en affinant votre requête de recherche."
 
@@ -4260,13 +4115,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "Personne n’a laissé de notes sur aucune de vos modifications dans les trois derniers mois."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Personne n’a encore tagué ceci."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Parutions non numériques avec des relations de téléchargement"
 
@@ -4276,7 +4131,7 @@ msgid "None"
 msgstr "Aucun"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr "Aucun des ID de disque joints ne peut correspondre à un silence préliminaire de la durée donnée."
@@ -4485,9 +4340,9 @@ msgid "Other lookups"
 msgstr "Autres recherches"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr "Autres tags"
 
@@ -4496,7 +4351,7 @@ msgid "Overall"
 msgstr "Global"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Vue d’ensemble"
@@ -4573,11 +4428,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Effectuer les opérations ci-dessus quand je n’utilise pas l’application"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Représentations"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Lien permanent  :"
 
@@ -4589,8 +4444,8 @@ msgstr "Phrase : "
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4616,23 +4471,20 @@ msgstr "Lieu :"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Lieux"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Lieux avec annotations"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Lieux avec des relations obsolètes"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr "Lieux sans coordonnées"
 
@@ -4755,22 +4607,14 @@ msgid "Possible duplicate events"
 msgstr "Événements probablement en double"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Groupes de parution probablement en double"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Valeurs possibles :"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Artiste  probablement en double"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Événements probablement en double"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4788,7 +4632,7 @@ msgstr "Aperçu :"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Précédent"
@@ -4840,7 +4684,7 @@ msgid "Public collection by {owner}"
 msgstr "Collection publique de {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Requête :"
 
@@ -4865,7 +4709,7 @@ msgstr "Évaluation"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Évaluations"
 
@@ -4895,7 +4739,7 @@ msgstr "Notes récentes laissées sur vos modifications"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4938,21 +4782,22 @@ msgstr "Enregistrement :"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Enregistrements"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr "Enregistrements crédités « Various Artists » mais pas liés à l’entité « Various Artists »."
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr "Enregistrements non crédités « Various Artists » et pourtant liés à l’entité « Various Artists »."
 
@@ -4966,40 +4811,28 @@ msgstr "Enregistrements avec des relations de parution la plus ancienne"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Enregistrements à durée de piste variable"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Enregistrements avec des annotations"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Enregistrements avec des relations obsolètes"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Enregistrements avec des relations de parution la plus ancienne"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Enregistrements avec relations probablement en double"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr "Enregistrements de même nom par des des artistes différents de même nom"
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Enregistrements avec un titre contenant des artistes invités"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Enregistrements avec des durées de piste variables"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5057,7 +4890,6 @@ msgid "Relationship Editor"
 msgstr "Éditeur de relation"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5065,6 +4897,7 @@ msgstr "Éditeur de relation"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Type de relation"
 
@@ -5114,7 +4947,7 @@ msgstr "Relation :"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Relations"
 
@@ -5146,7 +4979,7 @@ msgstr "Relations : "
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5178,7 +5011,7 @@ msgstr "Événements de parution :"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Groupe de parution"
@@ -5214,7 +5047,7 @@ msgstr "Groupes de parution :"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Groupes de parution avec des relations obsolètes"
 
@@ -5273,6 +5106,7 @@ msgid "Release group ratings"
 msgstr "Évaluations des groupes de parution"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Groupe de parution « {name} » par {artist}"
 
@@ -5284,40 +5118,29 @@ msgstr "Groupe de parution « {name} » par {artist}"
 msgid "Release group:"
 msgstr "Groupe de parution :"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Groupes de parution"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr "Groupes de parution crédités « Various Artists » mais pas liés à l’entité « Various Artists »."
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr "Groupes de parution crédités « Various Artists » et pourtant liés à l’entité « Various Artists »."
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Groupe de parution qu’il faudrait peut-être fusionner"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Groupes de parution avec des annotations"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Groupes de parution avec relations probablement en double"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
-msgstr "Groupe de parution avec des noms contenant des artistes invités"
+msgstr "Groupes de parution avec des noms contenant des artistes invités"
 
 #: ../root/release/edit/information.tt:3
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:120
@@ -5358,8 +5181,8 @@ msgstr "Parution :"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Parutions"
@@ -5393,67 +5216,43 @@ msgstr "Parutions avec des liens plusieurs Discogs"
 msgid "Releases With Some Formats Unset"
 msgstr "Parution avec un certains formats non précisés"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr "Parutions créditées « Various Artists » mais pas liées à l’entité « Various Artists »."
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Parutions dans la « Cover Art Archive » (archive d’illustrations) qui ont encore des relations d’Illustration"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr "Parutions dans la « Cover Art Archive » (archive d’illustrations) sans le moindre type d’illustration"
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr "Parutions en manque d’ID de disque"
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr "Parutions non créditées « Various Artists » et pourtant liées à l’entité « Various Artists »."
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Parutions de toutes sortes qui ont encore des relations d’Illustration."
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Parutions sorties trop tôt"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr "Parutions dont l’artiste et le label ont le même nom"
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Parution dont certains (mais pas tous) supports n’ont pas de format de précisé"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Parutions ayant plusieurs ASIN"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Parutions avec plusieurs liens Discogs"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Parutions ayant des relations de partie d’un ensemble"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Parutions ayant des URLs d’Amazon inattendues"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Parutions qui devraient peut-être être converties en « plusieurs artistes »"
 
@@ -5462,23 +5261,15 @@ msgstr "Parutions qui devraient peut-être être converties en « plusieurs art
 msgid "Releases with Cover Art relationships"
 msgstr "Parutions avec des relations d’illustration."
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Parutions avec un seul support qui a un nom"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Parutions avec des annotations"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Parutions avec des numéros de catalogue qui ressemble à des ASIN"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Parutions avec des relations obsolètes"
 
@@ -5487,31 +5278,25 @@ msgstr "Parutions avec des relations obsolètes"
 msgid "Releases with medium number issues"
 msgstr "Parutions avec un problème de numéro de support"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Parutions sans support"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Parution avec des supports non séquentiels"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Parutions avec des numéros de piste non séquentiels"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Parutions avec relations probablement en double"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Parutions avec des pistes de données superflues"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Parutions ayant des titres contenant des artistes invités"
 
@@ -5520,24 +5305,26 @@ msgstr "Parutions ayant des titres contenant des artistes invités"
 msgid "Releases with track number issues"
 msgstr "Parution avec des problèmes de numéro de piste"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Parutions avec des durées de piste inconnues"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Parution avec des paires langue/système d’écriture improbable"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Parutions sans langue"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Parutions sans système d’écriture"
 
@@ -5563,7 +5350,7 @@ msgstr "Parutions :"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5575,7 +5362,7 @@ msgstr "Parutions :"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Enlever"
@@ -5715,11 +5502,6 @@ msgstr "Signaler l’utilisateur"
 msgid "Report this user for bad behavior"
 msgstr "Signaler cet utilisateur pour mauvais comportement"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Rapports"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Délai de requête expiré"
@@ -5742,7 +5524,7 @@ msgstr "Réinitialiser le mot de passe"
 msgid "Reset track numbers"
 msgstr "Réinitialiser les numéros de piste"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Résultats par page :"
 
@@ -5782,7 +5564,7 @@ msgstr "Review the {url|documentation} on release editor seeding and make sure y
 msgid "Role"
 msgstr "Rôle"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5825,7 +5607,7 @@ msgstr "Système d’écriture :"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5872,7 +5654,7 @@ msgstr "Rechercher des modifications"
 msgid "Search for the target URL."
 msgstr "Rechercher l’URL cible."
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Méthode de recherche :"
 
@@ -5961,7 +5743,7 @@ msgstr "Envoyer une copie à mon adresse courriel personnelle"
 msgid "Sentence"
 msgstr "Phrase"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Série"
@@ -5976,8 +5758,8 @@ msgstr "Série"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -6000,10 +5782,6 @@ msgstr "Abonnements à des séries"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "Annotations sur les séries"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "Séries avec annotations"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -6032,7 +5810,7 @@ msgstr "Saisir un nouveau mot de passe pour votre compte MusicBrainz."
 msgid "Set cover art"
 msgstr "Assigner une illustration"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Saisir la durée des pistes"
 
@@ -6045,10 +5823,6 @@ msgstr "Programme"
 msgid "Setlist:"
 msgstr "Programme :"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Afficher tous les résultats."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "M’alerter quand je reçois une nouvelle note de modification."
@@ -6058,10 +5832,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Me montrer {autoedit_select_block} trié par {sort_select_block} qui {match_or_negation_block} {and_vs_or_block} pour les conditions suivantes :"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Afficher seulement les résultats pour des entités auxquelles je suis abonné."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6197,7 +5967,7 @@ msgstr "Désolé, la page que vous chercher n’est pas disponible sur un serveu
 msgid "Sorry, there was a problem with your request."
 msgstr "Désolé, il y a eu un problème avec votre requête."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Désolé, vous n’êtes pas autorisé à voir cette page."
 
@@ -6221,8 +5991,8 @@ msgstr "Désolé, « {id} » n’est pas une page de documentation valide."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Nom de tri"
 
@@ -6276,7 +6046,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Statut :"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Ne plus utiliser le site bêta"
 
@@ -6330,12 +6100,10 @@ msgstr "Éditeurs abonnés"
 msgid "Subscribed entities"
 msgstr "Abonné à ces entités"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6383,8 +6151,8 @@ msgid "Tagger"
 msgstr "Baliseur"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6455,7 +6223,7 @@ msgid ""
 "and may not display correctly"
 msgstr "Les données issues de cette modification proviennent d’une ancienne version du système, et pourraient ne pas d’afficher correctement."
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6466,7 +6234,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "Les données que vous avez propagées contenaient les erreurs suivantes :"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "La date saisie est invalide."
 
@@ -6565,7 +6333,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Le serveur de recherche n’a pas pu compléter votre requête du fait d’une erreur interne. Ceci est habituellement seulement temporaire, alors veuillez ressayer votre recherche plus tard."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "Le serveur est temporairement en lecture seule pour cause de maintenance de la base de données."
 
@@ -6604,21 +6372,9 @@ msgstr "Il n’y a actuellement aucun utilisateur abonné aux modifications que 
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Il n’y a actuellement aucun utilisateur abonné aux modifications que l’utilisateur {user} effectue."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Il n’y a actuellement aucun utilisateur abonné à {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "Aucun utilisateur n’est actuellement abonné à {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Il n’y a actuellement aucun utilisateur abonné à {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "Il n’y a actuellement aucun utilisateur abonné à {series}."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6627,12 +6383,12 @@ msgid ""
 msgstr "Il n’y aucun ID de disque de rattachée à cette parution ; pour en savoir plus sur comment en ajouter une voir {doc|Comment ajouter des ID de disque}."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr "Il n’y a aucun genre à montrer."
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr "Il n’y a aucun autre tag à montrer."
 
@@ -6658,29 +6414,11 @@ msgid_plural ""
 msgstr[0] "Il y a actuellement {num} utilisateur abonné aux modifications effectuées par {user} :"
 msgstr[1] "Il y a actuellement {num} utilisateurs abonnés aux modifications effectuées par {user} :"
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Il y a actuellement {num} utilisateur abonné à {artist} :"
-msgstr[1] "Il y a actuellement {num} utilisateurs abonnés à {artist} :"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "{num} utilisateur est actuellement abonné à {collection}."
 msgstr[1] "{num} utilisateurs sont actuellement abonnés à {collection}."
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Il y a actuellement {num} utilisateur abonné à {label} :"
-msgstr[1] "Il y a actuellement {num} utilisateurs abonnés à {label} :"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "Il y a actuellement {num} utilisateur abonné à {series} :"
-msgstr[1] "Il y a actuellement {num} utilisateurs abonnés à {series} :"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6788,7 +6526,7 @@ msgid ""
 msgstr "Cet artiste n’a pas de groupe de parution d’artistes divers. {show_non_va}|Afficher plutôt les groupes de parution de cet artiste}."
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Cet artiste n’en est plus un."
 
@@ -6838,7 +6576,7 @@ msgstr "Cet artiste n’a que des groupes de parution non officiels."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Ce type d’attribut est seulement utilisé pour le regroupement, veuillez choisir un sous-type"
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Ce serveur de test bêta permet de tester de nouvelles fonctions avec la base de données de production."
@@ -6945,11 +6683,11 @@ msgid ""
 "attributed to it."
 msgstr "Cet instrument ne peut pas être supprimé, car il y a des relations qui lui sont attribuées."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Ceci est un serveur de développement de MusicBrainz."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7069,7 +6807,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Cet enregistrement n’a aucun AcoustID associé."
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "Cet enregistrement est une vidéo"
@@ -7103,7 +6841,7 @@ msgstr "Ce type de relation ne permet pas d’attribut."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "Ce type de relation est obsolète et ne devrait pas être utilisé."
 
@@ -7137,16 +6875,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "Ce statut de parution devrait être utilisé pour les traductions et translittérations non officielles de listes de piste et de titres de parution, et n’indique pas une vraie parution séparée. Il ne devrait pas être utilisé pour indiquer les enregistrements pirates, albums « mixtape/street », démos ou albums numériques. Assurez-vous de faire le lien vers la vraie parution correspondante avec la {url|relation de translittération}."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Ce rapport tend à identifier les artistes avec des noms très similaires. Si deux artistes sont en fait le même, fusionnez-les (souvenez-vous d’{how_to_write_edit_notes|écrire une note de modification} et donnez votre preuve). S’ils sont différents, y ajouter des {disambiguation_comment|commentaires de désambiguïsation} (et quand un groupe d’artistes ayant le même nom auront des commentaires de désambiguïsation, ils n’apparaîtront plus ici)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7188,85 +6916,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr "Ce rapport liste toutes les parutions qui présentent des trous dans les nombres des supports (p. ex. il y a un support 1 et 3 mais pas de support 2)."
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "Ce rapport liste les artistes qui apparaissent plus d’une fois en différentes positions pour un même crédit d’artiste."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "Ce rapport liste les artistes pour lesquels aucun éditeur ne s’est abonné, et pour lesquels les changements manqueront de révision. Les artistes avec plus de groupes de parution et plus de modifications ouvertes sont listés en premier."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr "Ce rapport liste des artistes qui ont des commentaires de désambiguïsation identiques à leur nom. Le champ de commentaire de désambiguïsation ne devrait pas être rempli dans ce cas."
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "Ce rapport liste les artistes qui ont un type autre que <em>group</em> mais qui pourraient être <em>groups</em> car ils ont d’autres artistes de listés en tant que membres. Si vous trouvez qu’un artiste ici est vraiment un groupe, changez son type. Si non, veuillez vous assurer que les relations « membre de » sont dans le bon sens et correctes."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "Ce rapport liste les artistes qui ont un type autre que <em>person</em> mais qui pourraient être <em>persons</em> d’après leurs relations. Par exemple, un artiste apparaît ici s’il est listé en tant que membre d’un autre. Si vous trouvez qu’un artiste ici est vraiment une personne, changez son type. Si non, veuillez vous assurer que toutes les relations correctes et que cela a du sens."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Ce rapport liste des artistes qui on peut-être des commentaires de désambiguïsation dans leur nom plutôt que dans le champ de commentaire de désambiguïsation."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Ce rapport liste les artistes qui ont « & » dans leur nom mais pas de relation de membre ou de collaboration. Si l’artiste est habituellement vu en tant que groupe, une relation de membre devrait être ajoutée. Si c’est une collaboration de courte durée, il devrait être si possible scindé (voir {how_to_split_artists|Comment scinder les artistes}). Si c’est une collaboration avec son propre nom et ne peut être scindée, une relation de collaboration devrait y être ajoutée."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Ce rapport liste les artistes qui ont des relations de collaboration mais pas d’URL de relation. Si la collaboration à son propre nom, ne rien faire. Si c’est un format comme « X avec Y » ou « X & Y », vous devriez probablement le scinder. Voir {how_to_split_artists|Comment scinder des artistes}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "Ce rapport liste les artistes qui ont plusieurs relations vers le même artiste, label ou URL tout en ayant le même type de relation. Pour plusieurs relations vers des groupes de parution, enregistrements ou œuvres, voir les rapports pour ces entités."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "Ce rapport liste des artistes qui ont des relations utilisant des types de relations obsolètes et de regroupement-seulement."
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "Ce rapport liste les artistes avec des annotations."
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7428,10 +7077,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "Ce rapport liste les {iswc|ISWC} qui sont rattachés à plus d’une œuvre. Si les œuvres sont les mêmes, elles devraient habituellement être fusionnées."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr "Ce rapport liste les {url|éditeurs débutants / restreints}."
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7443,10 +7088,6 @@ msgid ""
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Ce rapport montre les URLs d’Amazon qui sont reliées à plusieurs parutions. Dans la plupart des cas les ASIN d’Amazon devrait mapper 1:1 vers des parutions MusicBrainz afin que seul un des liens soit correct. Vérifier quelle parution MusicBrainz convient avec la parution d’Amazon (regarder le format, liste de pistes, etc.) Si la parution a une code-barres vous pouvez le rechercher dans Amazon et voir quel ASIN concorde. Certains ASIN peuvent être reliés à plusieurs disques d’une parution multi-disques : fusionnez-lez (voir {how_to_merge_releases|Comment fusionner des parutions})."
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Ce rapport montre les URLs Discogs qui sont reliées à plusieurs artistes."
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
 msgstr "Ce rapport montre les URLs Discogs qui sont reliées à plusieurs labels."
@@ -7454,7 +7095,7 @@ msgstr "Ce rapport montre les URLs Discogs qui sont reliées à plusieurs labels
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:6
 msgid ""
 "This report shows Discogs URLs which are linked to multiple release groups."
-msgstr "Ce rapport montre les URLs Discogs qui sont reliées à plusieurs groupes de parution."
+msgstr "Ce rapport montre les URL Discogs qui sont reliées à plusieurs groupes de parution."
 
 #: ../root/report/discogs_links_with_multiple_releases.tt:6
 msgid ""
@@ -7725,7 +7366,7 @@ msgstr "Cette série est actuellement vide."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Cette table affiche un résumé des votes effectués par cet éditeur."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "Cette piste est une piste de données"
 
@@ -7851,29 +7492,6 @@ msgstr "Total des ISWC trouvés : {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Total des URLs trouvées : {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Nombre total d’artistes trouvés : {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Total des groupes en double : {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr "Total d’éditeurs trouvés : {count}"
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -8033,7 +7651,7 @@ msgstr "Piste :"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Liste de pistes"
 
@@ -8051,10 +7669,6 @@ msgstr "Liste de pistes : "
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Pistes"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Pistes dont le nom inclut leur numéro de séquence"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8083,16 +7697,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Les éditeurs de transclusions sont des utilisateurs qui ajoutent et maintiennent les enregistrements dans la table de transclusions {uri|WikiDocs}."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Pseudo-parutions traduites-translittérées sans lien vers une version originale."
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Turc"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8108,15 +7717,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8130,7 +7742,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Type"
 
@@ -8158,7 +7770,7 @@ msgstr "Type"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Type :"
 
@@ -8174,14 +7786,15 @@ msgstr "Type : {type}, statut : {status}"
 msgid "Types:"
 msgstr "Types : "
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8201,17 +7814,17 @@ msgid "URL:"
 msgstr "URL : "
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
-msgstr "URL; [URL]; [URL|label]; [<type_d_entité>:<mbid>|<nom>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
+msgstr "URL ; [URL] ; [URL|label] ; [type-d-entité:MBID|label]"
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URLs"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "URLs avec des relations obsolètes"
 
@@ -8233,8 +7846,12 @@ msgstr "Requête non autorisée"
 msgid "Unclassified instrument"
 msgstr "Instrument non classé"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -8261,9 +7878,9 @@ msgstr "Se désabonner "
 msgid "Untrusted"
 msgstr "Non-fiable"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Jusqu’à {n}"
 
@@ -8296,7 +7913,7 @@ msgstr "Téléversement de l’image en cours..."
 msgid "Uppercase roman numerals"
 msgstr "Mettre les chiffres romains en majuscule"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Utiliser le site bêta"
 
@@ -8352,7 +7969,7 @@ msgid "Username:"
 msgstr "Nom d’utilisateur :"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Utilisateurs"
 
@@ -8484,10 +8101,6 @@ msgstr "Avertissement : cette relation a des modifications en attente. {show|Cli
 msgid "Watched Artists"
 msgstr "Artistes surveillés"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Nous sommes désolé, mais les données de ce rapport ne sont pas disponibles pour l’instant."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "Nous ne pouvons afficher d’historique pour cette Illustration."
@@ -8533,10 +8146,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Nous sommes réellement désolés de ce problème. Veuillez attendre quelques minutes et renouveler votre demande &#x2014; le problème disparaîtra peut-être."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Site Web"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Site Web : "
@@ -8549,7 +8158,7 @@ msgid ""
 "and following the merge link."
 msgstr "Lorsque vous êtes prêt à fusionner ces données, cliquez le bouton » Fusionner ». Vous pourrez toujours ajouter d’autres données à cette fusion en cherchant les autres entités et en cliquant sur le lien « fusionner »."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8571,10 +8180,10 @@ msgstr "WikiDoc :"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Œuvre"
 
@@ -8613,35 +8222,32 @@ msgstr "Œuvre :"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Œuvres"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Œuvres avec des annotations"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Œuvres avec des relations obsolètes"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Œuvres avec relations probablement en double"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Écrivains"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML :"
 
@@ -8754,9 +8360,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Vous êtes sur le point de fusionner les œuvres suivantes en une seule œuvre. Veuillez choisir l’œuvre avec laquelle vous souhaitez fusionner les autres :"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Vous êtes actuellement abonné. {unsub|Vous désabonner} ?"
 
@@ -8772,9 +8377,8 @@ msgstr "Vous ne pouvez actuellement ajouter de note à cette modification. {{url
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Vous ne pouvez pas votez sur cette modification actuellement. ({url|Détails})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Vous n’êtes actuellement pas abonné. {sub|Vous abonner} ?"
 
@@ -8854,7 +8458,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr "Vous n’avez pas saisi de crédit d’artiste complet."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Vous n’avez apporté aucun changement !"
 
@@ -8879,7 +8483,7 @@ msgstr "Vous pouvez effacer vos informations personnelles de nos services à n�
 msgid "You must be logged in to vote on edits"
 msgstr "Vous devez être connecté pour voter sur les modifications"
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Vous devez saisir un commentaire de désambiguïsation pour cette entité."
 
@@ -8961,7 +8565,7 @@ msgstr "Votre recherche a pris trop de temps et a été annulée. Être plus sp�
 msgid "Your username will be publicly visible."
 msgstr "Votre nom d’utilisateur sera visible publiquement."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -9003,10 +8607,6 @@ msgstr "[inconnu]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "après"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "alias :"
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9069,10 +8669,6 @@ msgstr "annulé"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "crédité en tant que"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr "supprimer"
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9291,9 +8887,7 @@ msgstr "original"
 msgid "places"
 msgstr "lieux"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "plus {n} autre utilisateur anonyme"
@@ -9516,7 +9110,7 @@ msgstr[1] "{entity} a été ajouté à {num} collections :"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} n’a été ajouté à aucune collection."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9530,7 +9124,7 @@ msgstr "{link} n’a pas d’évaluation."
 msgid "{link} has no relationships."
 msgstr "{link} n’a pas de relation."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"IDentifiant MusicBrainz\">MBID</abbr>} :"
 
@@ -9643,7 +9237,7 @@ msgstr "{type} « {instrument} »"
 msgid "{type} “{work}”"
 msgstr "{type} “{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Retour vers musicbrainz.org}."
 
@@ -9850,34 +9444,34 @@ msgstr "'{id}' n’est pas un ID d’élection valide"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Le paramètre obligatoire TOC (table des matières) était invalide ou absent"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Veuillez fournir un ID de support"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Le support n’a pu être trouvé"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "La TOC (table des matières) de CD fournie est invalide"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "L’identifiant de support n’est pas valide"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Cette TOC (table des matières) de CD est déjà liée à ce support"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Le support sélectionné ne peut pas avoir d’ID de disque"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "L’ID d’artiste fourni n’est pas valide"
 
@@ -10259,7 +9853,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Convertir la parution en plusieurs artistes (historique)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Indiquer les durées de piste"
 
@@ -10559,6 +10153,12 @@ msgstr "Vote échoué"
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
 msgid "Failed dependency"
 msgstr "Dépendance échouée"
+
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Erreur"
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
@@ -10888,7 +10488,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Ces coordonnées n’ont pas pu être analysées"
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "La date de fin ne peut pas être inférieure à la date de début."
 
@@ -10992,13 +10592,13 @@ msgstr "Vous devez fournir une note de modification"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "Ébauche de CD"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Tag"
@@ -11006,7 +10606,7 @@ msgstr "Tag"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -11266,7 +10866,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Vérification de don"
 
@@ -11317,6 +10917,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr "Saisissez votre nom d'utilisateur et votre adresse courriel ci-dessous. Nous vous enverrons un courriel incluant un lien pour réinitialiser votre mot de passe. Si vous avez oublié votre mot de passe, {lien|retrouvez-le} en premier et après réinitialisez votre mot de passe. "
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "Courriel"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11348,7 +10954,7 @@ msgid ""
 msgstr "Nous vous avons envoyé des informations au sujet de votre compte MusicBrainz. Si vous ne recevez pas ce courriel ou que vous avez des problèmes pour vous connecter, {link|contactez nous}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -11484,7 +11090,7 @@ msgstr "Un courriel de validation a été envoyé à l’adresse {addr}. Veuille
 msgid "Unconfirmed Email Address"
 msgstr "Adresse mail non confirmée"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} dans {parent_areas}"
 
@@ -11524,32 +11130,32 @@ msgid ""
 msgstr "Désolé, nous n’avons pas trouvé d’artiste avec cet ID MusicBrainz. Vous souhaiteriez peut-être plutôt essayer de {search_url|le chercher}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Lieu de naissance :"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Fondé à :"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Début (région) :"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Lieu de décès :"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Séparé à :"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Fin (région) :"
 
@@ -11569,23 +11175,23 @@ msgstr "Collection introuvable"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Désolé, nous n’avons pas trouvé de collection avec cet ID MusicBrainz."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Début (date)"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Fin (date)"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr "principal"
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} n’a pas d’alias."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr "Ajouter un nouveau alias"
 
@@ -11627,19 +11233,19 @@ msgstr[1] "Expire dans <span class=\"tooltip\" title=\"{exactdate}\">{num} minut
 msgid "Already expired"
 msgstr "Déjà expiré"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profil"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Abonnements"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Modifier l’utilisateur"
 
@@ -11701,7 +11307,7 @@ msgid "For more information:"
 msgstr "Pour plus d’information :"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Ajouter une note"
 
@@ -11880,6 +11486,22 @@ msgstr "Vote"
 msgid "Votes cast"
 msgstr "Émettre des votes"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] "Il y a actuellement {num} utilisateur abonné à {entity} :"
+msgstr[1] "Il y a actuellement {num} utilisateurs abonnés à {entity} :"
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] "Plus {n} autre utilisateur anonyme"
+msgstr[1] "Plus {n} autres utilisateurs anonymes"
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr "Il n’y a actuellement aucun utilisateur abonné à {entity}."
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Événement introuvable"
@@ -11906,7 +11528,7 @@ msgid ""
 "ticket}."
 msgstr "Un genre manque dans cette liste ? Demandez le en créant un {link|ticket de style}."
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "instrument"
 
@@ -12148,6 +11770,11 @@ msgstr "Ajouter un évènement"
 msgid "Vote on Edits"
 msgstr "Voter sur les modifications"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Rapports"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Guide du débutant"
@@ -12188,23 +11815,23 @@ msgstr "Voir toutes les relations"
 msgid "Running: {git_details}"
 msgstr "Exécutant: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Page {n}"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr "MusicBrainz : Artiste"
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz : Label"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr "MusicBrainz : Parution"
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz : Piste"
 
@@ -12439,9 +12066,13 @@ msgstr "Informations sur l’instrument"
 msgid "Label information"
 msgstr "Informations du Label"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Modifié en dernier le {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr "Date de dernière mise à jour inconnue"
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12517,18 +12148,18 @@ msgid "see all ratings"
 msgstr "voir toutes les évaluations"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(aucun)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(aucune)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr "Voir tous les tags"
 
@@ -12697,11 +12328,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Désolé, nous n’avons pas trouvé d’enregistrement avec cet ID MusicBrainz. Vous souhaiteriez peut-être plutôt essayer de {search_url|le chercher}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "Vidéo par {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Enregistrement par {artist}"
 
@@ -12730,9 +12361,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Désolé, nous n’avons pas trouvé de groupe de parution avec cet ID MusicBrainz. Vous souhaiteriez peut-être plutôt essayer de {search_url|le chercher}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Groupe de parution par {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Annotations sur les artistes"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "Ce rapport liste les artistes avec des annotations."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Nombre total d’artistes trouvés : {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artistes contenant des commentaires de désambiguïsation dans leur nom"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Ce rapport liste des artistes qui on peut-être des commentaires de désambiguïsation dans leur nom plutôt que dans le champ de commentaire de désambiguïsation."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artistes contenant des commentaires de désambiguïsation identiques à leur nom"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr "Ce rapport liste des artistes qui ont des commentaires de désambiguïsation identiques à leur nom. Le champ de commentaire de désambiguïsation ne devrait pas être rempli dans ce cas."
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artistes pouvant être des groupes"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr "Ce rapport liste les artistes ayant un type autre que Groupe (ou un type dérivé) mais qui pourraient être un groupe car d’autres artistes sont listés comme leurs membres. Si vous trouvez ici un artiste qui est bien un groupe, changez son type. Sinon, veuillez vérifier que toutes ses relations « membre de » sont correctes et dans le bon sens."
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artistes pouvant être des personnes"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr "Ce rapport liste les artistes ayant un type autre que Personne mais qui pourraient être une personne au vu de leurs relations. Par exemple, un artiste apparaitra ici s’il est listé comme membre d’un autre. Si vous trouvez ici un artiste qui est bien une personne, changez son type. Sinon, veuillez vérifier que toutes ses relations sont correctes et sensées."
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr "Artistes apparaissant plusieurs fois dans le même crédit d’artiste"
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "Ce rapport liste les artistes qui apparaissent plus d’une fois en différentes positions pour un même crédit d’artiste."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artistes sans abonné"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "Ce rapport liste les artistes pour lesquels aucun éditeur ne s’est abonné, et pour lesquels les changements manqueront de révision. Les artistes avec plus de groupes de parution et plus de modifications ouvertes sont listés en premier."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr "Artistes ayant des relations de collaboration"
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Ce rapport liste les artistes qui ont des relations de collaboration mais pas d’URL de relation. Si la collaboration à son propre nom, ne rien faire. Si c’est un format comme « X avec Y » ou « X & Y », vous devriez probablement le scinder. Voir {how_to_split_artists|Comment scinder des artistes}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Collaboration"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Collaborateur"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artistes avec des relations obsolètes"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "Ce rapport liste des artistes qui ont des relations utilisant des types de relations obsolètes et de regroupement-seulement."
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "URLs Discogs reliées vers plusieurs artistes"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Ce rapport montre les URLs Discogs qui sont reliées à plusieurs artistes."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Artiste  probablement en double"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Ce rapport tend à identifier les artistes avec des noms très similaires. Si deux artistes sont en fait le même, fusionnez-les (souvenez-vous d’{how_to_write_edit_notes|écrire une note de modification} et donnez votre preuve). S’ils sont différents, y ajouter des {disambiguation_comment|commentaires de désambiguïsation} (et quand un groupe d’artistes ayant le même nom auront des commentaires de désambiguïsation, ils n’apparaîtront plus ici)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Total des groupes en double : {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias :"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Ajouter les artistes choisis pour la fusion"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artistes avec relations probablement en double"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "Ce rapport liste les artistes qui ont plusieurs relations vers le même artiste, label ou URL tout en ayant le même type de relation. Pour plusieurs relations vers des groupes de parution, enregistrements ou œuvres, voir les rapports pour ces entités."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Afficher tous les résultats."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Afficher seulement les résultats pour des entités auxquelles je suis abonné."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Éditeurs débutants / restreints"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr "Ce rapport liste les {url|éditeurs débutants / restreints}."
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr "Total d’éditeurs trouvés : {count}"
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artistes qui sont peut-être des collaborations"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Ce rapport liste les artistes qui ont « & » dans leur nom mais pas de relation de membre ou de collaboration. Si l’artiste est habituellement vu en tant que groupe, une relation de membre devrait être ajoutée. Si c’est une collaboration de courte durée, il devrait être si possible scindé (voir {how_to_split_artists|Comment scinder les artistes}). Si c’est une collaboration avec son propre nom et ne peut être scindée, une relation de collaboration devrait y être ajoutée."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Nous sommes désolé, mais les données de ce rapport ne sont pas disponibles pour l’instant."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Si vous souhaitez participer au processus d’édition mais que vous ne savez pas par où commencer, les rapports ci-dessous pourraient vous être utiles. Ces rapports fouillent la base de données à la recherche de données qui devraient peut-être être corrigées soit pour correspondre aux {style|directives de style}, ou pour toute autre tâche de « nettoyage administratif »."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artistes ayant des relations de collaboration"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artistes qui ressemblent à des collaborations"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Artistes avec des annotations"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Éditeurs"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Événements probablement en double"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "URLs Discogs reliées à plusieurs labels"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Labels avec des annotations"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Groupes de parution"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Groupes de parution qu’il faudrait peut-être fusionner"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "URL Discogs reliée à plusieurs groupes de parution"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Groupes de parution avec des annotations"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Parutions ayant des URLs d’Amazon inattendues"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Parutions ayant plusieurs ASIN"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Parutions avec plusieurs liens Discogs"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "URLs d’Amazon reliées à plusieurs parutions"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "URL Discogs reliée à plusieurs parutions"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Parutions ayant des relations de partie d’un ensemble"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Disques entrés sous forme de parutions séparées"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Parutions avec des numéros de piste non séquentiels"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Parution dont certains (mais pas tous) supports n’ont pas de format de précisé"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Parutions avec des numéros de catalogue qui ressemble à des ASIN"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Pseudo-parutions traduites-translittérées sans lien vers une version originale."
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Parutions de toutes sortes qui ont encore des relations d’Illustration."
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Parution avec des supports non séquentiels"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Parutions avec des annotations"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr "Parutions en manque d’ID de disque"
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Enregistrements avec des relations de parution la plus ancienne"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Pistes dont le nom inclut leur numéro de séquence"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Enregistrements avec des durées de piste variables"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Enregistrements avec des annotations"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Lieux avec annotations"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Séries avec annotations"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Œuvres avec des annotations"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Membre depuis"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Site Web"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Bio"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "supprimer"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12889,60 +12909,76 @@ msgstr "Pas de type"
 msgid "{place_type}: {place_link}"
 msgstr "{place_type} : {place_link}"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Une erreur est survenue durant la recherche. Cliquez ici pour ressayer."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Essayez plutôt une recherche directe."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Essayez plutôt une recherche indexée."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Essayer de rechercher ou de coller un MBID"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Effacer les éléments récents"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "En afficher plus..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Introuvable ? Essayez à nouveau avec la recherche directe."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Lent ? Revenez à la recherche indexée."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr "apparaît dans"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr "enregistrement isolé"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr "{release_group_type} par {artist}"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr "Interprètes"
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Voter pour toutes les modifications :"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Supprimer la note"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Afficher les crédits en bas"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Afficher les crédits en ligne"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Impossible de charger le support."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Image {current} sur {total}"
 
@@ -12964,7 +13000,7 @@ msgstr "Annotation modifiée en dernier le {date}."
 msgid "Show less..."
 msgstr "En afficher moins..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Images de Wikimedia Commons"
 
@@ -12981,67 +13017,84 @@ msgstr "Cet éditeur n’est pas connu de ce serveur, et ne peut pas être affic
 msgid "[missing editor]"
 msgstr "[éditeur manquant]"
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr "Annuler le vote"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Voter pour"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Vous avez voté pour ce tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Voter contre"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Vous avez voté contre ce tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "Les tags ayant un score de zéro ou moins, ainsi que les tags contre lesquels vous avez voté, sont cachés."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "Les tags avec un score de zéro ou moins sont masqués."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Montrer tous les tags."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Tous les tags sont affichés."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr "Masquer les tags avec un score de zéro ou moins."
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Ajouter des tags"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Vous pouvez ajouter vos propres {tagdocs|tags} ci-dessous. Utilisez des virgules pour séparer les tags."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Envoyer les tags"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "voir tous les tags"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Tag"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipédia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Lire la suite sur Wikipédia..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13159,21 +13212,21 @@ msgstr "{begin_date} – ????"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "A commencé par :"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Cette personne est décédée."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Ce groupe s’est dissout."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Champ requis."
 
@@ -13233,9 +13286,9 @@ msgid ""
 "entity from the others."
 msgstr "Veuillez saisir une {doc_disambiguation|désambiguïsation} pour aider à distinguer cette entité des autres."
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Tous vos changements seront perdus si vous quittez cette page."
 
@@ -13248,7 +13301,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Veuillez choisir un type de lien pour l’URL que vous avez saisie."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13265,7 +13318,7 @@ msgid "This relationship already exists."
 msgstr "Cette relation existe déjà."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|plus de documentation})"
 
@@ -13285,7 +13338,7 @@ msgstr "vidéo"
 msgid "Remove Link"
 msgstr "Enlever un lien"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Options de détermination de la casse"
 
@@ -13318,45 +13371,45 @@ msgid ""
 "language guidelines}. "
 msgstr "Ce mode supporte la capitalisation turque du 'i' ('İ') et du 'ı' ('I'). Certains mots peuvent devoir être changés manuellement suivant les {url|directives propres à la langue}. "
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "La série que vous avez choisie est pour les enregistrements."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "La série que vous avez choisie est pour les parutions."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "La série que vous avez choisie est pour les groupes de parution."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "La série que vous avez choisie est pour les œuvres."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Veuillez choisir un type de relation."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Veuillez choisir un sous-type pour le type de relation sélectionné actuellement. Le type de relation sélectionné est uniquement utilisé pour regrouper des sous-types."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Les entités d’une relation ne peuvent pas être les mêmes."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr "Changer les crédits pour les autres relations de {entity} dans cette page."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr "Seulement les relations avec une entité de type {entity_type}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr "Seulement les relations de type « {relationship_type} » avec une entité de type {entity_type}."
 
@@ -13364,19 +13417,19 @@ msgstr "Seulement les relations de type « {relationship_type} » avec une entit
 msgid "This attribute is required."
 msgstr "Cet attribut est requis."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} enregistrement de sélectionné"
 msgstr[1] "{n} enregistrements de sélectionnés"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} œuvre sélectionnée"
 msgstr[1] "{n} œuvres sélectionnées"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13393,64 +13446,64 @@ msgstr "Ce support a un ou plusieurs ID de disque ce qui empêche de changer les
 msgid "Page {page} of {total}"
 msgstr "Page {page} sur {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Support {position} : {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Support {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Vous n’avez pas choisi d’étiquette pour « {name} »."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Erreur lors chargement de la parution : {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Ajouter une parution"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Modifier la parution"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "Le chiffre de vérification est {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Veuillez vérifier soigneusement le code-barres de la parution."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Le code-barres que vous avez saisi ressemble à un code UPC, mais sans son chiffre de contrôle."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Le code-barres que vous avez saisi est un code UPC valide."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Le code-barres que vous avez saisi n’est pas un code UPC valide, ou est un code EAN sans le chiffre de contrôle."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Le code-barres que vous avez saisi est un code EAN valide."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Le code-barres que vous avez saisi n’est pas un code EAN valide."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Le code-barres que vous avez saisi n’est pas un code EAN ou UPC valide."
 
@@ -13458,7 +13511,7 @@ msgstr "Le code-barres que vous avez saisi n’est pas un code EAN ou UPC valide
 msgid "Add Language"
 msgstr "Ajouter une langue"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Supprimer la langue"
 

--- a/po/mb_server.it.po
+++ b/po/mb_server.it.po
@@ -13,7 +13,7 @@
 # leofiore <email address hidden>, 2012
 # leofiore <email address hidden>, 2012
 # Luca Salini <email address hidden>, 2012
-# Luca Salini <email address hidden>, 2012-2013,2016-2018
+# Luca Salini <email address hidden>, 2012-2013,2016-2019
 # nikki, 2012-2013
 # nikki, 2012-2013
 # nikki, 2013
@@ -26,9 +26,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-02-21 20:29+0000\n"
+"Last-Translator: Luca Salini <email address hidden>\n"
 "Language-Team: Italian (http://www.transifex.com/musicbrainz/musicbrainz/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -187,6 +187,7 @@ msgstr "(nessuno)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
@@ -393,7 +394,7 @@ msgstr "Amministratori account"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Gli amministratori degli account possono modificare ed eliminare gli account utente."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "Voce su AcousticBrainz:"
 
@@ -403,7 +404,7 @@ msgstr "Voce su AcousticBrainz:"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Azioni"
 
@@ -588,10 +589,6 @@ msgstr "Aggiungi opera collegata"
 msgid "Add relationship"
 msgstr "Aggiungi relazione"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Aggiungi gli artisti selezionati per unirli"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Aggiungi gli eventi selezionati per unirli"
@@ -664,7 +661,7 @@ msgstr "Età:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -684,9 +681,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Alias"
 
@@ -734,26 +732,21 @@ msgstr "Si esibisce anche come"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "URL di Amazon collegati a più pubblicazioni"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "URL di Amazon collegati a più pubblicazioni"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Un alias è un nome alternativo di un'entità. Solitamente contiene errori di ortografia comuni o varianti del nome ed è utilizzato anche per migliorare i risultati di ricerca. Visualizza la {doc|documentazione sugli alias} per maggiori dettagli."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Un utente anonimo"
 msgstr[1] "{n} utenti anonimi"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -775,8 +768,7 @@ msgstr "Si è verificato un errore: "
 msgid "An error occurred while creating the works."
 msgstr "Si è verificato un errore durante la creazione delle opere."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -785,8 +777,9 @@ msgstr "Si è verificato un errore durante la creazione delle opere."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Annotazione"
@@ -920,11 +913,11 @@ msgstr "Sei sicuro di voler rimuovere la serie {series} da MusicBrainz?"
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -975,24 +968,27 @@ msgstr "Aree"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1038,11 +1034,6 @@ msgstr "MBID artista"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Sottoscrizioni di artisti"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Annotazioni di artisti"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1090,7 +1081,7 @@ msgstr "Artista {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artista:"
 
@@ -1098,81 +1089,15 @@ msgstr "Artista:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artisti"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artisti che hanno commenti di disambiguazione nel loro nome"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artisti inseriti più volte nello stesso accreditamento"
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artisti che potrebbero essere collaborazioni"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artisti che potrebbero essere gruppi"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artisti che potrebbero essere persone"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artisti che hanno relazioni di collaborazione"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artisti che sembrano collaborazioni"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artisti con relazioni di collaborazione"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Artisti con annotazioni"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artisti con relazioni obsolete"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artisti con commento di disambiguazione uguale al nome"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artisti senza sottoscrittori"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artisti che potrebbero avere relazioni doppie"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1337,9 +1262,8 @@ msgstr "Aggiungi un batch di relazioni alle opere"
 msgid "Batch-create new works"
 msgstr "Crea un batch di nuove opere"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Vuoi essere il primo? {sub|Sottoscriviti!}"
 
@@ -1397,21 +1321,12 @@ msgstr "Data iniziale:"
 msgid "Beginner"
 msgstr "Principiante"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Editor principianti/con account limitati"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
 msgstr "Qui sotto trovi le informazioni sull'errore. Se desideri segnalare un bug, lo puoi fare nel nostro {bugs|bug tracker}. Queste informazioni possono essere utili, perciò assicurati di includerle!"
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Biografia"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1422,12 +1337,12 @@ msgstr "Biografia:"
 msgid "Birth date:"
 msgstr "Data di nascita:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Blog"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Nato:"
 
@@ -1439,13 +1354,13 @@ msgstr "Bot"
 msgid "Bots"
 msgstr "Bot"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "Offerto dalla {MeB|Fondazione MetaBrainz} e dai nostri {spon|sponsor} e {supp|supporter}. Copertine fornite dal {caa|Cover Art Archive}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Bug Tracker"
@@ -1590,7 +1505,7 @@ msgstr "Nº di catalogo"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Cambia password"
 
@@ -1669,14 +1584,6 @@ msgstr "Chiuse"
 msgid "Code"
 msgstr "Codice"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Collaborazione"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Collaboratore"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Comprimi disco"
@@ -1705,7 +1612,7 @@ msgstr "Collezione “{collection}”"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Collezioni"
@@ -1783,7 +1690,7 @@ msgid "Country:"
 msgstr "Paese:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Copertine"
 
@@ -1915,7 +1822,7 @@ msgstr "Le date sono nel formato AAAA-MM-GG. Date parziali come AAAA-MM o anche 
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Elimina account"
 
@@ -1967,13 +1874,14 @@ msgstr "Descrizione:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Dettagli"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Morto:"
 
@@ -1983,7 +1891,7 @@ msgstr "Confronto"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Ricerca diretta nel database"
 
@@ -2040,7 +1948,7 @@ msgid "Disc ID:"
 msgstr "ID disco:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "ID disco"
 
@@ -2060,11 +1968,6 @@ msgstr "Titolo del disco:"
 msgid "Discography"
 msgstr "Discografia"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "URL di Discogs collegati a più artisti"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2080,32 +1983,12 @@ msgstr "URL di Discogs collegati a più gruppi di pubblicazioni"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "URL di Discogs collegati a più pubblicazioni"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "URL di Discogs collegati a più artisti"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "URL di Discogs collegati a più etichette"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "URL di Discogs collegati a più gruppi di pubblicazioni"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "URL di Discogs collegati a più pubblicazioni"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Dischi come pubblicazioni separate"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Dischi inseriti come pubblicazioni separate"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Sciolto:"
 
@@ -2123,7 +2006,7 @@ msgstr "Documentazione:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Non hai un account? {uri|Creane uno ora}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Fai una donazione"
 
@@ -2154,9 +2037,9 @@ msgstr "Ogni traccia nel database di MusicBrainz deve essere collegata a una reg
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Modifica"
 
@@ -2209,7 +2092,7 @@ msgid "Edit Note Author"
 msgstr "Autore della nota di modifica"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Modifica profilo"
 
@@ -2284,10 +2167,10 @@ msgid "Editing/voting disabled"
 msgstr "Modifiche/voti disabilitati"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Editor"
 
@@ -2303,10 +2186,6 @@ msgstr "Sottoscrizioni di editor"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Editor “{user}”"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Editor"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2335,12 +2214,6 @@ msgstr "Modifiche a {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Modifiche caricate per la pagina:"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "Email"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2400,7 +2273,7 @@ msgstr "Data finale"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Fine:"
 
@@ -2443,11 +2316,6 @@ msgstr "Tipo di entità"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Tipi di entità:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Errore"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2497,8 +2365,8 @@ msgstr "Anche solo un link o due possono aiutare!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2525,13 +2393,14 @@ msgstr "Evento:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Eventi"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr "Eventi che dovrebbero essere parte di una serie o di un evento più grande"
 
@@ -2612,7 +2481,7 @@ msgid "Find Relationships"
 msgstr "Trova relazioni"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Impronte digitali"
 
@@ -2661,7 +2530,7 @@ msgstr "Per maggiori informazioni, controlla la {doc_doc|documentazione} e le {d
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Per maggiori informazioni, controlla la {doc_doc|documentazione}."
 
@@ -2693,7 +2562,7 @@ msgstr "Formato"
 msgid "Format:"
 msgstr "Formato:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Forum"
@@ -2749,7 +2618,7 @@ msgstr[1] "Trovati {n} risultati per \"{q}\""
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Fondato:"
 
@@ -2805,7 +2674,6 @@ msgstr "Sesso:"
 msgid "General Information"
 msgstr "Informazioni generali"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2813,17 +2681,9 @@ msgstr "Informazioni generali"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2831,13 +2691,10 @@ msgstr "Informazioni generali"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2852,13 +2709,11 @@ msgstr "Informazioni generali"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2889,13 +2744,27 @@ msgstr "Informazioni generali"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Generato il {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Generi"
 
@@ -3094,13 +2963,15 @@ msgstr "ISRC {isrc} a {recording}"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRC con più registrazioni"
 
@@ -3124,12 +2995,8 @@ msgstr "ISWC {iswc} a {work}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "ISWC con più opere"
 
@@ -3201,15 +3068,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Se ritieni che si tratti di un errore, contatta <code>support@musicbrainz.org</code> indicando il nome del tuo account."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Se vuoi partecipare al processo di modifica ma non sai dove cominciare, i seguenti report potrebbero tornarti utili. Sono stati creati perlustrando il database alla ricerca di dati che potrebbero aver bisogno di essere corretti, sia per conformarsi alle {style|linee guida di stile}, sia per altri casi che richiedono compiti amministrativi di \"ripulitura\"."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3247,11 +3105,11 @@ msgstr "Nome utente o password non corretta"
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Ricerca indicizzata"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Ricerca indicizzata con {doc|sintassi di ricerca avanzata}"
 
@@ -3262,7 +3120,7 @@ msgstr "Ricerca indicizzata con {doc|sintassi di ricerca avanzata}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3287,13 +3145,14 @@ msgstr "Dettagli sullo strumento"
 msgid "Instrument:"
 msgstr "Strumento:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Strumenti"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Strumenti senza un'immagine"
 
@@ -3359,9 +3218,9 @@ msgstr "Resta collegato"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3422,31 +3281,28 @@ msgstr "Etichetta:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Etichette"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Etichette con annotazioni"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Etichette con relazioni obsolete"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Etichette con commento di disambiguazione uguale al nome"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Etichette che potrebbero avere relazioni doppie"
 
@@ -3487,7 +3343,6 @@ msgstr "Ultime 24 ore"
 msgid "Last 28 days"
 msgstr "Ultimi 28 giorni"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3495,6 +3350,7 @@ msgstr "Ultimi 28 giorni"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Ultima modifica"
 
@@ -3502,7 +3358,7 @@ msgstr "Ultima modifica"
 msgid "Last login:"
 msgstr "Ultimo accesso:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Ultimo pacchetto di replica ricevuto il {datetime}"
 
@@ -3510,7 +3366,7 @@ msgstr "Ultimo pacchetto di replica ricevuto il {datetime}"
 msgid "Last updated"
 msgstr "Ultimo aggiornamento"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Ultimo aggiornamento:"
 
@@ -3580,14 +3436,14 @@ msgid "Loading edit previews..."
 msgstr "Caricamento anteprima modifiche in corso..."
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Caricamento in corso..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Ambiente linguistico"
 
@@ -3597,6 +3453,7 @@ msgstr "Ambiente linguistico:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Luogo"
 
@@ -3669,7 +3526,7 @@ msgstr "Bassa"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Lingue del testo"
 
@@ -3704,7 +3561,7 @@ msgid "Many relationships"
 msgstr "Molte relazioni"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Cartina"
 
@@ -3765,10 +3622,6 @@ msgstr "Supporto: "
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Supporti:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Membro da"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3880,7 +3733,7 @@ msgstr "Più popolari"
 msgid "Most Recent"
 msgstr "Più recenti"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Sposta"
 
@@ -4009,7 +3862,7 @@ msgstr "Nome"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Nome:"
 
@@ -4111,7 +3964,7 @@ msgstr "Nuova versione:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Seguente"
@@ -4187,7 +4040,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Nessuna pubblicazione ha una copertina contrassegnata come \"Frontale\", impossibile impostare una copertina."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -4201,7 +4054,7 @@ msgstr "Nessun risultato trovato."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Nessun risultato trovato. Prova a perfezionare la tua ricerca."
 
@@ -4226,13 +4079,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "Nessuno ha lasciato note sulle tue modifiche negli ultimi tre mesi."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Nessuna ha ancora taggato questo."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Pubblicazioni non digitali con relazioni di download"
 
@@ -4242,7 +4095,7 @@ msgid "None"
 msgstr "Nessuno"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr "Nessuno degli ID disco collegati può accettare una traccia pregap della durata fornita."
@@ -4451,9 +4304,9 @@ msgid "Other lookups"
 msgstr "Altre ricerche"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr "Altri tag"
 
@@ -4462,7 +4315,7 @@ msgid "Overall"
 msgstr "Totali"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Riepilogo"
@@ -4539,11 +4392,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Esegui le operazioni qui sopra quando non sto utilizzando l'applicazione"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Esibizioni"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Collegamento permanente"
 
@@ -4555,8 +4408,8 @@ msgstr "Frase:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4582,23 +4435,20 @@ msgstr "Luogo:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Luoghi"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Luoghi con annotazioni"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Luoghi con relazioni obsolete"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr "Luoghi senza coordinate"
 
@@ -4721,22 +4571,14 @@ msgid "Possible duplicate events"
 msgstr "Eventi che potrebbero essere doppioni"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Gruppi di pubblicazioni che potrebbero essere doppioni"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Valori possibili:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Artisti che potrebbero essere doppioni"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Eventi che potrebbero essere doppioni"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4754,7 +4596,7 @@ msgstr "Anteprima:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Precedente"
@@ -4806,7 +4648,7 @@ msgid "Public collection by {owner}"
 msgstr "Collezione pubblica di {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Ricerca:"
 
@@ -4831,7 +4673,7 @@ msgstr "Valutazione"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Valutazioni"
 
@@ -4861,7 +4703,7 @@ msgstr "Note recenti lasciate sulle tue modifiche"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4904,21 +4746,22 @@ msgstr "Registrazione:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Registrazioni"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr "Registrazioni accreditate ad \"Artisti Vari\" ma non collegate ad AV"
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr "Registrazioni non accreditate ad \"Artisti Vari\" ma collegate ad AV"
 
@@ -4932,40 +4775,28 @@ msgstr "Registrazioni con relazioni di prima pubblicazione"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Registrazioni con durata delle tracce variabile"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Registrazioni con annotazioni"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Registrazioni con relazioni obsolete"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Registrazioni con relazioni di prima pubblicazione"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Registrazioni che potrebbero avere relazioni doppie"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr "Registrazioni con lo stesso nome di artisti diversi con lo stesso nome"
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Registrazioni che contengono \"feat.\" nel titolo"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Registrazioni con durata delle tracce variabile"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5023,7 +4854,6 @@ msgid "Relationship Editor"
 msgstr "Editor di relazioni"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5031,6 +4861,7 @@ msgstr "Editor di relazioni"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Tipo di relazione"
 
@@ -5080,7 +4911,7 @@ msgstr "Relazione:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Relazioni"
 
@@ -5112,7 +4943,7 @@ msgstr "Relazioni:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5144,7 +4975,7 @@ msgstr "Eventi di pubblicazione:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Gruppo di pubblicazioni"
@@ -5180,7 +5011,7 @@ msgstr "Gruppi di pubblicazioni"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Gruppi di pubblicazioni con relazioni obsolete"
 
@@ -5239,6 +5070,7 @@ msgid "Release group ratings"
 msgstr "Valutazioni di gruppi di pubblicazioni"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Gruppo di pubblicazioni \"{name}\" di {artist}"
 
@@ -5250,38 +5082,27 @@ msgstr "Gruppo di pubblicazioni \"{name}\" di {artist}"
 msgid "Release group:"
 msgstr "Gruppo di pubblicazioni:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Gruppi di pubblicazioni"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr "Gruppi di pubblicazioni accreditati ad \"Artisti Vari\" ma non collegati ad AV"
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr "Gruppi di pubblicazioni non accreditati ad \"Artisti Vari\" ma collegati ad AV"
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Gruppi di pubblicazioni che forse dovrebbero essere uniti"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Gruppi di pubblicazioni con annotazioni"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Gruppi di pubblicazioni che potrebbero avere relazioni doppie"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Gruppi di pubblicazioni che contengono \"feat.\" nel titolo"
 
@@ -5324,8 +5145,8 @@ msgstr "Pubblicazione:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Pubblicazioni"
@@ -5359,67 +5180,43 @@ msgstr "Pubblicazioni con più collegamenti a Discogs"
 msgid "Releases With Some Formats Unset"
 msgstr "Pubblicazioni con alcuni formati non impostati"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr "Pubblicazioni accreditate ad \"Artisti Vari\" ma non collegate ad AV"
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Pubblicazioni nel Cover Art Archive che hanno ancora relazioni di copertina"
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr "Pubblicazioni nel Cover Art Archive in cui nessuna immagine di copertina ha un tipo"
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr "Pubblicazioni senza ID disco"
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr "Pubblicazioni non accreditate ad \"Artisti Vari\" ma collegate ad AV"
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Pubblicazioni di qualsiasi tipo che hanno ancora relazioni di copertina"
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Pubblicazioni pubblicate troppo presto"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr "Pubblicazioni in cui nome artista e nome etichetta sono uguali"
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Pubblicazioni in cui alcuni (ma non tutti) i supporti non hanno un formato impostato"
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Pubblicazioni che possiedono più ASIN"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Pubblicazioni che possiedono più collegamenti a Discogs"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Pubblicazioni che hanno relazioni di parte di un set"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Pubblicazioni che hanno URL di Amazon non previsti"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Pubblicazioni che potrebbero dover essere attribuite ad artisti multipli"
 
@@ -5428,23 +5225,15 @@ msgstr "Pubblicazioni che potrebbero dover essere attribuite ad artisti multipli
 msgid "Releases with Cover Art relationships"
 msgstr "Pubblicazioni con relazioni di copertina"
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Pubblicazioni con un solo supporto che ha un titolo"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Pubblicazioni con annotazioni"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Pubblicazioni con numeri di catalogo che sembrano ASIN"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Pubblicazioni con relazioni obsolete"
 
@@ -5453,31 +5242,25 @@ msgstr "Pubblicazioni con relazioni obsolete"
 msgid "Releases with medium number issues"
 msgstr "Pubblicazioni con problemi nella numerazione dei supporti"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Pubblicazioni senza supporti"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Pubblicazioni con supporti non sequenziali"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Pubblicazioni con numeri di traccia non sequenziali"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Pubblicazioni che potrebbero avere relazioni doppie"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Pubblicazioni con tracce dati superflue"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Pubblicazioni che contengono \"feat.\" nel titolo"
 
@@ -5486,24 +5269,26 @@ msgstr "Pubblicazioni che contengono \"feat.\" nel titolo"
 msgid "Releases with track number issues"
 msgstr "Pubblicazioni con problemi nella numerazione delle tracce"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Pubblicazioni con tracce di durata sconosciuta"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Pubblicazioni con combinazioni lingua/script improbabili"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Pubblicazioni senza lingua"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Pubblicazioni senza script"
 
@@ -5529,7 +5314,7 @@ msgstr "Pubblicazioni:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5541,7 +5326,7 @@ msgstr "Pubblicazioni:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Rimuovi"
@@ -5681,11 +5466,6 @@ msgstr "Segnala utente"
 msgid "Report this user for bad behavior"
 msgstr "Segnala questo utente per comportamento scorretto"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Report"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Richiesta scaduta"
@@ -5708,7 +5488,7 @@ msgstr "Reimposta password"
 msgid "Reset track numbers"
 msgstr "Reimposta numeri di traccia"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Risultati per pagina:"
 
@@ -5748,7 +5528,7 @@ msgstr "Consulta la {url|documentazione} sui valori di inizializzazione dell'edi
 msgid "Role"
 msgstr "Ruolo"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "In esecuzione: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5791,7 +5571,7 @@ msgstr "Script:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5838,7 +5618,7 @@ msgstr "Cerca modifiche"
 msgid "Search for the target URL."
 msgstr "Cerca l'URL di destinazione."
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Metodo di ricerca:"
 
@@ -5927,7 +5707,7 @@ msgstr "Invia una copia al mio indirizzo email"
 msgid "Sentence"
 msgstr "Frase"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Serie"
@@ -5942,8 +5722,8 @@ msgstr "Serie"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5966,10 +5746,6 @@ msgstr "Sottoscrizioni di serie"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "Annotazioni di serie"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "Serie con annotazioni"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -5998,7 +5774,7 @@ msgstr "Imposta una nuova password per il tuo account di MusicBrainz."
 msgid "Set cover art"
 msgstr "Imposta copertina"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Imposta durata tracce"
 
@@ -6011,10 +5787,6 @@ msgstr "Scaletta"
 msgid "Setlist:"
 msgstr "Scaletta:"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Visualizza tutti i risultati."
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "Mostrami un avviso ogni volta che ricevo una nuova nota di modifica."
@@ -6024,10 +5796,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Mostrami le {autoedit_select_block} ordinate {sort_select_block} che {match_or_negation_block} {and_vs_or_block} le seguenti condizioni:"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Visualizza solo i risultati delle entità che ho sottoscritto."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6163,7 +5931,7 @@ msgstr "Spiacenti, la pagina che stai cercando non è disponibile sui server mir
 msgid "Sorry, there was a problem with your request."
 msgstr "Spiacenti, si è verificato un problema con la tua richiesta."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Spiacenti, ma non sei autorizzato a visualizzare questa pagina."
 
@@ -6187,8 +5955,8 @@ msgstr "Spiacenti, “{id}” non è una pagina di documentazione valida."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Nome di ordinamento"
 
@@ -6242,7 +6010,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Status:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Smetti di utilizzare la versione beta del sito"
 
@@ -6296,12 +6064,10 @@ msgstr "Editor sottoscritti"
 msgid "Subscribed entities"
 msgstr "Entità sottoscritte"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6349,8 +6115,8 @@ msgid "Tagger"
 msgstr "Tagger"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6421,7 +6187,7 @@ msgid ""
 "and may not display correctly"
 msgstr "I dati presenti in questa modifica provengono originariamente da una versione più vecchia di questa modifica e potrebbero non essere visualizzati correttamente"
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6432,7 +6198,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "I dati che hai fornito contengono i seguenti errori:"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "La data che hai inserito non è valida."
 
@@ -6531,7 +6297,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "Il server di ricerca non ha potuto soddisfare la tua richiesta per colpa di un errore interno. Di solito si tratta di un problema temporaneo, perciò riprova la tua ricerca più tardi."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "Il server è temporaneamente in modalità di sola lettura per manutenzione del database."
 
@@ -6570,21 +6336,9 @@ msgstr "Al momento non ci sono utenti sottoscritti alle tue modifiche."
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Al momento non ci sono utenti sottoscritti alle modifiche di {user}."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Al momento non ci sono utenti sottoscritti a {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "Al momento non ci sono utenti sottoscritti a {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Al momento non ci sono utenti sottoscritti a {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "Al momento non ci sono utenti sottoscritti a {series}."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6593,12 +6347,12 @@ msgid ""
 msgstr "Non ci sono ID disco associati a questa pubblicazione; per maggiori informazioni su come aggiungerne uno, consulta {doc|Come aggiungere ID disco}."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr "Non ci sono generi da mostrare."
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr "Non ci sono altri tag da mostrare."
 
@@ -6624,29 +6378,11 @@ msgid_plural ""
 msgstr[0] "Al momento c'è {num} utente sottoscritto alle modifiche di {user}:"
 msgstr[1] "Al momento ci sono {num} utenti sottoscritti alle modifiche di {user}:"
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Al momento c'è {num} utente sottoscritto a {artist}:"
-msgstr[1] "Al momento ci sono {num} utenti sottoscritti a {artist}:"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "Al momento c'è {num} utente sottoscritto a {collection}:"
 msgstr[1] "Al momento ci sono {num} utenti sottoscritti a {collection}:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Al momento c'è {num} utente sottoscritto a {label}:"
-msgstr[1] "Al momento ci sono {num} utenti sottoscritti a {label}:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "Al momento c'è {num} utente sottoscritto a {series}:"
-msgstr[1] "Al momento ci sono {num} utenti sottoscritti a {series}:"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6754,7 +6490,7 @@ msgid ""
 msgstr "Questo artista non ha gruppi di pubblicazioni di artisti vari. {show_non_va|Visualizza i gruppi di pubblicazioni di questo artista}."
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Questo artista non è più in attività."
 
@@ -6804,7 +6540,7 @@ msgstr "Questo artista ha solo gruppi di pubblicazioni non ufficiali."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Questo tipo di attributo è utilizzato solamente per raggruppare altri tipi, seleziona un sottotipo."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Questo server di beta testing permette di provare le nuove funzioni sul database ufficiale di MusicBrainz."
@@ -6911,11 +6647,11 @@ msgid ""
 "attributed to it."
 msgstr "Lo strumento non può essere rimosso perché ci sono ancora relazioni attribuite ad esso."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Questo è un server di sviluppo di MusicBrainz."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7035,7 +6771,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Questa registrazione non ha nessun AcoustID associato."
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "Questa registrazione è un video"
@@ -7069,7 +6805,7 @@ msgstr "Questo tipo di relazione non consente nessun attributo."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "Questo tipo di relazione è obsoleto e non dovrebbe essere utilizzato."
 
@@ -7103,16 +6839,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "Questo status della pubblicazione va usato per traduzioni e traslitterazioni non ufficiali di elenchi di tracce e titoli di pubblicazioni, e non indica una reale pubblicazione distinta. Non deve essere usato per indicare bootleg, album mixtape/street, demo o album digitali. Assicurati che la pubblicazione sia collegata alla corrispondente pubblicazione reale con una {url|relazione di traduzione/traslitterazione}."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "Questo report mira a identificare gli artisti con nomi molto simili. Se due artisti sono in realtà lo stesso, uniscili (non ti dimenticare di {how_to_write_edit_notes|scrivere una nota di modifica} con le prove che hai a disposizione). Se sono diversi, aggiungi loro dei {disambiguation_comment|commenti di disambiguazione} (quando tutti gli artisti con un nome simile avranno un commento di disambiguazione, essi non appariranno più in questo report)."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7154,85 +6880,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr "Questo report elenca tutte le pubblicazioni con delle lacune nella numerazione dei supporti (es. c'è un \"supporto 1\" e un \"supporto 3\" ma nessun \"supporto 2\")."
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "Questo report elenca gli artisti che appaiono più di una volta in posizioni diverse all'interno dello stesso accreditamento."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "Questo report elenca gli artisti a cui nessun editor è sottoscritto e le cui modifiche potrebbero quindi essere poco controllate. Gli artisti con più gruppi di pubblicazioni e più modifiche aperte sono elencati per primi."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr "Questo report elenca gli artisti che hanno il commento di disambiguazione uguale al nome. In questo caso, il campo disambiguazione non dovrebbe essere completato."
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "Questo report elenca gli artisti il cui tipo non è impostato su <em>gruppo</em>, ma che potrebbero essere <em>gruppi</em> poiché hanno altri artisti elencati come membri. Se scopri che un artista tra questi è davvero un gruppo, modificane il tipo. Se non lo è, assicurati che le relazioni \"membro di\" siano state inserite nella giusta direzione e siano corrette."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "Questo report elenca gli artisti il cui tipo non è impostato su <em>persona</em>, ma che potrebbero essere <em>persone</em> in base alle loro relazioni. Per esempio, un artista apparirà qui se figura come membro di un altro. Se scopri che un artista tra questi è davvero una persona, modificane il tipo. Se non lo è, assicurati che tutte le relazioni siano corrette e abbiano senso."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "Questo report elenca gli artisti che potrebbero avere commenti di disambiguazione nel loro nome anziché nell'apposito campo per il commento di disambiguazione."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "Questo report elenca gli artisti che hanno una \"&\" nei loro nomi, ma nessuna relazione di collaborazione né membri. Se l'artista è solitamente ritenuto essere effettivamente un gruppo, bisognerebbe aggiungere relazioni con i membri. Se si tratta di una collaborazione a breve termine, dovrebbe essere divisa ove possibile (controlla {how_to_split_artists|come dividere gli artisti}). Se si tratta di una collaborazione con un proprio nome che non può essere divisa, bisognerebbe aggiungerle le opportune relazioni di collaborazione."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "Questo report elenca gli artisti che hanno relazioni di collaborazione ma nessuna relazione con URL. Se la collaborazione possiede un proprio nome indipendente, non fare nulla. Se invece è nel formato \"X con Y\" o \"X & Y\", dovresti probabilmente dividerla. Controlla {how_to_split_artists|come dividere gli artisti}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "Questo report elenca gli artisti che possiedono più relazioni verso lo stesso artista, etichetta o URL che utilizzano lo stesso tipo di relazione. Per più relazioni verso gruppi di pubblicazioni, registrazioni o opere, visualizza i report per quelle entità."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "Questo report elenca gli artisti che utilizzano tipi di relazione obsoleti o di raggruppamento"
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "Questo report elenca gli artisti con annotazioni."
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7394,10 +7041,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "Questo report elenca gli {iswc|ISWC} che sono associati a più di un'opera. Se le opere sono uguali, ciò vuole solitamente dire che dovrebbero essere unite."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr "Questo report elenca gli {url|editor principianti/con account limitati}."
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7408,10 +7051,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "Questo report mostra gli URL di Amazon che sono collegati a più pubblicazioni. Nella maggior parte dei casi un ASIN di Amazon dovrebbe corrispondere ad una sola pubblicazione di MusicBrainz, quindi solo uno dei link sarà corretto. Controlla quale pubblicazione di MusicBrainz corrisponde a quella di Amazon (per formato, tracce, ecc.). Se la pubblicazione ha un codice a barre, puoi anche cercarlo su Amazon e vedere a quale ASIN corrisponde. Potresti anche trovare qualche ASIN collegato a diversi dischi di una pubblicazione con più dischi: in quel caso, potrebbe essere necessario unirle (controlla {how_to_merge_releases|come unire le pubblicazioni})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "Questo report mostra gli URL di Discogs che sono collegati a più artisti."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7691,7 +7330,7 @@ msgstr "Al momento questa serie è vuota."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Questa tabella mostra un riassunto dei voti espressi da questo editor."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "Questa traccia è una traccia dati."
 
@@ -7817,29 +7456,6 @@ msgstr "Totale ISWC trovati: {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Totale URL trovati: {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Totale artisti trovati: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Totale gruppi di doppioni: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr "Totale editor trovati: {count}"
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -7999,7 +7615,7 @@ msgstr "Traccia:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Elenco di tracce"
 
@@ -8017,10 +7633,6 @@ msgstr "Elenco di tracce:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Tracce"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Tracce i cui titoli includono il loro numero di traccia"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8049,16 +7661,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Gli editor di transclusione sono utenti che aggiungono e aggiornano le voci nella tabella di transclusione {uri|WikiDocs}."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Pseudo-pubblicazioni tradotte/traslitterate non collegate a una versione originale"
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Turco"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8074,15 +7681,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8096,7 +7706,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Tipo"
 
@@ -8124,7 +7734,7 @@ msgstr "Tipo"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Tipo:"
 
@@ -8140,14 +7750,15 @@ msgstr "Tipo: {type}, status: {status}"
 msgid "Types:"
 msgstr "Tipi:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8167,17 +7778,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
-msgstr ""
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
+msgstr "URL; [URL]; [URL|etichetta]; [entity-type:MBID|etichetta]"
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URL"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "URL con relazioni obsolete"
 
@@ -8199,8 +7810,12 @@ msgstr "Richiesta non autorizzata"
 msgid "Unclassified instrument"
 msgstr "Strumento non classificato"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -8227,9 +7842,9 @@ msgstr "Annulla sottoscrizione"
 msgid "Untrusted"
 msgstr "Non attendibile"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Fino a {n}"
 
@@ -8262,7 +7877,7 @@ msgstr "Caricamento dell'immagine in corso..."
 msgid "Uppercase roman numerals"
 msgstr "Rendi maiuscoli i numeri romani"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Utilizza la versione beta del sito"
 
@@ -8318,7 +7933,7 @@ msgid "Username:"
 msgstr "Nome utente:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Utenti"
 
@@ -8450,10 +8065,6 @@ msgstr "Attenzione: questa relazione ha delle modifiche in corso. {show|Clicca q
 msgid "Watched Artists"
 msgstr "Artisti che seguo"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Spiacenti, ma i dati di questo report non sono al momento disponibili."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "Non è possibile visualizzare la cronologia di questa copertina."
@@ -8499,10 +8110,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Siamo desolati per questo inconveniente. Aspetta qualche minuto e poi riprova: il problema potrebbe essere stato risolto."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Sito web"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Sito web:"
@@ -8515,7 +8122,7 @@ msgid ""
 "and following the merge link."
 msgstr "Quando sei pronto ad unire queste entità, clicca il bottone \"Unisci\". Puoi ancora aggiungere altre entità a questa coda di unione semplicemente andando sulla loro pagina e cliccando su \"Unisci\"."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8537,10 +8144,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Opera"
 
@@ -8579,35 +8186,32 @@ msgstr "Opera:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Opere"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Opere con annotazioni"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Opere con relazioni obsolete"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Opere che potrebbero avere relazioni doppie"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Autori"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8720,9 +8324,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Stai per unire le seguenti opere in un'opera unica. Seleziona l'opera in cui vuoi che vengano unite le altre:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Al momento sei sottoscritto. Vuoi {unsub|annullare la sottoscrizione}?"
 
@@ -8738,9 +8341,8 @@ msgstr "Al momento non puoi aggiungere note a questa modifica. ({url|Maggiori in
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Al momento non puoi votare su questa modifica. ({url|Maggiori informazioni})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Al momento non sei sottoscritto. Vuoi {sub|sottoscriverti}?"
 
@@ -8820,7 +8422,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr "Non hai inserito un accreditamento artista completo."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Non hai effettuato nessuna modifica!"
 
@@ -8845,7 +8447,7 @@ msgstr "Puoi rimuovere le tue informazioni personali dai nostri servizi in ogni 
 msgid "You must be logged in to vote on edits"
 msgstr "Devi effettuare l'accesso per votare sulle modifiche."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Devi inserire un commento di disambiguazione per questa entità."
 
@@ -8927,7 +8529,7 @@ msgstr "La tua ricerca è durata troppo tempo ed è stata annullata. Puoi specif
 msgid "Your username will be publicly visible."
 msgstr "Il tuo nome utente sarà visibile pubblicamente."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8969,10 +8571,6 @@ msgstr "[sconosciuto]"
 #: ../root/edit/search_macros.tt:160
 msgid "after"
 msgstr "dopo"
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "alias:"
 
 #: ../root/edit/search_macros.tt:28
 msgid "all"
@@ -9035,10 +8633,6 @@ msgstr "cancellato"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "accreditato come"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr "elimina"
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9257,9 +8851,7 @@ msgstr "originale"
 msgid "places"
 msgstr "luoghi"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "più {n} altro utente anonimo"
@@ -9338,7 +8930,7 @@ msgstr "sottoscriviti"
 msgid ""
 "tab or 4 spaces and: * bullets or 1., a., A., i., I. numbered items "
 "(rendered with 1.)"
-msgstr ""
+msgstr "tab o 4 spazi e: * punti o 1., a., A., i., I. elementi numerati (visualizzati come 1.)"
 
 #: ../root/release/edit/recordings.tt:22
 msgid "track"
@@ -9482,7 +9074,7 @@ msgstr[1] "{entity} è stata aggiunta a {num} collezioni:"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} non è stata aggiunta a nessuna collezione."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9496,7 +9088,7 @@ msgstr "{link} non ha nessuna valutazione."
 msgid "{link} has no relationships."
 msgstr "{link} non ha relazioni."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"Identificatore di MusicBrainz\">MBID</abbr>}:"
 
@@ -9609,7 +9201,7 @@ msgstr "{type} “{instrument}”"
 msgid "{type} “{work}”"
 msgstr "{type} “{work}”"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Ritorna a musicbrainz.org}."
 
@@ -9816,34 +9408,34 @@ msgstr "'{id}' non è un ID elezione valido"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "Il parametro obbligatorio TOC non è valido o è assente"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Inserisci un ID supporto"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Impossibile trovare il supporto"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "Il CD TOC fornito non è valido"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "L'ID supporto fornito non è valido"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Questo CD TOC è già associato a questo supporto"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Il supporto selezionato non può possedere un ID disco"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "L'ID artista fornito non è valido"
 
@@ -10225,7 +9817,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Converti in pubblicazione di artisti multipli (storico)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Imposta durata tracce"
 
@@ -10526,6 +10118,12 @@ msgstr "Voto fallito"
 msgid "Failed dependency"
 msgstr "Dipendenza fallita"
 
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Errore"
+
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
 msgstr "Prerequisito fallito"
@@ -10739,7 +10337,7 @@ msgstr "{role} (come {credited_name})"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Gutenberg.pm:9
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Progetto Gutenberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/IMSLP.pm:31
 msgid "Score at IMSLP"
@@ -10751,11 +10349,11 @@ msgstr "Niconico"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Runeberg.pm:13
 msgid "Project Runeberg"
-msgstr ""
+msgstr "Progetto Runeberg"
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Wikisource.pm:9
 msgid "Wikisource"
-msgstr ""
+msgstr "Wikisource"
 
 #: ../lib/MusicBrainz/Server/FilterUtils.pm:22
 msgid "Filter release groups"
@@ -10854,7 +10452,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Non è stato possibile analizzare queste coordinate"
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "La data finale non può precedere quella iniziale."
 
@@ -10958,13 +10556,13 @@ msgstr "Devi inserire una nota di modifica"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "Bozza CD"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Tag"
@@ -10972,7 +10570,7 @@ msgstr "Tag"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Documentazione"
 
@@ -11232,7 +10830,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Verifica donazione"
 
@@ -11283,6 +10881,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr "Inserisci il tuo nome utente e la tua email qui sotto. Ti manderemo una email con un link per reimpostare la tua password. Se ti sei dimenticato il tuo nome utente, per prima cosa {link|recuperalo} e poi reimposta la tua password."
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "Email"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11314,7 +10918,7 @@ msgid ""
 msgstr "Ti abbiamo inviato le informazioni sul tuo account di MusicBrainz. Se non ricevi l'email o continui ad avere problemi ad effettuare l'accesso, {link|contattaci}."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Preferenze"
 
@@ -11450,7 +11054,7 @@ msgstr "Abbiamo inviato un'email a {addr}. Controlla la tua casella di posta e c
 msgid "Unconfirmed Email Address"
 msgstr "Indirizzo email non confermato"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} in {parent_areas}"
 
@@ -11490,32 +11094,32 @@ msgid ""
 msgstr "Spiacenti, non è stato possibile trovare un artista con quell'ID di MusicBrainz. Potresti provare a {search_url|usare la ricerca}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Nato in:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Fondato in:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Area iniziale:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Morto in:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Sciolto in:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Area finale:"
 
@@ -11535,23 +11139,23 @@ msgstr "Collezione non trovata"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Spiacenti, non è stato possibile trovare una collezione con quell'ID di MusicBrainz."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Data iniziale"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Data finale"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr "primario"
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} non ha nessun alias."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr "Aggiungi un nuovo alias"
 
@@ -11593,19 +11197,19 @@ msgstr[1] "Scade tra <span class=\"tooltip\" title=\"{exactdate}\">{num} minuti<
 msgid "Already expired"
 msgstr "Già scaduto"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profilo"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Sottoscrizioni"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Modifica utente"
 
@@ -11667,7 +11271,7 @@ msgid "For more information:"
 msgstr "Per maggiori informazioni:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Aggiungi nota"
 
@@ -11846,6 +11450,22 @@ msgstr "Votazione"
 msgid "Votes cast"
 msgstr "Voti espressi"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] "Al momento c'è {num} utente sottoscritto a {entity}:"
+msgstr[1] "Al momento ci sono {num} utenti sottoscritti a {entity}:"
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] "Più {n} altro utente anonimo"
+msgstr[1] "Più altri {n} utenti anonimi"
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr "Al momento non ci sono utenti sottoscritti a {entity}."
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Evento non trovato"
@@ -11872,7 +11492,7 @@ msgid ""
 "ticket}."
 msgstr "Manca un genere nell'elenco? Richiedilo {link|aggiungendo un ticket di stile}."
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "Strumento"
 
@@ -12114,6 +11734,11 @@ msgstr "Aggiungi evento"
 msgid "Vote on Edits"
 msgstr "Vota le modifiche"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Report"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Guida per principianti"
@@ -12154,23 +11779,23 @@ msgstr "Visualizza tutte le relazioni"
 msgid "Running: {git_details}"
 msgstr "In esecuzione: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Pagina {n}"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr "MusicBrainz: Artista"
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Etichetta"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr "MusicBrainz: Pubblicazione"
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Traccia"
 
@@ -12405,9 +12030,13 @@ msgstr "Informazioni sullo strumento"
 msgid "Label information"
 msgstr "Informazioni sull'etichetta"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Ultimo aggiornamento il {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr "Ultimo aggiornamento in data sconosciuta"
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12483,18 +12112,18 @@ msgid "see all ratings"
 msgstr "Visualizza tutte le valutazioni"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(nessuno)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr "Visualizza tutti i tag"
 
@@ -12663,11 +12292,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Spiacenti, non è stato possibile trovare una registrazione con quell'ID di MusicBrainz. Potresti provare a {search_url|usare la ricerca}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "Video di {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Registrazione di {artist}"
 
@@ -12696,9 +12325,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Spiacenti, non è stato possibile trovare un gruppo di pubblicazioni con quell'ID di MusicBrainz. Potresti provare a {search_url|usare la ricerca}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Gruppo di pubblicazioni di {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Annotazioni di artisti"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "Questo report elenca gli artisti con annotazioni."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Totale artisti trovati: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artisti che hanno commenti di disambiguazione nel loro nome"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "Questo report elenca gli artisti che potrebbero avere commenti di disambiguazione nel loro nome anziché nell'apposito campo per il commento di disambiguazione."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artisti con commento di disambiguazione uguale al nome"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr "Questo report elenca gli artisti che hanno il commento di disambiguazione uguale al nome. In questo caso, il campo disambiguazione non dovrebbe essere completato."
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artisti che potrebbero essere gruppi"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr "Questo report elenca gli artisti il cui tipo non è impostato su Gruppo (o un sottotipo di Gruppo), ma che potrebbero essere gruppi poiché hanno altri artisti elencati come membri. Se scopri che un artista tra questi è davvero un gruppo, modificane il tipo. Se non lo è, assicurati che le relazioni \"membro di\" siano state inserite nella giusta direzione e siano corrette."
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artisti che potrebbero essere persone"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr "Questo report elenca gli artisti il cui tipo non è impostato su Persona, ma che potrebbero essere persone in base alle loro relazioni. Per esempio, un artista apparirà qui se figura come membro di un altro. Se scopri che un artista tra questi è davvero una persona, modificane il tipo. Se non lo è, assicurati che tutte le relazioni siano corrette e abbiano senso."
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr "Artisti inseriti più volte nello stesso accreditamento"
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "Questo report elenca gli artisti che appaiono più di una volta in posizioni diverse all'interno dello stesso accreditamento."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artisti senza sottoscrittori"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "Questo report elenca gli artisti a cui nessun editor è sottoscritto e le cui modifiche potrebbero quindi essere poco controllate. Gli artisti con più gruppi di pubblicazioni e più modifiche aperte sono elencati per primi."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr "Artisti con relazioni di collaborazione"
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "Questo report elenca gli artisti che hanno relazioni di collaborazione ma nessuna relazione con URL. Se la collaborazione possiede un proprio nome indipendente, non fare nulla. Se invece è nel formato \"X con Y\" o \"X & Y\", dovresti probabilmente dividerla. Controlla {how_to_split_artists|come dividere gli artisti}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Collaborazione"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Collaboratore"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artisti con relazioni obsolete"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "Questo report elenca gli artisti che utilizzano tipi di relazione obsoleti o di raggruppamento"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "URL di Discogs collegati a più artisti"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "Questo report mostra gli URL di Discogs che sono collegati a più artisti."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Artisti che potrebbero essere doppioni"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "Questo report mira a identificare gli artisti con nomi molto simili. Se due artisti sono in realtà lo stesso, uniscili (non ti dimenticare di {how_to_write_edit_notes|scrivere una nota di modifica} con le prove che hai a disposizione). Se sono diversi, aggiungi loro dei {disambiguation_comment|commenti di disambiguazione} (quando tutti gli artisti con un nome simile avranno un commento di disambiguazione, essi non appariranno più in questo report)."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Totale gruppi di doppioni: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Aggiungi gli artisti selezionati per unirli"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artisti che potrebbero avere relazioni doppie"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "Questo report elenca gli artisti che possiedono più relazioni verso lo stesso artista, etichetta o URL che utilizzano lo stesso tipo di relazione. Per più relazioni verso gruppi di pubblicazioni, registrazioni o opere, visualizza i report per quelle entità."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Visualizza tutti i risultati."
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Visualizza solo i risultati delle entità che ho sottoscritto."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Editor principianti/con account limitati"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr "Questo report elenca gli {url|editor principianti/con account limitati}."
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr "Totale editor trovati: {count}"
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artisti che potrebbero essere collaborazioni"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "Questo report elenca gli artisti che hanno una \"&\" nei loro nomi, ma nessuna relazione di collaborazione né membri. Se l'artista è solitamente ritenuto essere effettivamente un gruppo, bisognerebbe aggiungere relazioni con i membri. Se si tratta di una collaborazione a breve termine, dovrebbe essere divisa ove possibile (controlla {how_to_split_artists|come dividere gli artisti}). Se si tratta di una collaborazione con un proprio nome che non può essere divisa, bisognerebbe aggiungerle le opportune relazioni di collaborazione."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Spiacenti, ma i dati di questo report non sono al momento disponibili."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Se vuoi partecipare al processo di modifica ma non sai dove cominciare, i seguenti report potrebbero tornarti utili. Sono stati creati perlustrando il database alla ricerca di dati che potrebbero aver bisogno di essere corretti, sia per conformarsi alle {style|linee guida di stile}, sia per altri casi che richiedono compiti amministrativi di \"ripulitura\"."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artisti che hanno relazioni di collaborazione"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artisti che sembrano collaborazioni"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Artisti con annotazioni"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Editor"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Eventi che potrebbero essere doppioni"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "URL di Discogs collegati a più etichette"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Etichette con annotazioni"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Gruppi di pubblicazioni"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Gruppi di pubblicazioni che forse dovrebbero essere uniti"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "URL di Discogs collegati a più gruppi di pubblicazioni"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Gruppi di pubblicazioni con annotazioni"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Pubblicazioni che hanno URL di Amazon non previsti"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Pubblicazioni che possiedono più ASIN"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Pubblicazioni che possiedono più collegamenti a Discogs"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "URL di Amazon collegati a più pubblicazioni"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "URL di Discogs collegati a più pubblicazioni"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Pubblicazioni che hanno relazioni di parte di un set"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Dischi inseriti come pubblicazioni separate"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Pubblicazioni con numeri di traccia non sequenziali"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Pubblicazioni in cui alcuni (ma non tutti) i supporti non hanno un formato impostato"
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Pubblicazioni con numeri di catalogo che sembrano ASIN"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Pseudo-pubblicazioni tradotte/traslitterate non collegate a una versione originale"
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Pubblicazioni di qualsiasi tipo che hanno ancora relazioni di copertina"
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Pubblicazioni con supporti non sequenziali"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Pubblicazioni con annotazioni"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr "Pubblicazioni senza ID disco"
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Registrazioni con relazioni di prima pubblicazione"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Tracce i cui titoli includono il loro numero di traccia"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Registrazioni con durata delle tracce variabile"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Registrazioni con annotazioni"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Luoghi con annotazioni"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Serie con annotazioni"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Opere con annotazioni"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Membro da"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Sito web"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Biografia"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "elimina"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12855,60 +12873,76 @@ msgstr "Nessun tipo"
 msgid "{place_type}: {place_link}"
 msgstr "{place_type}: {place_link}"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Si è verificato un errore durante la ricerca. Clicca qui per riprovare."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Prova a usare la ricerca diretta."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Prova a usare la ricerca indicizzata."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Digita per cercare o incolla un MBID"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Cancella elementi recenti"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Mostra di più..."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Non l'hai trovato? Riprova con la ricerca diretta."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Lento? Torna alla ricerca indicizzata."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr "compare in"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr "registrazione indipendente"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr "{release_group_type} di {artist}"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr "Esecutori"
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Vota tutte le modifiche:"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Elimina nota"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Visualizza gli accreditamenti in fondo"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Visualizza gli accreditamenti in linea"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Non è stato possibile caricare il supporto."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Immagine {current} di {total}"
 
@@ -12930,7 +12964,7 @@ msgstr "Annotazione modificata l'ultima volta il {date}."
 msgid "Show less..."
 msgstr "Mostra meno..."
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Immagine da Wikimedia Commons"
 
@@ -12941,73 +12975,90 @@ msgstr "{review_link|Recensione} di {author} del {date}"
 #: ../root/static/scripts/common/components/EditorLink.js:19
 msgid ""
 "This editor is missing from this server, and cannot be displayed correctly."
-msgstr ""
+msgstr "Questo editor non è presente nel server e non può essere visualizzato correttamente."
 
 #: ../root/static/scripts/common/components/EditorLink.js:20
 msgid "[missing editor]"
-msgstr ""
+msgstr "[editor mancante]"
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr "Ritira voto"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Vota a favore"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Hai votato a favore di questo tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Vota contro"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Hai votato contro questo tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "I tag con un punteggio di zero o minore e i tag cui hai votato contro sono nascosti."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "I tag con un punteggio di zero o minore sono nascosti."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Visualizza tutti i tag."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Tutti i tag sono visualizzati."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr "Nascondi i tag con un punteggio di zero o minore e i tag cui hai votato contro."
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr "Nascondi i tag con un punteggio di zero o minore."
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Aggiungi tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Puoi aggiungere i tuoi {tagdocs|tag} qui sotto. Usa una virgola per separare tag diversi."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Invia tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "visualizza tutti i tag"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Tag"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Continua a leggere su Wikipedia..."
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13125,21 +13176,21 @@ msgstr "{begin_date} – ????"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Inizio:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Questa persona è deceduta."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Questo gruppo si è sciolto."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Campo necessario."
 
@@ -13199,9 +13250,9 @@ msgid ""
 "entity from the others."
 msgstr "Inserisci una {doc_disambiguation|disambiguazione} per distinguere questa entità dalle altre."
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Se lasci questa pagina perderai tutte le tue modifiche."
 
@@ -13214,7 +13265,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Seleziona un tipo di collegamento per l'URL che hai inserito."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13231,7 +13282,7 @@ msgid "This relationship already exists."
 msgstr "Questa relazione è già esistente."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|altra documentazione})"
 
@@ -13251,7 +13302,7 @@ msgstr "video"
 msgid "Remove Link"
 msgstr "Rimuovi collegamento"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Opzioni ritocco maiuscolo/minuscolo"
 
@@ -13284,45 +13335,45 @@ msgid ""
 "language guidelines}. "
 msgstr "Questa modalità gestisce il maiuscolo/minuscolo in turco per 'i' ('İ') e 'ı' ('I'). Alcune parole potrebbero dover essere corrette manualmente per seguire le {url|linee guida su maiuscolo/minuscolo per il turco}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "La serie che hai selezionato è una serie di registrazioni."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "La serie che hai selezionato è una serie di pubblicazioni."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "La serie che hai selezionato è una serie di gruppi di pubblicazioni."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "La serie che hai selezionato è una serie di opere."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Seleziona un tipo di relazione."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Seleziona un sottotipo del tipo di relazione attualmente selezionato. Questo tipo di relazione è utilizzato solo per raggruppare altre relazioni."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Le entità in una relazione non possono essere le stesse."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr "Cambia gli accreditamenti per altre {entity} relazioni nella pagina."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr "Solo relazioni con entità {entity_type}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr "Solo relazioni “{relationship_type}” con entità {entity_type}."
 
@@ -13330,19 +13381,19 @@ msgstr "Solo relazioni “{relationship_type}” con entità {entity_type}."
 msgid "This attribute is required."
 msgstr "Questo attributo è necessario."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} registrazione selezionata"
 msgstr[1] "{n} registrazioni selezionate"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} opera selezionata"
 msgstr[1] "{n} opere selezionate"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13359,64 +13410,64 @@ msgstr "Questo supporto ha almeno un ID disco che impedisce la modifica di quest
 msgid "Page {page} of {total}"
 msgstr "Pagina {page} di {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Supporto {position}: {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Supporto {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Non hai selezionato un'etichetta per \"{name}\"."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Errore nel caricamento della pubblicazione: {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Aggiungi pubblicazione"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Modifica pubblicazione"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "La cifra di controllo è {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Per favore, verifica il codice a barre sulla pubblicazione."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "Il codice a barre inserito sembra essere un codice UPC senza la cifra di controllo."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "Il codice a barre inserito è un codice UPC valido."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "Il codice a barre inserito è un codice UPC non valido, oppure un codice EAN senza la cifra di controllo."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "Il codice a barre inserito è un codice EAN valido."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "Il codice a barre inserito non è un codice EAN valido."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "Il codice a barre inserito non è un codice UPC o EAN valido."
 
@@ -13424,7 +13475,7 @@ msgstr "Il codice a barre inserito non è un codice UPC o EAN valido."
 msgid "Add Language"
 msgstr "Aggiungi lingua"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Rimuovi lingua"
 

--- a/po/mb_server.ja.po
+++ b/po/mb_server.ja.po
@@ -25,15 +25,15 @@
 # th1rtyf0ur, 2013
 # th1rtyf0ur, 2013
 # wa2c <email address hidden>, 2018
-# 和田篤（wa2c） <email address hidden>, 2018
+# wa2c <email address hidden>, 2018
 # yvanz, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-09 17:37+0000\n"
-"Last-Translator: yvanz\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-03-05 12:58+0000\n"
+"Last-Translator: wa2c <email address hidden>\n"
 "Language-Team: Japanese (http://www.transifex.com/musicbrainz/musicbrainz/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -192,6 +192,7 @@ msgstr "(なし)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(不明)"
 
@@ -397,7 +398,7 @@ msgstr "アカウント管理者"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "アカウント管理者はユーザーアカウントを編集・削除できます。"
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr ""
 
@@ -407,7 +408,7 @@ msgstr ""
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "アクション"
 
@@ -592,10 +593,6 @@ msgstr "関連作品を追加"
 msgid "Add relationship"
 msgstr "関係を追加"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "選択されたアーティストをマージ"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "選択されたイベントをマージ"
@@ -668,7 +665,7 @@ msgstr "年齢:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "別名"
 
@@ -688,9 +685,10 @@ msgstr "別名:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "別名"
 
@@ -738,25 +736,20 @@ msgstr "他の活動名"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "複数のリリースに接続されたAmazonのURL"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "複数のリリースに接続されたAmazonのURL"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "エイリアスは、項目の代替名です。主に、よくあるスペルミスや、表記ブレが登録されており、検索結果を改善するために使用されます。詳細は{doc|alias documentation}を参照してください。"
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "匿名ユーザー{n}名"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -778,8 +771,7 @@ msgstr "エラーが発生しました: "
 msgid "An error occurred while creating the works."
 msgstr "作品の作成中にエラーが発生しました。"
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -788,8 +780,9 @@ msgstr "作品の作成中にエラーが発生しました。"
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "注釈"
@@ -923,11 +916,11 @@ msgstr "本当にMusicBrainzから{series}というシリーズを削除しま�
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -978,24 +971,27 @@ msgstr "地域\t"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1041,11 +1037,6 @@ msgstr "アーティストMBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "購読中のアーティスト"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "アーティストの注釈"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1093,7 +1084,7 @@ msgstr "アーティスト {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "アーティスト:"
 
@@ -1101,81 +1092,15 @@ msgstr "アーティスト:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "アーティスト"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "名前に曖昧さ回避メモを含むアーティスト一覧"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr ""
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "コラボであろうアーティスト"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "グループであろうアーティスト"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "人であろうアーティスト"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "コラボ関係があるアーティスト"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "コラボにみえるアーティスト"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "コラボ関係持ちのアーティスト"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "注釈のあるアーティスト"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "旧形式の関係があるアーティスト"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "名前と同じ曖昧さ回避メモを含むアーティスト一覧"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "購読者のないアーティスト一覧"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "重複した関係を持つ可能性のあるアーティスト一覧"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1340,9 +1265,8 @@ msgstr "作品に関係を一括追加"
 msgid "Batch-create new works"
 msgstr "新しい作品を一括作成"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "{sub|購読する}"
 
@@ -1400,20 +1324,11 @@ msgstr "開始日:"
 msgid "Beginner"
 msgstr "ビギナー"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "初心者/制限編集者"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
-msgstr ""
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
 msgstr ""
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
@@ -1425,12 +1340,12 @@ msgstr "プロフィール:"
 msgid "Birth date:"
 msgstr "生年月日:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "ブログ"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "出生:"
 
@@ -1442,13 +1357,13 @@ msgstr "ボット"
 msgid "Bots"
 msgstr "ボット"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr ""
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "バグ管理"
@@ -1593,7 +1508,7 @@ msgstr "カタログ番号"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "パスワード変更"
 
@@ -1672,14 +1587,6 @@ msgstr "終了"
 msgid "Code"
 msgstr "コード"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "コラボレーション"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "コラボレーター"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "ディスクを折りたたむ"
@@ -1708,7 +1615,7 @@ msgstr "「{collection}」のコレクション"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "コレクション"
@@ -1786,7 +1693,7 @@ msgid "Country:"
 msgstr "国:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "カバーアート"
 
@@ -1918,7 +1825,7 @@ msgstr "日付はYYYY-MM-DD（年月日）の形式で表記します。YYYY-MM�
 msgid "Delete"
 msgstr "削除"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "アカウント削除"
 
@@ -1970,13 +1877,14 @@ msgstr "説明:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "詳細"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "死没:"
 
@@ -1986,7 +1894,7 @@ msgstr "Diff"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "データベースの直接検索"
 
@@ -2043,7 +1951,7 @@ msgid "Disc ID:"
 msgstr "ディスク ID:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "ディスク ID"
 
@@ -2063,11 +1971,6 @@ msgstr "ディスクタイトル:"
 msgid "Discography"
 msgstr "ディスコグラフィー"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "複数のアーティストに結合されたDiscogsのURL"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2083,32 +1986,12 @@ msgstr "複数のリリースグループに接続されたDiscogsのURL"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "複数のリリースに接続されたDiscogsのURL"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "複数のアーティストに結合されたDiscogsのURL"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "複数のレーベルに接続されたDiscogsのURL"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "複数のリリースグループに接続されたDiscogsのURL"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "複数のリリースに接続されたDiscogsのURL"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "別リリースのディスク"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "別のリリースで入力されたディスク"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "解散:"
 
@@ -2126,7 +2009,7 @@ msgstr "ドキュメント:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "アカウント登録がまだの場合は{uri|こちらへ作成}。"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "寄付する"
 
@@ -2157,9 +2040,9 @@ msgstr "MusicBrainzデータベースの各トラックは、レコーディン�
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "編集"
 
@@ -2212,7 +2095,7 @@ msgid "Edit Note Author"
 msgstr "編集ノートの著者"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "プロフィールを編集"
 
@@ -2287,10 +2170,10 @@ msgid "Editing/voting disabled"
 msgstr "編集・投票が無効です"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "編集者"
 
@@ -2306,10 +2189,6 @@ msgstr "購読中の編集者"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "編集者 「{user}」"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "エディタ"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2338,12 +2217,6 @@ msgstr "{name} の編集"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr ""
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "メール"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2403,7 +2276,7 @@ msgstr "終了済み"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "終了:"
 
@@ -2446,11 +2319,6 @@ msgstr "項目タイプ"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "項目のタイプ:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "エラー"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2499,8 +2367,8 @@ msgstr "一つか二つのURLだけでも役立ちます！"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2527,13 +2395,14 @@ msgstr "イベント:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "イベント"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr ""
 
@@ -2614,7 +2483,7 @@ msgid "Find Relationships"
 msgstr "関係を検索"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "フィンガープリント"
 
@@ -2663,7 +2532,7 @@ msgstr ""
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr ""
 
@@ -2695,7 +2564,7 @@ msgstr "フォーマット"
 msgid "Format:"
 msgstr "フォーマット:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "フォーラム"
@@ -2747,7 +2616,7 @@ msgstr[0] "\"{q}\" に対して{n}件の結果が見つかりました"
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "結成:"
 
@@ -2803,7 +2672,6 @@ msgstr "性別:"
 msgid "General Information"
 msgstr "一般情報"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2811,17 +2679,9 @@ msgstr "一般情報"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2829,13 +2689,10 @@ msgstr "一般情報"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2850,13 +2707,11 @@ msgstr "一般情報"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2887,15 +2742,29 @@ msgstr "一般情報"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "{date} に生成された"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
-msgstr ""
+msgstr "ジャンル"
 
 #: ../root/components/forms.tt:223 ../root/release/edit/information.tt:14
 msgid "Guess case"
@@ -3092,13 +2961,15 @@ msgstr "ISRC「{isrc}」\t"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "複数レコーディングの ISRC"
 
@@ -3122,12 +2993,8 @@ msgstr "{work} の ISWC {iswc}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "複数の作品に対するISWC"
 
@@ -3199,15 +3066,6 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr ""
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr ""
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
@@ -3245,11 +3103,11 @@ msgstr "ユーザー名もしくはパスワードが無効でした。"
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "インデックス検索"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "{doc|高度なクエリ構文}を使ったインデックス検索"
 
@@ -3260,7 +3118,7 @@ msgstr "{doc|高度なクエリ構文}を使ったインデックス検索"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3285,13 +3143,14 @@ msgstr "楽器の詳細"
 msgid "Instrument:"
 msgstr "楽器:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "楽器"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr ""
 
@@ -3357,9 +3216,9 @@ msgstr "ログイン状態を保持"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3420,31 +3279,28 @@ msgstr "レーベル:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "レーベル"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "注釈のあるレーベル"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "旧形式の関係があるレーベル"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "名前と同じ曖昧さのないレーベル"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "重複した関係を持つ可能性のあるレーベル"
 
@@ -3485,7 +3341,6 @@ msgstr "最近24時間"
 msgid "Last 28 days"
 msgstr "最近28日間"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3493,6 +3348,7 @@ msgstr "最近28日間"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "最終編集"
 
@@ -3500,7 +3356,7 @@ msgstr "最終編集"
 msgid "Last login:"
 msgstr "最終ログイン:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr ""
 
@@ -3508,7 +3364,7 @@ msgstr ""
 msgid "Last updated"
 msgstr "最終更新"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "最終更新:"
 
@@ -3578,14 +3434,14 @@ msgid "Loading edit previews..."
 msgstr "編集プレビューを読込み中…"
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "ロード中..."
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "ロケール"
 
@@ -3595,6 +3451,7 @@ msgstr "ロケール:"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "地域"
 
@@ -3667,7 +3524,7 @@ msgstr "低"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "歌詞言語"
 
@@ -3702,7 +3559,7 @@ msgid "Many relationships"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "マップ"
 
@@ -3763,10 +3620,6 @@ msgstr "メディア:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "メディア:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr ""
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3878,7 +3731,7 @@ msgstr "最も人気"
 msgid "Most Recent"
 msgstr "最新"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "移動"
 
@@ -4007,7 +3860,7 @@ msgstr "名前"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "名前:"
 
@@ -4109,7 +3962,7 @@ msgstr "新しいバージョン:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "次へ"
@@ -4185,7 +4038,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr ""
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "結果がありません"
 
@@ -4199,7 +4052,7 @@ msgstr "結果が見つかりません。"
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "結果が見つかりません。検索条件を変更してください。"
 
@@ -4224,13 +4077,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr ""
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr ""
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr ""
 
@@ -4240,7 +4093,7 @@ msgid "None"
 msgstr "無し"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr ""
@@ -4449,9 +4302,9 @@ msgid "Other lookups"
 msgstr "他の探索"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr ""
 
@@ -4460,7 +4313,7 @@ msgid "Overall"
 msgstr "合計"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "概要"
@@ -4537,11 +4390,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr ""
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "永続リンク"
 
@@ -4553,8 +4406,8 @@ msgstr "句:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4580,23 +4433,20 @@ msgstr "場所:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "場所"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "注釈のある場所"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr ""
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr ""
 
@@ -4719,22 +4569,14 @@ msgid "Possible duplicate events"
 msgstr "重複している可能性のあるイベント"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "重複している可能性のあるリリースグループ"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr ""
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "重複している可能性のあるアーティスト"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "重複している可能性のあるイベント"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4752,7 +4594,7 @@ msgstr "プレビュー:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "前へ"
@@ -4804,7 +4646,7 @@ msgid "Public collection by {owner}"
 msgstr ""
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "クエリ:"
 
@@ -4828,7 +4670,7 @@ msgstr "評価"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "評価"
 
@@ -4858,7 +4700,7 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4901,21 +4743,22 @@ msgstr "レコーディング:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "レコーディング"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
@@ -4929,40 +4772,28 @@ msgstr ""
 msgid "Recordings with Varying Track Lengths"
 msgstr ""
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "注釈のあるレコーディング"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
-msgstr ""
-
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
 msgstr ""
 
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "重複した関係を持つ可能性のあるレコーディング"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
 msgstr ""
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "フィーチャリングアーティストを含むレコーディング名"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr ""
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5020,7 +4851,6 @@ msgid "Relationship Editor"
 msgstr "関係編集者"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5028,6 +4858,7 @@ msgstr "関係編集者"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "関係タイプ"
 
@@ -5077,7 +4908,7 @@ msgstr "関係:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "関係一覧"
 
@@ -5109,7 +4940,7 @@ msgstr "関係:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5141,7 +4972,7 @@ msgstr "リリースイベント:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "リリースグループ"
@@ -5177,7 +5008,7 @@ msgstr "リリースグループ"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "旧形式の関係があるリリースグループ"
 
@@ -5236,6 +5067,7 @@ msgid "Release group ratings"
 msgstr "リリースグループ評価"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "{artist}のリリースグループ「{name}」"
 
@@ -5247,38 +5079,27 @@ msgstr "{artist}のリリースグループ「{name}」"
 msgid "Release group:"
 msgstr "リリースグループ:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "リリースグループ"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr ""
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "注釈のあるリリースグループ"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "重複した関係を持つ可能性のあるリリースグループ"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "フィーチャリングアーティストを含む曲名のあるリリースグループ"
 
@@ -5321,8 +5142,8 @@ msgstr "リリース:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "リリース"
@@ -5356,67 +5177,43 @@ msgstr "Discogsリンクが複数あるリリース"
 msgid "Releases With Some Formats Unset"
 msgstr "フォーマット未定のリリース"
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr ""
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr ""
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr ""
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr ""
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr ""
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "発売日が早すぎるリリース"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr ""
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr ""
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "ASINが複数あるリリース"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Discogsリンクが複数あるリリース"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr ""
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "意外なAmazonリンクのあるリリース"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr ""
 
@@ -5425,23 +5222,15 @@ msgstr ""
 msgid "Releases with Cover Art relationships"
 msgstr "カバーアートと関係のあるリリース"
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr ""
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "注釈のあるリリース"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "ASINに見えるカタログ番号のあるリリース"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "旧形式の関係があるリリース"
 
@@ -5450,31 +5239,25 @@ msgstr "旧形式の関係があるリリース"
 msgid "Releases with medium number issues"
 msgstr ""
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "メディアのないリリース"
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr ""
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "非順次的なトラック番号のあるリリース"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "重複した関係を持つ可能性のあるリリース"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "余分なデータトラックのあるリリース"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "フィーチャリングアーティストを含む曲名のあるリリース"
 
@@ -5483,24 +5266,26 @@ msgstr "フィーチャリングアーティストを含む曲名のあるリリ
 msgid "Releases with track number issues"
 msgstr ""
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "トラック時間が不明のリリース"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "言語と表記が合わないリリース"
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "言語未定のリリース"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "表記未定のリリース"
 
@@ -5526,7 +5311,7 @@ msgstr "リリース:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5538,7 +5323,7 @@ msgstr "リリース:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "削除"
@@ -5678,11 +5463,6 @@ msgstr "ユーザーを報告"
 msgid "Report this user for bad behavior"
 msgstr "このユーザーの悪い行動を報告"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "レポート"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "要求がタイムアウトしました"
@@ -5705,7 +5485,7 @@ msgstr "パスワードをリセット"
 msgid "Reset track numbers"
 msgstr "トラック番号をリセット"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr ""
 
@@ -5745,7 +5525,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr ""
 
@@ -5788,7 +5568,7 @@ msgstr "表記:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5835,7 +5615,7 @@ msgstr "編集を検索"
 msgid "Search for the target URL."
 msgstr ""
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "検索方法:"
 
@@ -5924,7 +5704,7 @@ msgstr "自分のメールアドレスへも送信"
 msgid "Sentence"
 msgstr ""
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "シリーズ"
@@ -5939,8 +5719,8 @@ msgstr "シリーズ"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5963,10 +5743,6 @@ msgstr "購読中のシリーズ"
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
 msgstr "シリーズの注釈"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
-msgstr "注釈のあるシリーズ"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
@@ -5995,7 +5771,7 @@ msgstr ""
 msgid "Set cover art"
 msgstr "カバーアートを設定"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr ""
 
@@ -6008,10 +5784,6 @@ msgstr ""
 msgid "Setlist:"
 msgstr ""
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr ""
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr ""
@@ -6020,10 +5792,6 @@ msgstr ""
 msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
-msgstr ""
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
 msgstr ""
 
 #: ../root/artist/releases.tt:31
@@ -6160,7 +5928,7 @@ msgstr ""
 msgid "Sorry, there was a problem with your request."
 msgstr ""
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr ""
 
@@ -6184,8 +5952,8 @@ msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "ソート名"
 
@@ -6239,7 +6007,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "ステータス:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "ベータサイトを使わない"
 
@@ -6293,12 +6061,10 @@ msgstr "購読してる編集者"
 msgid "Subscribed entities"
 msgstr "購読してるエンティティ"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6346,8 +6112,8 @@ msgid "Tagger"
 msgstr "タグ者"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6418,7 +6184,7 @@ msgid ""
 "and may not display correctly"
 msgstr ""
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6429,7 +6195,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr ""
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "入力した日付は無効です。"
 
@@ -6528,7 +6294,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr ""
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr ""
 
@@ -6567,21 +6333,9 @@ msgstr ""
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr ""
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr ""
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "{collection}の購読者はございません。"
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr ""
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr ""
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6590,12 +6344,12 @@ msgid ""
 msgstr ""
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr ""
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr ""
 
@@ -6619,25 +6373,10 @@ msgid_plural ""
 "There are currently {num} users subscribed to edits that {user} makes:"
 msgstr[0] ""
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] ""
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "現在{collection}の購読者が{num}名います:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] ""
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] ""
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6744,7 +6483,7 @@ msgid ""
 msgstr ""
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "このアーティストは解散（死亡）しました。"
 
@@ -6794,7 +6533,7 @@ msgstr ""
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr ""
@@ -6900,11 +6639,11 @@ msgid ""
 "attributed to it."
 msgstr ""
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "これはMusicBrainzの開発サーバーです。"
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7024,7 +6763,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "このレコーディングは関連のAcoustIDがありません。"
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "このレコーディングはビデオです"
@@ -7058,7 +6797,7 @@ msgstr "この関係タイプには属性を設定できません。"
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "この関係タイプは非推奨のため使用しないでください。"
 
@@ -7091,16 +6830,6 @@ msgid ""
 "separate real release. It should not be used to denote bootlegs, "
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
-msgstr ""
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
 msgstr ""
 
 #: ../root/report/tracks_named_with_sequence.tt:6
@@ -7143,85 +6872,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr ""
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr ""
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "このレポートは、購読者がいないためレビューが不足の可能性があるアーティストを表示します。リリースグループや未解決な編集が多いアーティストは最初に表示されます。"
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr ""
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr ""
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr ""
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr ""
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "このレポートは注釈のあるアーティストを表示します。"
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7383,10 +7033,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "このレポートは複数の作品と繋がっている{iswc|ISWC}を表示します。作品が同じであれば、マージすべきかもしれません。"
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr ""
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7396,10 +7042,6 @@ msgid ""
 " barcode, you can also search Amazon for it and see which ASIN matches. You "
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
 msgstr ""
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
@@ -7680,7 +7322,7 @@ msgstr ""
 msgid "This table shows a summary of votes cast by this editor."
 msgstr ""
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr ""
 
@@ -7805,29 +7447,6 @@ msgstr "ISWC合計: {count}"
 
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "アーティスト合計: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "複製グループ合計: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
 msgstr ""
 
 #: ../root/report/duplicate_events.tt:10
@@ -7988,7 +7607,7 @@ msgstr "トラック:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "トラックリスト"
 
@@ -8006,10 +7625,6 @@ msgstr "トラックリスト:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "トラック"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "順序番号を含むトラック名"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8038,16 +7653,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr ""
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr ""
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8063,15 +7673,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8085,7 +7698,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "タイプ"
 
@@ -8113,7 +7726,7 @@ msgstr "タイプ"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "タイプ:"
 
@@ -8129,14 +7742,15 @@ msgstr "タイプ: {type}、ステータス: {status}"
 msgid "Types:"
 msgstr "タイプ:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8156,17 +7770,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URL"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "旧形式の関係があるURL"
 
@@ -8188,8 +7802,12 @@ msgstr "無許可のリクエスト"
 msgid "Unclassified instrument"
 msgstr ""
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "不明"
 
@@ -8216,9 +7834,9 @@ msgstr "購読解除"
 msgid "Untrusted"
 msgstr "信頼されない"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "{n} まで"
 
@@ -8251,7 +7869,7 @@ msgstr ""
 msgid "Uppercase roman numerals"
 msgstr "大文字のローマ数字"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "ベータサイトを使う"
 
@@ -8307,7 +7925,7 @@ msgid "Username:"
 msgstr "ユーザー名:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr ""
 
@@ -8439,10 +8057,6 @@ msgstr ""
 msgid "Watched Artists"
 msgstr ""
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "申し訳ございませんが、只今このレポートのデータが入手不可能です。"
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "このカバーアートの履歴を表示できません。"
@@ -8488,10 +8102,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "申し訳ございません。暫くお待ちして、再びやり直してください。"
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "ウェブサイト"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "ウェブサイト:"
@@ -8504,7 +8114,7 @@ msgid ""
 "and following the merge link."
 msgstr ""
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8526,10 +8136,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "作品"
 
@@ -8568,35 +8178,32 @@ msgstr "作品:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "作品"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "注釈のある作品"
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "旧形式の関係がある作品"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "重複した関係を持つ可能性のある作品"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "作者"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8709,9 +8316,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr ""
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "現在購読中。{unsub|購読を解除}？"
 
@@ -8727,9 +8333,8 @@ msgstr ""
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr ""
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "現在購読していません。{sub|購読しますか}?"
 
@@ -8808,7 +8413,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr ""
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr ""
 
@@ -8833,7 +8438,7 @@ msgstr ""
 msgid "You must be logged in to vote on edits"
 msgstr "編集に投票するため、ログインしてください。"
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "この項目には曖昧さ回避コメントが必要です。"
 
@@ -8915,7 +8520,7 @@ msgstr ""
 msgid "Your username will be publicly visible."
 msgstr "ユーザー名は全体に公開されます。"
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8956,10 +8561,6 @@ msgstr "［不明］"
 
 #: ../root/edit/search_macros.tt:160
 msgid "after"
-msgstr ""
-
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
 msgstr ""
 
 #: ../root/edit/search_macros.tt:28
@@ -9022,10 +8623,6 @@ msgstr ""
 #: ../root/components/relationship-editor.tt:208
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
-msgstr ""
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
 msgstr ""
 
 #: ../root/admin/wikidoc/index.tt:53
@@ -9245,9 +8842,7 @@ msgstr ""
 msgid "places"
 msgstr ""
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "兼匿名ユーザー{n}名"
@@ -9462,7 +9057,7 @@ msgstr[0] ""
 msgid "{entity} has not been added to any collections."
 msgstr ""
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9476,7 +9071,7 @@ msgstr "{link}は評価がありません。"
 msgid "{link} has no relationships."
 msgstr "{link}は関連がありません。"
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainz ID\">MBID</abbr>}:"
 
@@ -9580,7 +9175,7 @@ msgstr ""
 msgid "{type} “{work}”"
 msgstr "{type}「{work}」"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr ""
 
@@ -9784,34 +9379,34 @@ msgstr "選挙ID {id} は無効です。"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "必須のTOCパラメータが無効、あるいは指定されませんでした。"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "与えられた CD TOC は有効ではありません。"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "与えられたメディアIDは有効ではありません。"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "このCD TOCは、既にこのメディアに接続されてます。"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "選択されたメディアはDisc IDに与えられません。"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "与えたアーティストIDは無効です。"
 
@@ -10193,7 +9788,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "トラック長をセット"
 
@@ -10493,6 +10088,12 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
 msgid "Failed dependency"
 msgstr ""
+
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "エラー"
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
@@ -10822,7 +10423,7 @@ msgid "These coordinates could not be parsed"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr ""
 
@@ -10926,13 +10527,13 @@ msgstr ""
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "CDスタブ"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "タグ"
@@ -10940,7 +10541,7 @@ msgstr "タグ"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "ドキュメント"
 
@@ -11200,7 +10801,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "寄付の確認"
 
@@ -11251,6 +10852,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr ""
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "メール"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11282,7 +10889,7 @@ msgid ""
 msgstr ""
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "設定"
 
@@ -11418,7 +11025,7 @@ msgstr ""
 msgid "Unconfirmed Email Address"
 msgstr ""
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr ""
 
@@ -11458,32 +11065,32 @@ msgid ""
 msgstr ""
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "出身地:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "結成:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "開始地域:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "死没:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "解散:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "終了地域:"
 
@@ -11503,23 +11110,23 @@ msgstr "コレクションが見つかりません"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr ""
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "開始日"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "終了日"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr ""
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity}に別名がありません。"
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr ""
 
@@ -11558,19 +11165,19 @@ msgstr[0] "投票の締め切りまで<span class=\"tooltip\" title=\"{exactdate
 msgid "Already expired"
 msgstr "既に締め切りました"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "プロフィール"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "購読中"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "ユーザーを編集"
 
@@ -11631,7 +11238,7 @@ msgid "For more information:"
 msgstr "詳細:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "メモを追加"
 
@@ -11810,6 +11417,20 @@ msgstr "投票"
 msgid "Votes cast"
 msgstr "投票数"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] ""
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] ""
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr ""
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "イベントがありません"
@@ -11836,7 +11457,7 @@ msgid ""
 "ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr ""
 
@@ -12076,6 +11697,11 @@ msgstr "イベントを追加"
 msgid "Vote on Edits"
 msgstr "編集の投票"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "レポート"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "初心者ガイド"
@@ -12116,23 +11742,23 @@ msgstr "全関連を表示"
 msgid "Running: {git_details}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "{n} ページ"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr ""
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: レーベル"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr ""
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: トラック"
 
@@ -12365,9 +11991,13 @@ msgstr "楽器の情報"
 msgid "Label information"
 msgstr "レーベルの情報"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "{date} に最終更新"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr ""
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12443,18 +12073,18 @@ msgid "see all ratings"
 msgstr "すべての評価を表示"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(なし)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(なし)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr ""
 
@@ -12623,11 +12253,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "{artist} のビデオ"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "{artist}のレコーディング"
 
@@ -12656,9 +12286,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "{artist}のリリースグループ"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "アーティストの注釈"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "このレポートは注釈のあるアーティストを表示します。"
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "アーティスト合計: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "名前に曖昧さ回避メモを含むアーティスト一覧"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr ""
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "名前と同じ曖昧さ回避メモを含むアーティスト一覧"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "グループであろうアーティスト"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr ""
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "人であろうアーティスト"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr ""
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr ""
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "購読者のないアーティスト一覧"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "このレポートは、購読者がいないためレビューが不足の可能性があるアーティストを表示します。リリースグループや未解決な編集が多いアーティストは最初に表示されます。"
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "コラボレーション"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "コラボレーター"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "旧形式の関係があるアーティスト"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "複数のアーティストに結合されたDiscogsのURL"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr ""
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "重複している可能性のあるアーティスト"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr ""
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "複製グループ合計: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr ""
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "選択されたアーティストをマージ"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "重複した関係を持つ可能性のあるアーティスト一覧"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr ""
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr ""
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "初心者/制限編集者"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr ""
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "コラボであろうアーティスト"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr ""
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "申し訳ございませんが、只今このレポートのデータが入手不可能です。"
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "コラボ関係があるアーティスト"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "コラボにみえるアーティスト"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "注釈のあるアーティスト"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "エディタ"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "重複している可能性のあるイベント"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "複数のレーベルに接続されたDiscogsのURL"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "注釈のあるレーベル"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "リリースグループ"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "複数のリリースグループに接続されたDiscogsのURL"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "注釈のあるリリースグループ"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "意外なAmazonリンクのあるリリース"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "ASINが複数あるリリース"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Discogsリンクが複数あるリリース"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "複数のリリースに接続されたAmazonのURL"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "複数のリリースに接続されたDiscogsのURL"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "別のリリースで入力されたディスク"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "非順次的なトラック番号のあるリリース"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "ASINに見えるカタログ番号のあるリリース"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "注釈のあるリリース"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "順序番号を含むトラック名"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "注釈のあるレコーディング"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "注釈のある場所"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "注釈のあるシリーズ"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "注釈のある作品"
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "ウェブサイト"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr ""
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12814,60 +12833,76 @@ msgstr ""
 msgid "{place_type}: {place_link}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "全ての編集に投票"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "ノートを削除"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "クレジットを以下で表示"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "クレジットをインラインで表示"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr ""
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr ""
 
@@ -12889,7 +12924,7 @@ msgstr "注釈は{date}に更新しました。"
 msgid "Show less..."
 msgstr ""
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "ウィキメディア・コモンズからの画像"
 
@@ -12906,67 +12941,84 @@ msgstr ""
 msgid "[missing editor]"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "すべてのタグを表示します。"
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "タグの追加"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "タグの送信"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "タグ"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Wikipediaで続きを読む…"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13084,21 +13136,21 @@ msgstr ""
 msgid "{begin_date} –"
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "開始:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "この方は死亡しました。"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "このグループは解散しました。"
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "必須な項目"
 
@@ -13158,9 +13210,9 @@ msgid ""
 "entity from the others."
 msgstr "この項目を他の項目と区別するために{doc_disambiguation|曖昧さ回避}を入力してください。"
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr ""
 
@@ -13173,7 +13225,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "入力したURLの種類を選択してください。"
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13190,7 +13242,7 @@ msgid "This relationship already exists."
 msgstr ""
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr ""
 
@@ -13210,7 +13262,7 @@ msgstr "ビデオ"
 msgid "Remove Link"
 msgstr "リンクの削除"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "大文字と小文字を推測"
 
@@ -13243,45 +13295,45 @@ msgid ""
 "language guidelines}. "
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "関係タイプをお選びください。"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "関係する二つのエンティティは異なっていなければなりません。"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
@@ -13289,17 +13341,17 @@ msgstr ""
 msgid "This attribute is required."
 msgstr "属性が必要です。"
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} レコーディングを選択"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} 作品を選択"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13316,64 +13368,64 @@ msgstr ""
 msgid "Page {page} of {total}"
 msgstr "{page}/{total} ページ"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "メディア {position}: {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "メディア {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "リリースを追加"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "リリースを編集"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "チェックディジットは {checkdigit} です。"
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "リリースのバーコードをご確認ください。"
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "入力したバーコードは、チェックディジットがないUPCコードのようです。"
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "入力したバーコードは、有効なUPCコードです。"
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "入力したバーコードは、無効なUPCコードあるいはチェックディジットのないEANコードです。"
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "入力したバーコードは、有効なEANコードです。"
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "入力したバーコードは、有効なEANコードではありません。"
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "入力したバーコードは、有効なUPCコードないしEANコードではありません。"
 
@@ -13381,7 +13433,7 @@ msgstr "入力したバーコードは、有効なUPCコードないしEANコー
 msgid "Add Language"
 msgstr "言語を追加"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "言語を削除"
 

--- a/po/mb_server.nl.po
+++ b/po/mb_server.nl.po
@@ -28,8 +28,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 18:31+0100\n"
-"PO-Revision-Date: 2019-01-22 10:54+0000\n"
+"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"PO-Revision-Date: 2019-03-01 09:51+0000\n"
 "Last-Translator: Maurits Meulenbelt <email address hidden>\n"
 "Language-Team: Dutch (http://www.transifex.com/musicbrainz/musicbrainz/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -189,6 +189,7 @@ msgstr "(geen)"
 #: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
 #: ../lib/MusicBrainz/Server/Entity/Release.pm:176
+#: ../root/entity/Details.js:79
 msgid "(unknown)"
 msgstr "(onbekend)"
 
@@ -395,7 +396,7 @@ msgstr "Accountbeheerders"
 msgid "Account administrators can edit and delete user accounts."
 msgstr "Accountbeheerders kunnen accounts bewerken en verwijderen."
 
-#: ../root/entity/details.tt:41
+#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
 msgid "AcousticBrainz entry:"
 msgstr "AcousticBrainz-lemma:"
 
@@ -405,7 +406,7 @@ msgstr "AcousticBrainz-lemma:"
 #: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:33
 msgid "Actions"
 msgstr "Acties"
 
@@ -590,10 +591,6 @@ msgstr "Gerelateerde compositie toevoegen"
 msgid "Add relationship"
 msgstr "Relatie toevoegen"
 
-#: ../root/report/duplicate_artists.tt:51
-msgid "Add selected artists for merging"
-msgstr "Geselecteerde artiesten samenvoegen"
-
 #: ../root/artist/events.tt:8 ../root/place/events.tt:8
 msgid "Add selected events for merging"
 msgstr "Geselecteerde evenementen samenvoegen"
@@ -666,7 +663,7 @@ msgstr "Leeftijd:"
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:24
+#: ../root/components/Aliases/AliasTable.js:26
 msgid "Alias"
 msgstr "Alias"
 
@@ -686,9 +683,10 @@ msgstr "Alias:"
 #: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
 #: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
 #: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/release_group/aliases.tt:1
-#: ../root/series/aliases.tt:1 ../root/work/aliases.tt:1
-#: ../root/components/Aliases/index.js:27 ../root/components/EntityTabs.js:88
+#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
+#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
+#: ../root/components/EntityTabs.js:89
+#: ../root/release_group/ReleaseGroupAliases.js:23
 msgid "Aliases"
 msgstr "Aliassen"
 
@@ -736,26 +734,21 @@ msgstr "Treedt ook op als"
 msgid "Amazon URLs Linked to Multiple Releases"
 msgstr "URL’s van Amazon die aan meerdere uitgaves zijn gekoppeld"
 
-#: ../root/report/index.tt:86
-msgid "Amazon URLs linked to multiple releases"
-msgstr "URL’s van Amazon die aan meerdere uitgaves zijn gekoppeld"
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:29
+#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr "Een alias is een alternatieve naam voor een object. Dit is meestal een gebruikelijke spelfout of naamvariatie en het wordt ook gebruikt om de zoekresultaten te verbeteren. Zie de {doc|aliasdocumentatie} voor meer details."
 
-#: ../root/artist/subscribers.tt:17 ../root/collection/subscribers.tt:17
-#: ../root/label/subscribers.tt:17 ../root/series/subscribers.tt:17
-#: ../root/user/subscribers.tt:17
+#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
+#: ../root/entity/Subscribers.js:69
 msgid "An anonymous user"
 msgid_plural "{n} anonymous users"
 msgstr[0] "Eén anonieme gebruiker"
 msgstr[1] "{n} anonieme gebruikers"
 
-#: ../root/components/common-macros.tt:955
+#: ../root/components/common-macros.tt:950
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a"
 " unique disambiguation comment."
@@ -777,8 +770,7 @@ msgstr "Er is een fout opgetreden:"
 msgid "An error occurred while creating the works."
 msgstr "Er trad een fout op bij het toevoegen van de composities."
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_artists.tt:13
-#: ../root/report/annotations_labels.tt:13
+#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
 #: ../root/report/annotations_release_groups.tt:13
@@ -787,8 +779,9 @@ msgstr "Er trad een fout op bij het toevoegen van de composities."
 #: ../root/report/annotations_works.tt:13
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
+#: ../root/report/components/ArtistAnnotationList.js:29
 #: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:45
+#: ../root/search/components/SearchForm.js:46
 #: ../root/static/scripts/common/components/Annotation.js:59
 msgid "Annotation"
 msgstr "Aantekening"
@@ -922,11 +915,11 @@ msgstr "Weet je zeker dat je de serie {series} wil verwijderen van MusicBrainz?"
 #: ../root/report/places_without_coordinates.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:22 ../root/layout/components/Search.js:29
+#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
 #: ../root/search/components/ArtistResults.js:69
 #: ../root/search/components/LabelResults.js:65
 #: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:43
+#: ../root/search/components/SearchForm.js:44
 #: ../root/static/scripts/common/i18n.js:53
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
 msgid "Area"
@@ -977,24 +970,27 @@ msgstr "Gebieden"
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/artist_list.tt:7
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:17
-#: ../root/report/artist_url_list.tt:6 ../root/report/bad_amazon_urls.tt:19
+#: ../root/report/bad_amazon_urls.tt:19
 #: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/duplicate_artists.tt:25
 #: ../root/report/isrc_with_many_recordings.tt:24
 #: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
 #: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
 #: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:30 ../root/isrc/Index.js:55
+#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
 #: ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
+#: ../root/report/DuplicateArtists.js:66
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/ArtistList.js:27
+#: ../root/report/components/ArtistRelationshipList.js:29
+#: ../root/report/components/ArtistURLList.js:30
 #: ../root/search/components/CDStubResults.js:49
 #: ../root/search/components/RecordingResults.js:124
 #: ../root/search/components/ReleaseGroupResults.js:62
 #: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:37
+#: ../root/search/components/SearchForm.js:38
 #: ../root/static/scripts/common/i18n.js:54
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 #: ../root/taglookup/Form.js:25
@@ -1040,11 +1036,6 @@ msgstr "Artiest-MBID"
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr "Abonnementen op artiesten"
-
-#: ../root/report/annotations_artists.tt:1
-#: ../root/report/annotations_artists.tt:3
-msgid "Artist annotations"
-msgstr "Artiesten met aantekeningen"
 
 #: ../root/components/filter-form.tt:11
 msgid "Artist credit:"
@@ -1092,7 +1083,7 @@ msgstr "Artiest {n}:"
 #: ../root/taglookup/form.tt:4
 #: ../root/layout/components/sidebar/RecordingSidebar.js:45
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
-#: ../root/static/scripts/edit/components/forms.js:18
+#: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr "Artiest:"
 
@@ -1100,81 +1091,15 @@ msgstr "Artiest:"
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
 #: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/index.tt:14
-#: ../root/report/iswc_with_many_works.tt:21 ../root/work/merge.tt:13
-#: ../root/components/EntityTabs.js:20 ../root/iswc/Index.js:52
+#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
+#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
+#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
 #: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51 ../root/tag/TagIndex.js:81
-#: ../root/tag/TagLayout.js:27
+#: ../root/search/components/WorkResults.js:51
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
 msgid "Artists"
 msgstr "Artiesten"
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:1
-#: ../root/report/artists_containing_disambiguation_comments.tt:3
-#: ../root/report/index.tt:23
-msgid "Artists containing disambiguation comments in their name"
-msgstr "Artiesten met een verduidelijking in de naam"
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:1
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:3
-#: ../root/report/index.tt:26
-msgid "Artists occuring multiple times in the same artist credit"
-msgstr "Artiesten die meerdere keren als artiest van één nummer of opname worden vermeld."
-
-#: ../root/report/possible_collaborations.tt:1
-#: ../root/report/possible_collaborations.tt:3
-msgid "Artists that may be collaborations"
-msgstr "Artiesten die samenwerkingen zouden kunnen zijn"
-
-#: ../root/report/artists_that_may_be_groups.tt:1
-#: ../root/report/artists_that_may_be_groups.tt:3 ../root/report/index.tt:17
-msgid "Artists that may be groups"
-msgstr "Artiesten die groepen zouden kunnen zijn"
-
-#: ../root/report/artists_that_may_be_persons.tt:1
-#: ../root/report/artists_that_may_be_persons.tt:3 ../root/report/index.tt:18
-msgid "Artists that may be persons"
-msgstr "Artiesten die een persoon zouden kunnen zijn"
-
-#: ../root/report/index.tt:21
-msgid "Artists which have collaboration relationships"
-msgstr "Artiesten met samenwerkingsrelaties"
-
-#: ../root/report/index.tt:22
-msgid "Artists which look like collaborations"
-msgstr "Artiesten die samenwerkingen lijken te zijn"
-
-#: ../root/report/collaboration_relationships.tt:1
-#: ../root/report/collaboration_relationships.tt:3
-msgid "Artists with Collaboration Relationships"
-msgstr "Artiesten met samenwerkingsrelaties"
-
-#: ../root/report/index.tt:28
-msgid "Artists with annotations"
-msgstr "Artiesten met aantekeningen"
-
-#: ../root/report/deprecated_relationship_artists.tt:1
-#: ../root/report/deprecated_relationship_artists.tt:3
-#: ../root/report/index.tt:27
-msgid "Artists with deprecated relationships"
-msgstr "Artiesten met verouderde relaties"
-
-#: ../root/report/artists_disambiguation_same_name.tt:1
-#: ../root/report/artists_disambiguation_same_name.tt:3
-#: ../root/report/index.tt:29
-msgid "Artists with disambiguation the same as the name"
-msgstr "Artiesten met een verduidelijking die gelijk is aan de naam"
-
-#: ../root/report/artists_with_no_subscribers.tt:1
-#: ../root/report/artists_with_no_subscribers.tt:3 ../root/report/index.tt:19
-msgid "Artists with no subscribers"
-msgstr "Artiesten zonder abonnees"
-
-#: ../root/report/duplicate_relationships_artists.tt:1
-#: ../root/report/duplicate_relationships_artists.tt:3
-#: ../root/report/index.tt:25
-msgid "Artists with possible duplicate relationships"
-msgstr "Artiesten met mogelijk dubbele relaties"
 
 #: ../root/recording/fingerprints.tt:3
 msgid "Associated AcoustIDs"
@@ -1339,9 +1264,8 @@ msgstr "Een partij relaties aan composities toevoegen"
 msgid "Batch-create new works"
 msgstr "Een partij nieuwe composities toevoegen"
 
-#: ../root/artist/subscribers.tt:30 ../root/collection/subscribers.tt:30
-#: ../root/label/subscribers.tt:30 ../root/series/subscribers.tt:30
-#: ../root/user/subscribers.tt:35
+#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
+#: ../root/entity/Subscribers.js:94
 msgid "Be the first! {sub|Subscribe}?"
 msgstr "Wees de eerste! {sub|Abonneren}?"
 
@@ -1399,21 +1323,12 @@ msgstr "Begindatum:"
 msgid "Beginner"
 msgstr "Beginner"
 
-#: ../root/report/index.tt:36 ../root/report/limited_editors.tt:1
-#: ../root/report/limited_editors.tt:3
-msgid "Beginner/limited editors"
-msgstr "Beginners / beperkte redacteurs"
-
 #: ../root/search/error/internal-error.tt:6
 msgid ""
 "Below is the error information. If you wish to file a bug report, you may do"
 " so at {bugs|our bug tracker}. The information below will help, so please be"
 " sure to include it!"
-msgstr "Hieronder staat informatie over de foutmelding. Als je deze fout wil rapporteren, kan je dat doen op {bugs|onze bugtracker}. Voeg de onderstaande informatie alsjeblieft toe aan het rapport. Dit help ons om het op te lossen!"
-
-#: ../root/report/editor_list.tt:11
-msgid "Bio"
-msgstr "Bio"
+msgstr "Hieronder staat informatie over de foutmelding. Als je deze fout wil melden, kan je dat doen op {bugs|onze bugtracker}. Voeg de onderstaande informatie aan de melding toe. Dit help ons om het probleem op te lossen!"
 
 #: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
 #: ../root/user/profile.tt:137
@@ -1424,12 +1339,12 @@ msgstr "Biografie:"
 msgid "Birth date:"
 msgstr "Geboortedatum:"
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
 msgid "Blog"
 msgstr "Weblog"
 
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born:"
 msgstr "Geboren:"
 
@@ -1441,13 +1356,13 @@ msgstr "Robot"
 msgid "Bots"
 msgstr "Robots"
 
-#: ../root/layout.tt:128 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr "Aangeboden door de {MeB|MetaBrainz Foundation} en onze {spon|sponsors} en {supp|partners}. Hoesafbeeldingen worden geleverd door het {caa|Cover Art Archive}."
 
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:28
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
 #: ../root/main/index.js:142
 msgid "Bug Tracker"
 msgstr "Bugtracker"
@@ -1592,7 +1507,7 @@ msgstr "Catalogus#"
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/components/UserAccountTabs.js:61
 msgid "Change Password"
 msgstr "Wachtwoord veranderen"
 
@@ -1671,14 +1586,6 @@ msgstr "Afgesloten"
 msgid "Code"
 msgstr "Code"
 
-#: ../root/report/collaboration_relationships.tt:19
-msgid "Collaboration"
-msgstr "Samenwerking"
-
-#: ../root/report/collaboration_relationships.tt:20
-msgid "Collaborator"
-msgstr "Samenwerker"
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr "Medium inklappen"
@@ -1707,7 +1614,7 @@ msgstr "Collectie ‘{collection}’"
 
 #: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
 #: ../root/layout/components/sidebar/CollectionLinks.js:27
 msgid "Collections"
 msgstr "Collecties"
@@ -1785,7 +1692,7 @@ msgid "Country:"
 msgstr "Land:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
 msgid "Cover Art"
 msgstr "Afbeelding(en)"
 
@@ -1917,7 +1824,7 @@ msgstr "Data hebben de opmaak JJJJ-MM-DD. Gedeeltelijke data zoals JJJJ-MM of al
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
 msgid "Delete Account"
 msgstr "Account verwijderen"
 
@@ -1969,13 +1876,14 @@ msgstr "Omschrijving:"
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
 #: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:96
-#: ../root/elections/ElectionDetails.js:26
+#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
+#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
+#: ../root/entity/Details.js:61
 msgid "Details"
 msgstr "Details"
 
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died:"
 msgstr "Overleden:"
 
@@ -1985,7 +1893,7 @@ msgstr "Verschillen"
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:67
+#: ../root/search/components/SearchForm.js:68
 msgid "Direct database search"
 msgstr "Direct in de database zoeken"
 
@@ -2042,7 +1950,7 @@ msgid "Disc ID:"
 msgstr "Disc-ID:"
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
 msgid "Disc IDs"
 msgstr "Disc-ID’s"
 
@@ -2062,11 +1970,6 @@ msgstr "Mediumtitel:"
 msgid "Discography"
 msgstr "Discografie"
 
-#: ../root/report/discogs_links_with_multiple_artists.tt:1
-#: ../root/report/discogs_links_with_multiple_artists.tt:3
-msgid "Discogs URLs Linked to Multiple Artists"
-msgstr "URL’s van Discogs die aan meerdere artiesten zijn gekoppeld"
-
 #: ../root/report/discogs_links_with_multiple_labels.tt:1
 #: ../root/report/discogs_links_with_multiple_labels.tt:3
 msgid "Discogs URLs Linked to Multiple Labels"
@@ -2082,32 +1985,12 @@ msgstr "URL’s van Discogs die aan meerdere uitgavegroepen zijn gekoppeld"
 msgid "Discogs URLs Linked to Multiple Releases"
 msgstr "URL’s van Discogs die aan meerdere uitgaves zijn gekoppeld"
 
-#: ../root/report/index.tt:24
-msgid "Discogs URLs linked to multiple artists"
-msgstr "URL’s van Discogs die aan meerdere artiesten zijn gekoppeld"
-
-#: ../root/report/index.tt:56
-msgid "Discogs URLs linked to multiple labels"
-msgstr "URL’s van Discogs die aan meerdere platenmaatschappijen zijn gekoppeld"
-
-#: ../root/report/index.tt:68
-msgid "Discogs URLs linked to multiple release groups"
-msgstr "URL’s van Discogs die aan meerdere uitgavegroepen zijn gekoppeld"
-
-#: ../root/report/index.tt:87
-msgid "Discogs URLs linked to multiple releases"
-msgstr "URL’s van Discogs die aan meerdere uitgaves zijn gekoppeld"
-
 #: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
 msgid "Discs as Separate Releases"
 msgstr "Media als afzonderlijke uitgaves"
 
-#: ../root/report/index.tt:89
-msgid "Discs entered as separate releases"
-msgstr "Media die als afzonderlijke uitgaves zijn toegevoegd"
-
 #: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved:"
 msgstr "Opgeheven:"
 
@@ -2125,7 +2008,7 @@ msgstr "Documentatie:"
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr "Heb je geen account? {uri|Maak er dan nu een aan}!"
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
 msgid "Donate"
 msgstr "Doneren"
 
@@ -2156,9 +2039,9 @@ msgstr "Elk nummer op MusicBrainz moet gekoppeld zijn aan een opname. Kies de pa
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
 #: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
 #: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
-#: ../root/components/Aliases/AliasTableRow.js:56
-#: ../root/components/EntityTabs.js:103
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:401
+#: ../root/components/Aliases/AliasTableRow.js:57
+#: ../root/components/EntityTabs.js:104
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
 msgid "Edit"
 msgstr "Bewerken"
 
@@ -2211,7 +2094,7 @@ msgid "Edit Note Author"
 msgstr "Schrijver van de bewerkingsnotitie"
 
 #: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:58
+#: ../root/components/UserAccountTabs.js:59
 msgid "Edit Profile"
 msgstr "Profiel bewerken"
 
@@ -2286,10 +2169,10 @@ msgid "Editing/voting disabled"
 msgstr "Bewerken en stemmen uitgeschakeld"
 
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
-#: ../root/report/editor_list.tt:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/search/components/SearchForm.js:47
+#: ../root/report/components/EditorList.js:27
+#: ../root/search/components/SearchForm.js:48
 msgid "Editor"
 msgstr "Redacteur"
 
@@ -2305,10 +2188,6 @@ msgstr "Abonnementen op redacteurs"
 #: ../root/components/UserAccountLayout.js:37
 msgid "Editor “{user}”"
 msgstr "Redacteur ‘{user}’"
-
-#: ../root/report/index.tt:33
-msgid "Editors"
-msgstr "Redacteurs"
 
 #: ../root/user/edits.tt:1
 msgid "Edits"
@@ -2337,12 +2216,6 @@ msgstr "Bewerkingen voor {name}"
 #: ../root/main/500.tt:11
 msgid "Edits loaded for the page:"
 msgstr "Voor de pagina geladen bewerkinen:"
-
-#: ../root/report/editor_list.tt:10 ../root/account/LostPassword.js:43
-#: ../root/account/LostUsername.js:35
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
-msgid "Email"
-msgstr "E-mail"
 
 #: ../root/user/email_sent.tt:1 ../root/user/email_sent.tt:3
 msgid "Email Sent"
@@ -2402,7 +2275,7 @@ msgstr "Beëindigd"
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Ended:"
 msgstr "Beëindigd:"
 
@@ -2445,11 +2318,6 @@ msgstr "Objecttype"
 #: ../root/edit/details/edit_relationship_type.tt:6
 msgid "Entity types:"
 msgstr "Objecttypes:"
-
-#: ../root/report/not_available.tt:1 ../root/report/not_available.tt:3
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277 ../root/utility/edit.js:42
-msgid "Error"
-msgstr "Fout"
 
 #: ../root/edit/cannot_approve.tt:1 ../root/edit/cannot_approve.tt:2
 #: ../root/edit/require_note.tt:1 ../root/edit/require_note.tt:2
@@ -2499,8 +2367,8 @@ msgstr "Alleen al één of twee URL’s toevoegen helpt!"
 #: ../root/event/merge.tt:11 ../root/report/event_list.tt:7
 #: ../root/series/index.tt:15 ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:25 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:51
+#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
+#: ../root/search/components/SearchForm.js:52
 #: ../root/static/scripts/common/i18n.js:55
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Event"
@@ -2527,13 +2395,14 @@ msgstr "Evenement:"
 #: ../root/artist/events.tt:1 ../root/artist/events.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/report/index.tt:40 ../root/components/EntityTabs.js:23
+#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
 #: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
 msgid "Events"
 msgstr "Evenementen"
 
 #: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3 ../root/report/index.tt:44
+#: ../root/report/event_sequence_not_in_series.tt:3
+#: ../root/report/ReportsIndex.js:62
 msgid "Events which should be part of series or larger event"
 msgstr "Evenementen die in een serie of een groter evenement thuishoren"
 
@@ -2614,7 +2483,7 @@ msgid "Find Relationships"
 msgstr "Gevonden relaties"
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:24
+#: ../root/components/EntityTabs.js:25
 msgid "Fingerprints"
 msgstr "Vingerafdrukken"
 
@@ -2663,7 +2532,7 @@ msgstr "Lees de {doc_doc|documentatie} en {doc_styleguide|stijlgids} voor meer i
 
 #: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
 #: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:106
+#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr "Lees de {doc_doc|documentatie} voor meer informatie."
 
@@ -2695,7 +2564,7 @@ msgstr "Type medium"
 msgid "Format:"
 msgstr "Type medium:"
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:26
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
 #: ../root/main/index.js:143
 msgid "Forums"
 msgstr "Forum"
@@ -2714,13 +2583,13 @@ msgstr "Voorwaartse koppelzin:"
 msgid ""
 "Found a broken link on our site? Please let us know by {report|reporting a "
 "bug}."
-msgstr "Heb je op onze site een kapotte link gevonden? Laat het ons alsjeblieft weten door {report|een bug te rapporteren}."
+msgstr "Heb je op onze site een kapotte link gevonden? Laat het ons weten door {report|een bug te melden}."
 
 #: ../root/main/400.tt:16
 msgid ""
 "Found a problem on our site? Please {report|report a bug} and include any "
 "error message that is shown above."
-msgstr "Heb je op onze site een probleem gevonden? {report|Rapporteer het alsjeblieft} en voeg elke foutmelding toe die hierboven wordt weergegeven."
+msgstr "Heb je op onze site een probleem gevonden? {report|Laat het ons weten} en voeg elke foutmelding toe die hierboven wordt weergegeven."
 
 #: ../root/edit/list.tt:29
 msgid "Found at least {n} edit"
@@ -2751,7 +2620,7 @@ msgstr[1] "{n} resultaten gevonden voor ‘{q}’"
 #: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
 #: ../root/layout/components/MetaDescription.js:87
 #: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded:"
 msgstr "Opgericht:"
 
@@ -2807,7 +2676,6 @@ msgstr "Geslacht:"
 msgid "General Information"
 msgstr "Algemene informatie"
 
-#: ../root/report/annotations_artists.tt:9
 #: ../root/report/annotations_labels.tt:9
 #: ../root/report/annotations_places.tt:9
 #: ../root/report/annotations_recordings.tt:9
@@ -2815,17 +2683,9 @@ msgstr "Algemene informatie"
 #: ../root/report/annotations_releases.tt:9
 #: ../root/report/annotations_series.tt:9
 #: ../root/report/annotations_works.tt:9
-#: ../root/report/artists_containing_disambiguation_comments.tt:9
-#: ../root/report/artists_disambiguation_same_name.tt:9
-#: ../root/report/artists_that_may_be_groups.tt:12
-#: ../root/report/artists_that_may_be_persons.tt:13
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:9
-#: ../root/report/artists_with_no_subscribers.tt:8
 #: ../root/report/asins_with_multiple_releases.tt:16
 #: ../root/report/bad_amazon_urls.tt:11
 #: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/collaboration_relationships.tt:11
-#: ../root/report/deprecated_relationship_artists.tt:9
 #: ../root/report/deprecated_relationship_labels.tt:9
 #: ../root/report/deprecated_relationship_places.tt:9
 #: ../root/report/deprecated_relationship_recordings.tt:9
@@ -2833,13 +2693,10 @@ msgstr "Algemene informatie"
 #: ../root/report/deprecated_relationship_releases.tt:9
 #: ../root/report/deprecated_relationship_urls.tt:9
 #: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_artists.tt:8
 #: ../root/report/discogs_links_with_multiple_labels.tt:8
 #: ../root/report/discogs_links_with_multiple_release_groups.tt:8
 #: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_artists.tt:15
 #: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_artists.tt:10
 #: ../root/report/duplicate_relationships_labels.tt:9
 #: ../root/report/duplicate_relationships_recordings.tt:8
 #: ../root/report/duplicate_relationships_release_groups.tt:9
@@ -2854,13 +2711,11 @@ msgstr "Algemene informatie"
 #: ../root/report/isrc_with_many_recordings.tt:15
 #: ../root/report/iswc_with_many_works.tt:10
 #: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/limited_editors.tt:9
 #: ../root/report/mediums_with_sequence_issues.tt:8
 #: ../root/report/multiple_asins.tt:12
 #: ../root/report/multiple_discogs_links.tt:15
 #: ../root/report/part_of_set_relationships.tt:14
 #: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/possible_collaborations.tt:14
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:11
 #: ../root/report/recordings_with_earliest_release_relationships.tt:12
 #: ../root/report/recordings_without_va_credit.tt:9
@@ -2891,13 +2746,27 @@ msgstr "Algemene informatie"
 #: ../root/report/tracks_without_times.tt:8
 #: ../root/report/tracks_with_sequence_issues.tt:10
 #: ../root/report/unlinked_pseudo_releases.tt:8
+#: ../root/report/AnnotationsArtists.js:37
+#: ../root/report/ArtistsContainingDisambiguationComments.js:38
+#: ../root/report/ArtistsDisambiguationSameName.js:38
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
+#: ../root/report/ArtistsWithNoSubscribers.js:39
+#: ../root/report/CollaborationRelationships.js:45
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateArtists.js:55
+#: ../root/report/DuplicateRelationshipsArtists.js:38
+#: ../root/report/LimitedEditors.js:37
+#: ../root/report/PossibleCollaborations.js:43
 msgid "Generated on {date}"
 msgstr "Aangemaakt op {date}"
 
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:69
-#: ../root/static/scripts/common/components/TagEditor.js:440
-#: ../root/static/scripts/common/components/TagEditor.js:496
+#: ../root/layout/components/sidebar/SidebarTags.js:70
+#: ../root/static/scripts/common/components/TagEditor.js:455
+#: ../root/static/scripts/common/components/TagEditor.js:540
 msgid "Genres"
 msgstr "Genres"
 
@@ -3096,13 +2965,15 @@ msgstr "ISRC {isrc} naar {recording}"
 msgid "ISRC:"
 msgstr "ISRC:"
 
-#: ../root/components/recordings-list.tt:28 ../root/report/index.tt:162
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
 #: ../root/search/components/RecordingResults.js:125
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
 msgid "ISRCs"
 msgstr "ISRC’s"
 
-#: ../root/report/index.tt:165 ../root/report/isrc_with_many_recordings.tt:1
+#: ../root/report/isrc_with_many_recordings.tt:1
 #: ../root/report/isrc_with_many_recordings.tt:3
+#: ../root/report/ReportsIndex.js:180
 msgid "ISRCs with multiple recordings"
 msgstr "ISRC’s met meerdere opnames"
 
@@ -3126,12 +2997,8 @@ msgstr "ISWC {iswc} naar {work}"
 msgid "ISWC:"
 msgstr "ISWC:"
 
-#: ../root/report/index.tt:168
-msgid "ISWCs"
-msgstr "ISWC’s"
-
-#: ../root/report/index.tt:171 ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3
+#: ../root/report/iswc_with_many_works.tt:1
+#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
 msgid "ISWCs with multiple works"
 msgstr "ISWC’s met meerdere composities"
 
@@ -3144,7 +3011,7 @@ msgstr "ISWC’s:"
 msgid ""
 "If the problem persists, please {report|report a bug} and include any error "
 "message that is shown above."
-msgstr "{report|Rapporteer een bug} als het probleem zich blijft voordoen, en voeg dan elke foutmelding toe die hierboven wordt weergegeven."
+msgstr "Als het probleem zich blijft voordoen, {report|kun je een bug melden}; voeg elke foutmelding die je hierboven ziet aan de bug toe."
 
 #: ../root/release/edit/information.tt:291
 msgid ""
@@ -3189,7 +3056,7 @@ msgstr "Als je de uitgave die je zoekt niet kan vinden, kan je een nieuwe toevoe
 msgid ""
 "If you followed a link on our site to get here, please {report|report a bug}"
 " and the URL of the page that sent you here."
-msgstr "{report|Rapporteer een bug} als je hier via een link op onze site bent gekomen, en voeg de URL van de pagina die je hierheen stuurde, toe aan het rapport."
+msgstr "{report|Meld een bug} als je hier via een link op onze site bent gekomen, en voeg de URL van de pagina die je hierheen stuurde aan de melding toe."
 
 #: ../root/account/register.tt:50
 msgid ""
@@ -3203,20 +3070,11 @@ msgid ""
 "<code>support@musicbrainz.org</code> with the name of your account."
 msgstr "Neem, als je denkt dat dit een fout is, contact <code>support@musicbrainz.org</code> met ons op onder vermelding van je gebruikersnaam."
 
-#: ../root/report/index.tt:6
-msgid ""
-"If you'd like to participate in the editing process, but do not know where "
-"to start, the following reports should be useful. These reports scour the "
-"database looking for data that might require fixing, either to comply with "
-"the {style|style guidelines}, or in other cases where administrative \"clean"
-" up\" tasks are required."
-msgstr "Als je mee wil helpen om MusicBrainz te verbeteren, maar niet weet waar je moet beginnen, kunnen deze rapporten je helpen. In deze rapporten staan gegevens die misschien verbeterd moeten worden, bijvoorbeeld om ze te laten voldoen aan onze {style|stijlgids} of vanwege een administratieve opruiming."
-
 #: ../root/user/report.tt:10
 msgid ""
 "If you’d like us to be able to easily respond to your report, please check "
 "“Reveal my email address” below."
-msgstr "Als je wil dat we makkelijk op je rapport kunnen reageren, moet je hieronder “Toon mijn e-mailadres” aanvinken."
+msgstr "Als je wil dat we makkelijk op je melding kunnen reageren, moet je hieronder “Toon mijn e-mailadres” aanvinken."
 
 #: ../root/components/common-macros.tt:92 ../root/components/Artwork.js:45
 msgid "Image not available yet, please try again in a few minutes."
@@ -3249,11 +3107,11 @@ msgstr "Incorrecte gebruikersnaam of wachtwoord"
 
 #: ../root/search/form.tt:24
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:60
+#: ../root/search/components/SearchForm.js:61
 msgid "Indexed search"
 msgstr "Geïndexeerd zoeken"
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:62
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr "Geïndexeerd zoeken met {doc|geavanceerde zoeksyntaxis}"
 
@@ -3264,7 +3122,7 @@ msgstr "Geïndexeerd zoeken met {doc|geavanceerde zoeksyntaxis}"
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:50
 #: ../root/static/scripts/common/i18n.js:56
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Instrument"
@@ -3289,13 +3147,14 @@ msgstr "Details van het instrument"
 msgid "Instrument:"
 msgstr "Instrument:"
 
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:47
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
 #: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
 msgid "Instruments"
 msgstr "Instrumenten"
 
-#: ../root/report/index.tt:50 ../root/report/instruments_without_an_image.tt:1
+#: ../root/report/instruments_without_an_image.tt:1
 #: ../root/report/instruments_without_an_image.tt:3
+#: ../root/report/ReportsIndex.js:68
 msgid "Instruments without an image"
 msgstr "Instrumenten zonder afbeelding"
 
@@ -3361,9 +3220,9 @@ msgstr "Aangemeld blijven"
 #: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
 #: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:42
+#: ../root/search/components/SearchForm.js:43
 #: ../root/static/scripts/common/i18n.js:57
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Label"
@@ -3424,31 +3283,28 @@ msgstr "Platenmaatschappij:"
 
 #: ../root/area/labels.tt:1 ../root/area/labels.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:53 ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:26
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:32
+#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
+#: ../root/tag/TagLayout.js:32
 msgid "Labels"
 msgstr "Platenmaatschappijen"
 
-#: ../root/report/index.tt:59
-msgid "Labels with annotations"
-msgstr "Platenmaatschappijen met aantekeningen"
-
 #: ../root/report/deprecated_relationship_labels.tt:1
 #: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/index.tt:58
+#: ../root/report/ReportsIndex.js:76
 msgid "Labels with deprecated relationships"
 msgstr "Platenmaatschappijen met verouderde relaties"
 
-#: ../root/report/index.tt:60
 #: ../root/report/labels_disambiguation_same_name.tt:1
 #: ../root/report/labels_disambiguation_same_name.tt:3
+#: ../root/report/ReportsIndex.js:78
 msgid "Labels with disambiguation the same as the name"
 msgstr "Platenmaatschappijen met een verduidelijking die gelijk is aan de naam"
 
 #: ../root/report/duplicate_relationships_labels.tt:1
 #: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/index.tt:57
+#: ../root/report/ReportsIndex.js:75
 msgid "Labels with possible duplicate relationships"
 msgstr "Platenmaatschappijen met mogelijk dubbele relaties"
 
@@ -3489,7 +3345,6 @@ msgstr "Afgelopen 24 uur"
 msgid "Last 28 days"
 msgstr "Afgelopen 28 dagen"
 
-#: ../root/report/annotations_artists.tt:13
 #: ../root/report/annotations_labels.tt:13
 #: ../root/report/annotations_places.tt:12
 #: ../root/report/annotations_recordings.tt:13
@@ -3497,6 +3352,7 @@ msgstr "Afgelopen 28 dagen"
 #: ../root/report/annotations_releases.tt:13
 #: ../root/report/annotations_series.tt:13
 #: ../root/report/annotations_works.tt:13
+#: ../root/report/components/ArtistAnnotationList.js:30
 msgid "Last edited"
 msgstr "Laatst bewerkt op"
 
@@ -3504,7 +3360,7 @@ msgstr "Laatst bewerkt op"
 msgid "Last login:"
 msgstr "Laatste aanmelding:"
 
-#: ../root/layout.tt:122 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
 msgid "Last replication packet received at {datetime}"
 msgstr "Laatste replicatiepakket ontvangen op {datetime}"
 
@@ -3512,7 +3368,7 @@ msgstr "Laatste replicatiepakket ontvangen op {datetime}"
 msgid "Last updated"
 msgstr "Laatste bewerking"
 
-#: ../root/entity/details.tt:16
+#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
 msgid "Last updated:"
 msgstr "Het laatst bijgewerkt:"
 
@@ -3582,14 +3438,14 @@ msgid "Loading edit previews..."
 msgstr "Voorvertoningen van de bewerkingen worden geladen …"
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:57
-#: ../root/static/scripts/common/dialogs.js:14
+#: ../root/static/scripts/common/MB/release.js:59
+#: ../root/static/scripts/common/dialogs.js:16
 msgid "Loading..."
 msgstr "Aan het laden …"
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:31
 msgid "Locale"
 msgstr "Lokalisatie"
 
@@ -3599,6 +3455,7 @@ msgstr "Lokalisatie"
 
 #: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
 #: ../root/search/components/EventResults.js:76
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
 msgid "Location"
 msgstr "Locatie"
 
@@ -3671,7 +3528,7 @@ msgstr "Laag"
 #: ../root/layout/components/MetaDescription.js:148
 #: ../root/layout/components/sidebar/WorkSidebar.js:64
 #: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:289
+#: ../root/static/scripts/work.js:290
 msgid "Lyrics Languages"
 msgstr "Talen van de tekst"
 
@@ -3706,7 +3563,7 @@ msgid "Many relationships"
 msgstr "Veel relaties"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:26
+#: ../root/components/EntityTabs.js:27
 msgid "Map"
 msgstr "Kaart"
 
@@ -3767,10 +3624,6 @@ msgstr "Medium:"
 #: ../root/edit/details/set_track_lengths.tt:5
 msgid "Mediums:"
 msgstr "Media:"
-
-#: ../root/report/editor_list.tt:8
-msgid "Member since"
-msgstr "Lid sinds"
 
 #: ../root/user/profile.tt:86
 msgid "Member since:"
@@ -3882,7 +3735,7 @@ msgstr "Populairst"
 msgid "Most Recent"
 msgstr "Meest recent"
 
-#: ../root/cdtoc/list.tt:55 ../root/release/discids.tt:39
+#: ../root/cdtoc/list.tt:57 ../root/release/discids.tt:39
 msgid "Move"
 msgstr "Verplaatsen"
 
@@ -4011,7 +3864,7 @@ msgstr "Naam"
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
 msgid "Name:"
 msgstr "Naam:"
 
@@ -4113,7 +3966,7 @@ msgstr "Nieuwe versie:"
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
 #: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
 #: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:35
+#: ../root/static/scripts/common/artworkViewer.js:38
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr "Volgende"
@@ -4189,7 +4042,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr "Geen van de uitgaves heeft een afbeelding van de voorkant, dus er kan geen afbeelding worden ingesteld."
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:413
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
 msgid "No results"
 msgstr "Geen resultaten"
 
@@ -4203,7 +4056,7 @@ msgstr "Geen resultaten gevonden."
 
 #: ../root/cdtoc/attach_filter_artist.tt:41
 #: ../root/cdtoc/attach_filter_release.tt:61
-#: ../root/search/components/PaginatedSearchResults.js:45
+#: ../root/search/components/PaginatedSearchResults.js:44
 msgid "No results found. Try refining your search query."
 msgstr "Geen resultaten gevonden. Probeer je zoekopdracht te herdefiniëren."
 
@@ -4228,13 +4081,13 @@ msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr "De afgelopen drie maanden heeft niemand notities achtergelaten bij je bewerkingen."
 
 #: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:461
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "Nobody has tagged this yet."
 msgstr "Nog niemand heeft dit een etiket gegeven."
 
-#: ../root/report/index.tt:108
 #: ../root/report/releases_with_download_relationships.tt:1
 #: ../root/report/releases_with_download_relationships.tt:3
+#: ../root/report/ReportsIndex.js:123
 msgid "Non-digital releases with download relationships"
 msgstr "Niet-digitale uitgaves met downloadrelaties"
 
@@ -4244,7 +4097,7 @@ msgid "None"
 msgstr "Geen"
 
 #: ../root/release/edit/tracklist.tt:336
-#: ../root/static/scripts/release-editor/fields.js:184
+#: ../root/static/scripts/release-editor/fields.js:185
 msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr "Geen van de gekoppelde disc-ID’s past bij een pregapnummer met de opgegeven duur."
@@ -4453,9 +4306,9 @@ msgid "Other lookups"
 msgstr "Andere zoekmogelijkheden"
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:80
-#: ../root/static/scripts/common/components/TagEditor.js:450
-#: ../root/static/scripts/common/components/TagEditor.js:506
+#: ../root/layout/components/sidebar/SidebarTags.js:81
+#: ../root/static/scripts/common/components/TagEditor.js:465
+#: ../root/static/scripts/common/components/TagEditor.js:550
 msgid "Other tags"
 msgstr "Andere etiketten"
 
@@ -4464,7 +4317,7 @@ msgid "Overall"
 msgstr "Algemeen"
 
 #: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:73
+#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
 #: ../root/tag/TagLayout.js:26
 msgid "Overview"
 msgstr "Overzicht"
@@ -4541,11 +4394,11 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr "Voer de bovenstaande operaties uit als ik de applicatie niet gebruik"
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
 msgid "Performances"
 msgstr "Uitvoeringen"
 
-#: ../root/entity/details.tt:20
+#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
 msgid "Permanent link:"
 msgstr "Permanente verwijzing:"
 
@@ -4557,8 +4410,8 @@ msgstr "Zin:"
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
 #: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:25
-#: ../root/search/components/SearchForm.js:44
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
+#: ../root/search/components/SearchForm.js:45
 #: ../root/static/scripts/common/i18n.js:58
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Place"
@@ -4584,23 +4437,20 @@ msgstr "Plaats:"
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:133 ../root/components/EntityTabs.js:28
+#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
 #: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
 msgid "Places"
 msgstr "Plaatsen"
 
-#: ../root/report/index.tt:137
-msgid "Places with annotations"
-msgstr "Plaatsen met aantekeningen"
-
 #: ../root/report/deprecated_relationship_places.tt:1
 #: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/index.tt:136
+#: ../root/report/ReportsIndex.js:151
 msgid "Places with deprecated relationships"
 msgstr "Plaatsen met verouderde relaties"
 
-#: ../root/report/index.tt:138 ../root/report/places_without_coordinates.tt:1
+#: ../root/report/places_without_coordinates.tt:1
 #: ../root/report/places_without_coordinates.tt:3
+#: ../root/report/ReportsIndex.js:153
 msgid "Places without coordinates"
 msgstr "Plaatsen zonder coördinaten"
 
@@ -4627,7 +4477,7 @@ msgstr "Kies een voorwaarde"
 msgid ""
 "Please choose a valid image. Currently the Cover Art Archive only supports "
 "JPEG, PNG, GIF and PDF files."
-msgstr "Kies alsjeblieft een geldige afbeelding. Het Cover Art Archive ondersteunt nu alleen JPEG-, PNG-, GIF- en PDF-bestanden."
+msgstr "Je moet een geldige afbeelding kiezen. Het Cover Art Archive ondersteunt nu alleen JPEG-, PNG-, GIF- en PDF-bestanden."
 
 #: ../root/cdtoc/lookup.tt:86
 msgid ""
@@ -4668,17 +4518,17 @@ msgstr "Let op dat alle informatie die aan MusicBrainz wordt toegevoegd, onder {
 
 #: ../root/user/report.tt:4
 msgid "Please review our {uri|Code of Conduct} before sending a report."
-msgstr "Bekijk onze {uri|Gedragscode} voor je een gebruiker rapporteert."
+msgstr "Bekijk onze {uri|Gedragscode} voor je een gebruiker meldt."
 
 #: ../root/account/register.tt:45
 msgid ""
 "Please review the {coc|MusicBrainz Code of Conduct} before creating an "
 "account."
-msgstr "Lees alsjeblieft de {coc|Gedragscode van MusicBrainz} voordat je je registreert."
+msgstr "We raden je aan om de {coc|Gedragscode van MusicBrainz} voordat je je registreert."
 
 #: ../root/entity/alias/delete.tt:6
 msgid "Please review the {doc|alias documentation} before entering this edit."
-msgstr "Lees alsjeblieft de documentatie over {doc|aliassen} voordat je deze bewerking indient."
+msgstr "Lees de documentatie over {doc|aliassen} voordat je deze bewerking indient."
 
 #: ../root/cdstub/import.tt:3
 msgid "Please search for the artist you wish to create a new release for:"
@@ -4702,7 +4552,7 @@ msgstr "Selecteer het medium waar je deze TOC aan wil toevoegen."
 
 #: ../root/main/503.tt:8
 msgid "Please wait a few minutes and repeat your request."
-msgstr "Wacht alsjeblieft een paar minuten en herhaal dan je verzoek."
+msgstr "Wacht een paar minuten en herhaal dan je verzoek."
 
 #: ../root/cdtoc/list.tt:4 ../root/release/reorder_cover_art.tt:10
 msgid "Position"
@@ -4723,22 +4573,14 @@ msgid "Possible duplicate events"
 msgstr "Mogelijke dubbele evenementen"
 
 #: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3 ../root/report/index.tt:71
+#: ../root/report/duplicate_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:89
 msgid "Possible duplicate release groups"
 msgstr "Mogelijk dubbele uitgavegroepen"
 
 #: ../root/relationship/linkattributetype/index.tt:19
 msgid "Possible values:"
 msgstr "Mogelijke waarden:"
-
-#: ../root/report/duplicate_artists.tt:1 ../root/report/duplicate_artists.tt:3
-#: ../root/report/index.tt:20
-msgid "Possibly duplicate artists"
-msgstr "Mogelijk dubbele artiesten"
-
-#: ../root/report/index.tt:43
-msgid "Possibly duplicate events"
-msgstr "Mogelijk dubbele evenementen"
 
 #: ../root/release/edit/tracklist.tt:163
 msgid "Pregap"
@@ -4756,7 +4598,7 @@ msgstr "Voorbeeld:"
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
 #: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
 #: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:31
+#: ../root/static/scripts/common/artworkViewer.js:34
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr "Vorige"
@@ -4805,10 +4647,10 @@ msgstr "Publiek"
 
 #: ../root/collection/header.tt:14
 msgid "Public collection by {owner}"
-msgstr "Publieke collectie van {owner}"
+msgstr "Openbare collectie van {owner}"
 
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:79
+#: ../root/search/components/SearchForm.js:80
 msgid "Query:"
 msgstr "Zoekopdracht:"
 
@@ -4833,7 +4675,7 @@ msgstr "Waardering"
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:54
+#: ../root/components/UserAccountTabs.js:55
 msgid "Ratings"
 msgstr "Waarderingen"
 
@@ -4863,7 +4705,7 @@ msgstr "Recente notities bij mijn bewerkingen"
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:40
+#: ../root/search/components/SearchForm.js:41
 #: ../root/static/scripts/common/i18n.js:59
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
 msgid "Recording"
@@ -4906,21 +4748,22 @@ msgstr "Opname:"
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
-#: ../root/release/edit/layout.tt:17 ../root/report/index.tt:118
-#: ../root/series/index.tt:15 ../root/work/index.tt:17
-#: ../root/components/EntityTabs.js:29 ../root/tag/TagIndex.js:88
+#: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
+#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
 #: ../root/tag/TagLayout.js:30
 msgid "Recordings"
 msgstr "Opnames"
 
-#: ../root/report/index.tt:129 ../root/report/recordings_without_va_link.tt:1
+#: ../root/report/recordings_without_va_link.tt:1
 #: ../root/report/recordings_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:144
 msgid "Recordings credited to \"Various Artists\" but not linked to VA"
 msgstr "Opnames waarvan de artiest wordt vermeld als “Diverse Artiesten”, maar die aan een andere artiest zijn gekoppeld."
 
-#: ../root/report/index.tt:128
 #: ../root/report/recordings_without_va_credit.tt:1
 #: ../root/report/recordings_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:143
 msgid "Recordings not credited to \"Various Artists\" but linked to VA"
 msgstr "Opnames waarvan de artiest niet wordt vermeld als “Diverse Artiesten”, maar die wel aan “Diverse Artiesten” zijn gekoppeld."
 
@@ -4934,40 +4777,28 @@ msgstr "Opnames met eerste uitgave-relaties"
 msgid "Recordings with Varying Track Lengths"
 msgstr "Opnames met afwijkende nummerlengtes"
 
-#: ../root/report/index.tt:127
-msgid "Recordings with annotations"
-msgstr "Opnames met aantekeningen"
-
 #: ../root/report/deprecated_relationship_recordings.tt:1
 #: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/index.tt:126
+#: ../root/report/ReportsIndex.js:141
 msgid "Recordings with deprecated relationships"
 msgstr "Opnames met verouderde relaties"
 
-#: ../root/report/index.tt:121
-msgid "Recordings with earliest release relationships"
-msgstr "Opnames met eerste uitgave-relaties"
-
 #: ../root/report/duplicate_relationships_recordings.tt:1
 #: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/index.tt:124
+#: ../root/report/ReportsIndex.js:139
 msgid "Recordings with possible duplicate relationships"
 msgstr "Opnames met mogelijk dubbele relaties"
 
-#: ../root/report/index.tt:130
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:1
 #: ../root/report/recordings_same_name_different_artists_same_name.tt:3
+#: ../root/report/ReportsIndex.js:145
 msgid "Recordings with the same name by different artists with the same name"
-msgstr "Opnames met dezelfde naam van verschillende artiesten met dezelfde naam"
+msgstr "Opnames met dezelfde titel van verschillende artiesten met dezelfde naam"
 
 #: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/index.tt:123
+#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
 msgid "Recordings with titles containing featuring artists"
 msgstr "Opnames met de naam van een gastartiest in de titel"
-
-#: ../root/report/index.tt:125
-msgid "Recordings with varying track times"
-msgstr "Opnames met afwijkende nummerlengtes"
 
 #: ../root/edit/details/edit_medium.tt:171
 msgid "Recordings:"
@@ -5025,7 +4856,6 @@ msgid "Relationship Editor"
 msgstr "Relatieredacteur"
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_artists.tt:13
 #: ../root/report/deprecated_relationship_labels.tt:13
 #: ../root/report/deprecated_relationship_places.tt:13
 #: ../root/report/deprecated_relationship_recordings.tt:13
@@ -5033,6 +4863,7 @@ msgstr "Relatieredacteur"
 #: ../root/report/deprecated_relationship_releases.tt:13
 #: ../root/report/deprecated_relationship_urls.tt:13
 #: ../root/report/deprecated_relationship_works.tt:13
+#: ../root/report/components/ArtistRelationshipList.js:28
 msgid "Relationship Type"
 msgstr "Relatietype"
 
@@ -5082,7 +4913,7 @@ msgstr "Relatie:"
 #: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
 #: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
 #: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:84
+#: ../root/components/EntityTabs.js:85
 msgid "Relationships"
 msgstr "Relaties"
 
@@ -5114,7 +4945,7 @@ msgstr "Relaties:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
 #: ../root/layout/components/Search.js:23
 #: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:39
+#: ../root/search/components/SearchForm.js:40
 #: ../root/static/scripts/common/i18n.js:60
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 #: ../root/taglookup/Form.js:29
@@ -5146,7 +4977,7 @@ msgstr "Uitgavegebeurtenissen:"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
 #: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:38
+#: ../root/search/components/SearchForm.js:39
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgid "Release Group"
 msgstr "Uitgavegroep"
@@ -5182,7 +5013,7 @@ msgstr "Uitgavegroepen"
 
 #: ../root/report/deprecated_relationship_release_groups.tt:1
 #: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/index.tt:70
+#: ../root/report/ReportsIndex.js:88
 msgid "Release Groups with deprecated relationships"
 msgstr "Uitgavegroepen met verouderde relaties"
 
@@ -5241,6 +5072,7 @@ msgid "Release group ratings"
 msgstr "Waarderingen van uitgavegroepen"
 
 #: ../root/release_group/layout.tt:1
+#: ../root/release_group/ReleaseGroupLayout.js:35
 msgid "Release group “{name}” by {artist}"
 msgstr "Uitgavegroep ‘{name}’ van {artist}"
 
@@ -5252,38 +5084,27 @@ msgstr "Uitgavegroep ‘{name}’ van {artist}"
 msgid "Release group:"
 msgstr "Uitgavegroep:"
 
-#: ../root/report/index.tt:63
-msgid "Release groups"
-msgstr "Uitgavegroepen"
-
-#: ../root/report/index.tt:74
 #: ../root/report/release_groups_without_va_link.tt:1
 #: ../root/report/release_groups_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:92
 msgid "Release groups credited to \"Various Artists\" but not linked to VA"
 msgstr "Uitgavegroepen waarvan de artiest wordt vermeld als “Diverse Artiesten”, maar die gekoppeld is aan een andere artiest."
 
-#: ../root/report/index.tt:73
 #: ../root/report/release_groups_without_va_credit.tt:1
 #: ../root/report/release_groups_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:91
 msgid "Release groups not credited to \"Various Artists\" but linked to VA"
 msgstr "Uitgavegroepen waarvan de artiest niet wordt vermeld als “Diverse Artiesten”, maar die wel aan “Diverse Artiesten” gekoppeld zijn."
 
-#: ../root/report/index.tt:66
-msgid "Release groups that might need to be merged"
-msgstr "Uitgavegroepen die misschien moeten worden samengevoegd"
-
-#: ../root/report/index.tt:72
-msgid "Release groups with annotations"
-msgstr "Uitgavegroepen met aantekeningen"
-
 #: ../root/report/duplicate_relationships_release_groups.tt:1
 #: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/index.tt:69
+#: ../root/report/ReportsIndex.js:87
 msgid "Release groups with possible duplicate relationships"
 msgstr "Uitgavegroepen met mogelijk dubbele relaties"
 
 #: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3 ../root/report/index.tt:67
+#: ../root/report/featuring_release_groups.tt:3
+#: ../root/report/ReportsIndex.js:85
 msgid "Release groups with titles containing featuring artists"
 msgstr "Uitgavegroepen met de naam van een gastartiest in de titel"
 
@@ -5326,8 +5147,8 @@ msgstr "Uitgave:"
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/report/index.tt:77 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:30 ../root/tag/TagIndex.js:87
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
+#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
 #: ../root/tag/TagLayout.js:29
 msgid "Releases"
 msgstr "Uitgaves"
@@ -5361,67 +5182,43 @@ msgstr "Uitgaves met meerdere Discogs-verwijzingen"
 msgid "Releases With Some Formats Unset"
 msgstr "Uitgaves waarbij sommige mediumtypes ontbreken."
 
-#: ../root/report/index.tt:113 ../root/report/releases_without_va_link.tt:1
+#: ../root/report/releases_without_va_link.tt:1
 #: ../root/report/releases_without_va_link.tt:3
+#: ../root/report/ReportsIndex.js:128
 msgid "Releases credited to \"Various Artists\" but not linked to VA"
 msgstr "Uitgaves waarvan de artiest wordt vermeld als “Diverse Artiesten”, maar die aan een andere artiest zijn gekoppeld."
 
-#: ../root/report/index.tt:98
 #: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
+#: ../root/report/ReportsIndex.js:115
 msgid ""
 "Releases in the Cover Art Archive that still have cover art relationships"
 msgstr "Uitgaves in het Cover Art Archive die nog steeds relaties hebben voor afbeeldingen."
 
-#: ../root/report/index.tt:102 ../root/report/releases_with_caa_no_types.tt:1
+#: ../root/report/releases_with_caa_no_types.tt:1
 #: ../root/report/releases_with_caa_no_types.tt:3
+#: ../root/report/ReportsIndex.js:117
 msgid "Releases in the Cover Art Archive where no cover art piece has types"
 msgstr "Uitgaves met afbeeldingen in het Cover Art Archive die allemaal geen ingesteld type hebben"
 
-#: ../root/report/index.tt:114
-msgid "Releases missing disc IDs"
-msgstr "Uitgaves zonder disc-ID’s"
-
-#: ../root/report/index.tt:112 ../root/report/releases_without_va_credit.tt:1
+#: ../root/report/releases_without_va_credit.tt:1
 #: ../root/report/releases_without_va_credit.tt:3
+#: ../root/report/ReportsIndex.js:127
 msgid "Releases not credited to \"Various Artists\" but linked to VA"
 msgstr "Uitgaves waarvan de artiest niet wordt vermeld als “Diverse Artiesten”, maar die wel aan “Diverse Artiesten” zijn gekoppeld."
 
-#: ../root/report/index.tt:100
-msgid "Releases of any sort that still have cover art relationships"
-msgstr "Uitgaves van elk type die nog relaties voor afbeeldingen hebben."
-
-#: ../root/report/index.tt:93 ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3
+#: ../root/report/released_too_early.tt:1
+#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
 msgid "Releases released too early"
 msgstr "Uitgaves die te vroeg zijn uitgegeven"
 
-#: ../root/report/index.tt:115 ../root/report/release_label_same_artist.tt:1
+#: ../root/report/release_label_same_artist.tt:1
 #: ../root/report/release_label_same_artist.tt:3
+#: ../root/report/ReportsIndex.js:130
 msgid "Releases where artist name and label name are the same"
 msgstr "Uitgaves waarvan de platenmaatschappij hetzelfde is als de artiestennaam"
 
-#: ../root/report/index.tt:94
-msgid "Releases where some (but not all) mediums have no format set"
-msgstr "Uitgaves waar bij sommige (maar niet alle) media geen type zijn ingesteld."
-
-#: ../root/report/index.tt:84
-msgid "Releases which have multiple ASINs"
-msgstr "Uitgaves met meerdere ASIN’s"
-
-#: ../root/report/index.tt:85
-msgid "Releases which have multiple Discogs links"
-msgstr "Uitgaves met meerdere Discogs-verwijzingen"
-
-#: ../root/report/index.tt:88
-msgid "Releases which have part of set relationships"
-msgstr "Uitgaves met deel-van-een-stel-relaties"
-
-#: ../root/report/index.tt:83
-msgid "Releases which have unexpected Amazon URLs"
-msgstr "Uitgaves met onverwachte Amazon-URL’s"
-
-#: ../root/report/index.tt:80 ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3
+#: ../root/report/releases_to_convert.tt:1
+#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
 msgid "Releases which might need converting to \"multiple artists\""
 msgstr "Uitgaves die misschien moeten worden omgezet naar ‘diverse artiesten’"
 
@@ -5430,23 +5227,15 @@ msgstr "Uitgaves die misschien moeten worden omgezet naar ‘diverse artiesten�
 msgid "Releases with Cover Art relationships"
 msgstr "Uitgaves met relaties voor afbeeldingen."
 
-#: ../root/report/index.tt:107
 #: ../root/report/single_medium_releases_with_medium_titles.tt:1
 #: ../root/report/single_medium_releases_with_medium_titles.tt:3
+#: ../root/report/ReportsIndex.js:122
 msgid "Releases with a single medium that has a name"
 msgstr "Uitgaves met één medium met een naam"
 
-#: ../root/report/index.tt:110
-msgid "Releases with annotations"
-msgstr "Uitgaves met aantekeningen"
-
-#: ../root/report/index.tt:95
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr "Uitgaves met catalogusnummers die er uitzien als ASIN’s"
-
 #: ../root/report/deprecated_relationship_releases.tt:1
 #: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/index.tt:109
+#: ../root/report/ReportsIndex.js:124
 msgid "Releases with deprecated relationships"
 msgstr "Uitgaves met verouderde relaties"
 
@@ -5455,31 +5244,25 @@ msgstr "Uitgaves met verouderde relaties"
 msgid "Releases with medium number issues"
 msgstr "Uitgaves met problemen bij de mediumposities"
 
-#: ../root/report/index.tt:111 ../root/report/releases_with_no_mediums.tt:1
+#: ../root/report/releases_with_no_mediums.tt:1
 #: ../root/report/releases_with_no_mediums.tt:3
+#: ../root/report/ReportsIndex.js:126
 msgid "Releases with no mediums"
 msgstr "Uitgaves zonder media."
 
-#: ../root/report/index.tt:103
-msgid "Releases with non-sequential mediums"
-msgstr "Uitgaves met media die niet op volgorde zijn"
-
-#: ../root/report/index.tt:90
-msgid "Releases with non-sequential track numbers"
-msgstr "Uitgaves met nummers die niet op volgorde zijn"
-
 #: ../root/report/duplicate_relationships_releases.tt:1
 #: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/index.tt:106
+#: ../root/report/ReportsIndex.js:121
 msgid "Releases with possible duplicate relationships"
 msgstr "Uitgaves met mogelijk dubbele relaties"
 
-#: ../root/report/index.tt:91 ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/superfluous_data_tracks.tt:3
+#: ../root/report/ReportsIndex.js:109
 msgid "Releases with superfluous data tracks"
 msgstr "Uitgaves met overbodige gegevensnummers"
 
 #: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/index.tt:92
+#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
 msgid "Releases with titles containing featuring artists"
 msgstr "Uitgaves met de naam van een gastartiest in de titel"
 
@@ -5488,24 +5271,26 @@ msgstr "Uitgaves met de naam van een gastartiest in de titel"
 msgid "Releases with track number issues"
 msgstr "Uitgaves met problemen bij de nummerposities"
 
-#: ../root/report/index.tt:105 ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3
+#: ../root/report/tracks_without_times.tt:1
+#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
 msgid "Releases with unknown track times"
 msgstr "Uitgaves met onbekende nummerduur"
 
-#: ../root/report/index.tt:104
 #: ../root/report/releases_with_unlikely_language_script.tt:1
 #: ../root/report/releases_with_unlikely_language_script.tt:3
+#: ../root/report/ReportsIndex.js:119
 msgid "Releases with unlikely language/script pairs"
 msgstr "Uitgaves met een onwaarschijnlijke combinatie van taal en schrift."
 
-#: ../root/report/index.tt:81 ../root/report/releases_without_language.tt:1
+#: ../root/report/releases_without_language.tt:1
 #: ../root/report/releases_without_language.tt:3
+#: ../root/report/ReportsIndex.js:99
 msgid "Releases without language"
 msgstr "Uitgaves zonder taal"
 
-#: ../root/report/index.tt:82 ../root/report/releases_without_script.tt:1
+#: ../root/report/releases_without_script.tt:1
 #: ../root/report/releases_without_script.tt:3
+#: ../root/report/ReportsIndex.js:100
 msgid "Releases without script"
 msgstr "Uitgaves zonder schrift"
 
@@ -5531,7 +5316,7 @@ msgstr "Uitgaves:"
 #: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
 #: ../root/admin/attributes/language.tt:28
 #: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
-#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:52
+#: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
 #: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
 #: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
 #: ../root/recording/delete.tt:1
@@ -5543,7 +5328,7 @@ msgstr "Uitgaves:"
 #: ../root/release/delete.tt:1 ../root/release/discids.tt:36
 #: ../root/series/delete.tt:1 ../root/user/collections.tt:65
 #: ../root/account/applications/Index.js:36
-#: ../root/components/Aliases/AliasTableRow.js:60
+#: ../root/components/Aliases/AliasTableRow.js:61
 #: ../root/layout/components/sidebar/RemoveLink.js:27
 msgid "Remove"
 msgstr "Verwijderen"
@@ -5683,11 +5468,6 @@ msgstr "Gebruiker rapporteren"
 msgid "Report this user for bad behavior"
 msgstr "Deze gebruiker rapporteren voor slecht gedrag"
 
-#: ../root/report/index.tt:1 ../root/report/index.tt:3
-#: ../root/layout/components/BottomMenu.js:241
-msgid "Reports"
-msgstr "Rapporten"
-
 #: ../root/main/timeout.tt:1 ../root/main/timeout.tt:3
 msgid "Request Timed Out"
 msgstr "Verzoek duurde te lang"
@@ -5710,7 +5490,7 @@ msgstr "Wachtwoord opnieuw instellen"
 msgid "Reset track numbers"
 msgstr "Nummerposities herstellen"
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:90
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
 msgid "Results per page:"
 msgstr "Resultaten per pagina:"
 
@@ -5723,7 +5503,7 @@ msgstr "Resultaten:"
 
 #: ../root/release/edit/recordings.tt:7
 msgid "Reuse previous recordings"
-msgstr "Eerde opnames hergebruiken"
+msgstr "Eerder gekoppelde opnames hergebruiken"
 
 #: ../root/user/contact.tt:16 ../root/user/report.tt:23
 msgid "Reveal my email address"
@@ -5750,7 +5530,7 @@ msgstr "Lees de {url|documentatie} over het invullen van de uitgavebewerker en z
 msgid "Role"
 msgstr "Rol"
 
-#: ../root/layout.tt:115
+#: ../root/layout.tt:114
 msgid "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr "Draait <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 
@@ -5793,7 +5573,7 @@ msgstr "Schrift:"
 #: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
 #: ../root/layout/components/BottomMenu.js:181
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:100
+#: ../root/search/components/SearchForm.js:101
 #: ../root/static/scripts/common/components/Autocomplete.js:71
 #: ../root/taglookup/Form.js:48
 msgid "Search"
@@ -5840,7 +5620,7 @@ msgstr "Naar bewerkingen zoeken"
 msgid "Search for the target URL."
 msgstr "Zoek naar de doel URL."
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:96
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
 msgid "Search method:"
 msgstr "Zoekmethode:"
 
@@ -5873,7 +5653,7 @@ msgstr "Bekijk al je collecties"
 
 #: ../root/collection/header.tt:17
 msgid "See all of {editor}'s public collections"
-msgstr "Bekijk alle publieke collecties van {editor}"
+msgstr "Bekijk alle openbare collecties van {editor}"
 
 #: ../root/account/edit.tt:7
 msgid ""
@@ -5929,7 +5709,7 @@ msgstr "Stuur een kopie naar mijn e-mailadres"
 msgid "Sentence"
 msgstr "Zin"
 
-#: ../root/report/index.tt:141 ../root/report/series_list.tt:7
+#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
 #: ../root/tag/TagIndex.js:89
 msgid "Series"
 msgstr "Series"
@@ -5944,8 +5724,8 @@ msgstr "Series"
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:50
-#: ../root/series/SeriesHeader.js:25 ../root/static/scripts/common/i18n.js:62
+#: ../root/search/components/SearchForm.js:51
+#: ../root/series/SeriesHeader.js:26 ../root/static/scripts/common/i18n.js:62
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
 msgctxt "singular"
 msgid "Series"
@@ -5967,10 +5747,6 @@ msgstr "Abonnementen op series"
 #: ../root/report/annotations_series.tt:1
 #: ../root/report/annotations_series.tt:3
 msgid "Series annotations"
-msgstr "Series met aantekeningen"
-
-#: ../root/report/index.tt:144
-msgid "Series with annotations"
 msgstr "Series met aantekeningen"
 
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
@@ -6000,7 +5776,7 @@ msgstr "Stel een nieuw wachtwoord voor je MusicBrainz-account in."
 msgid "Set cover art"
 msgstr "Afbeelding instellen"
 
-#: ../root/cdtoc/list.tt:47
+#: ../root/cdtoc/list.tt:48
 msgid "Set track durations"
 msgstr "Vul de duur van de nummers in"
 
@@ -6013,10 +5789,6 @@ msgstr "Speellijst"
 msgid "Setlist:"
 msgstr "Speellijst:"
 
-#: ../root/report/filter_link.tt:4
-msgid "Show all results."
-msgstr "Toon alle resultaten"
-
 #: ../root/edit/notes-received.tt:10
 msgid "Show me an alert whenever I receive a new edit note."
 msgstr "Geef me een melding als een bewerking van mij een nieuwe notitie krijgt."
@@ -6026,10 +5798,6 @@ msgid ""
 "Show me {autoedit_select_block} sorted {sort_select_block} that "
 "{match_or_negation_block} {and_vs_or_block} of the following conditions:"
 msgstr "Toon {autoedit_select_block} sortering: {sort_select_block}, {match_or_negation_block} {and_vs_or_block} van de volgende voorwaarden:"
-
-#: ../root/report/filter_link.tt:6
-msgid "Show only results that are in my subscribed entities."
-msgstr "Toon alleen resultaten in mijn abonnementen."
 
 #: ../root/artist/releases.tt:31
 msgid ""
@@ -6165,7 +5933,7 @@ msgstr "Onze excuses, de pagina die je zoekt is niet beschikbaar op een spiegels
 msgid "Sorry, there was a problem with your request."
 msgstr "Onze excuses, er was een probleem met je verzoek."
 
-#: ../root/main/401.tt:5 ../root/report/limited_editors.tt:15
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
 msgid "Sorry, you are not authorized to view this page."
 msgstr "Onze excuses, je hebt geen toestemming om deze pagina te zien."
 
@@ -6189,8 +5957,8 @@ msgstr "Onze excuses, ‘{id}’ is geen geldige documentatiepagina."
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/report/duplicate_artists.tt:26
-#: ../root/components/Aliases/AliasTable.js:25
+#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/report/DuplicateArtists.js:67
 msgid "Sort name"
 msgstr "Sorteernaam"
 
@@ -6244,7 +6012,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr "Status:"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Stop using beta site"
 msgstr "Bètasite niet meer gebruiken"
 
@@ -6298,12 +6066,10 @@ msgstr "Geabonneerde redacteurs"
 msgid "Subscribed entities"
 msgstr "Geabonneerde objecten"
 
-#: ../root/artist/subscribers.tt:1 ../root/artist/subscribers.tt:2
 #: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/label/subscribers.tt:1 ../root/label/subscribers.tt:2
-#: ../root/series/subscribers.tt:1 ../root/series/subscribers.tt:2
 #: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:46
+#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
+#: ../root/entity/Subscribers.js:34
 #: ../root/layout/components/sidebar/CollectionSidebar.js:92
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:47
 msgid "Subscribers"
@@ -6351,8 +6117,8 @@ msgid "Tagger"
 msgstr "Tagger"
 
 #: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:92
-#: ../root/components/UserAccountTabs.js:50
+#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
+#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
 #: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
 #: ../root/tag/TagCloud.js:47
 msgid "Tags"
@@ -6423,7 +6189,7 @@ msgid ""
 "and may not display correctly"
 msgstr "De gegevens in deze bewerking komen oorspronkelijk uit een oudere versie van deze bewerking, en worden mogelijk niet correct weergegeven."
 
-#: ../root/layout.tt:82 ../root/layout/index.js:105
+#: ../root/layout.tt:81 ../root/layout/index.js:104
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6434,7 +6200,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr "De gegevens die je hebt ingevuld, geven de volgende foutmeldingen:"
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:487
+#: ../root/static/scripts/relationship-editor/common/dialog.js:488
 msgid "The date you've entered is not valid."
 msgstr "De datum die je hebt ingevoerd, is niet geldig."
 
@@ -6533,7 +6299,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr "De zoekserver kon je verzoek door een interne fout niet uitvoeren. Dit probleem is meestal tijdelijk, dus probeer het later opnieuw."
 
-#: ../root/layout.tt:63 ../root/layout/index.js:88
+#: ../root/layout.tt:62 ../root/layout/index.js:87
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr "De server is tijdelijk in alleenlezenmodus vanwege onderhoud aan de database."
 
@@ -6572,21 +6338,9 @@ msgstr "Er zijn momenteel geen gebruikers geabonneerd op bewerkingen die je maak
 msgid "There are currently no users subscribed to edits that {user} makes."
 msgstr "Er zijn momenteel geen gebruikers geabonneerd op bewerkingen die {user} maakt."
 
-#: ../root/artist/subscribers.tt:22
-msgid "There are currently no users subscribed to {artist}."
-msgstr "Er zijn momenteel geen gebruikers geabonneerd op {artist}."
-
 #: ../root/collection/subscribers.tt:22
 msgid "There are currently no users subscribed to {collection}."
 msgstr "Er zijn momenteel geen gebruikers geabonneerd op {collection}."
-
-#: ../root/label/subscribers.tt:22
-msgid "There are currently no users subscribed to {label}."
-msgstr "Er zijn momenteel geen gebruikers geabonneerd op {label}."
-
-#: ../root/series/subscribers.tt:22
-msgid "There are currently no users subscribed to {series}."
-msgstr "Er zijn momenteel geen gebruikers geabonneerd op {series}."
 
 #: ../root/release/discids.tt:49
 msgid ""
@@ -6595,12 +6349,12 @@ msgid ""
 msgstr "Er zijn geen disc-ID’s aan deze uitgave gekoppeld. Lees {doc|hoe disc-ID’s toe te voegen} om te zien hoe ze kunnen worden toegevoegd."
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:447
+#: ../root/static/scripts/common/components/TagEditor.js:462
 msgid "There are no genres to show."
 msgstr "Er zijn geen andere genres."
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:457
+#: ../root/static/scripts/common/components/TagEditor.js:472
 msgid "There are no other tags to show."
 msgstr "Er zijn geen andere etiketten."
 
@@ -6626,29 +6380,11 @@ msgid_plural ""
 msgstr[0] "Er is momenteel {num} gebruiker geabonneerd op bewerkingen die {user} maakt"
 msgstr[1] "Er zijn momenteel {num} gebruikers geabonneerd op bewerkingen die {user} maakt."
 
-#: ../root/artist/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {artist}:"
-msgid_plural "There are currently {num} users subscribed to {artist}:"
-msgstr[0] "Er is momenteel {num} gebruiker geabonneerd op {artist}:"
-msgstr[1] "Er zijn momenteel {num} gebruikers geabonneerd op {artist}:"
-
 #: ../root/collection/subscribers.tt:4
 msgid "There is currently {num} user subscribed to {collection}:"
 msgid_plural "There are currently {num} users subscribed to {collection}:"
 msgstr[0] "Er is momenteel {num} gebruiker geabonneerd op {collection}:"
 msgstr[1] "Er zijn momenteel {num} gebruikers geabonneerd op {collection}:"
-
-#: ../root/label/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {label}:"
-msgid_plural "There are currently {num} users subscribed to {label}:"
-msgstr[0] "Er is momenteel {num} gebruiker geabonneerd op {label}:"
-msgstr[1] "Er zijn momenteel {num} gebruikers geabonneerd op {label}:"
-
-#: ../root/series/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {series}:"
-msgid_plural "There are currently {num} users subscribed to {series}:"
-msgstr[0] "Er is momenteel {num} gebruiker geabonneerd op {series}:"
-msgstr[1] "Er zijn momenteel {num} gebruikers geabonneerd op {series}:"
 
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
@@ -6756,7 +6492,7 @@ msgid ""
 msgstr "Deze artiest heeft geen uitgavegroepen van diverse artiesten. {show_non_va|In plaats daarvan alle uitgavegroepen van deze artiest weergeven}."
 
 #: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "This artist has ended."
 msgstr "Deze artiest bestaat niet meer."
 
@@ -6806,7 +6542,7 @@ msgstr "Deze artiest heeft alleen onofficiële uitgavegroepen."
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr "Deze eigenschap wordt alleen gebruikt om te groeperen, gebruik een subtype."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:35
+#: ../root/layout.tt:28 ../root/layout/index.js:34
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr "Op deze bètaserver kunnen gebruikers nieuwe mogelijkheden testen met de productiedatabase."
@@ -6913,11 +6649,11 @@ msgid ""
 "attributed to it."
 msgstr "Dit instrument kan niet worden verwijderd omdat er nog steeds relaties aan gekoppeld zijn."
 
-#: ../root/layout.tt:29 ../root/layout/index.js:37
+#: ../root/layout.tt:28 ../root/layout/index.js:36
 msgid "This is a MusicBrainz development server."
 msgstr "Dit is een MusicBrainz-server voor ontwikkeling."
 
-#: ../root/layout.tt:46 ../root/layout/index.js:59
+#: ../root/layout.tt:45 ../root/layout/index.js:58
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
@@ -7037,7 +6773,7 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr "Deze opname heeft geen gekoppelde AcoustID’s"
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:616
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
 #: ../root/static/scripts/common/components/EntityLink.js:210
 msgid "This recording is a video"
 msgstr "Deze opname is een video"
@@ -7071,7 +6807,7 @@ msgstr "Dit relatietype kan geen eigenschappen hebben."
 
 #: ../root/doc/relationship_type.tt:11
 #: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:453
+#: ../root/static/scripts/relationship-editor/common/dialog.js:454
 msgid "This relationship type is deprecated and should not be used."
 msgstr "Dit relatietype is verouderd en moet niet meer worden gebruikt."
 
@@ -7105,16 +6841,6 @@ msgid ""
 "mixtape/street albums, demos, or digital albums. Be sure to link to the "
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr "Deze uitgavestatus wordt gebruikt voor onofficiële vertalingen en transliteraties van nummerlijsten en uitgavetitels, en geeft geen afzonderlijke echte uitgave aan. Hij moet niet worden gebruikt om bootlegs, mixtape/straat albums, demo’s of digitale albums aan te geven. Vergeet niet om de uitgave met de {url|vertaald/getranslitereerd}-relatie te koppelen aan de originele uitgave."
-
-#: ../root/report/duplicate_artists.tt:6
-msgid ""
-"This report aims to identify artists with very similar names. If two artists"
-" are actually the same, please merge them (remember to "
-"{how_to_write_edit_notes|write an edit note} and give your proof). If "
-"they're different, add {disambiguation_comment|disambiguation comments} to "
-"them (and once a group of similarly named artists have disambiguation "
-"comments, they will stop appearing here)."
-msgstr "In dit rapport staan artiesten met namen die erg op elkaar lijken. Als twee artiesten een en dezelfde artiest blijkt te zijn, kan je ze samenvoegen. Vergeet niet om {how_to_write_edit_notes|een notitie achter te laten} met bewijs voor je bewerking.\nAls het verschillende artiesten zijn, kan je een {disambiguation_comment|verduidelijking} aan de artiesten toevoegen. Als twee op elkaar lijkende artiesten een verduidelijking hebben, worden ze uit dit rapport verwijderd."
 
 #: ../root/report/tracks_named_with_sequence.tt:6
 msgid ""
@@ -7156,85 +6882,6 @@ msgid ""
 "This report lists all releases with gaps in the medium numbers (e.g. there "
 "is a medium 1 and 3 but no medium 2)."
 msgstr "In dit rapport staan alle uitgaves waarvan de media niet continu genummerd zijn (bijv. als er media met de posities 1 en 3 zijn, maar niet 2)."
-
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:6
-msgid ""
-"This report lists artists that appear more than once in different positions "
-"within the same artist credit."
-msgstr "In dit rapport staan artiesten die meerdere keren binnen één vermelding worden genoemd."
-
-#: ../root/report/artists_with_no_subscribers.tt:6
-msgid ""
-"This report lists artists that have no editors subscribed to them, and whose"
-" changes may therefore be under-reviewed. Artists with more release groups "
-"and more open edits are listed first."
-msgstr "In dit rapport staan artiesten waar geen redacteurs op geabonneerd zijn, waardoor bewerkingen misschien niet genoeg worden nagekeken. Artiesten met meer uitgavegroepen en open bewerkingen worden het eerst getoond."
-
-#: ../root/report/artists_disambiguation_same_name.tt:6
-msgid ""
-"This report lists artists that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr "In dit rapport staan artiesten die een verduidelijking hebben die overeenkomt met de naam van de artiest. In dat geval zou de artiest geen verduidelijking moeten hebben."
-
-#: ../root/report/artists_that_may_be_groups.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>group</em>, "
-"but may be <em>groups</em> because they have other artists listed as "
-"members. If you find that an artist here is indeed a group, change its type."
-" If it is not, please make sure that the \"member of\" relationships are in "
-"the right direction and are correct."
-msgstr "In dit rapport staan artiesten die op MusicBrainz niet als <em>groep</em> bekend zijn, maar dat misschien wel zouden moeten zijn, omdat andere artiesten als leden staan vermeld. Als een artiest inderdaad een groep zou moeten zijn, kan je het type artiest veranderen. Als een artiest toch geen groep is, kan je controleren of de ‘lid van’-relaties kloppen en de goede richting op wijzen."
-
-#: ../root/report/artists_that_may_be_persons.tt:6
-msgid ""
-"This report lists artists that have type set to other than <em>person</em>, "
-"but may be <em>persons</em>, based on their relationships. For example, an "
-"artist will appear here if it is listed as a member of another. If you find "
-"that an artist here is indeed a person, change its type. If it is not, "
-"please make sure that all the relationships are correct and make sense."
-msgstr "In dit rapport staan artiesten die op MusicBrainz niet als <em>persoon</em> bekend zijn, maar dat op basis van relaties misschien wel zouden moeten zijn. Een artiest staat hier bijvoorbeeld in omdat hij een lid is van een andere artiest. Verander het type als de artiest inderdaad een persoon is. Als de artiest geen persoon is, kan je controleren of alle relaties kloppen en logisch zijn."
-
-#: ../root/report/artists_containing_disambiguation_comments.tt:6
-msgid ""
-"This report lists artists that may have disambiguation comments in their "
-"name, rather than the actual disambiguation comment field."
-msgstr "In dit rapport staan artiesten die misschien verduidelijkingen in hun naam hebben, in plaats van het daarvoor bedoelde veld."
-
-#: ../root/report/possible_collaborations.tt:6
-msgid ""
-"This report lists artists which have \"&\" in their names but no member or "
-"collaboration relationships. If the artist is usually seen as an actual "
-"group, member relationships should be added. If it's a short term "
-"collaboration, it should be split if possible (see {how_to_split_artists|How"
-" to Split Artists}). If it is a collaboration with its own name and can't be"
-" split, collaboration relationships should be added to it."
-msgstr "In dit rapport staan artiesten met ‘&’ in de naam, maar die geen lid- of samenwerkingsrelatie hebben. Als de artiest doorgaans als groep wordt gezien, moeten er ledenrelaties worden toegevoegd. Als het een kort bestaande samenwerking is, moet het indien mogelijk worden gesplitst (zie {how_to_split_artists|artiesten splitsen}). Als het een samenwerking met een eigen naam is, en de artiest niet kan worden gesplitst, moeten er samenwerkingsrelaties worden toegevoegd."
-
-#: ../root/report/collaboration_relationships.tt:4
-msgid ""
-"This report lists artists which have collaboration relationships but no URL "
-"relationships. If the collaboration has its own independent name, do "
-"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
-"probably split it. See {how_to_split_artists|How to Split Artists}."
-msgstr "In dit rapport staan artiesten die een samenwerkingsrelatie hebben, maar geen URL-relaties. Als de samenwerking zijn eigen unieke naam heeft, moet er niets gebeuren. Als het lijkt op ‘X met Y’ of ‘X & Y’, moet de artiest waarschijnlijk worden gesplitst. Zie {how_to_split_artists|artiesten splitsen}."
-
-#: ../root/report/duplicate_relationships_artists.tt:6
-msgid ""
-"This report lists artists which have multiple relatonships to the same "
-"artist, label or URL using the same relationship type. For multiple "
-"relationships to release groups, recordings or works, see the reports for "
-"those entities."
-msgstr "In dit rapport staan artiesten die meerdere relaties van hetzelfde type met dezelfde artiest, platenmaatschappij of URL hebben. Zie voor meerdere relaties naar uitgavegroepen, opnames of composities de rapporten voor die objecten."
-
-#: ../root/report/deprecated_relationship_artists.tt:6
-msgid ""
-"This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr "In dit rapport staan artiesten met verouderde relaties of relaties die alleen voor het groeperen van relaties worden gebruikt."
-
-#: ../root/report/annotations_artists.tt:6
-msgid "This report lists artists with annotations."
-msgstr "In dit rapport staan artiesten met aantekeningen."
 
 #: ../root/report/duplicate_events.tt:6
 msgid ""
@@ -7396,10 +7043,6 @@ msgid ""
 "the works are the same, this usually means they should be merged."
 msgstr "In dit rapport staan {iswc|ISWC’s} die aan meerdere composities zijn verbonden. Als de composities hetzelfde zijn, moeten ze meestal worden samengevoegd."
 
-#: ../root/report/limited_editors.tt:6
-msgid "This report lists {url|beginner/limited editors}."
-msgstr "In dit rapport staan {url|beginners / beperkte redacteurs}."
-
 #: ../root/report/asins_with_multiple_releases.tt:6
 msgid ""
 "This report shows Amazon URLs which are linked to multiple releases. In most"
@@ -7410,10 +7053,6 @@ msgid ""
 "might also find some ASINs linked to several discs of a multi-disc release: "
 "just merge those (see {how_to_merge_releases|How to Merge Releases})."
 msgstr "In dit rapport staan URL’s van Amazon die aan meerdere uitgaves zijn gekoppeld. In de meeste gevallen zouden ASIN’s van Amazon 1:1 overeen moeten komen met uitgaves op MusicBrainz, zodat er maar één correcte koppeling kan zijn. Controleer of de uitgave in MusicBrainz overeenkomt met de uitgave op Amazon (let op het medium, de nummers op de uitgave en het land van uitgave). Soms is een URL van Amazon gekoppeld aan verschillende uitgaves in MusicBrainz die eigenlijk verschillende losse media van één uitgave zijn. In dat geval moeten deze uitgaves worden samengevoegd (zie {how_to_merge_releases|Hoe uitgaves samen te voegen})."
-
-#: ../root/report/discogs_links_with_multiple_artists.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple artists."
-msgstr "In dit rapport staan URL’s van Discogs die aan meerdere artiesten zijn gekoppeld."
 
 #: ../root/report/discogs_links_with_multiple_labels.tt:6
 msgid "This report shows Discogs URLs which are linked to multiple labels."
@@ -7439,7 +7078,7 @@ msgstr "In dit rapport staan URL’s van Discogs die aan meerdere uitgaves zijn 
 msgid ""
 "This report shows all recordings with the same name that have different "
 "artists (having different MBIDs) with the same name."
-msgstr "Dit rapport toont alle opnames met dezelfde naam van verschillende artiesten (met verschillende MBID’s) die dezelfde naam hebben."
+msgstr "Dit rapport toont alle opnames die dezelfde titel hebben en waarvan de artiesten dezelfde naam hebben, maar verschillende MBID’s (ze gelden binnen MusicBrainz dus als verschillende artiesten)."
 
 #: ../root/report/instruments_without_an_image.tt:6
 msgid ""
@@ -7693,7 +7332,7 @@ msgstr "Deze serie is momenteel leeg."
 msgid "This table shows a summary of votes cast by this editor."
 msgstr "Deze tabel geeft een samenvatting van alle stemmen die door deze redacteur zijn uitgebracht."
 
-#: ../root/components/common-macros.tt:937
+#: ../root/components/common-macros.tt:932
 msgid "This track is a data track."
 msgstr "Dit nummer is een datanummer."
 
@@ -7819,29 +7458,6 @@ msgstr "Totaal aantal gevonden ISWC’s: {count}"
 #: ../root/report/deprecated_relationship_urls.tt:8
 msgid "Total URLs found: {count}"
 msgstr "Totaal aantal gevonden URL’s: {count}"
-
-#: ../root/report/annotations_artists.tt:8
-#: ../root/report/artists_containing_disambiguation_comments.tt:8
-#: ../root/report/artists_disambiguation_same_name.tt:8
-#: ../root/report/artists_that_may_be_groups.tt:11
-#: ../root/report/artists_that_may_be_persons.tt:12
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:8
-#: ../root/report/artists_with_no_subscribers.tt:7
-#: ../root/report/collaboration_relationships.tt:10
-#: ../root/report/deprecated_relationship_artists.tt:8
-#: ../root/report/discogs_links_with_multiple_artists.tt:7
-#: ../root/report/duplicate_relationships_artists.tt:9
-#: ../root/report/possible_collaborations.tt:13
-msgid "Total artists found: {count}"
-msgstr "Totaal aantal gevonden artiesten: {count}"
-
-#: ../root/report/duplicate_artists.tt:14
-msgid "Total duplicate groups: {count}"
-msgstr "Totaal aantal dubbele groepen: {count}"
-
-#: ../root/report/limited_editors.tt:8
-msgid "Total editors found: {count}"
-msgstr "Totaal aantal gevonden redacteurs: {count}"
 
 #: ../root/report/duplicate_events.tt:10
 #: ../root/report/event_sequence_not_in_series.tt:7
@@ -8001,7 +7617,7 @@ msgstr "Nummer:"
 
 #: ../root/cdstub/edit_form.tt:12 ../root/cdstub/index.tt:7
 #: ../root/release/edit/layout.tt:16 ../root/release/index.tt:4
-#: ../root/static/scripts/release-editor/fields.js:580
+#: ../root/static/scripts/release-editor/fields.js:581
 msgid "Tracklist"
 msgstr "Nummerlijst"
 
@@ -8019,10 +7635,6 @@ msgstr "Nummerlijst:"
 #: ../root/search/components/ReleaseResults.js:102
 msgid "Tracks"
 msgstr "Nummers"
-
-#: ../root/report/index.tt:122
-msgid "Tracks whose names include their sequence numbers"
-msgstr "Nummers met de positie in de titel"
 
 #: ../root/edit/details/historic/add_release.tt:44
 #: ../root/release_group/set_cover_art.tt:25
@@ -8051,16 +7663,11 @@ msgid ""
 "{uri|WikiDocs} transclusion table."
 msgstr "Transclusieredacteurs zijn gebruikers die lemma’s in de transclusietabel van {uri|WikiDocs} toevoegen en onderhouden."
 
-#: ../root/report/index.tt:96
-msgid ""
-"Translated/Transliterated Pseudo-Releases not linked to an original version"
-msgstr "Vertaalde of getranslitereerde pseudo-uitgaves die niet aan de originele uitgave zijn gekoppeld."
-
 #: ../root/components/forms.tt:256 ../root/components/forms.tt:280
 msgid "Turkish"
 msgstr "Turks"
 
-#: ../root/layout.tt:109 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -8076,15 +7683,18 @@ msgstr "Twitter"
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/artist_list.tt:8
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:18
-#: ../root/report/duplicate_artists.tt:27 ../root/report/event_list.tt:8
+#: ../root/report/event_list.tt:8
 #: ../root/report/instruments_without_an_image.tt:20
 #: ../root/report/iswc_with_many_works.tt:22
 #: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
 #: ../root/user/collections.tt:45 ../root/work/merge.tt:15
 #: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:28 ../root/iswc/Index.js:53
+#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
+#: ../root/report/DuplicateArtists.js:68
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/ArtistList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:30
 #: ../root/search/components/AnnotationResults.js:57
 #: ../root/search/components/AreaResults.js:58
 #: ../root/search/components/ArtistResults.js:67
@@ -8098,7 +7708,7 @@ msgstr "Twitter"
 #: ../root/search/components/SeriesResults.js:52
 #: ../root/search/components/WorkResults.js:53
 #: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:770
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
 msgid "Type"
 msgstr "Type"
 
@@ -8126,7 +7736,7 @@ msgstr "Type"
 #: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
 #: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:84
+#: ../root/search/components/SearchForm.js:85
 msgid "Type:"
 msgstr "Type:"
 
@@ -8142,14 +7752,15 @@ msgstr "Type: {type}, status: {status}"
 msgid "Types:"
 msgstr "Types:"
 
-#: ../root/components/common-macros.tt:587 ../root/report/artist_url_list.tt:5
+#: ../root/components/common-macros.tt:587
 #: ../root/report/bad_amazon_urls.tt:21 ../root/report/label_url_list.tt:5
 #: ../root/report/release_group_url_list.tt:5
 #: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
 #: ../lib/MusicBrainz/Server/Edit/URL.pm:7
+#: ../root/report/components/ArtistURLList.js:29
 #: ../root/static/scripts/common/i18n.js:63
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:28
+#: ../root/url/URLHeader.js:29
 msgid "URL"
 msgstr "URL"
 
@@ -8169,17 +7780,17 @@ msgid "URL:"
 msgstr "URL:"
 
 #: ../root/annotation/edit.tt:58
-msgid "URL; [URL]; [URL|label]; [<entity_type>:<mbid>|<name>]"
-msgstr "URL; [URL]; [URL|platenmaatschappij]; [<entity_type>:<mbid>|<name>]"
+msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
+msgstr "URL; [URL]; [URL|platenmaatschappij]; [objecttype:MBID|platenmaatschappij]"
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/index.tt:155
+#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
 msgid "URLs"
 msgstr "URL’s"
 
 #: ../root/report/deprecated_relationship_urls.tt:1
 #: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/index.tt:158
+#: ../root/report/ReportsIndex.js:173
 msgid "URLs with deprecated relationships"
 msgstr "URL’s met verouderde relaties"
 
@@ -8201,8 +7812,12 @@ msgstr "Ongeautoriseerde aanvraag"
 msgid "Unclassified instrument"
 msgstr "Ongeclassificeerd instrument"
 
-#: ../root/components/common-macros.tt:918 ../root/report/artist_list.tt:19
-#: ../root/report/artists_with_multiple_occurances_in_artist_credits.tt:25
+#: ../root/components/common-macros.tt:918
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
+#: ../root/report/DuplicateArtists.js:94
+#: ../root/report/components/ArtistAnnotationList.js:39
+#: ../root/report/components/ArtistList.js:37
+#: ../root/report/components/ArtistRelationshipList.js:42
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -8229,9 +7844,9 @@ msgstr "Abonnement opzeggen"
 msgid "Untrusted"
 msgstr "Niet vertrouwd"
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:28
-#: ../root/search/components/SearchForm.js:29
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
 #: ../root/search/components/SearchForm.js:30
+#: ../root/search/components/SearchForm.js:31
 msgid "Up to {n}"
 msgstr "Tot {n}"
 
@@ -8264,7 +7879,7 @@ msgstr "Afbeelding aan het uploaden"
 msgid "Uppercase roman numerals"
 msgstr "Zet Romeinse cijfers in bovenkast"
 
-#: ../root/layout.tt:111 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
 msgid "Use beta site"
 msgstr "Bètasite gebruiken"
 
@@ -8320,7 +7935,7 @@ msgid "Username:"
 msgstr "Gebruikersnaam:"
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
 msgid "Users"
 msgstr "Gebruikers"
 
@@ -8452,10 +8067,6 @@ msgstr "Waarschuwing: Deze relatie heeft openstaande bewerkingen. {show|Klik hie
 msgid "Watched Artists"
 msgstr "Gevolgde artiesten"
 
-#: ../root/report/not_available.tt:6
-msgid "We are sorry, but data for this report is not available right now."
-msgstr "Onze excuses, maar voor dit rapport zijn nu geen gegevens beschikbaar."
-
 #: ../root/edit/details/macros.tt:112
 msgid "We are unable to display history for this cover art."
 msgstr "We kunnen de geschiedenis van deze afbeelding niet laten zien."
@@ -8501,10 +8112,6 @@ msgid ""
 "your request &#x2014; the problem may go away."
 msgstr "Dit probleem spijt ons enorm. Wacht een paar minuten en herhaal dan je verzoek. Het probleem kan ondertussen verholpen zijn."
 
-#: ../root/report/editor_list.tt:9
-msgid "Website"
-msgstr "Website"
-
 #: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr "Website:"
@@ -8517,7 +8124,7 @@ msgid ""
 "and following the merge link."
 msgstr "Klik op de knop “Samenvoegen” als je klaar bent om deze objecten samen te voegen. Je kan ook nog meer aan deze lijst samen te voegen objecten toevoegen door naar de pagina van het object te gaan en de link samenvoegen te volgen."
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -8539,10 +8146,10 @@ msgstr "WikiDoc:"
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:41
+#: ../root/search/components/SearchForm.js:42
 #: ../root/static/scripts/common/i18n.js:64
 #: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:25
+#: ../root/work/WorkHeader.js:26
 msgid "Work"
 msgstr "Compositie"
 
@@ -8581,35 +8188,32 @@ msgstr "Compositie:"
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
 #: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/report/index.tt:147 ../root/series/index.tt:15
-#: ../root/components/EntityTabs.js:32 ../root/tag/TagIndex.js:90
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
+#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
 #: ../root/tag/TagLayout.js:31
 msgid "Works"
 msgstr "Composities"
 
-#: ../root/report/index.tt:152
-msgid "Works with annotations"
-msgstr "Composities met aantekeningen."
-
 #: ../root/report/deprecated_relationship_works.tt:1
 #: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/index.tt:151
+#: ../root/report/ReportsIndex.js:166
 msgid "Works with deprecated relationships"
 msgstr "Composities met verouderde relaties"
 
 #: ../root/report/duplicate_relationships_works.tt:1
 #: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/index.tt:150
+#: ../root/report/ReportsIndex.js:165
 msgid "Works with possible duplicate relationships"
 msgstr "Composities met mogelijk dubbele relaties"
 
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
 #: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
 #: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
 msgid "Writers"
 msgstr "Auteurs"
 
-#: ../root/entity/details.tt:28
+#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
 msgid "XML:"
 msgstr "XML:"
 
@@ -8722,9 +8326,8 @@ msgid ""
 " the work that you would like the other works merged into:"
 msgstr "Je staat op het punt om de volgende composities samen te voegen. Selecteer de compositie waarin je de andere compositie(s) wil samenvoegen:"
 
-#: ../root/artist/subscribers.tt:27 ../root/collection/subscribers.tt:27
-#: ../root/label/subscribers.tt:27 ../root/series/subscribers.tt:27
-#: ../root/user/subscribers.tt:32
+#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
+#: ../root/entity/Subscribers.js:88
 msgid "You are currently subscribed. {unsub|Unsubscribe}?"
 msgstr "Je bent momenteel geabonneerd. {unsub|Opzeggen}?"
 
@@ -8740,9 +8343,8 @@ msgstr "Je kan momenteel geen notities aan deze bewerking toevoegen. ({url|Detai
 msgid "You are not currently able to vote on this edit. ({url|Details})"
 msgstr "Je kan momenteel niet op deze bewerking stemmen. ({url|Details})"
 
-#: ../root/artist/subscribers.tt:33 ../root/collection/subscribers.tt:33
-#: ../root/label/subscribers.tt:33 ../root/series/subscribers.tt:33
-#: ../root/user/subscribers.tt:38
+#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
+#: ../root/entity/Subscribers.js:99
 msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr "Je bent momenteel niet geabonneerd. {sub|Abonneren}?"
 
@@ -8822,7 +8424,7 @@ msgid "You haven’t entered a complete artist credit."
 msgstr "Je hebt de artiesten niet compleet ingevuld."
 
 #: ../root/release/edit/editnote.tt:10
-#: ../root/static/scripts/relationship-editor/release.js:159
+#: ../root/static/scripts/relationship-editor/release.js:160
 msgid "You haven’t made any changes!"
 msgstr "Je hebt niets veranderd!"
 
@@ -8847,7 +8449,7 @@ msgstr "Je kan je persoonsgegevens op elk moment van onze diensten verwijderen d
 msgid "You must be logged in to vote on edits"
 msgstr "Je moet aangemeld zijn om op bewerkingen te stemmen."
 
-#: ../root/components/common-macros.tt:954
+#: ../root/components/common-macros.tt:949
 msgid "You must enter a disambiguation comment for this entity."
 msgstr "Je moet een verduidelijking aan dit object toevoegen."
 
@@ -8929,7 +8531,7 @@ msgstr "Je zoekopdracht duurde te lang en werd geannuleerd. Het kan helpen om sp
 msgid "Your username will be publicly visible."
 msgstr "Je gebruikersnaam zal publiekelijk zichtbaar zijn."
 
-#: ../root/layout.tt:18
+#: ../root/layout.tt:17
 msgid ""
 "You’re currently not allowed to edit or vote because an admin has revoked "
 "your privileges. If you haven’t already been contacted about why, please "
@@ -8972,10 +8574,6 @@ msgstr "[onbekend]"
 msgid "after"
 msgstr "na"
 
-#: ../root/report/duplicate_artists.tt:41
-msgid "alias:"
-msgstr "alias:"
-
 #: ../root/edit/search_macros.tt:28
 msgid "all"
 msgstr "alle"
@@ -8990,7 +8588,7 @@ msgstr "enige"
 
 #: ../root/release/edit/recordings.tt:178
 msgid "appears on:"
-msgstr "verschijnt op:"
+msgstr "staat op:"
 
 #: ../root/components/common-macros.tt:121
 msgid "areas"
@@ -9037,10 +8635,6 @@ msgstr "afgelast"
 #: ../root/components/relationship-editor.tt:253
 msgid "credited as"
 msgstr "vermeld als"
-
-#: ../root/report/editor_list.tt:21
-msgid "delete"
-msgstr "verwijderen"
 
 #: ../root/admin/wikidoc/index.tt:53
 msgid "diff"
@@ -9259,9 +8853,7 @@ msgstr "Origineel"
 msgid "places"
 msgstr "plaatsen"
 
-#: ../root/artist/subscribers.tt:14 ../root/collection/subscribers.tt:14
-#: ../root/label/subscribers.tt:14 ../root/series/subscribers.tt:14
-#: ../root/user/subscribers.tt:14
+#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
 msgid "plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] "plus {n} andere anonieme gebruiker"
@@ -9484,7 +9076,7 @@ msgstr[1] "{entitiy} is aan {num} collecties toegevoegd:"
 msgid "{entity} has not been added to any collections."
 msgstr "{entity} is nog niet aan een collectie toegevoegd."
 
-#: ../root/layout.tt:73 ../root/layout/index.js:97
+#: ../root/layout.tt:72 ../root/layout/index.js:96
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9498,7 +9090,7 @@ msgstr "{link} heeft geen waarderingen"
 msgid "{link} has no relationships."
 msgstr "{link} heeft geen relaties."
 
-#: ../root/entity/details.tt:10
+#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
 msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
 msgstr "{mbid|<abbr title=\"MusicBrainz Identificator\">MBID</abbr>}:"
 
@@ -9611,7 +9203,7 @@ msgstr "{type} ‘{instrument}’"
 msgid "{type} “{work}”"
 msgstr "{type} ‘{work}’"
 
-#: ../root/layout.tt:37 ../root/layout/index.js:45
+#: ../root/layout.tt:36 ../root/layout/index.js:44
 msgid "{uri|Return to musicbrainz.org}."
 msgstr "{uri|Keer terug naar musicbrainz.org}."
 
@@ -9621,7 +9213,7 @@ msgstr "{user}"
 
 #: ../root/user/collections.tt:27
 msgid "{user} has no public collections."
-msgstr "{user} heeft geen publieke collecties."
+msgstr "{user} heeft geen openbare collecties."
 
 #: ../root/user/ratings_summary.tt:33
 msgid "{user} has not rated anything."
@@ -9818,34 +9410,34 @@ msgstr "“{id}” is geen geldige verkiezings-ID"
 msgid "The required TOC parameter was invalid or not present"
 msgstr "De benodigde TOC-parameter was ongeldig of niet aanwezig"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:112
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
 msgid "Please provide a medium ID"
 msgstr "Geef een medium-ID op"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:117
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:122
 msgid "Could not find medium"
 msgstr "Kon geen medium vinden"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:151
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:312
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:156
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:317
 msgid "The provided CD TOC is not valid"
 msgstr "De ingevoerde TOC is niet geldig"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:164
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:326
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:169
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:331
 msgid "The provided medium id is not valid"
 msgstr "De ingevoerde medium-ID is niet geldig"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:170
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:175
 msgid "This CDTOC is already attached to this medium"
 msgstr "Deze TOC is al aan dit medium gekoppeld"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:179
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:334
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:184
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:339
 msgid "The selected medium cannot have disc IDs"
 msgstr "Het geselecteerde medium kan geen disc-ID’s hebben"
 
-#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:206
+#: ../lib/MusicBrainz/Server/Controller/CDTOC.pm:211
 msgid "The provided artist id is not valid"
 msgstr "De ingevoerde artiest-ID is niet geldig"
 
@@ -10227,7 +9819,7 @@ msgid "Convert release to multiple artists (historic)"
 msgstr "Zet uitgave om naar meerdere artiesten (historisch)"
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/SetTrackLengthsFromCDTOC.pm:13
-#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm:21
 msgid "Set track lengths"
 msgstr "Duur van de nummers instellen"
 
@@ -10528,6 +10120,12 @@ msgstr "Stemming mislukt"
 msgid "Failed dependency"
 msgstr "Mislukt door afhankelijkheid"
 
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
+#: ../root/report/ReportNotAvailable.js:16
+#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+msgid "Error"
+msgstr "Fout"
+
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
 msgid "Failed prerequisite"
 msgstr "Mislukt door voorwaarde"
@@ -10660,7 +10258,7 @@ msgstr "[geen]"
 
 #: ../lib/MusicBrainz/Server/Entity/EditorOAuthToken.pm:67
 msgid "View your public account information"
-msgstr "Je publieke accountinformatie te bekijken."
+msgstr "Je openbare accountinformatie te bekijken."
 
 #: ../lib/MusicBrainz/Server/Entity/EditorOAuthToken.pm:68
 msgid "View your email address"
@@ -10834,7 +10432,7 @@ msgstr "Het type van de collectie moet overeenkomen met de objecten in de collec
 #: ../lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm:48
 #, perl-brace-format
 msgid "Please add an artist name for {credit}"
-msgstr "Voer alsjeblieft een artiestennaam in voor {credit}"
+msgstr "Voer een artiestennaam in voor {credit}"
 
 #: ../lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm:55
 #, perl-brace-format
@@ -10845,7 +10443,7 @@ msgstr "De artiest “{artist}” is niet gekoppeld. Je moet een bestaande artie
 
 #: ../lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm:61
 msgid "Please add an artist name for each credit."
-msgstr "Voer alsjeblieft een artiestennaam in voor elke vermelding."
+msgstr "Voer voor elke vermelding een artiestennaam in."
 
 #: ../lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm:76
 msgid "Artist credit field is required"
@@ -10856,7 +10454,7 @@ msgid "These coordinates could not be parsed"
 msgstr "Deze coördinaten konden niet worden ingevoerd"
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:498
+#: ../root/static/scripts/relationship-editor/common/dialog.js:499
 msgid "The end date cannot precede the begin date."
 msgstr "De einddatum kan niet voor de begindatum zijn."
 
@@ -10960,13 +10558,13 @@ msgstr "Je moet een opmerking toevoegen"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
 #: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:46
+#: ../root/search/components/SearchForm.js:47
 msgid "CD Stub"
 msgstr "Cd-beginnetje"
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:48
+#: ../root/search/components/SearchForm.js:49
 msgctxt "noun"
 msgid "Tag"
 msgstr "Etiket"
@@ -10974,7 +10572,7 @@ msgstr "Etiket"
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
 #: ../root/layout/components/BottomMenu.js:249
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:56
+#: ../root/search/components/SearchForm.js:57
 msgid "Documentation"
 msgstr "Documentatie"
 
@@ -11234,7 +10832,7 @@ msgstr "{list_item}, {rest}"
 msgid "{last_list_item}"
 msgstr "{last_list_item}"
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:61
+#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
 msgid "Donation Check"
 msgstr "Donatiecontrole"
 
@@ -11243,7 +10841,7 @@ msgid ""
 "We have not received a donation from you recently. If you have just made a "
 "PayPal donation, then we have not received a notification from PayPal yet. "
 "Please wait a few minutes and reload this page to check again."
-msgstr "We hebben de laatste tijd geen donatie meer van je gehad. Als je net een donatie hebt gedaan via PayPal, dan hebben we nog geen bericht van PayPal gehad. Wacht alsjeblieft een paar minuten en herlaad dan deze pagina om het opnieuw te controleren."
+msgstr "We hebben de laatste tijd geen donatie meer van je gehad. Als je net een donatie hebt gedaan via PayPal, dan hebben we nog geen bericht van PayPal gehad. Wacht een paar minuten en herlaad dan deze pagina om het opnieuw te controleren."
 
 #: ../root/account/Donation.js:30
 msgid ""
@@ -11285,6 +10883,12 @@ msgid ""
 "it} first and then reset your password."
 msgstr "Voer hieronder je gebruikersnaam en wachtwoord in. We zullen je een e-mail sturen met een link om je wachtwoord opnieuw in te stellen. Als je je gebruikersnaam bent vergeten, moet je die eerst {link|opvragen} en daarna je wachtwoord opnieuw instellen."
 
+#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:30
+#: ../root/static/scripts/account/components/PreferencesForm.js:213
+msgid "Email"
+msgstr "E-mail"
+
 #: ../root/account/LostPasswordSent.js:17
 #: ../root/account/LostUsernameSent.js:17
 msgid "Email Sent!"
@@ -11316,7 +10920,7 @@ msgid ""
 msgstr "We hebben je informatie gestuurd over je MusicBrainz-account. Neem {link|contact met ons op} als je deze e-mail niet hebt ontvangen of nog steeds problemen hebt met aanmelden."
 
 #: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:59
+#: ../root/components/UserAccountTabs.js:60
 msgid "Preferences"
 msgstr "Voorkeuren"
 
@@ -11452,7 +11056,7 @@ msgstr "Er is een e-mail gestuurd naar {addr}. Kijk in je e-mail en klik op de l
 msgid "Unconfirmed Email Address"
 msgstr "Niet-bevestigd e-mailadres"
 
-#: ../root/area/AreaHeader.js:26
+#: ../root/area/AreaHeader.js:27
 msgid "{area_type} in {parent_areas}"
 msgstr "{area_type} in {parent_areas}"
 
@@ -11492,32 +11096,32 @@ msgid ""
 msgstr "Onze excuses, we konden geen artiest vinden met die MBID. Je kan ook proberen om {search_url|ernaar te zoeken}."
 
 #: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Born in:"
 msgstr "Geboren in:"
 
 #: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Founded in:"
 msgstr "Opgericht in:"
 
 #: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "Begin area:"
 msgstr "Begingebied:"
 
 #: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
 msgid "Died in:"
 msgstr "Overleden in:"
 
 #: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
 msgid "Dissolved in:"
 msgstr "Opgeheven in:"
 
 #: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
 msgid "End area:"
 msgstr "Eindgebied:"
 
@@ -11537,23 +11141,23 @@ msgstr "Collectie niet gevonden"
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr "Onze excuses, we konden geen collectie vinden met die MBID."
 
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "Begin Date"
 msgstr "Begindatum"
 
-#: ../root/components/Aliases/AliasTable.js:27
+#: ../root/components/Aliases/AliasTable.js:29
 msgid "End Date"
 msgstr "Einddatum"
 
-#: ../root/components/Aliases/AliasTableRow.js:46
+#: ../root/components/Aliases/AliasTableRow.js:47
 msgid "primary"
 msgstr "primair"
 
-#: ../root/components/Aliases/index.js:34
+#: ../root/components/Aliases/index.js:35
 msgid "{entity} has no aliases."
 msgstr "{entity} heeft geen aliassen."
 
-#: ../root/components/Aliases/index.js:39
+#: ../root/components/Aliases/index.js:40
 msgid "Add a new alias"
 msgstr "Nieuwe alias toevoegen"
 
@@ -11595,19 +11199,19 @@ msgstr[1] "<span class=\"tooltip\" title=\"{exactdate}\">{num} minuten</span>"
 msgid "Already expired"
 msgstr "Al verlopen"
 
-#: ../root/components/UserAccountTabs.js:40
+#: ../root/components/UserAccountTabs.js:41
 #: ../root/layout/components/TopMenu.js:31
 msgid "Profile"
 msgstr "Profiel"
 
-#: ../root/components/UserAccountTabs.js:43
+#: ../root/components/UserAccountTabs.js:44
 #: ../root/layout/components/TopMenu.js:38
 #: ../root/layout/components/sidebar/CollectionSidebar.js:73
 #: ../root/layout/components/sidebar/SubscriptionLinks.js:29
 msgid "Subscriptions"
 msgstr "Abonnementen"
 
-#: ../root/components/UserAccountTabs.js:65
+#: ../root/components/UserAccountTabs.js:66
 msgid "Edit User"
 msgstr "Gebruiker bewerken"
 
@@ -11669,7 +11273,7 @@ msgid "For more information:"
 msgstr "Voor meer informatie:"
 
 #: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:26
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
 msgid "Add Note"
 msgstr "Notitie toevoegen"
 
@@ -11848,6 +11452,22 @@ msgstr "Stemmen"
 msgid "Votes cast"
 msgstr "Uitgebrachte stemmen"
 
+#: ../root/entity/Subscribers.js:40
+msgid "There is currently {num} user subscribed to {entity}:"
+msgid_plural "There are currently {num} users subscribed to {entity}:"
+msgstr[0] "Er is nu {num} gebruiker op {entity} geabonneerd:"
+msgstr[1] "Er zijn nu {num} gebruikers op {entity} geabonneerd:"
+
+#: ../root/entity/Subscribers.js:59
+msgid "Plus {n} other anonymous user"
+msgid_plural "Plus {n} other anonymous users"
+msgstr[0] "Plus {n} andere anonieme gebruiker"
+msgstr[1] "Plus {n} andere anonieme gebruikers"
+
+#: ../root/entity/Subscribers.js:81
+msgid "There are currently no users subscribed to {entity}."
+msgstr "Er zijn nu geen gebruikers op {entity} geabonneerd."
+
 #: ../root/event/NotFound.js:16
 msgid "Event Not Found"
 msgstr "Evenement niet gevonden"
@@ -11874,7 +11494,7 @@ msgid ""
 "ticket}."
 msgstr "Ontbreekt er een genre op deze lijst? Dan kan je het aanvragen door een {link|stijlticket} aan te maken."
 
-#: ../root/instrument/InstrumentHeader.js:25
+#: ../root/instrument/InstrumentHeader.js:26
 msgid "instrument"
 msgstr "instrument"
 
@@ -12116,6 +11736,11 @@ msgstr "Evenement toevoegen"
 msgid "Vote on Edits"
 msgstr "Op bewerkingen stemmen"
 
+#: ../root/layout/components/BottomMenu.js:241
+#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+msgid "Reports"
+msgstr "Rapporten"
+
 #: ../root/layout/components/BottomMenu.js:252
 msgid "Beginners Guide"
 msgstr "Handleiding voor beginners"
@@ -12156,23 +11781,23 @@ msgstr "Alle relaties bekijken"
 msgid "Running: {git_details}"
 msgstr "Draait: {git_details}"
 
-#: ../root/layout/components/Head.js:31
+#: ../root/layout/components/Head.js:32
 msgid "Page {n}"
 msgstr "Pagina {n}"
 
-#: ../root/layout/components/Head.js:64
+#: ../root/layout/components/Head.js:65
 msgid "MusicBrainz: Artist"
 msgstr "MusicBrainz: Artiest"
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:66
 msgid "MusicBrainz: Label"
 msgstr "MusicBrainz: Platenmaatschappij"
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:67
 msgid "MusicBrainz: Release"
 msgstr "MusicBrainz: Uitgave"
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:68
 msgid "MusicBrainz: Track"
 msgstr "MusicBrainz: Nummer"
 
@@ -12407,9 +12032,13 @@ msgstr "Informatie over het instrument"
 msgid "Label information"
 msgstr "Informatie over de platenmaatschappij"
 
-#: ../root/layout/components/sidebar/LastUpdated.js:23
+#: ../root/layout/components/sidebar/LastUpdated.js:26
 msgid "Last updated on {date}"
 msgstr "Het laatst bijgewerkt op {date}"
+
+#: ../root/layout/components/sidebar/LastUpdated.js:30
+msgid "Last updated on an unknown date"
+msgstr "Het laatst bijgewerkt op een onbekende datum"
 
 #: ../root/layout/components/sidebar/PlaceSidebar.js:49
 msgid "Place information"
@@ -12485,18 +12114,18 @@ msgid "see all ratings"
 msgstr "bekijk alle waarderingen"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:547
 msgctxt "genre"
 msgid "(none)"
 msgstr "(geen)"
 
 #: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:513
+#: ../root/static/scripts/common/components/TagEditor.js:557
 msgctxt "tag"
 msgid "(none)"
 msgstr "(geen)"
 
-#: ../root/layout/components/sidebar/SidebarTags.js:92
+#: ../root/layout/components/sidebar/SidebarTags.js:93
 msgid "See all tags"
 msgstr "Bekijk alle etiketten"
 
@@ -12512,7 +12141,7 @@ msgstr "Onze excuses, de pagina die je zoekt bestaat niet."
 msgid ""
 "Found a broken link on our site? Please {report|report a bug} and include "
 "any error message that is shown above."
-msgstr "Heb je een kapotte link op onze site gevonden? {report|Rapporteer hem alsjeblieft} en voeg elke foutmelding toe die hierboven wordt weergegeven."
+msgstr "Heb je op onze site een kapotte link gevonden? {report|Laat het ons weten} en voeg elke foutmelding toe die hierboven wordt weergegeven."
 
 #: ../root/main/index.js:32
 msgid "MusicBrainz - The Open Music Encyclopedia"
@@ -12665,11 +12294,11 @@ msgid ""
 "to try and {search_url|search for it} instead."
 msgstr "Onze excuses, we konden geen opname vinden met die MBID. Je kan ook proberen om {search_url|ernaar te zoeken}."
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Video by {artist}"
 msgstr "Video van {artist}"
 
-#: ../root/recording/RecordingHeader.js:37
+#: ../root/recording/RecordingHeader.js:38
 msgid "Recording by {artist}"
 msgstr "Opname van {artist}"
 
@@ -12698,9 +12327,398 @@ msgid ""
 "wish to try and {search_url|search for it} instead."
 msgstr "Onze excuses, we konden geen uitgavegroep vinden met die MBID. Je kan ook proberen om {search_url|ernaar te zoeken}."
 
-#: ../root/release_group/ReleaseGroupHeader.js:32
+#: ../root/release_group/ReleaseGroupHeader.js:33
 msgid "Release group by {artist}"
 msgstr "Uitgavegroep van {artist}"
+
+#: ../root/report/AnnotationsArtists.js:29
+#: ../root/report/AnnotationsArtists.js:30
+msgid "Artist annotations"
+msgstr "Artiesten met aantekeningen"
+
+#: ../root/report/AnnotationsArtists.js:34
+msgid "This report lists artists with annotations."
+msgstr "In dit rapport staan artiesten met aantekeningen."
+
+#: ../root/report/AnnotationsArtists.js:36
+#: ../root/report/ArtistsContainingDisambiguationComments.js:37
+#: ../root/report/ArtistsDisambiguationSameName.js:37
+#: ../root/report/ArtistsThatMayBeGroups.js:40
+#: ../root/report/ArtistsThatMayBePersons.js:40
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/ArtistsWithNoSubscribers.js:38
+#: ../root/report/CollaborationRelationships.js:44
+#: ../root/report/DeprecatedRelationshipArtists.js:36
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
+#: ../root/report/DuplicateRelationshipsArtists.js:37
+#: ../root/report/PossibleCollaborations.js:42
+msgid "Total artists found: {count}"
+msgstr "Totaal aantal gevonden artiesten: {count}"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/ArtistsContainingDisambiguationComments.js:30
+#: ../root/report/ReportsIndex.js:39
+msgid "Artists containing disambiguation comments in their name"
+msgstr "Artiesten met een verduidelijking in de naam"
+
+#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+msgid ""
+"This report lists artists that may have disambiguation comments in their "
+"name, rather than the actual disambiguation comment field."
+msgstr "In dit rapport staan artiesten die misschien verduidelijkingen in hun naam hebben, in plaats van het daarvoor bedoelde veld."
+
+#: ../root/report/ArtistsDisambiguationSameName.js:29
+#: ../root/report/ArtistsDisambiguationSameName.js:30
+#: ../root/report/ReportsIndex.js:45
+msgid "Artists with disambiguation the same as the name"
+msgstr "Artiesten met een verduidelijking die gelijk is aan de naam"
+
+#: ../root/report/ArtistsDisambiguationSameName.js:34
+msgid ""
+"This report lists artists that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr "In dit rapport staan artiesten die een verduidelijking hebben die overeenkomt met de naam van de artiest. In dat geval zou de artiest geen verduidelijking moeten hebben."
+
+#: ../root/report/ArtistsThatMayBeGroups.js:29
+#: ../root/report/ArtistsThatMayBeGroups.js:30
+#: ../root/report/ReportsIndex.js:33
+msgid "Artists that may be groups"
+msgstr "Artiesten die groepen zouden kunnen zijn"
+
+#: ../root/report/ArtistsThatMayBeGroups.js:34
+msgid ""
+"This report lists artists that have their type set to other than Group (or a"
+" subtype of Group) but may be a group, because they have other artists "
+"listed as members If you find that an artist here is indeed a group, change "
+"its type. If it is not, please make sure that the \"member of\" "
+"relationships are in the right direction and are correct."
+msgstr "In dit rapport staan artiesten die op MusicBrainz niet als groep (of een subtype van groep) bekend zijn, maar dat misschien wel zouden moeten zijn, omdat andere artiesten als leden staan vermeld. Als een artiest inderdaad een groep zou moeten zijn, kan je het type artiest veranderen. Als een artiest toch geen groep is, kan je controleren of de ‘lid van’-relaties kloppen en de goede richting op wijzen."
+
+#: ../root/report/ArtistsThatMayBePersons.js:29
+#: ../root/report/ArtistsThatMayBePersons.js:30
+#: ../root/report/ReportsIndex.js:34
+msgid "Artists that may be persons"
+msgstr "Artiesten die een persoon zouden kunnen zijn"
+
+#: ../root/report/ArtistsThatMayBePersons.js:34
+msgid ""
+"This report lists artists that have their type set to other than Person, but"
+" may be a person, based on their relationships. For example, an artist will "
+"appear here if it is listed as a member of another. If you find that an "
+"artist here is indeed a person, change its type. If it is not, please make "
+"sure that all the relationships are correct and make sense."
+msgstr "In dit rapport staan artiesten die op MusicBrainz niet als persoon bekend zijn, maar dat op basis van relaties misschien wel zouden moeten zijn. Een artiest staat hier bijvoorbeeld in omdat hij een lid is van een andere artiest. Verander het type als de artiest inderdaad een persoon is. Als de artiest geen persoon is, kan je controleren of alle relaties kloppen en logisch zijn."
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
+#: ../root/report/ReportsIndex.js:42
+msgid "Artists occurring multiple times in the same artist credit"
+msgstr "Artiesten die meerdere keren als artiest van één nummer of opname worden vermeld."
+
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+msgid ""
+"This report lists artists that appear more than once in different positions "
+"within the same artist credit."
+msgstr "In dit rapport staan artiesten die meerdere keren binnen één vermelding worden genoemd."
+
+#: ../root/report/ArtistsWithNoSubscribers.js:29
+#: ../root/report/ArtistsWithNoSubscribers.js:30
+#: ../root/report/ReportsIndex.js:35
+msgid "Artists with no subscribers"
+msgstr "Artiesten zonder abonnees"
+
+#: ../root/report/ArtistsWithNoSubscribers.js:34
+msgid ""
+"This report lists artists that have no editors subscribed to them, and whose"
+" changes may therefore be under-reviewed. Artists with more release groups "
+"and more open edits are listed first."
+msgstr "In dit rapport staan artiesten waar geen redacteurs op geabonneerd zijn, waardoor bewerkingen misschien niet genoeg worden nagekeken. Artiesten met meer uitgavegroepen en open bewerkingen worden het eerst getoond."
+
+#: ../root/report/CollaborationRelationships.js:34
+#: ../root/report/CollaborationRelationships.js:35
+msgid "Artists with collaboration relationships"
+msgstr "Artiesten met samenwerkingsrelaties"
+
+#: ../root/report/CollaborationRelationships.js:39
+msgid ""
+"This report lists artists which have collaboration relationships but no URL "
+"relationships. If the collaboration has its own independent name, do "
+"nothing. If it is in a format like \"X with Y\" or \"X & Y\", you should "
+"probably split it. See {how_to_split_artists|How to Split Artists}."
+msgstr "In dit rapport staan artiesten die een samenwerkingsrelatie hebben, maar geen URL-relaties. Als de samenwerking zijn eigen unieke naam heeft, moet er niets gebeuren. Als het lijkt op ‘X met Y’ of ‘X & Y’, moet de artiest waarschijnlijk worden gesplitst. Zie {how_to_split_artists|artiesten splitsen}."
+
+#: ../root/report/CollaborationRelationships.js:54
+msgid "Collaboration"
+msgstr "Samenwerking"
+
+#: ../root/report/CollaborationRelationships.js:55
+msgid "Collaborator"
+msgstr "Samenwerker"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:29
+#: ../root/report/DeprecatedRelationshipArtists.js:30
+#: ../root/report/ReportsIndex.js:43
+msgid "Artists with deprecated relationships"
+msgstr "Artiesten met verouderde relaties"
+
+#: ../root/report/DeprecatedRelationshipArtists.js:34
+msgid ""
+"This report lists artists which have relationships using deprecated and "
+"grouping-only relationship types"
+msgstr "In dit rapport staan artiesten met verouderde relaties of relaties die alleen voor het groeperen van relaties worden gebruikt."
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:29
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
+#: ../root/report/ReportsIndex.js:40
+msgid "Discogs URLs linked to multiple artists"
+msgstr "URL’s van Discogs die aan meerdere artiesten zijn gekoppeld"
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+msgid "This report shows Discogs URLs which are linked to multiple artists."
+msgstr "In dit rapport staan URL’s van Discogs die aan meerdere artiesten zijn gekoppeld."
+
+#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
+#: ../root/report/ReportsIndex.js:36
+msgid "Possibly duplicate artists"
+msgstr "Mogelijk dubbele artiesten"
+
+#: ../root/report/DuplicateArtists.js:43
+msgid ""
+"This report aims to identify artists with very similar names. If two artists"
+" are actually the same, please merge them (remember to "
+"{how_to_write_edit_notes|write an edit note} and give your proof). If "
+"they're different, add {disambiguation_comment|disambiguation comments} to "
+"them (and once a group of similarly named artists have disambiguation "
+"comments, they will stop appearing here)."
+msgstr "In dit rapport staan artiesten met namen die erg op elkaar lijken. Als twee artiesten een en dezelfde artiest blijkt te zijn, kan je ze samenvoegen. Vergeet niet om {how_to_write_edit_notes|een notitie achter te laten} met bewijs voor je bewerking.\nAls het verschillende artiesten zijn, kan je een {disambiguation_comment|verduidelijking} aan de artiesten toevoegen. Als twee op elkaar lijkende artiesten een verduidelijking hebben, worden ze uit dit rapport verwijderd."
+
+#: ../root/report/DuplicateArtists.js:54
+msgid "Total duplicate groups: {count}"
+msgstr "Totaal aantal dubbele groepen: {count}"
+
+#: ../root/report/DuplicateArtists.js:90
+msgid "alias:"
+msgstr "alias:"
+
+#: ../root/report/DuplicateArtists.js:103
+msgid "Add selected artists for merging"
+msgstr "Geselecteerde artiesten samenvoegen"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateRelationshipsArtists.js:30
+#: ../root/report/ReportsIndex.js:41
+msgid "Artists with possible duplicate relationships"
+msgstr "Artiesten met mogelijk dubbele relaties"
+
+#: ../root/report/DuplicateRelationshipsArtists.js:34
+msgid ""
+"This report lists artists which have multiple relatonships to the same "
+"artist, label or URL using the same relationship type. For multiple "
+"relationships to release groups, recordings or works, see the reports for "
+"those entities."
+msgstr "In dit rapport staan artiesten die meerdere relaties van hetzelfde type met dezelfde artiest, platenmaatschappij of URL hebben. Zie voor meerdere relaties naar uitgavegroepen, opnames of composities de rapporten voor die objecten."
+
+#: ../root/report/FilterLink.js:24
+msgid "Show all results."
+msgstr "Toon alle resultaten"
+
+#: ../root/report/FilterLink.js:26
+msgid "Show only results that are in my subscribed entities."
+msgstr "Toon alleen resultaten in mijn abonnementen."
+
+#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
+#: ../root/report/ReportsIndex.js:53
+msgid "Beginner/limited editors"
+msgstr "Beginners / beperkte redacteurs"
+
+#: ../root/report/LimitedEditors.js:33
+msgid "This report lists {url|beginner/limited editors}."
+msgstr "In dit rapport staan {url|beginners / beperkte redacteurs}."
+
+#: ../root/report/LimitedEditors.js:36
+msgid "Total editors found: {count}"
+msgstr "Totaal aantal gevonden redacteurs: {count}"
+
+#: ../root/report/PossibleCollaborations.js:29
+#: ../root/report/PossibleCollaborations.js:30
+msgid "Artists that may be collaborations"
+msgstr "Artiesten die samenwerkingen zouden kunnen zijn"
+
+#: ../root/report/PossibleCollaborations.js:34
+msgid ""
+"This report lists artists which have \"&\" in their names but no member or "
+"collaboration relationships. If the artist is usually seen as an actual "
+"group, member relationships should be added. If it's a short term "
+"collaboration, it should be split if possible (see {how_to_split_artists|How"
+" to Split Artists}). If it is a collaboration with its own name and can't be"
+" split, collaboration relationships should be added to it."
+msgstr "In dit rapport staan artiesten met ‘&’ in de naam, maar die geen lid- of samenwerkingsrelatie hebben. Als de artiest doorgaans als groep wordt gezien, moeten er ledenrelaties worden toegevoegd. Als het een kort bestaande samenwerking is, moet het indien mogelijk worden gesplitst (zie {how_to_split_artists|artiesten splitsen}). Als het een samenwerking met een eigen naam is, en de artiest niet kan worden gesplitst, moeten er samenwerkingsrelaties worden toegevoegd."
+
+#: ../root/report/ReportNotAvailable.js:20
+msgid "We are sorry, but data for this report is not available right now."
+msgstr "Onze excuses, maar voor dit rapport zijn nu geen gegevens beschikbaar."
+
+#: ../root/report/ReportsIndex.js:22
+msgid ""
+"If you'd like to participate in the editing process, but do not know where "
+"to start, the following reports should be useful. These reports scour the "
+"database looking for data that might require fixing, either to comply with "
+"the {style|style guidelines}, or in other cases where administrative \"clean"
+" up\" tasks are required."
+msgstr "Als je mee wil helpen om MusicBrainz te verbeteren, maar niet weet waar je moet beginnen, kunnen deze rapporten je helpen. In deze rapporten staan gegevens die misschien verbeterd moeten worden, bijvoorbeeld om ze te laten voldoen aan onze {style|stijlgids} of vanwege een administratieve opruiming."
+
+#: ../root/report/ReportsIndex.js:37
+msgid "Artists which have collaboration relationships"
+msgstr "Artiesten met samenwerkingsrelaties"
+
+#: ../root/report/ReportsIndex.js:38
+msgid "Artists which look like collaborations"
+msgstr "Artiesten die samenwerkingen lijken te zijn"
+
+#: ../root/report/ReportsIndex.js:44
+msgid "Artists with annotations"
+msgstr "Artiesten met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:50
+msgid "Editors"
+msgstr "Redacteurs"
+
+#: ../root/report/ReportsIndex.js:61
+msgid "Possibly duplicate events"
+msgstr "Mogelijk dubbele evenementen"
+
+#: ../root/report/ReportsIndex.js:74
+msgid "Discogs URLs linked to multiple labels"
+msgstr "URL’s van Discogs die aan meerdere platenmaatschappijen zijn gekoppeld"
+
+#: ../root/report/ReportsIndex.js:77
+msgid "Labels with annotations"
+msgstr "Platenmaatschappijen met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:81
+msgid "Release groups"
+msgstr "Uitgavegroepen"
+
+#: ../root/report/ReportsIndex.js:84
+msgid "Release groups that might need to be merged"
+msgstr "Uitgavegroepen die misschien moeten worden samengevoegd"
+
+#: ../root/report/ReportsIndex.js:86
+msgid "Discogs URLs linked to multiple release groups"
+msgstr "URL’s van Discogs die aan meerdere uitgavegroepen zijn gekoppeld"
+
+#: ../root/report/ReportsIndex.js:90
+msgid "Release groups with annotations"
+msgstr "Uitgavegroepen met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:101
+msgid "Releases which have unexpected Amazon URLs"
+msgstr "Uitgaves met onverwachte Amazon-URL’s"
+
+#: ../root/report/ReportsIndex.js:102
+msgid "Releases which have multiple ASINs"
+msgstr "Uitgaves met meerdere ASIN’s"
+
+#: ../root/report/ReportsIndex.js:103
+msgid "Releases which have multiple Discogs links"
+msgstr "Uitgaves met meerdere Discogs-verwijzingen"
+
+#: ../root/report/ReportsIndex.js:104
+msgid "Amazon URLs linked to multiple releases"
+msgstr "URL’s van Amazon die aan meerdere uitgaves zijn gekoppeld"
+
+#: ../root/report/ReportsIndex.js:105
+msgid "Discogs URLs linked to multiple releases"
+msgstr "URL’s van Discogs die aan meerdere uitgaves zijn gekoppeld"
+
+#: ../root/report/ReportsIndex.js:106
+msgid "Releases which have part of set relationships"
+msgstr "Uitgaves met deel-van-een-set-relaties"
+
+#: ../root/report/ReportsIndex.js:107
+msgid "Discs entered as separate releases"
+msgstr "Media die als afzonderlijke uitgaves zijn toegevoegd"
+
+#: ../root/report/ReportsIndex.js:108
+msgid "Releases with non-sequential track numbers"
+msgstr "Uitgaves met nummers die niet op volgorde zijn"
+
+#: ../root/report/ReportsIndex.js:112
+msgid "Releases where some (but not all) mediums have no format set"
+msgstr "Uitgaves waar bij sommige (maar niet alle) media geen type zijn ingesteld."
+
+#: ../root/report/ReportsIndex.js:113
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr "Uitgaves met catalogusnummers die er uitzien als ASIN’s"
+
+#: ../root/report/ReportsIndex.js:114
+msgid ""
+"Translated/Transliterated Pseudo-Releases not linked to an original version"
+msgstr "Vertaalde of getranslitereerde pseudo-uitgaves die niet aan de originele uitgave zijn gekoppeld."
+
+#: ../root/report/ReportsIndex.js:116
+msgid "Releases of any sort that still have cover art relationships"
+msgstr "Uitgaves van elk type die nog relaties voor afbeeldingen hebben."
+
+#: ../root/report/ReportsIndex.js:118
+msgid "Releases with non-sequential mediums"
+msgstr "Uitgaves met media die niet op volgorde zijn"
+
+#: ../root/report/ReportsIndex.js:125
+msgid "Releases with annotations"
+msgstr "Uitgaves met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:129
+msgid "Releases missing disc IDs"
+msgstr "Uitgaves zonder disc-ID’s"
+
+#: ../root/report/ReportsIndex.js:136
+msgid "Recordings with earliest release relationships"
+msgstr "Opnames met eerste uitgave-relaties"
+
+#: ../root/report/ReportsIndex.js:137
+msgid "Tracks whose names include their sequence numbers"
+msgstr "Nummers met de positie in de titel"
+
+#: ../root/report/ReportsIndex.js:140
+msgid "Recordings with varying track times"
+msgstr "Opnames met afwijkende nummerlengtes"
+
+#: ../root/report/ReportsIndex.js:142
+msgid "Recordings with annotations"
+msgstr "Opnames met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:152
+msgid "Places with annotations"
+msgstr "Plaatsen met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:159
+msgid "Series with annotations"
+msgstr "Series met aantekeningen"
+
+#: ../root/report/ReportsIndex.js:167
+msgid "Works with annotations"
+msgstr "Composities met aantekeningen."
+
+#: ../root/report/ReportsIndex.js:183
+msgid "ISWCs"
+msgstr "ISWC’s"
+
+#: ../root/report/components/EditorList.js:28
+msgid "Member since"
+msgstr "Lid sinds"
+
+#: ../root/report/components/EditorList.js:29
+msgid "Website"
+msgstr "Website"
+
+#: ../root/report/components/EditorList.js:31
+msgid "Bio"
+msgstr "Bio"
+
+#: ../root/report/components/EditorList.js:42
+msgid "delete"
+msgstr "verwijderen"
 
 #: ../root/search/components/AreaResults.js:70
 msgid "Alternatively, you may {uri|add a new area}."
@@ -12857,60 +12875,76 @@ msgstr "Geen type"
 msgid "{place_type}: {place_link}"
 msgstr "{place_type}: {place_link}"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:69
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
 msgid "An error occurred while searching. Click here to try again."
 msgstr "Er is een fout opgetreden bij het zoeken. Klik hier om het nogmaals te proberen."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:73
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
 msgid "Try with direct search instead."
 msgstr "Probeer het eens met een directe zoekopdracht."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
 msgid "Try with indexed search instead."
 msgstr "Probeer het eens met een geïndexeerde zoekopdracht."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:106
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
 msgid "Type to search, or paste an MBID"
 msgstr "Tik hier een naam om te zoeken, of plak een MBID"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:178
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
 msgid "Clear recent items"
 msgstr "Recente objecten leegmaken"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:420
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
 #: ../root/static/scripts/common/components/Collapsible.js:79
 msgid "Show more..."
 msgstr "Laat meer zien …"
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:426
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
 msgid "Not found? Try again with direct search."
 msgstr "Niet gevonden? Probeer het eens met een directe zoekopdracht."
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
 msgid "Slow? Switch back to indexed search."
 msgstr "Langzaam? Schakel terug naar geïndexeerd zoeken."
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:36
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+msgid "appears on"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+msgid "standalone recording"
+msgstr "opname zonder uitgave"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+msgid "{release_group_type} by {artist}"
+msgstr "{release_group_type} van {artist}"
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+msgid "Performers"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/EditList.js:39
 msgid "Vote on all edits:"
 msgstr "Op alle bewerkingen stemmen:"
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:18
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
 msgid "Delete Note"
 msgstr "Notitie verwijderen"
 
-#: ../root/static/scripts/common/MB/release.js:20
+#: ../root/static/scripts/common/MB/release.js:22
 msgid "Display Credits at Bottom"
 msgstr "Relaties onderaan weergeven"
 
-#: ../root/static/scripts/common/MB/release.js:29
+#: ../root/static/scripts/common/MB/release.js:31
 msgid "Display Credits Inline"
 msgstr "Relaties onder de nummers weergeven"
 
-#: ../root/static/scripts/common/MB/release.js:89
+#: ../root/static/scripts/common/MB/release.js:91
 msgid "Failed to load the medium."
 msgstr "Medium laden is mislukt."
 
-#: ../root/static/scripts/common/artworkViewer.js:68
+#: ../root/static/scripts/common/artworkViewer.js:71
 msgid "Image {current} of {total}"
 msgstr "Afbeelding {current} van {total}"
 
@@ -12932,7 +12966,7 @@ msgstr "Aantekening het laatst bewerkt op {date}"
 msgid "Show less..."
 msgstr "Laat minder zien …"
 
-#: ../root/static/scripts/common/components/CommonsImage.js:52
+#: ../root/static/scripts/common/components/CommonsImage.js:48
 msgid "Image from Wikimedia Commons"
 msgstr "Afbeelding van Wikimedia Commons"
 
@@ -12949,67 +12983,84 @@ msgstr "Deze redacteur ontbreekt op deze server en kan daardoor niet correct wor
 msgid "[missing editor]"
 msgstr "[ontbrekende redacteur]"
 
-#: ../root/static/scripts/common/components/TagEditor.js:89
+#: ../root/static/scripts/common/components/TagEditor.js:90
 msgid "Withdraw vote"
 msgstr "Stem intrekken"
 
-#: ../root/static/scripts/common/components/TagEditor.js:105
+#: ../root/static/scripts/common/components/TagEditor.js:106
 msgid "Upvote"
 msgstr "Plussen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
+#: ../root/static/scripts/common/components/TagEditor.js:107
 msgid "You’ve upvoted this tag"
 msgstr "Je hebt dit etiket omhoog gestemd."
 
-#: ../root/static/scripts/common/components/TagEditor.js:114
+#: ../root/static/scripts/common/components/TagEditor.js:115
 msgid "Downvote"
 msgstr "Minnen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
+#: ../root/static/scripts/common/components/TagEditor.js:116
 msgid "You’ve downvoted this tag"
 msgstr "Je hebt dit etiket omlaag gestemd."
 
-#: ../root/static/scripts/common/components/TagEditor.js:466
+#: ../root/static/scripts/common/components/TagEditor.js:483
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr "Etiketten met een score van nul of lager, of die je omlaag hebt gestemd, zijn verborgen."
 
-#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:487
+msgid "Tags with a score of zero or below are hidden."
+msgstr "Etiketten met een score van nul of lager zijn verborgen."
+
+#: ../root/static/scripts/common/components/TagEditor.js:491
 msgid "Show all tags."
 msgstr "Alle etiketten tonen."
 
-#: ../root/static/scripts/common/components/TagEditor.js:473
+#: ../root/static/scripts/common/components/TagEditor.js:499
+msgid "All tags are being shown."
+msgstr "Alle etiketten zijn zichtbaar."
+
+#: ../root/static/scripts/common/components/TagEditor.js:503
+msgid ""
+"Hide tags with a score of zero or below, and tags that you’ve downvoted."
+msgstr "Verberg etiketten met een score van nul of lager of die je omlaag hebt gestemd."
+
+#: ../root/static/scripts/common/components/TagEditor.js:507
+msgid "Hide tags with a score of zero or below."
+msgstr "Verberg etiketten met een score van nul of lager."
+
+#: ../root/static/scripts/common/components/TagEditor.js:515
 msgid "Add Tags"
 msgstr "Etiketten toevoegen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:475
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr "Je kan hieronder je eigen {tagdocs|etiketten} toevoegen. Gebruik komma’s tussen verschillende etiketten."
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:525
 msgid "Submit tags"
 msgstr "Etiketten indienen"
 
-#: ../root/static/scripts/common/components/TagEditor.js:520
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "see all tags"
 msgstr "bekijk alle etiketten"
 
-#: ../root/static/scripts/common/components/TagEditor.js:536
+#: ../root/static/scripts/common/components/TagEditor.js:580
 msgid "Tag"
 msgstr "Etiket toevoegen"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:50
+#: ../root/static/scripts/common/components/WikipediaExtract.js:46
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:56
+#: ../root/static/scripts/common/components/WikipediaExtract.js:52
 msgid "Continue reading at Wikipedia..."
 msgstr "Lees verder op Wikipedia …"
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:59
+#: ../root/static/scripts/common/components/WikipediaExtract.js:55
 msgid ""
 "Wikipedia content provided under the terms of the {license_link|Creative "
 "Commons BY-SA license}"
@@ -13127,21 +13178,21 @@ msgstr "{begin_date} – ????"
 msgid "{begin_date} –"
 msgstr "{begin_date} –"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:44
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Began:"
 msgstr "Begonnen:"
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:50
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "This person is deceased."
 msgstr "Deze persoon is overleden."
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:58
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "This group has dissolved."
 msgstr "Deze groep is opgeheven."
 
-#: ../root/static/scripts/edit/check-duplicates.js:137
+#: ../root/static/scripts/edit/check-duplicates.js:139
 #: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:471
+#: ../root/static/scripts/relationship-editor/common/dialog.js:472
 msgid "Required field."
 msgstr "Vereist veld."
 
@@ -13201,9 +13252,9 @@ msgid ""
 "entity from the others."
 msgstr "Voeg een {doc_disambiguation|verduidelijking} toe om dit object van anderen te onderscheiden."
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
-#: ../root/static/scripts/relationship-editor/release.js:73
-#: ../root/static/scripts/release-editor/init.js:218
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/relationship-editor/release.js:74
+#: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr "Al je veranderingen zullen verloren gaan als je deze pagina verlaat."
 
@@ -13216,7 +13267,7 @@ msgid "Please select a link type for the URL you’ve entered."
 msgstr "Selecteer links een passende relate voor deze URL."
 
 #: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:458
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
@@ -13233,7 +13284,7 @@ msgid "This relationship already exists."
 msgstr "De relatie bestaat al."
 
 #: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:339
+#: ../root/static/scripts/relationship-editor/common/dialog.js:340
 msgid "{description} ({url|more documentation})"
 msgstr "{description} ({url|meer documentatie})"
 
@@ -13253,7 +13304,7 @@ msgstr "video"
 msgid "Remove Link"
 msgstr "Website verwijderen"
 
-#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:18
+#: ../root/static/scripts/guess-case/MB/Control/GuessCase.js:23
 msgid "Guess Case Options"
 msgstr "Opties voor het gokken van hoofdlettergebruik"
 
@@ -13286,45 +13337,45 @@ msgid ""
 "language guidelines}. "
 msgstr "Deze methode regelt de hoofdletters voor de Turkse ‘i’ (‘İ’) en ‘ı’ (‘I’). Sommige woorden moeten misschien handmatig worden ingesteld aan de hand van de {url|richtlijn Turks}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:30
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for recordings."
 msgstr "De serie die je hebt geselecteerd, is voor opnames."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for releases."
 msgstr "De serie die je hebt geselecteerd, is voor uitgaves."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for release groups."
 msgstr "De serie die je hebt geselecteerd, is voor uitgavegroepen."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:34
 msgid "The series you’ve selected is for works."
 msgstr "De serie die je hebt geselecteerd, is voor composities."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:449
+#: ../root/static/scripts/relationship-editor/common/dialog.js:450
 msgid "Please select a relationship type."
 msgstr "Selecteer een relatietype"
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:451
+#: ../root/static/scripts/relationship-editor/common/dialog.js:452
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr "Selecteer een subtype van het nu gebruikte relatietype. Het geselecteerde relatietype wordt alleen gebruikt om subtypes te groeperen."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:473
+#: ../root/static/scripts/relationship-editor/common/dialog.js:474
 msgid "Entities in a relationship cannot be the same."
 msgstr "Objecten in een relatie kunnen niet hetzelfde zijn."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:519
+#: ../root/static/scripts/relationship-editor/common/dialog.js:520
 msgid "Change credits for other {entity} relationships on the page."
 msgstr "Verander vermeldingen voor andere {entity}-relaties op de pagina."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:525
+#: ../root/static/scripts/relationship-editor/common/dialog.js:526
 msgid "Only relationships to {entity_type} entities."
 msgstr "Alleen relaties naar een {entity_type}."
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:532
+#: ../root/static/scripts/relationship-editor/common/dialog.js:533
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr "Alleen {relationship_type}relaties naar een {entity_type}."
 
@@ -13332,19 +13383,19 @@ msgstr "Alleen {relationship_type}relaties naar een {entity_type}."
 msgid "This attribute is required."
 msgstr "Deze eigenschap is verplicht."
 
-#: ../root/static/scripts/relationship-editor/release.js:42
+#: ../root/static/scripts/relationship-editor/release.js:43
 msgid "{n} recording selected"
 msgid_plural "{n} recordings selected"
 msgstr[0] "{n} opname geselecteerd"
 msgstr[1] "{n} opnames geselecteerd"
 
-#: ../root/static/scripts/relationship-editor/release.js:47
+#: ../root/static/scripts/relationship-editor/release.js:48
 msgid "{n} work selected"
 msgid_plural "{n} works selected"
 msgstr[0] "{n} compositie geselecteerd"
 msgstr[1] "{n} composities geselecteerd"
 
-#: ../root/static/scripts/release-editor/actions.js:255
+#: ../root/static/scripts/release-editor/actions.js:256
 msgid ""
 "This tracklist has artist credits with information that will be lost if you "
 "swap artist credits with track titles. This cannot be undone. Do you wish to"
@@ -13361,64 +13412,64 @@ msgstr "Dit medium heeft één of meer disc-ID’s die voorkomen dat deze inform
 msgid "Page {page} of {total}"
 msgstr "Pagina {page} van {total}"
 
-#: ../root/static/scripts/release-editor/fields.js:572
+#: ../root/static/scripts/release-editor/fields.js:573
 msgid "Medium {position}: {title}"
 msgstr "Medium {position}: {title}"
 
-#: ../root/static/scripts/release-editor/fields.js:578
+#: ../root/static/scripts/release-editor/fields.js:579
 msgid "Medium {position}"
 msgstr "Medium {position}"
 
-#: ../root/static/scripts/release-editor/fields.js:673
+#: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr "Je hebt geen platenmaatschappij geselecteerd voor ‘{name}’."
 
-#: ../root/static/scripts/release-editor/init.js:31
+#: ../root/static/scripts/release-editor/init.js:32
 msgid "Error loading release: {error}"
 msgstr "Fout bij het laden van de uitgave: {error}"
 
-#: ../root/static/scripts/release-editor/init.js:174
 #: ../root/static/scripts/release-editor/init.js:175
+#: ../root/static/scripts/release-editor/init.js:176
 msgid "Add Release"
 msgstr "Uitgave toevoegen"
 
-#: ../root/static/scripts/release-editor/init.js:178
 #: ../root/static/scripts/release-editor/init.js:179
+#: ../root/static/scripts/release-editor/init.js:180
 msgid "Edit Release"
 msgstr "Uitgave bewerken"
 
-#: ../root/static/scripts/release-editor/validation.js:125
+#: ../root/static/scripts/release-editor/validation.js:129
 msgid "The check digit is {checkdigit}."
 msgstr "Het controlegetal is {checkdigit}."
 
-#: ../root/static/scripts/release-editor/validation.js:126
+#: ../root/static/scripts/release-editor/validation.js:130
 msgid "Please double-check the barcode on the release."
 msgstr "Controleer de streepjescode op de uitgave nog een keer."
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:134
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr "De streepjescode die je hebt ingevoerd, lijkt op een UPC waarvan het controlegetal ontbreekt."
 
-#: ../root/static/scripts/release-editor/validation.js:136
+#: ../root/static/scripts/release-editor/validation.js:140
 msgid "The barcode you entered is a valid UPC code."
 msgstr "De streepjescode die je hebt ingevoerd, is een geldige UPC."
 
-#: ../root/static/scripts/release-editor/validation.js:139
+#: ../root/static/scripts/release-editor/validation.js:143
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr "De streepjescode die je hebt ingevoerd, is of een ongeldige UPC, of een EAN-code waarvan het controlegetal ontbreekt."
 
-#: ../root/static/scripts/release-editor/validation.js:148
+#: ../root/static/scripts/release-editor/validation.js:152
 msgid "The barcode you entered is a valid EAN code."
 msgstr "De streepjescode die je hebt ingevoerd, is een geldige EAN-code."
 
-#: ../root/static/scripts/release-editor/validation.js:151
+#: ../root/static/scripts/release-editor/validation.js:155
 msgid "The barcode you entered is not a valid EAN code."
 msgstr "De streepjescode die je hebt ingevoerd, is geen geldige EAN-code."
 
-#: ../root/static/scripts/release-editor/validation.js:158
+#: ../root/static/scripts/release-editor/validation.js:162
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr "De streepjescode die je hebt ingevoerd, is geen geldige UPC of EAN-code."
 
@@ -13426,7 +13477,7 @@ msgstr "De streepjescode die je hebt ingevoerd, is geen geldige UPC of EAN-code.
 msgid "Add Language"
 msgstr "Taal toevoegen"
 
-#: ../root/static/scripts/work.js:295
+#: ../root/static/scripts/work.js:296
 msgid "Remove Language"
 msgstr "Taal verwijderen"
 

--- a/po/mb_server.pot
+++ b/po/mb_server.pot
@@ -10,7 +10,7 @@ msgstr ""
 "#-#-#-#-#  mb_server.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"POT-Creation-Date: 2019-04-10 18:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "#-#-#-#-#  javascript.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 09:43+0100\n"
+"POT-Creation-Date: 2019-04-10 18:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,46 +36,47 @@ msgstr ""
 msgid " ({text})"
 msgstr ""
 
-#: ../root/components/forms.tt:306
+#: ../root/components/forms.tt:299
 msgid "\"C\" is a single check digit."
 msgstr ""
 
-#: ../root/components/forms.tt:316
+#: ../root/components/forms.tt:309
 msgid ""
 "\"CC\" is the appropriate for the registrant two-character country code."
 msgstr ""
 
-#: ../root/components/forms.tt:305
+#: ../root/components/forms.tt:298
 msgid "\"DDD\" is a nine digit work identifier."
 msgstr ""
 
-#: ../root/components/forms.tt:319
+#: ../root/components/forms.tt:312
 msgid ""
 "\"NNNNN\" is a unique 5-digit number identifying the particular sound "
 "recording."
 msgstr ""
 
-#: ../root/components/forms.tt:317
+#: ../root/components/forms.tt:310
 msgid ""
 "\"XXX\" is a three character alphanumeric registrant code, uniquely "
 "identifying the organisation which registered the code."
 msgstr ""
 
-#: ../root/components/forms.tt:318
+#: ../root/components/forms.tt:311
 msgid "\"YY\" is the last two digits of the year of registration."
 msgstr ""
 
-#: ../root/cdstub/cdstub.tt:4 ../root/components/events-list.tt:11
-#: ../root/components/medium.tt:72 ../root/components/recordings-list.tt:22
+#: ../root/cdstub/cdstub.tt:4 ../root/components/medium.tt:72
+#: ../root/components/recordings-list.tt:22
 #: ../root/components/release_groups-list.tt:6
 #: ../root/components/releases-list.tt:8 ../root/components/works-list.tt:10
-#: ../root/edit/details/add_medium.tt:49 ../root/edit/details/edit_medium.tt:50
-#: ../root/edit/details/edit_medium.tt:54
-#: ../root/edit/details/edit_medium.tt:176
-#: ../root/edit/details/edit_medium.tt:207
+#: ../root/edit/details/add_medium.tt:49 ../root/edit/details/edit_medium.tt:52
+#: ../root/edit/details/edit_medium.tt:56
+#: ../root/edit/details/edit_medium.tt:178
+#: ../root/edit/details/edit_medium.tt:209
 #: ../root/edit/details/historic/add_release.tt:49
 #: ../root/recording/index.tt:10 ../root/release/edit_relationships.tt:48
 #: ../root/release/edit/tracklist.tt:130 ../root/release/edit/tracklist.tt:343
+#: ../root/components/EventsList.js:65
 msgid "#"
 msgstr ""
 
@@ -140,7 +141,7 @@ msgid "(new release group)"
 msgstr ""
 
 #: ../root/edit/details/add_event_annotation.tt:10
-#: ../root/static/scripts/common/components/Annotation.js:76
+#: ../root/static/scripts/common/components/Annotation.js:66
 msgid "(no changelog)"
 msgstr ""
 
@@ -179,10 +180,10 @@ msgstr ""
 #: ../root/edit/details/add_isrcs.tt:5
 #: ../root/edit/details/historic/convert_release_to_multiple_artists.tt:11
 #: ../root/edit/details/historic/mac_to_sac.tt:8
-#: ../root/edit/details/historic/mac_to_sac.tt:13 ../root/entity/details.tt:17
-#: ../root/recording/index.tt:24 ../root/release_group/index.tt:40
+#: ../root/edit/details/historic/mac_to_sac.tt:13 ../root/recording/index.tt:24
+#: ../root/release_group/index.tt:40
 #: ../lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm:97
-#: ../lib/MusicBrainz/Server/Entity/Release.pm:176 ../root/entity/Details.js:79
+#: ../lib/MusicBrainz/Server/Entity/Release.pm:176 ../root/entity/Details.js:80
 msgid "(unknown)"
 msgstr ""
 
@@ -196,11 +197,6 @@ msgstr ""
 
 #: ../root/release/merge.tt:81
 msgid "(was medium {position}: {name} on release {release})"
-msgstr ""
-
-#: ../root/report/iswc_with_many_works.tt:41
-#: ../root/report/iswc_with_many_works.tt:55
-msgid "-"
 msgstr ""
 
 #: ../root/user/profile.tt:124
@@ -274,7 +270,7 @@ msgstr ""
 msgid "<strong>Closed:</strong> {date}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:707
+#: ../root/components/common-macros.tt:697
 msgid "<strong>Error</strong>:"
 msgstr ""
 
@@ -302,7 +298,7 @@ msgid ""
 "you wish to continue with the merge."
 msgstr ""
 
-#: ../root/components/common-macros.tt:714 ../root/recording/edit_form.tt:6
+#: ../root/components/common-macros.tt:705 ../root/recording/edit_form.tt:6
 msgid "<strong>Warning</strong>:"
 msgstr ""
 
@@ -351,7 +347,7 @@ msgstr ""
 
 #: ../root/edit/search_macros.tt:263 ../root/edit/search_macros.tt:279
 #: ../lib/MusicBrainz/Server/Data/Vote.pm:174
-#: ../root/edit/components/Vote.js:77
+#: ../root/edit/components/Vote.js:76
 msgctxt "vote"
 msgid "Abstain"
 msgstr ""
@@ -360,7 +356,7 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: ../root/edit/index.tt:57 ../root/edit/components/EditSummary.js:78
+#: ../root/edit/index.tt:61 ../root/edit/components/EditSummary.js:77
 msgid "Accept edit"
 msgstr ""
 
@@ -370,39 +366,25 @@ msgid "Accepted"
 msgstr ""
 
 #: ../root/user/edits.tt:1
-msgid "Accepted Edits"
-msgstr ""
-
-#: ../root/user/edits.tt:1
-msgid "Accepted Edits by {name}"
+msgid "Accepted edits by {name}"
 msgstr ""
 
 #: ../root/admin/edit_user.tt:27 ../root/admin/edit_user.tt:31
 msgid "Account admin"
 msgstr ""
 
-#: ../root/user/privileged.tt:43
-msgid "Account administrators"
-msgstr ""
-
-#: ../root/user/privileged.tt:44
-msgid "Account administrators can edit and delete user accounts."
-msgstr ""
-
-#: ../root/entity/details.tt:41 ../root/entity/Details.js:101
-msgid "AcousticBrainz entry:"
-msgstr ""
-
-#: ../root/admin/attributes/index.tt:36 ../root/admin/attributes/language.tt:15
-#: ../root/admin/attributes/script.tt:13 ../root/admin/wikidoc/index.tt:36
-#: ../root/artist/aliases.tt:20 ../root/recording/fingerprints.tt:8
+#: ../root/admin/wikidoc/index.tt:36 ../root/recording/fingerprints.tt:8
 #: ../root/user/collections.tt:50 ../root/account/applications/Index.js:83
 #: ../root/account/applications/Index.js:115
-#: ../root/components/Aliases/AliasTable.js:33
+#: ../root/admin/attributes/Attribute.js:100
+#: ../root/admin/attributes/Language.js:39
+#: ../root/admin/attributes/Script.js:38
+#: ../root/components/Aliases/AliasTable.js:32
+#: ../root/components/Aliases/ArtistCreditList.js:51
 msgid "Actions"
 msgstr ""
 
-#: ../root/event/edit_form.tt:23
+#: ../root/event/edit_form.tt:22
 msgid ""
 "Add \"@ \" at line start to indicate artists, \"* \" for a work/song, \"# \" "
 "for additional info (such as \"Encore\"). [mbid|name] allows linking to "
@@ -453,7 +435,7 @@ msgstr ""
 
 #: ../root/release/edit/information.tt:206
 #: ../root/release/edit/information.tt:207
-#: ../root/layout/components/BottomMenu.js:209
+#: ../root/layout/components/BottomMenu.js:220
 msgctxt "button/menu"
 msgid "Add Label"
 msgstr ""
@@ -505,7 +487,7 @@ msgctxt "header"
 msgid "Add Work"
 msgstr ""
 
-#: ../root/work/edit_form.tt:78
+#: ../root/work/edit_form.tt:77
 msgctxt "button/menu"
 msgid "Add Work Attribute"
 msgstr ""
@@ -516,10 +498,6 @@ msgstr ""
 
 #: ../root/relationship/linktype/form.tt:105
 msgid "Add a New Example"
-msgstr ""
-
-#: ../root/account/edit.tt:65
-msgid "Add a language"
 msgstr ""
 
 #: ../root/release/edit/tracklist.tt:242
@@ -533,7 +511,7 @@ msgid "Add a new entry"
 msgstr ""
 
 #: ../root/release/edit/recordings.tt:191
-#: ../root/static/scripts/common/i18n.js:72
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:31
 msgid "Add a new recording"
 msgstr ""
 
@@ -554,7 +532,7 @@ msgid "Add an edit note"
 msgstr ""
 
 #: ../root/components/relationship-editor.tt:216
-#: ../root/static/scripts/common/i18n.js:82
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:26
 msgid "Add another instrument"
 msgstr ""
 
@@ -564,11 +542,6 @@ msgstr ""
 
 #: ../root/edit/add_note.tt:4
 msgid "Add edit note"
-msgstr ""
-
-#: ../root/admin/attributes/index.tt:66 ../root/admin/attributes/language.tt:33
-#: ../root/admin/attributes/script.tt:29
-msgid "Add new attribute"
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:216
@@ -582,12 +555,8 @@ msgstr ""
 msgid "Add relationship"
 msgstr ""
 
-#: ../root/artist/events.tt:8 ../root/place/events.tt:8
-msgid "Add selected events for merging"
-msgstr ""
-
 #: ../root/artist/recordings.tt:13 ../root/instrument/recordings.tt:8
-#: ../root/isrc/Index.js:90
+#: ../root/isrc/Index.js:89
 msgid "Add selected recordings for merging"
 msgstr ""
 
@@ -596,7 +565,7 @@ msgstr ""
 msgid "Add selected releases for merging"
 msgstr ""
 
-#: ../root/artist/works.tt:8 ../root/iswc/Index.js:73
+#: ../root/artist/works.tt:8 ../root/iswc/Index.js:72
 msgid "Add selected works for merging"
 msgstr ""
 
@@ -604,7 +573,7 @@ msgstr ""
 msgid "Add track(s)"
 msgstr ""
 
-#: ../root/components/forms.tt:173
+#: ../root/components/forms.tt:165
 msgid "Add {item}"
 msgstr ""
 
@@ -629,13 +598,13 @@ msgid "Additions:"
 msgstr ""
 
 #: ../root/components/places-list.tt:7 ../root/place/merge.tt:13
-#: ../root/report/places_without_coordinates.tt:12
-#: ../root/search/components/PlaceResults.js:59
+#: ../root/report/PlacesWithoutCoordinates.js:56
+#: ../root/search/components/PlaceResults.js:57
 msgid "Address"
 msgstr ""
 
 #: ../root/edit/details/add_place.tt:30 ../root/edit/details/edit_place.tt:23
-#: ../root/place/edit_form.tt:17
+#: ../root/place/edit_form.tt:16
 #: ../root/layout/components/sidebar/PlaceSidebar.js:60
 msgid "Address:"
 msgstr ""
@@ -654,15 +623,15 @@ msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:12
 #: ../root/edit/details/edit_alias.tt:18 ../root/edit/details/edit_alias.tt:32
-#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/components/Aliases/AliasTable.js:25
 msgid "Alias"
 msgstr ""
 
-#: ../root/entity/alias/edit_form.tt:14
+#: ../root/entity/alias/edit_form.tt:13
 msgid "Alias Details"
 msgstr ""
 
-#: ../root/entity/alias/edit_form.tt:15
+#: ../root/entity/alias/edit_form.tt:14
 msgid "Alias name:"
 msgstr ""
 
@@ -670,14 +639,8 @@ msgstr ""
 msgid "Alias:"
 msgstr ""
 
-#: ../root/area/aliases.tt:1 ../root/artist/aliases.tt:1
-#: ../root/components/entity-tabs.tt:47 ../root/event/aliases.tt:1
-#: ../root/instrument/aliases.tt:1 ../root/label/aliases.tt:1
-#: ../root/place/aliases.tt:1 ../root/recording/aliases.tt:1
-#: ../root/release/aliases.tt:1 ../root/series/aliases.tt:1
-#: ../root/work/aliases.tt:1 ../root/components/Aliases/index.js:28
-#: ../root/components/EntityTabs.js:89
-#: ../root/release_group/ReleaseGroupAliases.js:23
+#: ../root/components/entity-tabs.tt:47 ../root/components/Aliases/index.js:43
+#: ../root/components/EntityTabs.js:88 ../root/entity/Aliases.js:30
 msgid "Aliases"
 msgstr ""
 
@@ -720,60 +683,45 @@ msgstr ""
 msgid "Also performs as"
 msgstr ""
 
-#: ../root/report/asins_with_multiple_releases.tt:1
-#: ../root/report/asins_with_multiple_releases.tt:3
-msgid "Amazon URLs Linked to Multiple Releases"
-msgstr ""
-
-#: ../root/entity/alias/edit_form.tt:5 ../root/components/Aliases/index.js:30
+#: ../root/entity/alias/edit_form.tt:4 ../root/components/Aliases/index.js:46
 msgid ""
 "An alias is an alternate name for an entity. They typically contain common "
 "mispellings or variations of the name and are also used to improve search "
 "results. View the {doc|alias documentation} for more details."
 msgstr ""
 
-#: ../root/collection/subscribers.tt:17 ../root/user/subscribers.tt:17
-#: ../root/entity/Subscribers.js:69
-msgid "An anonymous user"
-msgid_plural "{n} anonymous users"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../root/components/common-macros.tt:950
+#: ../root/components/common-macros.tt:940
 msgid ""
 "An entity with that name and disambiguation already exists. You must enter a "
 "unique disambiguation comment."
-msgstr ""
-
-#: ../root/edit/list.tt:61
-msgid "An error occured while loading this edit"
-msgstr ""
-
-#: ../root/edit/index.tt:10
-msgid "An error occured while loading this edit."
-msgstr ""
-
-#: ../root/release/edit/tracklist.tt:113
-msgid "An error occured: "
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:174
 msgid "An error occurred while creating the works."
 msgstr ""
 
-#: ../root/annotation/revision.tt:1 ../root/report/annotations_labels.tt:13
-#: ../root/report/annotations_places.tt:12
-#: ../root/report/annotations_recordings.tt:13
-#: ../root/report/annotations_release_groups.tt:13
-#: ../root/report/annotations_releases.tt:13
-#: ../root/report/annotations_series.tt:13
-#: ../root/report/annotations_works.tt:13
+#: ../root/edit/index.tt:14 ../root/edit/list.tt:65
+msgid "An error occurred while loading this edit."
+msgstr ""
+
+#: ../root/release/edit/tracklist.tt:113
+msgid "An error occurred: "
+msgstr ""
+
+#: ../root/annotation/revision.tt:1
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:43
 #: ../root/layout/components/Search.js:35
-#: ../root/report/components/ArtistAnnotationList.js:29
-#: ../root/search/components/AnnotationResults.js:59
-#: ../root/search/components/SearchForm.js:46
-#: ../root/static/scripts/common/components/Annotation.js:59
+#: ../root/report/components/ArtistAnnotationList.js:27
+#: ../root/report/components/LabelAnnotationList.js:26
+#: ../root/report/components/PlaceAnnotationList.js:26
+#: ../root/report/components/RecordingAnnotationList.js:29
+#: ../root/report/components/ReleaseAnnotationList.js:30
+#: ../root/report/components/ReleaseGroupAnnotationList.js:30
+#: ../root/report/components/SeriesAnnotationList.js:26
+#: ../root/report/components/WorkAnnotationList.js:26
+#: ../root/search/components/AnnotationResults.js:57
+#: ../root/search/components/SearchForm.js:43
+#: ../root/static/scripts/common/components/Annotation.js:47
 msgid "Annotation"
 msgstr ""
 
@@ -797,7 +745,7 @@ msgstr ""
 msgid "Annotations support a limited set of wiki formatting options:"
 msgstr ""
 
-#: ../root/artist/relationships.tt:11 ../root/label/relationships.tt:10
+#: ../root/artist/relationships.tt:10 ../root/label/relationships.tt:9
 msgid "Appearances"
 msgstr ""
 
@@ -820,7 +768,7 @@ msgctxt "vote"
 msgid "Approve"
 msgstr ""
 
-#: ../root/edit/edit_header.tt:60 ../root/edit/components/EditSummary.js:62
+#: ../root/edit/edit_header.tt:60 ../root/edit/components/EditSummary.js:61
 msgid "Approve edit"
 msgstr ""
 
@@ -899,19 +847,20 @@ msgstr ""
 msgid "Are you sure you wish to remove the series {series} from MusicBrainz?"
 msgstr ""
 
-#: ../root/components/areas-list.tt:5 ../root/components/common-macros.tt:587
-#: ../root/components/labels-list.tt:9 ../root/edit/search_macros.tt:360
-#: ../root/label/merge.tt:15 ../root/place/merge.tt:14
-#: ../root/report/places_without_coordinates.tt:12
-#: ../lib/MusicBrainz/Server/Edit/Area.pm:7
+#: ../root/components/areas-list.tt:5 ../root/components/common-macros.tt:576
+#: ../root/edit/search_macros.tt:360 ../root/label/merge.tt:15
+#: ../root/place/merge.tt:14 ../lib/MusicBrainz/Server/Edit/Area.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:41
-#: ../root/area/AreaHeader.js:23 ../root/layout/components/Search.js:29
-#: ../root/search/components/ArtistResults.js:69
-#: ../root/search/components/LabelResults.js:65
-#: ../root/search/components/PlaceResults.js:60
-#: ../root/search/components/SearchForm.js:44
-#: ../root/static/scripts/common/i18n.js:53
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
+#: ../root/area/AreaHeader.js:21 ../root/components/LabelsList.js:83
+#: ../root/components/LabelsList.js:88 ../root/edit/details/AddArea.js:40
+#: ../root/edit/details/AddArtist.js:95 ../root/layout/components/Search.js:29
+#: ../root/report/PlacesWithoutCoordinates.js:57
+#: ../root/search/components/ArtistResults.js:66
+#: ../root/search/components/LabelResults.js:63
+#: ../root/search/components/PlaceResults.js:58
+#: ../root/search/components/SearchForm.js:41
+#: ../root/static/scripts/common/constants.js:15
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:13
 msgid "Area"
 msgstr ""
 
@@ -919,70 +868,78 @@ msgstr ""
 msgid "Area Collections"
 msgstr ""
 
-#: ../root/area/edit_form.tt:9
+#: ../root/area/edit_form.tt:8
 msgid "Area Details"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:21 ../root/components/common-macros.tt:570
-#: ../root/edit/details/add_area.tt:3 ../root/edit/details/add_artist.tt:37
+#: ../root/artist/edit_form.tt:20 ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_label.tt:49 ../root/edit/details/add_place.tt:37
 #: ../root/edit/details/edit_area.tt:5 ../root/edit/details/edit_artist.tt:34
 #: ../root/edit/details/edit_label.tt:47 ../root/edit/details/edit_place.tt:28
-#: ../root/label/edit_form.tt:19 ../root/place/edit_form.tt:20
+#: ../root/label/edit_form.tt:18 ../root/place/edit_form.tt:19
 #: ../root/layout/components/MetaDescription.js:50
 #: ../root/layout/components/MetaDescription.js:93
-#: ../root/layout/components/sidebar/ArtistSidebar.js:104
-#: ../root/layout/components/sidebar/LabelSidebar.js:75
+#: ../root/layout/components/sidebar/ArtistSidebar.js:103
+#: ../root/layout/components/sidebar/LabelSidebar.js:74
 #: ../root/layout/components/sidebar/PlaceSidebar.js:66
 msgid "Area:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:604 ../root/tag/TagIndex.js:80
-#: ../root/tag/TagLayout.js:34
+#: ../root/components/common-macros.tt:593 ../root/tag/TagIndex.js:78
+#: ../root/tag/TagLayout.js:32
 msgid "Areas"
 msgstr ""
 
 #: ../root/cdstub/browse.tt:9 ../root/cdstub/cdstub.tt:7
 #: ../root/cdtoc/attach_filter_release.tt:29 ../root/cdtoc/list.tt:6
 #: ../root/cdtoc/lookup.tt:39 ../root/components/artists-list.tt:5
-#: ../root/components/common-macros.tt:587 ../root/components/medium.tt:75
+#: ../root/components/common-macros.tt:576 ../root/components/medium.tt:75
 #: ../root/components/recordings-list.tt:26
 #: ../root/components/relationships-table.tt:28
 #: ../root/components/release_groups-list.tt:11
 #: ../root/components/releases-list.tt:12
 #: ../root/components/results-generic.tt:6
-#: ../root/edit/details/add_medium.tt:50 ../root/edit/details/edit_medium.tt:52
-#: ../root/edit/details/edit_medium.tt:56
+#: ../root/edit/details/add_medium.tt:50 ../root/edit/details/edit_medium.tt:54
+#: ../root/edit/details/edit_medium.tt:58
 #: ../root/edit/details/historic/add_release.tt:51
 #: ../root/edit/details/historic/edit_track.tt:13
 #: ../root/edit/details/merge_releases.tt:19 ../root/edit/search_macros.tt:360
 #: ../root/otherlookup/results-release.tt:11
 #: ../root/release/edit/tracklist.tt:132 ../root/release/edit/tracklist.tt:345
 #: ../root/release_group/merge.tt:13 ../root/release/merge.tt:14
-#: ../root/report/bad_amazon_urls.tt:19
-#: ../root/report/cat_no_looks_like_asin.tt:20
-#: ../root/report/isrc_with_many_recordings.tt:24
-#: ../root/report/recording_list.tt:7 ../root/report/release_group_list.tt:7
-#: ../root/report/release_group_url_list.tt:7 ../root/report/release_list.tt:8
-#: ../root/report/release_url_list.tt:7 ../root/watch/list.tt:14
-#: ../lib/MusicBrainz/Server/Edit/Artist.pm:7
+#: ../root/watch/list.tt:14 ../lib/MusicBrainz/Server/Edit/Artist.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:35
-#: ../root/artist/ArtistHeader.js:31 ../root/isrc/Index.js:55
-#: ../root/layout/components/Search.js:18
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:50
-#: ../root/report/DuplicateArtists.js:66
-#: ../root/report/components/ArtistAnnotationList.js:27
-#: ../root/report/components/ArtistList.js:27
-#: ../root/report/components/ArtistRelationshipList.js:29
-#: ../root/report/components/ArtistURLList.js:30
-#: ../root/search/components/CDStubResults.js:49
-#: ../root/search/components/RecordingResults.js:124
-#: ../root/search/components/ReleaseGroupResults.js:62
-#: ../root/search/components/ReleaseResults.js:100
-#: ../root/search/components/SearchForm.js:38
-#: ../root/static/scripts/common/i18n.js:54
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
-#: ../root/taglookup/Form.js:25
+#: ../root/artist/ArtistHeader.js:29 ../root/edit/details/AddArtist.js:52
+#: ../root/isrc/Index.js:54 ../root/layout/components/Search.js:18
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:57
+#: ../root/report/BadAmazonUrls.js:60 ../root/report/CatNoLooksLikeAsin.js:64
+#: ../root/report/DuplicateArtists.js:73
+#: ../root/report/IsrcsWithManyRecordings.js:73
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:73
+#: ../root/report/ReleaseLabelSameArtist.js:67
+#: ../root/report/components/ArtistAnnotationList.js:25
+#: ../root/report/components/ArtistList.js:25
+#: ../root/report/components/ArtistRelationshipList.js:26
+#: ../root/report/components/ArtistUrlList.js:29
+#: ../root/report/components/RecordingAnnotationList.js:27
+#: ../root/report/components/RecordingList.js:27
+#: ../root/report/components/RecordingRelationshipList.js:28
+#: ../root/report/components/ReleaseAnnotationList.js:29
+#: ../root/report/components/ReleaseGroupAnnotationList.js:27
+#: ../root/report/components/ReleaseGroupList.js:34
+#: ../root/report/components/ReleaseGroupRelationshipList.js:31
+#: ../root/report/components/ReleaseGroupUrlList.js:32
+#: ../root/report/components/ReleaseList.js:28
+#: ../root/report/components/ReleaseRelationshipList.js:29
+#: ../root/report/components/ReleaseUrlList.js:32
+#: ../root/search/components/CDStubResults.js:47
+#: ../root/search/components/RecordingResults.js:122
+#: ../root/search/components/ReleaseGroupResults.js:60
+#: ../root/search/components/ReleaseResults.js:106
+#: ../root/search/components/SearchForm.js:35
+#: ../root/static/scripts/common/constants.js:16
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:15
+#: ../root/taglookup/Form.js:24
 msgid "Artist"
 msgstr ""
 
@@ -998,7 +955,7 @@ msgstr ""
 msgid "Artist Credit:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:76
+#: ../root/artist/edit_form.tt:74
 msgid "Artist Credits"
 msgstr ""
 
@@ -1006,7 +963,7 @@ msgstr ""
 msgid "Artist Credits:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:11
+#: ../root/artist/edit_form.tt:10
 msgid "Artist Details"
 msgstr ""
 
@@ -1018,10 +975,6 @@ msgstr ""
 msgid "Artist ISNI:"
 msgstr ""
 
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:15
-msgid "Artist MBID"
-msgstr ""
-
 #: ../root/user/subscriptions/artist.tt:1 ../root/user/subscriptions/menu.tt:3
 msgid "Artist Subscriptions"
 msgstr ""
@@ -1030,11 +983,7 @@ msgstr ""
 msgid "Artist credit:"
 msgstr ""
 
-#: ../root/artist/aliases.tt:5
-msgid "Artist credits"
-msgstr ""
-
-#: ../root/edit/details/edit_medium.tt:202
+#: ../root/edit/details/edit_medium.tt:204
 msgid "Artist credits:"
 msgstr ""
 
@@ -1052,7 +1001,7 @@ msgstr ""
 
 #: ../root/cdstub/edit_form.tt:6 ../root/cdstub/import.tt:7
 #: ../root/cdtoc/attach_filter_artist.tt:8 ../root/cdtoc/lookup.tt:61
-#: ../root/components/common-macros.tt:570 ../root/edit/details/add_artist.tt:3
+#: ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_release_group.tt:15
 #: ../root/edit/details/add_release.tt:15
 #: ../root/edit/details/add_standalone_recording.tt:15
@@ -1069,23 +1018,23 @@ msgstr ""
 #: ../root/edit/details/historic/remove_release.tt:17
 #: ../root/release/edit/information.tt:26 ../root/release/edit/tracklist.tt:80
 #: ../root/taglookup/form.tt:4
-#: ../root/layout/components/sidebar/RecordingSidebar.js:45
-#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:52
+#: ../root/layout/components/sidebar/RecordingSidebar.js:44
+#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:51
 #: ../root/static/scripts/edit/components/forms.js:19
 msgid "Artist:"
 msgstr ""
 
 #: ../root/area/artists.tt:1 ../root/area/artists.tt:2
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/components/events-list.tt:18 ../root/components/works-list.tt:14
-#: ../root/event/merge.tt:12 ../root/otherlookup/results-work.tt:9
-#: ../root/report/event_list.tt:9 ../root/report/iswc_with_many_works.tt:21
-#: ../root/work/merge.tt:13 ../root/components/EntityTabs.js:21
-#: ../root/iswc/Index.js:52 ../root/report/ReportsIndex.js:30
-#: ../root/search/components/EventResults.js:75
-#: ../root/search/components/WorkResults.js:51
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:793
-#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:27
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
+#: ../root/components/works-list.tt:14 ../root/event/merge.tt:12
+#: ../root/otherlookup/results-work.tt:9 ../root/work/merge.tt:13
+#: ../root/components/EntityTabs.js:20 ../root/components/EventsList.js:90
+#: ../root/iswc/Index.js:51 ../root/report/IswcsWithManyWorks.js:66
+#: ../root/report/ReportsIndex.js:31 ../root/report/components/EventList.js:31
+#: ../root/search/components/EventResults.js:62
+#: ../root/search/components/WorkResults.js:50
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:803
+#: ../root/tag/TagIndex.js:79 ../root/tag/TagLayout.js:25
 msgid "Artists"
 msgstr ""
 
@@ -1117,12 +1066,12 @@ msgstr ""
 msgid "Attached to releases"
 msgstr ""
 
-#: ../root/admin/attributes/index.tt:1 ../root/admin/attributes/index.tt:4
-#: ../root/admin/attributes/index.tt:12 ../root/admin/attributes/language.tt:3
-#: ../root/admin/attributes/script.tt:3
 #: ../root/components/relationships-table.tt:25
 #: ../root/components/works-list.tt:18 ../root/doc/relationship_type.tt:49
-#: ../root/work/merge.tt:17
+#: ../root/work/merge.tt:17 ../root/admin/attributes/Attribute.js:88
+#: ../root/admin/attributes/Index.js:20 ../root/admin/attributes/Index.js:21
+#: ../root/admin/attributes/Language.js:26
+#: ../root/admin/attributes/Script.js:26
 msgid "Attributes"
 msgstr ""
 
@@ -1141,66 +1090,32 @@ msgstr ""
 msgid "Auto-Editor"
 msgstr ""
 
-#: ../root/user/edits.tt:1
-msgid "Auto-Edits"
-msgstr ""
-
-#: ../root/user/edits.tt:1
-msgid "Auto-Edits by {name}"
-msgstr ""
-
 #: ../root/admin/edit_user.tt:7
 msgid "Auto-editor"
-msgstr ""
-
-#: ../root/user/privileged.tt:9
-msgid "Auto-editors"
-msgstr ""
-
-#: ../root/user/privileged.tt:10
-msgid ""
-"Auto-editors are trusted users who have been given {url|auto-editor} "
-"privileges. These privileges allow them to make select edits that are "
-"automatically approved without going through the normal voting process, as "
-"well as the ability to instantly approve other users' edits."
 msgstr ""
 
 #: ../root/user/profile.tt:179
 msgid "Auto-edits"
 msgstr ""
 
+#: ../root/user/edits.tt:1
+msgid "Auto-edits by {name}"
+msgstr ""
+
 #: ../root/entity/ratings.tt:20
 msgid "Average rating:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:925
+#: ../root/components/common-macros.tt:915
 msgid "Backward"
-msgstr ""
-
-#: ../root/report/bad_amazon_urls.tt:1 ../root/report/bad_amazon_urls.tt:3
-msgid "Bad Amazon URLs"
 msgstr ""
 
 #: ../root/main/400.tt:1 ../root/main/400.tt:3
 msgid "Bad Request"
 msgstr ""
 
-#: ../root/admin/edit_banner.tt:12
-msgid "Banner message"
-msgstr ""
-
 #: ../root/admin/edit_user.tt:11
 msgid "Banner message editor"
-msgstr ""
-
-#: ../root/user/privileged.tt:37
-msgid "Banner message editors"
-msgstr ""
-
-#: ../root/user/privileged.tt:38
-msgid ""
-"Banner message editors are users who can set a message that is shown in a "
-"banner on all pages, e.g. to warn users about upcoming site maintenance."
 msgstr ""
 
 #: ../root/cdtoc/attach_artist_releases.tt:20
@@ -1211,7 +1126,7 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:26
 #: ../root/otherlookup/results-release.tt:18
 #: ../root/release/edit/duplicates.tt:17 ../root/release_group/index.tt:30
-#: ../root/release/merge.tt:21 ../root/search/components/ReleaseResults.js:107
+#: ../root/release/merge.tt:21 ../root/search/components/ReleaseResults.js:113
 msgid "Barcode"
 msgstr ""
 
@@ -1222,7 +1137,7 @@ msgstr ""
 #: ../root/edit/details/edit_release.tt:75 ../root/otherlookup/form.tt:3
 #: ../root/release/edit/information.tt:213
 #: ../root/layout/components/MetaDescription.js:136
-#: ../root/layout/components/sidebar/CDStubSidebar.js:66
+#: ../root/layout/components/sidebar/CDStubSidebar.js:67
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:125
 msgid "Barcode:"
 msgstr ""
@@ -1252,11 +1167,6 @@ msgstr ""
 msgid "Batch-create new works"
 msgstr ""
 
-#: ../root/collection/subscribers.tt:30 ../root/user/subscribers.tt:35
-#: ../root/entity/Subscribers.js:94
-msgid "Be the first! {sub|Subscribe}?"
-msgstr ""
-
 #: ../root/annotation/edit.tt:63
 msgid ""
 "Because square brackets [] are used to create hyperlinks, you have to use "
@@ -1276,34 +1186,34 @@ msgid ""
 "{login_url|login}."
 msgstr ""
 
-#: ../root/components/labels-list.tt:11 ../root/event/merge.tt:14
-#: ../root/label/merge.tt:16 ../root/place/merge.tt:15
-#: ../root/search/components/AreaResults.js:60
-#: ../root/search/components/ArtistResults.js:70
-#: ../root/search/components/LabelResults.js:66
-#: ../root/search/components/PlaceResults.js:61
+#: ../root/event/merge.tt:14 ../root/label/merge.tt:16
+#: ../root/place/merge.tt:15 ../root/components/LabelsList.js:94
+#: ../root/components/LabelsList.js:99
+#: ../root/search/components/AreaResults.js:58
+#: ../root/search/components/ArtistResults.js:67
+#: ../root/search/components/LabelResults.js:64
+#: ../root/search/components/PlaceResults.js:59
 msgid "Begin"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:43 ../root/edit/details/add_artist.tt:49
-#: ../root/edit/details/edit_artist.tt:46
+#: ../root/artist/edit_form.tt:41 ../root/edit/details/edit_artist.tt:46
 msgid "Begin Area:"
 msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:39
-#: ../root/edit/details/edit_alias.tt:54
+#: ../root/edit/details/edit_alias.tt:54 ../root/edit/details/AddArea.js:99
+#: ../root/edit/details/AddEvent.js:75
 msgid "Begin date"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:40 ../root/components/common-macros.tt:795
-#: ../root/components/forms.tt:203
+#: ../root/artist/edit_form.tt:38 ../root/components/common-macros.tt:785
+#: ../root/components/forms.tt:196
 #: ../root/components/relationship-editor.tt:152
-#: ../root/edit/details/add_area.tt:58 ../root/edit/details/add_event.tt:35
 #: ../root/edit/details/add_label.tt:30 ../root/edit/details/add_place.tt:51
 #: ../root/edit/details/edit_area.tt:42 ../root/edit/details/edit_event.tt:27
 #: ../root/edit/details/edit_label.tt:33 ../root/edit/details/edit_place.tt:36
-#: ../root/event/edit_form.tt:34 ../root/artist/utils.js:34
-#: ../root/layout/components/sidebar/AreaSidebar.js:54
+#: ../root/event/edit_form.tt:33 ../root/artist/utils.js:32
+#: ../root/layout/components/sidebar/AreaSidebar.js:53
 msgid "Begin date:"
 msgstr ""
 
@@ -1318,21 +1228,17 @@ msgid ""
 "sure to include it!"
 msgstr ""
 
-#: ../root/account/edit.tt:46 ../root/admin/edit_user.tt:40
-#: ../root/user/profile.tt:137
+#: ../root/admin/edit_user.tt:40 ../root/user/profile.tt:137
+#: ../root/static/scripts/account/components/EditProfileForm.js:248
 msgid "Bio:"
 msgstr ""
 
-#: ../root/account/edit.tt:38
-msgid "Birth date:"
-msgstr ""
-
-#: ../root/layout.tt:107 ../root/layout/components/Footer.js:30
+#: ../root/layout.tt:107 ../root/layout/components/Footer.js:29
 msgid "Blog"
 msgstr ""
 
-#: ../root/components/common-macros.tt:795 ../root/artist/utils.js:28
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
+#: ../root/components/common-macros.tt:785 ../root/artist/utils.js:26
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:52
 msgid "Born:"
 msgstr ""
 
@@ -1340,18 +1246,14 @@ msgstr ""
 msgid "Bot"
 msgstr ""
 
-#: ../root/user/privileged.tt:48
-msgid "Bots"
-msgstr ""
-
-#: ../root/layout.tt:127 ../root/layout/components/Footer.js:69
+#: ../root/layout.tt:127 ../root/layout/components/Footer.js:70
 msgid ""
 "Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and "
 "{supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}."
 msgstr ""
 
-#: ../root/layout.tt:106 ../root/layout/components/Footer.js:28
-#: ../root/main/index.js:142
+#: ../root/layout.tt:106 ../root/layout/components/Footer.js:27
+#: ../root/main/index.js:141
 msgid "Bug Tracker"
 msgstr ""
 
@@ -1409,9 +1311,9 @@ msgstr ""
 #: ../root/recording/merge.tt:26 ../root/release/edit/layout.tt:58
 #: ../root/release/edit/tracklist.tt:87 ../root/release_group/merge.tt:41
 #: ../root/release/merge.tt:130 ../root/series/merge.tt:37
-#: ../root/work/merge.tt:73 ../root/artist/Merge.js:64
-#: ../root/components/ConfirmLayout.js:32
-#: ../root/layout/components/MergeHelper.js:39
+#: ../root/work/merge.tt:73 ../root/artist/Merge.js:63
+#: ../root/components/ConfirmLayout.js:31
+#: ../root/layout/components/MergeHelper.js:40
 msgid "Cancel"
 msgstr ""
 
@@ -1420,24 +1322,20 @@ msgid "Cancel Edit"
 msgstr ""
 
 #: ../root/edit/cancel.tt:24 ../root/edit/edit_header.tt:64
-#: ../root/edit/components/EditSummary.js:71
+#: ../root/edit/components/EditSummary.js:70
 msgid "Cancel edit"
 msgstr ""
 
 #: ../root/user/profile.tt:195 ../lib/MusicBrainz/Server/Edit/Utils.pm:280
-#: ../root/utility/edit.js:45
+#: ../root/edit/details/AddEvent.js:62 ../root/utility/edit.js:44
 msgid "Cancelled"
 msgstr ""
 
 #: ../root/user/edits.tt:1
-msgid "Cancelled Edits"
+msgid "Cancelled edits by {name}"
 msgstr ""
 
-#: ../root/user/edits.tt:1
-msgid "Cancelled Edits by {name}"
-msgstr ""
-
-#: ../root/edit/details/add_event.tt:22 ../root/edit/details/edit_event.tt:19
+#: ../root/edit/details/edit_event.tt:19
 msgid "Cancelled:"
 msgstr ""
 
@@ -1448,10 +1346,6 @@ msgstr ""
 
 #: ../root/admin/attributes/in_use.tt:1 ../root/admin/attributes/in_use.tt:2
 msgid "Cannot Remove Attribute"
-msgstr ""
-
-#: ../root/artist/special_purpose.tt:1
-msgid "Cannot edit"
 msgstr ""
 
 #: ../root/account/register.tt:40
@@ -1467,7 +1361,7 @@ msgid "Cat. No:"
 msgstr ""
 
 #: ../root/edit/details/historic/add_release.tt:78
-#: ../root/report/cat_no_looks_like_asin.tt:18
+#: ../root/report/CatNoLooksLikeAsin.js:62
 msgid "Catalog Number"
 msgstr ""
 
@@ -1489,13 +1383,13 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:25
 #: ../root/otherlookup/results-release.tt:17 ../root/recording/index.tt:18
 #: ../root/release/edit/duplicates.tt:16 ../root/release_group/index.tt:29
-#: ../root/release/merge.tt:20 ../root/search/components/ReleaseResults.js:106
+#: ../root/release/merge.tt:20 ../root/search/components/ReleaseResults.js:112
 msgid "Catalog#"
 msgstr ""
 
 #: ../root/account/change_password.tt:1 ../root/account/change_password.tt:3
 #: ../root/account/change_password.tt:27
-#: ../root/components/UserAccountTabs.js:61
+#: ../root/components/UserAccountTabs.js:60
 msgid "Change Password"
 msgstr ""
 
@@ -1504,6 +1398,7 @@ msgid "Change direction"
 msgstr ""
 
 #: ../root/release/change_quality.tt:1 ../root/release/change_quality.tt:2
+#: ../lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm:24
 msgid "Change release data quality"
 msgstr ""
 
@@ -1512,7 +1407,7 @@ msgid "Change track artists:"
 msgstr ""
 
 #: ../root/annotation/edit.tt:24 ../root/edit/details/add_event_annotation.tt:7
-#: ../root/static/scripts/common/components/Annotation.js:74
+#: ../root/static/scripts/common/components/Annotation.js:64
 msgid "Changelog:"
 msgstr ""
 
@@ -1520,7 +1415,7 @@ msgstr ""
 msgid "Changes"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:54 ../root/admin/attributes/index.tt:20
+#: ../root/admin/attributes/form.tt:54 ../root/admin/attributes/Attribute.js:97
 msgid "Child order"
 msgstr ""
 
@@ -1567,12 +1462,6 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: ../root/components/labels-list.tt:7
-#: ../root/search/components/AreaResults.js:59
-#: ../root/search/components/LabelResults.js:64
-msgid "Code"
-msgstr ""
-
 #: ../root/release/edit/tracklist.tt:270
 msgid "Collapse Disc"
 msgstr ""
@@ -1581,8 +1470,8 @@ msgstr ""
 msgid "Collapse all descriptions"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/user/collections.tt:44
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:19
+#: ../root/components/common-macros.tt:576 ../root/user/collections.tt:44
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:17
 msgid "Collection"
 msgstr ""
 
@@ -1595,14 +1484,14 @@ msgstr ""
 msgid "Collection details"
 msgstr ""
 
-#: ../root/collection/layout.tt:1
+#: ../root/collection/layout.tt:1 ../root/collection/CollectionLayout.js:34
 msgid "Collection “{collection}”"
 msgstr ""
 
-#: ../root/components/common-macros.tt:604 ../root/entity/collections.tt:1
+#: ../root/components/common-macros.tt:593 ../root/entity/collections.tt:1
 #: ../root/entity/collections.tt:2 ../root/user/collections.tt:16
-#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:48
-#: ../root/layout/components/sidebar/CollectionLinks.js:27
+#: ../root/user/collections.tt:23 ../root/components/UserAccountTabs.js:47
+#: ../root/layout/components/sidebar/CollectionLinks.js:30
 msgid "Collections"
 msgstr ""
 
@@ -1632,7 +1521,7 @@ msgstr ""
 msgid "Confirm password:"
 msgstr ""
 
-#: ../root/place/edit_form.tt:29
+#: ../root/place/edit_form.tt:28
 msgid "Coordinates"
 msgstr ""
 
@@ -1649,7 +1538,7 @@ msgstr ""
 msgid "Copy all track titles to associated recordings."
 msgstr ""
 
-#: ../root/components/forms.tt:237
+#: ../root/components/forms.tt:230
 msgid "Copy name"
 msgstr ""
 
@@ -1669,7 +1558,7 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:23
 #: ../root/otherlookup/results-release.tt:15 ../root/recording/index.tt:16
 #: ../root/release/edit/duplicates.tt:14 ../root/release_group/index.tt:27
-#: ../root/release/merge.tt:18 ../root/search/components/ReleaseResults.js:104
+#: ../root/release/merge.tt:18 ../root/search/components/ReleaseResults.js:110
 msgid "Country"
 msgstr ""
 
@@ -1679,7 +1568,7 @@ msgid "Country:"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/cover_art.tt:1
-#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:22
+#: ../root/release/cover_art.tt:2 ../root/components/EntityTabs.js:21
 msgid "Cover Art"
 msgstr ""
 
@@ -1691,7 +1580,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: ../root/account/register.tt:46 ../root/layout/components/TopMenu.js:141
+#: ../root/account/register.tt:46 ../root/layout/components/TopMenu.js:149
 msgid "Create Account"
 msgstr ""
 
@@ -1743,23 +1632,19 @@ msgstr ""
 msgid "Current version:"
 msgstr ""
 
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:9
-msgid "Currently, this report only works with recordings that have one artist."
-msgstr ""
-
 #: ../root/components/relationship-editor.tt:127
 #: ../root/release/edit/information.tt:140
 #: ../lib/MusicBrainz/Server/Plugin/FormRenderer.pm:252
+#: ../root/components/PartialDateInput.js:51
 msgid "DD"
 msgstr ""
 
-#: ../root/edit/details/change_release_quality.tt:7
+#: ../root/edit/details/change_release_data_quality.tt:7
 #: ../root/edit/details/historic/change_artist_quality.tt:7
 #: ../root/edit/details/historic/change_release_quality.tt:14
 #: ../root/release/change_quality.tt:5
-#: ../root/edit/components/EditSidebar.js:67
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:188
-msgid "Data Quality:"
+#: ../root/layout/components/sidebar/SidebarDataQuality.js:23
+msgid "Data Quality"
 msgstr ""
 
 #: ../root/components/medium.tt:89 ../root/medium/tracklist.tt:35
@@ -1773,7 +1658,7 @@ msgstr ""
 
 #: ../root/annotation/history.tt:12 ../root/cdtoc/attach_artist_releases.tt:16
 #: ../root/cdtoc/attach_filter_release.tt:30 ../root/cdtoc/list.tt:8
-#: ../root/components/events-list.tt:26 ../root/components/places-list.tt:8
+#: ../root/components/places-list.tt:8
 #: ../root/components/relationships-table.tt:19
 #: ../root/components/releases-list.tt:16
 #: ../root/edit/details/edit_release_events.tt:5
@@ -1781,26 +1666,27 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:22
 #: ../root/otherlookup/results-release.tt:14 ../root/recording/index.tt:15
 #: ../root/release/edit/duplicates.tt:13 ../root/release_group/index.tt:26
-#: ../root/release/merge.tt:17 ../root/report/event_list.tt:11
-#: ../root/elections/ElectionVotes.js:28
-#: ../root/search/components/EventResults.js:72
-#: ../root/search/components/ReleaseResults.js:103
+#: ../root/release/merge.tt:17 ../root/components/EventsList.js:97
+#: ../root/components/EventsList.js:102 ../root/elections/ElectionVotes.js:27
+#: ../root/report/components/EventList.js:33
+#: ../root/search/components/EventResults.js:59
+#: ../root/search/components/ReleaseResults.js:109
 msgid "Date"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:36 ../root/components/forms.tt:199
-#: ../root/event/edit_form.tt:30
+#: ../root/artist/edit_form.tt:34 ../root/components/forms.tt:192
+#: ../root/event/edit_form.tt:29
 msgid "Date Period"
 msgstr ""
 
 #: ../root/edit/details/edit_release_label.tt:38
 #: ../root/release/edit/information.tt:122
-#: ../root/layout/components/sidebar/EventSidebar.js:57
+#: ../root/layout/components/sidebar/EventSidebar.js:56
 msgid "Date:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:38 ../root/components/forms.tt:201
-#: ../root/event/edit_form.tt:32
+#: ../root/artist/edit_form.tt:36 ../root/components/forms.tt:194
+#: ../root/event/edit_form.tt:31
 msgid ""
 "Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just "
 "YYYY are OK, or you can omit the date entirely."
@@ -1810,7 +1696,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:70
+#: ../root/admin/delete_user.tt:3 ../root/components/UserAccountTabs.js:69
 msgid "Delete Account"
 msgstr ""
 
@@ -1834,12 +1720,12 @@ msgstr ""
 msgid "Deprecated:"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:62 ../root/admin/attributes/index.tt:19
-#: ../root/collection/index.tt:4 ../root/components/instruments-list.tt:7
-#: ../root/doc/edit_type.tt:23 ../root/doc/relationship_type.tt:25
-#: ../root/instrument/index.tt:3 ../root/instrument/merge.tt:13
-#: ../root/work/edit_form.tt:111
-#: ../root/search/components/InstrumentResults.js:57
+#: ../root/admin/attributes/form.tt:62 ../root/collection/index.tt:4
+#: ../root/components/instruments-list.tt:7 ../root/doc/edit_type.tt:23
+#: ../root/doc/relationship_type.tt:25 ../root/instrument/index.tt:3
+#: ../root/instrument/merge.tt:13 ../root/work/edit_form.tt:110
+#: ../root/admin/attributes/Attribute.js:96
+#: ../root/search/components/InstrumentResults.js:52
 msgid "Description"
 msgstr ""
 
@@ -1852,7 +1738,7 @@ msgstr ""
 #: ../root/edit/details/edit_url.tt:25
 #: ../root/edit/details/remove_relationship_attribute.tt:7
 #: ../root/edit/details/remove_relationship_type.tt:15
-#: ../root/instrument/edit_form.tt:14
+#: ../root/instrument/edit_form.tt:13
 #: ../root/relationship/linkattributetype/form.tt:15
 #: ../root/relationship/linktype/form.tt:20
 #: ../root/relationship/linktype/tree.tt:11
@@ -1861,15 +1747,13 @@ msgid "Description:"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:55 ../root/doc/edit_type.tt:28
-#: ../root/entity/details.tt:1 ../root/entity/details.tt:3
-#: ../root/event/details.tt:1 ../root/components/EntityTabs.js:97
-#: ../root/elections/ElectionDetails.js:26 ../root/entity/Details.js:60
-#: ../root/entity/Details.js:61
+#: ../root/components/EntityTabs.js:96 ../root/elections/ElectionDetails.js:25
+#: ../root/entity/Details.js:59 ../root/entity/Details.js:60
 msgid "Details"
 msgstr ""
 
-#: ../root/components/common-macros.tt:799 ../root/artist/utils.js:54
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
+#: ../root/components/common-macros.tt:789 ../root/artist/utils.js:52
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:52
 msgid "Died:"
 msgstr ""
 
@@ -1879,13 +1763,11 @@ msgstr ""
 
 #: ../root/search/form.tt:35 ../root/search/form.tt:40
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:62
-#: ../root/search/components/SearchForm.js:68
+#: ../root/search/components/SearchForm.js:65
 msgid "Direct database search"
 msgstr ""
 
-#: ../root/area/edit_form.tt:11 ../root/artist/edit_form.tt:15
-#: ../root/edit/details/add_area.tt:23 ../root/edit/details/add_artist.tt:19
-#: ../root/edit/details/add_event.tt:16
+#: ../root/area/edit_form.tt:10 ../root/artist/edit_form.tt:14
 #: ../root/edit/details/add_instrument.tt:16
 #: ../root/edit/details/add_label.tt:23 ../root/edit/details/add_place.tt:16
 #: ../root/edit/details/add_release_group.tt:21
@@ -1899,12 +1781,13 @@ msgstr ""
 #: ../root/edit/details/edit_release_group.tt:15
 #: ../root/edit/details/edit_release.tt:25
 #: ../root/edit/details/edit_series.tt:14 ../root/edit/details/edit_work.tt:15
-#: ../root/event/edit_form.tt:14 ../root/instrument/edit_form.tt:11
-#: ../root/label/edit_form.tt:14 ../root/place/edit_form.tt:14
-#: ../root/recording/edit_form.tt:27 ../root/release/edit/information.tt:249
-#: ../root/release_group/edit_form.tt:16 ../root/series/edit_form.tt:14
-#: ../root/work/edit_form.tt:14
-msgid "Disambiguation:"
+#: ../root/event/edit_form.tt:13 ../root/instrument/edit_form.tt:10
+#: ../root/label/edit_form.tt:13 ../root/place/edit_form.tt:13
+#: ../root/recording/edit_form.tt:26 ../root/release/edit/information.tt:249
+#: ../root/release_group/edit_form.tt:15 ../root/series/edit_form.tt:13
+#: ../root/work/edit_form.tt:13 ../root/edit/details/AddArea.js:64
+#: ../root/edit/details/AddArtist.js:74 ../root/edit/details/AddEvent.js:56
+msgid "Disambiguation"
 msgstr ""
 
 #: ../root/release/discids.tt:8
@@ -1934,16 +1817,8 @@ msgid "Disc ID:"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/release/discids.tt:1
-#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:23
+#: ../root/release/discids.tt:3 ../root/components/EntityTabs.js:22
 msgid "Disc IDs"
-msgstr ""
-
-#: ../root/admin/attributes/index.tt:25
-msgid "Disc IDs allowed"
-msgstr ""
-
-#: ../root/report/superfluous_data_tracks.tt:1
-msgid "Disc IDs with superfluous data tracks"
 msgstr ""
 
 #: ../root/release/edit/tracklist.tt:287
@@ -1954,27 +1829,8 @@ msgstr ""
 msgid "Discography"
 msgstr ""
 
-#: ../root/report/discogs_links_with_multiple_labels.tt:1
-#: ../root/report/discogs_links_with_multiple_labels.tt:3
-msgid "Discogs URLs Linked to Multiple Labels"
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_release_groups.tt:1
-#: ../root/report/discogs_links_with_multiple_release_groups.tt:3
-msgid "Discogs URLs Linked to Multiple Release Groups"
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_releases.tt:1
-#: ../root/report/discogs_links_with_multiple_releases.tt:3
-msgid "Discogs URLs Linked to Multiple Releases"
-msgstr ""
-
-#: ../root/report/separate_discs.tt:1 ../root/report/separate_discs.tt:3
-msgid "Discs as Separate Releases"
-msgstr ""
-
-#: ../root/components/common-macros.tt:799 ../root/artist/utils.js:58
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
+#: ../root/components/common-macros.tt:789 ../root/artist/utils.js:56
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:60
 msgid "Dissolved:"
 msgstr ""
 
@@ -1992,13 +1848,13 @@ msgstr ""
 msgid "Don't have an account? {uri|Create one now}!"
 msgstr ""
 
-#: ../root/layout.tt:103 ../root/layout/components/Footer.js:22
+#: ../root/layout.tt:103 ../root/layout/components/Footer.js:21
 msgid "Donate"
 msgstr ""
 
 #: ../root/components/relationship-editor.tt:7
 #: ../root/release/edit/macros.tt:45
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:114
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:115
 msgid "Done"
 msgstr ""
 
@@ -2012,19 +1868,21 @@ msgid ""
 "choose the appropriate recording or look for it in the database."
 msgstr ""
 
-#: ../root/admin/attributes/index.tt:61 ../root/admin/attributes/language.tt:28
-#: ../root/admin/attributes/script.tt:24 ../root/artist/aliases.tt:34
 #: ../root/cdstub/header.tt:9 ../root/cdtoc/list.tt:17
-#: ../root/collection/header.tt:6 ../root/components/entity-tabs.tt:59
-#: ../root/doc/relationship_type.tt:17 ../root/entity/edit.tt:1
-#: ../root/relationship/linkattributetype/common.tt:25
+#: ../root/components/entity-tabs.tt:59 ../root/doc/relationship_type.tt:17
+#: ../root/entity/edit.tt:1 ../root/relationship/linkattributetype/common.tt:25
 #: ../root/relationship/linktype/tree.tt:17 ../root/release/cover_art.tt:26
 #: ../root/release/discids.tt:12 ../root/release/edit/recordings.tt:58
-#: ../root/release/edit/recordings.tt:94 ../root/release/header.tt:15
-#: ../root/user/collections.tt:64 ../root/account/applications/Index.js:34
+#: ../root/release/edit/recordings.tt:94 ../root/user/collections.tt:64
+#: ../root/account/applications/Index.js:34
+#: ../root/admin/attributes/Attribute.js:116
+#: ../root/admin/attributes/Language.js:57
+#: ../root/admin/attributes/Script.js:54
+#: ../root/collection/CollectionHeader.js:78
 #: ../root/components/Aliases/AliasTableRow.js:57
-#: ../root/components/EntityTabs.js:104
-#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:394
+#: ../root/components/Aliases/ArtistCreditList.js:65
+#: ../root/components/EntityTabs.js:103
+#: ../root/static/scripts/edit/components/ArtistCreditEditor.js:390
 msgid "Edit"
 msgstr ""
 
@@ -2053,11 +1911,6 @@ msgstr ""
 msgid "Edit Attribute"
 msgstr ""
 
-#: ../root/admin/edit_banner.tt:1 ../root/admin/edit_banner.tt:3
-#: ../root/layout/components/TopMenu.js:113
-msgid "Edit Banner Message"
-msgstr ""
-
 #: ../root/collection/edit.tt:1
 msgid "Edit Collection"
 msgstr ""
@@ -2068,17 +1921,12 @@ msgstr ""
 
 #: ../root/forms/edit-note.tt:2 ../root/release/edit/editnote.tt:27
 #: ../root/release/edit/layout.tt:18 ../root/release/edit_relationships.tt:96
-#: ../root/components/EnterEditNote.js:27
+#: ../root/components/EnterEditNote.js:25
 msgid "Edit Note"
 msgstr ""
 
 #: ../root/edit/search_macros.tt:360
 msgid "Edit Note Author"
-msgstr ""
-
-#: ../root/account/edit.tt:1 ../root/account/edit.tt:4
-#: ../root/components/UserAccountTabs.js:59
-msgid "Edit Profile"
 msgstr ""
 
 #: ../root/relationship/linkattributetype/edit.tt:1
@@ -2096,8 +1944,8 @@ msgid "Edit Relationships: {release}"
 msgstr ""
 
 #: ../root/doc/edit_types.tt:1 ../root/doc/edit_types.tt:3
-#: ../root/doc/edit_type.tt:18 ../root/edit/components/EditSidebar.js:96
-#: ../root/layout/components/BottomMenu.js:267
+#: ../root/doc/edit_type.tt:18 ../root/edit/components/EditSidebar.js:94
+#: ../root/layout/components/BottomMenu.js:281
 msgid "Edit Types"
 msgstr ""
 
@@ -2110,7 +1958,7 @@ msgid "Edit alias"
 msgstr ""
 
 #: ../root/annotation/edit.tt:2
-#: ../root/layout/components/sidebar/AnnotationLinks.js:27
+#: ../root/layout/components/sidebar/AnnotationLinks.js:26
 msgid "Edit annotation"
 msgstr ""
 
@@ -2123,11 +1971,11 @@ msgid "Edit data for edit #{id}"
 msgstr ""
 
 #: ../root/components/forms.tt:36 ../root/components/forms.tt:40
-#: ../root/edit/cancel.tt:19 ../root/components/EnterEditNote.js:39
+#: ../root/edit/cancel.tt:19 ../root/components/EnterEditNote.js:37
 msgid "Edit note:"
 msgstr ""
 
-#: ../root/edit/index.tt:68
+#: ../root/edit/index.tt:72
 msgid "Edit notes"
 msgstr ""
 
@@ -2143,7 +1991,7 @@ msgstr ""
 msgid "Edited"
 msgstr ""
 
-#: ../root/edit/list_header.tt:30 ../root/edit/components/EditSidebar.js:95
+#: ../root/edit/list_header.tt:30 ../root/edit/components/EditSidebar.js:93
 msgid "Editing FAQ"
 msgstr ""
 
@@ -2154,8 +2002,8 @@ msgstr ""
 #: ../root/annotation/history.tt:11 ../root/edit/search_macros.tt:360
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:45
 #: ../root/layout/components/Search.js:42
-#: ../root/report/components/EditorList.js:27
-#: ../root/search/components/SearchForm.js:48
+#: ../root/report/components/EditorList.js:26
+#: ../root/search/components/SearchForm.js:45
 msgid "Editor"
 msgstr ""
 
@@ -2167,13 +2015,9 @@ msgstr ""
 msgid "Editor Subscriptions"
 msgstr ""
 
-#: ../root/user/profile/layout.tt:1 ../root/components/UserAccountLayout.js:36
-#: ../root/components/UserAccountLayout.js:37
+#: ../root/user/profile/layout.tt:1 ../root/components/UserAccountLayout.js:35
+#: ../root/components/UserAccountLayout.js:36
 msgid "Editor “{user}”"
-msgstr ""
-
-#: ../root/user/edits.tt:1
-msgid "Edits"
 msgstr ""
 
 #: ../root/user/profile.tt:170
@@ -2204,8 +2048,8 @@ msgstr ""
 msgid "Email Sent"
 msgstr ""
 
-#: ../root/account/edit.tt:17 ../root/account/register.tt:34
-#: ../root/admin/edit_user.tt:36 ../root/user/profile.tt:22
+#: ../root/account/register.tt:34 ../root/admin/edit_user.tt:36
+#: ../root/user/profile.tt:22
 msgid "Email:"
 msgstr ""
 
@@ -2217,48 +2061,48 @@ msgstr ""
 msgid "Enable vinyl track numbers"
 msgstr ""
 
-#: ../root/cdtoc/info.tt:34 ../root/components/labels-list.tt:12
-#: ../root/event/merge.tt:15 ../root/label/merge.tt:17
-#: ../root/place/merge.tt:16 ../root/search/components/AreaResults.js:61
-#: ../root/search/components/ArtistResults.js:72
-#: ../root/search/components/LabelResults.js:67
-#: ../root/search/components/PlaceResults.js:62
+#: ../root/cdtoc/info.tt:34 ../root/event/merge.tt:15 ../root/label/merge.tt:17
+#: ../root/place/merge.tt:16 ../root/components/LabelsList.js:105
+#: ../root/components/LabelsList.js:110
+#: ../root/search/components/AreaResults.js:59
+#: ../root/search/components/ArtistResults.js:69
+#: ../root/search/components/LabelResults.js:65
+#: ../root/search/components/PlaceResults.js:60
 msgid "End"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:56 ../root/edit/details/add_artist.tt:61
-#: ../root/edit/details/edit_artist.tt:54
+#: ../root/artist/edit_form.tt:54 ../root/edit/details/edit_artist.tt:54
 msgid "End Area:"
 msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:45
-#: ../root/edit/details/edit_alias.tt:59
-#: ../root/elections/ElectionTable/index.js:27
+#: ../root/edit/details/edit_alias.tt:59 ../root/edit/details/AddArea.js:106
+#: ../root/edit/details/AddEvent.js:82
+#: ../root/elections/ElectionTable/index.js:25
 msgid "End date"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:52 ../root/components/common-macros.tt:799
-#: ../root/components/forms.tt:204
+#: ../root/artist/edit_form.tt:50 ../root/components/common-macros.tt:789
+#: ../root/components/forms.tt:197
 #: ../root/components/relationship-editor.tt:156
-#: ../root/edit/details/add_area.tt:65 ../root/edit/details/add_event.tt:42
 #: ../root/edit/details/add_label.tt:37 ../root/edit/details/add_place.tt:58
 #: ../root/edit/details/edit_area.tt:47 ../root/edit/details/edit_event.tt:32
 #: ../root/edit/details/edit_label.tt:38 ../root/edit/details/edit_place.tt:41
-#: ../root/event/edit_form.tt:35 ../root/artist/utils.js:60
-#: ../root/layout/components/sidebar/AreaSidebar.js:56
+#: ../root/event/edit_form.tt:34 ../root/artist/utils.js:58
+#: ../root/layout/components/sidebar/AreaSidebar.js:55
 msgid "End date:"
 msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:50
-#: ../root/edit/details/edit_alias.tt:64
+#: ../root/edit/details/edit_alias.tt:64 ../root/edit/details/AddArea.js:112
+#: ../root/edit/details/AddArtist.js:141
 msgid "Ended"
 msgstr ""
 
-#: ../root/edit/details/add_area.tt:71 ../root/edit/details/add_artist.tt:66
 #: ../root/edit/details/add_label.tt:43 ../root/edit/details/add_place.tt:64
 #: ../root/edit/details/edit_area.tt:52 ../root/edit/details/edit_artist.tt:58
 #: ../root/edit/details/edit_label.tt:43 ../root/edit/details/edit_place.tt:46
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:46
 msgid "Ended:"
 msgstr ""
 
@@ -2266,7 +2110,7 @@ msgstr ""
 msgid "Endpoint:"
 msgstr ""
 
-#: ../root/components/forms.tt:253 ../root/components/forms.tt:277
+#: ../root/components/forms.tt:246 ../root/components/forms.tt:270
 msgid "English"
 msgstr ""
 
@@ -2274,7 +2118,7 @@ msgstr ""
 msgid "Enter a tracklist below:"
 msgstr ""
 
-#: ../root/place/edit_form.tt:51
+#: ../root/place/edit_form.tt:50
 msgid ""
 "Enter coordinates manually or drag the marker to get coordinates from the "
 "map."
@@ -2282,7 +2126,7 @@ msgstr ""
 
 #: ../root/components/forms.tt:51 ../root/release/add_cover_art.tt:151
 #: ../root/release/edit/layout.tt:67 ../root/release/edit_relationships.tt:103
-#: ../root/components/EnterEdit.js:38
+#: ../root/components/EnterEdit.js:37
 msgid "Enter edit"
 msgstr ""
 
@@ -2294,7 +2138,7 @@ msgid ""
 "&#x2014; thus making your edit get applied faster."
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:38 ../root/admin/attributes/index.tt:29
+#: ../root/admin/attributes/form.tt:38 ../root/admin/attributes/Attribute.js:55
 msgid "Entity type"
 msgstr ""
 
@@ -2315,7 +2159,7 @@ msgstr ""
 msgid "Error Voting on Edits"
 msgstr ""
 
-#: ../root/main/info/error.tt:22 ../root/main/404.js:25
+#: ../root/main/info/error.tt:22 ../root/main/404.js:24
 msgid "Error message: "
 msgstr ""
 
@@ -2341,19 +2185,21 @@ msgstr ""
 msgid "Error: {error}"
 msgstr ""
 
-#: ../root/components/forms.tt:32 ../root/components/EnterEditNote.js:35
+#: ../root/components/forms.tt:32 ../root/components/EnterEditNote.js:33
 msgid "Even just providing a URL or two is helpful!"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/components/events-list.tt:13
-#: ../root/edit/search_macros.tt:360 ../root/event/merge.tt:11
-#: ../root/report/event_list.tt:7 ../root/series/index.tt:15
+#: ../root/components/common-macros.tt:576 ../root/edit/search_macros.tt:360
+#: ../root/event/merge.tt:11 ../root/series/index.tt:15
 #: ../lib/MusicBrainz/Server/Edit/Event.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:49
-#: ../root/event/EventHeader.js:26 ../root/layout/components/Search.js:21
-#: ../root/search/components/SearchForm.js:52
-#: ../root/static/scripts/common/i18n.js:55
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
+#: ../root/components/EventsList.js:70 ../root/components/EventsList.js:75
+#: ../root/edit/details/AddEvent.js:39 ../root/event/EventHeader.js:24
+#: ../root/layout/components/Search.js:21
+#: ../root/report/components/EventList.js:29
+#: ../root/search/components/SearchForm.js:49
+#: ../root/static/scripts/common/constants.js:17
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:19
 msgid "Event"
 msgstr ""
 
@@ -2361,7 +2207,7 @@ msgstr ""
 msgid "Event Collections"
 msgstr ""
 
-#: ../root/event/edit_form.tt:12
+#: ../root/event/edit_form.tt:11
 msgid "Event Details"
 msgstr ""
 
@@ -2369,24 +2215,19 @@ msgstr ""
 msgid "Event ratings"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570
+#: ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_event_annotation.tt:3
-#: ../root/edit/details/add_event.tt:3 ../root/edit/details/edit_event.tt:5
+#: ../root/edit/details/edit_event.tt:5
 msgid "Event:"
 msgstr ""
 
-#: ../root/artist/events.tt:1 ../root/artist/events.tt:2
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/place/events.tt:1 ../root/place/events.tt:2
-#: ../root/components/EntityTabs.js:24 ../root/report/ReportsIndex.js:58
-#: ../root/tag/TagIndex.js:82 ../root/tag/TagLayout.js:37
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
+#: ../root/area/AreaEvents.js:31 ../root/area/AreaEvents.js:32
+#: ../root/artist/ArtistEvents.js:31 ../root/artist/ArtistEvents.js:32
+#: ../root/components/EntityTabs.js:23 ../root/place/PlaceEvents.js:31
+#: ../root/place/PlaceEvents.js:32 ../root/report/ReportsIndex.js:115
+#: ../root/tag/TagIndex.js:80 ../root/tag/TagLayout.js:35
 msgid "Events"
-msgstr ""
-
-#: ../root/report/event_sequence_not_in_series.tt:1
-#: ../root/report/event_sequence_not_in_series.tt:3
-#: ../root/report/ReportsIndex.js:62
-msgid "Events which should be part of series or larger event"
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:85 ../root/relationship/linktype/form.tt:71
@@ -2421,12 +2262,12 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: ../root/area/edit_form.tt:23 ../root/artist/edit_form.tt:70
-#: ../root/event/edit_form.tt:42 ../root/instrument/edit_form.tt:23
-#: ../root/label/edit_form.tt:42 ../root/place/edit_form.tt:38
-#: ../root/recording/edit_form.tt:38 ../root/release/edit/information.tt:259
-#: ../root/release_group/edit_form.tt:24 ../root/series/edit_form.tt:23
-#: ../root/work/edit_form.tt:91
+#: ../root/area/edit_form.tt:22 ../root/artist/edit_form.tt:68
+#: ../root/event/edit_form.tt:41 ../root/instrument/edit_form.tt:22
+#: ../root/label/edit_form.tt:41 ../root/place/edit_form.tt:37
+#: ../root/recording/edit_form.tt:37 ../root/release/edit/information.tt:259
+#: ../root/release_group/edit_form.tt:23 ../root/series/edit_form.tt:22
+#: ../root/work/edit_form.tt:90
 msgid "External Links"
 msgstr ""
 
@@ -2435,14 +2276,10 @@ msgid "Failed"
 msgstr ""
 
 #: ../root/user/edits.tt:1
-msgid "Failed Edits"
+msgid "Failed edits by {name}"
 msgstr ""
 
-#: ../root/user/edits.tt:1
-msgid "Failed Edits by {name}"
-msgstr ""
-
-#: ../root/components/common-macros.tt:918
+#: ../root/components/common-macros.tt:908
 msgid "Few relationships"
 msgstr ""
 
@@ -2456,7 +2293,7 @@ msgstr ""
 msgid "Filename:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:781
+#: ../root/components/common-macros.tt:771
 msgid "Filter"
 msgstr ""
 
@@ -2465,7 +2302,7 @@ msgid "Find Relationships"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/recording/fingerprints.tt:1
-#: ../root/components/EntityTabs.js:25
+#: ../root/components/EntityTabs.js:24
 msgid "Fingerprints"
 msgstr ""
 
@@ -2493,27 +2330,16 @@ msgid ""
 "account FAQ}."
 msgstr ""
 
-#: ../root/report/releases_missing_disc_i_ds.tt:7
-msgid ""
-"For instructions on how to add one, see the {add_discids|documentation page}."
-msgstr ""
-
-#: ../root/report/separate_discs.tt:7
-msgid ""
-"For instructions on how to fix them, please see the documentation about "
-"{howto|how to merge releases}."
-msgstr ""
-
-#: ../root/artist/edit_form.tt:4 ../root/recording/edit_form.tt:17
-#: ../root/release_group/edit_form.tt:6 ../root/series/edit_form.tt:4
+#: ../root/artist/edit_form.tt:3 ../root/recording/edit_form.tt:16
+#: ../root/release_group/edit_form.tt:5 ../root/series/edit_form.tt:3
 msgid ""
 "For more information, check the {doc_doc|documentation} and {doc_styleguide|"
 "style guidelines}."
 msgstr ""
 
-#: ../root/event/edit_form.tt:4 ../root/label/edit_form.tt:4
-#: ../root/place/edit_form.tt:4 ../root/search/form.tt:48
-#: ../root/work/edit_form.tt:5 ../root/search/components/SearchForm.js:107
+#: ../root/event/edit_form.tt:3 ../root/label/edit_form.tt:3
+#: ../root/place/edit_form.tt:3 ../root/search/form.tt:48
+#: ../root/work/edit_form.tt:4 ../root/search/components/SearchForm.js:101
 msgid "For more information, check the {doc_doc|documentation}."
 msgstr ""
 
@@ -2532,11 +2358,11 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:20
 #: ../root/otherlookup/results-release.tt:12
 #: ../root/release/edit/duplicates.tt:11 ../root/release_group/index.tt:24
-#: ../root/release/merge.tt:15 ../root/search/components/ReleaseResults.js:101
+#: ../root/release/merge.tt:15 ../root/search/components/ReleaseResults.js:107
 msgid "Format"
 msgstr ""
 
-#: ../root/edit/details/add_medium.tt:26 ../root/edit/details/edit_medium.tt:31
+#: ../root/edit/details/add_medium.tt:26 ../root/edit/details/edit_medium.tt:33
 #: ../root/edit/details/edit_release_label.tt:62
 #: ../root/release/edit/tracklist.tt:274
 #: ../root/layout/components/MetaDescription.js:114
@@ -2544,12 +2370,12 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../root/layout.tt:105 ../root/layout/components/Footer.js:26
-#: ../root/main/index.js:143
+#: ../root/layout.tt:105 ../root/layout/components/Footer.js:25
+#: ../root/main/index.js:142
 msgid "Forums"
 msgstr ""
 
-#: ../root/components/common-macros.tt:925
+#: ../root/components/common-macros.tt:915
 msgid "Forward"
 msgstr ""
 
@@ -2582,27 +2408,23 @@ msgid_plural "Found {n} edits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/with-pager.tt:5 ../root/components/PaginatedResults.js:39
+#: ../root/components/with-pager.tt:5 ../root/components/PaginatedResults.js:38
 msgid "Found {n} result"
 msgid_plural "Found {n} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/with-pager.tt:7 ../root/components/PaginatedResults.js:43
+#: ../root/components/with-pager.tt:7 ../root/components/PaginatedResults.js:42
 msgid "Found {n} result for \"{q}\""
 msgid_plural "Found {n} results for \"{q}\""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/common-macros.tt:795 ../root/artist/utils.js:32
+#: ../root/components/common-macros.tt:785 ../root/artist/utils.js:30
 #: ../root/layout/components/MetaDescription.js:87
-#: ../root/layout/components/sidebar/LabelSidebar.js:60
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
+#: ../root/layout/components/sidebar/LabelSidebar.js:59
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:60
 msgid "Founded:"
-msgstr ""
-
-#: ../root/admin/attributes/index.tt:33
-msgid "Free text"
 msgstr ""
 
 #: ../root/otherlookup/form.tt:3
@@ -2613,13 +2435,13 @@ msgstr ""
 msgid "FreeDB:"
 msgstr ""
 
-#: ../root/components/forms.tt:255 ../root/components/forms.tt:279
+#: ../root/components/forms.tt:248 ../root/components/forms.tt:272
 msgid "French"
 msgstr ""
 
 #: ../root/admin/attributes/form.tt:10 ../root/admin/attributes/form.tt:25
-#: ../root/admin/attributes/language.tt:14
-#: ../root/admin/attributes/script.tt:12
+#: ../root/admin/attributes/Language.js:38
+#: ../root/admin/attributes/Script.js:37
 msgid "Frequency"
 msgstr ""
 
@@ -2636,15 +2458,15 @@ msgstr ""
 msgid "Full TOC:"
 msgstr ""
 
-#: ../root/components/artists-list.tt:7
-#: ../root/search/components/ArtistResults.js:68
+#: ../root/components/artists-list.tt:7 ../root/edit/details/AddArtist.js:88
+#: ../root/search/components/ArtistResults.js:65
 msgid "Gender"
 msgstr ""
 
-#: ../root/account/edit.tt:22 ../root/artist/edit_form.tt:18
-#: ../root/edit/details/add_artist.tt:31 ../root/edit/details/edit_artist.tt:30
+#: ../root/artist/edit_form.tt:17 ../root/edit/details/edit_artist.tt:30
 #: ../root/user/profile.tt:74 ../root/layout/components/MetaDescription.js:33
-#: ../root/layout/components/sidebar/ArtistSidebar.js:74
+#: ../root/layout/components/sidebar/ArtistSidebar.js:73
+#: ../root/static/scripts/account/components/EditProfileForm.js:203
 msgid "Gender:"
 msgstr ""
 
@@ -2652,108 +2474,23 @@ msgstr ""
 msgid "General Information"
 msgstr ""
 
-#: ../root/report/annotations_labels.tt:9
-#: ../root/report/annotations_places.tt:9
-#: ../root/report/annotations_recordings.tt:9
-#: ../root/report/annotations_release_groups.tt:9
-#: ../root/report/annotations_releases.tt:9
-#: ../root/report/annotations_series.tt:9 ../root/report/annotations_works.tt:9
-#: ../root/report/asins_with_multiple_releases.tt:16
-#: ../root/report/bad_amazon_urls.tt:11
-#: ../root/report/cat_no_looks_like_asin.tt:10
-#: ../root/report/deprecated_relationship_labels.tt:9
-#: ../root/report/deprecated_relationship_places.tt:9
-#: ../root/report/deprecated_relationship_recordings.tt:9
-#: ../root/report/deprecated_relationship_release_groups.tt:9
-#: ../root/report/deprecated_relationship_releases.tt:9
-#: ../root/report/deprecated_relationship_urls.tt:9
-#: ../root/report/deprecated_relationship_works.tt:9
-#: ../root/report/discogs_links_with_multiple_labels.tt:8
-#: ../root/report/discogs_links_with_multiple_release_groups.tt:8
-#: ../root/report/discogs_links_with_multiple_releases.tt:15
-#: ../root/report/duplicate_events.tt:11
-#: ../root/report/duplicate_relationships_labels.tt:9
-#: ../root/report/duplicate_relationships_recordings.tt:8
-#: ../root/report/duplicate_relationships_release_groups.tt:9
-#: ../root/report/duplicate_relationships_releases.tt:9
-#: ../root/report/duplicate_relationships_works.tt:9
-#: ../root/report/duplicate_release_groups.tt:14
-#: ../root/report/event_sequence_not_in_series.tt:8
-#: ../root/report/featuring_recordings.tt:14
-#: ../root/report/featuring_release_groups.tt:13
-#: ../root/report/featuring_releases.tt:13
-#: ../root/report/instruments_without_an_image.tt:10
-#: ../root/report/isrc_with_many_recordings.tt:15
-#: ../root/report/iswc_with_many_works.tt:10
-#: ../root/report/labels_disambiguation_same_name.tt:9
-#: ../root/report/mediums_with_sequence_issues.tt:8
-#: ../root/report/multiple_asins.tt:12
-#: ../root/report/multiple_discogs_links.tt:15
-#: ../root/report/part_of_set_relationships.tt:14
-#: ../root/report/places_without_coordinates.tt:9
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:11
-#: ../root/report/recordings_with_earliest_release_relationships.tt:12
-#: ../root/report/recordings_without_va_credit.tt:9
-#: ../root/report/recordings_without_va_link.tt:9
-#: ../root/report/recordings_with_varying_track_lengths.tt:9
-#: ../root/report/released_too_early.tt:8
-#: ../root/report/release_groups_without_va_credit.tt:9
-#: ../root/report/release_groups_without_va_link.tt:9
-#: ../root/report/release_label_same_artist.tt:10
-#: ../root/report/releases_in_caa_with_cover_art_relationships.tt:10
-#: ../root/report/releases_missing_disc_i_ds.tt:10
-#: ../root/report/releases_to_convert.tt:12
-#: ../root/report/releases_with_caa_no_types.tt:8
-#: ../root/report/releases_with_coverart_links.tt:8
-#: ../root/report/releases_with_download_relationships.tt:10
-#: ../root/report/releases_with_no_mediums.tt:8
-#: ../root/report/releases_without_language.tt:11
-#: ../root/report/releases_without_script.tt:10
-#: ../root/report/releases_without_va_credit.tt:9
-#: ../root/report/releases_without_va_link.tt:9
-#: ../root/report/releases_with_unlikely_language_script.tt:10
-#: ../root/report/separate_discs.tt:10 ../root/report/set_in_different_rg.tt:14
-#: ../root/report/single_medium_releases_with_medium_titles.tt:10
-#: ../root/report/some_formats_unset.tt:10
-#: ../root/report/superfluous_data_tracks.tt:10
-#: ../root/report/tracks_named_with_sequence.tt:11
-#: ../root/report/tracks_without_times.tt:8
-#: ../root/report/tracks_with_sequence_issues.tt:10
-#: ../root/report/unlinked_pseudo_releases.tt:8
-#: ../root/report/AnnotationsArtists.js:37
-#: ../root/report/ArtistsContainingDisambiguationComments.js:38
-#: ../root/report/ArtistsDisambiguationSameName.js:38
-#: ../root/report/ArtistsThatMayBeGroups.js:41
-#: ../root/report/ArtistsThatMayBePersons.js:41
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:41
-#: ../root/report/ArtistsWithNoSubscribers.js:39
-#: ../root/report/CollaborationRelationships.js:45
-#: ../root/report/DeprecatedRelationshipArtists.js:37
-#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
-#: ../root/report/DuplicateArtists.js:55
-#: ../root/report/DuplicateRelationshipsArtists.js:38
-#: ../root/report/LimitedEditors.js:37
-#: ../root/report/PossibleCollaborations.js:43
-msgid "Generated on {date}"
-msgstr ""
-
 #: ../root/components/tags.tt:7
-#: ../root/layout/components/sidebar/SidebarTags.js:70
-#: ../root/static/scripts/common/components/TagEditor.js:455
-#: ../root/static/scripts/common/components/TagEditor.js:540
+#: ../root/layout/components/sidebar/SidebarTags.js:69
+#: ../root/static/scripts/common/components/TagEditor.js:469
+#: ../root/static/scripts/common/components/TagEditor.js:554
 msgid "Genres"
 msgstr ""
 
-#: ../root/components/forms.tt:223 ../root/release/edit/information.tt:14
+#: ../root/components/forms.tt:216 ../root/release/edit/information.tt:14
 msgid "Guess case"
 msgstr ""
 
-#: ../root/components/forms.tt:249
+#: ../root/components/forms.tt:242
 msgctxt "button/menu"
 msgid "Guess case"
 msgstr ""
 
-#: ../root/components/forms.tt:244
+#: ../root/components/forms.tt:237
 msgctxt "header"
 msgid "Guess case"
 msgstr ""
@@ -2762,7 +2499,7 @@ msgstr ""
 msgid "Guess case disc title"
 msgstr ""
 
-#: ../root/components/forms.tt:227 ../root/release/edit/information.tt:16
+#: ../root/components/forms.tt:220 ../root/release/edit/information.tt:16
 msgid "Guess case options"
 msgstr ""
 
@@ -2770,7 +2507,7 @@ msgstr ""
 msgid "Guess case track"
 msgstr ""
 
-#: ../root/components/forms.tt:225 ../root/release/edit/information.tt:15
+#: ../root/components/forms.tt:218 ../root/release/edit/information.tt:15
 #: ../root/release/edit/tracklist.tt:194
 msgid "Guess feat. artists"
 msgstr ""
@@ -2779,7 +2516,7 @@ msgstr ""
 msgid "Guess feat. artists from track titles"
 msgstr ""
 
-#: ../root/components/forms.tt:236
+#: ../root/components/forms.tt:229
 msgid "Guess sort name"
 msgstr ""
 
@@ -2803,9 +2540,9 @@ msgstr ""
 msgid "Help:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:620
+#: ../root/components/common-macros.tt:609
 #: ../lib/MusicBrainz/Server/Controller/Edit.pm:219
-#: ../root/static/scripts/common/constants.js:211
+#: ../root/static/scripts/common/constants.js:230
 msgid "High"
 msgstr ""
 
@@ -2834,8 +2571,9 @@ msgstr ""
 msgid "I don’t know"
 msgstr ""
 
-#: ../root/admin/attributes/index.tt:17 ../root/admin/attributes/language.tt:8
-#: ../root/admin/attributes/script.tt:8 ../root/edit/search_macros.tt:360
+#: ../root/edit/search_macros.tt:360 ../root/admin/attributes/Attribute.js:94
+#: ../root/admin/attributes/Language.js:32
+#: ../root/admin/attributes/Script.js:33
 msgid "ID"
 msgstr ""
 
@@ -2843,90 +2581,89 @@ msgstr ""
 msgid "ID:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:31 ../root/label/edit_form.tt:33
+#: ../root/artist/edit_form.tt:29 ../root/label/edit_form.tt:32
+#: ../root/edit/details/AddArtist.js:148
 msgid "IPI code"
 msgstr ""
 
-#: ../root/edit/details/add_artist.tt:73 ../root/edit/details/add_label.tt:71
-#: ../root/layout/components/sidebar/SidebarIpis.js:20
+#: ../root/edit/details/add_label.tt:71
+#: ../root/layout/components/sidebar/SidebarIpis.js:19
 msgid "IPI code:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:31 ../root/edit/details/edit_artist.tt:62
-#: ../root/edit/details/edit_label.tt:51 ../root/label/edit_form.tt:33
+#: ../root/artist/edit_form.tt:29 ../root/edit/details/edit_artist.tt:62
+#: ../root/edit/details/edit_label.tt:51 ../root/label/edit_form.tt:32
 msgid "IPI codes:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:32 ../root/label/edit_form.tt:34
+#: ../root/artist/edit_form.tt:30 ../root/label/edit_form.tt:33
+#: ../root/edit/details/AddArtist.js:157
 msgid "ISNI code"
 msgstr ""
 
-#: ../root/edit/details/add_artist.tt:82 ../root/edit/details/add_label.tt:80
-#: ../root/layout/components/sidebar/SidebarIsnis.js:23
+#: ../root/edit/details/add_label.tt:80
+#: ../root/layout/components/sidebar/SidebarIsnis.js:22
 msgid "ISNI code:"
 msgstr ""
 
-#: ../root/artist/edit_form.tt:32 ../root/edit/details/edit_artist.tt:67
-#: ../root/edit/details/edit_label.tt:56 ../root/label/edit_form.tt:34
+#: ../root/artist/edit_form.tt:30 ../root/edit/details/edit_artist.tt:67
+#: ../root/edit/details/edit_label.tt:56 ../root/label/edit_form.tt:33
 msgid "ISNI codes:"
 msgstr ""
 
-#: ../root/area/edit_form.tt:13
+#: ../root/area/edit_form.tt:12 ../root/edit/details/AddArea.js:78
 msgid "ISO 3166-1"
 msgstr ""
 
-#: ../root/area/edit_form.tt:13 ../root/edit/details/add_area.tt:37
-#: ../root/edit/details/edit_area.tt:30
-#: ../root/layout/components/sidebar/AreaSidebar.js:62
+#: ../root/area/edit_form.tt:12 ../root/edit/details/edit_area.tt:30
+#: ../root/layout/components/sidebar/AreaSidebar.js:61
 msgid "ISO 3166-1:"
 msgstr ""
 
-#: ../root/area/edit_form.tt:14
+#: ../root/area/edit_form.tt:13 ../root/edit/details/AddArea.js:85
 msgid "ISO 3166-2"
 msgstr ""
 
-#: ../root/area/edit_form.tt:14 ../root/edit/details/add_area.tt:44
-#: ../root/edit/details/edit_area.tt:34
-#: ../root/layout/components/sidebar/AreaSidebar.js:72
+#: ../root/area/edit_form.tt:13 ../root/edit/details/edit_area.tt:34
+#: ../root/layout/components/sidebar/AreaSidebar.js:71
 msgid "ISO 3166-2:"
 msgstr ""
 
-#: ../root/area/edit_form.tt:15
+#: ../root/area/edit_form.tt:14 ../root/edit/details/AddArea.js:92
 msgid "ISO 3166-3"
 msgstr ""
 
-#: ../root/area/edit_form.tt:15 ../root/edit/details/add_area.tt:51
-#: ../root/edit/details/edit_area.tt:38
-#: ../root/layout/components/sidebar/AreaSidebar.js:82
+#: ../root/area/edit_form.tt:14 ../root/edit/details/edit_area.tt:38
+#: ../root/layout/components/sidebar/AreaSidebar.js:81
 msgid "ISO 3166-3:"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:6 ../root/admin/attributes/language.tt:10
+#: ../root/admin/attributes/form.tt:6 ../root/admin/attributes/Language.js:34
 msgid "ISO 639-1"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:7 ../root/admin/attributes/language.tt:11
+#: ../root/admin/attributes/form.tt:7 ../root/admin/attributes/Language.js:35
 msgid "ISO 639-2/B"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:8 ../root/admin/attributes/language.tt:12
+#: ../root/admin/attributes/form.tt:8 ../root/admin/attributes/Language.js:36
 msgid "ISO 639-2/T"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:9 ../root/admin/attributes/language.tt:13
+#: ../root/admin/attributes/form.tt:9 ../root/admin/attributes/Language.js:37
 msgid "ISO 639-3"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:23 ../root/admin/attributes/script.tt:10
+#: ../root/admin/attributes/form.tt:23 ../root/admin/attributes/Script.js:35
 msgid "ISO code"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:24 ../root/admin/attributes/script.tt:11
+#: ../root/admin/attributes/form.tt:24 ../root/admin/attributes/Script.js:36
 msgid "ISO number"
 msgstr ""
 
-#: ../root/recording/edit_form.tt:32
-#: ../root/report/isrc_with_many_recordings.tt:23
+#: ../root/recording/edit_form.tt:31
+#: ../root/report/IsrcsWithManyRecordings.js:72
 msgid "ISRC"
 msgstr ""
 
@@ -2935,29 +2672,23 @@ msgid "ISRC {isrc} to {recording}"
 msgstr ""
 
 #: ../root/edit/details/remove_isrc.tt:3 ../root/otherlookup/form.tt:3
-#: ../root/layout/components/sidebar/RecordingSidebar.js:56
+#: ../root/layout/components/sidebar/RecordingSidebar.js:55
 msgid "ISRC:"
 msgstr ""
 
-#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:177
-#: ../root/search/components/RecordingResults.js:125
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:645
+#: ../root/components/recordings-list.tt:28 ../root/report/ReportsIndex.js:516
+#: ../root/search/components/RecordingResults.js:123
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:655
 msgid "ISRCs"
 msgstr ""
 
-#: ../root/report/isrc_with_many_recordings.tt:1
-#: ../root/report/isrc_with_many_recordings.tt:3
-#: ../root/report/ReportsIndex.js:180
-msgid "ISRCs with multiple recordings"
-msgstr ""
-
-#: ../root/recording/edit_form.tt:32
+#: ../root/recording/edit_form.tt:31
 msgid "ISRCs:"
 msgstr ""
 
-#: ../root/components/works-list.tt:15
-#: ../root/report/iswc_with_many_works.tt:18 ../root/work/edit_form.tt:17
-#: ../root/work/merge.tt:14 ../root/search/components/WorkResults.js:52
+#: ../root/components/works-list.tt:15 ../root/work/edit_form.tt:16
+#: ../root/work/merge.tt:14 ../root/report/IswcsWithManyWorks.js:63
+#: ../root/search/components/WorkResults.js:51
 msgid "ISWC"
 msgstr ""
 
@@ -2967,16 +2698,11 @@ msgstr ""
 
 #: ../root/edit/details/add_work.tt:23 ../root/edit/details/edit_work.tt:19
 #: ../root/edit/details/remove_iswc.tt:3 ../root/otherlookup/form.tt:3
-#: ../root/layout/components/sidebar/WorkSidebar.js:79
+#: ../root/layout/components/sidebar/WorkSidebar.js:78
 msgid "ISWC:"
 msgstr ""
 
-#: ../root/report/iswc_with_many_works.tt:1
-#: ../root/report/iswc_with_many_works.tt:3 ../root/report/ReportsIndex.js:186
-msgid "ISWCs with multiple works"
-msgstr ""
-
-#: ../root/work/edit_form.tt:17
+#: ../root/work/edit_form.tt:16
 #: ../root/layout/components/MetaDescription.js:160
 msgid "ISWCs:"
 msgstr ""
@@ -3001,10 +2727,6 @@ msgstr ""
 
 #: ../root/cdtoc/attach_artist_releases.tt:50
 msgid "If you can't find what you're looking for, you can add a new release:"
-msgstr ""
-
-#: ../root/account/edit.tt:19
-msgid "If you change your email address, you will be required to verify it."
 msgstr ""
 
 #: ../root/release/edit/information.tt:320
@@ -3044,13 +2766,7 @@ msgid ""
 "org</code> with the name of your account."
 msgstr ""
 
-#: ../root/user/report.tt:10
-msgid ""
-"If you’d like us to be able to easily respond to your report, please check "
-"“Reveal my email address” below."
-msgstr ""
-
-#: ../root/components/common-macros.tt:92 ../root/components/Artwork.js:45
+#: ../root/components/common-macros.tt:92 ../root/components/Artwork.js:43
 msgid "Image not available yet, please try again in a few minutes."
 msgstr ""
 
@@ -3080,24 +2796,24 @@ msgid "Incorrect username or password"
 msgstr ""
 
 #: ../root/search/form.tt:24 ../lib/MusicBrainz/Server/Form/Search/Search.pm:60
-#: ../root/search/components/SearchForm.js:61
+#: ../root/search/components/SearchForm.js:58
 msgid "Indexed search"
 msgstr ""
 
-#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:63
+#: ../root/search/form.tt:29 ../root/search/components/SearchForm.js:60
 msgid "Indexed search with {doc|advanced query syntax}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587
+#: ../root/components/common-macros.tt:576
 #: ../root/components/instruments-list.tt:5 ../root/edit/search_macros.tt:360
 #: ../root/instrument/merge.tt:11
-#: ../root/report/instruments_without_an_image.tt:19
 #: ../lib/MusicBrainz/Server/Edit/Instrument.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:47
 #: ../root/layout/components/Search.js:30
-#: ../root/search/components/SearchForm.js:50
-#: ../root/static/scripts/common/i18n.js:56
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
+#: ../root/report/components/InstrumentList.js:32
+#: ../root/search/components/SearchForm.js:47
+#: ../root/static/scripts/common/constants.js:18
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:21
 msgid "Instrument"
 msgstr ""
 
@@ -3110,25 +2826,19 @@ msgstr ""
 msgid "Instrument Credits"
 msgstr ""
 
-#: ../root/instrument/edit_form.tt:9
+#: ../root/instrument/edit_form.tt:8
 msgid "Instrument Details"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570
+#: ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_instrument.tt:3
 #: ../root/edit/details/edit_instrument.tt:5
 msgid "Instrument:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:65
-#: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:35
+#: ../root/components/common-macros.tt:593 ../root/report/ReportsIndex.js:130
+#: ../root/tag/TagIndex.js:81 ../root/tag/TagLayout.js:33
 msgid "Instruments"
-msgstr ""
-
-#: ../root/report/instruments_without_an_image.tt:1
-#: ../root/report/instruments_without_an_image.tt:3
-#: ../root/report/ReportsIndex.js:68
-msgid "Instruments without an image"
 msgstr ""
 
 #: ../root/main/info/environment.tt:13
@@ -3146,7 +2856,7 @@ msgstr ""
 #: ../root/edit/details/merge_common.tt:17
 #: ../root/edit/details/merge_events.tt:9
 #: ../root/edit/details/merge_instruments.tt:9
-#: ../root/edit/details/merge_labels.tt:10
+#: ../root/edit/details/merge_labels.tt:9
 #: ../root/edit/details/merge_places.tt:9
 #: ../root/edit/details/merge_recordings.tt:11
 #: ../root/edit/details/merge_release_groups.tt:10
@@ -3167,11 +2877,11 @@ msgstr ""
 msgid "It may help to try again by reloading the page."
 msgstr ""
 
-#: ../root/components/common-macros.tt:720
+#: ../root/components/common-macros.tt:711
 msgid "Javascript is required for this page to work properly."
 msgstr ""
 
-#: ../root/components/forms.tt:261 ../root/components/forms.tt:285
+#: ../root/components/forms.tt:254 ../root/components/forms.tt:278
 msgid "Keep all-uppercase words uppercased"
 msgstr ""
 
@@ -3181,7 +2891,7 @@ msgstr ""
 
 #: ../root/cdtoc/attach_artist_releases.tt:18
 #: ../root/cdtoc/attach_filter_release.tt:32 ../root/cdtoc/list.tt:10
-#: ../root/components/common-macros.tt:587 ../root/components/labels-list.tt:5
+#: ../root/components/common-macros.tt:576
 #: ../root/components/releases-list.tt:19
 #: ../root/edit/details/edit_release_events.tt:7
 #: ../root/edit/details/historic/add_release.tt:77
@@ -3189,15 +2899,19 @@ msgstr ""
 #: ../root/label/merge.tt:12 ../root/otherlookup/results-release.tt:16
 #: ../root/recording/index.tt:17 ../root/release/edit/duplicates.tt:15
 #: ../root/release_group/index.tt:28 ../root/release/merge.tt:19
-#: ../root/report/label_list.tt:7 ../root/report/label_url_list.tt:6
-#: ../root/report/release_label_same_artist.tt:14
 #: ../lib/MusicBrainz/Server/Edit/Label.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:40
-#: ../root/label/LabelHeader.js:25 ../root/layout/components/Search.js:31
-#: ../root/search/components/ReleaseResults.js:105
-#: ../root/search/components/SearchForm.js:43
-#: ../root/static/scripts/common/i18n.js:57
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
+#: ../root/components/LabelsList.js:50 ../root/components/LabelsList.js:55
+#: ../root/label/LabelHeader.js:24 ../root/layout/components/Search.js:31
+#: ../root/report/ReleaseLabelSameArtist.js:68
+#: ../root/report/components/LabelAnnotationList.js:25
+#: ../root/report/components/LabelList.js:25
+#: ../root/report/components/LabelRelationshipList.js:26
+#: ../root/report/components/LabelUrlList.js:29
+#: ../root/search/components/ReleaseResults.js:111
+#: ../root/search/components/SearchForm.js:40
+#: ../root/static/scripts/common/constants.js:19
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:23
 msgid "Label"
 msgstr ""
 
@@ -3213,7 +2927,7 @@ msgstr ""
 msgid "Label Collections"
 msgstr ""
 
-#: ../root/label/edit_form.tt:11
+#: ../root/label/edit_form.tt:10
 msgid "Label Details"
 msgstr ""
 
@@ -3229,14 +2943,9 @@ msgstr ""
 msgid "Label Subscriptions"
 msgstr ""
 
-#: ../root/report/annotations_labels.tt:1
-#: ../root/report/annotations_labels.tt:3
-msgid "Label annotations"
-msgstr ""
-
 #: ../root/edit/details/add_label.tt:63 ../root/edit/details/edit_label.tt:29
-#: ../root/label/edit_form.tt:29
-#: ../root/layout/components/sidebar/LabelSidebar.js:69
+#: ../root/label/edit_form.tt:28
+#: ../root/layout/components/sidebar/LabelSidebar.js:68
 msgid "Label code:"
 msgstr ""
 
@@ -3244,7 +2953,7 @@ msgstr ""
 msgid "Label ratings"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570 ../root/edit/details/add_label.tt:3
+#: ../root/components/common-macros.tt:559 ../root/edit/details/add_label.tt:3
 #: ../root/edit/details/add_release_label.tt:9
 #: ../root/edit/details/edit_label.tt:5
 #: ../root/edit/details/edit_release_label.tt:11
@@ -3254,38 +2963,20 @@ msgstr ""
 msgid "Label:"
 msgstr ""
 
-#: ../root/area/labels.tt:1 ../root/area/labels.tt:2
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/components/EntityTabs.js:26
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:196
-#: ../root/report/ReportsIndex.js:71 ../root/tag/TagIndex.js:84
-#: ../root/tag/TagLayout.js:32
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
+#: ../root/area/AreaLabels.js:28 ../root/area/AreaLabels.js:29
+#: ../root/components/EntityTabs.js:25
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:194
+#: ../root/report/ReportsIndex.js:140 ../root/tag/TagIndex.js:82
+#: ../root/tag/TagLayout.js:30
 msgid "Labels"
 msgstr ""
 
-#: ../root/report/deprecated_relationship_labels.tt:1
-#: ../root/report/deprecated_relationship_labels.tt:3
-#: ../root/report/ReportsIndex.js:76
-msgid "Labels with deprecated relationships"
-msgstr ""
-
-#: ../root/report/labels_disambiguation_same_name.tt:1
-#: ../root/report/labels_disambiguation_same_name.tt:3
-#: ../root/report/ReportsIndex.js:78
-msgid "Labels with disambiguation the same as the name"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_labels.tt:1
-#: ../root/report/duplicate_relationships_labels.tt:3
-#: ../root/report/ReportsIndex.js:75
-msgid "Labels with possible duplicate relationships"
-msgstr ""
-
-#: ../root/admin/attributes/language.tt:1
-#: ../root/admin/attributes/language.tt:3
-#: ../root/otherlookup/results-release.tt:19
-#: ../root/report/iswc_with_many_works.tt:23 ../root/work/merge.tt:16
-#: ../root/iswc/Index.js:54 ../root/search/components/ReleaseResults.js:108
+#: ../root/otherlookup/results-release.tt:19 ../root/work/merge.tt:16
+#: ../root/admin/attributes/Language.js:24
+#: ../root/admin/attributes/Language.js:27 ../root/iswc/Index.js:53
+#: ../root/report/IswcsWithManyWorks.js:68
+#: ../root/search/components/ReleaseResults.js:114
 msgid "Language"
 msgstr ""
 
@@ -3301,10 +2992,6 @@ msgstr ""
 msgid "Language: {language}, script: {script}"
 msgstr ""
 
-#: ../root/account/edit.tt:52
-msgid "Languages Known:"
-msgstr ""
-
 #: ../root/user/profile.tt:149
 msgid "Languages:"
 msgstr ""
@@ -3317,31 +3004,12 @@ msgstr ""
 msgid "Last 28 days"
 msgstr ""
 
-#: ../root/report/annotations_labels.tt:13
-#: ../root/report/annotations_places.tt:12
-#: ../root/report/annotations_recordings.tt:13
-#: ../root/report/annotations_release_groups.tt:13
-#: ../root/report/annotations_releases.tt:13
-#: ../root/report/annotations_series.tt:13
-#: ../root/report/annotations_works.tt:13
-#: ../root/report/components/ArtistAnnotationList.js:30
-msgid "Last edited"
-msgstr ""
-
 #: ../root/user/profile.tt:96
 msgid "Last login:"
 msgstr ""
 
-#: ../root/layout.tt:121 ../root/layout/components/Footer.js:59
+#: ../root/layout.tt:121 ../root/layout/components/Footer.js:60
 msgid "Last replication packet received at {datetime}"
-msgstr ""
-
-#: ../root/report/instruments_without_an_image.tt:21
-msgid "Last updated"
-msgstr ""
-
-#: ../root/entity/details.tt:16 ../root/entity/Details.js:77
-msgid "Last updated:"
 msgstr ""
 
 #: ../root/artist/index.tt:21 ../root/artist/index.tt:24
@@ -3351,13 +3019,13 @@ msgstr ""
 #: ../root/cdstub/cdstub.tt:9 ../root/cdtoc/info.tt:33
 #: ../root/components/medium.tt:78 ../root/components/recordings-list.tt:30
 #: ../root/components/relationships-table.tt:31
-#: ../root/edit/details/edit_medium.tt:53
-#: ../root/edit/details/edit_medium.tt:57
+#: ../root/edit/details/edit_medium.tt:55
+#: ../root/edit/details/edit_medium.tt:59
 #: ../root/edit/details/historic/add_release.tt:52
 #: ../root/recording/index.tt:12 ../root/release/discids.tt:10
 #: ../root/release/edit/tracklist.tt:133 ../root/release/edit/tracklist.tt:346
-#: ../root/report/isrc_with_many_recordings.tt:26 ../root/isrc/Index.js:56
-#: ../root/search/components/RecordingResults.js:123
+#: ../root/isrc/Index.js:55 ../root/report/IsrcsWithManyRecordings.js:75
+#: ../root/search/components/RecordingResults.js:121
 msgid "Length"
 msgstr ""
 
@@ -3365,9 +3033,9 @@ msgstr ""
 #: ../root/edit/details/add_track_kv.tt:7
 #: ../root/edit/details/edit_recording.tt:22
 #: ../root/edit/details/historic/add_track_kv.tt:31
-#: ../root/recording/edit_form.tt:28
+#: ../root/recording/edit_form.tt:27
 #: ../root/layout/components/MetaDescription.js:139
-#: ../root/layout/components/sidebar/RecordingSidebar.js:50
+#: ../root/layout/components/sidebar/RecordingSidebar.js:49
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:137
 msgid "Length:"
 msgstr ""
@@ -3410,25 +3078,19 @@ msgid "Loading edit previews..."
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:75
-#: ../root/static/scripts/common/MB/release.js:59
-#: ../root/static/scripts/common/dialogs.js:16
+#: ../root/static/scripts/common/MB/release.js:58
+#: ../root/static/scripts/common/dialogs.js:15
 msgid "Loading..."
 msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:23
 #: ../root/edit/details/edit_alias.tt:42
-#: ../root/components/Aliases/AliasTable.js:31
+#: ../root/components/Aliases/AliasTable.js:30
 msgid "Locale"
 msgstr ""
 
-#: ../root/entity/alias/edit_form.tt:17
+#: ../root/entity/alias/edit_form.tt:16
 msgid "Locale:"
-msgstr ""
-
-#: ../root/components/events-list.tt:24 ../root/report/event_list.tt:10
-#: ../root/search/components/EventResults.js:76
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:940
-msgid "Location"
 msgstr ""
 
 #: ../root/edit/search_macros.tt:339
@@ -3439,25 +3101,18 @@ msgstr ""
 msgid "Location editor"
 msgstr ""
 
-#: ../root/user/privileged.tt:31
-msgid "Location editors"
-msgstr ""
-
-#: ../root/user/privileged.tt:32
-msgid "Location editors are users who can add or modify {uri|areas}."
-msgstr ""
-
-#: ../root/account/edit.tt:25 ../root/user/profile.tt:80
+#: ../root/user/profile.tt:80
+#: ../root/static/scripts/account/components/EditProfileForm.js:211
 msgid "Location:"
 msgstr ""
 
 #: ../root/user/login.tt:1 ../root/user/login.tt:3 ../root/user/login.tt:34
-#: ../root/layout/components/TopMenu.js:137
+#: ../root/layout/components/TopMenu.js:145
 msgid "Log In"
 msgstr ""
 
 #: ../root/components/common-macros.tt:522
-#: ../root/components/RequestLogin.js:19
+#: ../root/components/RequestLogin.js:18
 msgid "Log in"
 msgstr ""
 
@@ -3472,7 +3127,7 @@ msgstr ""
 msgid "Long link phrase:"
 msgstr ""
 
-#: ../root/doc/bare_error.tt:11 ../root/main/400.tt:10 ../root/main/404.js:29
+#: ../root/doc/bare_error.tt:11 ../root/main/400.tt:10 ../root/main/404.js:28
 msgid "Looking for help? Check out our {doc|documentation} or {faq|FAQ}."
 msgstr ""
 
@@ -3488,9 +3143,9 @@ msgstr ""
 msgid "Lookup count"
 msgstr ""
 
-#: ../root/components/common-macros.tt:620
+#: ../root/components/common-macros.tt:609
 #: ../lib/MusicBrainz/Server/Controller/Edit.pm:219
-#: ../root/static/scripts/common/constants.js:208
+#: ../root/static/scripts/common/constants.js:227
 msgid "Low"
 msgstr ""
 
@@ -3498,9 +3153,9 @@ msgstr ""
 #: ../root/edit/details/edit_work.tt:31
 #: ../root/release/edit_relationships.tt:150
 #: ../root/layout/components/MetaDescription.js:148
-#: ../root/layout/components/sidebar/WorkSidebar.js:64
-#: ../root/search/components/WorkResults.js:54
-#: ../root/static/scripts/work.js:290
+#: ../root/layout/components/sidebar/WorkSidebar.js:63
+#: ../root/search/components/WorkResults.js:53
+#: ../root/static/scripts/work.js:279
 msgid "Lyrics Languages"
 msgstr ""
 
@@ -3511,11 +3166,12 @@ msgstr ""
 #: ../root/components/relationship-editor.tt:126
 #: ../root/release/edit/information.tt:133
 #: ../lib/MusicBrainz/Server/Plugin/FormRenderer.pm:251
+#: ../root/components/PartialDateInput.js:39
 msgid "MM"
 msgstr ""
 
 #: ../root/components/forms.tt:15 ../root/components/forms.tt:20
-#: ../root/components/EnterEdit.js:32
+#: ../root/components/EnterEdit.js:31
 msgid "Make all edits votable."
 msgstr ""
 
@@ -3530,12 +3186,12 @@ msgstr ""
 msgid "Manual entry"
 msgstr ""
 
-#: ../root/components/common-macros.tt:918
+#: ../root/components/common-macros.tt:908
 msgid "Many relationships"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/map.tt:1
-#: ../root/components/EntityTabs.js:27
+#: ../root/components/EntityTabs.js:26
 msgid "Map"
 msgstr ""
 
@@ -3544,9 +3200,9 @@ msgid "Matching CDs"
 msgstr ""
 
 #: ../root/cdtoc/lookup.tt:38 ../root/cdtoc/set_durations.tt:10
-#: ../root/components/common-macros.tt:746
+#: ../root/components/common-macros.tt:736
 #: ../lib/MusicBrainz/Server/Edit/Medium.pm:8
-#: ../root/search/components/RecordingResults.js:129
+#: ../root/search/components/RecordingResults.js:127
 msgid "Medium"
 msgstr ""
 
@@ -3586,7 +3242,7 @@ msgstr ""
 msgid "Medium {position}: {name} is now medium {new_position}: {new_name}"
 msgstr ""
 
-#: ../root/edit/details/add_disc_id.tt:4 ../root/edit/details/edit_medium.tt:8
+#: ../root/edit/details/add_disc_id.tt:4 ../root/edit/details/edit_medium.tt:10
 #: ../root/edit/details/remove_disc_id.tt:3
 #: ../root/edit/details/remove_medium.tt:3
 msgid "Medium:"
@@ -3602,8 +3258,8 @@ msgid "Member since:"
 msgstr ""
 
 #: ../root/layout/merge-helper.tt:30
-#: ../root/layout/components/MergeHelper.js:37
-#: ../root/layout/components/sidebar/MergeLink.js:27
+#: ../root/layout/components/MergeHelper.js:38
+#: ../root/layout/components/sidebar/MergeLink.js:26
 msgid "Merge"
 msgstr ""
 
@@ -3627,7 +3283,7 @@ msgstr ""
 msgid "Merge Places"
 msgstr ""
 
-#: ../root/layout/merge-helper.tt:3 ../root/layout/components/MergeHelper.js:15
+#: ../root/layout/merge-helper.tt:3 ../root/layout/components/MergeHelper.js:16
 msgid "Merge Process"
 msgstr ""
 
@@ -3684,13 +3340,8 @@ msgstr ""
 msgid "Merge:"
 msgstr ""
 
-#: ../root/user/contact.tt:11 ../root/user/report.tt:18
-msgid "Message:"
-msgstr ""
-
-#: ../root/report/set_in_different_rg.tt:1
-#: ../root/report/set_in_different_rg.tt:3
-msgid "Mismatched release groups"
+#: ../root/user/contact.tt:11 ../root/user/ReportUser.js:124
+msgid "Message"
 msgstr ""
 
 #: ../root/cdstub/browse.tt:11
@@ -3762,7 +3413,7 @@ msgid ""
 "or label, please use the above form to create an account."
 msgstr ""
 
-#: ../root/edit/index.tt:26
+#: ../root/edit/index.tt:30
 msgid "My vote:"
 msgstr ""
 
@@ -3776,35 +3427,37 @@ msgid "N/A"
 msgstr ""
 
 #: ../root/admin/attributes/form.tt:5 ../root/admin/attributes/form.tt:22
-#: ../root/admin/attributes/form.tt:59 ../root/admin/attributes/index.tt:18
-#: ../root/admin/attributes/language.tt:9 ../root/admin/attributes/script.tt:9
-#: ../root/artist/aliases.tt:16 ../root/components/recordings-list.tt:24
+#: ../root/admin/attributes/form.tt:59 ../root/components/recordings-list.tt:24
 #: ../root/components/results-generic.tt:5
 #: ../root/edit/details/historic/add_release.tt:50
 #: ../root/otherlookup/results-release.tt:10
 #: ../root/otherlookup/results-work.tt:7 ../root/release_group/merge.tt:12
 #: ../root/user/subscriptions/table.tt:12
-#: ../root/search/components/AnnotationResults.js:58
-#: ../root/search/components/AreaResults.js:57
-#: ../root/search/components/ArtistResults.js:65
-#: ../root/search/components/EditorResults.js:45
-#: ../root/search/components/EventResults.js:71
-#: ../root/search/components/InstrumentResults.js:55
-#: ../root/search/components/LabelResults.js:62
-#: ../root/search/components/PlaceResults.js:57
-#: ../root/search/components/RecordingResults.js:122
-#: ../root/search/components/ReleaseResults.js:99
-#: ../root/search/components/SeriesResults.js:51
-#: ../root/search/components/TagResults.js:45
-#: ../root/search/components/WorkResults.js:49
-#: ../root/static/scripts/account/components/ApplicationForm.js:93
+#: ../root/admin/attributes/Attribute.js:95
+#: ../root/admin/attributes/Language.js:33
+#: ../root/admin/attributes/Script.js:34
+#: ../root/components/Aliases/ArtistCreditList.js:47
+#: ../root/edit/details/AddArea.js:51 ../root/edit/details/AddArtist.js:63
+#: ../root/edit/details/AddEvent.js:50
+#: ../root/search/components/AnnotationResults.js:56
+#: ../root/search/components/AreaResults.js:55
+#: ../root/search/components/ArtistResults.js:62
+#: ../root/search/components/EditorResults.js:44
+#: ../root/search/components/EventResults.js:58
+#: ../root/search/components/InstrumentResults.js:50
+#: ../root/search/components/LabelResults.js:60
+#: ../root/search/components/PlaceResults.js:55
+#: ../root/search/components/RecordingResults.js:120
+#: ../root/search/components/ReleaseResults.js:105
+#: ../root/search/components/SeriesResults.js:49
+#: ../root/search/components/TagResults.js:44
+#: ../root/search/components/WorkResults.js:48
+#: ../root/static/scripts/account/components/ApplicationForm.js:77
 msgid "Name"
 msgstr ""
 
 #: ../root/collection/edit_form.tt:5 ../root/components/filter-form.tt:16
-#: ../root/components/forms.tt:221 ../root/edit/details/add_area.tt:10
-#: ../root/edit/details/add_artist.tt:10 ../root/edit/details/add_event.tt:10
-#: ../root/edit/details/add_instrument.tt:10
+#: ../root/components/forms.tt:214 ../root/edit/details/add_instrument.tt:10
 #: ../root/edit/details/add_label.tt:10 ../root/edit/details/add_medium.tt:19
 #: ../root/edit/details/add_place.tt:10
 #: ../root/edit/details/add_relationship_attribute.tt:3
@@ -3815,7 +3468,7 @@ msgstr ""
 #: ../root/edit/details/add_work.tt:10 ../root/edit/details/edit_area.tt:11
 #: ../root/edit/details/edit_artist.tt:11 ../root/edit/details/edit_event.tt:9
 #: ../root/edit/details/edit_instrument.tt:9
-#: ../root/edit/details/edit_label.tt:9 ../root/edit/details/edit_medium.tt:16
+#: ../root/edit/details/edit_label.tt:9 ../root/edit/details/edit_medium.tt:18
 #: ../root/edit/details/edit_place.tt:9
 #: ../root/edit/details/edit_recording.tt:12
 #: ../root/edit/details/edit_relationship_attribute.tt:4
@@ -3829,11 +3482,10 @@ msgstr ""
 #: ../root/edit/details/historic/edit_release_name.tt:15
 #: ../root/edit/details/remove_relationship_attribute.tt:3
 #: ../root/edit/details/remove_relationship_type.tt:7
-#: ../root/entity/details.tt:6
 #: ../root/relationship/linkattributetype/form.tt:12
 #: ../root/relationship/linktype/form.tt:12
 #: ../root/relationship/linktype/form.tt:77
-#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:64
+#: ../root/relationship/linktype/form.tt:107 ../root/entity/Details.js:63
 msgid "Name:"
 msgstr ""
 
@@ -3841,7 +3493,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:209
+#: ../root/edit/details/edit_medium.tt:211
 msgid "New Artist"
 msgstr ""
 
@@ -3879,7 +3531,7 @@ msgstr ""
 msgid "New Status:"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:46
+#: ../root/edit/details/edit_medium.tt:48
 msgid "New Tracklist"
 msgstr ""
 
@@ -3915,7 +3567,7 @@ msgstr ""
 msgid "New positions:"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:178
+#: ../root/edit/details/edit_medium.tt:180
 msgid "New recording"
 msgstr ""
 
@@ -3933,9 +3585,9 @@ msgid "New version:"
 msgstr ""
 
 #: ../root/components/paginator.tt:44 ../root/components/paginator.tt:46
-#: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:110
-#: ../root/components/Paginator.js:114
-#: ../root/static/scripts/common/artworkViewer.js:38
+#: ../root/release/edit/macros.tt:44 ../root/components/Paginator.js:109
+#: ../root/components/Paginator.js:113
+#: ../root/static/scripts/common/artworkViewer.js:36
 #: ../root/static/scripts/release-editor/bindingHandlers.js:32
 msgid "Next"
 msgstr ""
@@ -3945,12 +3597,13 @@ msgid "Next »"
 msgstr ""
 
 #: ../root/components/common-macros.tt:30
+#: ../root/static/scripts/common/utility/yesNo.js:11
 msgid "No"
 msgstr ""
 
 #: ../root/edit/search_macros.tt:263 ../root/edit/search_macros.tt:279
 #: ../lib/MusicBrainz/Server/Data/Vote.pm:175
-#: ../root/edit/components/Vote.js:74
+#: ../root/edit/components/Vote.js:73
 msgctxt "vote"
 msgid "No"
 msgstr ""
@@ -3959,7 +3612,7 @@ msgstr ""
 msgid "No edit notes have been added."
 msgstr ""
 
-#: ../root/edit/list.tt:81
+#: ../root/edit/list.tt:85
 msgid "No edits were found matching your query. Please {search|try again}."
 msgstr ""
 
@@ -3968,7 +3621,7 @@ msgid "No nag"
 msgstr ""
 
 #: ../root/components/critiquebrainz.tt:1
-#: ../root/components/CritiqueBrainzLinks.js:38
+#: ../root/components/CritiqueBrainzLinks.js:37
 msgid ""
 "No one has reviewed this release group yet. Be the first to {write_link|"
 "write a review}."
@@ -4011,7 +3664,7 @@ msgid "No releases have cover art marked as \"Front\", cannot set cover art."
 msgstr ""
 
 #: ../root/release/edit/tracklist.tt:109
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:414
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:422
 msgid "No results"
 msgstr ""
 
@@ -4049,19 +3702,8 @@ msgstr ""
 msgid "Nobody has left notes on any of your edits in the past three months."
 msgstr ""
 
-#: ../root/entity/tags.tt:5
-#: ../root/static/scripts/common/components/TagEditor.js:476
-msgid "Nobody has tagged this yet."
-msgstr ""
-
-#: ../root/report/releases_with_download_relationships.tt:1
-#: ../root/report/releases_with_download_relationships.tt:3
-#: ../root/report/ReportsIndex.js:123
-msgid "Non-digital releases with download relationships"
-msgstr ""
-
-#: ../root/components/common-macros.tt:925 ../root/edit/edit_header.tt:27
-#: ../root/edit/components/Vote.js:80
+#: ../root/components/common-macros.tt:915 ../root/edit/edit_header.tt:27
+#: ../root/edit/components/Vote.js:79
 msgid "None"
 msgstr ""
 
@@ -4071,10 +3713,10 @@ msgid ""
 "None of the attached disc IDs can fit a pregap track of the given length."
 msgstr ""
 
-#: ../root/components/common-macros.tt:620
+#: ../root/components/common-macros.tt:609
 #: ../lib/MusicBrainz/Server/Controller/Edit.pm:219
-#: ../root/static/scripts/common/constants.js:209
-#: ../root/static/scripts/common/constants.js:210
+#: ../root/static/scripts/common/constants.js:228
+#: ../root/static/scripts/common/constants.js:229
 msgid "Normal"
 msgstr ""
 
@@ -4084,7 +3726,7 @@ msgstr ""
 
 #: ../root/edit/details/edit_release.tt:81
 #: ../root/edit/details/historic/merge_releases.tt:36
-#: ../root/edit/details/merge_releases.tt:144
+#: ../root/edit/details/merge_releases.tt:144 ../root/user/ReportUser.js:97
 msgid "Note"
 msgstr ""
 
@@ -4127,7 +3769,7 @@ msgstr ""
 msgid "Old"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:208
+#: ../root/edit/details/edit_medium.tt:210
 msgid "Old Artist"
 msgstr ""
 
@@ -4135,7 +3777,7 @@ msgstr ""
 msgid "Old Order"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:45
+#: ../root/edit/details/edit_medium.tt:47
 msgid "Old Tracklist"
 msgstr ""
 
@@ -4151,7 +3793,7 @@ msgstr ""
 msgid "Old positions:"
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:177
+#: ../root/edit/details/edit_medium.tt:179
 msgid "Old recording"
 msgstr ""
 
@@ -4209,16 +3851,12 @@ msgid "Oops, something went wrong!"
 msgstr ""
 
 #: ../root/user/profile.tt:191 ../lib/MusicBrainz/Server/Edit/Utils.pm:273
-#: ../root/utility/edit.js:38
+#: ../root/utility/edit.js:37
 msgid "Open"
 msgstr ""
 
-#: ../root/edit/open.tt:1 ../root/edit/open.tt:3 ../root/user/edits.tt:1
+#: ../root/edit/open.tt:1 ../root/edit/open.tt:3
 msgid "Open Edits"
-msgstr ""
-
-#: ../root/user/edits.tt:1
-msgid "Open Edits by {name}"
 msgstr ""
 
 #: ../root/entity/edits.tt:1
@@ -4226,15 +3864,13 @@ msgid "Open Edits for {name}"
 msgstr ""
 
 #: ../root/edit/list_header.tt:16
-#: ../root/layout/components/sidebar/CollectionSidebar.js:53
-#: ../root/layout/components/sidebar/EditLinks.js:32
+#: ../root/layout/components/sidebar/CollectionSidebar.js:49
+#: ../root/layout/components/sidebar/EditLinks.js:31
 msgid "Open edits"
 msgstr ""
 
-#: ../root/components/common-macros.tt:530
-#: ../root/components/common-macros.tt:535
-#: ../root/static/scripts/common/components/TaggerIcon.js:41
-msgid "Open in tagger"
+#: ../root/user/edits.tt:1
+msgid "Open edits by {name}"
 msgstr ""
 
 #: ../root/release/edit/recordings.tt:118 ../root/release/edit/tracklist.tt:11
@@ -4253,12 +3889,12 @@ msgid "Orderable direction:"
 msgstr ""
 
 #: ../root/components/series-list.tt:7 ../root/series/merge.tt:14
-#: ../root/layout/components/sidebar/SeriesSidebar.js:51
+#: ../root/layout/components/sidebar/SeriesSidebar.js:50
 msgid "Ordering Type"
 msgstr ""
 
 #: ../root/edit/details/add_series.tt:30 ../root/edit/details/edit_series.tt:23
-#: ../root/series/edit_form.tt:17
+#: ../root/series/edit_form.tt:16
 msgid "Ordering Type:"
 msgstr ""
 
@@ -4275,9 +3911,9 @@ msgid "Other lookups"
 msgstr ""
 
 #: ../root/components/tags.tt:26
-#: ../root/layout/components/sidebar/SidebarTags.js:81
-#: ../root/static/scripts/common/components/TagEditor.js:465
-#: ../root/static/scripts/common/components/TagEditor.js:550
+#: ../root/layout/components/sidebar/SidebarTags.js:80
+#: ../root/static/scripts/common/components/TagEditor.js:479
+#: ../root/static/scripts/common/components/TagEditor.js:564
 msgid "Other tags"
 msgstr ""
 
@@ -4285,13 +3921,13 @@ msgstr ""
 msgid "Overall"
 msgstr ""
 
-#: ../root/cdstub/header.tt:9 ../root/collection/header.tt:1
-#: ../root/components/entity-tabs.tt:33 ../root/components/EntityTabs.js:74
-#: ../root/tag/TagLayout.js:26
+#: ../root/cdstub/header.tt:9 ../root/components/entity-tabs.tt:33
+#: ../root/collection/CollectionHeader.js:69
+#: ../root/components/EntityTabs.js:73 ../root/tag/TagLayout.js:24
 msgid "Overview"
 msgstr ""
 
-#: ../root/components/common-macros.tt:99 ../root/components/Artwork.js:63
+#: ../root/components/common-macros.tt:99 ../root/components/Artwork.js:61
 msgid "PDF file"
 msgstr ""
 
@@ -4312,7 +3948,7 @@ msgstr ""
 
 #: ../root/doc/bare_error.tt:1 ../root/doc/error.tt:1
 #: ../root/main/mirror_404.tt:1 ../root/main/mirror_404.tt:3
-#: ../root/main/404.js:17 ../root/main/404.js:19
+#: ../root/main/404.js:16 ../root/main/404.js:18
 msgid "Page Not Found"
 msgstr ""
 
@@ -4333,10 +3969,6 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: ../root/admin/attributes/index.tt:21
-msgid "Parent ID"
-msgstr ""
-
 #: ../root/edit/details/add_relationship_attribute.tt:15
 #: ../root/edit/details/edit_relationship_attribute.tt:14
 #: ../root/relationship/linkattributetype/form.tt:4
@@ -4346,11 +3978,6 @@ msgstr ""
 
 #: ../root/release/edit/tracklist.tt:207
 msgid "Parse Tracks"
-msgstr ""
-
-#: ../root/report/part_of_set_relationships.tt:1
-#: ../root/report/part_of_set_relationships.tt:3
-msgid "Part of Set Relationships"
 msgstr ""
 
 #: ../root/account/register.tt:32 ../root/account/reset_password.tt:10
@@ -4363,26 +3990,25 @@ msgid "Perform the above operations when I'm not using the application"
 msgstr ""
 
 #: ../root/components/entity-tabs.tt:1 ../root/place/performances.tt:1
-#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:28
+#: ../root/place/performances.tt:2 ../root/components/EntityTabs.js:27
 msgid "Performances"
-msgstr ""
-
-#: ../root/entity/details.tt:20 ../root/entity/Details.js:83
-msgid "Permanent link:"
 msgstr ""
 
 #: ../root/edit/details/remove_relationship_type.tt:11
 msgid "Phrase:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/components/places-list.tt:5
+#: ../root/components/common-macros.tt:576 ../root/components/places-list.tt:5
 #: ../root/edit/search_macros.tt:360 ../root/place/merge.tt:11
-#: ../root/report/place_list.tt:7 ../lib/MusicBrainz/Server/Edit/Place.pm:8
+#: ../lib/MusicBrainz/Server/Edit/Place.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:42
-#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:26
-#: ../root/search/components/SearchForm.js:45
-#: ../root/static/scripts/common/i18n.js:58
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
+#: ../root/layout/components/Search.js:32 ../root/place/PlaceHeader.js:24
+#: ../root/report/PlacesWithoutCoordinates.js:55
+#: ../root/report/components/PlaceAnnotationList.js:25
+#: ../root/report/components/PlaceRelationshipList.js:26
+#: ../root/search/components/SearchForm.js:42
+#: ../root/static/scripts/common/constants.js:20
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:25
 msgid "Place"
 msgstr ""
 
@@ -4390,37 +4016,20 @@ msgstr ""
 msgid "Place Collections"
 msgstr ""
 
-#: ../root/place/edit_form.tt:11
+#: ../root/place/edit_form.tt:10
 msgid "Place Details"
 msgstr ""
 
-#: ../root/report/annotations_places.tt:1
-#: ../root/report/annotations_places.tt:3
-msgid "Place annotations"
-msgstr ""
-
-#: ../root/components/common-macros.tt:570 ../root/edit/details/add_place.tt:3
+#: ../root/components/common-macros.tt:559 ../root/edit/details/add_place.tt:3
 #: ../root/edit/details/edit_place.tt:5
 msgid "Place:"
 msgstr ""
 
 #: ../root/area/places.tt:1 ../root/area/places.tt:2
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/components/EntityTabs.js:29 ../root/report/ReportsIndex.js:148
-#: ../root/tag/TagIndex.js:85 ../root/tag/TagLayout.js:33
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
+#: ../root/components/EntityTabs.js:28 ../root/report/ReportsIndex.js:455
+#: ../root/tag/TagIndex.js:83 ../root/tag/TagLayout.js:31
 msgid "Places"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_places.tt:1
-#: ../root/report/deprecated_relationship_places.tt:3
-#: ../root/report/ReportsIndex.js:151
-msgid "Places with deprecated relationships"
-msgstr ""
-
-#: ../root/report/places_without_coordinates.tt:1
-#: ../root/report/places_without_coordinates.tt:3
-#: ../root/report/ReportsIndex.js:153
-msgid "Places without coordinates"
 msgstr ""
 
 #: ../root/main/500.tt:31
@@ -4471,7 +4080,7 @@ msgid ""
 msgstr ""
 
 #: ../root/layout/merge-helper.tt:24
-#: ../root/layout/components/MergeHelper.js:32
+#: ../root/layout/components/MergeHelper.js:33
 msgid ""
 "Please navigate to the pages of other entities you wish to merge and select "
 "the \"merge\" link."
@@ -4482,10 +4091,6 @@ msgid ""
 "Please note that any content submitted to MusicBrainz will be made available "
 "to the public under {open|open licenses}, do not submit any copyrighted text "
 "here! "
-msgstr ""
-
-#: ../root/user/report.tt:4
-msgid "Please review our {uri|Code of Conduct} before sending a report."
 msgstr ""
 
 #: ../root/account/register.tt:45
@@ -4508,7 +4113,7 @@ msgid ""
 "these types."
 msgstr ""
 
-#: ../root/artist/edit_form.tt:78
+#: ../root/artist/edit_form.tt:76
 msgid ""
 "Please select the artist credits that you want to rename to follow the new "
 "artist name."
@@ -4528,22 +4133,12 @@ msgstr ""
 
 #: ../root/edit/details/add_medium.tt:13
 #: ../root/edit/details/edit_cover_art.tt:20
-#: ../root/edit/details/edit_medium.tt:23 ../root/release/add_cover_art.tt:112
+#: ../root/edit/details/edit_medium.tt:25 ../root/release/add_cover_art.tt:112
 msgid "Position:"
 msgstr ""
 
 #: ../root/cdtoc/lookup.tt:29
 msgid "Possible Mediums"
-msgstr ""
-
-#: ../root/report/duplicate_events.tt:1 ../root/report/duplicate_events.tt:3
-msgid "Possible duplicate events"
-msgstr ""
-
-#: ../root/report/duplicate_release_groups.tt:1
-#: ../root/report/duplicate_release_groups.tt:3
-#: ../root/report/ReportsIndex.js:89
-msgid "Possible duplicate release groups"
 msgstr ""
 
 #: ../root/relationship/linkattributetype/index.tt:19
@@ -4559,21 +4154,21 @@ msgid "Preview"
 msgstr ""
 
 #: ../root/annotation/edit.tt:10
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:61
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:62
 msgid "Preview:"
 msgstr ""
 
 #: ../root/components/paginator.tt:6 ../root/components/paginator.tt:8
-#: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:48
-#: ../root/components/Paginator.js:53
-#: ../root/static/scripts/common/artworkViewer.js:34
+#: ../root/release/edit/macros.tt:43 ../root/components/Paginator.js:47
+#: ../root/components/Paginator.js:52
+#: ../root/static/scripts/common/artworkViewer.js:32
 #: ../root/static/scripts/release-editor/bindingHandlers.js:35
 msgid "Previous"
 msgstr ""
 
 #: ../root/edit/details/add_release_group.tt:28
 #: ../root/edit/details/edit_release_group.tt:19
-#: ../root/release/edit/information.tt:89 ../root/release_group/edit_form.tt:17
+#: ../root/release/edit/information.tt:89 ../root/release_group/edit_form.tt:16
 msgid "Primary Type:"
 msgstr ""
 
@@ -4587,21 +4182,12 @@ msgid "Priority:"
 msgstr ""
 
 #: ../root/user/collections.tt:49
-#: ../root/static/scripts/account/components/PreferencesForm.js:194
+#: ../root/static/scripts/account/components/PreferencesForm.js:168
 msgid "Privacy"
 msgstr ""
 
 #: ../root/user/collections.tt:62
 msgid "Private"
-msgstr ""
-
-#: ../root/collection/header.tt:14
-msgid "Private collection"
-msgstr ""
-
-#: ../root/user/privileged.tt:5 ../root/user/privileged.tt:7
-#: ../root/layout/components/BottomMenu.js:129
-msgid "Privileged User Accounts"
 msgstr ""
 
 #: ../root/main/timeout.tt:5
@@ -4612,12 +4198,8 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: ../root/collection/header.tt:14
-msgid "Public collection by {owner}"
-msgstr ""
-
 #: ../root/components/search.tt:9 ../root/search/form.tt:4
-#: ../root/search/components/SearchForm.js:80
+#: ../root/search/components/SearchForm.js:74
 msgid "Query:"
 msgstr ""
 
@@ -4625,28 +4207,28 @@ msgstr ""
 msgid "Quick links:"
 msgstr ""
 
-#: ../root/components/rating-macros.tt:1 ../root/utility/ratingTooltip.js:13
+#: ../root/components/rating-macros.tt:1 ../root/utility/ratingTooltip.js:11
 msgid "Rate: {rating} star"
 msgid_plural "Rate: {rating} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/artists-list.tt:9 ../root/components/events-list.tt:29
-#: ../root/components/labels-list.tt:14 ../root/components/medium.tt:77
+#: ../root/components/artists-list.tt:9 ../root/components/medium.tt:77
 #: ../root/components/recordings-list.tt:29
 #: ../root/components/release_groups-list.tt:17
 #: ../root/components/releases-list.tt:24 ../root/components/works-list.tt:20
-#: ../root/layout/components/sidebar/SidebarRating.js:21
+#: ../root/components/EventsList.js:105 ../root/components/LabelsList.js:112
+#: ../root/layout/components/sidebar/SidebarRating.js:22
 msgid "Rating"
 msgstr ""
 
 #: ../root/entity/ratings.tt:1 ../root/entity/ratings.tt:2
 #: ../root/user/ratings_summary.tt:1 ../root/user/ratings_summary.tt:32
-#: ../root/components/UserAccountTabs.js:55
+#: ../root/components/UserAccountTabs.js:54
 msgid "Ratings"
 msgstr ""
 
-#: ../root/edit/index.tt:11
+#: ../root/edit/index.tt:15
 msgid "Raw edit data may be available."
 msgstr ""
 
@@ -4656,25 +4238,24 @@ msgid ""
 "works."
 msgstr ""
 
-#: ../root/user/report.tt:15
-msgid "Reason:"
-msgstr ""
-
 #: ../root/edit/notes-received.tt:1 ../root/edit/notes-received.tt:3
 msgid "Recent Notes Left on Your Edits"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587
+#: ../root/components/common-macros.tt:576
 #: ../root/edit/details/merge_releases.tt:100 ../root/edit/search_macros.tt:360
 #: ../root/release/edit_relationships.tt:50
-#: ../root/report/isrc_with_many_recordings.tt:25
-#: ../root/report/recording_list.tt:8
 #: ../lib/MusicBrainz/Server/Edit/Recording.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:38
 #: ../root/layout/components/Search.js:22
-#: ../root/search/components/SearchForm.js:41
-#: ../root/static/scripts/common/i18n.js:59
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
+#: ../root/report/IsrcsWithManyRecordings.js:74
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:74
+#: ../root/report/components/RecordingAnnotationList.js:28
+#: ../root/report/components/RecordingList.js:28
+#: ../root/report/components/RecordingRelationshipList.js:29
+#: ../root/search/components/SearchForm.js:38
+#: ../root/static/scripts/common/constants.js:21
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:27
 msgid "Recording"
 msgstr ""
 
@@ -4682,7 +4263,7 @@ msgstr ""
 msgid "Recording Collections"
 msgstr ""
 
-#: ../root/recording/edit_form.tt:24
+#: ../root/recording/edit_form.tt:23
 msgid "Recording Details"
 msgstr ""
 
@@ -4690,20 +4271,15 @@ msgstr ""
 msgid "Recording Merges"
 msgstr ""
 
-#: ../root/report/annotations_recordings.tt:1
-#: ../root/report/annotations_recordings.tt:3
-msgid "Recording annotations"
-msgstr ""
-
 #: ../root/user/ratings_summary.tt:3 ../root/user/ratings.tt:2
 msgid "Recording ratings"
 msgstr ""
 
-#: ../root/recording/layout.tt:3
+#: ../root/recording/layout.tt:3 ../root/recording/RecordingLayout.js:45
 msgid "Recording “{name}” by {artist}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570
+#: ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_standalone_recording.tt:3
 #: ../root/edit/details/edit_recording.tt:8
 #: ../root/edit/details/historic/edit_track.tt:6
@@ -4713,61 +4289,16 @@ msgid "Recording:"
 msgstr ""
 
 #: ../root/artist/recordings.tt:1 ../root/artist/recordings.tt:4
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
 #: ../root/instrument/recordings.tt:1 ../root/instrument/recordings.tt:2
 #: ../root/release/edit/layout.tt:17 ../root/series/index.tt:15
-#: ../root/work/index.tt:17 ../root/components/EntityTabs.js:30
-#: ../root/report/ReportsIndex.js:133 ../root/tag/TagIndex.js:88
-#: ../root/tag/TagLayout.js:30
+#: ../root/work/index.tt:16 ../root/components/EntityTabs.js:29
+#: ../root/report/ReportsIndex.js:402 ../root/tag/TagIndex.js:86
+#: ../root/tag/TagLayout.js:28
 msgid "Recordings"
 msgstr ""
 
-#: ../root/report/recordings_without_va_link.tt:1
-#: ../root/report/recordings_without_va_link.tt:3
-#: ../root/report/ReportsIndex.js:144
-msgid "Recordings credited to \"Various Artists\" but not linked to VA"
-msgstr ""
-
-#: ../root/report/recordings_without_va_credit.tt:1
-#: ../root/report/recordings_without_va_credit.tt:3
-#: ../root/report/ReportsIndex.js:143
-msgid "Recordings not credited to \"Various Artists\" but linked to VA"
-msgstr ""
-
-#: ../root/report/recordings_with_earliest_release_relationships.tt:1
-#: ../root/report/recordings_with_earliest_release_relationships.tt:3
-msgid "Recordings with Earliest Release Relationships"
-msgstr ""
-
-#: ../root/report/recordings_with_varying_track_lengths.tt:1
-#: ../root/report/recordings_with_varying_track_lengths.tt:3
-msgid "Recordings with Varying Track Lengths"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_recordings.tt:1
-#: ../root/report/deprecated_relationship_recordings.tt:3
-#: ../root/report/ReportsIndex.js:141
-msgid "Recordings with deprecated relationships"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_recordings.tt:1
-#: ../root/report/duplicate_relationships_recordings.tt:3
-#: ../root/report/ReportsIndex.js:139
-msgid "Recordings with possible duplicate relationships"
-msgstr ""
-
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:1
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:3
-#: ../root/report/ReportsIndex.js:145
-msgid "Recordings with the same name by different artists with the same name"
-msgstr ""
-
-#: ../root/report/featuring_recordings.tt:1
-#: ../root/report/featuring_recordings.tt:3 ../root/report/ReportsIndex.js:138
-msgid "Recordings with titles containing featuring artists"
-msgstr ""
-
-#: ../root/edit/details/edit_medium.tt:171
+#: ../root/edit/details/edit_medium.tt:173
 msgid "Recordings:"
 msgstr ""
 
@@ -4779,16 +4310,12 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: ../root/edit/index.tt:58 ../root/edit/components/EditSummary.js:81
+#: ../root/edit/index.tt:62 ../root/edit/components/EditSummary.js:80
 msgid "Reject edit"
 msgstr ""
 
 #: ../root/user/edits.tt:1
-msgid "Rejected Edits"
-msgstr ""
-
-#: ../root/user/edits.tt:1
-msgid "Rejected Edits by {name}"
+msgid "Rejected edits by {name}"
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:55
@@ -4799,14 +4326,6 @@ msgstr ""
 msgid "Related entities:"
 msgstr ""
 
-#: ../root/components/relationships.tt:45
-msgid "Related series"
-msgstr ""
-
-#: ../root/components/relationships.tt:37
-msgid "Related works"
-msgstr ""
-
 #: ../root/edit/details/reorder_relationships.tt:4
 #: ../lib/MusicBrainz/Server/Edit/Relationship.pm:18
 msgid "Relationship"
@@ -4814,7 +4333,7 @@ msgstr ""
 
 #: ../root/relationship/header.tt:1
 #: ../root/relationship/linkattributetype/index.tt:3
-#: ../root/relationship/linkattributetype/NotFound.js:16
+#: ../root/relationship/linkattributetype/NotFound.js:15
 msgid "Relationship Attributes"
 msgstr ""
 
@@ -4823,14 +4342,14 @@ msgid "Relationship Editor"
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:2 ../root/edit/search_macros.tt:360
-#: ../root/report/deprecated_relationship_labels.tt:13
-#: ../root/report/deprecated_relationship_places.tt:13
-#: ../root/report/deprecated_relationship_recordings.tt:13
-#: ../root/report/deprecated_relationship_release_groups.tt:13
-#: ../root/report/deprecated_relationship_releases.tt:13
-#: ../root/report/deprecated_relationship_urls.tt:13
-#: ../root/report/deprecated_relationship_works.tt:13
-#: ../root/report/components/ArtistRelationshipList.js:28
+#: ../root/report/components/ArtistRelationshipList.js:25
+#: ../root/report/components/LabelRelationshipList.js:25
+#: ../root/report/components/PlaceRelationshipList.js:25
+#: ../root/report/components/RecordingRelationshipList.js:27
+#: ../root/report/components/ReleaseGroupRelationshipList.js:30
+#: ../root/report/components/ReleaseRelationshipList.js:27
+#: ../root/report/components/UrlRelationshipList.js:27
+#: ../root/report/components/WorkRelationshipList.js:25
 msgid "Relationship Type"
 msgstr ""
 
@@ -4841,7 +4360,7 @@ msgstr ""
 
 #: ../root/doc/relationship_type.tt:4 ../root/relationship/header.tt:1
 #: ../root/relationship/linktype/index.tt:1
-#: ../root/layout/components/BottomMenu.js:270
+#: ../root/layout/components/BottomMenu.js:284
 msgid "Relationship Types"
 msgstr ""
 
@@ -4857,18 +4376,6 @@ msgstr ""
 msgid "Relationship editor"
 msgstr ""
 
-#: ../root/user/privileged.tt:17
-msgid "Relationship editors"
-msgstr ""
-
-#: ../root/user/privileged.tt:18
-msgid ""
-"Relationship editors are users who can add or modify relationship types in "
-"the database. If you would like to propose a new relationship, please do so "
-"through the {url|Style Council}. Relationship editors will only make changes "
-"that have been approved by the Style Council."
-msgstr ""
-
 #: ../root/edit/details/add_relationship.tt:3
 #: ../root/edit/details/edit_relationship.tt:8
 #: ../root/edit/details/macros.tt:83
@@ -4876,11 +4383,11 @@ msgstr ""
 msgid "Relationship:"
 msgstr ""
 
-#: ../root/artist/relationships.tt:1 ../root/artist/relationships.tt:7
-#: ../root/components/entity-tabs.tt:43 ../root/components/relationships.tt:31
-#: ../root/forms/relationship-editor.tt:5 ../root/label/relationships.tt:1
-#: ../root/label/relationships.tt:6 ../root/relationship/header.tt:6
-#: ../root/components/EntityTabs.js:85
+#: ../root/artist/relationships.tt:1 ../root/artist/relationships.tt:6
+#: ../root/components/entity-tabs.tt:43 ../root/forms/relationship-editor.tt:5
+#: ../root/label/relationships.tt:1 ../root/label/relationships.tt:5
+#: ../root/relationship/header.tt:6 ../root/components/EntityTabs.js:84
+#: ../root/components/Relationships.js:98
 msgid "Relationships"
 msgstr ""
 
@@ -4899,23 +4406,26 @@ msgstr ""
 
 #: ../root/cdtoc/attach_artist_releases.tt:15
 #: ../root/cdtoc/attach_filter_release.tt:28 ../root/cdtoc/lookup.tt:37
-#: ../root/components/common-macros.tt:587
+#: ../root/components/common-macros.tt:576
 #: ../root/components/releases-list.tt:10
 #: ../root/edit/details/edit_release_events.tt:4
 #: ../root/edit/details/merge_releases.tt:18 ../root/edit/search_macros.tt:360
 #: ../root/release/edit/duplicates.tt:10 ../root/release_group/index.tt:23
 #: ../root/release/index.tt:50 ../root/release/merge.tt:13
-#: ../root/report/bad_amazon_urls.tt:20
-#: ../root/report/cat_no_looks_like_asin.tt:19 ../root/report/release_list.tt:7
-#: ../root/report/release_url_list.tt:6
 #: ../lib/MusicBrainz/Server/Edit/Release.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:37
-#: ../root/layout/components/Search.js:23
-#: ../root/search/components/RecordingResults.js:126
-#: ../root/search/components/SearchForm.js:40
-#: ../root/static/scripts/common/i18n.js:60
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
-#: ../root/taglookup/Form.js:29
+#: ../root/layout/components/Search.js:23 ../root/report/BadAmazonUrls.js:59
+#: ../root/report/CatNoLooksLikeAsin.js:63
+#: ../root/report/ReleaseLabelSameArtist.js:66
+#: ../root/report/components/ReleaseAnnotationList.js:28
+#: ../root/report/components/ReleaseList.js:27
+#: ../root/report/components/ReleaseRelationshipList.js:28
+#: ../root/report/components/ReleaseUrlList.js:31
+#: ../root/search/components/RecordingResults.js:124
+#: ../root/search/components/SearchForm.js:37
+#: ../root/static/scripts/common/constants.js:22
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:29
+#: ../root/taglookup/Form.js:28
 msgid "Release"
 msgstr ""
 
@@ -4939,13 +4449,17 @@ msgstr ""
 msgid "Release Events:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/edit/search_macros.tt:360
-#: ../root/release/index.tt:57 ../root/report/release_group_list.tt:8
+#: ../root/components/common-macros.tt:576 ../root/edit/search_macros.tt:360
+#: ../root/release/index.tt:57
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:36
 #: ../root/layout/components/Search.js:24
-#: ../root/search/components/ReleaseGroupResults.js:61
-#: ../root/search/components/SearchForm.js:39
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
+#: ../root/report/components/ReleaseGroupAnnotationList.js:28
+#: ../root/report/components/ReleaseGroupList.js:35
+#: ../root/report/components/ReleaseGroupRelationshipList.js:32
+#: ../root/report/components/ReleaseGroupUrlList.js:31
+#: ../root/search/components/ReleaseGroupResults.js:59
+#: ../root/search/components/SearchForm.js:36
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:31
 msgid "Release Group"
 msgstr ""
 
@@ -4953,7 +4467,7 @@ msgstr ""
 msgid "Release Group Collections"
 msgstr ""
 
-#: ../root/release_group/edit_form.tt:13
+#: ../root/release_group/edit_form.tt:12
 msgid "Release Group Details"
 msgstr ""
 
@@ -4973,15 +4487,9 @@ msgstr ""
 msgid "Release Group: {release_group_link}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:604 ../root/series/index.tt:15
-#: ../root/tag/TagIndex.js:86 ../root/tag/TagLayout.js:28
+#: ../root/components/common-macros.tt:593 ../root/series/index.tt:15
+#: ../root/tag/TagIndex.js:84 ../root/tag/TagLayout.js:26
 msgid "Release Groups"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_release_groups.tt:1
-#: ../root/report/deprecated_relationship_release_groups.tt:3
-#: ../root/report/ReportsIndex.js:88
-msgid "Release Groups with deprecated relationships"
 msgstr ""
 
 #: ../root/release/edit/layout.tt:12
@@ -5004,15 +4512,6 @@ msgstr ""
 msgid "Release Title"
 msgstr ""
 
-#: ../root/report/annotations_releases.tt:1
-#: ../root/report/annotations_releases.tt:3
-msgid "Release annotations"
-msgstr ""
-
-#: ../root/release/header.tt:8
-msgid "Release by {artist}"
-msgstr ""
-
 #: ../root/release/edit/information.tt:116
 msgid "Release event"
 msgstr ""
@@ -5023,56 +4522,21 @@ msgstr ""
 msgid "Release events:"
 msgstr ""
 
-#: ../root/report/release_group_url_list.tt:6
-#: ../lib/MusicBrainz/Server/Edit/ReleaseGroup.pm:7
-#: ../root/static/scripts/common/i18n.js:61
-msgid "Release group"
-msgstr ""
-
-#: ../root/report/annotations_release_groups.tt:1
-#: ../root/report/annotations_release_groups.tt:3
-msgid "Release group annotations"
-msgstr ""
-
 #: ../root/user/ratings_summary.tt:3 ../root/user/ratings.tt:2
 msgid "Release group ratings"
 msgstr ""
 
 #: ../root/release_group/layout.tt:1
-#: ../root/release_group/ReleaseGroupLayout.js:35
+#: ../root/release_group/ReleaseGroupLayout.js:34
 msgid "Release group “{name}” by {artist}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570
+#: ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_release.tt:20
 #: ../root/edit/details/historic/change_release_group.tt:13
 #: ../root/edit/details/historic/move_release_to_rg.tt:7
 #: ../root/edit/details/set_cover_art.tt:5
 msgid "Release group:"
-msgstr ""
-
-#: ../root/report/release_groups_without_va_link.tt:1
-#: ../root/report/release_groups_without_va_link.tt:3
-#: ../root/report/ReportsIndex.js:92
-msgid "Release groups credited to \"Various Artists\" but not linked to VA"
-msgstr ""
-
-#: ../root/report/release_groups_without_va_credit.tt:1
-#: ../root/report/release_groups_without_va_credit.tt:3
-#: ../root/report/ReportsIndex.js:91
-msgid "Release groups not credited to \"Various Artists\" but linked to VA"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_release_groups.tt:1
-#: ../root/report/duplicate_relationships_release_groups.tt:3
-#: ../root/report/ReportsIndex.js:87
-msgid "Release groups with possible duplicate relationships"
-msgstr ""
-
-#: ../root/report/featuring_release_groups.tt:1
-#: ../root/report/featuring_release_groups.tt:3
-#: ../root/report/ReportsIndex.js:85
-msgid "Release groups with titles containing featuring artists"
 msgstr ""
 
 #: ../root/release/edit/information.tt:3
@@ -5084,15 +4548,15 @@ msgstr ""
 msgid "Release title:"
 msgstr ""
 
-#: ../root/release/layout.tt:1
+#: ../root/release/layout.tt:1 ../root/release/ReleaseLayout.js:34
 msgid "Release “{name}” by {artist}"
 msgstr ""
 
-#: ../root/cdtoc/lookup.tt:71 ../root/components/common-macros.tt:570
+#: ../root/cdtoc/lookup.tt:71 ../root/components/common-macros.tt:559
 #: ../root/edit/details/add_cover_art.tt:5 ../root/edit/details/add_medium.tt:5
 #: ../root/edit/details/add_release_label.tt:4
 #: ../root/edit/details/add_release.tt:3
-#: ../root/edit/details/change_release_quality.tt:3
+#: ../root/edit/details/change_release_data_quality.tt:3
 #: ../root/edit/details/edit_barcodes.tt:12
 #: ../root/edit/details/edit_cover_art.tt:5
 #: ../root/edit/details/edit_release_label.tt:5
@@ -5108,156 +4572,15 @@ msgstr ""
 
 #: ../root/area/releases.tt:1 ../root/area/releases.tt:4
 #: ../root/artist/releases.tt:1 ../root/artist/releases.tt:4
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
 #: ../root/components/release_groups-list.tt:19
 #: ../root/edit/details/historic/add_release_annotation.tt:3
 #: ../root/instrument/releases.tt:1 ../root/instrument/releases.tt:2
 #: ../root/label/index.tt:14 ../root/release_group/merge.tt:16
-#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:31
-#: ../root/report/ReportsIndex.js:95 ../root/tag/TagIndex.js:87
-#: ../root/tag/TagLayout.js:29
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:30
+#: ../root/report/ReportsIndex.js:222 ../root/tag/TagIndex.js:85
+#: ../root/tag/TagLayout.js:27
 msgid "Releases"
-msgstr ""
-
-#: ../root/report/releases_missing_disc_i_ds.tt:1
-#: ../root/report/releases_missing_disc_i_ds.tt:3
-msgid "Releases Missing Disc IDs"
-msgstr ""
-
-#: ../root/report/tracks_named_with_sequence.tt:1
-#: ../root/report/tracks_named_with_sequence.tt:3
-msgid "Releases Where Track Names Start With Their Track Number"
-msgstr ""
-
-#: ../root/report/cat_no_looks_like_asin.tt:1
-#: ../root/report/cat_no_looks_like_asin.tt:3
-msgid "Releases With Catalog Numbers That Look Like ASINs"
-msgstr ""
-
-#: ../root/report/multiple_asins.tt:1 ../root/report/multiple_asins.tt:3
-msgid "Releases With Multiple ASINs"
-msgstr ""
-
-#: ../root/report/multiple_discogs_links.tt:1
-#: ../root/report/multiple_discogs_links.tt:3
-msgid "Releases With Multiple Discogs Links"
-msgstr ""
-
-#: ../root/report/some_formats_unset.tt:1
-#: ../root/report/some_formats_unset.tt:3
-msgid "Releases With Some Formats Unset"
-msgstr ""
-
-#: ../root/report/releases_without_va_link.tt:1
-#: ../root/report/releases_without_va_link.tt:3
-#: ../root/report/ReportsIndex.js:128
-msgid "Releases credited to \"Various Artists\" but not linked to VA"
-msgstr ""
-
-#: ../root/report/releases_in_caa_with_cover_art_relationships.tt:1
-#: ../root/report/ReportsIndex.js:115
-msgid ""
-"Releases in the Cover Art Archive that still have cover art relationships"
-msgstr ""
-
-#: ../root/report/releases_with_caa_no_types.tt:1
-#: ../root/report/releases_with_caa_no_types.tt:3
-#: ../root/report/ReportsIndex.js:117
-msgid "Releases in the Cover Art Archive where no cover art piece has types"
-msgstr ""
-
-#: ../root/report/releases_without_va_credit.tt:1
-#: ../root/report/releases_without_va_credit.tt:3
-#: ../root/report/ReportsIndex.js:127
-msgid "Releases not credited to \"Various Artists\" but linked to VA"
-msgstr ""
-
-#: ../root/report/released_too_early.tt:1
-#: ../root/report/released_too_early.tt:3 ../root/report/ReportsIndex.js:111
-msgid "Releases released too early"
-msgstr ""
-
-#: ../root/report/release_label_same_artist.tt:1
-#: ../root/report/release_label_same_artist.tt:3
-#: ../root/report/ReportsIndex.js:130
-msgid "Releases where artist name and label name are the same"
-msgstr ""
-
-#: ../root/report/releases_to_convert.tt:1
-#: ../root/report/releases_to_convert.tt:3 ../root/report/ReportsIndex.js:98
-msgid "Releases which might need converting to \"multiple artists\""
-msgstr ""
-
-#: ../root/report/releases_with_coverart_links.tt:1
-#: ../root/report/releases_with_coverart_links.tt:3
-msgid "Releases with Cover Art relationships"
-msgstr ""
-
-#: ../root/report/single_medium_releases_with_medium_titles.tt:1
-#: ../root/report/single_medium_releases_with_medium_titles.tt:3
-#: ../root/report/ReportsIndex.js:122
-msgid "Releases with a single medium that has a name"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_releases.tt:1
-#: ../root/report/deprecated_relationship_releases.tt:3
-#: ../root/report/ReportsIndex.js:124
-msgid "Releases with deprecated relationships"
-msgstr ""
-
-#: ../root/report/mediums_with_sequence_issues.tt:1
-#: ../root/report/mediums_with_sequence_issues.tt:3
-msgid "Releases with medium number issues"
-msgstr ""
-
-#: ../root/report/releases_with_no_mediums.tt:1
-#: ../root/report/releases_with_no_mediums.tt:3
-#: ../root/report/ReportsIndex.js:126
-msgid "Releases with no mediums"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_releases.tt:1
-#: ../root/report/duplicate_relationships_releases.tt:3
-#: ../root/report/ReportsIndex.js:121
-msgid "Releases with possible duplicate relationships"
-msgstr ""
-
-#: ../root/report/superfluous_data_tracks.tt:3
-#: ../root/report/ReportsIndex.js:109
-msgid "Releases with superfluous data tracks"
-msgstr ""
-
-#: ../root/report/featuring_releases.tt:1
-#: ../root/report/featuring_releases.tt:3 ../root/report/ReportsIndex.js:110
-msgid "Releases with titles containing featuring artists"
-msgstr ""
-
-#: ../root/report/tracks_with_sequence_issues.tt:1
-#: ../root/report/tracks_with_sequence_issues.tt:3
-msgid "Releases with track number issues"
-msgstr ""
-
-#: ../root/report/tracks_without_times.tt:1
-#: ../root/report/tracks_without_times.tt:3 ../root/report/ReportsIndex.js:120
-msgid "Releases with unknown track times"
-msgstr ""
-
-#: ../root/report/releases_with_unlikely_language_script.tt:1
-#: ../root/report/releases_with_unlikely_language_script.tt:3
-#: ../root/report/ReportsIndex.js:119
-msgid "Releases with unlikely language/script pairs"
-msgstr ""
-
-#: ../root/report/releases_without_language.tt:1
-#: ../root/report/releases_without_language.tt:3
-#: ../root/report/ReportsIndex.js:99
-msgid "Releases without language"
-msgstr ""
-
-#: ../root/report/releases_without_script.tt:1
-#: ../root/report/releases_without_script.tt:3
-#: ../root/report/ReportsIndex.js:100
-msgid "Releases without script"
 msgstr ""
 
 #: ../root/edit/details/historic/add_disc_id.tt:3
@@ -5278,14 +4601,10 @@ msgstr ""
 msgid "Releases:"
 msgstr ""
 
-#: ../root/account/edit.tt:59 ../root/account/edit.tt:72
-#: ../root/admin/attributes/delete.tt:11 ../root/admin/attributes/index.tt:61
-#: ../root/admin/attributes/language.tt:28
-#: ../root/admin/attributes/script.tt:24 ../root/admin/wikidoc/index.tt:62
+#: ../root/admin/attributes/delete.tt:11 ../root/admin/wikidoc/index.tt:62
 #: ../root/area/delete.tt:1 ../root/cdtoc/list.tt:54
-#: ../root/collection/delete.tt:1 ../root/collection/header.tt:7
-#: ../root/doc/relationship_type.tt:19 ../root/label/delete.tt:1
-#: ../root/recording/delete.tt:1
+#: ../root/collection/delete.tt:1 ../root/doc/relationship_type.tt:19
+#: ../root/label/delete.tt:1 ../root/recording/delete.tt:1
 #: ../root/relationship/linkattributetype/common.tt:26
 #: ../root/relationship/linkattributetype/delete.tt:11
 #: ../root/relationship/linktype/delete.tt:11
@@ -5293,8 +4612,13 @@ msgstr ""
 #: ../root/release/cover_art.tt:29 ../root/release/delete.tt:1
 #: ../root/release/discids.tt:36 ../root/series/delete.tt:1
 #: ../root/user/collections.tt:65 ../root/account/applications/Index.js:36
+#: ../root/admin/attributes/Attribute.js:120
+#: ../root/admin/attributes/Language.js:61
+#: ../root/admin/attributes/Script.js:58
+#: ../root/collection/CollectionHeader.js:85
 #: ../root/components/Aliases/AliasTableRow.js:61
-#: ../root/layout/components/sidebar/RemoveLink.js:27
+#: ../root/layout/components/sidebar/RemoveLink.js:26
+#: ../root/static/scripts/account/components/EditProfileForm.js:274
 msgid "Remove"
 msgstr ""
 
@@ -5372,7 +4696,7 @@ msgstr ""
 msgid "Remove alias"
 msgstr ""
 
-#: ../root/work/edit_form.tt:61
+#: ../root/work/edit_form.tt:60
 msgid "Remove attribute"
 msgstr ""
 
@@ -5385,11 +4709,11 @@ msgid "Remove disc"
 msgstr ""
 
 #: ../root/layout/merge-helper.tt:33
-#: ../root/layout/components/MergeHelper.js:38
+#: ../root/layout/components/MergeHelper.js:39
 msgid "Remove selected entities"
 msgstr ""
 
-#: ../root/collection/index.tt:22
+#: ../root/collection/index.tt:29
 msgid "Remove selected items from collection"
 msgstr ""
 
@@ -5398,11 +4722,11 @@ msgstr ""
 msgid "Remove track"
 msgstr ""
 
-#: ../root/components/rating-macros.tt:1 ../root/utility/ratingTooltip.js:12
+#: ../root/components/rating-macros.tt:1 ../root/utility/ratingTooltip.js:10
 msgid "Remove your rating"
 msgstr ""
 
-#: ../root/components/forms.tt:163 ../root/components/forms.tt:168
+#: ../root/components/forms.tt:155 ../root/components/forms.tt:160
 msgid "Remove {item}"
 msgstr ""
 
@@ -5425,10 +4749,6 @@ msgctxt "header"
 msgid "Reorder Cover Art"
 msgstr ""
 
-#: ../root/user/report.tt:1 ../root/user/report.tt:2
-msgid "Report User"
-msgstr ""
-
 #: ../root/user/profile.tt:275
 msgid "Report this user for bad behavior"
 msgstr ""
@@ -5446,8 +4766,8 @@ msgid "Request signature..."
 msgstr ""
 
 #: ../root/account/reset_password.tt:1 ../root/account/reset_password.tt:3
-#: ../root/account/reset_password.tt:14 ../root/account/LostPassword.js:47
-#: ../root/account/ResetPasswordStatus.js:20
+#: ../root/account/reset_password.tt:14 ../root/account/LostPassword.js:51
+#: ../root/account/ResetPasswordStatus.js:19
 msgid "Reset Password"
 msgstr ""
 
@@ -5455,7 +4775,7 @@ msgstr ""
 msgid "Reset track numbers"
 msgstr ""
 
-#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:91
+#: ../root/search/form.tt:7 ../root/search/components/SearchForm.js:85
 msgid "Results per page:"
 msgstr ""
 
@@ -5470,7 +4790,7 @@ msgstr ""
 msgid "Reuse previous recordings"
 msgstr ""
 
-#: ../root/user/contact.tt:16 ../root/user/report.tt:23
+#: ../root/user/contact.tt:16 ../root/user/ReportUser.js:143
 msgid "Reveal my email address"
 msgstr ""
 
@@ -5491,24 +4811,17 @@ msgid ""
 "data is formatted correctly."
 msgstr ""
 
-#: ../root/components/events-list.tt:21
-msgid "Role"
-msgstr ""
-
 #: ../root/layout.tt:114
 msgid ""
 "Running: <span class=\"tooltip\" title=\"{msg}\">{branch} ({sha})</span>"
 msgstr ""
 
-#: ../root/account/edit.tt:109 ../root/admin/attributes/form.tt:83
+#: ../root/admin/attributes/form.tt:83
 #: ../root/relationship/linkattributetype/form.tt:21
 #: ../root/relationship/linktype/form.tt:200
-#: ../root/static/scripts/account/components/PreferencesForm.js:249
+#: ../root/static/scripts/account/components/EditProfileForm.js:294
+#: ../root/static/scripts/account/components/PreferencesForm.js:223
 msgid "Save"
-msgstr ""
-
-#: ../root/admin/attributes/script.tt:1 ../root/admin/attributes/script.tt:3
-msgid "Script"
 msgstr ""
 
 #: ../root/edit/details/add_release.tt:53
@@ -5519,29 +4832,18 @@ msgstr ""
 msgid "Script:"
 msgstr ""
 
-#: ../root/account/edit.tt:27 ../root/artist/edit_form.tt:23
-#: ../root/artist/edit_form.tt:45 ../root/artist/edit_form.tt:58
 #: ../root/cdtoc/attach_filter_artist.tt:10
 #: ../root/cdtoc/attach_filter_release.tt:11 ../root/cdtoc/lookup.tt:63
 #: ../root/cdtoc/lookup.tt:73 ../root/cdtoc/move_search.tt:17
-#: ../root/components/common-macros.tt:789
-#: ../root/components/relationship-editor.tt:87
-#: ../root/components/relationship-editor.tt:205
-#: ../root/components/search.tt:11 ../root/edit/search_macros.tt:102
-#: ../root/edit/search_macros.tt:237 ../root/edit/search_macros.tt:252
-#: ../root/edit/search_macros.tt:299 ../root/edit/search_macros.tt:327
-#: ../root/label/edit_form.tt:21 ../root/otherlookup/form.tt:20
-#: ../root/place/edit_form.tt:22 ../root/relationship/linktype/form.tt:118
-#: ../root/release/edit/information.tt:45
-#: ../root/release/edit/information.tt:182
-#: ../root/release/edit/recordings.tt:144 ../root/release/edit/tracklist.tt:87
-#: ../root/search/form.tt:42 ../root/search/index.tt:1
-#: ../root/search/index.tt:3 ../root/taglookup/form.tt:12
-#: ../root/layout/components/BottomMenu.js:181
+#: ../root/components/common-macros.tt:779 ../root/components/search.tt:11
+#: ../root/edit/search_macros.tt:102 ../root/otherlookup/form.tt:20
+#: ../root/release/edit/tracklist.tt:87 ../root/search/form.tt:42
+#: ../root/search/index.tt:1 ../root/search/index.tt:3
+#: ../root/taglookup/form.tt:12 ../root/layout/components/BottomMenu.js:187
 #: ../root/layout/components/Search.js:78
-#: ../root/search/components/SearchForm.js:101
-#: ../root/static/scripts/common/components/Autocomplete.js:71
-#: ../root/taglookup/Form.js:48
+#: ../root/search/components/SearchForm.js:95
+#: ../root/static/scripts/common/components/SearchIcon.js:14
+#: ../root/taglookup/Form.js:47
 msgid "Search"
 msgstr ""
 
@@ -5552,8 +4854,8 @@ msgstr ""
 #: ../root/otherlookup/results-release.tt:1
 #: ../root/otherlookup/results-release.tt:3
 #: ../root/otherlookup/results-work.tt:1 ../root/otherlookup/results-work.tt:3
+#: ../root/search/components/ResultsLayout.js:27
 #: ../root/search/components/ResultsLayout.js:29
-#: ../root/search/components/ResultsLayout.js:31
 msgid "Search Results"
 msgstr ""
 
@@ -5574,10 +4876,6 @@ msgstr ""
 msgid "Search for an artist"
 msgstr ""
 
-#: ../root/report/places_without_coordinates.tt:12
-msgid "Search for coordinates"
-msgstr ""
-
 #: ../root/edit/list_header.tt:8
 msgid "Search for edits"
 msgstr ""
@@ -5586,11 +4884,11 @@ msgstr ""
 msgid "Search for the target URL."
 msgstr ""
 
-#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:97
+#: ../root/search/form.tt:20 ../root/search/components/SearchForm.js:91
 msgid "Search method:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:788
+#: ../root/components/common-macros.tt:778
 msgid "Search the documentation..."
 msgstr ""
 
@@ -5604,25 +4902,12 @@ msgstr ""
 
 #: ../root/edit/details/add_release_group.tt:35
 #: ../root/edit/details/edit_release_group.tt:23
-#: ../root/release/edit/information.tt:92 ../root/release_group/edit_form.tt:18
+#: ../root/release/edit/information.tt:92 ../root/release_group/edit_form.tt:17
 msgid "Secondary Types:"
 msgstr ""
 
 #: ../root/cdtoc/info.tt:38 ../root/cdtoc/info.tt:40 ../root/cdtoc/info.tt:42
 msgid "Sectors"
-msgstr ""
-
-#: ../root/collection/header.tt:17
-msgid "See all of your collections"
-msgstr ""
-
-#: ../root/collection/header.tt:17
-msgid "See all of {editor}'s public collections"
-msgstr ""
-
-#: ../root/account/edit.tt:7
-msgid ""
-"See also your {uri|user preferences}, which include your privacy settings."
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:75
@@ -5645,7 +4930,7 @@ msgid ""
 "to."
 msgstr ""
 
-#: ../root/work/edit_form.tt:105
+#: ../root/work/edit_form.tt:104
 msgid ""
 "Select any type from the list to see its description. If the work doesn’t "
 "seem to match any type, just leave this blank."
@@ -5655,7 +4940,7 @@ msgstr ""
 msgid "Select images..."
 msgstr ""
 
-#: ../root/user/contact.tt:20 ../root/user/report.tt:26
+#: ../root/user/contact.tt:20 ../root/user/ReportUser.js:147
 msgid "Send"
 msgstr ""
 
@@ -5670,28 +4955,23 @@ msgstr ""
 msgid "Send a copy to my own email address"
 msgstr ""
 
-#: ../root/components/forms.tt:254 ../root/components/forms.tt:278
+#: ../root/components/forms.tt:247 ../root/components/forms.tt:271
 msgid "Sentence"
 msgstr ""
 
-#: ../root/report/series_list.tt:7 ../root/report/ReportsIndex.js:156
-#: ../root/tag/TagIndex.js:89
-msgid "Series"
-msgstr ""
-
-#: ../root/components/common-macros.tt:604 ../root/tag/TagLayout.js:36
+#: ../root/components/common-macros.tt:593 ../root/tag/TagLayout.js:34
 msgctxt "plural"
 msgid "Series"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/components/series-list.tt:5
+#: ../root/components/common-macros.tt:576 ../root/components/series-list.tt:5
 #: ../root/edit/search_macros.tt:360 ../root/series/merge.tt:12
 #: ../lib/MusicBrainz/Server/Edit/Series.pm:7
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:48
 #: ../root/layout/components/Search.js:25
-#: ../root/search/components/SearchForm.js:51 ../root/series/SeriesHeader.js:26
-#: ../root/static/scripts/common/i18n.js:62
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
+#: ../root/search/components/SearchForm.js:48 ../root/series/SeriesHeader.js:24
+#: ../root/static/scripts/common/constants.js:24
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:33
 msgctxt "singular"
 msgid "Series"
 msgstr ""
@@ -5701,7 +4981,7 @@ msgctxt "plural"
 msgid "Series Collections"
 msgstr ""
 
-#: ../root/series/edit_form.tt:11
+#: ../root/series/edit_form.tt:10
 msgid "Series Details"
 msgstr ""
 
@@ -5709,16 +4989,11 @@ msgstr ""
 msgid "Series Subscriptions"
 msgstr ""
 
-#: ../root/report/annotations_series.tt:1
-#: ../root/report/annotations_series.tt:3
-msgid "Series annotations"
-msgstr ""
-
 #: ../root/edit/details/add_series.tt:3 ../root/edit/details/edit_series.tt:5
 msgid "Series:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570
+#: ../root/components/common-macros.tt:559
 msgctxt "singular"
 msgid "Series:"
 msgstr ""
@@ -5737,7 +5012,7 @@ msgstr ""
 
 #: ../root/release_group/set_cover_art.tt:4
 #: ../lib/MusicBrainz/Server/Edit/ReleaseGroup/SetCoverArt.pm:20
-#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:85
+#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:84
 msgid "Set cover art"
 msgstr ""
 
@@ -5745,12 +5020,11 @@ msgstr ""
 msgid "Set track durations"
 msgstr ""
 
-#: ../root/event/index.tt:17
+#: ../root/event/index.tt:17 ../root/edit/details/AddEvent.js:96
 msgid "Setlist"
 msgstr ""
 
-#: ../root/edit/details/add_event.tt:56 ../root/edit/details/edit_event.tt:41
-#: ../root/event/edit_form.tt:18
+#: ../root/edit/details/edit_event.tt:41 ../root/event/edit_form.tt:17
 msgid "Setlist:"
 msgstr ""
 
@@ -5897,7 +5171,7 @@ msgstr ""
 msgid "Sorry, there was a problem with your request."
 msgstr ""
 
-#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:43
+#: ../root/main/401.tt:5 ../root/report/LimitedEditors.js:46
 msgid "Sorry, you are not authorized to view this page."
 msgstr ""
 
@@ -5921,16 +5195,16 @@ msgstr ""
 
 #: ../root/edit/details/add_remove_alias.tt:17
 #: ../root/edit/details/edit_alias.tt:37
-#: ../root/components/Aliases/AliasTable.js:27
-#: ../root/report/DuplicateArtists.js:67
+#: ../root/components/Aliases/AliasTable.js:26
+#: ../root/edit/details/AddArea.js:57 ../root/edit/details/AddArtist.js:68
+#: ../root/report/DuplicateArtists.js:74
 msgid "Sort name"
 msgstr ""
 
-#: ../root/components/forms.tt:234 ../root/edit/details/add_area.tt:16
-#: ../root/edit/details/add_artist.tt:14 ../root/edit/details/add_label.tt:16
+#: ../root/components/forms.tt:227 ../root/edit/details/add_label.tt:16
 #: ../root/edit/details/edit_area.tt:16 ../root/edit/details/edit_artist.tt:16
 #: ../root/edit/details/edit_label.tt:14
-#: ../root/layout/components/sidebar/ArtistSidebar.js:66
+#: ../root/layout/components/sidebar/ArtistSidebar.js:65
 msgid "Sort name:"
 msgstr ""
 
@@ -5938,7 +5212,7 @@ msgstr ""
 msgid "Split Artist"
 msgstr ""
 
-#: ../root/artist/cannot_split.tt:2 ../root/artist/split.tt:6
+#: ../root/artist/split.tt:6 ../root/artist/CannotSplit.js:16
 msgid "Split Into Separate Artists"
 msgstr ""
 
@@ -5950,12 +5224,12 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: ../root/user/profile.tt:166 ../root/layout/components/BottomMenu.js:132
+#: ../root/user/profile.tt:166 ../root/layout/components/BottomMenu.js:134
 msgid "Statistics"
 msgstr ""
 
 #: ../root/otherlookup/results-release.tt:21
-#: ../root/search/components/ReleaseResults.js:110
+#: ../root/search/components/ReleaseResults.js:116
 msgid "Status"
 msgstr ""
 
@@ -5976,7 +5250,7 @@ msgctxt "release status"
 msgid "Status:"
 msgstr ""
 
-#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:37
 msgid "Stop using beta site"
 msgstr ""
 
@@ -5984,7 +5258,7 @@ msgstr ""
 msgid "Stop watching selected artists"
 msgstr ""
 
-#: ../root/edit/list_header.tt:32 ../root/main/index.js:129
+#: ../root/edit/list_header.tt:32 ../root/main/index.js:128
 msgid "Style guidelines"
 msgstr ""
 
@@ -5996,7 +5270,7 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: ../root/edit/index.tt:73
+#: ../root/edit/index.tt:77
 msgid "Submit note"
 msgstr ""
 
@@ -6004,11 +5278,11 @@ msgstr ""
 msgid "Submit this CD using the simple method."
 msgstr ""
 
-#: ../root/edit/index.tt:71 ../root/edit/components/Vote.js:82
+#: ../root/edit/index.tt:75 ../root/edit/components/Vote.js:81
 msgid "Submit vote and note"
 msgstr ""
 
-#: ../root/edit/list.tt:74
+#: ../root/edit/list.tt:78
 msgid "Submit votes &amp; edit notes"
 msgstr ""
 
@@ -6030,15 +5304,6 @@ msgstr ""
 msgid "Subscribed entities"
 msgstr ""
 
-#: ../root/collection/subscribers.tt:1 ../root/collection/subscribers.tt:2
-#: ../root/user/subscribers.tt:1 ../root/user/subscribers.tt:2
-#: ../root/components/UserAccountTabs.js:47 ../root/entity/Subscribers.js:33
-#: ../root/entity/Subscribers.js:34
-#: ../root/layout/components/sidebar/CollectionSidebar.js:92
-#: ../root/layout/components/sidebar/SubscriptionLinks.js:47
-msgid "Subscribers"
-msgstr ""
-
 #: ../root/user/profile.tt:120
 msgid "Subscribers:"
 msgstr ""
@@ -6051,8 +5316,8 @@ msgstr ""
 msgid "Suggested recordings:"
 msgstr ""
 
-#: ../root/edit/details/add_annotation.tt:21
 #: ../root/edit/details/historic/add_release_annotation.tt:25
+#: ../root/edit/details/AddAnnotation.js:73
 msgid "Summary"
 msgstr ""
 
@@ -6070,21 +5335,18 @@ msgstr ""
 
 #: ../root/cdtoc/attach_artist_releases.tt:22
 #: ../root/cdtoc/attach_filter_release.tt:36 ../root/cdtoc/list.tt:14
-#: ../root/components/common-macros.tt:531
-#: ../root/components/common-macros.tt:536
 #: ../root/components/releases-list.tt:28
 #: ../root/otherlookup/results-release.tt:23 ../root/release_group/index.tt:32
-#: ../root/search/components/RecordingResults.js:127
-#: ../root/search/components/ReleaseResults.js:111
-#: ../root/static/scripts/common/components/TaggerIcon.js:44
+#: ../root/search/components/RecordingResults.js:125
+#: ../root/search/components/ReleaseResults.js:117
+#: ../root/static/scripts/common/components/TaggerIcon.js:43
 msgid "Tagger"
 msgstr ""
 
-#: ../root/components/entity-tabs.tt:51 ../root/entity/tags.tt:1
-#: ../root/user/tags.tt:1 ../root/components/EntityTabs.js:93
-#: ../root/components/UserAccountTabs.js:51 ../root/entity/Tags.js:39
-#: ../root/layout/components/BottomMenu.js:192 ../root/tag/TagCloud.js:45
-#: ../root/tag/TagCloud.js:47
+#: ../root/components/entity-tabs.tt:51 ../root/user/tags.tt:1
+#: ../root/components/EntityTabs.js:92 ../root/components/UserAccountTabs.js:50
+#: ../root/entity/Tags.js:38 ../root/layout/components/BottomMenu.js:200
+#: ../root/tag/TagCloud.js:44 ../root/tag/TagCloud.js:46
 msgid "Tags"
 msgstr ""
 
@@ -6096,12 +5358,12 @@ msgstr ""
 msgid "Technical flags"
 msgstr ""
 
-#: ../root/edit/index.tt:54
+#: ../root/edit/index.tt:58
 msgid "Testing features"
 msgstr ""
 
-#: ../root/edit/details/add_annotation.tt:10
 #: ../root/edit/details/historic/add_release_annotation.tt:14
+#: ../root/edit/details/AddAnnotation.js:53
 msgid "Text"
 msgstr ""
 
@@ -6123,12 +5385,6 @@ msgstr ""
 
 #: ../root/release/edit/information.tt:326
 msgid "The annotation field functions like a miniature wiki."
-msgstr ""
-
-#: ../root/artist/special_purpose.tt:3
-msgid ""
-"The artist you are trying to edit is a special purpose artist, and you may "
-"not make direct changes to this data."
 msgstr ""
 
 #: ../root/release/cover_art.tt:44
@@ -6153,7 +5409,7 @@ msgid ""
 "and may not display correctly"
 msgstr ""
 
-#: ../root/layout.tt:81 ../root/layout/index.js:104
+#: ../root/layout.tt:81 ../root/layout/index.js:134
 msgid ""
 "The data you have submitted does not make any changes to the data already "
 "present."
@@ -6164,7 +5420,7 @@ msgid "The data you’ve seeded contained the following errors:"
 msgstr ""
 
 #: ../root/release/edit/information.tt:155
-#: ../root/static/scripts/relationship-editor/common/dialog.js:488
+#: ../root/static/scripts/relationship-editor/common/dialog.js:497
 msgid "The date you've entered is not valid."
 msgstr ""
 
@@ -6182,34 +5438,6 @@ msgstr ""
 
 #: ../root/doc/relationship_type.tt:54
 msgid "The following attributes can be used with this relationship type:"
-msgstr ""
-
-#: ../root/user/privileged.tt:49
-msgid "The following {count} user accounts are bots:"
-msgstr ""
-
-#: ../root/user/privileged.tt:45
-msgid "The following {count} users are account administrators:"
-msgstr ""
-
-#: ../root/user/privileged.tt:40
-msgid "The following {count} users are banner message editors:"
-msgstr ""
-
-#: ../root/user/privileged.tt:34
-msgid "The following {count} users are location editors:"
-msgstr ""
-
-#: ../root/user/privileged.tt:22
-msgid "The following {count} users are relationship editors:"
-msgstr ""
-
-#: ../root/user/privileged.tt:28
-msgid "The following {count} users are transclusion editors:"
-msgstr ""
-
-#: ../root/user/privileged.tt:14
-msgid "The following {count} users have auto-editor privileges:"
 msgstr ""
 
 #: ../root/cdtoc/set_durations.tt:19
@@ -6262,7 +5490,7 @@ msgid ""
 "This is usually only temporary, so please retry your search again later."
 msgstr ""
 
-#: ../root/layout.tt:62 ../root/layout/index.js:87
+#: ../root/layout.tt:62 ../root/layout/index.js:105
 msgid "The server is temporarily in read-only mode for database maintenance."
 msgstr ""
 
@@ -6293,18 +5521,6 @@ msgstr ""
 msgid "There are currently no users in this area."
 msgstr ""
 
-#: ../root/user/subscribers.tt:23
-msgid "There are currently no users subscribed to edits that you make."
-msgstr ""
-
-#: ../root/user/subscribers.tt:25
-msgid "There are currently no users subscribed to edits that {user} makes."
-msgstr ""
-
-#: ../root/collection/subscribers.tt:22
-msgid "There are currently no users subscribed to {collection}."
-msgstr ""
-
 #: ../root/release/discids.tt:49
 msgid ""
 "There are no disc IDs attached to this release; to find out more about how "
@@ -6312,12 +5528,12 @@ msgid ""
 msgstr ""
 
 #: ../root/components/tags.tt:22
-#: ../root/static/scripts/common/components/TagEditor.js:462
+#: ../root/static/scripts/common/components/TagEditor.js:476
 msgid "There are no genres to show."
 msgstr ""
 
 #: ../root/components/tags.tt:41
-#: ../root/static/scripts/common/components/TagEditor.js:472
+#: ../root/static/scripts/common/components/TagEditor.js:486
 msgid "There are no other tags to show."
 msgstr ""
 
@@ -6336,19 +5552,6 @@ msgid_plural "There are currently {num} users in this area."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/user/subscribers.tt:4
-msgid "There is currently {num} user subscribed to edits that {user} makes:"
-msgid_plural ""
-"There are currently {num} users subscribed to edits that {user} makes:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../root/collection/subscribers.tt:4
-msgid "There is currently {num} user subscribed to {collection}:"
-msgid_plural "There are currently {num} users subscribed to {collection}:"
-msgstr[0] ""
-msgstr[1] ""
-
 #: ../root/admin/wikidoc/index.tt:25
 msgid "There was a problem accessing the wiki API."
 msgstr ""
@@ -6362,7 +5565,7 @@ msgid "There was a problem cancelling {edit}."
 msgstr ""
 
 #: ../root/components/critiquebrainz.tt:1
-#: ../root/components/CritiqueBrainzLinks.js:43
+#: ../root/components/CritiqueBrainzLinks.js:42
 msgid ""
 "There’s {reviews_link|{review_count} review} on CritiqueBrainz. You can also "
 "{write_link|write your own}."
@@ -6372,13 +5575,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:7
-msgid ""
-"These are most likely cases where the {ac|artist credit} is incorrect for at "
-"least one of the recordings."
-msgstr ""
-
-#: ../root/place/edit_form.tt:30
+#: ../root/place/edit_form.tt:29
 msgid "These coordinates could not be parsed."
 msgstr ""
 
@@ -6396,12 +5593,12 @@ msgstr ""
 msgid "This CD has tracks from more than one artist (e.g. a compilation CD)"
 msgstr ""
 
-#: ../root/entity/alias/edit_form.tt:24
+#: ../root/entity/alias/edit_form.tt:23
 msgid "This alias is no longer current."
 msgstr ""
 
-#: ../root/edit/details/add_annotation.tt:15
 #: ../root/edit/details/historic/add_release_annotation.tt:19
+#: ../root/edit/details/AddAnnotation.js:65
 msgid "This annotation is empty."
 msgstr ""
 
@@ -6420,16 +5617,12 @@ msgid ""
 "releases using it."
 msgstr ""
 
-#: ../root/area/edit_form.tt:18
+#: ../root/area/edit_form.tt:17
 msgid "This area has ended."
 msgstr ""
 
 #: ../root/area/artists.tt:7
 msgid "This area is not currently associated with any artists."
-msgstr ""
-
-#: ../root/area/labels.tt:7
-msgid "This area is not currently associated with any labels."
 msgstr ""
 
 #: ../root/area/places.tt:9
@@ -6454,8 +5647,8 @@ msgid ""
 "Show release groups by this artist instead}."
 msgstr ""
 
-#: ../root/artist/edit_form.tt:53
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
+#: ../root/artist/edit_form.tt:51
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:46
 msgid "This artist has ended."
 msgstr ""
 
@@ -6468,17 +5661,6 @@ msgstr ""
 
 #: ../root/artist/index.tt:49
 msgid "This artist has no release groups, only standalone recordings."
-msgstr ""
-
-#: ../root/artist/cannot_split.tt:3
-msgid ""
-"This artist has relationships other than collaboration relationships, and "
-"cannot be split until these are removed. {relationships|View all "
-"relationships}."
-msgstr ""
-
-#: ../root/artist/events.tt:11
-msgid "This artist is not currently associated with any events."
 msgstr ""
 
 #: ../root/artist/works.tt:11
@@ -6501,11 +5683,11 @@ msgstr ""
 msgid "This artist only has unofficial release groups."
 msgstr ""
 
-#: ../root/work/edit_form.tt:57
+#: ../root/work/edit_form.tt:56
 msgid "This attribute type is only used for grouping, please select a subtype"
 msgstr ""
 
-#: ../root/layout.tt:28 ../root/layout/index.js:34
+#: ../root/layout.tt:28 ../root/layout/index.js:52
 msgid ""
 "This beta test server allows testing of new features with the live database."
 msgstr ""
@@ -6516,7 +5698,7 @@ msgid_plural "This change affects {num} relationships."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/collection/index.tt:25
+#: ../root/collection/index.tt:32
 msgid "This collection is empty."
 msgstr ""
 
@@ -6538,7 +5720,7 @@ msgstr ""
 msgid "This edit also changed the track artists."
 msgstr ""
 
-#: ../root/edit/details/edit_medium.tt:162
+#: ../root/edit/details/edit_medium.tt:164
 msgid "This edit changes which tracks are data tracks."
 msgstr ""
 
@@ -6563,12 +5745,12 @@ msgid "This edit was a merge."
 msgstr ""
 
 #: ../root/components/common-macros.tt:256
-#: ../root/static/scripts/common/components/EntityLink.js:26
+#: ../root/static/scripts/common/components/EntityLink.js:27
 msgid "This entity has been removed, and cannot be displayed correctly."
 msgstr ""
 
 #: ../root/components/common-macros.tt:256
-#: ../root/static/scripts/common/components/EntityLink.js:25
+#: ../root/static/scripts/common/components/EntityLink.js:26
 msgid "This entity will be created when edits are entered."
 msgstr ""
 
@@ -6578,7 +5760,7 @@ msgid ""
 "next few days. If this is not intended, please add more data to this event."
 msgstr ""
 
-#: ../root/event/edit_form.tt:16
+#: ../root/event/edit_form.tt:15
 msgid "This event was cancelled."
 msgstr ""
 
@@ -6612,26 +5794,20 @@ msgid ""
 "attributed to it."
 msgstr ""
 
-#: ../root/layout.tt:28 ../root/layout/index.js:36
+#: ../root/layout.tt:28 ../root/layout/index.js:54
 msgid "This is a MusicBrainz development server."
 msgstr ""
 
-#: ../root/layout.tt:45 ../root/layout/index.js:58
+#: ../root/layout.tt:45 ../root/layout/index.js:76
 msgid ""
 "This is a MusicBrainz mirror server. To edit or make changes to the data, "
 "please {uri|return to musicbrainz.org}."
 msgstr ""
 
-#: ../root/components/common-macros.tt:99 ../root/components/Artwork.js:61
+#: ../root/components/common-macros.tt:99 ../root/components/Artwork.js:59
 msgid ""
 "This is a PDF file, the thumbnail may not show the entire contents of the "
 "file."
-msgstr ""
-
-#: ../root/account/edit.tt:15
-msgid ""
-"This is a development server. Your email address is not private or secure. "
-"Proceed with caution!"
 msgstr ""
 
 #: ../root/user/login.tt:27
@@ -6642,13 +5818,7 @@ msgstr ""
 msgid "This is a free text work attribute"
 msgstr ""
 
-#: ../root/artist/aliases.tt:7
-msgid ""
-"This is a list of all the different ways {artist} is credited in the "
-"database. View the {doc|artist credit documentation} for more details."
-msgstr ""
-
-#: ../root/entity/alias/edit_form.tt:19
+#: ../root/entity/alias/edit_form.tt:18
 msgid "This is the primary alias for this locale"
 msgstr ""
 
@@ -6667,7 +5837,7 @@ msgstr ""
 msgid "This label does not have any releases."
 msgstr ""
 
-#: ../root/label/edit_form.tt:37
+#: ../root/label/edit_form.tt:36
 msgid "This label has ended."
 msgstr ""
 
@@ -6713,7 +5883,7 @@ msgstr ""
 msgid "This page is {doc|transcluded} from {title}."
 msgstr ""
 
-#: ../root/place/edit_form.tt:33
+#: ../root/place/edit_form.tt:32
 msgid "This place has ended."
 msgstr ""
 
@@ -6721,10 +5891,6 @@ msgstr ""
 msgid ""
 "This place has no relationships and will be removed automatically in the "
 "next few days. If this is not intended, please add more data to this place."
-msgstr ""
-
-#: ../root/place/events.tt:11
-msgid "This place is not currently associated with any events."
 msgstr ""
 
 #: ../root/recording/delete.tt:14
@@ -6736,8 +5902,8 @@ msgid "This recording does not have any associated AcoustIDs"
 msgstr ""
 
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:617
-#: ../root/static/scripts/common/components/EntityLink.js:210
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:627
+#: ../root/static/scripts/common/components/EntityLink.js:221
 msgid "This recording is a video"
 msgstr ""
 
@@ -6769,8 +5935,8 @@ msgid "This relationship type doesn't allow any attributes."
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:11
-#: ../root/static/scripts/edit/externalLinks.js:202
-#: ../root/static/scripts/relationship-editor/common/dialog.js:454
+#: ../root/static/scripts/edit/externalLinks.js:221
+#: ../root/static/scripts/relationship-editor/common/dialog.js:463
 msgid "This relationship type is deprecated and should not be used."
 msgstr ""
 
@@ -6805,470 +5971,6 @@ msgid ""
 "corresponding real release with the {url|transl(iter)ation relationship}."
 msgstr ""
 
-#: ../root/report/tracks_named_with_sequence.tt:6
-msgid ""
-"This report aims to identify releases where track names include their own "
-"track number, e.g. \"1) Some Name\" (instead of just \"Some Name\"). Notice "
-"that sometimes this is justified and correct, don't automatically assume it "
-"is a mistake! If you confirm it is a mistake, please correct it."
-msgstr ""
-
-#: ../root/report/releases_to_convert.tt:7
-msgid ""
-"This report aims to identify releases which need converting to multiple "
-"artists (because the track artists are on the title field, for example). "
-"Currently it does this by looking for releases where every track contains \"/"
-"\" or \"-\"."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_urls.tt:6
-msgid ""
-"This report lists URLs which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/tracks_without_times.tt:6
-msgid ""
-"This report lists all releases where some or all tracks have unknown track "
-"lengths."
-msgstr ""
-
-#: ../root/report/tracks_with_sequence_issues.tt:6
-msgid ""
-"This report lists all releases where the track numbers are not continuous (e."
-"g. there is no \"track 2\"), or with duplicated track numbers (e.g. there "
-"are two \"track 4\"s)."
-msgstr ""
-
-#: ../root/report/mediums_with_sequence_issues.tt:6
-msgid ""
-"This report lists all releases with gaps in the medium numbers (e.g. there "
-"is a medium 1 and 3 but no medium 2)."
-msgstr ""
-
-#: ../root/report/duplicate_events.tt:6
-msgid ""
-"This report lists events happening at the same place on the same date. If "
-"they're duplicates (for example, if there are separate events for headliner "
-"and supporting artist) please merge them."
-msgstr ""
-
-#: ../root/report/event_sequence_not_in_series.tt:6
-msgid ""
-"This report lists events where the event name indicates that it may have to "
-"be part of a series or a larger event."
-msgstr ""
-
-#: ../root/report/labels_disambiguation_same_name.tt:6
-msgid ""
-"This report lists labels that have their disambiguation set to be the same "
-"as their name. Disambiguation should not be filled in this case."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_labels.tt:6
-msgid ""
-"This report lists labels which have multiple relationships to the same "
-"entity using the same relationship type."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_labels.tt:6
-msgid ""
-"This report lists labels which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_labels.tt:6
-msgid "This report lists labels with annotations."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_places.tt:6
-msgid ""
-"This report lists places which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_places.tt:6
-msgid "This report lists places with annotations."
-msgstr ""
-
-#: ../root/report/places_without_coordinates.tt:6
-msgid "This report lists places without coordinates."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_recordings.tt:6
-msgid ""
-"This report lists recordings which have multiple relationships to the same "
-"entity using the same relationship type."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_recordings.tt:6
-msgid ""
-"This report lists recordings which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_recordings.tt:6
-msgid "This report lists recordings with annotations."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_release_groups.tt:6
-msgid ""
-"This report lists release groups which have multiple relationships to the "
-"same entity using the same relationship type."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_release_groups.tt:6
-msgid ""
-"This report lists release groups which have relationships using deprecated "
-"and grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_release_groups.tt:6
-msgid "This report lists release groups with annotations."
-msgstr ""
-
-#: ../root/report/duplicate_release_groups.tt:6
-msgid ""
-"This report lists release groups with very similar names and artists. If the "
-"releases in the release groups should be grouped together (see the {url|"
-"guidelines}), they can be merged. If they shouldn't be grouped together but "
-"they can be distinguished by the release group types, e.g. when an artist "
-"has an album and single with the same name, then there is usually no need to "
-"change anything. In other cases, a disambiguation comment may be helpful."
-msgstr ""
-
-#: ../root/report/release_label_same_artist.tt:6
-msgid ""
-"This report lists releases where the label name is the same as the artist "
-"name. Often this means the release is self-released, and the label "
-"{SpecialPurposeLabel|should be \"[no label]\" instead}."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_releases.tt:6
-msgid ""
-"This report lists releases which have multiple relationships to the same "
-"entity using the same relationship type."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_releases.tt:6
-msgid ""
-"This report lists releases which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_releases.tt:6
-msgid "This report lists releases with annotations."
-msgstr ""
-
-#: ../root/report/superfluous_data_tracks.tt:6
-msgid ""
-"This report lists releases without any disc IDs that probably contain data "
-"tracks (like videos). A data track should be deleted if it is the last track "
-"of the CD and there is no disc ID."
-msgstr ""
-
-#: ../root/report/annotations_series.tt:6
-msgid "This report lists series with annotations."
-msgstr ""
-
-#: ../root/report/duplicate_relationships_works.tt:6
-msgid ""
-"This report lists works which have multiple relationships to the same entity "
-"using the same relationship type. This excludes recording-work "
-"relationships. See the recording version of this report for those."
-msgstr ""
-
-#: ../root/report/deprecated_relationship_works.tt:6
-msgid ""
-"This report lists works which have relationships using deprecated and "
-"grouping-only relationship types"
-msgstr ""
-
-#: ../root/report/annotations_works.tt:6
-msgid "This report lists works with annotations."
-msgstr ""
-
-#: ../root/report/isrc_with_many_recordings.tt:6
-msgid ""
-"This report lists {isrc|ISRCs} that are attached to more than one recording. "
-"If the recordings are the same, this usually means they should be merged "
-"(ISRCs can be wrongly assigned so care should still be taken to make sure "
-"they really are the same). If the recordings are parts of a larger "
-"recording, the ISRCs are probably correct and should be left alone. If the "
-"same ISRC appears on two unrelated recordings on the same release, this is "
-"usually means there was an error when reading the disc."
-msgstr ""
-
-#: ../root/report/iswc_with_many_works.tt:6
-msgid ""
-"This report lists {iswc|ISWCs} that are attached to more than one work. If "
-"the works are the same, this usually means they should be merged."
-msgstr ""
-
-#: ../root/report/asins_with_multiple_releases.tt:6
-msgid ""
-"This report shows Amazon URLs which are linked to multiple releases. In most "
-"cases Amazon ASINs should map to MusicBrainz releases 1:1, so only one of "
-"the links will be correct. Just check which MusicBrainz release fits the "
-"release in Amazon (look at the format, tracklist, etc). If the release has a "
-"barcode, you can also search Amazon for it and see which ASIN matches. You "
-"might also find some ASINs linked to several discs of a multi-disc release: "
-"just merge those (see {how_to_merge_releases|How to Merge Releases})."
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_labels.tt:6
-msgid "This report shows Discogs URLs which are linked to multiple labels."
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_release_groups.tt:6
-msgid ""
-"This report shows Discogs URLs which are linked to multiple release groups."
-msgstr ""
-
-#: ../root/report/discogs_links_with_multiple_releases.tt:6
-msgid ""
-"This report shows Discogs URLs which are linked to multiple releases. In "
-"most cases Discogs releases should map to MusicBrainz releases 1:1, so only "
-"one of the links will be correct. Just check which MusicBrainz release fits "
-"the release in Discogs (look at the format, tracklist, release country, "
-"etc.). You might also find some Discogs URLs linked to several discs of a "
-"multi-disc release: just merge those (see {how_to_merge_releases|How to "
-"Merge Releases})."
-msgstr ""
-
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:6
-msgid ""
-"This report shows all recordings with the same name that have different "
-"artists (having different MBIDs) with the same name."
-msgstr ""
-
-#: ../root/report/instruments_without_an_image.tt:6
-msgid ""
-"This report shows instruments without {image_rel} relationships or "
-"{wikidata_rel} relationships."
-msgstr ""
-
-#: ../root/report/recordings_without_va_credit.tt:6
-msgid ""
-"This report shows recordings linked to the Various Artists entity without "
-"\"Various Artists\" as the credited name."
-msgstr ""
-
-#: ../root/report/recordings_with_earliest_release_relationships.tt:6
-msgid ""
-"This report shows recordings that have the deprecated \"earliest release\" "
-"relationship. They should be merged if they are truly the same recording; if "
-"they're not, the relationship should be removed. Please, do not merge "
-"recordings blindly just because the lengths fit, and do not merge recordings "
-"with very different times!"
-msgstr ""
-
-#: ../root/report/recordings_with_varying_track_lengths.tt:6
-msgid ""
-"This report shows recordings where the linked tracks have times that vary by "
-"more than 30 seconds."
-msgstr ""
-
-#: ../root/report/recordings_without_va_link.tt:6
-msgid ""
-"This report shows recordings with \"Various Artists\" as the credited name "
-"but not linked to the Various Artists entity."
-msgstr ""
-
-#: ../root/report/featuring_recordings.tt:6
-msgid ""
-"This report shows recordings with (feat. Artist) in the title. For classical "
-"recordings, consult the {CSG|classical style guidelines}. For non-classical "
-"recordings, this is inherited from an older version of MusicBrainz and "
-"should be fixed (both on the recordings and on the tracks!). Consult the "
-"{featured_artists|page about featured artists} to know more."
-msgstr ""
-
-#: ../root/report/release_groups_without_va_credit.tt:6
-msgid ""
-"This report shows release groups linked to the Various Artists entity "
-"without \"Various Artists\" as the credited name."
-msgstr ""
-
-#: ../root/report/release_groups_without_va_link.tt:6
-msgid ""
-"This report shows release groups with \"Various Artists\" as the credited "
-"name but not linked to the Various Artists entity."
-msgstr ""
-
-#: ../root/report/featuring_release_groups.tt:6
-msgid ""
-"This report shows release groups with (feat. Artist) in the title. For "
-"classical release groups, consult the {CSG|classical style guidelines}. For "
-"non-classical release groups, this is inherited from an older version of "
-"MusicBrainz and should be fixed. Consult the {featured_artists|page about "
-"featured artists} to know more."
-msgstr ""
-
-#: ../root/report/set_in_different_rg.tt:6
-msgid ""
-"This report shows release groups with releases that are linked to releases "
-"in different release groups by part-of-set or transliteration relationships. "
-"If a pair of release groups are listed here, you should probably merge them. "
-"If the releases are discs linked with \"part of set\" relationships, you "
-"might want to merge them too into one multi-disc release (see "
-"{how_to_merge_releases|How to Merge Releases})."
-msgstr ""
-
-#: ../root/report/releases_missing_disc_i_ds.tt:6
-msgid ""
-"This report shows releases (official and promotional only) that have at "
-"least one medium with a format that supports disc IDs, but is missing one."
-msgstr ""
-
-#: ../root/report/releases_without_va_credit.tt:6
-msgid ""
-"This report shows releases linked to the Various Artists entity without "
-"\"Various Artists\" as the credited name."
-msgstr ""
-
-#: ../root/report/single_medium_releases_with_medium_titles.tt:6
-msgid ""
-"This report shows releases that have a single medium, where this medium also "
-"has a specific name. Usually, this is not necessary and is duplicate "
-"information which can be removed."
-msgstr ""
-
-#: ../root/report/releases_with_unlikely_language_script.tt:6
-msgid ""
-"This report shows releases that have an unlikely combination of language and "
-"script properties, such as German and Ethiopic."
-msgstr ""
-
-#: ../root/report/releases_with_download_relationships.tt:6
-msgid ""
-"This report shows releases that have download relationships, but have media "
-"who's format is not \"Digital Media\"."
-msgstr ""
-
-#: ../root/report/multiple_asins.tt:6
-msgid ""
-"This report shows releases that have more than one Amazon ASIN. In most "
-"cases ASINs should map to MusicBrainz releases 1:1, so only one of them will "
-"be correct. Just check which ones do not fit the release (because of format, "
-"different number of tracks, etc). If the release has a barcode, you can "
-"search Amazon for it and see which ASIN matches."
-msgstr ""
-
-#: ../root/report/multiple_discogs_links.tt:6
-msgid ""
-"This report shows releases that have more than one link to Discogs. In most "
-"cases a MusicBrainz release should have only one equivalent in Discogs, so "
-"only one of them will be correct. Just check which ones do not fit the "
-"release (because of format, different number of tracks, etc). Any \"master\" "
-"Discogs page belongs at the {release_group|release group level}, not at the "
-"release level, and should be removed from releases too."
-msgstr ""
-
-#: ../root/report/releases_without_language.tt:6
-msgid ""
-"This report shows releases that have no language set. If you recognize the "
-"language, please set it! Do it only if you are pretty sure, don't just "
-"guess: not everything written in Cyrillic is Russian, for example."
-msgstr ""
-
-#: ../root/report/releases_with_no_mediums.tt:6
-msgid "This report shows releases that have no mediums added."
-msgstr ""
-
-#: ../root/report/releases_without_script.tt:6
-msgid ""
-"This report shows releases that have no script set. If you recognize the "
-"script, just add it! Remember that the script used for English (and most "
-"other European languages) is Latin."
-msgstr ""
-
-#: ../root/report/releases_with_coverart_links.tt:6
-msgid "This report shows releases that still have Cover Art relationships."
-msgstr ""
-
-#: ../root/report/part_of_set_relationships.tt:6
-msgid ""
-"This report shows releases that still have the deprecated \"part of set\" "
-"relationship and should probably be merged. For instructions on how to fix "
-"them, please see the documentation about {how_to_merge_releases|how to merge "
-"releases}. If the releases are not really part of a set (for example, if "
-"they are independently-released volumes in a series) just remove the "
-"relationship."
-msgstr ""
-
-#: ../root/report/some_formats_unset.tt:6
-msgid ""
-"This report shows releases where some of the medium formats are set, but "
-"others are unset. In most cases, it should be easy to find out which the "
-"correct formats are (don't just assume that they're all CDs because one is "
-"though!)."
-msgstr ""
-
-#: ../root/report/separate_discs.tt:6
-msgid ""
-"This report shows releases which have (disc n) or (bonus disc) in the title."
-msgstr ""
-
-#: ../root/report/releases_in_caa_with_cover_art_relationships.tt:7
-msgid ""
-"This report shows releases which have artwork in the Cover Art Archive, but "
-"still have a cover art relationship (pointing to a URL)."
-msgstr ""
-
-#: ../root/report/cat_no_looks_like_asin.tt:6
-msgid ""
-"This report shows releases which have catalog numbers that look like ASINs. "
-"This is almost always wrong: ASINs are just Amazon's entries for the "
-"releases and should be linked to the release with an Amazon URL relationship "
-"instead."
-msgstr ""
-
-#: ../root/report/releases_with_caa_no_types.tt:6
-msgid ""
-"This report shows releases which have cover art in the Cover Art Archive, "
-"but where none of it has any types set. This often means a front cover was "
-"added, but not marked as such."
-msgstr ""
-
-#: ../root/report/released_too_early.tt:6
-msgid ""
-"This report shows releases which have disc IDs even though they were "
-"released too early to have disc IDs, where one of the medium formats didn't "
-"exist at the time the release was released or where a disc ID is attached to "
-"a medium whose format does not have disc IDs."
-msgstr ""
-
-#: ../root/report/releases_without_va_link.tt:6
-msgid ""
-"This report shows releases with \"Various Artists\" as the credited name but "
-"not linked to the Various Artists entity."
-msgstr ""
-
-#: ../root/report/featuring_releases.tt:6
-msgid ""
-"This report shows releases with (feat. Artist) in the title. For classical "
-"releases, consult the {CSG|classical style guidelines}. For non-classical "
-"releases, this is inherited from an older version of MusicBrainz and should "
-"be fixed. Consult the {featured_artists|page about featured artists} to know "
-"more."
-msgstr ""
-
-#: ../root/report/bad_amazon_urls.tt:6
-msgid ""
-"This report shows releases with Amazon URLs which don't follow the expected "
-"format. They might still be correct if they're archive.org cover links, but "
-"in any other case they should probably be fixed or removed."
-msgstr ""
-
-#: ../root/report/unlinked_pseudo_releases.tt:6
-msgid ""
-"This report shows releases with status Pseudo-Release that aren't linked via "
-"the translation/transliteration relationship to an original version. This "
-"could be because the original version is missing, or just that the release "
-"status is set wrong."
-msgstr ""
-
 #: ../root/release/merge.tt:111
 msgid ""
 "This requires that corresponding mediums have the same number of tracks."
@@ -7285,7 +5987,7 @@ msgid ""
 "next few days. If this is not intended, please add more data to this series."
 msgstr ""
 
-#: ../root/series/index.tt:55
+#: ../root/series/index.tt:54
 msgid "This series is currently empty."
 msgstr ""
 
@@ -7293,7 +5995,7 @@ msgstr ""
 msgid "This table shows a summary of votes cast by this editor."
 msgstr ""
 
-#: ../root/components/common-macros.tt:932
+#: ../root/components/common-macros.tt:922
 msgid "This track is a data track."
 msgstr ""
 
@@ -7323,12 +6025,6 @@ msgid ""
 "already. The work names will be the same as their respective recording."
 msgstr ""
 
-#: ../root/admin/edit_banner.tt:6
-msgid ""
-"This will set the banner message that is shown at the top of each page. An "
-"empty string removes the banner."
-msgstr ""
-
 #: ../root/work/index.tt:4
 msgid ""
 "This work has no relationships and will be removed automatically in the next "
@@ -7336,14 +6032,16 @@ msgid ""
 msgstr ""
 
 #: ../root/cdtoc/info.tt:37 ../root/cdtoc/info.tt:39 ../root/cdtoc/info.tt:41
-#: ../root/components/events-list.tt:27 ../root/event/merge.tt:16
-#: ../root/report/event_list.tt:12 ../root/search/components/EventResults.js:73
+#: ../root/event/merge.tt:16 ../root/components/EventsList.js:104
+#: ../root/edit/details/AddEvent.js:89
+#: ../root/report/components/EventList.js:34
+#: ../root/search/components/EventResults.js:60
 msgid "Time"
 msgstr ""
 
-#: ../root/edit/details/add_event.tt:49 ../root/edit/details/edit_event.tt:37
-#: ../root/event/edit_form.tt:36 ../root/main/info/environment.tt:2
-#: ../root/layout/components/sidebar/EventSidebar.js:67
+#: ../root/edit/details/edit_event.tt:37 ../root/event/edit_form.tt:35
+#: ../root/main/info/environment.tt:2
+#: ../root/layout/components/sidebar/EventSidebar.js:66
 msgid "Time:"
 msgstr ""
 
@@ -7351,10 +6049,10 @@ msgstr ""
 #: ../root/cdtoc/list.tt:5 ../root/components/medium.tt:73
 #: ../root/components/relationships-table.tt:20
 #: ../root/components/release_groups-list.tt:9
-#: ../root/edit/details/edit_medium.tt:51
-#: ../root/edit/details/edit_medium.tt:55 ../root/recording/index.tt:11
+#: ../root/edit/details/edit_medium.tt:53
+#: ../root/edit/details/edit_medium.tt:57 ../root/recording/index.tt:11
 #: ../root/release/edit/tracklist.tt:131 ../root/release/edit/tracklist.tt:344
-#: ../root/isrc/Index.js:54 ../root/iswc/Index.js:50
+#: ../root/isrc/Index.js:53 ../root/iswc/Index.js:49
 msgid "Title"
 msgstr ""
 
@@ -7369,7 +6067,7 @@ msgid ""
 "g. \"composer\")."
 msgstr ""
 
-#: ../root/edit/index.tt:55
+#: ../root/edit/index.tt:59
 msgid ""
 "To aid in testing, the following features have been made available on "
 "testing servers:"
@@ -7402,131 +6100,20 @@ msgid "To:"
 msgstr ""
 
 #: ../root/cdstub/browse.tt:2 ../root/cdstub/browse.tt:3
-#: ../root/layout/components/BottomMenu.js:195
+#: ../root/layout/components/BottomMenu.js:203
 msgid "Top CD Stubs"
-msgstr ""
-
-#: ../root/report/isrc_with_many_recordings.tt:14
-msgid "Total ISRCs found: {count}"
-msgstr ""
-
-#: ../root/report/iswc_with_many_works.tt:9
-msgid "Total ISWCs found: {count}"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_urls.tt:8
-msgid "Total URLs found: {count}"
-msgstr ""
-
-#: ../root/report/duplicate_events.tt:10
-#: ../root/report/event_sequence_not_in_series.tt:7
-msgid "Total events found: {count}"
-msgstr ""
-
-#: ../root/report/instruments_without_an_image.tt:9
-msgid "Total instruments found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_labels.tt:8
-#: ../root/report/deprecated_relationship_labels.tt:8
-#: ../root/report/discogs_links_with_multiple_labels.tt:7
-#: ../root/report/duplicate_relationships_labels.tt:8
-#: ../root/report/labels_disambiguation_same_name.tt:8
-msgid "Total labels found: {count}"
 msgstr ""
 
 #: ../root/cdstub/index.tt:21 ../root/cdtoc/info.tt:23
 msgid "Total length:"
 msgstr ""
 
-#: ../root/report/annotations_places.tt:8
-#: ../root/report/deprecated_relationship_places.tt:8
-#: ../root/report/places_without_coordinates.tt:8
-msgid "Total places found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_recordings.tt:8
-#: ../root/report/deprecated_relationship_recordings.tt:8
-#: ../root/report/duplicate_relationships_recordings.tt:7
-#: ../root/report/featuring_recordings.tt:13
-#: ../root/report/recordings_same_name_different_artists_same_name.tt:10
-#: ../root/report/recordings_with_earliest_release_relationships.tt:11
-#: ../root/report/recordings_without_va_credit.tt:8
-#: ../root/report/recordings_without_va_link.tt:8
-#: ../root/report/recordings_with_varying_track_lengths.tt:8
-msgid "Total recordings found: {count}"
-msgstr ""
-
-#: ../root/report/annotations_release_groups.tt:8
-#: ../root/report/deprecated_relationship_release_groups.tt:8
-#: ../root/report/discogs_links_with_multiple_release_groups.tt:7
-#: ../root/report/duplicate_relationships_release_groups.tt:8
-#: ../root/report/duplicate_release_groups.tt:13
-#: ../root/report/featuring_release_groups.tt:12
-#: ../root/report/release_groups_without_va_credit.tt:8
-#: ../root/report/release_groups_without_va_link.tt:8
-msgid "Total release groups found: {count}"
-msgstr ""
-
-#: ../root/report/set_in_different_rg.tt:13
-msgid "Total release groups: {count}"
-msgstr ""
-
-#: ../root/report/annotations_releases.tt:8
-#: ../root/report/asins_with_multiple_releases.tt:15
-#: ../root/report/bad_amazon_urls.tt:10
-#: ../root/report/cat_no_looks_like_asin.tt:9
-#: ../root/report/deprecated_relationship_releases.tt:8
-#: ../root/report/discogs_links_with_multiple_releases.tt:14
-#: ../root/report/duplicate_relationships_releases.tt:8
-#: ../root/report/featuring_releases.tt:12 ../root/report/multiple_asins.tt:11
-#: ../root/report/multiple_discogs_links.tt:14
-#: ../root/report/part_of_set_relationships.tt:13
-#: ../root/report/released_too_early.tt:7
-#: ../root/report/release_label_same_artist.tt:9
-#: ../root/report/releases_in_caa_with_cover_art_relationships.tt:9
-#: ../root/report/releases_missing_disc_i_ds.tt:9
-#: ../root/report/releases_to_convert.tt:11
-#: ../root/report/releases_with_caa_no_types.tt:7
-#: ../root/report/releases_with_coverart_links.tt:7
-#: ../root/report/releases_with_download_relationships.tt:8
-#: ../root/report/releases_with_no_mediums.tt:7
-#: ../root/report/releases_without_language.tt:10
-#: ../root/report/releases_without_script.tt:9
-#: ../root/report/releases_without_va_credit.tt:8
-#: ../root/report/releases_without_va_link.tt:8
-#: ../root/report/releases_with_unlikely_language_script.tt:8
-#: ../root/report/separate_discs.tt:9
-#: ../root/report/single_medium_releases_with_medium_titles.tt:9
-#: ../root/report/some_formats_unset.tt:9
-#: ../root/report/unlinked_pseudo_releases.tt:7
-msgid "Total releases found: {count}"
-msgstr ""
-
-#: ../root/report/mediums_with_sequence_issues.tt:7
-#: ../root/report/superfluous_data_tracks.tt:9
-#: ../root/report/tracks_named_with_sequence.tt:10
-#: ../root/report/tracks_without_times.tt:7
-#: ../root/report/tracks_with_sequence_issues.tt:9
-msgid "Total releases: {count}"
-msgstr ""
-
-#: ../root/report/annotations_series.tt:8
-msgid "Total series found: {count}"
-msgstr ""
-
 #: ../root/cdstub/index.tt:17 ../root/cdtoc/info.tt:19
 msgid "Total tracks:"
 msgstr ""
 
-#: ../root/report/annotations_works.tt:8
-#: ../root/report/deprecated_relationship_works.tt:8
-#: ../root/report/duplicate_relationships_works.tt:8
-msgid "Total works found: {count}"
-msgstr ""
-
-#: ../root/cdtoc/info.tt:31 ../root/search/components/RecordingResults.js:128
-#: ../root/taglookup/Form.js:37
+#: ../root/cdtoc/info.tt:31 ../root/search/components/RecordingResults.js:126
+#: ../root/taglookup/Form.js:36
 msgid "Track"
 msgstr ""
 
@@ -7555,7 +6142,7 @@ msgstr ""
 msgid "Track lengths:"
 msgstr ""
 
-#: ../root/edit/details/historic/edit_track.tt:19 ../root/taglookup/Form.js:33
+#: ../root/edit/details/historic/edit_track.tt:19 ../root/taglookup/Form.js:32
 msgid "Track number"
 msgstr ""
 
@@ -7579,7 +6166,7 @@ msgstr ""
 msgid "Tracklist"
 msgstr ""
 
-#: ../root/edit/details/add_medium.tt:32 ../root/edit/details/edit_medium.tt:40
+#: ../root/edit/details/add_medium.tt:32 ../root/edit/details/edit_medium.tt:42
 #: ../root/edit/details/remove_medium.tt:9
 msgid "Tracklist:"
 msgstr ""
@@ -7588,8 +6175,8 @@ msgstr ""
 #: ../root/edit/details/merge_releases.tt:21
 #: ../root/otherlookup/results-release.tt:13 ../root/release/discids.tt:9
 #: ../root/release/edit/duplicates.tt:12 ../root/release_group/index.tt:25
-#: ../root/release/merge.tt:16 ../root/search/components/CDStubResults.js:50
-#: ../root/search/components/ReleaseResults.js:102
+#: ../root/release/merge.tt:16 ../root/search/components/CDStubResults.js:48
+#: ../root/search/components/ReleaseResults.js:108
 msgid "Tracks"
 msgstr ""
 
@@ -7610,28 +6197,16 @@ msgstr ""
 msgid "Transclusion editor"
 msgstr ""
 
-#: ../root/user/privileged.tt:25
-msgid "Transclusion editors"
-msgstr ""
-
-#: ../root/user/privileged.tt:26
-msgid ""
-"Transclusion editors are users who add and maintain entries in the {uri|"
-"WikiDocs} transclusion table."
-msgstr ""
-
-#: ../root/components/forms.tt:256 ../root/components/forms.tt:280
+#: ../root/components/forms.tt:249 ../root/components/forms.tt:273
 msgid "Turkish"
 msgstr ""
 
-#: ../root/layout.tt:108 ../root/layout/components/Footer.js:32
+#: ../root/layout.tt:108 ../root/layout/components/Footer.js:31
 msgid "Twitter"
 msgstr ""
 
 #: ../root/components/areas-list.tt:6 ../root/components/artists-list.tt:6
-#: ../root/components/events-list.tt:15
-#: ../root/components/instruments-list.tt:6 ../root/components/labels-list.tt:6
-#: ../root/components/places-list.tt:6
+#: ../root/components/instruments-list.tt:6 ../root/components/places-list.tt:6
 #: ../root/components/relationship-editor.tt:98
 #: ../root/components/release_groups-list.tt:14
 #: ../root/components/series-list.tt:6 ../root/components/works-list.tt:16
@@ -7640,40 +6215,44 @@ msgstr ""
 #: ../root/event/merge.tt:13 ../root/instrument/merge.tt:12
 #: ../root/label/merge.tt:13 ../root/otherlookup/results-release.tt:20
 #: ../root/place/merge.tt:12 ../root/release_group/merge.tt:14
-#: ../root/report/event_list.tt:8
-#: ../root/report/instruments_without_an_image.tt:20
-#: ../root/report/iswc_with_many_works.tt:22
-#: ../root/report/release_group_list.tt:9 ../root/series/merge.tt:13
-#: ../root/user/collections.tt:45 ../root/work/merge.tt:15
-#: ../root/account/applications/Index.js:112
-#: ../root/components/Aliases/AliasTable.js:30 ../root/iswc/Index.js:53
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:51
-#: ../root/report/DuplicateArtists.js:68
-#: ../root/report/components/ArtistAnnotationList.js:28
-#: ../root/report/components/ArtistList.js:28
-#: ../root/report/components/ArtistRelationshipList.js:30
-#: ../root/search/components/AnnotationResults.js:57
-#: ../root/search/components/AreaResults.js:58
-#: ../root/search/components/ArtistResults.js:67
-#: ../root/search/components/EventResults.js:74
-#: ../root/search/components/InstrumentResults.js:56
-#: ../root/search/components/LabelResults.js:63
-#: ../root/search/components/PlaceResults.js:58
-#: ../root/search/components/RecordingResults.js:130
-#: ../root/search/components/ReleaseGroupResults.js:63
-#: ../root/search/components/ReleaseResults.js:109
-#: ../root/search/components/SeriesResults.js:52
-#: ../root/search/components/WorkResults.js:53
-#: ../root/static/scripts/account/components/ApplicationForm.js:99
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:774
+#: ../root/series/merge.tt:13 ../root/user/collections.tt:45
+#: ../root/work/merge.tt:15 ../root/account/applications/Index.js:112
+#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/EventsList.js:82 ../root/components/EventsList.js:87
+#: ../root/components/LabelsList.js:61 ../root/components/LabelsList.js:66
+#: ../root/edit/details/AddArea.js:71 ../root/edit/details/AddArtist.js:81
+#: ../root/edit/details/AddEvent.js:68 ../root/iswc/Index.js:52
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:58
+#: ../root/report/DuplicateArtists.js:75
+#: ../root/report/IswcsWithManyWorks.js:67
+#: ../root/report/components/ArtistAnnotationList.js:26
+#: ../root/report/components/ArtistList.js:26
+#: ../root/report/components/ArtistRelationshipList.js:27
+#: ../root/report/components/EventList.js:30
+#: ../root/report/components/InstrumentList.js:33
+#: ../root/report/components/ReleaseGroupAnnotationList.js:29
+#: ../root/report/components/ReleaseGroupList.js:36
+#: ../root/report/components/ReleaseGroupRelationshipList.js:33
+#: ../root/search/components/AnnotationResults.js:55
+#: ../root/search/components/AreaResults.js:56
+#: ../root/search/components/ArtistResults.js:64
+#: ../root/search/components/EventResults.js:61
+#: ../root/search/components/InstrumentResults.js:51
+#: ../root/search/components/LabelResults.js:61
+#: ../root/search/components/PlaceResults.js:56
+#: ../root/search/components/RecordingResults.js:128
+#: ../root/search/components/ReleaseGroupResults.js:61
+#: ../root/search/components/ReleaseResults.js:115
+#: ../root/search/components/SeriesResults.js:50
+#: ../root/search/components/WorkResults.js:52
+#: ../root/static/scripts/account/components/ApplicationForm.js:83
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:784
 msgid "Type"
 msgstr ""
 
-#: ../root/area/edit_form.tt:12 ../root/artist/edit_form.tt:17
+#: ../root/area/edit_form.tt:11 ../root/artist/edit_form.tt:16
 #: ../root/collection/edit_form.tt:6 ../root/components/filter-form.tt:5
-#: ../root/edit/data.tt:5 ../root/edit/details/add_area.tt:30
-#: ../root/edit/details/add_artist.tt:25 ../root/edit/details/add_event.tt:28
-#: ../root/edit/details/add_instrument.tt:23
+#: ../root/edit/data.tt:5 ../root/edit/details/add_instrument.tt:23
 #: ../root/edit/details/add_label.tt:56 ../root/edit/details/add_place.tt:23
 #: ../root/edit/details/add_series.tt:23 ../root/edit/details/add_work.tt:30
 #: ../root/edit/details/edit_area.tt:26 ../root/edit/details/edit_artist.tt:26
@@ -7682,17 +6261,17 @@ msgstr ""
 #: ../root/edit/details/edit_label.tt:25 ../root/edit/details/edit_place.tt:19
 #: ../root/edit/details/edit_series.tt:19
 #: ../root/edit/details/historic/add_release.tt:24
-#: ../root/entity/alias/edit_form.tt:21 ../root/event/edit_form.tt:15
-#: ../root/instrument/edit_form.tt:12 ../root/label/edit_form.tt:16
-#: ../root/place/edit_form.tt:16 ../root/release/add_cover_art.tt:81
+#: ../root/entity/alias/edit_form.tt:20 ../root/event/edit_form.tt:14
+#: ../root/instrument/edit_form.tt:11 ../root/label/edit_form.tt:15
+#: ../root/place/edit_form.tt:15 ../root/release/add_cover_art.tt:81
 #: ../root/release/cover_art_fields.tt:3 ../root/release/edit/information.tt:97
-#: ../root/search/form.tt:5 ../root/series/edit_form.tt:16
-#: ../root/work/edit_form.tt:15 ../root/layout/components/MetaDescription.js:23
-#: ../root/layout/components/sidebar/CollectionSidebar.js:38
-#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:57
+#: ../root/search/form.tt:5 ../root/series/edit_form.tt:15
+#: ../root/work/edit_form.tt:14 ../root/layout/components/MetaDescription.js:23
+#: ../root/layout/components/sidebar/CollectionSidebar.js:36
+#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:56
 #: ../root/layout/components/sidebar/ReleaseSidebar.js:149
-#: ../root/layout/components/sidebar/SidebarType.js:26
-#: ../root/search/components/SearchForm.js:85
+#: ../root/layout/components/sidebar/SidebarType.js:24
+#: ../root/search/components/SearchForm.js:79
 msgid "Type:"
 msgstr ""
 
@@ -7708,15 +6287,16 @@ msgstr ""
 msgid "Types:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/report/bad_amazon_urls.tt:21
-#: ../root/report/label_url_list.tt:5
-#: ../root/report/release_group_url_list.tt:5
-#: ../root/report/release_url_list.tt:5 ../root/report/url_list.tt:7
-#: ../lib/MusicBrainz/Server/Edit/URL.pm:7
-#: ../root/report/components/ArtistURLList.js:29
-#: ../root/static/scripts/common/i18n.js:63
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
-#: ../root/url/URLHeader.js:29
+#: ../root/components/common-macros.tt:576
+#: ../lib/MusicBrainz/Server/Edit/URL.pm:7 ../root/report/BadAmazonUrls.js:61
+#: ../root/report/components/ArtistUrlList.js:28
+#: ../root/report/components/LabelUrlList.js:28
+#: ../root/report/components/ReleaseGroupUrlList.js:30
+#: ../root/report/components/ReleaseUrlList.js:30
+#: ../root/report/components/UrlRelationshipList.js:28
+#: ../root/static/scripts/common/constants.js:25
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:35
+#: ../root/url/UrlHeader.js:28
 msgid "URL"
 msgstr ""
 
@@ -7728,7 +6308,7 @@ msgstr ""
 msgid "URL Information"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570 ../root/edit/details/edit_url.tt:5
+#: ../root/components/common-macros.tt:559 ../root/edit/details/edit_url.tt:5
 #: ../root/edit/details/edit_url.tt:11 ../root/main/info/environment.tt:18
 #: ../root/otherlookup/form.tt:3 ../root/url/edit_form.tt:6
 #: ../root/url/index.tt:5
@@ -7740,14 +6320,8 @@ msgid "URL; [URL]; [URL|label]; [entity-type:MBID|label]"
 msgstr ""
 
 #: ../root/components/common-macros.tt:121
-#: ../root/components/common-macros.tt:604 ../root/report/ReportsIndex.js:170
+#: ../root/components/common-macros.tt:593 ../root/report/ReportsIndex.js:505
 msgid "URLs"
-msgstr ""
-
-#: ../root/report/deprecated_relationship_urls.tt:1
-#: ../root/report/deprecated_relationship_urls.tt:3
-#: ../root/report/ReportsIndex.js:173
-msgid "URLs with deprecated relationships"
 msgstr ""
 
 #: ../root/doc/relationship_type.tt:37 ../root/relationship/linktype/tree.tt:14
@@ -7762,17 +6336,15 @@ msgstr ""
 msgid "Unauthorized Request"
 msgstr ""
 
-#: ../root/report/instruments_without_an_image.tt:32
-#: ../root/instrument/List.js:63
-msgid "Unclassified instrument"
-msgstr ""
-
-#: ../root/components/common-macros.tt:918
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:60
-#: ../root/report/DuplicateArtists.js:94
-#: ../root/report/components/ArtistAnnotationList.js:39
-#: ../root/report/components/ArtistList.js:37
-#: ../root/report/components/ArtistRelationshipList.js:42
+#: ../root/components/common-macros.tt:908
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:70
+#: ../root/report/DuplicateArtists.js:101
+#: ../root/report/components/ArtistAnnotationList.js:40
+#: ../root/report/components/ArtistList.js:38
+#: ../root/report/components/ArtistRelationshipList.js:44
+#: ../root/report/components/ReleaseGroupAnnotationList.js:48
+#: ../root/report/components/ReleaseGroupList.js:68
+#: ../root/report/components/ReleaseGroupRelationshipList.js:55
 msgid "Unknown"
 msgstr ""
 
@@ -7780,18 +6352,13 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: ../root/report/unlinked_pseudo_releases.tt:1
-#: ../root/report/unlinked_pseudo_releases.tt:3
-msgid "Unlinked Pseudo-Releases"
-msgstr ""
-
 #: ../root/components/release_groups-list.tt:38
 msgid "Unspecified type"
 msgstr ""
 
 #: ../root/user/subscriptions/table.tt:28
-#: ../root/layout/components/sidebar/CollectionSidebar.js:78
-#: ../root/layout/components/sidebar/SubscriptionLinks.js:35
+#: ../root/layout/components/sidebar/CollectionSidebar.js:76
+#: ../root/layout/components/sidebar/SubscriptionLinks.js:34
 msgid "Unsubscribe"
 msgstr ""
 
@@ -7799,14 +6366,14 @@ msgstr ""
 msgid "Untrusted"
 msgstr ""
 
-#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:29
-#: ../root/search/components/SearchForm.js:30
-#: ../root/search/components/SearchForm.js:31
+#: ../root/search/form.tt:13 ../root/search/components/SearchForm.js:26
+#: ../root/search/components/SearchForm.js:27
+#: ../root/search/components/SearchForm.js:28
 msgid "Up to {n}"
 msgstr ""
 
-#: ../root/admin/edit_banner.tt:15 ../root/admin/wikidoc/edit.tt:21
-#: ../root/admin/wikidoc/index.tt:61 ../root/account/applications/Edit.js:29
+#: ../root/admin/wikidoc/edit.tt:21 ../root/admin/wikidoc/index.tt:61
+#: ../root/account/applications/Edit.js:28 ../root/admin/EditBanner.js:36
 msgid "Update"
 msgstr ""
 
@@ -7830,11 +6397,11 @@ msgstr ""
 msgid "Uploading image..."
 msgstr ""
 
-#: ../root/components/forms.tt:266 ../root/components/forms.tt:290
+#: ../root/components/forms.tt:259 ../root/components/forms.tt:283
 msgid "Uppercase roman numerals"
 msgstr ""
 
-#: ../root/layout.tt:110 ../root/layout/components/Footer.js:38
+#: ../root/layout.tt:110 ../root/layout/components/Footer.js:37
 msgid "Use beta site"
 msgstr ""
 
@@ -7885,12 +6452,12 @@ msgid "User type:"
 msgstr ""
 
 #: ../root/account/register.tt:28 ../root/admin/edit_user.tt:35
-#: ../root/user/login.tt:23 ../root/account/LostPassword.js:38
+#: ../root/user/login.tt:23 ../root/account/LostPassword.js:42
 msgid "Username:"
 msgstr ""
 
 #: ../root/area/users.tt:1 ../root/area/users.tt:3
-#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:32
+#: ../root/components/entity-tabs.tt:1 ../root/components/EntityTabs.js:31
 msgid "Users"
 msgstr ""
 
@@ -7907,7 +6474,7 @@ msgid "Validating file..."
 msgstr ""
 
 #: ../root/cdstub/browse.tt:18
-#: ../root/layout/components/sidebar/CDStubSidebar.js:40
+#: ../root/layout/components/sidebar/CDStubSidebar.js:39
 msgid "Various Artists"
 msgstr ""
 
@@ -7919,11 +6486,11 @@ msgstr ""
 msgid "Version:"
 msgstr ""
 
-#: ../root/recording/edit_form.tt:31
+#: ../root/recording/edit_form.tt:30
 msgid "Video"
 msgstr ""
 
-#: ../root/recording/layout.tt:3
+#: ../root/recording/layout.tt:3 ../root/recording/RecordingLayout.js:44
 msgid "Video “{name}” by {artist}"
 msgstr ""
 
@@ -7964,7 +6531,7 @@ msgstr ""
 msgid "Vote tally"
 msgstr ""
 
-#: ../root/edit/index.tt:21
+#: ../root/edit/index.tt:25
 msgid "Vote tally:"
 msgstr ""
 
@@ -7972,11 +6539,11 @@ msgstr ""
 msgid "Voted down"
 msgstr ""
 
-#: ../root/edit/search_macros.tt:360 ../root/elections/ElectionVotes.js:26
+#: ../root/edit/search_macros.tt:360 ../root/elections/ElectionVotes.js:25
 msgid "Voter"
 msgstr ""
 
-#: ../root/doc/edit_type.tt:35 ../root/edit/index.tt:14 ../root/user/edits.tt:1
+#: ../root/doc/edit_type.tt:35 ../root/edit/index.tt:18
 msgid "Votes"
 msgstr ""
 
@@ -7988,16 +6555,12 @@ msgstr ""
 msgid "Votes by {name}"
 msgstr ""
 
-#: ../root/edit/list_header.tt:28 ../root/edit/components/EditSidebar.js:94
+#: ../root/edit/list_header.tt:28 ../root/edit/components/EditSidebar.js:92
 msgid "Voting FAQ"
 msgstr ""
 
 #: ../root/doc/edit_type.tt:32
 msgid "Voting period (days)"
-msgstr ""
-
-#: ../root/components/common-macros.tt:701
-msgid "Warning"
 msgstr ""
 
 #: ../root/release/edit/information.tt:273
@@ -8054,31 +6617,25 @@ msgstr ""
 msgid "We used DiscID <code>{discid}</code> to look up this information."
 msgstr ""
 
-#: ../root/account/edit.tt:43
-msgid ""
-"We will use your birth date to display your age in years on your profile "
-"page."
-msgstr ""
-
 #: ../root/main/500.tt:22
 msgid ""
 "We're terribly sorry for this problem. Please wait a few minutes and repeat "
 "your request &#x2014; the problem may go away."
 msgstr ""
 
-#: ../root/account/edit.tt:21 ../root/admin/edit_user.tt:38
+#: ../root/admin/edit_user.tt:38
 msgid "Website:"
 msgstr ""
 
 #: ../root/layout/merge-helper.tt:18
-#: ../root/layout/components/MergeHelper.js:29
+#: ../root/layout/components/MergeHelper.js:30
 msgid ""
 "When you are ready to merge these, just click the Merge button. You may "
 "still add more to this merge queue by simply browsing to the entities page "
 "and following the merge link."
 msgstr ""
 
-#: ../root/layout.tt:104 ../root/layout/components/Footer.js:24
+#: ../root/layout.tt:104 ../root/layout/components/Footer.js:23
 msgid "Wiki"
 msgstr ""
 
@@ -8094,20 +6651,23 @@ msgstr ""
 msgid "WikiDoc:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:587 ../root/components/works-list.tt:12
-#: ../root/edit/search_macros.tt:360 ../root/report/iswc_with_many_works.tt:19
-#: ../root/report/work_list.tt:7 ../root/work/merge.tt:11
+#: ../root/components/common-macros.tt:576 ../root/components/works-list.tt:12
+#: ../root/edit/search_macros.tt:360 ../root/work/merge.tt:11
 #: ../lib/MusicBrainz/Server/Edit/Work.pm:8
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:39
 #: ../root/layout/components/Search.js:26
-#: ../root/search/components/SearchForm.js:42
-#: ../root/static/scripts/common/i18n.js:64
-#: ../root/static/scripts/common/utility/formatEntityTypeName.js:39
-#: ../root/work/WorkHeader.js:26
+#: ../root/report/IswcsWithManyWorks.js:64
+#: ../root/report/components/WorkAnnotationList.js:25
+#: ../root/report/components/WorkList.js:25
+#: ../root/report/components/WorkRelationshipList.js:26
+#: ../root/search/components/SearchForm.js:39
+#: ../root/static/scripts/common/constants.js:26
+#: ../root/static/scripts/common/utility/formatEntityTypeName.js:37
+#: ../root/work/WorkHeader.js:24 ../root/work/WorkLayout.js:34
 msgid "Work"
 msgstr ""
 
-#: ../root/work/edit_form.tt:21
+#: ../root/work/edit_form.tt:20
 msgid "Work Attributes"
 msgstr ""
 
@@ -8115,16 +6675,12 @@ msgstr ""
 msgid "Work Collections"
 msgstr ""
 
-#: ../root/work/edit_form.tt:12
+#: ../root/work/edit_form.tt:11
 msgid "Work Details"
 msgstr ""
 
 #: ../root/release/edit_relationships.tt:139
 msgid "Work Type:"
-msgstr ""
-
-#: ../root/report/annotations_works.tt:1 ../root/report/annotations_works.tt:3
-msgid "Work annotations"
 msgstr ""
 
 #: ../root/user/ratings_summary.tt:3 ../root/user/ratings.tt:2
@@ -8135,61 +6691,48 @@ msgstr ""
 msgid "Work type:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:570 ../root/edit/details/add_work.tt:3
+#: ../root/components/common-macros.tt:559 ../root/edit/details/add_work.tt:3
 #: ../root/edit/details/edit_work.tt:5 ../root/edit/details/remove_iswc.tt:7
 msgid "Work:"
 msgstr ""
 
 #: ../root/artist/works.tt:1 ../root/artist/works.tt:2
-#: ../root/components/common-macros.tt:604 ../root/components/entity-tabs.tt:1
-#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:33
-#: ../root/report/ReportsIndex.js:162 ../root/tag/TagIndex.js:90
-#: ../root/tag/TagLayout.js:31
+#: ../root/components/common-macros.tt:593 ../root/components/entity-tabs.tt:1
+#: ../root/series/index.tt:15 ../root/components/EntityTabs.js:32
+#: ../root/report/ReportsIndex.js:485 ../root/tag/TagIndex.js:88
+#: ../root/tag/TagLayout.js:29
 msgid "Works"
 msgstr ""
 
-#: ../root/report/deprecated_relationship_works.tt:1
-#: ../root/report/deprecated_relationship_works.tt:3
-#: ../root/report/ReportsIndex.js:166
-msgid "Works with deprecated relationships"
-msgstr ""
-
-#: ../root/report/duplicate_relationships_works.tt:1
-#: ../root/report/duplicate_relationships_works.tt:3
-#: ../root/report/ReportsIndex.js:165
-msgid "Works with possible duplicate relationships"
-msgstr ""
-
 #: ../root/components/works-list.tt:13 ../root/otherlookup/results-work.tt:8
-#: ../root/report/iswc_with_many_works.tt:20 ../root/work/merge.tt:12
-#: ../root/iswc/Index.js:51 ../root/search/components/WorkResults.js:50
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:792
+#: ../root/work/merge.tt:12 ../root/iswc/Index.js:50
+#: ../root/report/IswcsWithManyWorks.js:65
+#: ../root/search/components/WorkResults.js:49
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:802
 msgid "Writers"
-msgstr ""
-
-#: ../root/entity/details.tt:28 ../root/entity/Details.js:89
-msgid "XML:"
 msgstr ""
 
 #: ../root/components/relationship-editor.tt:125
 #: ../root/release/edit/information.tt:125
 #: ../lib/MusicBrainz/Server/Plugin/FormRenderer.pm:250
+#: ../root/components/PartialDateInput.js:27
 msgid "YYYY"
 msgstr ""
 
-#: ../root/admin/attributes/form.tt:69 ../root/admin/attributes/index.tt:24
+#: ../root/admin/attributes/form.tt:69
 #: ../root/components/release_groups-list.tt:8
-#: ../root/release_group/merge.tt:15
+#: ../root/release_group/merge.tt:15 ../root/admin/attributes/Attribute.js:48
 msgid "Year"
 msgstr ""
 
 #: ../root/components/common-macros.tt:30
+#: ../root/static/scripts/common/utility/yesNo.js:11
 msgid "Yes"
 msgstr ""
 
 #: ../root/edit/search_macros.tt:263 ../root/edit/search_macros.tt:279
 #: ../lib/MusicBrainz/Server/Data/Vote.pm:176
-#: ../root/edit/components/Vote.js:71
+#: ../root/edit/components/Vote.js:70
 msgctxt "vote"
 msgid "Yes"
 msgstr ""
@@ -8198,13 +6741,13 @@ msgstr ""
 msgid "Yes, I'm sure"
 msgstr ""
 
-#: ../root/components/forms.tt:313
+#: ../root/components/forms.tt:306
 msgid ""
 "You are about to add an ISRC to this recording. The ISRC must be entered in "
 "standard <code>CCXXXYYNNNNN</code> format:"
 msgstr ""
 
-#: ../root/components/forms.tt:302
+#: ../root/components/forms.tt:295
 msgid ""
 "You are about to add an ISWC to this work. The ISWC must be entered in "
 "standard <code>T-DDD.DDD.DDD-C</code> format:"
@@ -8279,11 +6822,6 @@ msgid ""
 "the work that you would like the other works merged into:"
 msgstr ""
 
-#: ../root/collection/subscribers.tt:27 ../root/user/subscribers.tt:32
-#: ../root/entity/Subscribers.js:88
-msgid "You are currently subscribed. {unsub|Unsubscribe}?"
-msgstr ""
-
 #: ../root/watch/list.tt:7
 msgid "You are currently watching the following artists for new releases."
 msgstr ""
@@ -8292,13 +6830,8 @@ msgstr ""
 msgid "You are not currently able to add notes to this edit. ({url|Details})"
 msgstr ""
 
-#: ../root/edit/index.tt:47
+#: ../root/edit/index.tt:51
 msgid "You are not currently able to vote on this edit. ({url|Details})"
-msgstr ""
-
-#: ../root/collection/subscribers.tt:33 ../root/user/subscribers.tt:38
-#: ../root/entity/Subscribers.js:99
-msgid "You are not currently subscribed. {sub|Subscribe}?"
 msgstr ""
 
 #: ../root/watch/list.tt:32
@@ -8325,12 +6858,6 @@ msgid ""
 "database."
 msgstr ""
 
-#: ../root/account/edit.tt:35
-msgid ""
-"You can pick the level you prefer here: your country, region or city. Be as "
-"specific as you want to!"
-msgstr ""
-
 #: ../root/cdstub/logged_in.tt:3
 msgid ""
 "You cannot add a CD stub while logged in to MusicBrainz. Please {add_rel|add "
@@ -8351,7 +6878,7 @@ msgstr ""
 msgid "You cannot use the same country more than once."
 msgstr ""
 
-#: ../root/layout/merge-helper.tt:4 ../root/layout/components/MergeHelper.js:16
+#: ../root/layout/merge-helper.tt:4 ../root/layout/components/MergeHelper.js:17
 msgid "You currently have the following entities selected for merging:"
 msgstr ""
 
@@ -8386,10 +6913,6 @@ msgid ""
 "point editors to another edit."
 msgstr ""
 
-#: ../root/artist/special_purpose.tt:2
-msgid "You may not edit special purpose artists"
-msgstr ""
-
 #: ../root/account/register.tt:21
 msgid ""
 "You may remove your personal information from our services anytime by "
@@ -8397,11 +6920,11 @@ msgid ""
 "statement}."
 msgstr ""
 
-#: ../root/edit/index.tt:63
+#: ../root/edit/index.tt:67
 msgid "You must be logged in to vote on edits"
 msgstr ""
 
-#: ../root/components/common-macros.tt:949
+#: ../root/components/common-macros.tt:939
 msgid "You must enter a disambiguation comment for this entity."
 msgstr ""
 
@@ -8462,12 +6985,6 @@ msgid ""
 "email."
 msgstr ""
 
-#: ../root/user/report.tt:7
-msgid ""
-"Your report will be sent to our {uri|account administrators}, who will "
-"decide what action to take."
-msgstr ""
-
 #: ../root/search/error/invalid.tt:3
 msgid "Your search query was deemed invalid by our ruthless search server."
 msgstr ""
@@ -8508,16 +7025,16 @@ msgstr ""
 
 #: ../root/components/common-macros.tt:256
 #: ../root/edit/details/edit_alias.tt:21
-#: ../lib/MusicBrainz/Server/Edit/Work/Create.pm:75
-#: ../lib/MusicBrainz/Server/Edit/Work/Edit.pm:181
-#: ../root/static/scripts/common/components/EntityLink.js:30
+#: ../lib/MusicBrainz/Server/Edit/Work/Create.pm:78
+#: ../lib/MusicBrainz/Server/Edit/Work/Edit.pm:184
+#: ../root/static/scripts/common/components/EntityLink.js:31
 msgid "[removed]"
 msgstr ""
 
-#: ../root/components/labels-list.tt:41 ../root/event/merge.tt:42
-#: ../root/label/merge.tt:36 ../root/place/merge.tt:35
-#: ../root/layout/components/sidebar/SidebarEndDate.js:35
-#: ../root/static/scripts/common/utility/formatEndDate.js:17
+#: ../root/event/merge.tt:42 ../root/label/merge.tt:36
+#: ../root/place/merge.tt:35
+#: ../root/layout/components/sidebar/SidebarEndDate.js:34
+#: ../root/static/scripts/common/utility/formatEndDate.js:15
 msgid "[unknown]"
 msgstr ""
 
@@ -8553,7 +7070,7 @@ msgstr ""
 msgid "auto-edits"
 msgstr ""
 
-#: ../root/components/common-macros.tt:644
+#: ../root/components/common-macros.tt:633
 msgid "automatically applied"
 msgstr ""
 
@@ -8578,7 +7095,7 @@ msgid "by"
 msgstr ""
 
 #: ../root/components/common-macros.tt:184
-#: ../root/static/scripts/common/components/EntityLink.js:53
+#: ../root/static/scripts/common/components/EntityLink.js:60
 msgid "cancelled"
 msgstr ""
 
@@ -8607,7 +7124,7 @@ msgstr ""
 msgid "end date"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652
+#: ../root/components/common-macros.tt:641
 #: ../root/components/relationship-editor.tt:182
 #: ../root/edit/details/macros.tt:38
 msgid "ended"
@@ -8633,15 +7150,15 @@ msgstr ""
 msgid "events"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "from {begin_date} until {end_date}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "from {date} to ????"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "from {date} to present"
 msgstr ""
 
@@ -8660,28 +7177,28 @@ msgid "hide tracklist"
 msgstr ""
 
 #: ../root/components/common-macros.tt:175
-#: ../root/static/scripts/common/components/EntityLink.js:73
+#: ../root/static/scripts/common/components/EntityLink.js:83
 msgid "historical"
 msgstr ""
 
 #: ../root/components/common-macros.tt:173
-#: ../root/static/scripts/common/components/EntityLink.js:71
+#: ../root/static/scripts/common/components/EntityLink.js:81
 msgid "historical, until {end}"
 msgstr ""
 
 #: ../root/components/common-macros.tt:171
-#: ../root/static/scripts/common/components/EntityLink.js:69
+#: ../root/static/scripts/common/components/EntityLink.js:77
 msgid "historical, {begin}-{end}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "in {date}"
 msgstr ""
 
 #: ../root/components/common-macros.tt:223
 #: ../root/components/common-macros.tt:299
-#: ../root/static/scripts/common/components/EntityLink.js:85
-#: ../root/static/scripts/common/components/EntityLink.js:240
+#: ../root/static/scripts/common/components/EntityLink.js:95
+#: ../root/static/scripts/common/components/EntityLink.js:257
 msgid "info"
 msgstr ""
 
@@ -8788,7 +7305,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "on {date}"
 msgstr ""
 
@@ -8804,19 +7321,13 @@ msgstr ""
 msgid "places"
 msgstr ""
 
-#: ../root/collection/subscribers.tt:14 ../root/user/subscribers.tt:14
-msgid "plus {n} other anonymous user"
-msgid_plural "Plus {n} other anonymous users"
-msgstr[0] ""
-msgstr[1] ""
-
 #: ../root/entity/collections.tt:15
 msgid "plus {n} other private collection"
 msgid_plural "plus {n} other private collections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/artist/edit_form.tt:83
+#: ../root/artist/edit_form.tt:81
 msgid "preview:"
 msgstr ""
 
@@ -8851,12 +7362,6 @@ msgstr ""
 #: ../root/user/profile.tt:39
 msgid "resend verification email"
 msgstr ""
-
-#: ../root/release/header.tt:10
-msgid "see all versions of this release, {count} available"
-msgid_plural "see all versions of this release, {count} available"
-msgstr[0] ""
-msgstr[1] ""
 
 #: ../root/user/profile.tt:43
 msgid "send email"
@@ -8903,7 +7408,7 @@ msgstr ""
 msgid "unsubscribe"
 msgstr ""
 
-#: ../root/components/common-macros.tt:652 ../root/edit/details/macros.tt:38
+#: ../root/components/common-macros.tt:641 ../root/edit/details/macros.tt:38
 msgid "until {date}"
 msgstr ""
 
@@ -8920,11 +7425,9 @@ msgstr ""
 msgid "{app} is requesting permission to:"
 msgstr ""
 
-#: ../root/components/events-list.tt:60 ../root/components/works-list.tt:45
-#: ../root/event/merge.tt:34 ../root/otherlookup/results-work.tt:20
-#: ../root/report/event_list.tt:28 ../root/report/iswc_with_many_works.tt:46
-#: ../root/work/merge.tt:35
-#: ../root/static/scripts/common/components/ArtistRoles.js:29
+#: ../root/components/works-list.tt:45 ../root/event/merge.tt:34
+#: ../root/otherlookup/results-work.tt:20 ../root/work/merge.tt:35
+#: ../root/static/scripts/common/components/ArtistRoles.js:28
 msgid "{artist} ({roles})"
 msgstr ""
 
@@ -9011,8 +7514,8 @@ msgstr ""
 msgid "{entity_type} by {artist}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:269 ../root/main/index.js:200
-#: ../root/static/scripts/common/components/DescriptiveLink.js:30
+#: ../root/components/common-macros.tt:269 ../root/main/index.js:199
+#: ../root/static/scripts/common/components/DescriptiveLink.js:32
 #: ../root/static/scripts/release-editor/dialogs.js:138
 msgid "{entity} by {artist}"
 msgstr ""
@@ -9027,7 +7530,7 @@ msgstr[1] ""
 msgid "{entity} has not been added to any collections."
 msgstr ""
 
-#: ../root/layout.tt:72 ../root/layout/index.js:96
+#: ../root/layout.tt:72 ../root/layout/index.js:126
 msgid ""
 "{link|New notes} have been left on some of your edits. Please make sure to "
 "read them and respond if necessary."
@@ -9037,24 +7540,21 @@ msgstr ""
 msgid "{link} has no ratings."
 msgstr ""
 
-#: ../root/artist/relationships.tt:8 ../root/label/relationships.tt:7
+#: ../root/artist/relationships.tt:7 ../root/label/relationships.tt:6
 msgid "{link} has no relationships."
 msgstr ""
 
-#: ../root/entity/details.tt:10 ../root/entity/Details.js:71
-msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
-msgstr ""
-
-#: ../root/components/common-macros.tt:749
+#: ../root/components/common-macros.tt:739
+#: ../root/static/scripts/common/entity.js:434
 msgid "{medium_format} {position}"
 msgstr ""
 
-#: ../root/components/common-macros.tt:761
+#: ../root/components/common-macros.tt:751
 msgid "{medium} on {release}"
 msgstr ""
 
 #: ../root/components/common-macros.tt:330
-#: ../root/static/scripts/common/components/EntityLink.js:168
+#: ../root/static/scripts/common/components/EntityLink.js:179
 msgid "{name} – {additional_info}"
 msgstr ""
 
@@ -9070,7 +7570,7 @@ msgid_plural "{num} collections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/common-macros.tt:67 ../root/utility/age.js:161
+#: ../root/components/common-macros.tt:67 ../root/utility/age.js:160
 msgid "{num} day ago"
 msgid_plural "{num} days ago"
 msgstr[0] ""
@@ -9088,7 +7588,7 @@ msgid_plural "{num} labels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/common-macros.tt:67 ../root/utility/age.js:159
+#: ../root/components/common-macros.tt:67 ../root/utility/age.js:158
 msgid "{num} month ago"
 msgid_plural "{num} months ago"
 msgstr[0] ""
@@ -9106,23 +7606,18 @@ msgid_plural "{num} series"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/common-macros.tt:67 ../root/utility/age.js:157
+#: ../root/components/common-macros.tt:67 ../root/utility/age.js:156
 msgid "{num} year ago"
 msgid_plural "{num} years ago"
 msgstr[0] ""
 msgstr[1] ""
-
-#: ../root/components/relationships.tt:16
-#: ../root/static/scripts/relationship-editor/common/fields.js:440
-msgid "{num}. {relationship}"
-msgstr ""
 
 #: ../root/user/profile.tt:245 ../root/user/profile.tt:249
 msgid "{percentage}%"
 msgstr ""
 
 #: ../root/components/common-macros.tt:269
-#: ../root/static/scripts/common/components/DescriptiveLink.js:42
+#: ../root/static/scripts/common/components/DescriptiveLink.js:45
 msgid "{place} in {area}"
 msgstr ""
 
@@ -9150,11 +7645,11 @@ msgstr ""
 msgid "{type} “{instrument}”"
 msgstr ""
 
-#: ../root/work/layout.tt:1
+#: ../root/work/layout.tt:1 ../root/work/WorkLayout.js:33
 msgid "{type} “{work}”"
 msgstr ""
 
-#: ../root/layout.tt:36 ../root/layout/index.js:44
+#: ../root/layout.tt:36 ../root/layout/index.js:62
 msgid "{uri|Return to musicbrainz.org}."
 msgstr ""
 
@@ -9184,12 +7679,13 @@ msgid ""
 "that the artist has been entered correctly."
 msgstr ""
 
-#: ../root/components/common-macros.tt:903
-#: ../root/static/scripts/common/i18n.js:43
+#: ../root/components/common-macros.tt:893
+#: ../root/static/scripts/common/i18n/addColon.js:11
+#: ../root/static/scripts/common/i18n/addColon.js:15
 msgid "{variable}:"
 msgstr ""
 
-#: ../root/components/common-macros.tt:644
+#: ../root/components/common-macros.tt:633
 msgid "{yes} yes : {no} no"
 msgstr ""
 
@@ -9198,8 +7694,8 @@ msgid "« Previous"
 msgstr ""
 
 #: ../root/components/paginator.tt:19 ../root/components/paginator.tt:31
-#: ../root/components/paginator.tt:39 ../root/components/Paginator.js:69
-#: ../root/components/Paginator.js:89 ../root/components/Paginator.js:103
+#: ../root/components/paginator.tt:39 ../root/components/Paginator.js:68
+#: ../root/components/Paginator.js:88 ../root/components/Paginator.js:102
 msgid "…"
 msgstr ""
 
@@ -9243,79 +7739,79 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:51
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:55
 msgid "The user ID is missing or is in an invalid format."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:61
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:65
 msgid "The email address is missing."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:71
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:75
 msgid "The time is missing or is in an invalid format."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:82
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:86
 msgid "The verification key is missing."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:93
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:265
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:97
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:269
 msgid "The checksum is invalid, please double check your email."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:104
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:108
 msgid "Sorry, this email verification link has expired."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:116
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:277
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:120
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:281
 #, perl-brace-format
 msgid "The user with ID '{user_id}' could not be found."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:163
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:167
 msgid ""
 "We were unable to send login information to your email address.  Please try "
 "again, however if you continue to experience difficulty contact us at "
 "support@musicbrainz.org."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:190
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:194
 msgid "There is no user with this username"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:195
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:199
 msgid "There is no user with this username and email"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:198
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:202
 msgid ""
 "We can't send a password reset email, because we have no email on record for "
 "this user."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:228
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:232
 msgid "Your password has been reset."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:243
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:247
 msgid "Missing one or more required parameters."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:254
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:258
 msgid "Sorry, this password reset link has expired."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:321
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:325
 msgid "There is no user with this email"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:404
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:408
 msgid "Your profile has been updated."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:408
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:412
 #, perl-brace-format
 msgid ""
 "We have sent you a verification email to <code>{email}</code>. Please check "
@@ -9323,11 +7819,11 @@ msgid ""
 "address."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:433
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:451
 msgid "Your password has been changed."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Account.pm:650
+#: ../lib/MusicBrainz/Server/Controller/Account.pm:668
 msgid ""
 "<strong>We were unable to send a confirmation email to you.</strong><br/"
 ">Please confirm that you have entered a valid address by editing your "
@@ -9344,11 +7840,11 @@ msgid ""
 "Banner updated. Remember that each server has its own, independent banner."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Artist.pm:531
+#: ../lib/MusicBrainz/Server/Controller/Artist.pm:542
 msgid "You cannot merge a special purpose artist into another artist"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Artist.pm:536
+#: ../lib/MusicBrainz/Server/Controller/Artist.pm:547
 msgid "You cannot merge into Deleted Artist"
 msgstr ""
 
@@ -9401,7 +7897,7 @@ msgstr ""
 msgid "'{types}' is not a valid pair of types for relationships."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/Release.pm:505
+#: ../lib/MusicBrainz/Server/Controller/Release.pm:504
 msgid ""
 "This merge strategy is not applicable to the releases you have selected."
 msgstr ""
@@ -9450,11 +7946,11 @@ msgstr ""
 msgid "'{type}' is not an entity type that can have ratings."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/User.pm:537
+#: ../lib/MusicBrainz/Server/Controller/User.pm:550
 msgid "An error occurred while trying to send your report."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/User.pm:541
+#: ../lib/MusicBrainz/Server/Controller/User.pm:554
 msgid "Your report has been sent."
 msgstr ""
 
@@ -9462,7 +7958,7 @@ msgstr ""
 msgid "Invalid TOC"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Controller/WS/js/Edit.pm:587
+#: ../lib/MusicBrainz/Server/Controller/WS/js/Edit.pm:592
 msgid ""
 "You must be logged in to submit edits. {url|Log in} first, and then try "
 "submitting your edits again."
@@ -9523,7 +8019,9 @@ msgid "There is already a CD stub with this disc ID"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Data/Language.pm:61
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:44
+#: ../lib/MusicBrainz/Server/Edit/Work/Create.pm:76
+#: ../lib/MusicBrainz/Server/Edit/Work/Edit.pm:182
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:48
 msgid "[No lyrics]"
 msgstr ""
 
@@ -9559,7 +8057,7 @@ msgstr ""
 msgid "Add area annotation"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Area/Create.pm:20
+#: ../lib/MusicBrainz/Server/Edit/Area/Create.pm:21
 msgid "Add area"
 msgstr ""
 
@@ -9591,7 +8089,7 @@ msgstr ""
 msgid "Add artist annotation"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Artist/Create.pm:26
+#: ../lib/MusicBrainz/Server/Edit/Artist/Create.pm:27
 msgid "Add artist"
 msgstr ""
 
@@ -9627,9 +8125,9 @@ msgstr ""
 msgid "Add event annotation"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Event/Create.pm:20
-#: ../root/layout/components/sidebar/ArtistSidebar.js:150
-#: ../root/layout/components/sidebar/PlaceSidebar.js:93
+#: ../lib/MusicBrainz/Server/Edit/Event/Create.pm:21
+#: ../root/layout/components/sidebar/ArtistSidebar.js:149
+#: ../root/layout/components/sidebar/PlaceSidebar.js:92
 msgid "Add event"
 msgstr ""
 
@@ -9660,9 +8158,9 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/AddRelease.pm:17
 #: ../lib/MusicBrainz/Server/Edit/Release/Create.pm:31
-#: ../root/layout/components/sidebar/ArtistSidebar.js:135
-#: ../root/layout/components/sidebar/LabelSidebar.js:95
-#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:77
+#: ../root/layout/components/sidebar/ArtistSidebar.js:134
+#: ../root/layout/components/sidebar/LabelSidebar.js:94
+#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:76
 msgid "Add release"
 msgstr ""
 
@@ -9696,8 +8194,6 @@ msgid "Edit release"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Historic/ChangeReleaseQuality.pm:12
-#: ../lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm:24
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:269
 msgid "Change release quality"
 msgstr ""
 
@@ -9998,6 +8494,11 @@ msgstr ""
 msgid "Reorder mediums"
 msgstr ""
 
+#: ../lib/MusicBrainz/Server/Edit/ReleaseGroup.pm:7
+#: ../root/static/scripts/common/constants.js:23
+msgid "Release group"
+msgstr ""
+
 #: ../lib/MusicBrainz/Server/Edit/ReleaseGroup/AddAlias.pm:11
 msgid "Add release group alias"
 msgstr ""
@@ -10007,7 +8508,7 @@ msgid "Add release group annotation"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm:25
-#: ../root/layout/components/sidebar/ArtistSidebar.js:130
+#: ../root/layout/components/sidebar/ArtistSidebar.js:129
 msgid "Add release group"
 msgstr ""
 
@@ -10059,29 +8560,29 @@ msgstr ""
 msgid "Merge series"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:274 ../root/utility/edit.js:39
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:274 ../root/utility/edit.js:38
 msgid "Applied"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:275 ../root/utility/edit.js:40
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:275 ../root/utility/edit.js:39
 msgid "Failed vote"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:41
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:276 ../root/utility/edit.js:40
 msgid "Failed dependency"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Utils.pm:277
-#: ../root/report/ReportNotAvailable.js:16
-#: ../root/report/ReportNotAvailable.js:18 ../root/utility/edit.js:42
+#: ../root/report/ReportNotAvailable.js:15
+#: ../root/report/ReportNotAvailable.js:17 ../root/utility/edit.js:41
 msgid "Error"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:43
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:278 ../root/utility/edit.js:42
 msgid "Failed prerequisite"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Edit/Utils.pm:279 ../root/utility/edit.js:44
+#: ../lib/MusicBrainz/Server/Edit/Utils.pm:279 ../root/utility/edit.js:43
 msgid "No votes"
 msgstr ""
 
@@ -10106,7 +8607,7 @@ msgid "Add ISWCs"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Edit/Work/Create.pm:17
-#: ../root/layout/components/sidebar/ArtistSidebar.js:145
+#: ../root/layout/components/sidebar/ArtistSidebar.js:144
 msgid "Add work"
 msgstr ""
 
@@ -10203,7 +8704,7 @@ msgid "Cancelled"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/Barcode.pm:25
-#: ../root/static/scripts/common/utility/formatBarcode.js:13
+#: ../root/static/scripts/common/utility/formatBarcode.js:11
 msgid "[none]"
 msgstr ""
 
@@ -10236,13 +8737,13 @@ msgid "Submit new barcodes to the database"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/LinkAttribute.pm:33
-#: ../root/static/scripts/edit/utility/linkPhrase.js:68
+#: ../root/static/scripts/edit/utility/linkPhrase.js:169
 #, perl-brace-format
 msgid "{attribute} [{credited_as}]"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/LinkAttribute.pm:37
-#: ../root/static/scripts/edit/utility/linkPhrase.js:61
+#: ../root/static/scripts/edit/utility/linkPhrase.js:159
 #, perl-brace-format
 msgid "{attribute}: {value}"
 msgstr ""
@@ -10254,7 +8755,7 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/Medium.pm:265
 #: ../lib/MusicBrainz/Server/Translation.pm:262
-#: ../root/static/scripts/common/i18n/commaOnlyList.js:20
+#: ../root/static/scripts/common/i18n/commaOnlyList.js:18
 #, perl-brace-format
 msgid "{commas_only_list_item}, {rest}"
 msgstr ""
@@ -10283,9 +8784,15 @@ msgstr ""
 msgid "{begindate} &#x2013;"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Entity/Role/Linkable.pm:41
+#: ../lib/MusicBrainz/Server/Entity/Role/Linkable.pm:42
+#: ../root/utility/groupRelationships.js:102
+#: ../root/utility/groupRelationships.js:108
 #, perl-brace-format
 msgid "{role} (as {credited_name})"
+msgstr ""
+
+#: ../lib/MusicBrainz/Server/Entity/URL/CPDL.pm:9
+msgid "Score(s) at CPDL"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Entity/URL/Gutenberg.pm:9
@@ -10334,8 +8841,20 @@ msgstr ""
 msgid "This alias already exists."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Application.pm:43
+#: ../lib/MusicBrainz/Server/Form/Application.pm:45
 msgid "Redirect URL must be entered for web applications."
+msgstr ""
+
+#: ../lib/MusicBrainz/Server/Form/Application.pm:49
+msgid ""
+"Redirect URL scheme must be either <code>http</code> or <code>https</code> "
+"for web applications."
+msgstr ""
+
+#: ../lib/MusicBrainz/Server/Form/Application.pm:56
+msgid ""
+"Redirect URL scheme must be a reverse-DNS string, as in <code>org.example."
+"app://auth</code>, for installed applications."
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Area.pm:85
@@ -10405,7 +8924,7 @@ msgid "These coordinates could not be parsed"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Field/DatePeriod.pm:40
-#: ../root/static/scripts/relationship-editor/common/dialog.js:499
+#: ../root/static/scripts/relationship-editor/common/dialog.js:508
 msgid "The end date cannot precede the begin date."
 msgstr ""
 
@@ -10454,10 +8973,6 @@ msgstr ""
 msgid "Not a valid time. Must be in the format MM:SS"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm:20
-msgid "URL protocol must be HTTP or HTTPS"
-msgstr ""
-
 #: ../lib/MusicBrainz/Server/Form/Field/PartialDate.pm:64
 #: ../lib/MusicBrainz/Server/Form/User/EditProfile.pm:96
 msgid "invalid date"
@@ -10472,7 +8987,7 @@ msgid "This is not a valid time."
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Field/URL.pm:21
-#: ../root/static/scripts/edit/externalLinks.js:196
+#: ../root/static/scripts/edit/externalLinks.js:212
 msgid "Enter a valid url e.g. \"http://google.com/\""
 msgstr ""
 
@@ -10508,22 +9023,22 @@ msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:44
 #: ../root/layout/components/Search.js:39
-#: ../root/search/components/CDStubResults.js:48
-#: ../root/search/components/SearchForm.js:47
+#: ../root/search/components/CDStubResults.js:46
+#: ../root/search/components/SearchForm.js:44
 msgid "CD Stub"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:46
 #: ../root/layout/components/Search.js:36
-#: ../root/search/components/SearchForm.js:49
+#: ../root/search/components/SearchForm.js:46
 msgctxt "noun"
 msgid "Tag"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/Search/Search.pm:52
-#: ../root/layout/components/BottomMenu.js:249
+#: ../root/layout/components/BottomMenu.js:261
 #: ../root/layout/components/Search.js:45
-#: ../root/search/components/SearchForm.js:57
+#: ../root/search/components/SearchForm.js:54
 msgid "Documentation"
 msgstr ""
 
@@ -10544,18 +9059,22 @@ msgid "Invalid URL format"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/EditProfile.pm:72
+#: ../root/static/scripts/account/components/EditProfileForm.js:78
 msgid "Basic"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/EditProfile.pm:73
+#: ../root/static/scripts/account/components/EditProfileForm.js:79
 msgid "Intermediate"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/EditProfile.pm:74
+#: ../root/static/scripts/account/components/EditProfileForm.js:80
 msgid "Advanced"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/EditProfile.pm:75
+#: ../root/static/scripts/account/components/EditProfileForm.js:81
 msgid "Native"
 msgstr ""
 
@@ -10576,17 +9095,17 @@ msgid "Password field is required"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/Preferences.pm:84
-#: ../root/static/scripts/account/components/PreferencesForm.js:80
+#: ../root/static/scripts/account/components/PreferencesForm.js:79
 msgid "Daily"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/Preferences.pm:85
-#: ../root/static/scripts/account/components/PreferencesForm.js:81
+#: ../root/static/scripts/account/components/PreferencesForm.js:80
 msgid "Weekly"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Form/User/Preferences.pm:86
-#: ../root/static/scripts/account/components/PreferencesForm.js:82
+#: ../root/static/scripts/account/components/PreferencesForm.js:81
 msgid "Never"
 msgstr ""
 
@@ -10598,27 +9117,33 @@ msgstr ""
 msgid "The password confirmation does not match the password"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:28
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:29
+#: ../root/user/ReportUser.js:44
 msgid "Editor is spamming"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:29
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:30
+#: ../root/user/ReportUser.js:48
 msgid "Editor is unresponsive to edit notes"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:30
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:31
+#: ../root/user/ReportUser.js:52
 msgid "Editor intentionally ignores accepted guidelines"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:31
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:32
+#: ../root/user/ReportUser.js:56
 msgid "Editor is overzealous in enforcing guidelines as rules"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:32
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:33
+#: ../root/user/ReportUser.js:60
 msgid "Editor engages in overzealous or abusive yes/no voting"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/User/Report.pm:33
+#: ../lib/MusicBrainz/Server/Form/User/Report.pm:34
+#: ../root/user/ReportUser.js:65
 msgid "Editor has violated some other part of our Code of Conduct"
 msgstr ""
 
@@ -10638,31 +9163,31 @@ msgstr ""
 msgid "A month"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:56
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:60
 msgctxt "language optgroup"
 msgid "Frequently used"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:56
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:60
 msgctxt "language optgroup"
 msgid "Other"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:80
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:84
 msgctxt "script optgroup"
 msgid "Frequently used"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:80
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:84
 msgctxt "script optgroup"
 msgid "Other"
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:222
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:213
 msgid "This username is reserved for internal use."
 msgstr ""
 
-#: ../lib/MusicBrainz/Server/Form/Utils.pm:225
+#: ../lib/MusicBrainz/Server/Form/Utils.pm:216
 msgid "Please choose another username, this one is already taken."
 msgstr ""
 
@@ -10766,64 +9291,74 @@ msgid ""
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Translation.pm:242
-#: ../root/static/scripts/common/i18n/commaList.js:15
+#: ../root/static/scripts/common/i18n/commaList.js:13
 #, perl-brace-format
 msgid "{almost_last_list_item} and {last_list_item}"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Translation.pm:248
-#: ../root/static/scripts/common/i18n/commaList.js:24
+#: ../root/static/scripts/common/i18n/commaList.js:22
 #, perl-brace-format
 msgid "{list_item}, {rest}"
 msgstr ""
 
 #: ../lib/MusicBrainz/Server/Translation.pm:259
-#: ../root/static/scripts/common/i18n/commaOnlyList.js:13
+#: ../root/static/scripts/common/i18n/commaOnlyList.js:11
 #, perl-brace-format
 msgid "{last_list_item}"
 msgstr ""
 
-#: ../root/account/Donation.js:22 ../root/components/UserAccountTabs.js:62
+#: ../root/account/Donation.js:21 ../root/components/UserAccountTabs.js:61
 msgid "Donation Check"
 msgstr ""
 
-#: ../root/account/Donation.js:27
+#: ../root/account/Donation.js:26
 msgid ""
 "We have not received a donation from you recently. If you have just made a "
 "PayPal donation, then we have not received a notification from PayPal yet. "
 "Please wait a few minutes and reload this page to check again."
 msgstr ""
 
-#: ../root/account/Donation.js:30
+#: ../root/account/Donation.js:33
 msgid ""
 "If you would like to make a donation, {donate|you can do that here}. If you "
 "have donated, but you are still being nagged, please {contact|contact us}."
 msgstr ""
 
-#: ../root/account/Donation.js:37
+#: ../root/account/Donation.js:43
 msgid "Thank you for contributing to MusicBrainz."
 msgstr ""
 
-#: ../root/account/Donation.js:42
+#: ../root/account/Donation.js:49
 msgid "You will not be nagged for another {days} days."
 msgstr ""
 
-#: ../root/account/Donation.js:46
+#: ../root/account/Donation.js:55
 msgid "You will never be nagged again!"
 msgstr ""
 
-#: ../root/account/EmailVerificationStatus.js:20
+#: ../root/account/EditProfile.js:33 ../root/account/EditProfile.js:35
+#: ../root/components/UserAccountTabs.js:58
+msgid "Edit Profile"
+msgstr ""
+
+#: ../root/account/EditProfile.js:37
+msgid ""
+"See also your {uri|user preferences}, which include your privacy settings."
+msgstr ""
+
+#: ../root/account/EmailVerificationStatus.js:19
 msgid "Email Verification"
 msgstr ""
 
-#: ../root/account/EmailVerificationStatus.js:24
+#: ../root/account/EmailVerificationStatus.js:23
 msgid ""
 "Thank you, your email address has now been verified! If you still can't "
 "edit, please try to log out and log in again."
 msgstr ""
 
-#: ../root/account/LostPassword.js:29 ../root/account/LostPassword.js:30
-#: ../root/account/LostPasswordSent.js:17
+#: ../root/account/LostPassword.js:28 ../root/account/LostPassword.js:29
+#: ../root/account/LostPasswordSent.js:16
 msgid "Lost Password"
 msgstr ""
 
@@ -10834,14 +9369,15 @@ msgid ""
 "it} first and then reset your password."
 msgstr ""
 
-#: ../root/account/LostPassword.js:43 ../root/account/LostUsername.js:35
-#: ../root/report/components/EditorList.js:30
-#: ../root/static/scripts/account/components/PreferencesForm.js:213
+#: ../root/account/LostPassword.js:47 ../root/account/LostUsername.js:35
+#: ../root/report/components/EditorList.js:29
+#: ../root/static/scripts/account/components/EditProfileForm.js:189
+#: ../root/static/scripts/account/components/PreferencesForm.js:187
 msgid "Email"
 msgstr ""
 
-#: ../root/account/LostPasswordSent.js:17
-#: ../root/account/LostUsernameSent.js:17
+#: ../root/account/LostPasswordSent.js:16
+#: ../root/account/LostUsernameSent.js:16
 msgid "Email Sent!"
 msgstr ""
 
@@ -10852,12 +9388,12 @@ msgid ""
 "us}."
 msgstr ""
 
-#: ../root/account/LostUsername.js:27 ../root/account/LostUsername.js:28
-#: ../root/account/LostUsernameSent.js:17
+#: ../root/account/LostUsername.js:26 ../root/account/LostUsername.js:27
+#: ../root/account/LostUsernameSent.js:16
 msgid "Lost Username"
 msgstr ""
 
-#: ../root/account/LostUsername.js:30
+#: ../root/account/LostUsername.js:29
 msgid ""
 "Enter your email address below and we will send you an email with your "
 "MusicBrainz account information."
@@ -10870,8 +9406,8 @@ msgid ""
 "us}."
 msgstr ""
 
-#: ../root/account/Preferences.js:27 ../root/account/PreferencesSaved.js:21
-#: ../root/components/UserAccountTabs.js:60
+#: ../root/account/Preferences.js:29 ../root/account/PreferencesSaved.js:20
+#: ../root/components/UserAccountTabs.js:59
 msgid "Preferences"
 msgstr ""
 
@@ -10881,18 +9417,18 @@ msgid ""
 "page."
 msgstr ""
 
+#: ../root/account/applications/Edit.js:23
 #: ../root/account/applications/Edit.js:24
-#: ../root/account/applications/Edit.js:25
 msgid "Edit Application"
 msgstr ""
 
 #: ../root/account/applications/Index.js:29
-#: ../root/static/scripts/account/components/ApplicationForm.js:43
+#: ../root/static/scripts/account/components/ApplicationForm.js:41
 msgid "Web Application"
 msgstr ""
 
 #: ../root/account/applications/Index.js:29
-#: ../root/static/scripts/account/components/ApplicationForm.js:44
+#: ../root/static/scripts/account/components/ApplicationForm.js:42
 msgid "Installed Application"
 msgstr ""
 
@@ -10906,7 +9442,7 @@ msgstr ""
 
 #: ../root/account/applications/Index.js:66
 #: ../root/account/applications/Index.js:67
-#: ../root/layout/components/TopMenu.js:34
+#: ../root/layout/components/TopMenu.js:36
 msgid "Applications"
 msgstr ""
 
@@ -10959,144 +9495,238 @@ msgstr ""
 msgid "You do not have any registered applications."
 msgstr ""
 
+#: ../root/account/applications/Register.js:23
 #: ../root/account/applications/Register.js:24
-#: ../root/account/applications/Register.js:25
 msgid "Register Application"
 msgstr ""
 
-#: ../root/account/applications/Register.js:29
+#: ../root/account/applications/Register.js:28
 msgid "Register"
 msgstr ""
 
-#: ../root/account/applications/Remove.js:16
+#: ../root/account/applications/Remove.js:15
 msgid "Are you sure you want to remove this application?"
 msgstr ""
 
-#: ../root/account/applications/Remove.js:17
+#: ../root/account/applications/Remove.js:16
 msgid "Remove Application"
 msgstr ""
 
-#: ../root/account/applications/RevokeAccess.js:16
+#: ../root/account/applications/RevokeAccess.js:15
 msgid "Are you sure you want to revoke this application's access?"
 msgstr ""
 
-#: ../root/account/applications/RevokeAccess.js:17
+#: ../root/account/applications/RevokeAccess.js:16
 msgid "Revoke Application Access"
 msgstr ""
 
+#: ../root/account/sso/DiscourseRegistered.js:19
 #: ../root/account/sso/DiscourseRegistered.js:20
-#: ../root/account/sso/DiscourseRegistered.js:21
 msgid "Account Created"
 msgstr ""
 
-#: ../root/account/sso/DiscourseRegistered.js:23
-#: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:19
+#: ../root/account/sso/DiscourseRegistered.js:22
+#: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:18
 msgid ""
 "You must verify your email address before you can log in to {discourse|"
 "MetaBrainz Community Discourse}."
 msgstr ""
 
-#: ../root/account/sso/DiscourseRegistered.js:27
+#: ../root/account/sso/DiscourseRegistered.js:26
 msgid ""
 "An email has been sent to {addr}. Please check your mailbox and click on the "
 "link in the email to verify your email address."
 msgstr ""
 
+#: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:15
 #: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:16
-#: ../root/account/sso/DiscourseUnconfirmedEmailAddress.js:17
 msgid "Unconfirmed Email Address"
 msgstr ""
 
-#: ../root/area/AreaHeader.js:27
+#: ../root/admin/EditBanner.js:23 ../root/layout/components/TopMenu.js:121
+msgid "Edit Banner Message"
+msgstr ""
+
+#: ../root/admin/EditBanner.js:25
+msgid "Edit banner message"
+msgstr ""
+
+#: ../root/admin/EditBanner.js:27
+msgid ""
+"This will set the banner message that is shown at the top of each page. An "
+"empty string removes the banner."
+msgstr ""
+
+#: ../root/admin/EditBanner.js:33
+msgid "Banner message"
+msgstr ""
+
+#: ../root/admin/attributes/Attribute.js:49
+msgid "Disc IDs allowed"
+msgstr ""
+
+#: ../root/admin/attributes/Attribute.js:58
+msgid "Free text"
+msgstr ""
+
+#: ../root/admin/attributes/Attribute.js:98
+msgid "Parent ID"
+msgstr ""
+
+#: ../root/admin/attributes/Attribute.js:130
+#: ../root/admin/attributes/Language.js:70
+#: ../root/admin/attributes/Script.js:68
+msgid "Add new attribute"
+msgstr ""
+
+#: ../root/admin/attributes/Script.js:24 ../root/admin/attributes/Script.js:27
+msgid "Script"
+msgstr ""
+
+#: ../root/area/AreaEvents.js:46 ../root/artist/ArtistEvents.js:49
+#: ../root/place/PlaceEvents.js:47
+msgid "Add selected events for merging"
+msgstr ""
+
+#: ../root/area/AreaEvents.js:54
+msgid "This area is not currently associated with any events."
+msgstr ""
+
+#: ../root/area/AreaHeader.js:25
 msgid "{area_type} in {parent_areas}"
 msgstr ""
 
-#: ../root/area/NotFound.js:16
+#: ../root/area/AreaLabels.js:39
+msgid "This area is not currently associated with any labels."
+msgstr ""
+
+#: ../root/area/NotFound.js:15
 msgid "Area Not Found"
 msgstr ""
 
-#: ../root/area/NotFound.js:18
+#: ../root/area/NotFound.js:17
 msgid ""
 "Sorry, we could not find an area with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/artist/Merge.js:45 ../root/artist/Merge.js:47
+#: ../root/artist/ArtistEvents.js:57
+msgid "This artist is not currently associated with any events."
+msgstr ""
+
+#: ../root/artist/CannotSplit.js:19
+msgid ""
+"This artist has relationships other than collaboration relationships, and "
+"cannot be split until these are removed. {relationships|View all "
+"relationships}."
+msgstr ""
+
+#: ../root/artist/Merge.js:44 ../root/artist/Merge.js:46
 msgid "Merge Artists"
 msgstr ""
 
-#: ../root/artist/Merge.js:48
+#: ../root/artist/Merge.js:47
 msgid ""
 "You are about to merge the following artists into a single artist. Please "
 "select the artist which you would like other artists to be merged into:"
 msgstr ""
 
-#: ../root/artist/Merge.js:57
+#: ../root/artist/Merge.js:56
 msgid ""
 "Update matching artist and relationship credits to use the new artist’s name"
 msgstr ""
 
-#: ../root/artist/NotFound.js:16
+#: ../root/artist/NotFound.js:15
 msgid "Artist Not Found"
 msgstr ""
 
-#: ../root/artist/NotFound.js:18
+#: ../root/artist/NotFound.js:17
 msgid ""
 "Sorry, we could not find an artist with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/artist/utils.js:15
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
+#: ../root/artist/SpecialPurpose.js:19
+msgid "Cannot edit"
+msgstr ""
+
+#: ../root/artist/SpecialPurpose.js:21
+msgid "You may not edit special purpose artists"
+msgstr ""
+
+#: ../root/artist/SpecialPurpose.js:23
+msgid ""
+"The artist you are trying to edit is a special purpose artist, and you may "
+"not make direct changes to this data."
+msgstr ""
+
+#: ../root/artist/utils.js:13
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Born in:"
 msgstr ""
 
-#: ../root/artist/utils.js:19
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
+#: ../root/artist/utils.js:17
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Founded in:"
 msgstr ""
 
-#: ../root/artist/utils.js:21
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
+#: ../root/artist/utils.js:19
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "Begin area:"
 msgstr ""
 
-#: ../root/artist/utils.js:41
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:54
+#: ../root/artist/utils.js:39
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
 msgid "Died in:"
 msgstr ""
 
-#: ../root/artist/utils.js:45
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:62
+#: ../root/artist/utils.js:43
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
 msgid "Dissolved in:"
 msgstr ""
 
-#: ../root/artist/utils.js:47
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:48
+#: ../root/artist/utils.js:45
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
 msgid "End area:"
 msgstr ""
 
-#: ../root/cdtoc/NotFound.js:16
+#: ../root/cdtoc/NotFound.js:15
 msgid "CD TOC Not Found"
 msgstr ""
 
-#: ../root/cdtoc/NotFound.js:17
+#: ../root/cdtoc/NotFound.js:16
 msgid "Sorry, we could not find the CD TOC you specified."
 msgstr ""
 
-#: ../root/collection/NotFound.js:16
+#: ../root/collection/CollectionHeader.js:32
+msgid "Public collection by {owner}"
+msgstr ""
+
+#: ../root/collection/CollectionHeader.js:34
+msgid "Private collection"
+msgstr ""
+
+#: ../root/collection/CollectionHeader.js:47
+msgid "See all of your collections"
+msgstr ""
+
+#: ../root/collection/CollectionHeader.js:49
+msgid "See all of {editor}'s public collections"
+msgstr ""
+
+#: ../root/collection/NotFound.js:15
 msgid "Collection Not Found"
 msgstr ""
 
-#: ../root/collection/NotFound.js:17
+#: ../root/collection/NotFound.js:16
 msgid "Sorry, we could not find an collection with that MusicBrainz ID."
 msgstr ""
 
-#: ../root/components/Aliases/AliasTable.js:28
+#: ../root/components/Aliases/AliasTable.js:27
 msgid "Begin Date"
 msgstr ""
 
-#: ../root/components/Aliases/AliasTable.js:29
+#: ../root/components/Aliases/AliasTable.js:28
 msgid "End Date"
 msgstr ""
 
@@ -11104,19 +9734,29 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: ../root/components/Aliases/index.js:35
+#: ../root/components/Aliases/ArtistCreditList.js:30
+msgid "Artist credits"
+msgstr ""
+
+#: ../root/components/Aliases/ArtistCreditList.js:33
+msgid ""
+"This is a list of all the different ways {artist} is credited in the "
+"database. View the {doc|artist credit documentation} for more details."
+msgstr ""
+
+#: ../root/components/Aliases/index.js:61
 msgid "{entity} has no aliases."
 msgstr ""
 
-#: ../root/components/Aliases/index.js:40
+#: ../root/components/Aliases/index.js:69
 msgid "Add a new alias"
 msgstr ""
 
-#: ../root/components/ConfirmLayout.js:38
+#: ../root/components/ConfirmLayout.js:37
 msgid "Yes, I am sure"
 msgstr ""
 
-#: ../root/components/EnterEditNote.js:31
+#: ../root/components/EnterEditNote.js:29
 msgid ""
 "Entering an {note|edit note} that describes where you got your information "
 "is highly recommended. Not only does it make it clear where you got your "
@@ -11124,7 +9764,18 @@ msgid ""
 "thus making your edit get applied faster."
 msgstr ""
 
-#: ../root/components/ExpirationTime.js:28
+#: ../root/components/EventsList.js:91
+msgid "Role"
+msgstr ""
+
+#: ../root/components/EventsList.js:92
+#: ../root/report/components/EventList.js:32
+#: ../root/search/components/EventResults.js:63
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:950
+msgid "Location"
+msgstr ""
+
+#: ../root/components/ExpirationTime.js:27
 msgid ""
 "Expires in <span class=\"tooltip\" title=\"{exactdate}\">{num} day</span>"
 msgid_plural ""
@@ -11132,7 +9783,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/ExpirationTime.js:35
+#: ../root/components/ExpirationTime.js:34
 msgid ""
 "Expires in <span class=\"tooltip\" title=\"{exactdate}\">{num} hour</span>"
 msgid_plural ""
@@ -11140,7 +9791,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/ExpirationTime.js:42
+#: ../root/components/ExpirationTime.js:41
 msgid ""
 "Expires in <span class=\"tooltip\" title=\"{exactdate}\">{num} minute</span>"
 msgid_plural ""
@@ -11148,31 +9799,57 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/components/ExpirationTime.js:49
+#: ../root/components/ExpirationTime.js:48
 msgid "Already expired"
 msgstr ""
 
-#: ../root/components/UserAccountTabs.js:41
-#: ../root/layout/components/TopMenu.js:31
+#: ../root/components/LabelsList.js:72 ../root/components/LabelsList.js:77
+#: ../root/search/components/AreaResults.js:57
+#: ../root/search/components/LabelResults.js:62
+msgid "Code"
+msgstr ""
+
+#: ../root/components/RelatedSeries.js:30
+msgid "Related series"
+msgstr ""
+
+#: ../root/components/RelatedWorks.js:36
+msgid "Related works"
+msgstr ""
+
+#: ../root/components/StaticRelationshipsDisplay.js:75
+#: ../root/static/scripts/relationship-editor/common/fields.js:451
+msgid "{num}. {relationship}"
+msgstr ""
+
+#: ../root/components/UserAccountTabs.js:40
+#: ../root/layout/components/TopMenu.js:33
 msgid "Profile"
 msgstr ""
 
-#: ../root/components/UserAccountTabs.js:44
-#: ../root/layout/components/TopMenu.js:38
-#: ../root/layout/components/sidebar/CollectionSidebar.js:73
-#: ../root/layout/components/sidebar/SubscriptionLinks.js:29
+#: ../root/components/UserAccountTabs.js:43
+#: ../root/layout/components/TopMenu.js:40
+#: ../root/layout/components/sidebar/CollectionSidebar.js:71
+#: ../root/layout/components/sidebar/SubscriptionLinks.js:28
 msgid "Subscriptions"
 msgstr ""
 
-#: ../root/components/UserAccountTabs.js:66
+#: ../root/components/UserAccountTabs.js:46 ../root/entity/Subscribers.js:44
+#: ../root/entity/Subscribers.js:46
+#: ../root/layout/components/sidebar/CollectionSidebar.js:88
+#: ../root/layout/components/sidebar/SubscriptionLinks.js:46
+msgid "Subscribers"
+msgstr ""
+
+#: ../root/components/UserAccountTabs.js:65
 msgid "Edit User"
 msgstr ""
 
-#: ../root/edit/NotFound.js:16
+#: ../root/edit/NotFound.js:15
 msgid "Edit Not Found"
 msgstr ""
 
-#: ../root/edit/NotFound.js:18
+#: ../root/edit/NotFound.js:17
 msgid ""
 "Sorry, we could not find an edit with that edit ID. You may wish to try and "
 "perform an {search_url|edit search} instead."
@@ -11203,130 +9880,130 @@ msgstr ""
 msgid "<em>Cancelling</em>"
 msgstr ""
 
-#: ../root/edit/components/EditSidebar.js:71
+#: ../root/edit/components/EditSidebar.js:69
 msgid "Requires:"
 msgstr ""
 
-#: ../root/edit/components/EditSidebar.js:73
+#: ../root/edit/components/EditSidebar.js:71
 msgid "1 vote"
 msgid_plural "{n} unanimous votes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/edit/components/EditSidebar.js:80
+#: ../root/edit/components/EditSidebar.js:78
 msgid "Conditions:"
 msgstr ""
 
-#: ../root/edit/components/EditSidebar.js:87
+#: ../root/edit/components/EditSidebar.js:85
 msgid "Raw edit data for this edit"
 msgstr ""
 
-#: ../root/edit/components/EditSidebar.js:91
+#: ../root/edit/components/EditSidebar.js:89
 msgid "For more information:"
 msgstr ""
 
-#: ../root/edit/components/EditSummary.js:54
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:29
+#: ../root/edit/components/EditSummary.js:53
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:28
 msgid "Add Note"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:29
+#: ../root/elections/ElectionDetails.js:28
 msgid "Candidate:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:33
+#: ../root/elections/ElectionDetails.js:32
 msgid "Proposer:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:37
+#: ../root/elections/ElectionDetails.js:36
 msgid "1st seconder:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:45
+#: ../root/elections/ElectionDetails.js:44
 msgid "2nd seconder:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:56
+#: ../root/elections/ElectionDetails.js:55
 msgid "Votes for:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:60
+#: ../root/elections/ElectionDetails.js:59
 msgid "Votes against:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:68
+#: ../root/elections/ElectionDetails.js:67
 msgid "Votes for/against:"
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:69
+#: ../root/elections/ElectionDetails.js:68
 msgid ""
 "The tally of votes cast will only be shown when the election is complete."
 msgstr ""
 
-#: ../root/elections/ElectionDetails.js:75
+#: ../root/elections/ElectionDetails.js:74
 msgctxt "election status"
 msgid "Status:"
 msgstr ""
 
-#: ../root/elections/ElectionTable/ElectionTableRows.js:52
+#: ../root/elections/ElectionTable/ElectionTableRows.js:55
 msgid "View details"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:24
+#: ../root/elections/ElectionTable/index.js:22
 msgid "Candidate"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:25
+#: ../root/elections/ElectionTable/index.js:23
 msgctxt "election status"
 msgid "Status"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:26
+#: ../root/elections/ElectionTable/index.js:24
 msgid "Start date"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:28
+#: ../root/elections/ElectionTable/index.js:26
 msgid "Proposer"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:29
+#: ../root/elections/ElectionTable/index.js:27
 msgid "Seconder 1"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:30
+#: ../root/elections/ElectionTable/index.js:28
 msgid "Seconder 2"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:31
+#: ../root/elections/ElectionTable/index.js:29
 msgid "Votes for"
 msgstr ""
 
-#: ../root/elections/ElectionTable/index.js:32
+#: ../root/elections/ElectionTable/index.js:30
 msgid "Votes against"
 msgstr ""
 
-#: ../root/elections/ElectionVotes.js:27
+#: ../root/elections/ElectionVotes.js:26
 msgid "Vote"
 msgstr ""
 
-#: ../root/elections/ElectionVotes.js:38
+#: ../root/elections/ElectionVotes.js:37
 msgid "(private)"
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:23
+#: ../root/elections/ElectionVoting.js:22
 msgid "To find out if you can vote for this candidate, please {url|log in}."
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:27
+#: ../root/elections/ElectionVoting.js:26
 msgid "You cannot vote for this candidate, because you are not an auto-editor."
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:29
+#: ../root/elections/ElectionVoting.js:28
 msgid ""
 "You cannot vote for this candidate, because you proposed / seconded them."
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:31
+#: ../root/elections/ElectionVoting.js:30
 msgid ""
 "Voting is not yet open. If you would like to support this candidate, you can "
 "second their nomination. If you do not support this candidate, please note "
@@ -11334,196 +10011,260 @@ msgid ""
 "been found."
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:33
+#: ../root/elections/ElectionVoting.js:32
 msgid "Voting is closed."
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:42
+#: ../root/elections/ElectionVoting.js:41
 msgid "Second this candidate"
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:51
+#: ../root/elections/ElectionVoting.js:50
 msgid "Vote YES"
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:52
+#: ../root/elections/ElectionVoting.js:51
 msgid "Vote NO"
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:53
+#: ../root/elections/ElectionVoting.js:52
 msgid "Abstain"
 msgstr ""
 
-#: ../root/elections/ElectionVoting.js:62
+#: ../root/elections/ElectionVoting.js:61
 msgid "Cancel the election"
 msgstr ""
 
-#: ../root/elections/Index.js:20 ../root/elections/Index.js:21
+#: ../root/elections/Index.js:19 ../root/elections/Index.js:20
 msgid "Auto-editor elections"
 msgstr ""
 
-#: ../root/elections/Index.js:24
+#: ../root/elections/Index.js:23
 msgid "No elections found."
 msgstr ""
 
-#: ../root/elections/Nominate.js:17
+#: ../root/elections/Nominate.js:16
 msgid ""
 "Are you sure you want to nominate the editor {editor} for auto-editor status?"
 msgstr ""
 
-#: ../root/elections/Nominate.js:20
+#: ../root/elections/Nominate.js:19
 msgid "Nominate a candidate for auto-editor"
 msgstr ""
 
-#: ../root/elections/NotFound.js:16
+#: ../root/elections/NotFound.js:15
 msgid "Election Not Found"
 msgstr ""
 
-#: ../root/elections/NotFound.js:17
+#: ../root/elections/NotFound.js:16
 msgid "Sorry, we could not find this election."
 msgstr ""
 
-#: ../root/elections/NotFound.js:18
+#: ../root/elections/NotFound.js:17
 msgid "Back to all elections."
 msgstr ""
 
-#: ../root/elections/Show.js:30
+#: ../root/elections/Show.js:29
 msgid "Auto-editor election #{no}"
 msgstr ""
 
-#: ../root/elections/Show.js:35
+#: ../root/elections/Show.js:34
 msgid "Back to elections"
 msgstr ""
 
-#: ../root/elections/Show.js:38
+#: ../root/elections/Show.js:37
 msgid "Voting"
 msgstr ""
 
-#: ../root/elections/Show.js:40
+#: ../root/elections/Show.js:39
 msgid "Votes cast"
 msgstr ""
 
-#: ../root/entity/Subscribers.js:40
+#: ../root/entity/Details.js:70
+msgid "{mbid|<abbr title=\"MusicBrainz Identifier\">MBID</abbr>}:"
+msgstr ""
+
+#: ../root/entity/Details.js:76
+msgid "Last updated:"
+msgstr ""
+
+#: ../root/entity/Details.js:84
+msgid "Permanent link:"
+msgstr ""
+
+#: ../root/entity/Details.js:90
+msgid "XML:"
+msgstr ""
+
+#: ../root/entity/Details.js:102
+msgid "AcousticBrainz entry:"
+msgstr ""
+
+#: ../root/entity/Subscribers.js:54
+msgid "There is currently {num} user subscribed to edits that you make:"
+msgid_plural ""
+"There are currently {num} users subscribed to edits that you make:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:65
+msgid "There is currently {num} user subscribed to edits that {user} makes:"
+msgid_plural ""
+"There are currently {num} users subscribed to edits that {user} makes:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:78
 msgid "There is currently {num} user subscribed to {entity}:"
 msgid_plural "There are currently {num} users subscribed to {entity}:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/entity/Subscribers.js:59
+#: ../root/entity/Subscribers.js:97
 msgid "Plus {n} other anonymous user"
 msgid_plural "Plus {n} other anonymous users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/entity/Subscribers.js:81
+#: ../root/entity/Subscribers.js:107
+msgid "An anonymous user"
+msgid_plural "{n} anonymous users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/entity/Subscribers.js:121
+msgid "There are currently no users subscribed to edits that you make."
+msgstr ""
+
+#: ../root/entity/Subscribers.js:124
+msgid "There are currently no users subscribed to edits that {user} makes."
+msgstr ""
+
+#: ../root/entity/Subscribers.js:129
 msgid "There are currently no users subscribed to {entity}."
 msgstr ""
 
-#: ../root/event/NotFound.js:16
+#: ../root/entity/Subscribers.js:138
+msgid "You are currently subscribed. {unsub|Unsubscribe}?"
+msgstr ""
+
+#: ../root/entity/Subscribers.js:142
+msgid "Be the first! {sub|Subscribe}?"
+msgstr ""
+
+#: ../root/entity/Subscribers.js:145
+msgid "You are not currently subscribed. {sub|Subscribe}?"
+msgstr ""
+
+#: ../root/event/NotFound.js:15
 msgid "Event Not Found"
 msgstr ""
 
-#: ../root/event/NotFound.js:18
+#: ../root/event/NotFound.js:17
 msgid ""
 "Sorry, we could not find an event with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/genre/List.js:22 ../root/genre/List.js:24
-#: ../root/layout/components/BottomMenu.js:276
+#: ../root/genre/List.js:20 ../root/genre/List.js:22
+#: ../root/layout/components/BottomMenu.js:290
 msgid "Genre List"
 msgstr ""
 
-#: ../root/genre/List.js:26
+#: ../root/genre/List.js:24
 msgid ""
 "These are all the tags that will be understood as genres by the tag system."
 msgstr ""
 
-#: ../root/genre/List.js:36
+#: ../root/genre/List.js:34
 msgid ""
 "Is a genre missing from the list? Request it by {link|adding a style ticket}."
 msgstr ""
 
-#: ../root/instrument/InstrumentHeader.js:26
+#: ../root/instrument/InstrumentHeader.js:24
 msgid "instrument"
 msgstr ""
 
-#: ../root/instrument/List.js:47 ../root/instrument/List.js:49
-#: ../root/layout/components/BottomMenu.js:273
+#: ../root/instrument/List.js:44 ../root/instrument/List.js:46
+#: ../root/layout/components/BottomMenu.js:287
 msgid "Instrument List"
 msgstr ""
 
-#: ../root/instrument/List.js:73
+#: ../root/instrument/List.js:60 ../root/report/components/InstrumentList.js:46
+msgid "Unclassified instrument"
+msgstr ""
+
+#: ../root/instrument/List.js:70
 msgid ""
 "Is this list missing an instrument? Request it by following {link|these "
 "instructions}."
 msgstr ""
 
-#: ../root/instrument/NotFound.js:16
+#: ../root/instrument/NotFound.js:15
 msgid "Instrument Not Found"
 msgstr ""
 
-#: ../root/instrument/NotFound.js:18
+#: ../root/instrument/NotFound.js:17
 msgid ""
 "Sorry, we could not find an instrument with that MusicBrainz ID. You may "
 "wish to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/isrc/Index.js:32 ../root/isrc/Index.js:34
+#: ../root/isrc/Index.js:31 ../root/isrc/Index.js:33
 msgid "ISRC “{isrc}”"
 msgstr ""
 
-#: ../root/isrc/Index.js:39
+#: ../root/isrc/Index.js:38
 msgid "Associated with {num} recording"
 msgid_plural "Associated with {num} recordings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/isrc/NotFound.js:16
+#: ../root/isrc/NotFound.js:15
 msgid "ISRC Not Currently Used"
 msgstr ""
 
-#: ../root/isrc/NotFound.js:18
+#: ../root/isrc/NotFound.js:17
 msgid ""
 "This ISRC is not associated with any recordings. If you wish to associate it "
 "with a recording, please {search_url|search for the recording} and add it."
 msgstr ""
 
-#: ../root/iswc/Index.js:28 ../root/iswc/Index.js:30
+#: ../root/iswc/Index.js:27 ../root/iswc/Index.js:29
 msgid "ISWC “{iswc}”"
 msgstr ""
 
-#: ../root/iswc/Index.js:35
+#: ../root/iswc/Index.js:34
 msgid "Associated with {num} work"
 msgid_plural "Associated with {num} works"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/iswc/NotFound.js:16
+#: ../root/iswc/NotFound.js:15
 msgid "ISWC Not Currently Used"
 msgstr ""
 
-#: ../root/iswc/NotFound.js:18
+#: ../root/iswc/NotFound.js:17
 msgid ""
 "This ISWC is not associated with any works. If you wish to associate it with "
 "a work, please {search_url|search for the work} and add it."
 msgstr ""
 
-#: ../root/label/NotFound.js:16
+#: ../root/label/NotFound.js:15
 msgid "Label Not Found"
 msgstr ""
 
-#: ../root/label/NotFound.js:18
+#: ../root/label/NotFound.js:17
 msgid ""
 "Sorry, we could not find a label with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:79
+#: ../root/layout/components/BottomMenu.js:78
 msgid "(reset language)"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:84
+#: ../root/layout/components/BottomMenu.js:83
 msgid "Help Translate"
 msgstr ""
 
@@ -11531,223 +10272,227 @@ msgstr ""
 msgid "About Us"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:96
+#: ../root/layout/components/BottomMenu.js:98
 msgid "About MusicBrainz"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:99
+#: ../root/layout/components/BottomMenu.js:101
 msgid "Sponsors"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:102
+#: ../root/layout/components/BottomMenu.js:104
 msgid "Team"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:105
+#: ../root/layout/components/BottomMenu.js:107
 msgid "Shop"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:108
+#: ../root/layout/components/BottomMenu.js:110
 msgid "Contact Us"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:111
+#: ../root/layout/components/BottomMenu.js:113
 msgid "Data Licenses"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:114
+#: ../root/layout/components/BottomMenu.js:116
 msgid "Social Contract"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:117
+#: ../root/layout/components/BottomMenu.js:119
 msgid "Code of Conduct"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:120
+#: ../root/layout/components/BottomMenu.js:122
 msgid "Privacy Policy"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:123
+#: ../root/layout/components/BottomMenu.js:125
 msgid "GDPR Compliance"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:126
+#: ../root/layout/components/BottomMenu.js:128
 msgid "Auto-editor Elections"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:135
+#: ../root/layout/components/BottomMenu.js:131
+msgid "Privileged User Accounts"
+msgstr ""
+
+#: ../root/layout/components/BottomMenu.js:137
 msgid "Timeline Graph"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:143
+#: ../root/layout/components/BottomMenu.js:146
 msgid "Products"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:146 ../root/main/index.js:118
+#: ../root/layout/components/BottomMenu.js:151 ../root/main/index.js:117
 msgid "MusicBrainz Picard"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:149 ../root/main/index.js:119
+#: ../root/layout/components/BottomMenu.js:154 ../root/main/index.js:118
 msgid "Magic MP3 Tagger"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:152 ../root/main/index.js:120
+#: ../root/layout/components/BottomMenu.js:157 ../root/main/index.js:119
 msgid "Yate Music Tagger"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:155
+#: ../root/layout/components/BottomMenu.js:160
 msgid "MusicBrainz for Android"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:158
+#: ../root/layout/components/BottomMenu.js:163
 msgid "MusicBrainz Server"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:161 ../root/main/index.js:148
+#: ../root/layout/components/BottomMenu.js:166 ../root/main/index.js:147
 msgid "MusicBrainz Database"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:164
+#: ../root/layout/components/BottomMenu.js:169
 msgid "Developer Resources"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:167
+#: ../root/layout/components/BottomMenu.js:172
 msgid "XML Web Service"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:170
+#: ../root/layout/components/BottomMenu.js:175
 msgid "Live Data Feed"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:173
+#: ../root/layout/components/BottomMenu.js:178
 msgid "FreeDB Gateway"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:184
+#: ../root/layout/components/BottomMenu.js:192
 msgid "Search Entities"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:188
+#: ../root/layout/components/BottomMenu.js:196
 msgid "Search Edits"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:203
-#: ../root/layout/components/sidebar/CollectionSidebar.js:44
-#: ../root/layout/components/sidebar/EditLinks.js:25
-#: ../root/static/scripts/account/components/PreferencesForm.js:234
+#: ../root/layout/components/BottomMenu.js:212
+#: ../root/layout/components/sidebar/CollectionSidebar.js:42
+#: ../root/layout/components/sidebar/EditLinks.js:24
+#: ../root/static/scripts/account/components/PreferencesForm.js:208
 msgid "Editing"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:206
+#: ../root/layout/components/BottomMenu.js:217
 msgctxt "button/menu"
 msgid "Add Artist"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:212
+#: ../root/layout/components/BottomMenu.js:223
 msgctxt "button/menu"
 msgid "Add Release Group"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:215
+#: ../root/layout/components/BottomMenu.js:226
 msgctxt "button/menu"
 msgid "Add Release"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:219
+#: ../root/layout/components/BottomMenu.js:230
 msgid "Add Various Artists Release"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:223
+#: ../root/layout/components/BottomMenu.js:234
 msgctxt "button/menu"
 msgid "Add Standalone Recording"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:226
+#: ../root/layout/components/BottomMenu.js:237
 msgctxt "button/menu"
 msgid "Add Work"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:229
+#: ../root/layout/components/BottomMenu.js:240
 msgctxt "button/menu"
 msgid "Add Place"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:232
+#: ../root/layout/components/BottomMenu.js:243
 msgctxt "button/menu"
 msgid "Add Series"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:235
+#: ../root/layout/components/BottomMenu.js:246
 msgctxt "button/menu"
 msgid "Add Event"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:238
+#: ../root/layout/components/BottomMenu.js:249
 msgid "Vote on Edits"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:241
-#: ../root/report/ReportsIndex.js:17 ../root/report/ReportsIndex.js:19
+#: ../root/layout/components/BottomMenu.js:252
+#: ../root/report/ReportsIndex.js:16 ../root/report/ReportsIndex.js:18
 msgid "Reports"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:252
+#: ../root/layout/components/BottomMenu.js:266
 msgid "Beginners Guide"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:255
+#: ../root/layout/components/BottomMenu.js:269
 msgid "Style Guidelines"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:258
+#: ../root/layout/components/BottomMenu.js:272
 msgid "How Tos"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:261 ../root/main/index.js:130
+#: ../root/layout/components/BottomMenu.js:275 ../root/main/index.js:129
 msgid "FAQs"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:264
+#: ../root/layout/components/BottomMenu.js:278
 msgid "Documentation Index"
 msgstr ""
 
-#: ../root/layout/components/BottomMenu.js:279
+#: ../root/layout/components/BottomMenu.js:293
 msgid "Development"
 msgstr ""
 
-#: ../root/layout/components/ExternalLinks.js:74
+#: ../root/layout/components/ExternalLinks.js:75
 msgid "Official homepage"
 msgstr ""
 
-#: ../root/layout/components/ExternalLinks.js:102
+#: ../root/layout/components/ExternalLinks.js:103
 msgid "External links"
 msgstr ""
 
-#: ../root/layout/components/ExternalLinks.js:109
+#: ../root/layout/components/ExternalLinks.js:110
 msgid "View all relationships"
 msgstr ""
 
-#: ../root/layout/components/Footer.js:46
+#: ../root/layout/components/Footer.js:45
 msgid "Running: {git_details}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:32
+#: ../root/layout/components/Head.js:35
 msgid "Page {n}"
 msgstr ""
 
-#: ../root/layout/components/Head.js:65
+#: ../root/layout/components/Head.js:81
 msgid "MusicBrainz: Artist"
 msgstr ""
 
-#: ../root/layout/components/Head.js:66
+#: ../root/layout/components/Head.js:87
 msgid "MusicBrainz: Label"
 msgstr ""
 
-#: ../root/layout/components/Head.js:67
+#: ../root/layout/components/Head.js:93
 msgid "MusicBrainz: Release"
 msgstr ""
 
-#: ../root/layout/components/Head.js:68
+#: ../root/layout/components/Head.js:99
 msgid "MusicBrainz: Track"
 msgstr ""
 
@@ -11764,7 +10509,7 @@ msgid "Label Code:"
 msgstr ""
 
 #: ../root/layout/components/MetaDescription.js:90
-#: ../root/layout/components/sidebar/LabelSidebar.js:62
+#: ../root/layout/components/sidebar/LabelSidebar.js:61
 msgid "Defunct:"
 msgstr ""
 
@@ -11780,132 +10525,132 @@ msgstr ""
 msgid "Writers:"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:42
+#: ../root/layout/components/TopMenu.js:44
 msgid "Log Out"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:53
+#: ../root/layout/components/TopMenu.js:56
 msgid "My Data"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:56
+#: ../root/layout/components/TopMenu.js:61
 msgid "My Collections"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:59
+#: ../root/layout/components/TopMenu.js:64
 msgid "My Ratings"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:62
+#: ../root/layout/components/TopMenu.js:67
 msgid "My Tags"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:65
+#: ../root/layout/components/TopMenu.js:70
 msgid "My Open Edits"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:68
+#: ../root/layout/components/TopMenu.js:73
 msgid "All My Edits"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:71
+#: ../root/layout/components/TopMenu.js:76
 msgid "Edits for Subscribed Entities"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:74
+#: ../root/layout/components/TopMenu.js:79
 msgid "Edits by Subscribed Editors"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:77
+#: ../root/layout/components/TopMenu.js:82
 msgid "Notes Left on My Edits"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:86
+#: ../root/layout/components/TopMenu.js:92
 msgid "Admin"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:90
+#: ../root/layout/components/TopMenu.js:98
 msgctxt "button/menu"
 msgid "Add Area"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:97
+#: ../root/layout/components/TopMenu.js:105
 msgctxt "button/menu"
 msgid "Add Instrument"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:100
+#: ../root/layout/components/TopMenu.js:108
 msgid "Edit Relationship Types"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:107
+#: ../root/layout/components/TopMenu.js:115
 msgid "Transclude WikiDocs"
 msgstr ""
 
-#: ../root/layout/components/TopMenu.js:119
+#: ../root/layout/components/TopMenu.js:127
 msgid "Edit Attributes"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AnnotationLinks.js:28
+#: ../root/layout/components/sidebar/AnnotationLinks.js:27
 msgid "Add annotation"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AnnotationLinks.js:34
-#: ../root/static/scripts/common/components/Annotation.js:92
+#: ../root/layout/components/sidebar/AnnotationLinks.js:33
+#: ../root/static/scripts/common/components/Annotation.js:82
 msgid "View annotation history"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AreaSidebar.js:48
+#: ../root/layout/components/sidebar/AreaSidebar.js:47
 msgid "Area information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ArtistSidebar.js:61
+#: ../root/layout/components/sidebar/ArtistSidebar.js:60
 msgid "Artist information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ArtistSidebar.js:140
+#: ../root/layout/components/sidebar/ArtistSidebar.js:139
 msgid "Add recording"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ArtistSidebar.js:158
+#: ../root/layout/components/sidebar/ArtistSidebar.js:157
 msgid "Split into separate artists"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AttendanceLinks.js:27
+#: ../root/layout/components/sidebar/AttendanceLinks.js:30
 msgid "Attendance"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AttendanceLinks.js:30
+#: ../root/layout/components/sidebar/AttendanceLinks.js:33
 msgid "Add to a new list"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AttendanceLinks.js:32
+#: ../root/layout/components/sidebar/AttendanceLinks.js:35
 msgid "You have no attendance lists!"
 msgstr ""
 
-#: ../root/layout/components/sidebar/AttendanceLinks.js:36
+#: ../root/layout/components/sidebar/AttendanceLinks.js:39
 msgid "Found in {num} attendance list"
 msgid_plural "Found in {num} attendance lists"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/layout/components/sidebar/CDStubSidebar.js:49
+#: ../root/layout/components/sidebar/CDStubSidebar.js:50
 msgid "Added:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CDStubSidebar.js:53
+#: ../root/layout/components/sidebar/CDStubSidebar.js:54
 msgid "Last modified:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CDStubSidebar.js:57
+#: ../root/layout/components/sidebar/CDStubSidebar.js:58
 msgid "Lookup count:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CDStubSidebar.js:61
+#: ../root/layout/components/sidebar/CDStubSidebar.js:62
 msgid "Modify count:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CDStubSidebar.js:76
+#: ../root/layout/components/sidebar/CDStubSidebar.js:77
 msgid "Import as MusicBrainz release"
 msgstr ""
 
@@ -11917,76 +10662,76 @@ msgstr ""
 msgid "Search the database for this CD"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionLinks.js:30
+#: ../root/layout/components/sidebar/CollectionLinks.js:33
 msgid "Add to a new collection"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionLinks.js:32
+#: ../root/layout/components/sidebar/CollectionLinks.js:35
 msgid "You have no collections!"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionLinks.js:36
+#: ../root/layout/components/sidebar/CollectionLinks.js:39
 msgid "Found in {num} user collection"
 msgid_plural "Found in {num} user collections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/layout/components/sidebar/CollectionList.js:53
+#: ../root/layout/components/sidebar/CollectionList.js:52
 msgid "Remove from {collection}"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionList.js:57
+#: ../root/layout/components/sidebar/CollectionList.js:56
 msgid "Add to {collection}"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionSidebar.js:29
+#: ../root/layout/components/sidebar/CollectionSidebar.js:27
 msgid "Collection information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionSidebar.js:33
+#: ../root/layout/components/sidebar/CollectionSidebar.js:31
 msgid "Owner:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionSidebar.js:60
-#: ../root/layout/components/sidebar/EditLinks.js:39
+#: ../root/layout/components/sidebar/CollectionSidebar.js:56
+#: ../root/layout/components/sidebar/EditLinks.js:38
 msgid "Editing history"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionSidebar.js:66
-#: ../root/layout/components/sidebar/EditLinks.js:47
+#: ../root/layout/components/sidebar/CollectionSidebar.js:64
+#: ../root/layout/components/sidebar/EditLinks.js:46
 msgid "Log in to edit"
 msgstr ""
 
-#: ../root/layout/components/sidebar/CollectionSidebar.js:84
-#: ../root/layout/components/sidebar/SubscriptionLinks.js:41
+#: ../root/layout/components/sidebar/CollectionSidebar.js:82
+#: ../root/layout/components/sidebar/SubscriptionLinks.js:40
 msgid "Subscribe"
 msgstr ""
 
-#: ../root/layout/components/sidebar/EventSidebar.js:49
+#: ../root/layout/components/sidebar/EventSidebar.js:48
 msgid "Event information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/EventSidebar.js:60
+#: ../root/layout/components/sidebar/EventSidebar.js:59
 msgid "Start Date:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/EventSidebar.js:61
+#: ../root/layout/components/sidebar/EventSidebar.js:60
 msgid "End Date:"
 msgstr ""
 
-#: ../root/layout/components/sidebar/InstrumentSidebar.js:45
+#: ../root/layout/components/sidebar/InstrumentSidebar.js:44
 msgid "Instrument information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/LabelSidebar.js:54
+#: ../root/layout/components/sidebar/LabelSidebar.js:53
 msgid "Label information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/LastUpdated.js:26
+#: ../root/layout/components/sidebar/LastUpdated.js:25
 msgid "Last updated on {date}"
 msgstr ""
 
-#: ../root/layout/components/sidebar/LastUpdated.js:30
+#: ../root/layout/components/sidebar/LastUpdated.js:29
 msgid "Last updated on an unknown date"
 msgstr ""
 
@@ -11994,11 +10739,11 @@ msgstr ""
 msgid "Place information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/RecordingSidebar.js:41
+#: ../root/layout/components/sidebar/RecordingSidebar.js:40
 msgid "Recording information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:48
+#: ../root/layout/components/sidebar/ReleaseGroupSidebar.js:47
 msgid "Release group information"
 msgstr ""
 
@@ -12030,180 +10775,192 @@ msgstr ""
 msgid "Additional details"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:223
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:220
 msgid "Release events"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:231
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:227
 msgid "Release group rating"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:237
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:233
 msgid "Release group reviews"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:257
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:253
 msgid "Release group external links"
 msgstr ""
 
-#: ../root/layout/components/sidebar/ReleaseSidebar.js:263
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:259
 msgid "Edit relationships"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SeriesSidebar.js:45
+#: ../root/layout/components/sidebar/ReleaseSidebar.js:265
+msgid "Change data quality"
+msgstr ""
+
+#: ../root/layout/components/sidebar/SeriesSidebar.js:44
 msgid "Series information"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SidebarLicenses.js:87
+#: ../root/layout/components/sidebar/SidebarLicenses.js:121
 msgid "License"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SidebarRating.js:30
+#: ../root/layout/components/sidebar/SidebarRating.js:29
 msgid "see all ratings"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:547
+#: ../root/layout/components/sidebar/SidebarTags.js:45
+#: ../root/static/scripts/common/components/TagEditor.js:561
 msgctxt "genre"
 msgid "(none)"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SidebarTags.js:46
-#: ../root/static/scripts/common/components/TagEditor.js:557
+#: ../root/layout/components/sidebar/SidebarTags.js:45
+#: ../root/static/scripts/common/components/TagEditor.js:571
 msgctxt "tag"
 msgid "(none)"
 msgstr ""
 
-#: ../root/layout/components/sidebar/SidebarTags.js:93
+#: ../root/layout/components/sidebar/SidebarTags.js:92
 msgid "See all tags"
 msgstr ""
 
-#: ../root/layout/components/sidebar/WorkSidebar.js:57
+#: ../root/layout/components/sidebar/WorkSidebar.js:56
 msgid "Work information"
 msgstr ""
 
-#: ../root/main/404.js:21
+#: ../root/layout/index.js:29
+msgid "Birthday cakes"
+msgstr ""
+
+#: ../root/layout/index.js:114
+msgid "Happy birthday, and thanks for contributing to MusicBrainz!"
+msgstr ""
+
+#: ../root/main/404.js:20
 msgid "Sorry, the page you're looking for does not exist."
 msgstr ""
 
-#: ../root/main/404.js:33
+#: ../root/main/404.js:32
 msgid ""
 "Found a broken link on our site? Please {report|report a bug} and include "
 "any error message that is shown above."
 msgstr ""
 
-#: ../root/main/index.js:32
+#: ../root/main/index.js:31
 msgid "MusicBrainz - The Open Music Encyclopedia"
 msgstr ""
 
-#: ../root/main/index.js:35
+#: ../root/main/index.js:34
 msgid "Welcome to MusicBrainz!"
 msgstr ""
 
-#: ../root/main/index.js:38
+#: ../root/main/index.js:37
 msgid ""
 "MusicBrainz is an open music encyclopedia that collects music metadata and "
 "makes it available to the public."
 msgstr ""
 
-#: ../root/main/index.js:42
+#: ../root/main/index.js:41
 msgid "MusicBrainz aims to be:"
 msgstr ""
 
-#: ../root/main/index.js:47
+#: ../root/main/index.js:46
 msgid ""
 "<strong>The ultimate source of music information</strong> by allowing anyone "
 "to contribute and releasing the {doc|data} under {doc2|open licenses}."
 msgstr ""
 
-#: ../root/main/index.js:53
+#: ../root/main/index.js:52
 msgid ""
 "<strong>The universal lingua franca for music</strong> by providing a "
 "reliable and unambiguous form of {doc|music identification}, enabling both "
 "people and machines to have meaningful conversations about music."
 msgstr ""
 
-#: ../root/main/index.js:60
+#: ../root/main/index.js:59
 msgid ""
 "Like Wikipedia, MusicBrainz is maintained by a global community of users and "
 "we want everyone &#x2014; including you &#x2014; to {doc|participate and "
 "contribute}."
 msgstr ""
 
-#: ../root/main/index.js:66
+#: ../root/main/index.js:65
 msgid ""
 "{about|More Information} &#x2014; {faq|FAQs} &#x2014; {contact|Contact Us}"
 msgstr ""
 
-#: ../root/main/index.js:74
+#: ../root/main/index.js:73
 msgid ""
 "MusicBrainz is operated by the {uri|MetaBrainz Foundation}, a California "
 "based 501(c)(3) tax-exempt non-profit corporation dedicated to keeping "
 "MusicBrainz {free|free and open source}."
 msgstr ""
 
-#: ../root/main/index.js:83
-msgid "MusicBrainz Blog"
+#: ../root/main/index.js:82
+msgid "MetaBrainz Blog"
 msgstr ""
 
-#: ../root/main/index.js:88
+#: ../root/main/index.js:87
 msgid "Latest posts:"
 msgstr ""
 
-#: ../root/main/index.js:100
+#: ../root/main/index.js:99
 msgid "Read more »"
 msgstr ""
 
-#: ../root/main/index.js:107
+#: ../root/main/index.js:106
 msgid "The blog is currently unavailable."
 msgstr ""
 
-#: ../root/main/index.js:116
+#: ../root/main/index.js:115
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../root/main/index.js:125
+#: ../root/main/index.js:124
 msgid "Quick Start"
 msgstr ""
 
-#: ../root/main/index.js:127
+#: ../root/main/index.js:126
 msgid "Beginners guide"
 msgstr ""
 
-#: ../root/main/index.js:128
+#: ../root/main/index.js:127
 msgid "Editing introduction"
 msgstr ""
 
-#: ../root/main/index.js:139
+#: ../root/main/index.js:138
 msgid "Community"
 msgstr ""
 
-#: ../root/main/index.js:141
+#: ../root/main/index.js:140
 msgid "How to Contribute"
 msgstr ""
 
-#: ../root/main/index.js:151
+#: ../root/main/index.js:150
 msgid ""
 "The majority of the data in the <strong>MusicBrainz Database</strong> is "
 "released into the <strong>Public Domain</strong> and can be downloaded and "
 "used <strong>for free</strong>."
 msgstr ""
 
-#: ../root/main/index.js:157
+#: ../root/main/index.js:156
 msgid "Developers"
 msgstr ""
 
-#: ../root/main/index.js:160
+#: ../root/main/index.js:159
 msgid ""
 "Use our <strong>XML web service</strong> or <strong>development libraries</"
 "strong> to create your own MusicBrainz-enabled applications."
 msgstr ""
 
-#: ../root/main/index.js:167
+#: ../root/main/index.js:166
 msgid "Recent Additions"
 msgstr ""
 
-#: ../root/main/index.js:170
+#: ../root/main/index.js:169
 msgid ""
 "Cover art on the homepage is disabled for Chrome-based browsers, which are "
 "known to issue an incorrect phishing warning since the 11th of November "
@@ -12213,70 +10970,84 @@ msgid ""
 "inconvenience!"
 msgstr ""
 
-#: ../root/otherlookup/NotFound.js:16
+#: ../root/otherlookup/NotFound.js:15
 msgid "Entity Not Found"
 msgstr ""
 
-#: ../root/otherlookup/NotFound.js:18
+#: ../root/otherlookup/NotFound.js:17
 msgid ""
 "Sorry, we could not find a MusicBrainz entity with that ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/place/NotFound.js:16
+#: ../root/place/NotFound.js:15
 msgid "Place Not Found"
 msgstr ""
 
-#: ../root/place/NotFound.js:18
+#: ../root/place/NotFound.js:17
 msgid ""
 "Sorry, we could not find a place with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/recording/NotFound.js:16
+#: ../root/place/PlaceEvents.js:55
+msgid "This place is not currently associated with any events."
+msgstr ""
+
+#: ../root/recording/NotFound.js:15
 msgid "Recording Not Found"
 msgstr ""
 
-#: ../root/recording/NotFound.js:18
+#: ../root/recording/NotFound.js:17
 msgid ""
 "Sorry, we could not find a recording with that MusicBrainz ID. You may wish "
 "to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/recording/RecordingHeader.js:38
+#: ../root/recording/RecordingHeader.js:37
 msgid "Video by {artist}"
 msgstr ""
 
-#: ../root/recording/RecordingHeader.js:38
+#: ../root/recording/RecordingHeader.js:37
 msgid "Recording by {artist}"
 msgstr ""
 
-#: ../root/relationship/linkattributetype/NotFound.js:18
+#: ../root/relationship/linkattributetype/NotFound.js:17
 msgid ""
 "Sorry, we could not find a relationship attribute with that MusicBrainz ID."
 msgstr ""
 
-#: ../root/release/NotFound.js:16
+#: ../root/release/NotFound.js:15
 msgid "Release Not Found"
 msgstr ""
 
-#: ../root/release/NotFound.js:18
+#: ../root/release/NotFound.js:17
 msgid ""
 "Sorry, we could not find a release with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/release_group/NotFound.js:16
+#: ../root/release/ReleaseHeader.js:32
+msgid "see all versions of this release, {count} available"
+msgid_plural "see all versions of this release, {count} available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/release/ReleaseHeader.js:39
+msgid "Release by {artist}"
+msgstr ""
+
+#: ../root/release_group/NotFound.js:15
 msgid "Release Group Not Found"
 msgstr ""
 
-#: ../root/release_group/NotFound.js:18
+#: ../root/release_group/NotFound.js:17
 msgid ""
 "Sorry, we could not find a release group with that MusicBrainz ID. You may "
 "wish to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/release_group/ReleaseGroupHeader.js:33
+#: ../root/release_group/ReleaseGroupHeader.js:32
 msgid "Release group by {artist}"
 msgstr ""
 
@@ -12289,67 +11060,292 @@ msgstr ""
 msgid "This report lists artists with annotations."
 msgstr ""
 
-#: ../root/report/AnnotationsArtists.js:36
-#: ../root/report/ArtistsContainingDisambiguationComments.js:37
-#: ../root/report/ArtistsDisambiguationSameName.js:37
-#: ../root/report/ArtistsThatMayBeGroups.js:40
-#: ../root/report/ArtistsThatMayBePersons.js:40
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:40
+#: ../root/report/AnnotationsArtists.js:38
+#: ../root/report/ArtistsContainingDisambiguationComments.js:41
+#: ../root/report/ArtistsDisambiguationSameName.js:41
+#: ../root/report/ArtistsThatMayBeGroups.js:41
+#: ../root/report/ArtistsThatMayBePersons.js:41
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:42
 #: ../root/report/ArtistsWithNoSubscribers.js:38
-#: ../root/report/CollaborationRelationships.js:44
-#: ../root/report/DeprecatedRelationshipArtists.js:36
-#: ../root/report/DiscogsLinksWithMultipleArtists.js:36
-#: ../root/report/DuplicateRelationshipsArtists.js:37
-#: ../root/report/PossibleCollaborations.js:42
+#: ../root/report/CollaborationRelationships.js:48
+#: ../root/report/DeprecatedRelationshipArtists.js:37
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:37
+#: ../root/report/DuplicateRelationshipsArtists.js:42
+#: ../root/report/PossibleCollaborations.js:45
 msgid "Total artists found: {count}"
 msgstr ""
 
-#: ../root/report/ArtistsContainingDisambiguationComments.js:29
+#: ../root/report/AnnotationsArtists.js:42
+#: ../root/report/AnnotationsLabels.js:42
+#: ../root/report/AnnotationsPlaces.js:42
+#: ../root/report/AnnotationsRecordings.js:42
+#: ../root/report/AnnotationsReleaseGroups.js:42
+#: ../root/report/AnnotationsReleases.js:42
+#: ../root/report/AnnotationsSeries.js:42 ../root/report/AnnotationsWorks.js:42
+#: ../root/report/ArtistsContainingDisambiguationComments.js:45
+#: ../root/report/ArtistsDisambiguationSameName.js:45
+#: ../root/report/ArtistsThatMayBeGroups.js:45
+#: ../root/report/ArtistsThatMayBePersons.js:45
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:46
+#: ../root/report/ArtistsWithNoSubscribers.js:42
+#: ../root/report/AsinsWithMultipleReleases.js:51
+#: ../root/report/BadAmazonUrls.js:48 ../root/report/CatNoLooksLikeAsin.js:51
+#: ../root/report/CollaborationRelationships.js:52
+#: ../root/report/CoverArtRelationships.js:41
+#: ../root/report/DeprecatedRelationshipArtists.js:41
+#: ../root/report/DeprecatedRelationshipLabels.js:41
+#: ../root/report/DeprecatedRelationshipPlaces.js:41
+#: ../root/report/DeprecatedRelationshipRecordings.js:41
+#: ../root/report/DeprecatedRelationshipReleaseGroups.js:41
+#: ../root/report/DeprecatedRelationshipReleases.js:41
+#: ../root/report/DeprecatedRelationshipUrls.js:41
+#: ../root/report/DeprecatedRelationshipWorks.js:41
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:41
+#: ../root/report/DiscogsLinksWithMultipleLabels.js:41
+#: ../root/report/DiscogsLinksWithMultipleReleaseGroups.js:44
+#: ../root/report/DiscogsLinksWithMultipleReleases.js:49
+#: ../root/report/DuplicateArtists.js:60 ../root/report/DuplicateEvents.js:43
+#: ../root/report/DuplicateRelationshipsArtists.js:46
+#: ../root/report/DuplicateRelationshipsLabels.js:41
+#: ../root/report/DuplicateRelationshipsRecordings.js:44
+#: ../root/report/DuplicateRelationshipsReleaseGroups.js:44
+#: ../root/report/DuplicateRelationshipsReleases.js:44
+#: ../root/report/DuplicateRelationshipsWorks.js:43
+#: ../root/report/DuplicateReleaseGroups.js:50
+#: ../root/report/EventSequenceNotInSeries.js:44
+#: ../root/report/FeaturingRecordings.js:55
+#: ../root/report/FeaturingReleaseGroups.js:54
+#: ../root/report/FeaturingReleases.js:53
+#: ../root/report/InstrumentsWithoutAnImage.js:38
+#: ../root/report/IsrcsWithManyRecordings.js:61
+#: ../root/report/IswcsWithManyWorks.js:52
+#: ../root/report/LabelsDisambiguationSameName.js:45
+#: ../root/report/LimitedEditors.js:38
+#: ../root/report/MediumsWithSequenceIssues.js:41
+#: ../root/report/MultipleAsins.js:45 ../root/report/MultipleDiscogsLinks.js:49
+#: ../root/report/NoLanguage.js:43 ../root/report/NoScript.js:42
+#: ../root/report/PartOfSetRelationships.js:49
+#: ../root/report/PlacesWithoutCoordinates.js:44
+#: ../root/report/PossibleCollaborations.js:49
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:62
+#: ../root/report/RecordingsWithEarliestReleaseRelationships.js:48
+#: ../root/report/RecordingsWithVaryingTrackLengths.js:41
+#: ../root/report/RecordingsWithoutVaCredit.js:46
+#: ../root/report/RecordingsWithoutVaLink.js:46
+#: ../root/report/ReleaseGroupsWithoutVaCredit.js:47
+#: ../root/report/ReleaseGroupsWithoutVaLink.js:47
+#: ../root/report/ReleaseLabelSameArtist.js:55
+#: ../root/report/ReleasedTooEarly.js:44
+#: ../root/report/ReleasesInCaaWithCoverArtRelationships.js:49
+#: ../root/report/ReleasesMissingDiscIds.js:47
+#: ../root/report/ReleasesToConvert.js:46
+#: ../root/report/ReleasesWithCaaNoTypes.js:49
+#: ../root/report/ReleasesWithDownloadRelationships.js:46
+#: ../root/report/ReleasesWithNoMediums.js:40
+#: ../root/report/ReleasesWithUnlikelyLanguageScript.js:41
+#: ../root/report/ReleasesWithoutVaCredit.js:46
+#: ../root/report/ReleasesWithoutVaLink.js:46
+#: ../root/report/SeparateDiscs.js:46 ../root/report/SetInDifferentRg.js:49
+#: ../root/report/SingleMediumReleasesWithMediumTitles.js:45
+#: ../root/report/SomeFormatsUnset.js:43
+#: ../root/report/SuperfluousDataTracks.js:51
+#: ../root/report/TracksNamedWithSequence.js:47
+#: ../root/report/TracksWithSequenceIssues.js:42
+#: ../root/report/TracksWithoutTimes.js:41
+#: ../root/report/UnlinkedPseudoReleases.js:43
+msgid "Generated on {date}"
+msgstr ""
+
+#: ../root/report/AnnotationsLabels.js:29
+#: ../root/report/AnnotationsLabels.js:30
+msgid "Label annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsLabels.js:34
+msgid "This report lists labels with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsLabels.js:38
+#: ../root/report/DeprecatedRelationshipLabels.js:37
+#: ../root/report/DiscogsLinksWithMultipleLabels.js:37
+#: ../root/report/DuplicateRelationshipsLabels.js:37
+#: ../root/report/LabelsDisambiguationSameName.js:41
+msgid "Total labels found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsPlaces.js:29
+#: ../root/report/AnnotationsPlaces.js:30
+msgid "Place annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsPlaces.js:34
+msgid "This report lists places with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsPlaces.js:38
+#: ../root/report/DeprecatedRelationshipPlaces.js:37
+#: ../root/report/PlacesWithoutCoordinates.js:40
+msgid "Total places found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsRecordings.js:29
+#: ../root/report/AnnotationsRecordings.js:30
+msgid "Recording annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsRecordings.js:34
+msgid "This report lists recordings with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsRecordings.js:38
+#: ../root/report/DeprecatedRelationshipRecordings.js:37
+#: ../root/report/DuplicateRelationshipsRecordings.js:40
+#: ../root/report/FeaturingRecordings.js:51
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:58
+#: ../root/report/RecordingsWithEarliestReleaseRelationships.js:44
+#: ../root/report/RecordingsWithVaryingTrackLengths.js:37
+#: ../root/report/RecordingsWithoutVaCredit.js:42
+#: ../root/report/RecordingsWithoutVaLink.js:42
+msgid "Total recordings found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsReleaseGroups.js:29
+#: ../root/report/AnnotationsReleaseGroups.js:30
+msgid "Release group annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsReleaseGroups.js:34
+msgid "This report lists release groups with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsReleaseGroups.js:38
+#: ../root/report/DeprecatedRelationshipReleaseGroups.js:37
+#: ../root/report/DiscogsLinksWithMultipleReleaseGroups.js:40
+#: ../root/report/DuplicateRelationshipsReleaseGroups.js:40
+#: ../root/report/DuplicateReleaseGroups.js:46
+#: ../root/report/FeaturingReleaseGroups.js:50
+#: ../root/report/ReleaseGroupsWithoutVaCredit.js:43
+#: ../root/report/ReleaseGroupsWithoutVaLink.js:43
+#: ../root/report/SetInDifferentRg.js:45
+msgid "Total release groups found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsReleases.js:29
+#: ../root/report/AnnotationsReleases.js:30
+msgid "Release annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsReleases.js:34
+msgid "This report lists releases with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsReleases.js:38
+#: ../root/report/AsinsWithMultipleReleases.js:47
+#: ../root/report/BadAmazonUrls.js:44 ../root/report/CatNoLooksLikeAsin.js:47
+#: ../root/report/CoverArtRelationships.js:37
+#: ../root/report/DeprecatedRelationshipReleases.js:37
+#: ../root/report/DiscogsLinksWithMultipleReleases.js:45
+#: ../root/report/DuplicateRelationshipsReleases.js:40
+#: ../root/report/FeaturingReleases.js:49
+#: ../root/report/MediumsWithSequenceIssues.js:37
+#: ../root/report/MultipleAsins.js:41 ../root/report/MultipleDiscogsLinks.js:45
+#: ../root/report/NoLanguage.js:39 ../root/report/NoScript.js:38
+#: ../root/report/PartOfSetRelationships.js:45
+#: ../root/report/ReleaseLabelSameArtist.js:51
+#: ../root/report/ReleasedTooEarly.js:40
+#: ../root/report/ReleasesInCaaWithCoverArtRelationships.js:45
+#: ../root/report/ReleasesMissingDiscIds.js:43
+#: ../root/report/ReleasesToConvert.js:42
+#: ../root/report/ReleasesWithCaaNoTypes.js:45
+#: ../root/report/ReleasesWithDownloadRelationships.js:42
+#: ../root/report/ReleasesWithNoMediums.js:36
+#: ../root/report/ReleasesWithUnlikelyLanguageScript.js:37
+#: ../root/report/ReleasesWithoutVaCredit.js:42
+#: ../root/report/ReleasesWithoutVaLink.js:42
+#: ../root/report/SeparateDiscs.js:42
+#: ../root/report/SingleMediumReleasesWithMediumTitles.js:41
+#: ../root/report/SomeFormatsUnset.js:39
+#: ../root/report/SuperfluousDataTracks.js:47
+#: ../root/report/TracksNamedWithSequence.js:43
+#: ../root/report/TracksWithSequenceIssues.js:38
+#: ../root/report/TracksWithoutTimes.js:37
+#: ../root/report/UnlinkedPseudoReleases.js:39
+msgid "Total releases found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsSeries.js:29
+#: ../root/report/AnnotationsSeries.js:30
+msgid "Series annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsSeries.js:34
+msgid "This report lists series with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsSeries.js:38
+msgid "Total series found: {count}"
+msgstr ""
+
+#: ../root/report/AnnotationsWorks.js:29 ../root/report/AnnotationsWorks.js:30
+msgid "Work annotations"
+msgstr ""
+
+#: ../root/report/AnnotationsWorks.js:34
+msgid "This report lists works with annotations."
+msgstr ""
+
+#: ../root/report/AnnotationsWorks.js:38
+#: ../root/report/DeprecatedRelationshipWorks.js:37
+#: ../root/report/DuplicateRelationshipsWorks.js:39
+msgid "Total works found: {count}"
+msgstr ""
+
 #: ../root/report/ArtistsContainingDisambiguationComments.js:30
-#: ../root/report/ReportsIndex.js:39
+#: ../root/report/ArtistsContainingDisambiguationComments.js:32
+#: ../root/report/ReportsIndex.js:66
 msgid "Artists containing disambiguation comments in their name"
 msgstr ""
 
-#: ../root/report/ArtistsContainingDisambiguationComments.js:34
+#: ../root/report/ArtistsContainingDisambiguationComments.js:36
 msgid ""
 "This report lists artists that may have disambiguation comments in their "
 "name, rather than the actual disambiguation comment field."
 msgstr ""
 
-#: ../root/report/ArtistsDisambiguationSameName.js:29
 #: ../root/report/ArtistsDisambiguationSameName.js:30
-#: ../root/report/ReportsIndex.js:45
+#: ../root/report/ArtistsDisambiguationSameName.js:32
+#: ../root/report/ReportsIndex.js:96
 msgid "Artists with disambiguation the same as the name"
 msgstr ""
 
-#: ../root/report/ArtistsDisambiguationSameName.js:34
+#: ../root/report/ArtistsDisambiguationSameName.js:36
 msgid ""
 "This report lists artists that have their disambiguation set to be the same "
 "as their name. Disambiguation should not be filled in this case."
 msgstr ""
 
+#: ../root/report/ArtistsThatMayBeGroups.js:28
 #: ../root/report/ArtistsThatMayBeGroups.js:29
-#: ../root/report/ArtistsThatMayBeGroups.js:30
-#: ../root/report/ReportsIndex.js:33
+#: ../root/report/ReportsIndex.js:36
 msgid "Artists that may be groups"
 msgstr ""
 
-#: ../root/report/ArtistsThatMayBeGroups.js:34
+#: ../root/report/ArtistsThatMayBeGroups.js:33
 msgid ""
 "This report lists artists that have their type set to other than Group (or a "
 "subtype of Group) but may be a group, because they have other artists listed "
-"as members If you find that an artist here is indeed a group, change its "
-"type. If it is not, please make sure that the \"member of\" relationships "
-"are in the right direction and are correct."
+"as members. If you find that an artist here is indeed a group, change its "
+"type. If it is not, please make sure that the “member of” relationships are "
+"in the right direction and are correct."
 msgstr ""
 
+#: ../root/report/ArtistsThatMayBePersons.js:28
 #: ../root/report/ArtistsThatMayBePersons.js:29
-#: ../root/report/ArtistsThatMayBePersons.js:30
-#: ../root/report/ReportsIndex.js:34
+#: ../root/report/ReportsIndex.js:41
 msgid "Artists that may be persons"
 msgstr ""
 
-#: ../root/report/ArtistsThatMayBePersons.js:34
+#: ../root/report/ArtistsThatMayBePersons.js:33
 msgid ""
 "This report lists artists that have their type set to other than Person, but "
 "may be a person, based on their relationships. For example, an artist will "
@@ -12359,32 +11355,73 @@ msgid ""
 msgstr ""
 
 #: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:32
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:33
-#: ../root/report/ReportsIndex.js:42
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:34
+#: ../root/report/ReportsIndex.js:81
 msgid "Artists occurring multiple times in the same artist credit"
 msgstr ""
 
-#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:37
+#: ../root/report/ArtistsWithMultipleOccurrencesInArtistCredits.js:38
 msgid ""
 "This report lists artists that appear more than once in different positions "
 "within the same artist credit."
 msgstr ""
 
+#: ../root/report/ArtistsWithNoSubscribers.js:28
 #: ../root/report/ArtistsWithNoSubscribers.js:29
-#: ../root/report/ArtistsWithNoSubscribers.js:30
-#: ../root/report/ReportsIndex.js:35
+#: ../root/report/ReportsIndex.js:46
 msgid "Artists with no subscribers"
 msgstr ""
 
-#: ../root/report/ArtistsWithNoSubscribers.js:34
+#: ../root/report/ArtistsWithNoSubscribers.js:33
 msgid ""
 "This report lists artists that have no editors subscribed to them, and whose "
 "changes may therefore be under-reviewed. Artists with more release groups "
 "and more open edits are listed first."
 msgstr ""
 
+#: ../root/report/AsinsWithMultipleReleases.js:28
+#: ../root/report/AsinsWithMultipleReleases.js:29
+#: ../root/report/ReportsIndex.js:257
+msgid "Amazon URLs linked to multiple releases"
+msgstr ""
+
+#: ../root/report/AsinsWithMultipleReleases.js:34
+msgid ""
+"This report shows Amazon URLs which are linked to multiple releases. In most "
+"cases Amazon ASINs should map to MusicBrainz releases 1:1, so only one of "
+"the links will be correct. Just check which MusicBrainz release fits the "
+"release in Amazon (look at the format, tracklist, etc). If the release has a "
+"barcode, you can also search Amazon for it and see which ASIN matches. You "
+"might also find some ASINs linked to several discs of a multi-disc release: "
+"just merge those (see {how_to_merge_releases|How to Merge Releases})."
+msgstr ""
+
+#: ../root/report/BadAmazonUrls.js:33 ../root/report/BadAmazonUrls.js:34
+msgid "Bad Amazon URLs"
+msgstr ""
+
+#: ../root/report/BadAmazonUrls.js:38
+msgid ""
+"This report shows releases with Amazon URLs which don't follow the expected "
+"format. They might still be correct if they're archive.org cover links, but "
+"in any other case they should probably be fixed or removed."
+msgstr ""
+
+#: ../root/report/CatNoLooksLikeAsin.js:35
+#: ../root/report/CatNoLooksLikeAsin.js:37 ../root/report/ReportsIndex.js:308
+msgid "Releases with catalog numbers that look like ASINs"
+msgstr ""
+
+#: ../root/report/CatNoLooksLikeAsin.js:41
+msgid ""
+"This report shows releases which have catalog numbers that look like ASINs. "
+"This is almost always wrong: ASINs are just Amazon's entries for the "
+"releases and should be linked to the release with an Amazon URL relationship "
+"instead."
+msgstr ""
+
+#: ../root/report/CollaborationRelationships.js:33
 #: ../root/report/CollaborationRelationships.js:34
-#: ../root/report/CollaborationRelationships.js:35
 msgid "Artists with collaboration relationships"
 msgstr ""
 
@@ -12396,42 +11433,177 @@ msgid ""
 "probably split it. See {how_to_split_artists|How to Split Artists}."
 msgstr ""
 
-#: ../root/report/CollaborationRelationships.js:54
+#: ../root/report/CollaborationRelationships.js:63
 msgid "Collaboration"
 msgstr ""
 
-#: ../root/report/CollaborationRelationships.js:55
+#: ../root/report/CollaborationRelationships.js:64
 msgid "Collaborator"
 msgstr ""
 
+#: ../root/report/CoverArtRelationships.js:28
+#: ../root/report/CoverArtRelationships.js:29
+msgid "Releases with cover art relationships"
+msgstr ""
+
+#: ../root/report/CoverArtRelationships.js:33
+msgid "This report shows releases that still have cover art relationships."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipArtists.js:28
 #: ../root/report/DeprecatedRelationshipArtists.js:29
-#: ../root/report/DeprecatedRelationshipArtists.js:30
-#: ../root/report/ReportsIndex.js:43
+#: ../root/report/ReportsIndex.js:86
 msgid "Artists with deprecated relationships"
 msgstr ""
 
-#: ../root/report/DeprecatedRelationshipArtists.js:34
+#: ../root/report/DeprecatedRelationshipArtists.js:33
 msgid ""
 "This report lists artists which have relationships using deprecated and "
-"grouping-only relationship types"
+"grouping-only relationship types."
 msgstr ""
 
+#: ../root/report/DeprecatedRelationshipLabels.js:28
+#: ../root/report/DeprecatedRelationshipLabels.js:29
+#: ../root/report/ReportsIndex.js:155
+msgid "Labels with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipLabels.js:33
+msgid ""
+"This report lists labels which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipPlaces.js:28
+#: ../root/report/DeprecatedRelationshipPlaces.js:29
+#: ../root/report/ReportsIndex.js:460
+msgid "Places with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipPlaces.js:33
+msgid ""
+"This report lists places which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipRecordings.js:28
+#: ../root/report/DeprecatedRelationshipRecordings.js:29
+#: ../root/report/ReportsIndex.js:427
+msgid "Recordings with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipRecordings.js:33
+msgid ""
+"This report lists recordings which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipReleaseGroups.js:28
+#: ../root/report/DeprecatedRelationshipReleaseGroups.js:29
+#: ../root/report/ReportsIndex.js:195
+msgid "Release groups with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipReleaseGroups.js:33
+msgid ""
+"This report lists release groups which have relationships using deprecated "
+"and grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipReleases.js:28
+#: ../root/report/DeprecatedRelationshipReleases.js:29
+#: ../root/report/ReportsIndex.js:367
+msgid "Releases with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipReleases.js:33
+msgid ""
+"This report lists releases which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipUrls.js:28
+#: ../root/report/DeprecatedRelationshipUrls.js:29
+#: ../root/report/ReportsIndex.js:510
+msgid "URLs with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipUrls.js:33
+msgid ""
+"This report lists URLs which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipUrls.js:37
+msgid "Total URLs found: {count}"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipWorks.js:28
+#: ../root/report/DeprecatedRelationshipWorks.js:29
+#: ../root/report/ReportsIndex.js:495
+msgid "Works with deprecated relationships"
+msgstr ""
+
+#: ../root/report/DeprecatedRelationshipWorks.js:33
+msgid ""
+"This report lists works which have relationships using deprecated and "
+"grouping-only relationship types."
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:28
 #: ../root/report/DiscogsLinksWithMultipleArtists.js:29
-#: ../root/report/DiscogsLinksWithMultipleArtists.js:30
-#: ../root/report/ReportsIndex.js:40
+#: ../root/report/ReportsIndex.js:71
 msgid "Discogs URLs linked to multiple artists"
 msgstr ""
 
-#: ../root/report/DiscogsLinksWithMultipleArtists.js:34
+#: ../root/report/DiscogsLinksWithMultipleArtists.js:33
 msgid "This report shows Discogs URLs which are linked to multiple artists."
 msgstr ""
 
-#: ../root/report/DuplicateArtists.js:38 ../root/report/DuplicateArtists.js:39
-#: ../root/report/ReportsIndex.js:36
+#: ../root/report/DiscogsLinksWithMultipleLabels.js:28
+#: ../root/report/DiscogsLinksWithMultipleLabels.js:29
+#: ../root/report/ReportsIndex.js:145
+msgid "Discogs URLs linked to multiple labels"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleLabels.js:33
+msgid "This report shows Discogs URLs which are linked to multiple labels."
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleReleaseGroups.js:30
+#: ../root/report/DiscogsLinksWithMultipleReleaseGroups.js:32
+#: ../root/report/ReportsIndex.js:185
+msgid "Discogs URLs linked to multiple release groups"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleReleaseGroups.js:36
+msgid ""
+"This report shows Discogs URLs which are linked to multiple release groups."
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleReleases.js:28
+#: ../root/report/DiscogsLinksWithMultipleReleases.js:29
+#: ../root/report/ReportsIndex.js:262
+msgid "Discogs URLs linked to multiple releases"
+msgstr ""
+
+#: ../root/report/DiscogsLinksWithMultipleReleases.js:34
+msgid ""
+"This report shows Discogs URLs which are linked to multiple releases. In "
+"most cases Discogs releases should map to MusicBrainz releases 1:1, so only "
+"one of the links will be correct. Just check which MusicBrainz release fits "
+"the release in Discogs (look at the format, tracklist, release country, "
+"etc.). You might also find some Discogs URLs linked to several discs of a "
+"multi-disc release: just merge those (see {how_to_merge_releases|How to "
+"Merge Releases})."
+msgstr ""
+
+#: ../root/report/DuplicateArtists.js:36 ../root/report/DuplicateArtists.js:37
+#: ../root/report/ReportsIndex.js:51
 msgid "Possibly duplicate artists"
 msgstr ""
 
-#: ../root/report/DuplicateArtists.js:43
+#: ../root/report/DuplicateArtists.js:42
 msgid ""
 "This report aims to identify artists with very similar names. If two artists "
 "are actually the same, please merge them (remember to "
@@ -12441,25 +11613,41 @@ msgid ""
 "comments, they will stop appearing here)."
 msgstr ""
 
-#: ../root/report/DuplicateArtists.js:54
+#: ../root/report/DuplicateArtists.js:56
 msgid "Total duplicate groups: {count}"
 msgstr ""
 
-#: ../root/report/DuplicateArtists.js:90
+#: ../root/report/DuplicateArtists.js:97
 msgid "alias:"
 msgstr ""
 
-#: ../root/report/DuplicateArtists.js:103
+#: ../root/report/DuplicateArtists.js:110
 msgid "Add selected artists for merging"
 msgstr ""
 
-#: ../root/report/DuplicateRelationshipsArtists.js:29
+#: ../root/report/DuplicateEvents.js:28 ../root/report/DuplicateEvents.js:29
+msgid "Possible duplicate events"
+msgstr ""
+
+#: ../root/report/DuplicateEvents.js:33
+msgid ""
+"This report lists events happening at the same place on the same date. If "
+"there are duplicates (for example, if there are separate events for "
+"headliner and supporting artist) please merge them."
+msgstr ""
+
+#: ../root/report/DuplicateEvents.js:39
+#: ../root/report/EventSequenceNotInSeries.js:40
+msgid "Total events found: {count}"
+msgstr ""
+
 #: ../root/report/DuplicateRelationshipsArtists.js:30
-#: ../root/report/ReportsIndex.js:41
+#: ../root/report/DuplicateRelationshipsArtists.js:32
+#: ../root/report/ReportsIndex.js:76
 msgid "Artists with possible duplicate relationships"
 msgstr ""
 
-#: ../root/report/DuplicateRelationshipsArtists.js:34
+#: ../root/report/DuplicateRelationshipsArtists.js:36
 msgid ""
 "This report lists artists which have multiple relatonships to the same "
 "artist, label or URL using the same relationship type. For multiple "
@@ -12467,29 +11655,317 @@ msgid ""
 "those entities."
 msgstr ""
 
+#: ../root/report/DuplicateRelationshipsLabels.js:28
+#: ../root/report/DuplicateRelationshipsLabels.js:29
+#: ../root/report/ReportsIndex.js:150
+msgid "Labels with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsLabels.js:33
+msgid ""
+"This report lists labels which have multiple relationships to the same "
+"entity using the same relationship type."
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsRecordings.js:30
+#: ../root/report/DuplicateRelationshipsRecordings.js:32
+#: ../root/report/ReportsIndex.js:417
+msgid "Recordings with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsRecordings.js:36
+msgid ""
+"This report lists recordings which have multiple relationships to the same "
+"entity using the same relationship type."
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsReleaseGroups.js:30
+#: ../root/report/DuplicateRelationshipsReleaseGroups.js:32
+#: ../root/report/ReportsIndex.js:190
+msgid "Release groups with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsReleaseGroups.js:36
+msgid ""
+"This report lists release groups which have multiple relationships to the "
+"same entity using the same relationship type."
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsReleases.js:30
+#: ../root/report/DuplicateRelationshipsReleases.js:32
+#: ../root/report/ReportsIndex.js:352
+msgid "Releases with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsReleases.js:36
+msgid ""
+"This report lists releases which have multiple relationships to the same "
+"entity using the same relationship type."
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsWorks.js:28
+#: ../root/report/DuplicateRelationshipsWorks.js:29
+#: ../root/report/ReportsIndex.js:490
+msgid "Works with possible duplicate relationships"
+msgstr ""
+
+#: ../root/report/DuplicateRelationshipsWorks.js:33
+msgid ""
+"This report lists works which have multiple relationships to the same entity "
+"using the same relationship type. This excludes recording-work "
+"relationships. See the recording version of this report for those."
+msgstr ""
+
+#: ../root/report/DuplicateReleaseGroups.js:28
+#: ../root/report/DuplicateReleaseGroups.js:29
+#: ../root/report/ReportsIndex.js:200
+msgid "Possible duplicate release groups"
+msgstr ""
+
+#: ../root/report/DuplicateReleaseGroups.js:34
+msgid ""
+"This report lists release groups with very similar names and artists. If the "
+"releases in the release groups should be grouped together (see the {url|"
+"guidelines}), they can be merged. If they shouldn't be grouped together but "
+"they can be distinguished by the release group types, e.g. when an artist "
+"has an album and single with the same name, then there is usually no need to "
+"change anything. In other cases, a disambiguation comment may be helpful."
+msgstr ""
+
+#: ../root/report/EventSequenceNotInSeries.js:30
+#: ../root/report/EventSequenceNotInSeries.js:32
+#: ../root/report/ReportsIndex.js:125
+msgid "Events which should be part of series or larger event"
+msgstr ""
+
+#: ../root/report/EventSequenceNotInSeries.js:36
+msgid ""
+"This report lists events where the event name indicates that it may have to "
+"be part of a series or a larger event."
+msgstr ""
+
+#: ../root/report/FeaturingRecordings.js:30
+#: ../root/report/FeaturingRecordings.js:32 ../root/report/ReportsIndex.js:412
+msgid "Recordings with titles containing featuring artists"
+msgstr ""
+
+#: ../root/report/FeaturingRecordings.js:37
+msgid ""
+"This report shows recordings with (feat. Artist) in the title. For classical "
+"recordings, consult the {CSG|classical style guidelines}. For non-classical "
+"recordings, this is inherited from an older version of MusicBrainz and "
+"should be fixed (both on the recordings and on the tracks!). Consult the "
+"{featured_artists|page about featured artists} to know more."
+msgstr ""
+
+#: ../root/report/FeaturingReleaseGroups.js:30
+#: ../root/report/FeaturingReleaseGroups.js:32
+#: ../root/report/ReportsIndex.js:180
+msgid "Release groups with titles containing featuring artists"
+msgstr ""
+
+#: ../root/report/FeaturingReleaseGroups.js:37
+msgid ""
+"This report shows release groups with (feat. Artist) in the title. For "
+"classical release groups, consult the {CSG|classical style guidelines}. For "
+"non-classical release groups, this is inherited from an older version of "
+"MusicBrainz and should be fixed. Consult the {featured_artists|page about "
+"featured artists} to know more."
+msgstr ""
+
+#: ../root/report/FeaturingReleases.js:30
+#: ../root/report/FeaturingReleases.js:32 ../root/report/ReportsIndex.js:292
+msgid "Releases with titles containing featuring artists"
+msgstr ""
+
+#: ../root/report/FeaturingReleases.js:37
+msgid ""
+"This report shows releases with (feat. Artist) in the title. For classical "
+"releases, consult the {CSG|classical style guidelines}. For non-classical "
+"releases, this is inherited from an older version of MusicBrainz and should "
+"be fixed. Consult the {featured_artists|page about featured artists} to know "
+"more."
+msgstr ""
+
 #: ../root/report/FilterLink.js:24
 msgid "Show all results."
 msgstr ""
 
-#: ../root/report/FilterLink.js:26
+#: ../root/report/FilterLink.js:28
 msgid "Show only results that are in my subscribed entities."
 msgstr ""
 
-#: ../root/report/LimitedEditors.js:28 ../root/report/LimitedEditors.js:29
-#: ../root/report/ReportsIndex.js:53
+#: ../root/report/InstrumentsWithoutAnImage.js:25
+#: ../root/report/InstrumentsWithoutAnImage.js:26
+#: ../root/report/ReportsIndex.js:135
+msgid "Instruments without an image"
+msgstr ""
+
+#: ../root/report/InstrumentsWithoutAnImage.js:30
+msgid ""
+"This report shows instruments without image relationships nor Wikidata "
+"relationships."
+msgstr ""
+
+#: ../root/report/InstrumentsWithoutAnImage.js:34
+msgid "Total instruments found: {count}"
+msgstr ""
+
+#: ../root/report/IsrcsWithManyRecordings.js:38
+#: ../root/report/IsrcsWithManyRecordings.js:39
+#: ../root/report/ReportsIndex.js:521
+msgid "ISRCs with multiple recordings"
+msgstr ""
+
+#: ../root/report/IsrcsWithManyRecordings.js:44
+msgid ""
+"This report lists {isrc|ISRCs} that are attached to more than one recording. "
+"If the recordings are the same, this usually means they should be merged "
+"(ISRCs can be wrongly assigned so care should still be taken to make sure "
+"they really are the same). If the recordings are parts of a larger "
+"recording, the ISRCs are probably correct and should be left alone. If the "
+"same ISRC appears on two unrelated recordings on the same release, this is "
+"usually means there was an error when reading the disc."
+msgstr ""
+
+#: ../root/report/IsrcsWithManyRecordings.js:57
+msgid "Total ISRCs found: {count}"
+msgstr ""
+
+#: ../root/report/IswcsWithManyWorks.js:35
+#: ../root/report/IswcsWithManyWorks.js:36 ../root/report/ReportsIndex.js:531
+msgid "ISWCs with multiple works"
+msgstr ""
+
+#: ../root/report/IswcsWithManyWorks.js:41
+msgid ""
+"This report lists {iswc|ISWCs} that are attached to more than one work. If "
+"the works are the same, this usually means they should be merged."
+msgstr ""
+
+#: ../root/report/IswcsWithManyWorks.js:48
+msgid "Total ISWCs found: {count}"
+msgstr ""
+
+#: ../root/report/LabelsDisambiguationSameName.js:30
+#: ../root/report/LabelsDisambiguationSameName.js:32
+#: ../root/report/ReportsIndex.js:165
+msgid "Labels with disambiguation the same as the name"
+msgstr ""
+
+#: ../root/report/LabelsDisambiguationSameName.js:36
+msgid ""
+"This report lists labels that have their disambiguation set to be the same "
+"as their name. Disambiguation should not be filled in this case."
+msgstr ""
+
+#: ../root/report/LimitedEditors.js:25 ../root/report/LimitedEditors.js:26
+#: ../root/report/ReportsIndex.js:108
 msgid "Beginner/limited editors"
 msgstr ""
 
-#: ../root/report/LimitedEditors.js:33
+#: ../root/report/LimitedEditors.js:30
 msgid "This report lists {url|beginner/limited editors}."
 msgstr ""
 
-#: ../root/report/LimitedEditors.js:36
+#: ../root/report/LimitedEditors.js:34
 msgid "Total editors found: {count}"
 msgstr ""
 
+#: ../root/report/MediumsWithSequenceIssues.js:28
+#: ../root/report/MediumsWithSequenceIssues.js:29
+msgid "Releases with medium number issues"
+msgstr ""
+
+#: ../root/report/MediumsWithSequenceIssues.js:33
+msgid ""
+"This report lists all releases with gaps in the medium numbers (e.g. there "
+"is a medium 1 and 3 but no medium 2)."
+msgstr ""
+
+#: ../root/report/MultipleAsins.js:28 ../root/report/MultipleAsins.js:29
+msgid "Releases with multiple ASINs"
+msgstr ""
+
+#: ../root/report/MultipleAsins.js:33
+msgid ""
+"This report shows releases that have more than one Amazon ASIN. In most "
+"cases ASINs should map to MusicBrainz releases 1:1, so only one of them will "
+"be correct. Just check which ones do not fit the release (because of format, "
+"different number of tracks, etc). If the release has a barcode, you can "
+"search Amazon for it and see which ASIN matches."
+msgstr ""
+
+#: ../root/report/MultipleDiscogsLinks.js:28
+#: ../root/report/MultipleDiscogsLinks.js:29
+msgid "Releases with multiple Discogs links"
+msgstr ""
+
+#: ../root/report/MultipleDiscogsLinks.js:34
+msgid ""
+"This report shows releases that have more than one link to Discogs. In most "
+"cases a MusicBrainz release should have only one equivalent in Discogs, so "
+"only one of them will be correct. Just check which ones do not fit the "
+"release (because of format, different number of tracks, etc). Any \"master\" "
+"Discogs page belongs at the {release_group|release group level}, not at the "
+"release level, and should be removed from releases too."
+msgstr ""
+
+#: ../root/report/NoLanguage.js:28 ../root/report/NoLanguage.js:29
+#: ../root/report/ReportsIndex.js:232
+msgid "Releases without language"
+msgstr ""
+
+#: ../root/report/NoLanguage.js:33
+msgid ""
+"This report shows releases that have no language set. If you recognize the "
+"language, please set it! Do it only if you are pretty sure, don't just "
+"guess: not everything written in Cyrillic is Russian, for example."
+msgstr ""
+
+#: ../root/report/NoScript.js:28 ../root/report/NoScript.js:29
+#: ../root/report/ReportsIndex.js:237
+msgid "Releases without script"
+msgstr ""
+
+#: ../root/report/NoScript.js:33
+msgid ""
+"This report shows releases that have no script set. If you recognize the "
+"script, just add it! Remember that the script used for English (and most "
+"other European languages) is Latin."
+msgstr ""
+
+#: ../root/report/PartOfSetRelationships.js:28
+#: ../root/report/PartOfSetRelationships.js:29
+msgid "Releases with “part of set” relationships"
+msgstr ""
+
+#: ../root/report/PartOfSetRelationships.js:34
+msgid ""
+"This report shows releases that still have the deprecated \"part of set\" "
+"relationship and should probably be merged. For instructions on how to fix "
+"them, please see the documentation about {how_to_merge_releases|how to merge "
+"releases}. If the releases are not really part of a set (for example, if "
+"they are independently-released volumes in a series) just remove the "
+"relationship."
+msgstr ""
+
+#: ../root/report/PlacesWithoutCoordinates.js:32
+#: ../root/report/PlacesWithoutCoordinates.js:33
+#: ../root/report/ReportsIndex.js:470
+msgid "Places without coordinates"
+msgstr ""
+
+#: ../root/report/PlacesWithoutCoordinates.js:37
+msgid "This report lists places without coordinates."
+msgstr ""
+
+#: ../root/report/PlacesWithoutCoordinates.js:58
+msgid "Search for coordinates"
+msgstr ""
+
+#: ../root/report/PossibleCollaborations.js:28
 #: ../root/report/PossibleCollaborations.js:29
-#: ../root/report/PossibleCollaborations.js:30
 msgid "Artists that may be collaborations"
 msgstr ""
 
@@ -12501,6 +11977,243 @@ msgid ""
 "collaboration, it should be split if possible (see {how_to_split_artists|How "
 "to Split Artists}). If it is a collaboration with its own name and can't be "
 "split, collaboration relationships should be added to it."
+msgstr ""
+
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:35
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:39
+#: ../root/report/ReportsIndex.js:449
+msgid "Recordings with the same name by different artists with the same name"
+msgstr ""
+
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:45
+msgid ""
+"This report shows all recordings with the same name that have different "
+"artists (having different MBIDs) with the same name."
+msgstr ""
+
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:49
+msgid ""
+"These are most likely cases where the {ac|artist credit} is incorrect for at "
+"least one of the recordings."
+msgstr ""
+
+#: ../root/report/RecordingsSameNameDifferentArtistsSameName.js:54
+msgid "Currently, this report only works with recordings that have one artist."
+msgstr ""
+
+#: ../root/report/RecordingsWithEarliestReleaseRelationships.js:30
+#: ../root/report/RecordingsWithEarliestReleaseRelationships.js:32
+#: ../root/report/ReportsIndex.js:407
+msgid "Recordings with earliest release relationships"
+msgstr ""
+
+#: ../root/report/RecordingsWithEarliestReleaseRelationships.js:36
+msgid ""
+"This report shows recordings that have the deprecated \"earliest release\" "
+"relationship. They should be merged if they are truly the same recording; if "
+"they're not, the relationship should be removed. Please, do not merge "
+"recordings blindly just because the lengths fit, and do not merge recordings "
+"with very different times!"
+msgstr ""
+
+#: ../root/report/RecordingsWithVaryingTrackLengths.js:28
+#: ../root/report/RecordingsWithVaryingTrackLengths.js:29
+#: ../root/report/ReportsIndex.js:422
+msgid "Recordings with varying track times"
+msgstr ""
+
+#: ../root/report/RecordingsWithVaryingTrackLengths.js:33
+msgid ""
+"This report shows recordings where the linked tracks have times that vary by "
+"more than 30 seconds."
+msgstr ""
+
+#: ../root/report/RecordingsWithoutVaCredit.js:30
+#: ../root/report/RecordingsWithoutVaCredit.js:33
+#: ../root/report/ReportsIndex.js:437
+msgid "Recordings not credited to \"Various Artists\" but linked to VA"
+msgstr ""
+
+#: ../root/report/RecordingsWithoutVaCredit.js:38
+msgid ""
+"This report shows recordings linked to the Various Artists entity without "
+"\"Various Artists\" as the credited name."
+msgstr ""
+
+#: ../root/report/RecordingsWithoutVaLink.js:30
+#: ../root/report/RecordingsWithoutVaLink.js:33
+#: ../root/report/ReportsIndex.js:443
+msgid "Recordings credited to \"Various Artists\" but not linked to VA"
+msgstr ""
+
+#: ../root/report/RecordingsWithoutVaLink.js:38
+msgid ""
+"This report shows recordings with \"Various Artists\" as the credited name "
+"but not linked to the Various Artists entity."
+msgstr ""
+
+#: ../root/report/ReleaseGroupsWithoutVaCredit.js:30
+#: ../root/report/ReleaseGroupsWithoutVaCredit.js:34
+#: ../root/report/ReportsIndex.js:210
+msgid "Release groups not credited to \"Various Artists\" but linked to VA"
+msgstr ""
+
+#: ../root/report/ReleaseGroupsWithoutVaCredit.js:39
+msgid ""
+"This report shows release groups linked to the Various Artists entity "
+"without \"Various Artists\" as the credited name."
+msgstr ""
+
+#: ../root/report/ReleaseGroupsWithoutVaLink.js:30
+#: ../root/report/ReleaseGroupsWithoutVaLink.js:34
+#: ../root/report/ReportsIndex.js:216
+msgid "Release groups credited to \"Various Artists\" but not linked to VA"
+msgstr ""
+
+#: ../root/report/ReleaseGroupsWithoutVaLink.js:39
+msgid ""
+"This report shows release groups with \"Various Artists\" as the credited "
+"name but not linked to the Various Artists entity."
+msgstr ""
+
+#: ../root/report/ReleaseLabelSameArtist.js:34
+#: ../root/report/ReleaseLabelSameArtist.js:36
+#: ../root/report/ReportsIndex.js:397
+msgid "Releases where artist name and label name are the same"
+msgstr ""
+
+#: ../root/report/ReleaseLabelSameArtist.js:41
+msgid ""
+"This report lists releases where the label name is the same as the artist "
+"name. Often this means the release is self-released, and the label "
+"{SpecialPurposeLabel|should be \"[no label]\" instead}."
+msgstr ""
+
+#: ../root/report/ReleasedTooEarly.js:28 ../root/report/ReleasedTooEarly.js:29
+#: ../root/report/ReportsIndex.js:297
+msgid "Releases released too early"
+msgstr ""
+
+#: ../root/report/ReleasedTooEarly.js:33
+msgid ""
+"This report shows releases which have disc IDs even though they were "
+"released too early to have disc IDs, where one of the medium formats didn't "
+"exist at the time the release was released or where a disc ID is attached to "
+"a medium whose format does not have disc IDs."
+msgstr ""
+
+#: ../root/report/ReleasesInCaaWithCoverArtRelationships.js:30
+#: ../root/report/ReleasesInCaaWithCoverArtRelationships.js:34
+#: ../root/report/ReportsIndex.js:319
+msgid ""
+"Releases in the Cover Art Archive that still have cover art relationships"
+msgstr ""
+
+#: ../root/report/ReleasesInCaaWithCoverArtRelationships.js:40
+msgid ""
+"This report shows releases which have artwork in the Cover Art Archive, but "
+"still have a cover art relationship (pointing to a URL)."
+msgstr ""
+
+#: ../root/report/ReleasesMissingDiscIds.js:28
+#: ../root/report/ReleasesMissingDiscIds.js:29
+#: ../root/report/ReportsIndex.js:392
+msgid "Releases missing disc IDs"
+msgstr ""
+
+#: ../root/report/ReleasesMissingDiscIds.js:33
+msgid ""
+"This report shows releases (official and promotional only) that have at "
+"least one medium with a format that supports disc IDs, but is missing one."
+msgstr ""
+
+#: ../root/report/ReleasesMissingDiscIds.js:38
+msgid ""
+"For instructions on how to add one, see the {add_discids|documentation page}."
+msgstr ""
+
+#: ../root/report/ReleasesToConvert.js:30
+#: ../root/report/ReleasesToConvert.js:32 ../root/report/ReportsIndex.js:227
+msgid "Releases which might need converting to \"multiple artists\""
+msgstr ""
+
+#: ../root/report/ReleasesToConvert.js:36
+msgid ""
+"This report aims to identify releases which need converting to multiple "
+"artists (because the track artists are on the title field, for example). "
+"Currently it does this by looking for releases where every track contains \"/"
+"\" or \"-\"."
+msgstr ""
+
+#: ../root/report/ReleasesWithCaaNoTypes.js:30
+#: ../root/report/ReleasesWithCaaNoTypes.js:34
+#: ../root/report/ReportsIndex.js:331
+msgid "Releases in the Cover Art Archive where no cover art piece has types"
+msgstr ""
+
+#: ../root/report/ReleasesWithCaaNoTypes.js:40
+msgid ""
+"This report shows releases which have cover art in the Cover Art Archive, "
+"but where none of it has any types set. This often means a front cover was "
+"added, but not marked as such."
+msgstr ""
+
+#: ../root/report/ReleasesWithDownloadRelationships.js:30
+#: ../root/report/ReleasesWithDownloadRelationships.js:33
+#: ../root/report/ReportsIndex.js:362
+msgid "Non-digital releases with download relationships"
+msgstr ""
+
+#: ../root/report/ReleasesWithDownloadRelationships.js:38
+msgid ""
+"This report shows releases that have download relationships, but have media "
+"whose format is not “Digital Media”."
+msgstr ""
+
+#: ../root/report/ReleasesWithNoMediums.js:28
+#: ../root/report/ReleasesWithNoMediums.js:29
+#: ../root/report/ReportsIndex.js:377
+msgid "Releases with no mediums"
+msgstr ""
+
+#: ../root/report/ReleasesWithNoMediums.js:33
+msgid "This report shows releases without any mediums (no tracklist)."
+msgstr ""
+
+#: ../root/report/ReleasesWithUnlikelyLanguageScript.js:28
+#: ../root/report/ReleasesWithUnlikelyLanguageScript.js:29
+#: ../root/report/ReportsIndex.js:342
+msgid "Releases with unlikely language/script pairs"
+msgstr ""
+
+#: ../root/report/ReleasesWithUnlikelyLanguageScript.js:33
+msgid ""
+"This report shows releases that have an unlikely combination of language and "
+"script properties, such as German and Ethiopic."
+msgstr ""
+
+#: ../root/report/ReleasesWithoutVaCredit.js:30
+#: ../root/report/ReleasesWithoutVaCredit.js:33
+#: ../root/report/ReportsIndex.js:382
+msgid "Releases not credited to \"Various Artists\" but linked to VA"
+msgstr ""
+
+#: ../root/report/ReleasesWithoutVaCredit.js:38
+msgid ""
+"This report shows releases linked to the Various Artists entity without "
+"\"Various Artists\" as the credited name."
+msgstr ""
+
+#: ../root/report/ReleasesWithoutVaLink.js:30
+#: ../root/report/ReleasesWithoutVaLink.js:33
+#: ../root/report/ReportsIndex.js:387
+msgid "Releases credited to \"Various Artists\" but not linked to VA"
+msgstr ""
+
+#: ../root/report/ReleasesWithoutVaLink.js:38
+msgid ""
+"This report shows releases with \"Various Artists\" as the credited name but "
+"not linked to the Various Artists entity."
 msgstr ""
 
 #: ../root/report/ReportNotAvailable.js:20
@@ -12516,496 +12229,703 @@ msgid ""
 "up\" tasks are required."
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:37
+#: ../root/report/ReportsIndex.js:56
 msgid "Artists which have collaboration relationships"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:38
+#: ../root/report/ReportsIndex.js:61
 msgid "Artists which look like collaborations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:44
+#: ../root/report/ReportsIndex.js:91
 msgid "Artists with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:50
+#: ../root/report/ReportsIndex.js:103
 msgid "Editors"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:61
+#: ../root/report/ReportsIndex.js:120
 msgid "Possibly duplicate events"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:74
-msgid "Discogs URLs linked to multiple labels"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:77
+#: ../root/report/ReportsIndex.js:160
 msgid "Labels with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:81
+#: ../root/report/ReportsIndex.js:170
 msgid "Release groups"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:84
+#: ../root/report/ReportsIndex.js:175
 msgid "Release groups that might need to be merged"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:86
-msgid "Discogs URLs linked to multiple release groups"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:90
+#: ../root/report/ReportsIndex.js:205
 msgid "Release groups with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:101
+#: ../root/report/ReportsIndex.js:242
 msgid "Releases which have unexpected Amazon URLs"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:102
+#: ../root/report/ReportsIndex.js:247
 msgid "Releases which have multiple ASINs"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:103
+#: ../root/report/ReportsIndex.js:252
 msgid "Releases which have multiple Discogs links"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:104
-msgid "Amazon URLs linked to multiple releases"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:105
-msgid "Discogs URLs linked to multiple releases"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:106
+#: ../root/report/ReportsIndex.js:267
 msgid "Releases which have part of set relationships"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:107
+#: ../root/report/ReportsIndex.js:272
 msgid "Discs entered as separate releases"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:108
+#: ../root/report/ReportsIndex.js:277
+msgid "Tracks whose names include their sequence numbers"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:282
 msgid "Releases with non-sequential track numbers"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:112
+#: ../root/report/ReportsIndex.js:287
+#: ../root/report/SuperfluousDataTracks.js:28
+#: ../root/report/SuperfluousDataTracks.js:29
+msgid "Releases with superfluous data tracks"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:302
 msgid "Releases where some (but not all) mediums have no format set"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:113
-msgid "Releases with catalog numbers that look like ASINs"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:114
+#: ../root/report/ReportsIndex.js:313
 msgid ""
 "Translated/Transliterated Pseudo-Releases not linked to an original version"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:116
+#: ../root/report/ReportsIndex.js:325
 msgid "Releases of any sort that still have cover art relationships"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:118
+#: ../root/report/ReportsIndex.js:337
 msgid "Releases with non-sequential mediums"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:125
+#: ../root/report/ReportsIndex.js:347 ../root/report/TracksWithoutTimes.js:28
+#: ../root/report/TracksWithoutTimes.js:29
+msgid "Releases with unknown track times"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:357
+#: ../root/report/SingleMediumReleasesWithMediumTitles.js:30
+#: ../root/report/SingleMediumReleasesWithMediumTitles.js:32
+msgid "Releases with a single medium that has a name"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:372
 msgid "Releases with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:129
-msgid "Releases missing disc IDs"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:136
-msgid "Recordings with earliest release relationships"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:137
-msgid "Tracks whose names include their sequence numbers"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:140
-msgid "Recordings with varying track times"
-msgstr ""
-
-#: ../root/report/ReportsIndex.js:142
+#: ../root/report/ReportsIndex.js:432
 msgid "Recordings with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:152
+#: ../root/report/ReportsIndex.js:465
 msgid "Places with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:159
+#: ../root/report/ReportsIndex.js:475
+#: ../root/report/components/SeriesAnnotationList.js:25
+#: ../root/tag/TagIndex.js:87
+msgid "Series"
+msgstr ""
+
+#: ../root/report/ReportsIndex.js:480
 msgid "Series with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:167
+#: ../root/report/ReportsIndex.js:500
 msgid "Works with annotations"
 msgstr ""
 
-#: ../root/report/ReportsIndex.js:183
+#: ../root/report/ReportsIndex.js:526
 msgid "ISWCs"
 msgstr ""
 
-#: ../root/report/components/EditorList.js:28
+#: ../root/report/SeparateDiscs.js:28 ../root/report/SeparateDiscs.js:29
+msgid "Discs as separate releases"
+msgstr ""
+
+#: ../root/report/SeparateDiscs.js:33
+msgid ""
+"This report shows releases which have (disc n) or (bonus disc) in the title."
+msgstr ""
+
+#: ../root/report/SeparateDiscs.js:37
+msgid ""
+"For instructions on how to fix them, please see the documentation about "
+"{howto|how to merge releases}."
+msgstr ""
+
+#: ../root/report/SetInDifferentRg.js:28 ../root/report/SetInDifferentRg.js:29
+msgid "Mismatched release groups"
+msgstr ""
+
+#: ../root/report/SetInDifferentRg.js:34
+msgid ""
+"This report shows release groups with releases that are linked to releases "
+"in different release groups by part-of-set or transliteration relationships. "
+"If a pair of release groups are listed here, you should probably merge them. "
+"If the releases are discs linked with \"part of set\" relationships, you "
+"might want to merge them too into one multi-disc release (see "
+"{how_to_merge_releases|How to Merge Releases})."
+msgstr ""
+
+#: ../root/report/SingleMediumReleasesWithMediumTitles.js:36
+msgid ""
+"This report shows releases that have a single medium, where this medium also "
+"has a specific name. Usually, this is not necessary and is duplicate "
+"information which can be removed."
+msgstr ""
+
+#: ../root/report/SomeFormatsUnset.js:28 ../root/report/SomeFormatsUnset.js:29
+msgid "Releases with some formats unset"
+msgstr ""
+
+#: ../root/report/SomeFormatsUnset.js:33
+msgid ""
+"This report shows releases where some of the medium formats are set, but "
+"others are unset. In most cases, it should be easy to find out which the "
+"correct formats are (don't just assume that they're all CDs because one is "
+"though!)."
+msgstr ""
+
+#: ../root/report/SuperfluousDataTracks.js:34
+msgid ""
+"This report lists releases without any disc IDs that probably contain data "
+"tracks (like videos) at the end of a medium, but have no tracks marked as "
+"data tracks. A data track should be marked as such if it is the last track "
+"of the CD and contains audio or video. Otherwise, it should just be removed. "
+"See the {data_track_guidelines|data track guidelines}."
+msgstr ""
+
+#: ../root/report/TracksNamedWithSequence.js:30
+#: ../root/report/TracksNamedWithSequence.js:32
+msgid "Releases where track names start with their track number"
+msgstr ""
+
+#: ../root/report/TracksNamedWithSequence.js:36
+msgid ""
+"This report aims to identify releases where track names include their own "
+"track number, e.g. \"1) Some Name\" (instead of just \"Some Name\"). Notice "
+"that sometimes this is justified and correct, don't automatically assume it "
+"is a mistake! If you confirm it is a mistake, please correct it."
+msgstr ""
+
+#: ../root/report/TracksWithSequenceIssues.js:28
+#: ../root/report/TracksWithSequenceIssues.js:29
+msgid "Releases with track number issues"
+msgstr ""
+
+#: ../root/report/TracksWithSequenceIssues.js:33
+msgid ""
+"This report lists all releases where the track numbers are not continuous (e."
+"g. there is no \"track 2\"), or with duplicated track numbers (e.g. there "
+"are two \"track 4\"s)."
+msgstr ""
+
+#: ../root/report/TracksWithoutTimes.js:33
+msgid ""
+"This report lists all releases where some or all tracks have unknown track "
+"lengths."
+msgstr ""
+
+#: ../root/report/UnlinkedPseudoReleases.js:28
+#: ../root/report/UnlinkedPseudoReleases.js:29
+msgid "Unlinked pseudo-releases"
+msgstr ""
+
+#: ../root/report/UnlinkedPseudoReleases.js:33
+msgid ""
+"This report shows releases with status Pseudo-Release that aren’t linked via "
+"the translation/transliteration relationship to an original version. This "
+"could be because the original version is missing, or just because the "
+"release status is wrongly set."
+msgstr ""
+
+#: ../root/report/components/ArtistAnnotationList.js:28
+#: ../root/report/components/LabelAnnotationList.js:27
+#: ../root/report/components/PlaceAnnotationList.js:27
+#: ../root/report/components/RecordingAnnotationList.js:30
+#: ../root/report/components/ReleaseAnnotationList.js:31
+#: ../root/report/components/ReleaseGroupAnnotationList.js:31
+#: ../root/report/components/SeriesAnnotationList.js:27
+#: ../root/report/components/WorkAnnotationList.js:27
+msgid "Last edited"
+msgstr ""
+
+#: ../root/report/components/EditorList.js:27
 msgid "Member since"
 msgstr ""
 
-#: ../root/report/components/EditorList.js:29
+#: ../root/report/components/EditorList.js:28
+#: ../root/static/scripts/account/components/EditProfileForm.js:197
 msgid "Website"
 msgstr ""
 
-#: ../root/report/components/EditorList.js:31
+#: ../root/report/components/EditorList.js:30
 msgid "Bio"
 msgstr ""
 
-#: ../root/report/components/EditorList.js:42
+#: ../root/report/components/EditorList.js:46
 msgid "delete"
 msgstr ""
 
-#: ../root/search/components/AreaResults.js:70
+#: ../root/report/components/InstrumentList.js:34
+msgid "Last updated"
+msgstr ""
+
+#: ../root/report/constants.js:11
+msgid ""
+"If you see something in these annotations that can be represented with a "
+"relationship instead, please add a relationship and remove that part of the "
+"annotation. If something is marked as “sub-optimal”, consider checking if a "
+"better way to store that data has been added in the meantime."
+msgstr ""
+
+#: ../root/search/components/AreaResults.js:68
 msgid "Alternatively, you may {uri|add a new area}."
 msgstr ""
 
-#: ../root/search/components/ArtistResults.js:66
+#: ../root/search/components/ArtistResults.js:63
 msgid "Sort Name"
 msgstr ""
 
-#: ../root/search/components/ArtistResults.js:71
+#: ../root/search/components/ArtistResults.js:68
 msgid "Begin Area"
 msgstr ""
 
-#: ../root/search/components/ArtistResults.js:73
+#: ../root/search/components/ArtistResults.js:70
 msgid "End Area"
 msgstr ""
 
-#: ../root/search/components/ArtistResults.js:99
+#: ../root/search/components/ArtistResults.js:95
 msgid "Alternatively, you may {uri|add a new artist}."
 msgstr ""
 
-#: ../root/search/components/DocResults.js:17
-#: ../root/search/components/DocResults.js:19
+#: ../root/search/components/DocResults.js:16
+#: ../root/search/components/DocResults.js:18
 msgid "Documentation Search"
 msgstr ""
 
-#: ../root/search/components/EventResults.js:85
+#: ../root/search/components/EventResults.js:72
 msgid "Alternatively, you may {uri|add a new event}."
 msgstr ""
 
-#: ../root/search/components/LabelResults.js:76
+#: ../root/search/components/LabelResults.js:74
 msgid "Alternatively, you may {uri|add a new label}."
 msgstr ""
 
-#: ../root/search/components/PlaceResults.js:71
+#: ../root/search/components/PlaceResults.js:69
 msgid "Alternatively, you may {uri|add a new place}."
 msgstr ""
 
-#: ../root/search/components/RecordingResults.js:104
+#: ../root/search/components/RecordingResults.js:102
 msgid "(standalone recording)"
 msgstr ""
 
-#: ../root/search/components/RecordingResults.js:158
+#: ../root/search/components/RecordingResults.js:156
 msgid "Alternatively, you may {uri|add a new recording}."
 msgstr ""
 
-#: ../root/search/components/ReleaseGroupResults.js:72
+#: ../root/search/components/ReleaseGroupResults.js:70
 msgid "Alternatively, you may {uri|add a new release group}."
 msgstr ""
 
-#: ../root/search/components/ReleaseResults.js:137
+#: ../root/search/components/ReleaseResults.js:41
+msgid "[missing media]"
+msgstr ""
+
+#: ../root/search/components/ReleaseResults.js:44
+msgid "-"
+msgstr ""
+
+#: ../root/search/components/ReleaseResults.js:143
 msgid "Alternatively, you may {uri|add a new release}."
 msgstr ""
 
-#: ../root/search/components/ResultsLayout.js:34
+#: ../root/search/components/ResultsLayout.js:33
 msgid "Last updated: {date}"
 msgstr ""
 
-#: ../root/search/components/SeriesResults.js:61
+#: ../root/search/components/SeriesResults.js:59
 msgid "Alternatively, you may {uri|add a new series}."
 msgstr ""
 
-#: ../root/search/components/WorkResults.js:63
+#: ../root/search/components/WorkResults.js:62
 msgid "Alternatively, you may {uri|add a new work}."
 msgstr ""
 
-#: ../root/series/NotFound.js:16
+#: ../root/series/NotFound.js:15
 msgid "Series Not Found"
 msgstr ""
 
-#: ../root/series/NotFound.js:18
+#: ../root/series/NotFound.js:17
 msgid ""
 "Sorry, we could not find a series with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/static/scripts/account/components/ApplicationForm.js:107
+#: ../root/static/scripts/account/components/ApplicationForm.js:90
 msgid "Callback URL"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:168
+#: ../root/static/scripts/account/components/ApplicationForm.js:98
+msgid ""
+"Callback URI is optional for installed applications. If set, its scheme must "
+"be a custom reverse-DNS string, as in <code>org.example.app://auth</code>, "
+"for installed applications."
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:183
+msgid ""
+"This is a development server. Your email address is not private or secure. "
+"Proceed with caution!"
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:192
+msgid "If you change your email address, you will be required to verify it."
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:235
+msgid ""
+"You can pick the level you prefer here: your country, region or city. Be as "
+"specific as you want to!"
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:240
+msgid "Birth date:"
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:243
+msgid ""
+"We will use your birth date to display your age in years on your profile "
+"page."
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:252
+msgid "Languages Known:"
+msgstr ""
+
+#: ../root/static/scripts/account/components/EditProfileForm.js:286
+msgid "Add a language"
+msgstr ""
+
+#: ../root/static/scripts/account/components/PreferencesForm.js:142
 msgid "Regional settings"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:177
+#: ../root/static/scripts/account/components/PreferencesForm.js:151
 msgid "Guess timezone"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:182
+#: ../root/static/scripts/account/components/PreferencesForm.js:156
 msgid "Timezone:"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:188
+#: ../root/static/scripts/account/components/PreferencesForm.js:162
 msgid "Date/time format:"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:197
+#: ../root/static/scripts/account/components/PreferencesForm.js:171
 msgid "Allow other users to see my subscriptions"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:201
+#: ../root/static/scripts/account/components/PreferencesForm.js:175
 msgid "Allow other users to see my tags"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:205
+#: ../root/static/scripts/account/components/PreferencesForm.js:179
 msgid "Allow other users to see my ratings"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:209
+#: ../root/static/scripts/account/components/PreferencesForm.js:183
 msgid "Show my Gravatar"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:216
+#: ../root/static/scripts/account/components/PreferencesForm.js:190
 msgid ""
 "Mail me when one of my edits gets a \"no\" vote. (Note: the email is only "
 "sent for the first \"no\" vote, not each one)"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:220
+#: ../root/static/scripts/account/components/PreferencesForm.js:194
 msgid "When I add a note to an edit, mail me all future notes for that edit."
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:224
+#: ../root/static/scripts/account/components/PreferencesForm.js:198
 msgid "When I vote on an edit, mail me all future notes for that edit."
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:228
+#: ../root/static/scripts/account/components/PreferencesForm.js:202
 msgid "Send me mails with edits to my subscriptions:"
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:237
+#: ../root/static/scripts/account/components/PreferencesForm.js:211
 msgid "Automatically subscribe me to artists I create."
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:241
+#: ../root/static/scripts/account/components/PreferencesForm.js:215
 msgid "Automatically subscribe me to labels I create."
 msgstr ""
 
-#: ../root/static/scripts/account/components/PreferencesForm.js:245
+#: ../root/static/scripts/account/components/PreferencesForm.js:219
 msgid "Automatically subscribe me to series I create."
 msgstr ""
 
-#: ../root/static/scripts/area/places-map.js:78
+#: ../root/static/scripts/area/places-map.js:75
 msgid "… and {place_count} other"
 msgid_plural "… and {place_count} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/static/scripts/area/places-map.js:90
+#: ../root/static/scripts/area/places-map.js:87
 msgid "No type"
 msgstr ""
 
-#: ../root/static/scripts/area/places-map.js:101
+#: ../root/static/scripts/area/places-map.js:98
 msgid "{place_type}: {place_link}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:70
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:27
+msgid "Add a new artist"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:28
+msgid "Add a new event"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:29
+msgid "Add a new label"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:30
+msgid "Add a new place"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:32
+msgid "Add a new release group"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:33
+msgid "Add a new series"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:34
+msgid "Add a new work"
+msgstr ""
+
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:78
 msgid "An error occurred while searching. Click here to try again."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:74
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:82
 msgid "Try with direct search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:75
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:83
 msgid "Try with indexed search instead."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:107
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:115
 msgid "Type to search, or paste an MBID"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:179
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:187
 msgid "Clear recent items"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:421
-#: ../root/static/scripts/common/components/Collapsible.js:79
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:429
+#: ../root/static/scripts/common/components/Collapsible.js:78
 msgid "Show more..."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:427
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:435
 msgid "Not found? Try again with direct search."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:428
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:436
 msgid "Slow? Switch back to indexed search."
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:636
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:646
 msgid "appears on"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:640
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:650
 msgid "standalone recording"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:723
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:733
 msgid "{release_group_type} by {artist}"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/Autocomplete.js:939
+#: ../root/static/scripts/common/MB/Control/Autocomplete.js:949
 msgid "Performers"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/EditList.js:39
+#: ../root/static/scripts/common/MB/Control/EditList.js:38
 msgid "Vote on all edits:"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/Control/EditSummary.js:21
+#: ../root/static/scripts/common/MB/Control/EditSummary.js:20
 msgid "Delete Note"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:22
+#: ../root/static/scripts/common/MB/release.js:21
 msgid "Display Credits at Bottom"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:31
+#: ../root/static/scripts/common/MB/release.js:30
 msgid "Display Credits Inline"
 msgstr ""
 
-#: ../root/static/scripts/common/MB/release.js:91
+#: ../root/static/scripts/common/MB/release.js:90
 msgid "Failed to load the medium."
 msgstr ""
 
-#: ../root/static/scripts/common/artworkViewer.js:71
+#: ../root/static/scripts/common/artworkViewer.js:69
 msgid "Image {current} of {total}"
 msgstr ""
 
-#: ../root/static/scripts/common/components/Annotation.js:84
+#: ../root/static/scripts/common/components/Annotation.js:74
 msgid "Annotation last modified by {user} on {date}."
 msgstr ""
 
-#: ../root/static/scripts/common/components/Annotation.js:98
+#: ../root/static/scripts/common/components/Annotation.js:88
 msgid ""
 "This is an {history|old revision} of this annotation, as edited by {user} on "
 "{date}. {current|View current revision}."
 msgstr ""
 
-#: ../root/static/scripts/common/components/Annotation.js:106
+#: ../root/static/scripts/common/components/Annotation.js:96
 msgid "Annotation last modified on {date}."
 msgstr ""
 
-#: ../root/static/scripts/common/components/Collapsible.js:79
+#: ../root/static/scripts/common/components/Collapsible.js:78
 msgid "Show less..."
 msgstr ""
 
-#: ../root/static/scripts/common/components/CommonsImage.js:48
+#: ../root/static/scripts/common/components/CommonsImage.js:47
 msgid "Image from Wikimedia Commons"
 msgstr ""
 
-#: ../root/static/scripts/common/components/CritiqueBrainzReview.js:39
+#: ../root/static/scripts/common/components/CritiqueBrainzReview.js:37
 msgid "{review_link|Review} by {author} on {date}"
 msgstr ""
 
-#: ../root/static/scripts/common/components/EditorLink.js:19
+#: ../root/static/scripts/common/components/EditorLink.js:17
 msgid ""
 "This editor is missing from this server, and cannot be displayed correctly."
 msgstr ""
 
-#: ../root/static/scripts/common/components/EditorLink.js:20
+#: ../root/static/scripts/common/components/EditorLink.js:18
 msgid "[missing editor]"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:90
+#: ../root/static/scripts/common/components/TagEditor.js:93
 msgid "Withdraw vote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:106
-msgid "Upvote"
-msgstr ""
-
-#: ../root/static/scripts/common/components/TagEditor.js:107
+#: ../root/static/scripts/common/components/TagEditor.js:110
 msgid "You’ve upvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:115
-msgid "Downvote"
+#: ../root/static/scripts/common/components/TagEditor.js:112
+msgid "Upvote"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:116
+#: ../root/static/scripts/common/components/TagEditor.js:119
 msgid "You’ve downvoted this tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:483
+#: ../root/static/scripts/common/components/TagEditor.js:121
+msgid "Downvote"
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:490
+msgid "Nobody has tagged this yet."
+msgstr ""
+
+#: ../root/static/scripts/common/components/TagEditor.js:497
 msgid ""
 "Tags with a score of zero or below, and tags that you’ve downvoted are "
 "hidden."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:487
+#: ../root/static/scripts/common/components/TagEditor.js:501
 msgid "Tags with a score of zero or below are hidden."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:491
+#: ../root/static/scripts/common/components/TagEditor.js:505
 msgid "Show all tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:499
+#: ../root/static/scripts/common/components/TagEditor.js:513
 msgid "All tags are being shown."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:503
+#: ../root/static/scripts/common/components/TagEditor.js:517
 msgid ""
 "Hide tags with a score of zero or below, and tags that you’ve downvoted."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:507
+#: ../root/static/scripts/common/components/TagEditor.js:521
 msgid "Hide tags with a score of zero or below."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:515
+#: ../root/static/scripts/common/components/TagEditor.js:529
 msgid "Add Tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:517
+#: ../root/static/scripts/common/components/TagEditor.js:531
 msgid ""
 "You can add your own {tagdocs|tags} below. Use commas to separate multiple "
 "tags."
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:525
+#: ../root/static/scripts/common/components/TagEditor.js:539
 msgid "Submit tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:564
+#: ../root/static/scripts/common/components/TagEditor.js:578
 msgid "see all tags"
 msgstr ""
 
-#: ../root/static/scripts/common/components/TagEditor.js:580
+#: ../root/static/scripts/common/components/TagEditor.js:594
+msgctxt "verb"
 msgid "Tag"
 msgstr ""
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:46
+#: ../root/static/scripts/common/components/TaggerIcon.js:40
+msgid "Open in tagger"
+msgstr ""
+
+#: ../root/static/scripts/common/components/Warning.js:27
+#: ../root/static/scripts/common/components/WarningIcon.js:14
+msgid "Warning"
+msgstr ""
+
+#: ../root/static/scripts/common/components/WikipediaExtract.js:45
 msgid "Wikipedia"
 msgstr ""
 
-#: ../root/static/scripts/common/components/WikipediaExtract.js:52
+#: ../root/static/scripts/common/components/WikipediaExtract.js:51
 msgid "Continue reading at Wikipedia..."
 msgstr ""
 
@@ -13015,95 +12935,41 @@ msgid ""
 "Commons BY-SA license}"
 msgstr ""
 
-#: ../root/static/scripts/common/entity.js:235
+#: ../root/static/scripts/common/entity.js:234
 msgid "You selected {label}."
 msgstr ""
 
-#: ../root/static/scripts/common/entity.js:245
+#: ../root/static/scripts/common/entity.js:244
 msgid "You selected {area}."
 msgstr ""
 
-#: ../root/static/scripts/common/entity.js:330
+#: ../root/static/scripts/common/entity.js:329
 msgid "You selected {releasegroup}."
 msgstr ""
 
-#: ../root/static/scripts/common/i18n.js:47
+#: ../root/static/scripts/common/entity.js:430
+msgid "{medium_format} {position}: {title}"
+msgstr ""
+
+#: ../root/static/scripts/common/entity.js:431
+#: ../root/static/scripts/release-editor/fields.js:573
+msgid "Medium {position}: {title}"
+msgstr ""
+
+#: ../root/static/scripts/common/entity.js:435
+#: ../root/static/scripts/release-editor/fields.js:579
+msgid "Medium {position}"
+msgstr ""
+
+#: ../root/static/scripts/common/i18n/hyphenateTitle.js:10
 msgid "{title} - {subtitle}"
 msgstr ""
 
-#: ../root/static/scripts/common/i18n.js:68
-msgid "Add a new artist"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:69
-msgid "Add a new event"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:70
-msgid "Add a new label"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:71
-msgid "Add a new place"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:73
-msgid "Add a new release group"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:74
-msgid "Add a new series"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:75
-msgid "Add a new work"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:79
-msgid "Add another area"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:80
-msgid "Add another artist"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:81
-msgid "Add another event"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:83
-msgid "Add another label"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:84
-msgid "Add another place"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:85
-msgid "Add another recording"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:86
-msgid "Add another release"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:87
-msgid "Add another release group"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:88
-msgid "Add another series"
-msgstr ""
-
-#: ../root/static/scripts/common/i18n.js:89
-msgid "Add another work"
-msgstr ""
-
-#: ../root/static/scripts/common/utility/bracketed.js:24
+#: ../root/static/scripts/common/utility/bracketed.js:19
 msgid "[{text}]"
 msgstr ""
 
-#: ../root/static/scripts/common/utility/bracketed.js:27
+#: ../root/static/scripts/common/utility/bracketed.js:22
 msgid "({text})"
 msgstr ""
 
@@ -13119,137 +12985,137 @@ msgstr ""
 msgid "– {end_date}"
 msgstr ""
 
-#: ../root/static/scripts/common/utility/formatDatePeriod.js:35
+#: ../root/static/scripts/common/utility/formatDatePeriod.js:36
 msgid "{begin_date} – ????"
 msgstr ""
 
-#: ../root/static/scripts/common/utility/formatDatePeriod.js:35
+#: ../root/static/scripts/common/utility/formatDatePeriod.js:37
 msgid "{begin_date} –"
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:47
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:46
 msgid "Began:"
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:53
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:52
 msgid "This person is deceased."
 msgstr ""
 
-#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:61
+#: ../root/static/scripts/edit/MB/Control/ArtistEdit.js:60
 msgid "This group has dissolved."
 msgstr ""
 
 #: ../root/static/scripts/edit/check-duplicates.js:139
-#: ../root/static/scripts/edit/externalLinks.js:194
-#: ../root/static/scripts/relationship-editor/common/dialog.js:472
+#: ../root/static/scripts/edit/externalLinks.js:210
+#: ../root/static/scripts/relationship-editor/common/dialog.js:481
 msgid "Required field."
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:54
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:55
 msgid ""
 "Use the following fields to enter collaborations. See the {ac|Artist Credit} "
 "documentation for more information."
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:75
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:76
 msgid "Artist in MusicBrainz:"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:76
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:77
 msgid "Artist as credited:"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:77
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:78
 msgid "Join phrase:"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:95
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:96
 msgid "Add Artist Credit"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:105
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:106
 msgid "Change all artists on this release that match “{name}”"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:112
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:113
 msgid "Copy Credits"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:113
+#: ../root/static/scripts/edit/components/ArtistCreditBubble.js:114
 msgid "Paste Credits"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/ArtistCreditNameEditor.js:127
+#: ../root/static/scripts/edit/components/ArtistCreditNameEditor.js:126
 msgid "Remove Artist Credit"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/PossibleDuplicates.js:15
+#: ../root/static/scripts/edit/components/PossibleDuplicates.js:14
 msgid "Possible Duplicates"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/PossibleDuplicates.js:16
+#: ../root/static/scripts/edit/components/PossibleDuplicates.js:15
 msgid "We found the following entities with very similar names:"
 msgstr ""
 
-#: ../root/static/scripts/edit/components/PossibleDuplicates.js:28
+#: ../root/static/scripts/edit/components/PossibleDuplicates.js:27
 msgid "Yes, I still want to enter “{entity_name}”."
 msgstr ""
 
-#: ../root/static/scripts/edit/components/PossibleDuplicates.js:32
+#: ../root/static/scripts/edit/components/PossibleDuplicates.js:31
 msgid ""
 "Please enter a {doc_disambiguation|disambiguation} to help distinguish this "
 "entity from the others."
 msgstr ""
 
-#: ../root/static/scripts/edit/confirmNavigationFallback.js:35
+#: ../root/static/scripts/edit/confirmNavigationFallback.js:34
 #: ../root/static/scripts/relationship-editor/release.js:74
 #: ../root/static/scripts/release-editor/init.js:219
 msgid "All of your changes will be lost if you leave this page."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:198
+#: ../root/static/scripts/edit/externalLinks.js:214
 msgid "Please don't use shortened URLs."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:200
+#: ../root/static/scripts/edit/externalLinks.js:216
 msgid "Please select a link type for the URL you’ve entered."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:204
-#: ../root/static/scripts/relationship-editor/common/dialog.js:459
+#: ../root/static/scripts/edit/externalLinks.js:226
+#: ../root/static/scripts/relationship-editor/common/dialog.js:468
 msgid ""
 "This URL is not allowed for the selected link type, or is incorrectly "
 "formatted."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:207
+#: ../root/static/scripts/edit/externalLinks.js:235
 msgid ""
 "Links to specific sections of Wikipedia articles are not allowed. Please "
 "remove “{fragment}” if still appropriate. See the {url|guidelines}."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:212
+#: ../root/static/scripts/edit/externalLinks.js:256
 msgid "This relationship already exists."
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:283
-#: ../root/static/scripts/relationship-editor/common/dialog.js:340
+#: ../root/static/scripts/edit/externalLinks.js:346
+#: ../root/static/scripts/relationship-editor/common/dialog.js:349
 msgid "{description} ({url|more documentation})"
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:317
+#: ../root/static/scripts/edit/externalLinks.js:402
 msgid "Add link:"
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:317
+#: ../root/static/scripts/edit/externalLinks.js:403
 msgid "Add another link:"
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:330
+#: ../root/static/scripts/edit/externalLinks.js:429
 msgid "video"
 msgstr ""
 
-#: ../root/static/scripts/edit/externalLinks.js:336
+#: ../root/static/scripts/edit/externalLinks.js:438
 msgid "Remove Link"
 msgstr ""
 
@@ -13257,14 +13123,14 @@ msgstr ""
 msgid "Guess Case Options"
 msgstr ""
 
-#: ../root/static/scripts/guess-case/modes.js:251
+#: ../root/static/scripts/guess-case/modes.js:256
 msgid ""
 "This mode capitalises almost all words, with some words (mainly articles and "
 "short prepositions) lowercased. Some words may need to be manually "
 "capitalised to follow the {url|English capitalisation guidelines}."
 msgstr ""
 
-#: ../root/static/scripts/guess-case/modes.js:265
+#: ../root/static/scripts/guess-case/modes.js:270
 msgid ""
 "This mode capitalises titles as sentence mode, but also inserts spaces "
 "before semicolons, colons, exclamation marks and question marks, and inside "
@@ -13272,64 +13138,104 @@ msgid ""
 "{url|French capitalisation guidelines}."
 msgstr ""
 
-#: ../root/static/scripts/guess-case/modes.js:285
+#: ../root/static/scripts/guess-case/modes.js:290
 msgid ""
 "This mode capitalises the first word of a sentence, most other words are "
 "lowercased. Some words, often proper nouns, may need to be manually fixed "
 "according to the {url|relevant language guidelines}."
 msgstr ""
 
-#: ../root/static/scripts/guess-case/modes.js:295
+#: ../root/static/scripts/guess-case/modes.js:300
 msgid ""
 "This mode handles the Turkish capitalisation of 'i' ('İ') and 'ı' ('I'). "
 "Some words may need to be manually corrected according to the {url|Turkish "
 "language guidelines}. "
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:31
+#: ../root/static/scripts/relationship-editor/common/dialog.js:30
 msgid "The series you’ve selected is for recordings."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:32
+#: ../root/static/scripts/relationship-editor/common/dialog.js:31
 msgid "The series you’ve selected is for releases."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:33
+#: ../root/static/scripts/relationship-editor/common/dialog.js:32
 msgid "The series you’ve selected is for release groups."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:34
+#: ../root/static/scripts/relationship-editor/common/dialog.js:33
 msgid "The series you’ve selected is for works."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:450
+#: ../root/static/scripts/relationship-editor/common/dialog.js:459
 msgid "Please select a relationship type."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:452
+#: ../root/static/scripts/relationship-editor/common/dialog.js:461
 msgid ""
 "Please select a subtype of the currently selected relationship type. The "
 "selected relationship type is only used for grouping subtypes."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:474
+#: ../root/static/scripts/relationship-editor/common/dialog.js:483
 msgid "Entities in a relationship cannot be the same."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:520
+#: ../root/static/scripts/relationship-editor/common/dialog.js:529
 msgid "Change credits for other {entity} relationships on the page."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:526
+#: ../root/static/scripts/relationship-editor/common/dialog.js:535
 msgid "Only relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/dialog.js:533
+#: ../root/static/scripts/relationship-editor/common/dialog.js:542
 msgid "Only “{relationship_type}” relationships to {entity_type} entities."
 msgstr ""
 
-#: ../root/static/scripts/relationship-editor/common/fields.js:304
+#: ../root/static/scripts/relationship-editor/common/fields.js:309
 msgid "This attribute is required."
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:23
+msgid "Add another area"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:24
+msgid "Add another artist"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:25
+msgid "Add another event"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:27
+msgid "Add another label"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:28
+msgid "Add another place"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:29
+msgid "Add another recording"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:30
+msgid "Add another release"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:31
+msgid "Add another release group"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:32
+msgid "Add another series"
+msgstr ""
+
+#: ../root/static/scripts/relationship-editor/common/viewModel.js:33
+msgid "Add another work"
 msgstr ""
 
 #: ../root/static/scripts/relationship-editor/release.js:43
@@ -13361,14 +13267,6 @@ msgstr ""
 msgid "Page {page} of {total}"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/fields.js:573
-msgid "Medium {position}: {title}"
-msgstr ""
-
-#: ../root/static/scripts/release-editor/fields.js:579
-msgid "Medium {position}"
-msgstr ""
-
 #: ../root/static/scripts/release-editor/fields.js:674
 msgid "You haven’t selected a label for “{name}”."
 msgstr ""
@@ -13387,46 +13285,46 @@ msgstr ""
 msgid "Edit Release"
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:129
+#: ../root/static/scripts/release-editor/validation.js:131
 msgid "The check digit is {checkdigit}."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:130
+#: ../root/static/scripts/release-editor/validation.js:132
 msgid "Please double-check the barcode on the release."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:134
+#: ../root/static/scripts/release-editor/validation.js:136
 msgid ""
 "The barcode you entered looks like a UPC code with the check digit missing."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:140
+#: ../root/static/scripts/release-editor/validation.js:142
 msgid "The barcode you entered is a valid UPC code."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:143
+#: ../root/static/scripts/release-editor/validation.js:145
 msgid ""
 "The barcode you entered is either an invalid UPC code, or an EAN code with "
 "the check digit missing."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:152
+#: ../root/static/scripts/release-editor/validation.js:154
 msgid "The barcode you entered is a valid EAN code."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:155
+#: ../root/static/scripts/release-editor/validation.js:157
 msgid "The barcode you entered is not a valid EAN code."
 msgstr ""
 
-#: ../root/static/scripts/release-editor/validation.js:162
+#: ../root/static/scripts/release-editor/validation.js:164
 msgid "The barcode you entered is not a valid UPC or EAN code."
 msgstr ""
 
-#: ../root/static/scripts/work.js:287
+#: ../root/static/scripts/work.js:276
 msgid "Add Language"
 msgstr ""
 
-#: ../root/static/scripts/work.js:296
+#: ../root/static/scripts/work.js:285
 msgid "Remove Language"
 msgstr ""
 
@@ -13540,116 +13438,116 @@ msgstr ""
 msgid "No works with this tag were found."
 msgstr ""
 
-#: ../root/tag/NotFound.js:16
+#: ../root/tag/NotFound.js:15
 msgid "Tag Not Used"
 msgstr ""
 
-#: ../root/tag/NotFound.js:18
+#: ../root/tag/NotFound.js:17
 msgid "No MusicBrainz entities have yet been tagged with \"{tag}\"."
 msgstr ""
 
-#: ../root/tag/NotFound.js:21
+#: ../root/tag/NotFound.js:20
 msgid ""
 "If you wish to use this tag, please {url|search} for the entity first and "
 "apply the tag using the sidebar."
 msgstr ""
 
-#: ../root/tag/TagCloud.js:55
+#: ../root/tag/TagCloud.js:54
 msgid "'{tag}' has been used {num} times"
 msgstr ""
 
-#: ../root/tag/TagCloud.js:62
+#: ../root/tag/TagCloud.js:61
 msgid "The database has no tags."
 msgstr ""
 
-#: ../root/tag/TagIndex.js:80
+#: ../root/tag/TagIndex.js:78
 msgid "See all {num} areas"
 msgid_plural "See all {num} areas"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:81
+#: ../root/tag/TagIndex.js:79
 msgid "See all {num} artists"
 msgid_plural "See all {num} artists"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:82
+#: ../root/tag/TagIndex.js:80
 msgid "See all {num} events"
 msgid_plural "See all {num} events"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:83
+#: ../root/tag/TagIndex.js:81
 msgid "See all {num} instruments"
 msgid_plural "See all {num} instruments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:84
+#: ../root/tag/TagIndex.js:82
 msgid "See all {num} labels"
 msgid_plural "See all {num} labels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:85
+#: ../root/tag/TagIndex.js:83
 msgid "See all {num} places"
 msgid_plural "See all {num} places"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:86
+#: ../root/tag/TagIndex.js:84
 msgid "See all {num} release groups"
 msgid_plural "See all {num} release groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:87
+#: ../root/tag/TagIndex.js:85
 msgid "See all {num} releases"
 msgid_plural "See all {num} releases"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:88
+#: ../root/tag/TagIndex.js:86
 msgid "See all {num} recordings"
 msgid_plural "See all {num} recordings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:89
+#: ../root/tag/TagIndex.js:87
 msgid "See all {num} series"
 msgid_plural "See all {num} series"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagIndex.js:90
+#: ../root/tag/TagIndex.js:88
 msgid "See all {num} works"
 msgid_plural "See all {num} works"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/tag/TagLayout.js:45 ../root/tag/TagLayout.js:46
-#: ../root/tag/TagLayout.js:51
+#: ../root/tag/TagLayout.js:43 ../root/tag/TagLayout.js:44
+#: ../root/tag/TagLayout.js:49
 msgid "Tag “{tag}”"
 msgstr ""
 
-#: ../root/taglookup/Form.js:41
+#: ../root/taglookup/Form.js:40
 msgid "Duration"
 msgstr ""
 
-#: ../root/taglookup/Form.js:45
+#: ../root/taglookup/Form.js:44
 msgid "Filename"
 msgstr ""
 
-#: ../root/taglookup/Index.js:20 ../root/taglookup/Index.js:22
+#: ../root/taglookup/Index.js:19 ../root/taglookup/Index.js:21
 msgid "Tag Lookup"
 msgstr ""
 
-#: ../root/taglookup/Nag.js:17
+#: ../root/taglookup/Nag.js:15
 msgid "The users make MusicBrainz happen and we appreciate your help!"
 msgstr ""
 
-#: ../root/taglookup/Nag.js:20
+#: ../root/taglookup/Nag.js:18
 msgid ""
 "However, we still have to pay the bills and hosting this site costs "
 "{finances|more than $1000 per month}. We need our users to help us make ends "
@@ -13660,7 +13558,7 @@ msgid ""
 "good karma everywhere else!"
 msgstr ""
 
-#: ../root/taglookup/Nag.js:26
+#: ../root/taglookup/Nag.js:24
 msgid ""
 "If you donate <b>$4</b> you will not get this nag text for a <b>month</b>. "
 "We encourage people to donate $12 to make the nag screen disappear for 3 "
@@ -13668,143 +13566,277 @@ msgid ""
 "to not have to think about or see this nag again."
 msgstr ""
 
-#: ../root/taglookup/Nag.js:30
+#: ../root/taglookup/Nag.js:28
 msgid "Make a donation now!"
 msgstr ""
 
-#: ../root/taglookup/Nag.js:34
+#: ../root/taglookup/Nag.js:32
 msgid "I just donated! Why am I seeing this?"
 msgstr ""
 
-#: ../root/taglookup/NotFound.js:16
+#: ../root/taglookup/NotFound.js:15
 msgid "Tag Lookup Error"
 msgstr ""
 
-#: ../root/taglookup/NotFound.js:18
+#: ../root/taglookup/NotFound.js:17
 msgid ""
 "That search can't be performed, because you must provide at least one of "
 "'recording', 'track number', 'duration', 'release', or 'artist'."
 msgstr ""
 
-#: ../root/taglookup/NotFound.js:21
+#: ../root/taglookup/NotFound.js:20
 msgid "Please {search|try again}, providing at least one of these parameters"
 msgstr ""
 
-#: ../root/taglookup/Results.js:20 ../root/taglookup/Results.js:22
+#: ../root/taglookup/Results.js:19 ../root/taglookup/Results.js:21
 msgid "Tag Lookup Results"
 msgstr ""
 
-#: ../root/track/NotFound.js:16
+#: ../root/track/NotFound.js:15
 msgid "Track Not Found"
 msgstr ""
 
-#: ../root/track/NotFound.js:18
+#: ../root/track/NotFound.js:17
 msgid ""
 "Sorry, we could find neither a recording nor a track with that MusicBrainz "
 "ID. You may wish to try and {search_url|search for it} instead."
 msgstr ""
 
-#: ../root/url/NotFound.js:16
+#: ../root/url/NotFound.js:15
 msgid "URL Not Found"
 msgstr ""
 
-#: ../root/url/NotFound.js:17
+#: ../root/url/NotFound.js:16
 msgid "Sorry, we could not find a URL with that MusicBrainz ID."
 msgstr ""
 
-#: ../root/user/NotFound.js:16
+#: ../root/user/NotFound.js:15
 msgid "Editor Not Found"
 msgstr ""
 
-#: ../root/user/NotFound.js:18
+#: ../root/user/NotFound.js:17
 msgid ""
 "Sorry, we could not find an editor with that name. You may wish to try and "
 "{search_url|search for them} instead."
 msgstr ""
 
-#: ../root/user/components/UserInlineList.js:27
+#: ../root/user/PrivilegedUsers.js:35 ../root/user/PrivilegedUsers.js:37
+msgid "Privileged user accounts"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:39
+msgid "Auto-editors"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:42
+msgid ""
+"Auto-editors are trusted users who have been given {url|auto-editor} "
+"privileges. These privileges allow them to make select edits that are "
+"automatically approved without going through the normal voting process, as "
+"well as the ability to instantly approve other users' edits."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:52
+msgid "The following {count} users have auto-editor privileges:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:58
+msgid "Relationship editors"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:61
+msgid ""
+"Relationship editors are users who can add or modify relationship types in "
+"the database. If you would like to propose a new relationship, you must "
+"follow our {url|proposal system}. Relationship editors will only make "
+"changes that have been accepted through the proposal system."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:71
+msgid "The following {count} users are relationship editors:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:77
+msgid "Transclusion editors"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:80
+msgid ""
+"Transclusion editors are users who add and maintain entries in the {uri|"
+"WikiDocs} transclusion table."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:87
+msgid "The following {count} users are transclusion editors:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:93
+msgid "Location editors"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:95
+msgid "Location editors are users who can add or modify {uri|areas}."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:100
+msgid "The following {count} users are location editors:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:106
+msgid "Banner message editors"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:108
+msgid ""
+"Banner message editors are users who can set a message that is shown in a "
+"banner on all pages, e.g. to warn users about upcoming site maintenance."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:114
+msgid "The following {count} users are banner message editors:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:120
+msgid "Account administrators"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:121
+msgid "Account administrators can edit and delete user accounts."
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:124
+msgid "The following {count} users are account administrators:"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:130
+msgid "Bots"
+msgstr ""
+
+#: ../root/user/PrivilegedUsers.js:133
+msgid "The following {count} user accounts are bots:"
+msgstr ""
+
+#: ../root/user/ReportUser.js:80 ../root/user/ReportUser.js:82
+msgid "Report User"
+msgstr ""
+
+#: ../root/user/ReportUser.js:85
+msgid "Please review our {uri|Code of Conduct} before sending a report."
+msgstr ""
+
+#: ../root/user/ReportUser.js:91
+msgid ""
+"Your report will be sent to our {uri|account administrators}, who will "
+"decide what action to take."
+msgstr ""
+
+#: ../root/user/ReportUser.js:99
+msgid ""
+"Be sure to provide direct links to examples of the behaviour you’re "
+"reporting (for example, use “<code>https://musicbrainz.org/edit/23</code>” "
+"instead of “edit #23”, and use “<code>https://musicbrainz.org/edit/42</code> "
+"and <code>https://musicbrainz.org/edit/43</code>” instead of “<code>https://"
+"musicbrainz.org/user/SomeUser/edits</code>”). Providing links makes it much "
+"easier for the recipients of the report to look into the issues; a report "
+"without links is unlikely to be acted on fast, since it will require a lot "
+"of additional research."
+msgstr ""
+
+#: ../root/user/ReportUser.js:116
+msgid "Reason"
+msgstr ""
+
+#: ../root/user/ReportUser.js:132
+msgid ""
+"If you don’t want our admins to contact you further regarding this report, "
+"you can uncheck the checkbox below. <br /> We recommend leaving it checked, "
+"so that you can be contacted if the report is resolved or the admins need "
+"more information."
+msgstr ""
+
+#: ../root/user/components/UserInlineList.js:26
 msgid "No users found"
 msgstr ""
 
-#: ../root/utility/age.js:144
+#: ../root/utility/age.js:143
 msgid "aged {num}"
 msgstr ""
 
-#: ../root/utility/age.js:146
+#: ../root/utility/age.js:145
 msgid "{num} year"
 msgid_plural "{num} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/utility/age.js:148
+#: ../root/utility/age.js:147
 msgid "{num} month"
 msgid_plural "{num} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/utility/age.js:150
+#: ../root/utility/age.js:149
 msgid "{num} day"
 msgid_plural "{num} days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/utility/edit.js:33
+#: ../root/utility/edit.js:32
 msgid "Accept upon expiration"
 msgstr ""
 
-#: ../root/utility/edit.js:34
+#: ../root/utility/edit.js:33
 msgid "Reject upon expiration"
 msgstr ""
 
-#: ../root/utility/edit.js:59
+#: ../root/utility/edit.js:58
 msgid "This edit is open and awaiting votes before it can be applied."
 msgstr ""
 
-#: ../root/utility/edit.js:61
+#: ../root/utility/edit.js:60
 msgid "This edit has been successfully applied."
 msgstr ""
 
-#: ../root/utility/edit.js:63
+#: ../root/utility/edit.js:62
 msgid "This edit failed because there were insufficient \"yes\" votes."
 msgstr ""
 
-#: ../root/utility/edit.js:65
+#: ../root/utility/edit.js:64
 msgid ""
 "This edit failed either because an entity it was modifying no longer exists, "
 "or the entity can not be modified in this manner anymore."
 msgstr ""
 
-#: ../root/utility/edit.js:67
+#: ../root/utility/edit.js:66
 msgid ""
 "This edit failed due to an internal error and may need to be entered again."
 msgstr ""
 
-#: ../root/utility/edit.js:69
+#: ../root/utility/edit.js:68
 msgid ""
 "This edit failed because the data it was changing was modified after this "
 "edit was created. This may happen when the same edit is entered in twice; "
 "one will pass but the other will fail."
 msgstr ""
 
-#: ../root/utility/edit.js:71
+#: ../root/utility/edit.js:70
 msgid ""
 "This edit failed because it affected high quality data and did not receive "
 "any votes."
 msgstr ""
 
-#: ../root/utility/edit.js:73
+#: ../root/utility/edit.js:72
 msgid "This edit was recently cancelled."
 msgstr ""
 
-#: ../root/utility/edit.js:75
+#: ../root/utility/edit.js:74
 msgid "This edit was cancelled."
 msgstr ""
 
-#: ../root/work/NotFound.js:16
+#: ../root/work/NotFound.js:15
 msgid "Work Not Found"
 msgstr ""
 
-#: ../root/work/NotFound.js:18
+#: ../root/work/NotFound.js:17
 msgid ""
 "Sorry, we could not find a work with that MusicBrainz ID. You may wish to "
 "try and {search_url|search for it} instead."

--- a/po/relationships.nl.po
+++ b/po/relationships.nl.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz\n"
-"PO-Revision-Date: 2019-01-15 20:40+0000\n"
+"PO-Revision-Date: 2019-04-04 17:28+0000\n"
 "Last-Translator: Maurits Meulenbelt <email address hidden>\n"
 "Language-Team: Dutch (http://www.transifex.com/musicbrainz/musicbrainz/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -3973,7 +3973,7 @@ msgstr "heeft zijn of haar geschiedenis gepresenteerd op"
 
 #: DB:link_type/long_link_phrase:93 DB:link_type/long_link_phrase:197
 msgid "has lyrics available at"
-msgstr "liedtekst op"
+msgstr "tekst op"
 
 #: DB:link_type/long_link_phrase:857
 msgid "has music video"
@@ -4128,10 +4128,6 @@ msgstr "uitvinder van"
 msgid "invented by"
 msgstr "uitgevonden door"
 
-#: DB:link_type/link_phrase:112 DB:link_type/reverse_link_phrase:112
-msgid "involved with"
-msgstr "heeft een relatie met"
-
 #: DB:link_type/long_link_phrase:8 DB:link_type/long_link_phrase:227
 msgid "is a DJ-mix of"
 msgstr "is een dj-mix van"
@@ -4259,10 +4255,6 @@ msgstr "is/was artistiek directeur van"
 msgid "is/was distributing the catalog of"
 msgstr "distribueert/distribueerde de catalogus van"
 
-#: DB:link_type/long_link_phrase:112
-msgid "is/was involved with"
-msgstr "is/was betrokken bij"
-
 #: DB:link_type/long_link_phrase:111
 msgid "is/was married to"
 msgstr "is/was getrouwd met"
@@ -4270,6 +4262,10 @@ msgstr "is/was getrouwd met"
 #: DB:link_type/long_link_phrase:201
 msgid "is/was reissuing the catalog of"
 msgstr "geeft/gaf opnieuw de catalogus uit van"
+
+#: DB:link_type/long_link_phrase:112
+msgid "is/was romantically involved with"
+msgstr "heeft of had een verhouding met"
 
 #: DB:link_type/long_link_phrase:200
 msgid "is/was the parent label of"
@@ -4394,12 +4390,12 @@ msgstr "logo’s"
 #: DB:link_type/link_phrase:93 DB:link_type/link_phrase:197
 #: DB:link_type/reverse_link_phrase:271
 msgid "lyrics page"
-msgstr "liedtekst"
+msgstr "tekst"
 
 #: DB:link_type/link_phrase:271 DB:link_type/reverse_link_phrase:93
 #: DB:link_type/reverse_link_phrase:197
 msgid "lyrics page for"
-msgstr "liedtekst van"
+msgstr "tekst van"
 
 #: DB:link_type/reverse_link_phrase:960 DB:link_type/reverse_link_phrase:175
 #: DB:link_type/reverse_link_phrase:79
@@ -5141,6 +5137,10 @@ msgstr "auteursrechtenorganisatie"
 #: DB:link_type/link_phrase:349
 msgid "rights society associated with"
 msgstr "auteursrechtenorganisatie verbonden met"
+
+#: DB:link_type/link_phrase:112 DB:link_type/reverse_link_phrase:112
+msgid "romantically involved with"
+msgstr "verhouding met"
 
 #: DB:link_type/link_phrase:83 DB:link_type/link_phrase:258
 msgid "samples IMDb entry"

--- a/po/relationships.pot
+++ b/po/relationships.pot
@@ -945,13 +945,15 @@ msgstr ""
 msgid "PureVolume page for"
 msgstr ""
 
-#: DB:link_type/link_phrase:307 DB:link_type/link_phrase:308
+#: DB:link_type/link_phrase:308 DB:link_type/link_phrase:976
+#: DB:link_type/link_phrase:977 DB:link_type/link_phrase:307
 #: DB:link_type/reverse_link_phrase:280
 msgid "SecondHandSongs"
 msgstr ""
 
-#: DB:link_type/link_phrase:280 DB:link_type/reverse_link_phrase:307
-#: DB:link_type/reverse_link_phrase:308
+#: DB:link_type/link_phrase:280 DB:link_type/reverse_link_phrase:308
+#: DB:link_type/reverse_link_phrase:976 DB:link_type/reverse_link_phrase:977
+#: DB:link_type/reverse_link_phrase:307
 msgid "SecondHandSongs page for"
 msgstr ""
 
@@ -981,6 +983,18 @@ msgstr ""
 #: DB:link_type/reverse_link_phrase:870 DB:link_type/reverse_link_phrase:291
 #: DB:link_type/reverse_link_phrase:290 DB:link_type/reverse_link_phrase:940
 msgid "SoundCloud page for"
+msgstr ""
+
+#: DB:link_attribute_type/description:1135
+msgid ""
+"Specifies the level of studies that a student studied towards in an "
+"educational institution."
+msgstr ""
+
+#: DB:link_attribute_type/description:1125
+msgid ""
+"Specifies the subject that was taught by a teacher in an institution and/or "
+"to a student."
 msgstr ""
 
 #: DB:link_attribute_type/description:561
@@ -1499,6 +1513,14 @@ msgid ""
 "part."
 msgstr ""
 
+#: DB:link_type/description:973
+msgid "This indicates the artist that inspired this artist’s name."
+msgstr ""
+
+#: DB:link_type/description:975
+msgid "This indicates the artist that inspired this place’s name."
+msgstr ""
+
 #: DB:link_type/description:962
 msgid "This indicates the artist was the director of this music video."
 msgstr ""
@@ -1633,6 +1655,10 @@ msgid ""
 "label</a>."
 msgstr ""
 
+#: DB:link_type/description:974
+msgid "This indicates the release group that inspired this artist’s name."
+msgstr ""
+
 #: DB:link_type/description:349
 msgid ""
 "This indicates the rights society associated with a release. The rights "
@@ -1667,6 +1693,10 @@ msgstr ""
 msgid ""
 "This indicates the work is dedicated to a specific person. This is most "
 "common for classical works, but also exists in other genres to a degree."
+msgstr ""
+
+#: DB:link_type/description:972
+msgid "This indicates the work that inspired this artist’s name."
 msgstr ""
 
 #: DB:link_type/description:915
@@ -1728,6 +1758,12 @@ msgstr ""
 msgid "This is used to link a label to its corresponding Wikipedia page."
 msgstr ""
 
+#: DB:link_type/description:977
+msgid ""
+"This is used to link a label to its corresponding page in the "
+"SecondHandSongs database."
+msgstr ""
+
 #: DB:link_type/description:857
 msgid ""
 "This is used to link a music video to the corresponding audio recording."
@@ -1735,6 +1771,12 @@ msgstr ""
 
 #: DB:link_type/description:705
 msgid "This is used to link a place to the equivalent entry in Discogs."
+msgstr ""
+
+#: DB:link_type/description:976
+msgid ""
+"This is used to link a recording to its corresponding page in the "
+"SecondHandSongs database."
 msgstr ""
 
 #: DB:link_type/description:285
@@ -1757,8 +1799,8 @@ msgstr ""
 
 #: DB:link_type/description:308
 msgid ""
-"This is used to link a release to its corresponding page in SecondHandSongs "
-"database."
+"This is used to link a release to its corresponding page in the "
+"SecondHandSongs database."
 msgstr ""
 
 #: DB:link_type/description:755
@@ -1771,7 +1813,7 @@ msgstr ""
 
 #: DB:link_type/description:280
 msgid ""
-"This is used to link a work to its corresponding page in SecondHandSongs "
+"This is used to link a work to its corresponding page in the SecondHandSongs "
 "database."
 msgstr ""
 
@@ -1781,8 +1823,8 @@ msgstr ""
 
 #: DB:link_type/description:307
 msgid ""
-"This is used to link an artist to its corresponding page in SecondHandSongs "
-"database."
+"This is used to link an artist to its corresponding page in the "
+"SecondHandSongs database."
 msgstr ""
 
 #: DB:link_type/description:283
@@ -3182,6 +3224,10 @@ msgstr ""
 msgid "available releases"
 msgstr ""
 
+#: DB:link_attribute_type/name:1137
+msgid "bachelor’s degree"
+msgstr ""
+
 #: DB:link_attribute_type/description:12 DB:link_attribute_type/name:12
 msgid "background vocals"
 msgstr ""
@@ -3334,10 +3380,15 @@ msgstr ""
 msgid "composers-in-residence"
 msgstr ""
 
-#: DB:link_type/link_phrase:58 DB:link_type/link_phrase:170
-#: DB:link_type/reverse_link_phrase:58 DB:link_type/reverse_link_phrase:170
-#: DB:link_type/long_link_phrase:58 DB:link_type/long_link_phrase:170
+#: DB:link_attribute_type/name:1126 DB:link_type/link_phrase:58
+#: DB:link_type/link_phrase:170 DB:link_type/reverse_link_phrase:58
+#: DB:link_type/reverse_link_phrase:170 DB:link_type/long_link_phrase:58
+#: DB:link_type/long_link_phrase:170
 msgid "composition"
+msgstr ""
+
+#: DB:link_attribute_type/name:1130
+msgid "conducting"
 msgstr ""
 
 #: DB:link_type/link_phrase:806
@@ -3525,6 +3576,10 @@ msgstr ""
 msgid "distributors"
 msgstr ""
 
+#: DB:link_attribute_type/name:1139
+msgid "doctoral degree"
+msgstr ""
+
 #: DB:link_type/long_link_phrase:105
 msgid "does/did {instrument} support for"
 msgstr ""
@@ -3558,6 +3613,10 @@ msgstr ""
 msgid "earliest release"
 msgstr ""
 
+#: DB:link_attribute_type/name:1131
+msgid "early music"
+msgstr ""
+
 #: DB:link_type/link_phrase:309
 msgid "edit of"
 msgstr ""
@@ -3576,6 +3635,10 @@ msgstr ""
 
 #: DB:link_type/reverse_link_phrase:924
 msgid "educators"
+msgstr ""
+
+#: DB:link_attribute_type/name:1127
+msgid "electronic music"
 msgstr ""
 
 #: DB:link_attribute_type/name:617
@@ -3608,6 +3671,10 @@ msgstr ""
 
 #: DB:link_type/link_phrase:172 DB:link_type/link_phrase:214
 msgid "fan pages"
+msgstr ""
+
+#: DB:link_attribute_type/name:1133
+msgid "folk music"
 msgstr ""
 
 #: DB:link_type/link_phrase:116 DB:link_type/link_phrase:832
@@ -3770,7 +3837,8 @@ msgstr ""
 msgid "has a PureVolume page at"
 msgstr ""
 
-#: DB:link_type/long_link_phrase:307 DB:link_type/long_link_phrase:308
+#: DB:link_type/long_link_phrase:308 DB:link_type/long_link_phrase:976
+#: DB:link_type/long_link_phrase:977 DB:link_type/long_link_phrase:307
 msgid "has a SecondHandSongs page at"
 msgstr ""
 
@@ -4080,6 +4148,10 @@ msgstr ""
 msgid "imprints"
 msgstr ""
 
+#: DB:link_attribute_type/name:1134
+msgid "improvisation"
+msgstr ""
+
 #: DB:link_type/link_phrase:894
 msgid "included in"
 msgstr ""
@@ -4091,6 +4163,11 @@ msgstr ""
 #: DB:link_type/description:734 DB:link_type/link_phrase:734
 #: DB:link_type/reverse_link_phrase:734 DB:link_type/long_link_phrase:734
 msgid "information page"
+msgstr ""
+
+#: DB:link_type/link_phrase:975 DB:link_type/reverse_link_phrase:973
+#: DB:link_type/reverse_link_phrase:972 DB:link_type/reverse_link_phrase:974
+msgid "inspired the name of"
 msgstr ""
 
 #: DB:link_attribute_type/name:580
@@ -4134,7 +4211,7 @@ msgstr ""
 msgid "is a live performance of"
 msgstr ""
 
-#: DB:link_type/long_link_phrase:232 DB:link_type/long_link_phrase:10
+#: DB:link_type/long_link_phrase:10 DB:link_type/long_link_phrase:232
 msgid "is a mash-up of"
 msgstr ""
 
@@ -4199,6 +4276,11 @@ msgstr ""
 
 #: DB:link_type/long_link_phrase:302 DB:link_type/long_link_phrase:301
 msgid "is licensed under"
+msgstr ""
+
+#: DB:link_type/long_link_phrase:973 DB:link_type/long_link_phrase:972
+#: DB:link_type/long_link_phrase:974
+msgid "is named after"
 msgstr ""
 
 #: DB:link_type/long_link_phrase:738
@@ -4271,6 +4353,10 @@ msgid ""
 "for"
 msgstr ""
 
+#: DB:link_attribute_type/name:1132
+msgid "jazz"
+msgstr ""
+
 #: DB:link_type/reverse_link_phrase:226
 msgid "karaoke version of"
 msgstr ""
@@ -4321,6 +4407,10 @@ msgstr ""
 
 #: DB:link_type/link_phrase:142 DB:link_type/reverse_link_phrase:142
 msgid "legal representation"
+msgstr ""
+
+#: DB:link_attribute_type/name:1135
+msgid "level of studies"
 msgstr ""
 
 #: DB:link_type/reverse_link_phrase:880
@@ -4440,11 +4530,11 @@ msgstr ""
 msgid "married"
 msgstr ""
 
-#: DB:link_type/link_phrase:232 DB:link_type/link_phrase:10
+#: DB:link_type/link_phrase:10 DB:link_type/link_phrase:232
 msgid "mash-up of"
 msgstr ""
 
-#: DB:link_type/reverse_link_phrase:232 DB:link_type/reverse_link_phrase:10
+#: DB:link_type/reverse_link_phrase:10 DB:link_type/reverse_link_phrase:232
 msgid "mash-ups"
 msgstr ""
 
@@ -4454,6 +4544,10 @@ msgstr ""
 
 #: DB:link_type/reverse_link_phrase:704
 msgid "mastering engineers"
+msgstr ""
+
+#: DB:link_attribute_type/name:1136
+msgid "master’s degree"
 msgstr ""
 
 #: DB:link_attribute_type/name:1060
@@ -4571,6 +4665,15 @@ msgstr ""
 msgid "musical relationship"
 msgstr ""
 
+#: DB:link_attribute_type/name:1141
+msgid "musicology"
+msgstr ""
+
+#: DB:link_type/link_phrase:973 DB:link_type/link_phrase:972
+#: DB:link_type/link_phrase:974 DB:link_type/reverse_link_phrase:975
+msgid "named after"
+msgstr ""
+
 #: DB:link_type/link_phrase:935 DB:link_type/reverse_link_phrase:935
 #: DB:link_type/long_link_phrase:935
 msgid "non-performing relationships"
@@ -4646,6 +4749,10 @@ msgstr ""
 
 #: DB:link_type/reverse_link_phrase:836
 msgid "originally scheduled as"
+msgstr ""
+
+#: DB:link_attribute_type/name:1128
+msgid "other"
 msgstr ""
 
 #: DB:link_type/link_phrase:746 DB:link_type/link_phrase:803
@@ -5226,6 +5333,10 @@ msgstr ""
 msgid "subgroups"
 msgstr ""
 
+#: DB:link_attribute_type/name:1125
+msgid "subject"
+msgstr ""
+
 #: DB:link_type/link_phrase:823
 msgid "subseries"
 msgstr ""
@@ -5282,8 +5393,8 @@ msgstr ""
 msgid "taught"
 msgstr ""
 
-#: DB:link_type/link_phrase:924 DB:link_type/link_phrase:893
-#: DB:link_type/long_link_phrase:924 DB:link_type/long_link_phrase:893
+#: DB:link_type/link_phrase:893 DB:link_type/link_phrase:924
+#: DB:link_type/long_link_phrase:893 DB:link_type/long_link_phrase:924
 msgid "taught at"
 msgstr ""
 
@@ -6106,6 +6217,10 @@ msgstr ""
 
 #: DB:link_type/long_link_phrase:939
 msgid "{entity1} is licensed under {entity0}"
+msgstr ""
+
+#: DB:link_type/long_link_phrase:975
+msgid "{entity1} is named after {entity0}"
 msgstr ""
 
 #: DB:link_type/long_link_phrase:357

--- a/po/statistics.es.po
+++ b/po/statistics.es.po
@@ -19,8 +19,8 @@ msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-04-23 18:29+0200\n"
-"PO-Revision-Date: 2019-01-05 20:47+0000\n"
-"Last-Translator: Robert Schneider <email address hidden>\n"
+"PO-Revision-Date: 2019-03-05 11:26+0000\n"
+"Last-Translator: Jaime Marquínez Ferrándiz\n"
 "Language-Team: Spanish (http://www.transifex.com/musicbrainz/musicbrainz/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -445,7 +445,7 @@ msgstr "Oliver Charles se une a MusicBrainz a tiempo completo"
 
 #: DB:statistics.statistic_event/title:2012-10-15
 msgid "Relationship Editor"
-msgstr ""
+msgstr "Editor de relaciones"
 
 #: DB:statistics.statistic_event/title:2009-05-24
 msgid "Release Groups, ISRCs, CDStub searching"

--- a/po/statistics.pot
+++ b/po/statistics.pot
@@ -20,7 +20,7 @@ msgstr ""
 "#-#-#-#-#  statistics_js.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-02 23:55-0600\n"
+"POT-Creation-Date: 2019-04-10 18:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -501,7 +501,7 @@ msgid "TRM collisions"
 msgstr ""
 
 #: DB:statistics.statistic_event/title:2007-10-17
-#: ../root/statistics/stats.js:626
+#: ../root/statistics/stats.js:625
 msgid "Tags"
 msgstr ""
 
@@ -593,103 +593,8 @@ msgstr ""
 msgid "mb_server now hosted on Git"
 msgstr ""
 
-#: ../root/statistics/formats.tt:29
-msgid "% of total mediums"
-msgstr ""
-
-#: ../root/statistics/formats.tt:27
-msgid "% of total releases"
-msgstr ""
-
-#: ../root/statistics/formats.tt:37 ../root/statistics/formats.tt:39
-msgid "100%"
-msgstr ""
-
-#: ../root/statistics/index.tt:952
-msgctxt "vote"
-msgid "Abstain"
-msgstr ""
-
 #: ../root/statistics/timeline.tt:18
 msgid "Add/remove lines:"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:23
-msgid "All other available languages and scripts have 0 releases and works."
-msgstr ""
-
-#: ../root/statistics/index.tt:328
-msgid "Amazon:"
-msgstr ""
-
-#: ../root/statistics/index.tt:870
-msgid "Applied:"
-msgstr ""
-
-#: ../root/statistics/index.tt:934
-msgctxt "vote"
-msgid "Approve"
-msgstr ""
-
-#: ../root/statistics/index.tt:605 ../root/statistics/stats.js:56
-msgid "Areas"
-msgstr ""
-
-#: ../root/statistics/index.tt:52 ../root/statistics/index.tt:612
-msgid "Areas:"
-msgstr ""
-
-#: ../root/statistics/countries.tt:26 ../root/statistics/index.tt:142
-#: ../root/statistics/index.tt:146 ../root/statistics/stats.js:62
-msgid "Artists"
-msgstr ""
-
-#: ../root/statistics/index.tt:16 ../root/statistics/index.tt:149
-msgid "Artists:"
-msgstr ""
-
-#: ../root/statistics/index.tt:581
-msgid "Attributes"
-msgstr ""
-
-#: ../root/statistics/index.tt:128
-msgid "Barcodes:"
-msgstr ""
-
-#: ../root/statistics/index.tt:9
-msgid "Basic metadata"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:13
-msgid "Basics"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:129
-msgid "By Cover Art Type"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:78
-msgid "By Release Format"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:46
-msgid "By Release Group Type"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:62
-msgid "By Release Status"
-msgstr ""
-
-#: ../root/statistics/index.tt:322
-msgid "CAA:"
-msgstr ""
-
-#: ../root/statistics/index.tt:87
-msgid "CD Stubs (all time / current):"
-msgstr ""
-
-#: ../root/statistics/index.tt:900
-msgid "Cancelled:"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:18
@@ -704,32 +609,19 @@ msgstr ""
 msgid "Controls"
 msgstr ""
 
-#: ../root/statistics/index.tt:13 ../root/statistics/stats.js:33
-msgid "Core Entities"
-msgstr ""
-
-#: ../root/statistics/countries.tt:16 ../root/statistics/layout.tt:4
+#: ../root/statistics/layout.tt:4 ../root/statistics/Countries.js:36
+#: ../root/statistics/StatisticsLayout.js:49
 msgid "Countries"
 msgstr ""
 
-#: ../root/statistics/countries.tt:25
-msgid "Country"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:5 ../root/statistics/layout.tt:4
-#: ../root/statistics/stats.js:34
+#: ../root/statistics/layout.tt:4 ../root/statistics/CoverArt.js:68
+#: ../root/statistics/StatisticsLayout.js:59 ../root/statistics/stats.js:27
 msgid "Cover Art"
 msgstr ""
 
-#: ../root/statistics/index.tt:313
-msgid "Cover Art Sources"
-msgstr ""
-
-#: ../root/statistics/index.tt:347
-msgid "Data Quality"
-msgstr ""
-
 #: ../root/statistics/layout.tt:23 ../root/statistics/layout.tt:34
+#: ../root/statistics/StatisticsLayout.js:95
+#: ../root/statistics/StatisticsLayout.js:109
 msgid "Database Statistics"
 msgstr ""
 
@@ -737,219 +629,42 @@ msgstr ""
 msgid "Database Statistics - {title}"
 msgstr ""
 
-#: ../root/statistics/index.tt:362
-msgid "Default Data Quality:"
-msgstr ""
-
-#: ../root/statistics/index.tt:389 ../root/statistics/stats.js:188
-msgid "Disc IDs"
-msgstr ""
-
-#: ../root/statistics/index.tt:124 ../root/statistics/index.tt:392
-msgid "Disc IDs:"
-msgstr ""
-
 #: ../root/statistics/timeline.tt:16
 msgid "Draw a rectangle on either graph"
 msgstr ""
 
-#: ../root/statistics/editors.tt:37 ../root/statistics/editors.tt:38
-msgid "Editor"
-msgstr ""
-
-#: ../root/statistics/editors.tt:1 ../root/statistics/editors.tt:36
-#: ../root/statistics/index.tt:743 ../root/statistics/layout.tt:4
+#: ../root/statistics/layout.tt:4 ../root/statistics/Editors.js:97
+#: ../root/statistics/Editors.js:108 ../root/statistics/Index.js:834
+#: ../root/statistics/StatisticsLayout.js:79
 msgid "Editors"
 msgstr ""
 
-#: ../root/statistics/index.tt:848
-msgid "Editors (deleted):"
-msgstr ""
-
-#: ../root/statistics/index.tt:77
-msgid "Editors (valid / deleted):"
-msgstr ""
-
-#: ../root/statistics/index.tt:746
-msgid "Editors (valid):"
-msgstr ""
-
-#: ../root/statistics/index.tt:739
-msgid "Editors, Edits, and Votes"
-msgstr ""
-
-#: ../root/statistics/edits.tt:1 ../root/statistics/edits.tt:9
-#: ../root/statistics/index.tt:855 ../root/statistics/layout.tt:4
-#: ../root/statistics/stats.js:195
+#: ../root/statistics/layout.tt:4 ../root/statistics/Edits.js:32
+#: ../root/statistics/Edits.js:36 ../root/statistics/Edits.js:45
+#: ../root/statistics/Index.js:950 ../root/statistics/StatisticsLayout.js:69
+#: ../root/statistics/stats.js:194
 msgid "Edits"
-msgstr ""
-
-#: ../root/statistics/edits.tt:18 ../root/statistics/index.tt:858
-#: ../root/statistics/index.tt:905
-msgid "Edits:"
-msgstr ""
-
-#: ../root/statistics/index.tt:711 ../root/statistics/stats.js:314
-msgid "Events"
-msgstr ""
-
-#: ../root/statistics/index.tt:68 ../root/statistics/index.tt:718
-msgid "Events:"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:28
 msgid "Exact Values (items vs. day)"
 msgstr ""
 
-#: ../root/statistics/relationships.tt:30
-msgid "Exclusive"
-msgstr ""
-
-#: ../root/statistics/index.tt:882
-msgid "Failed (dependency):"
-msgstr ""
-
-#: ../root/statistics/index.tt:894
-msgid "Failed (internal error):"
-msgstr ""
-
-#: ../root/statistics/index.tt:888
-msgid "Failed (prerequisite):"
-msgstr ""
-
-#: ../root/statistics/index.tt:220
-msgid "Female:"
-msgstr ""
-
-#: ../root/statistics/editors.tt:32
-msgid ""
-"For the vote statistics, only yes or no votes are counted, abstain votes are "
-"not counted."
-msgstr ""
-
-#: ../root/statistics/formats.tt:25
-msgid "Format"
-msgstr ""
-
-#: ../root/statistics/layout.tt:4 ../root/statistics/stats.js:36
+#: ../root/statistics/layout.tt:4 ../root/statistics/StatisticsLayout.js:74
+#: ../root/statistics/stats.js:29
 msgid "Formats"
-msgstr ""
-
-#: ../root/statistics/index.tt:356
-msgid "High Data Quality:"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:19
 msgid "Hover and click on vertical lines"
 msgstr ""
 
-#: ../root/statistics/index.tt:132
-msgid "IPIs:"
-msgstr ""
-
-#: ../root/statistics/index.tt:136
-msgid "ISNIs:"
-msgstr ""
-
-#: ../root/statistics/index.tt:116
-msgid "ISRCs (all / unique):"
-msgstr ""
-
-#: ../root/statistics/index.tt:120
-msgid "ISWCs (all / unique):"
-msgstr ""
-
-#: ../root/statistics/index.tt:109
-msgid "Identifiers"
-msgstr ""
-
-#: ../root/statistics/relationships.tt:30
-msgid "Inclusive"
-msgstr ""
-
-#: ../root/statistics/index.tt:683 ../root/statistics/stats.js:320
-msgid "Instruments"
-msgstr ""
-
-#: ../root/statistics/index.tt:64 ../root/statistics/index.tt:690
-msgid "Instruments:"
-msgstr ""
-
-#: ../root/statistics/countries.tt:28 ../root/statistics/index.tt:522
-#: ../root/statistics/index.tt:529 ../root/statistics/stats.js:386
-msgid "Labels"
-msgstr ""
-
-#: ../root/statistics/index.tt:40
-msgid "Labels:"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:31
-msgid "Language"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:26
-msgid "Languages"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:19
-msgid "Languages and Scripts"
-msgstr ""
-
-#: ../root/statistics/layout.tt:4
+#: ../root/statistics/layout.tt:4 ../root/statistics/StatisticsLayout.js:54
 msgid "Languages/Scripts"
-msgstr ""
-
-#: ../root/statistics/index.tt:911 ../root/statistics/index.tt:963
-msgid "Last 7 days:"
-msgstr ""
-
-#: ../root/statistics/countries.tt:19 ../root/statistics/coverart.tt:11
-#: ../root/statistics/editors.tt:30 ../root/statistics/edits.tt:7
-#: ../root/statistics/formats.tt:18 ../root/statistics/index.tt:7
-#: ../root/statistics/languages_scripts.tt:22
-#: ../root/statistics/relationships.tt:19
-msgid "Last updated: {date}"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:2
 msgid "Legend"
-msgstr ""
-
-#: ../root/statistics/index.tt:382
-msgid "Low Data Quality:"
-msgstr ""
-
-#: ../root/statistics/index.tt:112
-msgid "MBIDs:"
-msgstr ""
-
-#: ../root/statistics/index.tt:214
-msgid "Male:"
-msgstr ""
-
-#: ../root/statistics/formats.tt:28 ../root/statistics/stats.js:398
-msgid "Mediums"
-msgstr ""
-
-#: ../root/statistics/index.tt:442
-msgid "Mediums with at least one disc ID:"
-msgstr ""
-
-#: ../root/statistics/index.tt:436
-msgid "Mediums with no disc IDs:"
-msgstr ""
-
-#: ../root/statistics/index.tt:28 ../root/statistics/index.tt:430
-msgid "Mediums:"
-msgstr ""
-
-#: ../root/statistics/editors.tt:37
-msgid "Most active editors in the past week"
-msgstr ""
-
-#: ../root/statistics/editors.tt:43
-msgid "Most active voters in the past week"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:6
@@ -960,115 +675,9 @@ msgstr ""
 msgid "MusicBrainz Events:"
 msgstr ""
 
-#: ../root/statistics/index.tt:946
-msgctxt "vote"
-msgid "No"
-msgstr ""
-
-#: ../root/statistics/no_statistics.tt:2
-msgid "No Statistics"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:16 ../root/statistics/coverart.tt:40
-#: ../root/statistics/coverart.tt:123
-msgid "No coverart statistics available."
-msgstr ""
-
-#: ../root/statistics/edits.tt:12
-msgid "No edit statistics available."
-msgstr ""
-
-#: ../root/statistics/coverart.tt:88
-msgid "No format"
-msgstr ""
-
-#: ../root/statistics/index.tt:340
-msgid "No front cover art:"
-msgstr ""
-
-#: ../root/statistics/index.tt:306
-msgid "No packaging set"
-msgstr ""
-
-#: ../root/statistics/relationships.tt:24
-msgid "No relationship statistics available."
-msgstr ""
-
-#: ../root/statistics/coverart.tt:72
-msgid "No status"
-msgstr ""
-
-#: ../root/statistics/index.tt:282
-msgid "No status set"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:56 ../root/statistics/coverart.tt:139
-msgid "No type"
-msgstr ""
-
-#: ../root/statistics/index.tt:208
-msgid "Non-group artists:"
-msgstr ""
-
-#: ../root/statistics/index.tt:543 ../root/statistics/index.tt:571
-#: ../root/statistics/index.tt:598 ../root/statistics/index.tt:626
-#: ../root/statistics/index.tt:654 ../root/statistics/index.tt:704
-#: ../root/statistics/index.tt:732
-msgid "None"
-msgstr ""
-
-#: ../root/statistics/index.tt:369
-msgid "Normal Data Quality:"
-msgstr ""
-
-#: ../root/statistics/editors.tt:37
-msgid "Open and applied edits in past week"
-msgstr ""
-
-#: ../root/statistics/index.tt:864
-msgid "Open:"
-msgstr ""
-
-#: ../root/statistics/index.tt:74
-msgid "Other Entities"
-msgstr ""
-
-#: ../root/statistics/index.tt:226
-msgid "Other gender:"
-msgstr ""
-
-#: ../root/statistics/index.tt:1 ../root/statistics/layout.tt:4
+#: ../root/statistics/layout.tt:4 ../root/statistics/Index.js:63
+#: ../root/statistics/StatisticsLayout.js:44
 msgid "Overview"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:145
-msgid "Per release"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:120
-msgid "Pieces of cover art"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:27 ../root/statistics/coverart.tt:132
-msgid "Pieces of cover art:"
-msgstr ""
-
-#: ../root/statistics/index.tt:633 ../root/statistics/stats.js:416
-msgid "Places"
-msgstr ""
-
-#: ../root/statistics/index.tt:56 ../root/statistics/index.tt:640
-msgid "Places:"
-msgstr ""
-
-#: ../root/statistics/index.tt:469
-msgid "Primary Types"
-msgstr ""
-
-#: ../root/statistics/countries.tt:24 ../root/statistics/editors.tt:9
-#: ../root/statistics/formats.tt:24 ../root/statistics/languages_scripts.tt:30
-#: ../root/statistics/languages_scripts.tt:51
-msgid "Rank"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:30
@@ -1079,132 +688,18 @@ msgstr ""
 msgid "Rate of Change Graph"
 msgstr ""
 
-#: ../root/statistics/index.tt:99
-msgid "Ratings (raw / aggregated):"
-msgstr ""
-
-#: ../root/statistics/index.tt:503 ../root/statistics/index.tt:507
-#: ../root/statistics/stats.js:524
-msgid "Recordings"
-msgstr ""
-
-#: ../root/statistics/index.tt:32 ../root/statistics/index.tt:510
-msgid "Recordings:"
-msgstr ""
-
-#: ../root/statistics/layout.tt:4 ../root/statistics/relationships.tt:13
-#: ../root/statistics/relationships.tt:21 ../root/statistics/stats.js:40
-#: ../root/statistics/stats.js:50
+#: ../root/statistics/layout.tt:4 ../root/statistics/Relationships.js:77
+#: ../root/statistics/Relationships.js:81
+#: ../root/statistics/StatisticsLayout.js:64 ../root/statistics/stats.js:33
+#: ../root/statistics/stats.js:43
 msgid "Relationships"
-msgstr ""
-
-#: ../root/statistics/index.tt:83 ../root/statistics/relationships.tt:33
-msgid "Relationships:"
-msgstr ""
-
-#: ../root/statistics/index.tt:465 ../root/statistics/stats.js:614
-msgid "Release Groups"
-msgstr ""
-
-#: ../root/statistics/index.tt:20 ../root/statistics/index.tt:472
-#: ../root/statistics/index.tt:488
-msgid "Release Groups:"
-msgstr ""
-
-#: ../root/statistics/index.tt:289
-msgid "Release Packaging"
-msgstr ""
-
-#: ../root/statistics/index.tt:265
-msgid "Release Status"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:97
-msgid "Release groups"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:101
-msgid "Release groups with cover art:"
-msgstr ""
-
-#: ../root/statistics/formats.tt:15 ../root/statistics/formats.tt:20
-msgid "Release/Medium Formats"
-msgstr ""
-
-#: ../root/statistics/countries.tt:27 ../root/statistics/coverart.tt:35
-#: ../root/statistics/formats.tt:26 ../root/statistics/index.tt:243
-#: ../root/statistics/languages_scripts.tt:32
-#: ../root/statistics/languages_scripts.tt:53 ../root/statistics/stats.js:536
-msgid "Releases"
-msgstr ""
-
-#: ../root/statistics/index.tt:409
-msgid "Releases with at least one disc ID:"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:22 ../root/statistics/coverart.tt:49
-#: ../root/statistics/coverart.tt:65 ../root/statistics/coverart.tt:81
-#: ../root/statistics/coverart.tt:148
-msgid "Releases with cover art:"
-msgstr ""
-
-#: ../root/statistics/index.tt:403
-msgid "Releases with no disc IDs:"
-msgstr ""
-
-#: ../root/statistics/index.tt:239
-msgid "Releases, Data Quality, and Disc IDs"
-msgstr ""
-
-#: ../root/statistics/index.tt:24 ../root/statistics/index.tt:246
-#: ../root/statistics/index.tt:268 ../root/statistics/index.tt:292
-#: ../root/statistics/index.tt:316 ../root/statistics/index.tt:350
-#: ../root/statistics/index.tt:397
-msgid "Releases:"
 msgstr ""
 
 #: ../root/statistics/timeline.tt:17
 msgid "Reset:"
 msgstr ""
 
-#: ../root/statistics/languages_scripts.tt:52
-msgid "Script"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:47
-msgid "Scripts"
-msgstr ""
-
-#: ../root/statistics/index.tt:485
-msgid "Secondary Types"
-msgstr ""
-
-#: ../root/statistics/index.tt:661 ../root/statistics/stats.js:620
-msgctxt "plural"
-msgid "Series"
-msgstr ""
-
-#: ../root/statistics/index.tt:60 ../root/statistics/index.tt:668
-msgctxt "plural"
-msgid "Series:"
-msgstr ""
-
-#: ../root/statistics/no_statistics.tt:3
-msgid ""
-"Statistics have never been collected for this server. If you are the "
-"administrator for this server, you should run <code>./admin/CollectStats.pl</"
-"code> or import <code>mbdump-stats.tar.bz2</code>."
-msgstr ""
-
-#: ../root/statistics/index.tt:91
-msgid "Tags (raw / aggregated):"
-msgstr ""
-
-#: ../root/statistics/editors.tt:17
-msgid "There is no data to display here."
-msgstr ""
-
-#: ../root/statistics/layout.tt:4
+#: ../root/statistics/layout.tt:4 ../root/statistics/StatisticsLayout.js:84
 msgid "Timeline"
 msgstr ""
 
@@ -1212,1219 +707,1685 @@ msgstr ""
 msgid "Timeline Graph"
 msgstr ""
 
-#: ../root/statistics/editors.tt:38
-msgid "Top editors overall"
-msgstr ""
-
-#: ../root/statistics/editors.tt:44
-msgid "Top voters overall"
-msgstr ""
-
-#: ../root/statistics/countries.tt:29 ../root/statistics/formats.tt:35
-#: ../root/statistics/languages_scripts.tt:34
-msgid "Total"
-msgstr ""
-
-#: ../root/statistics/editors.tt:38
-msgid "Total applied edits"
-msgstr ""
-
-#: ../root/statistics/editors.tt:44
-msgid "Total votes"
-msgstr ""
-
-#: ../root/statistics/index.tt:36
-msgid "Tracks:"
-msgstr ""
-
-#: ../root/statistics/index.tt:526 ../root/statistics/index.tt:554
-#: ../root/statistics/index.tt:609 ../root/statistics/index.tt:637
-#: ../root/statistics/index.tt:665 ../root/statistics/index.tt:687
-#: ../root/statistics/index.tt:715
-msgid "Types"
-msgstr ""
-
-#: ../root/statistics/index.tt:334
-msgid "URL Relationships:"
-msgstr ""
-
-#: ../root/statistics/index.tt:48
-msgid "URLs:"
-msgstr ""
-
-#: ../root/statistics/countries.tt:7 ../root/statistics/stats.js:74
-#: ../root/statistics/stats.js:392 ../root/statistics/stats.js:542
-msgid "Unknown Country"
-msgstr ""
-
-#: ../root/statistics/index.tt:376
-msgid "Unknown Data Quality:"
-msgstr ""
-
-#: ../root/statistics/formats.tt:4
-msgid "Unknown Format"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:5
-msgid "Unknown language"
-msgstr ""
-
-#: ../root/statistics/languages_scripts.tt:12
-msgid "Unknown script"
-msgstr ""
-
-#: ../root/statistics/index.tt:515
-msgid "Videos:"
-msgstr ""
-
-#: ../root/statistics/index.tt:876
-msgid "Voted down:"
-msgstr ""
-
-#: ../root/statistics/editors.tt:43 ../root/statistics/editors.tt:44
-msgid "Voter"
-msgstr ""
-
-#: ../root/statistics/editors.tt:42
-msgid "Voters"
-msgstr ""
-
-#: ../root/statistics/index.tt:925 ../root/statistics/stats.js:699
-msgid "Votes"
-msgstr ""
-
-#: ../root/statistics/editors.tt:43
-msgid "Votes in past week"
-msgstr ""
-
-#: ../root/statistics/index.tt:928 ../root/statistics/index.tt:957
-msgid "Votes:"
-msgstr ""
-
-#: ../root/statistics/index.tt:550 ../root/statistics/languages_scripts.tt:33
-#: ../root/statistics/stats.js:736
-msgid "Works"
-msgstr ""
-
-#: ../root/statistics/index.tt:44 ../root/statistics/index.tt:557
-#: ../root/statistics/index.tt:584
-msgid "Works:"
-msgstr ""
-
-#: ../root/statistics/index.tt:940
-msgctxt "vote"
-msgid "Yes"
-msgstr ""
-
-#: ../root/statistics/index.tt:918 ../root/statistics/index.tt:970
-msgid "Yesterday:"
-msgstr ""
-
 #: ../root/statistics/timeline.tt:16
 msgid "Zoom:"
 msgstr ""
 
-#: ../root/statistics/index.tt:752
-msgid "active ever:"
+#: ../root/statistics/Countries.js:38 ../root/statistics/CoverArt.js:70
+#: ../root/statistics/Editors.js:99 ../root/statistics/Edits.js:34
+#: ../root/statistics/Formats.js:43 ../root/statistics/Index.js:65
+#: ../root/statistics/LanguagesScripts.js:49
+#: ../root/statistics/Relationships.js:79
+msgid "Last updated: {date}"
 msgstr ""
 
-#: ../root/statistics/coverart.tt:113
-msgid "automatically inferred:"
+#: ../root/statistics/Countries.js:44 ../root/statistics/Editors.js:53
+#: ../root/statistics/Formats.js:50 ../root/statistics/LanguagesScripts.js:57
+#: ../root/statistics/LanguagesScripts.js:108
+msgid "Rank"
 msgstr ""
 
-#: ../root/statistics/index.tt:258
-msgid "by a single artist:"
+#: ../root/statistics/Countries.js:46
+msgid "Country"
 msgstr ""
 
-#: ../root/statistics/index.tt:252
-msgid "by various artists:"
+#: ../root/statistics/Countries.js:50 ../root/statistics/Index.js:219
+#: ../root/statistics/Index.js:223 ../root/statistics/stats.js:55
+msgid "Artists"
 msgstr ""
 
-#: ../root/statistics/index.tt:843
-msgid "inactive:"
+#: ../root/statistics/Countries.js:54 ../root/statistics/CoverArt.js:99
+#: ../root/statistics/Formats.js:52 ../root/statistics/Index.js:326
+#: ../root/statistics/LanguagesScripts.js:63
+#: ../root/statistics/LanguagesScripts.js:114 ../root/statistics/stats.js:535
+msgid "Releases"
 msgstr ""
 
-#: ../root/statistics/coverart.tt:107
+#: ../root/statistics/Countries.js:58 ../root/statistics/Index.js:613
+#: ../root/statistics/Index.js:620 ../root/statistics/stats.js:385
+msgid "Labels"
+msgstr ""
+
+#: ../root/statistics/Countries.js:62 ../root/statistics/Formats.js:61
+#: ../root/statistics/LanguagesScripts.js:71
+msgid "Total"
+msgstr ""
+
+#: ../root/statistics/Countries.js:84 ../root/statistics/stats.js:67
+#: ../root/statistics/stats.js:391 ../root/statistics/stats.js:541
+msgid "Unknown Country"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:72
+msgid "Basics"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:75 ../root/statistics/CoverArt.js:104
+#: ../root/statistics/CoverArt.js:231
+msgid "No cover art statistics available."
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:81 ../root/statistics/CoverArt.js:113
+#: ../root/statistics/CoverArt.js:140 ../root/statistics/CoverArt.js:167
+#: ../root/statistics/CoverArt.js:267
+msgid "Releases with cover art:"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:92 ../root/statistics/CoverArt.js:240
+msgid "Pieces of cover art:"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:110
+msgid "By Release Group Type"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:123 ../root/statistics/CoverArt.js:250
+msgid "No type"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:137
+msgid "By Release Status"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:150
+msgid "No status"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:164
+msgid "By Release Format"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:177
+msgid "No format"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:193
+msgid "Release groups"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:197
+msgid "Release groups with cover art:"
+msgstr ""
+
+#: ../root/statistics/CoverArt.js:203
 msgid "manually selected:"
 msgstr ""
 
-#: ../root/statistics/index.tt:179
-msgid "of type Character:"
+#: ../root/statistics/CoverArt.js:215
+msgid "automatically inferred:"
 msgstr ""
 
-#: ../root/statistics/index.tt:173
-msgid "of type Choir:"
+#: ../root/statistics/CoverArt.js:228
+msgid "Pieces of cover art"
 msgstr ""
 
-#: ../root/statistics/index.tt:161
-msgid "of type Group:"
+#: ../root/statistics/CoverArt.js:237
+msgid "By Cover Art Type"
 msgstr ""
 
-#: ../root/statistics/index.tt:167
-msgid "of type Orchestra:"
+#: ../root/statistics/CoverArt.js:264
+msgid "Per release"
 msgstr ""
 
-#: ../root/statistics/index.tt:185
-msgid "of type Other:"
-msgstr ""
-
-#: ../root/statistics/index.tt:155
-msgid "of type Person:"
-msgstr ""
-
-#: ../root/statistics/index.tt:837
-msgid "validated email only:"
-msgstr ""
-
-#: ../root/statistics/index.tt:782
-msgid "who edit:"
-msgstr ""
-
-#: ../root/statistics/index.tt:759
-msgid "who edited and/or voted in the last 7 days:"
-msgstr ""
-
-#: ../root/statistics/index.tt:767
-msgid "who edited in the last 7 days:"
-msgstr ""
-
-#: ../root/statistics/index.tt:831
-msgid "who have registered applications:"
-msgstr ""
-
-#: ../root/statistics/index.tt:796
-msgid "who leave edit notes:"
-msgstr ""
-
-#: ../root/statistics/index.tt:824
-msgid "who use collections:"
-msgstr ""
-
-#: ../root/statistics/index.tt:810
-msgid "who use ratings:"
-msgstr ""
-
-#: ../root/statistics/index.tt:817
-msgid "who use subscriptions:"
-msgstr ""
-
-#: ../root/statistics/index.tt:803
-msgid "who use tags:"
-msgstr ""
-
-#: ../root/statistics/index.tt:789
-msgid "who vote:"
-msgstr ""
-
-#: ../root/statistics/index.tt:775
-msgid "who voted in the last 7 days:"
-msgstr ""
-
-#: ../root/statistics/index.tt:425 ../root/statistics/index.tt:458
-msgid "with 10 or more disc IDs:"
-msgstr ""
-
-#: ../root/statistics/coverart.tt:162
-msgid "with 30 or more pieces of cover art:"
-msgstr ""
-
-#: ../root/statistics/index.tt:197
-msgid "with appearances in artist credits:"
-msgstr ""
-
-#: ../root/statistics/index.tt:203
-msgid "with no appearances in artist credits:"
-msgstr ""
-
-#: ../root/statistics/index.tt:232
-msgid "with no gender set:"
-msgstr ""
-
-#: ../root/statistics/index.tt:191
-msgid "with no type set:"
-msgstr ""
-
-#: ../root/statistics/index.tt:417 ../root/statistics/index.tt:450
-msgid "with {num} disc ID:"
-msgid_plural "with {num} disc IDs:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../root/statistics/coverart.tt:155
+#: ../root/statistics/CoverArt.js:276
 msgid "with {num} piece of cover art:"
 msgid_plural "with {num} pieces of cover art:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/statistics/coverart.tt:24 ../root/statistics/coverart.tt:58
-#: ../root/statistics/coverart.tt:74 ../root/statistics/coverart.tt:90
-#: ../root/statistics/coverart.tt:109 ../root/statistics/coverart.tt:115
-#: ../root/statistics/coverart.tt:141 ../root/statistics/coverart.tt:157
-#: ../root/statistics/coverart.tt:164 ../root/statistics/edits.tt:29
-#: ../root/statistics/formats.tt:6 ../root/statistics/formats.tt:8
-#: ../root/statistics/index.tt:157 ../root/statistics/index.tt:163
-#: ../root/statistics/index.tt:169 ../root/statistics/index.tt:175
-#: ../root/statistics/index.tt:181 ../root/statistics/index.tt:187
-#: ../root/statistics/index.tt:193 ../root/statistics/index.tt:199
-#: ../root/statistics/index.tt:205 ../root/statistics/index.tt:216
-#: ../root/statistics/index.tt:222 ../root/statistics/index.tt:228
-#: ../root/statistics/index.tt:234 ../root/statistics/index.tt:254
-#: ../root/statistics/index.tt:260 ../root/statistics/index.tt:277
-#: ../root/statistics/index.tt:284 ../root/statistics/index.tt:301
-#: ../root/statistics/index.tt:308 ../root/statistics/index.tt:324
-#: ../root/statistics/index.tt:330 ../root/statistics/index.tt:336
-#: ../root/statistics/index.tt:342 ../root/statistics/index.tt:358
-#: ../root/statistics/index.tt:364 ../root/statistics/index.tt:371
-#: ../root/statistics/index.tt:378 ../root/statistics/index.tt:384
-#: ../root/statistics/index.tt:405 ../root/statistics/index.tt:411
-#: ../root/statistics/index.tt:419 ../root/statistics/index.tt:427
-#: ../root/statistics/index.tt:438 ../root/statistics/index.tt:444
-#: ../root/statistics/index.tt:452 ../root/statistics/index.tt:460
-#: ../root/statistics/index.tt:481 ../root/statistics/index.tt:497
-#: ../root/statistics/index.tt:517 ../root/statistics/index.tt:538
-#: ../root/statistics/index.tt:545 ../root/statistics/index.tt:566
-#: ../root/statistics/index.tt:573 ../root/statistics/index.tt:593
-#: ../root/statistics/index.tt:600 ../root/statistics/index.tt:621
-#: ../root/statistics/index.tt:628 ../root/statistics/index.tt:649
-#: ../root/statistics/index.tt:656 ../root/statistics/index.tt:677
-#: ../root/statistics/index.tt:699 ../root/statistics/index.tt:706
-#: ../root/statistics/index.tt:727 ../root/statistics/index.tt:734
-#: ../root/statistics/index.tt:754 ../root/statistics/index.tt:761
-#: ../root/statistics/index.tt:769 ../root/statistics/index.tt:777
-#: ../root/statistics/index.tt:784 ../root/statistics/index.tt:791
-#: ../root/statistics/index.tt:798 ../root/statistics/index.tt:805
-#: ../root/statistics/index.tt:812 ../root/statistics/index.tt:819
-#: ../root/statistics/index.tt:826 ../root/statistics/index.tt:833
-#: ../root/statistics/index.tt:839 ../root/statistics/index.tt:845
-#: ../root/statistics/index.tt:866 ../root/statistics/index.tt:872
-#: ../root/statistics/index.tt:878 ../root/statistics/index.tt:884
-#: ../root/statistics/index.tt:890 ../root/statistics/index.tt:896
-#: ../root/statistics/index.tt:902 ../root/statistics/index.tt:913
-#: ../root/statistics/index.tt:920 ../root/statistics/index.tt:936
-#: ../root/statistics/index.tt:942 ../root/statistics/index.tt:948
-#: ../root/statistics/index.tt:954 ../root/statistics/index.tt:965
-#: ../root/statistics/index.tt:972 ../root/statistics/relationships.tt:6
-#: ../root/statistics/relationships.tt:49
-msgid "{n}%"
+#: ../root/statistics/CoverArt.js:299
+msgid "with 30 or more pieces of cover art:"
 msgstr ""
 
-#: ../root/statistics/relationships.tt:44
+#: ../root/statistics/Editors.js:82
+msgid "There is no data to display here."
+msgstr ""
+
+#: ../root/statistics/Editors.js:102
+msgid ""
+"For the vote statistics, only yes or no votes are counted, abstain votes are "
+"not counted."
+msgstr ""
+
+#: ../root/statistics/Editors.js:110
+msgid "Open and applied edits in past week"
+msgstr ""
+
+#: ../root/statistics/Editors.js:112 ../root/statistics/Editors.js:118
+msgid "Editor"
+msgstr ""
+
+#: ../root/statistics/Editors.js:113
+msgid "Most active editors in the past week"
+msgstr ""
+
+#: ../root/statistics/Editors.js:116
+msgid "Total applied edits"
+msgstr ""
+
+#: ../root/statistics/Editors.js:119
+msgid "Top editors overall"
+msgstr ""
+
+#: ../root/statistics/Editors.js:125
+msgid "Voters"
+msgstr ""
+
+#: ../root/statistics/Editors.js:127
+msgid "Votes in past week"
+msgstr ""
+
+#: ../root/statistics/Editors.js:129 ../root/statistics/Editors.js:135
+msgid "Voter"
+msgstr ""
+
+#: ../root/statistics/Editors.js:130
+msgid "Most active voters in the past week"
+msgstr ""
+
+#: ../root/statistics/Editors.js:133
+msgid "Total votes"
+msgstr ""
+
+#: ../root/statistics/Editors.js:136
+msgid "Top voters overall"
+msgstr ""
+
+#: ../root/statistics/Edits.js:39
+msgid "No edit statistics available."
+msgstr ""
+
+#: ../root/statistics/Formats.js:40 ../root/statistics/Formats.js:46
+msgid "Release/Medium Formats"
+msgstr ""
+
+#: ../root/statistics/Formats.js:51
+msgid "Format"
+msgstr ""
+
+#: ../root/statistics/Formats.js:53
+msgid "% of total releases"
+msgstr ""
+
+#: ../root/statistics/Formats.js:54 ../root/statistics/stats.js:397
+msgid "Mediums"
+msgstr ""
+
+#: ../root/statistics/Formats.js:55
+msgid "% of total mediums"
+msgstr ""
+
+#: ../root/statistics/Formats.js:81
+msgid "Unknown Format"
+msgstr ""
+
+#: ../root/statistics/Index.js:67
+msgid "Basic metadata"
+msgstr ""
+
+#: ../root/statistics/Index.js:71 ../root/statistics/stats.js:26
+msgid "Core Entities"
+msgstr ""
+
+#: ../root/statistics/Index.js:74 ../root/statistics/Index.js:226
+msgid "Artists:"
+msgstr ""
+
+#: ../root/statistics/Index.js:78 ../root/statistics/Index.js:563
+#: ../root/statistics/Index.js:579
+msgid "Release Groups:"
+msgstr ""
+
+#: ../root/statistics/Index.js:84 ../root/statistics/Index.js:329
+#: ../root/statistics/Index.js:351 ../root/statistics/Index.js:377
+#: ../root/statistics/Index.js:403 ../root/statistics/Index.js:437
+#: ../root/statistics/Index.js:484
+msgid "Releases:"
+msgstr ""
+
+#: ../root/statistics/Index.js:88 ../root/statistics/Index.js:519
+msgid "Mediums:"
+msgstr ""
+
+#: ../root/statistics/Index.js:92 ../root/statistics/Index.js:601
+msgid "Recordings:"
+msgstr ""
+
+#: ../root/statistics/Index.js:98
+msgid "Tracks:"
+msgstr ""
+
+#: ../root/statistics/Index.js:102
+msgid "Labels:"
+msgstr ""
+
+#: ../root/statistics/Index.js:106 ../root/statistics/Index.js:648
+#: ../root/statistics/Index.js:675
+msgid "Works:"
+msgstr ""
+
+#: ../root/statistics/Index.js:110
+msgid "URLs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:114 ../root/statistics/Index.js:703
+msgid "Areas:"
+msgstr ""
+
+#: ../root/statistics/Index.js:118 ../root/statistics/Index.js:731
+msgid "Places:"
+msgstr ""
+
+#: ../root/statistics/Index.js:122 ../root/statistics/Index.js:759
+msgctxt "plural"
+msgid "Series:"
+msgstr ""
+
+#: ../root/statistics/Index.js:126 ../root/statistics/Index.js:781
+msgid "Instruments:"
+msgstr ""
+
+#: ../root/statistics/Index.js:132 ../root/statistics/Index.js:809
+msgid "Events:"
+msgstr ""
+
+#: ../root/statistics/Index.js:138
+msgid "Other Entities"
+msgstr ""
+
+#: ../root/statistics/Index.js:141
+msgid "Editors (valid / deleted):"
+msgstr ""
+
+#: ../root/statistics/Index.js:147 ../root/statistics/Relationships.js:96
+msgid "Relationships:"
+msgstr ""
+
+#: ../root/statistics/Index.js:151
+msgid "CD Stubs (all time / current):"
+msgstr ""
+
+#: ../root/statistics/Index.js:160
+msgid "Tags (raw / aggregated):"
+msgstr ""
+
+#: ../root/statistics/Index.js:170
+msgid "Ratings (raw / aggregated):"
+msgstr ""
+
+#: ../root/statistics/Index.js:182
+msgid "Identifiers"
+msgstr ""
+
+#: ../root/statistics/Index.js:185
+msgid "MBIDs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:189
+msgid "ISRCs (all / unique):"
+msgstr ""
+
+#: ../root/statistics/Index.js:195
+msgid "ISWCs (all / unique):"
+msgstr ""
+
+#: ../root/statistics/Index.js:201 ../root/statistics/Index.js:479
+msgid "Disc IDs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:205
+msgid "Barcodes:"
+msgstr ""
+
+#: ../root/statistics/Index.js:209
+msgid "IPIs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:213
+msgid "ISNIs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:232
+msgid "of type Person:"
+msgstr ""
+
+#: ../root/statistics/Index.js:238
+msgid "of type Group:"
+msgstr ""
+
+#: ../root/statistics/Index.js:244
+msgid "of type Orchestra:"
+msgstr ""
+
+#: ../root/statistics/Index.js:250
+msgid "of type Choir:"
+msgstr ""
+
+#: ../root/statistics/Index.js:256
+msgid "of type Character:"
+msgstr ""
+
+#: ../root/statistics/Index.js:262
+msgid "of type Other:"
+msgstr ""
+
+#: ../root/statistics/Index.js:268
+msgid "with no type set:"
+msgstr ""
+
+#: ../root/statistics/Index.js:274
+msgid "with appearances in artist credits:"
+msgstr ""
+
+#: ../root/statistics/Index.js:280
+msgid "with no appearances in artist credits:"
+msgstr ""
+
+#: ../root/statistics/Index.js:285
+msgid "Non-group artists:"
+msgstr ""
+
+#: ../root/statistics/Index.js:291
+msgid "Male:"
+msgstr ""
+
+#: ../root/statistics/Index.js:297
+msgid "Female:"
+msgstr ""
+
+#: ../root/statistics/Index.js:303
+msgid "Other gender:"
+msgstr ""
+
+#: ../root/statistics/Index.js:309
+msgid "Gender not applicable:"
+msgstr ""
+
+#: ../root/statistics/Index.js:315
+msgid "with no gender set:"
+msgstr ""
+
+#: ../root/statistics/Index.js:322
+msgid "Releases, Data Quality, and Disc IDs"
+msgstr ""
+
+#: ../root/statistics/Index.js:335
+msgid "by various artists:"
+msgstr ""
+
+#: ../root/statistics/Index.js:341
+msgid "by a single artist:"
+msgstr ""
+
+#: ../root/statistics/Index.js:348
+msgid "Release Status"
+msgstr ""
+
+#: ../root/statistics/Index.js:367
+msgid "No status set"
+msgstr ""
+
+#: ../root/statistics/Index.js:374
+msgid "Release Packaging"
+msgstr ""
+
+#: ../root/statistics/Index.js:393
+msgid "No packaging set"
+msgstr ""
+
+#: ../root/statistics/Index.js:400
+msgid "Cover Art Sources"
+msgstr ""
+
+#: ../root/statistics/Index.js:409
+msgid "CAA:"
+msgstr ""
+
+#: ../root/statistics/Index.js:415
+msgid "Amazon:"
+msgstr ""
+
+#: ../root/statistics/Index.js:421
+msgid "URL Relationships:"
+msgstr ""
+
+#: ../root/statistics/Index.js:427
+msgid "No front cover art:"
+msgstr ""
+
+#: ../root/statistics/Index.js:434
+msgid "Data Quality"
+msgstr ""
+
+#: ../root/statistics/Index.js:443
+msgid "High Data Quality:"
+msgstr ""
+
+#: ../root/statistics/Index.js:449
+msgid "Default Data Quality:"
+msgstr ""
+
+#: ../root/statistics/Index.js:456
+msgid "Normal Data Quality:"
+msgstr ""
+
+#: ../root/statistics/Index.js:463
+msgid "Unknown Data Quality:"
+msgstr ""
+
+#: ../root/statistics/Index.js:469
+msgid "Low Data Quality:"
+msgstr ""
+
+#: ../root/statistics/Index.js:476 ../root/statistics/stats.js:187
+msgid "Disc IDs"
+msgstr ""
+
+#: ../root/statistics/Index.js:490
+msgid "Releases with no disc IDs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:497
+msgid "Releases with at least one disc ID:"
+msgstr ""
+
+#: ../root/statistics/Index.js:506 ../root/statistics/Index.js:541
+msgid "with {num} disc ID:"
+msgid_plural "with {num} disc IDs:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../root/statistics/Index.js:514 ../root/statistics/Index.js:549
+msgid "with 10 or more disc IDs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:525
+msgid "Mediums with no disc IDs:"
+msgstr ""
+
+#: ../root/statistics/Index.js:532
+msgid "Mediums with at least one disc ID:"
+msgstr ""
+
+#: ../root/statistics/Index.js:556 ../root/statistics/stats.js:613
+msgid "Release Groups"
+msgstr ""
+
+#: ../root/statistics/Index.js:560
+msgid "Primary Types"
+msgstr ""
+
+#: ../root/statistics/Index.js:576
+msgid "Secondary Types"
+msgstr ""
+
+#: ../root/statistics/Index.js:594 ../root/statistics/Index.js:598
+#: ../root/statistics/stats.js:523
+msgid "Recordings"
+msgstr ""
+
+#: ../root/statistics/Index.js:606
+msgid "Videos:"
+msgstr ""
+
+#: ../root/statistics/Index.js:617 ../root/statistics/Index.js:645
+#: ../root/statistics/Index.js:700 ../root/statistics/Index.js:728
+#: ../root/statistics/Index.js:756 ../root/statistics/Index.js:778
+#: ../root/statistics/Index.js:806
+msgid "Types"
+msgstr ""
+
+#: ../root/statistics/Index.js:634 ../root/statistics/Index.js:662
+#: ../root/statistics/Index.js:689 ../root/statistics/Index.js:717
+#: ../root/statistics/Index.js:745 ../root/statistics/Index.js:795
+#: ../root/statistics/Index.js:823
+msgid "None"
+msgstr ""
+
+#: ../root/statistics/Index.js:641 ../root/statistics/LanguagesScripts.js:67
+#: ../root/statistics/stats.js:735
+msgid "Works"
+msgstr ""
+
+#: ../root/statistics/Index.js:672
+msgid "Attributes"
+msgstr ""
+
+#: ../root/statistics/Index.js:696 ../root/statistics/stats.js:49
+msgid "Areas"
+msgstr ""
+
+#: ../root/statistics/Index.js:724 ../root/statistics/stats.js:415
+msgid "Places"
+msgstr ""
+
+#: ../root/statistics/Index.js:752 ../root/statistics/stats.js:619
+msgctxt "plural"
+msgid "Series"
+msgstr ""
+
+#: ../root/statistics/Index.js:774 ../root/statistics/stats.js:319
+msgid "Instruments"
+msgstr ""
+
+#: ../root/statistics/Index.js:802 ../root/statistics/stats.js:313
+msgid "Events"
+msgstr ""
+
+#: ../root/statistics/Index.js:830
+msgid "Editors, Edits, and Votes"
+msgstr ""
+
+#: ../root/statistics/Index.js:837
+msgid "Editors (valid):"
+msgstr ""
+
+#: ../root/statistics/Index.js:843
+msgid "active ever:"
+msgstr ""
+
+#: ../root/statistics/Index.js:851
+msgid "who edited and/or voted in the last 7 days:"
+msgstr ""
+
+#: ../root/statistics/Index.js:860
+msgid "who edited in the last 7 days:"
+msgstr ""
+
+#: ../root/statistics/Index.js:868
+msgid "who voted in the last 7 days:"
+msgstr ""
+
+#: ../root/statistics/Index.js:875
+msgid "who edit:"
+msgstr ""
+
+#: ../root/statistics/Index.js:882
+msgid "who vote:"
+msgstr ""
+
+#: ../root/statistics/Index.js:889
+msgid "who leave edit notes:"
+msgstr ""
+
+#: ../root/statistics/Index.js:896
+msgid "who use tags:"
+msgstr ""
+
+#: ../root/statistics/Index.js:903
+msgid "who use ratings:"
+msgstr ""
+
+#: ../root/statistics/Index.js:910
+msgid "who use subscriptions:"
+msgstr ""
+
+#: ../root/statistics/Index.js:917
+msgid "who use collections:"
+msgstr ""
+
+#: ../root/statistics/Index.js:925
+msgid "who have registered applications:"
+msgstr ""
+
+#: ../root/statistics/Index.js:932
+msgid "validated email only:"
+msgstr ""
+
+#: ../root/statistics/Index.js:938
+msgid "inactive:"
+msgstr ""
+
+#: ../root/statistics/Index.js:943
+msgid "Editors (deleted):"
+msgstr ""
+
+#: ../root/statistics/Index.js:953 ../root/statistics/Index.js:1000
+msgid "Edits:"
+msgstr ""
+
+#: ../root/statistics/Index.js:959
+msgid "Open:"
+msgstr ""
+
+#: ../root/statistics/Index.js:965
+msgid "Applied:"
+msgstr ""
+
+#: ../root/statistics/Index.js:971
+msgid "Voted down:"
+msgstr ""
+
+#: ../root/statistics/Index.js:977
+msgid "Failed (dependency):"
+msgstr ""
+
+#: ../root/statistics/Index.js:983
+msgid "Failed (prerequisite):"
+msgstr ""
+
+#: ../root/statistics/Index.js:989
+msgid "Failed (internal error):"
+msgstr ""
+
+#: ../root/statistics/Index.js:995
+msgid "Cancelled:"
+msgstr ""
+
+#: ../root/statistics/Index.js:1006 ../root/statistics/Index.js:1058
+msgid "Last 7 days:"
+msgstr ""
+
+#: ../root/statistics/Index.js:1013 ../root/statistics/Index.js:1065
+msgid "Yesterday:"
+msgstr ""
+
+#: ../root/statistics/Index.js:1020 ../root/statistics/stats.js:698
+msgid "Votes"
+msgstr ""
+
+#: ../root/statistics/Index.js:1023 ../root/statistics/Index.js:1052
+msgid "Votes:"
+msgstr ""
+
+#: ../root/statistics/Index.js:1029
+msgctxt "vote"
+msgid "Approve"
+msgstr ""
+
+#: ../root/statistics/Index.js:1035
+msgctxt "vote"
+msgid "Yes"
+msgstr ""
+
+#: ../root/statistics/Index.js:1041
+msgctxt "vote"
+msgid "No"
+msgstr ""
+
+#: ../root/statistics/Index.js:1047
+msgctxt "vote"
+msgid "Abstain"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:47
+msgid "Languages and Scripts"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:51
+msgid "All other available languages and scripts have 0 releases and works."
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:53
+#: ../root/statistics/LanguagesScripts.js:59
+msgid "Languages"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:81
+msgid "Unknown language"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:104
+msgid "Scripts"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:110
+msgid "Script"
+msgstr ""
+
+#: ../root/statistics/LanguagesScripts.js:124
+msgid "Unknown script"
+msgstr ""
+
+#: ../root/statistics/NoStatistics.js:17 ../root/statistics/NoStatistics.js:18
+msgid "No Statistics"
+msgstr ""
+
+#: ../root/statistics/NoStatistics.js:21
+msgid ""
+"Statistics have never been collected for this server. If you are the "
+"administrator for this server, you should run <code>./admin/CollectStats.pl</"
+"code> or import <code>mbdump-stats.tar.bz2</code>."
+msgstr ""
+
+#: ../root/statistics/Relationships.js:84
+msgid "No relationship statistics available."
+msgstr ""
+
+#: ../root/statistics/Relationships.js:91
+msgid "Exclusive"
+msgstr ""
+
+#: ../root/statistics/Relationships.js:92
+msgid "Inclusive"
+msgstr ""
+
+#: ../root/statistics/Relationships.js:109
 msgid "{type0}-{type1}"
 msgstr ""
 
-#: ../root/statistics/relationships.tt:47
+#: ../root/statistics/Relationships.js:115
 msgid "{type0}-{type1} relationships:"
 msgstr ""
 
-#: ../root/statistics/stats.js:31
+#: ../root/statistics/stats.js:24
 msgid "Artist Countries"
 msgstr ""
 
-#: ../root/statistics/stats.js:32
+#: ../root/statistics/stats.js:25
 msgid "Artist Types and Genders"
 msgstr ""
 
-#: ../root/statistics/stats.js:35
+#: ../root/statistics/stats.js:28
 msgid "Edit Information"
 msgstr ""
 
-#: ../root/statistics/stats.js:37
+#: ../root/statistics/stats.js:30
 msgid "Label Countries"
 msgstr ""
 
-#: ../root/statistics/stats.js:38
+#: ../root/statistics/stats.js:31
+msgctxt "stats category"
 msgid "Other"
 msgstr ""
 
-#: ../root/statistics/stats.js:39
+#: ../root/statistics/stats.js:32
 msgid "Ratings and Tags"
 msgstr ""
 
-#: ../root/statistics/stats.js:41
+#: ../root/statistics/stats.js:34
 msgid "Release Countries"
 msgstr ""
 
-#: ../root/statistics/stats.js:42
+#: ../root/statistics/stats.js:35
 msgid "Release Languages"
 msgstr ""
 
-#: ../root/statistics/stats.js:43
+#: ../root/statistics/stats.js:36
 msgid "Release Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:44
+#: ../root/statistics/stats.js:37
 msgid "Release Scripts"
 msgstr ""
 
-#: ../root/statistics/stats.js:49
+#: ../root/statistics/stats.js:42
 msgid "Count of all Relationships"
 msgstr ""
 
-#: ../root/statistics/stats.js:55
+#: ../root/statistics/stats.js:48
 msgid "Count of all areas"
 msgstr ""
 
-#: ../root/statistics/stats.js:61
+#: ../root/statistics/stats.js:54
 msgid "Count of all artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:67
+#: ../root/statistics/stats.js:60
 msgid "Artists with no appearances in artist credits"
 msgstr ""
 
-#: ../root/statistics/stats.js:68
+#: ../root/statistics/stats.js:61
 msgid "Artists not in ACs"
 msgstr ""
 
-#: ../root/statistics/stats.js:73
+#: ../root/statistics/stats.js:66
 msgid "Artists with no country set"
 msgstr ""
 
-#: ../root/statistics/stats.js:79
+#: ../root/statistics/stats.js:72
 msgid "Artists with gender set to female"
 msgstr ""
 
-#: ../root/statistics/stats.js:80
+#: ../root/statistics/stats.js:73
 msgid "Female Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:85
+#: ../root/statistics/stats.js:78
 msgid "Artists with gender set to male"
 msgstr ""
 
-#: ../root/statistics/stats.js:86
+#: ../root/statistics/stats.js:79
 msgid "Male Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:91
+#: ../root/statistics/stats.js:84
+msgid "Artists with gender set to not applicable"
+msgstr ""
+
+#: ../root/statistics/stats.js:85
+msgid "Gender Not Applicable"
+msgstr ""
+
+#: ../root/statistics/stats.js:90
 msgid "Artists with gender unset (non-group artists)"
 msgstr ""
 
-#: ../root/statistics/stats.js:92
+#: ../root/statistics/stats.js:91
 msgid "Unknown-gender Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:97
+#: ../root/statistics/stats.js:96
 msgid "Artists with gender set to other"
 msgstr ""
 
-#: ../root/statistics/stats.js:98
+#: ../root/statistics/stats.js:97
 msgid "Other-gender Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:103
+#: ../root/statistics/stats.js:102
 msgid "Artists with at least one artist credit appearance"
 msgstr ""
 
-#: ../root/statistics/stats.js:104
+#: ../root/statistics/stats.js:103
 msgid "Artists in ACs"
 msgstr ""
 
-#: ../root/statistics/stats.js:109
+#: ../root/statistics/stats.js:108
 msgid "Artists with type set to character"
 msgstr ""
 
-#: ../root/statistics/stats.js:110
+#: ../root/statistics/stats.js:109
 msgid "Characters"
 msgstr ""
 
-#: ../root/statistics/stats.js:115
+#: ../root/statistics/stats.js:114
 msgid "Artists with type set to choir"
 msgstr ""
 
-#: ../root/statistics/stats.js:116
+#: ../root/statistics/stats.js:115
 msgid "Choirs"
 msgstr ""
 
-#: ../root/statistics/stats.js:121
+#: ../root/statistics/stats.js:120
 msgid "Artists with type set to group"
 msgstr ""
 
-#: ../root/statistics/stats.js:122
+#: ../root/statistics/stats.js:121
 msgid "Groups"
 msgstr ""
 
-#: ../root/statistics/stats.js:127
+#: ../root/statistics/stats.js:126
 msgid "Artists with type unset"
 msgstr ""
 
-#: ../root/statistics/stats.js:128
+#: ../root/statistics/stats.js:127
 msgid "Unknown-type Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:133
+#: ../root/statistics/stats.js:132
 msgid "Artists with type set to orchestra"
 msgstr ""
 
-#: ../root/statistics/stats.js:134
+#: ../root/statistics/stats.js:133
 msgid "Orchestras"
 msgstr ""
 
-#: ../root/statistics/stats.js:139
+#: ../root/statistics/stats.js:138
 msgid "Artists with type set to other"
 msgstr ""
 
-#: ../root/statistics/stats.js:140
+#: ../root/statistics/stats.js:139
 msgid "Other-type Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:145
+#: ../root/statistics/stats.js:144
 msgid "Artists with type set to person"
 msgstr ""
 
-#: ../root/statistics/stats.js:146
+#: ../root/statistics/stats.js:145
 msgid "Persons"
 msgstr ""
 
-#: ../root/statistics/stats.js:151
+#: ../root/statistics/stats.js:150
 msgid "Count of all Artist Credits"
 msgstr ""
 
-#: ../root/statistics/stats.js:152
+#: ../root/statistics/stats.js:151
 msgid "Artist Credits"
 msgstr ""
 
-#: ../root/statistics/stats.js:157
+#: ../root/statistics/stats.js:156
 msgid "Count of all Barcodes"
 msgstr ""
 
-#: ../root/statistics/stats.js:158
+#: ../root/statistics/stats.js:157
 msgid "Barcodes"
 msgstr ""
 
-#: ../root/statistics/stats.js:163
+#: ../root/statistics/stats.js:162
 msgid "Count of all CDStubs"
 msgstr ""
 
-#: ../root/statistics/stats.js:164
+#: ../root/statistics/stats.js:163
 msgid "CDStubs (all)"
 msgstr ""
 
-#: ../root/statistics/stats.js:169
+#: ../root/statistics/stats.js:168
 msgid "Count of all CDStubs ever submitted"
 msgstr ""
 
-#: ../root/statistics/stats.js:170
+#: ../root/statistics/stats.js:169
 msgid "CDStubs (submitted)"
 msgstr ""
 
-#: ../root/statistics/stats.js:175
+#: ../root/statistics/stats.js:174
 msgid "Count of all CDStub tracks"
 msgstr ""
 
-#: ../root/statistics/stats.js:176
+#: ../root/statistics/stats.js:175
 msgid "CDStub tracks"
 msgstr ""
 
-#: ../root/statistics/stats.js:181 ../root/statistics/stats.js:182
+#: ../root/statistics/stats.js:180 ../root/statistics/stats.js:181
 msgid "Pieces of Cover Art"
 msgstr ""
 
-#: ../root/statistics/stats.js:187
+#: ../root/statistics/stats.js:186
 msgid "Count of all Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:193
+#: ../root/statistics/stats.js:192
 msgid "Count of all edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:200
+#: ../root/statistics/stats.js:199
 msgid "All edits that have been applied"
 msgstr ""
 
-#: ../root/statistics/stats.js:201
+#: ../root/statistics/stats.js:200
 msgid "Applied edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:206 ../root/statistics/stats.js:207
+#: ../root/statistics/stats.js:205 ../root/statistics/stats.js:206
 msgid "Cancelled edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:212
+#: ../root/statistics/stats.js:211
 msgid "All edits that have hit an error"
 msgstr ""
 
-#: ../root/statistics/stats.js:213
+#: ../root/statistics/stats.js:212
 msgid "Error edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:218
+#: ../root/statistics/stats.js:217
 msgid "Evalnochange edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:219
+#: ../root/statistics/stats.js:218
 msgid "Evalnochange Edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:224
+#: ../root/statistics/stats.js:223
 msgid "All edits that have failed dependency checks"
 msgstr ""
 
-#: ../root/statistics/stats.js:225
+#: ../root/statistics/stats.js:224
 msgid "Failed edits (dependency)"
 msgstr ""
 
-#: ../root/statistics/stats.js:230
+#: ../root/statistics/stats.js:229
 msgid "All edits that have failed prerequisite checks"
 msgstr ""
 
-#: ../root/statistics/stats.js:231
+#: ../root/statistics/stats.js:230
 msgid "Failed edits (prerequisite)"
 msgstr ""
 
-#: ../root/statistics/stats.js:236
+#: ../root/statistics/stats.js:235
 msgid "All edits that have failed by being voted down"
 msgstr ""
 
-#: ../root/statistics/stats.js:237
+#: ../root/statistics/stats.js:236
 msgid "Failed edits (voted down)"
 msgstr ""
 
-#: ../root/statistics/stats.js:242
+#: ../root/statistics/stats.js:241
 msgid "Count of open edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:243
+#: ../root/statistics/stats.js:242
 msgid "Open Edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:248
+#: ../root/statistics/stats.js:247
 msgid "Count of edits per day"
 msgstr ""
 
-#: ../root/statistics/stats.js:250
+#: ../root/statistics/stats.js:249
 msgid "Edits per day"
 msgstr ""
 
-#: ../root/statistics/stats.js:255
+#: ../root/statistics/stats.js:254
 msgid "Count of edits per week"
 msgstr ""
 
-#: ../root/statistics/stats.js:256
+#: ../root/statistics/stats.js:255
 msgid "Edits per week"
 msgstr ""
 
-#: ../root/statistics/stats.js:261
+#: ../root/statistics/stats.js:260
 msgid "Edits about to be cancelled"
 msgstr ""
 
-#: ../root/statistics/stats.js:262
+#: ../root/statistics/stats.js:261
 msgid "To-be-cancelled edits"
 msgstr ""
 
-#: ../root/statistics/stats.js:267
+#: ../root/statistics/stats.js:266
 msgid "Count of all editors"
 msgstr ""
 
-#: ../root/statistics/stats.js:269
+#: ../root/statistics/stats.js:268
 msgid "Editors (all)"
 msgstr ""
 
-#: ../root/statistics/stats.js:274
+#: ../root/statistics/stats.js:273
 msgid "Count of active editors (editing or voting) during the last week"
 msgstr ""
 
-#: ../root/statistics/stats.js:275
+#: ../root/statistics/stats.js:274
 msgid "Active Users"
 msgstr ""
 
-#: ../root/statistics/stats.js:280
+#: ../root/statistics/stats.js:279
 msgid "Count of deleted editors"
 msgstr ""
 
-#: ../root/statistics/stats.js:282
+#: ../root/statistics/stats.js:281
 msgid "Editors (deleted)"
 msgstr ""
 
-#: ../root/statistics/stats.js:287
+#: ../root/statistics/stats.js:286
 msgid "Count of editors who have submitted edits during the last 7 days"
 msgstr ""
 
-#: ../root/statistics/stats.js:288
+#: ../root/statistics/stats.js:287
 msgid "Active Editors"
 msgstr ""
 
-#: ../root/statistics/stats.js:293
+#: ../root/statistics/stats.js:292
 msgid "Count of non-deleted editors"
 msgstr ""
 
-#: ../root/statistics/stats.js:295
+#: ../root/statistics/stats.js:294
 msgid "Editors (valid)"
 msgstr ""
 
-#: ../root/statistics/stats.js:300
+#: ../root/statistics/stats.js:299
 msgid "Count of active editors"
 msgstr ""
 
-#: ../root/statistics/stats.js:302
+#: ../root/statistics/stats.js:301
 msgid "Editors (valid & active ever)"
 msgstr ""
 
-#: ../root/statistics/stats.js:307
+#: ../root/statistics/stats.js:306
 msgid "Count of editors who have voted on during the last 7 days"
 msgstr ""
 
-#: ../root/statistics/stats.js:308
+#: ../root/statistics/stats.js:307
 msgid "Active Voters"
 msgstr ""
 
-#: ../root/statistics/stats.js:313
+#: ../root/statistics/stats.js:312
 msgid "Count of all events"
 msgstr ""
 
-#: ../root/statistics/stats.js:319
+#: ../root/statistics/stats.js:318
 msgid "Count of all instruments"
 msgstr ""
 
-#: ../root/statistics/stats.js:325
+#: ../root/statistics/stats.js:324
 msgid "Count of all IPIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:326
+#: ../root/statistics/stats.js:325
 msgid "IPIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:331
+#: ../root/statistics/stats.js:330
 msgid "Count of all IPIs for Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:332
+#: ../root/statistics/stats.js:331
 msgid "Artist IPIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:337
+#: ../root/statistics/stats.js:336
 msgid "Count of all IPIs for Labels"
 msgstr ""
 
-#: ../root/statistics/stats.js:338
+#: ../root/statistics/stats.js:337
 msgid "Label IPIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:343
+#: ../root/statistics/stats.js:342
 msgid "Count of all ISNIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:344
+#: ../root/statistics/stats.js:343
 msgid "ISNIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:349
+#: ../root/statistics/stats.js:348
 msgid "Count of all ISNIs for Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:350
+#: ../root/statistics/stats.js:349
 msgid "Artist ISNIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:355
+#: ../root/statistics/stats.js:354
 msgid "Count of all ISNIs for Labels"
 msgstr ""
 
-#: ../root/statistics/stats.js:356
+#: ../root/statistics/stats.js:355
 msgid "Label ISNIs"
 msgstr ""
 
-#: ../root/statistics/stats.js:361 ../root/statistics/stats.js:367
+#: ../root/statistics/stats.js:360 ../root/statistics/stats.js:366
 msgid "Count of all ISRCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:362
+#: ../root/statistics/stats.js:361
 msgid "ISRCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:368
+#: ../root/statistics/stats.js:367
 msgid "ISRCs (all)"
 msgstr ""
 
-#: ../root/statistics/stats.js:373 ../root/statistics/stats.js:379
+#: ../root/statistics/stats.js:372 ../root/statistics/stats.js:378
 msgid "Count of all ISWCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:374
+#: ../root/statistics/stats.js:373
 msgid "ISWCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:380
+#: ../root/statistics/stats.js:379
 msgid "ISWCs (all)"
 msgstr ""
 
-#: ../root/statistics/stats.js:385
+#: ../root/statistics/stats.js:384
 msgid "Count of all labels"
 msgstr ""
 
-#: ../root/statistics/stats.js:391
+#: ../root/statistics/stats.js:390
 msgid "Labels with no country set"
 msgstr ""
 
-#: ../root/statistics/stats.js:397
+#: ../root/statistics/stats.js:396
 msgid "Count of all mediums"
 msgstr ""
 
-#: ../root/statistics/stats.js:403
+#: ../root/statistics/stats.js:402
 msgid "Mediums with no format set"
 msgstr ""
 
-#: ../root/statistics/stats.js:404
+#: ../root/statistics/stats.js:403
 msgid "Unknown Format (medium)"
 msgstr ""
 
-#: ../root/statistics/stats.js:409
+#: ../root/statistics/stats.js:408
 msgid "Count of all Mediums with Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:410
+#: ../root/statistics/stats.js:409
 msgid "Mediums with Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:415
+#: ../root/statistics/stats.js:414
 msgid "Count of all places"
 msgstr ""
 
-#: ../root/statistics/stats.js:421
+#: ../root/statistics/stats.js:420
 msgid "Count of all Releases at Default Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:422
+#: ../root/statistics/stats.js:421
 msgid "Default Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:427
+#: ../root/statistics/stats.js:426
 msgid "Count of all Releases at High Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:428
+#: ../root/statistics/stats.js:427
 msgid "High Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:433
+#: ../root/statistics/stats.js:432
 msgid "Count of all Releases at Low Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:434
+#: ../root/statistics/stats.js:433
 msgid "Low Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:439
+#: ../root/statistics/stats.js:438
 msgid "Count of all Releases at Normal Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:440
+#: ../root/statistics/stats.js:439
 msgid "Normal Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:445
+#: ../root/statistics/stats.js:444
 msgid "Count of all Releases at Unknown Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:446
+#: ../root/statistics/stats.js:445
 msgid "Unknown Data Quality"
 msgstr ""
 
-#: ../root/statistics/stats.js:451
+#: ../root/statistics/stats.js:450
 msgid "Count of all Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:452
+#: ../root/statistics/stats.js:451
 msgid "Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:457
+#: ../root/statistics/stats.js:456
 msgid "Count of all Artist Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:458
+#: ../root/statistics/stats.js:457
 msgid "Artist Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:463
+#: ../root/statistics/stats.js:462
 msgid "Count of all Label Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:464
+#: ../root/statistics/stats.js:463
 msgid "Label Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:469
+#: ../root/statistics/stats.js:468
 msgid "Count of all Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:470
+#: ../root/statistics/stats.js:469
 msgid "Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:475
+#: ../root/statistics/stats.js:474
 msgid "Count of all Artist Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:476
+#: ../root/statistics/stats.js:475
 msgid "Artist Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:481
+#: ../root/statistics/stats.js:480
 msgid "Count of all Label Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:482
+#: ../root/statistics/stats.js:481
 msgid "Label Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:487
+#: ../root/statistics/stats.js:486
 msgid "Count of all Recording Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:488
+#: ../root/statistics/stats.js:487
 msgid "Recording Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:493
+#: ../root/statistics/stats.js:492
 msgid "Count of all Release Group Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:494
+#: ../root/statistics/stats.js:493
 msgid "Release Group Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:499
+#: ../root/statistics/stats.js:498
 msgid "Count of all Work Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:500
+#: ../root/statistics/stats.js:499
 msgid "Work Ratings (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:505
+#: ../root/statistics/stats.js:504
 msgid "Count of all Recording Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:506
+#: ../root/statistics/stats.js:505
 msgid "Recording Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:511
+#: ../root/statistics/stats.js:510
 msgid "Count of all Release Group Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:512
+#: ../root/statistics/stats.js:511
 msgid "Release Group Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:517
+#: ../root/statistics/stats.js:516
 msgid "Count of all Work Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:518
+#: ../root/statistics/stats.js:517
 msgid "Work Ratings"
 msgstr ""
 
-#: ../root/statistics/stats.js:523
+#: ../root/statistics/stats.js:522
 msgid "Count of all recordings"
 msgstr ""
 
-#: ../root/statistics/stats.js:529
+#: ../root/statistics/stats.js:528
 msgid "Count of all Recordings with ISRCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:530
+#: ../root/statistics/stats.js:529
 msgid "Recordings with ISRCs"
 msgstr ""
 
-#: ../root/statistics/stats.js:535
+#: ../root/statistics/stats.js:534
 msgid "Count of all releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:541
+#: ../root/statistics/stats.js:540
 msgid "Releases with no country set"
 msgstr ""
 
-#: ../root/statistics/stats.js:547 ../root/statistics/stats.js:548
-#: ../root/statistics/stats.js:565
+#: ../root/statistics/stats.js:546 ../root/statistics/stats.js:547
+#: ../root/statistics/stats.js:564
 msgid "Releases with Amazon Cover Art"
 msgstr ""
 
-#: ../root/statistics/stats.js:553 ../root/statistics/stats.js:554
+#: ../root/statistics/stats.js:552 ../root/statistics/stats.js:553
 msgid "Releases with CAA Cover Art"
 msgstr ""
 
-#: ../root/statistics/stats.js:559 ../root/statistics/stats.js:560
+#: ../root/statistics/stats.js:558 ../root/statistics/stats.js:559
 msgid "Releases with No Cover Art"
 msgstr ""
 
-#: ../root/statistics/stats.js:566
+#: ../root/statistics/stats.js:565
 msgid "Releases with Cover Art from Relationships"
 msgstr ""
 
-#: ../root/statistics/stats.js:571
+#: ../root/statistics/stats.js:570
 msgid "Releases with a no-format medium"
 msgstr ""
 
-#: ../root/statistics/stats.js:572
+#: ../root/statistics/stats.js:571
 msgid "Unknown Format (release)"
 msgstr ""
 
-#: ../root/statistics/stats.js:577 ../root/statistics/stats.js:578
+#: ../root/statistics/stats.js:576 ../root/statistics/stats.js:577
 msgid "Releases with Cover Art"
 msgstr ""
 
-#: ../root/statistics/stats.js:583
+#: ../root/statistics/stats.js:582
 msgid "Count of all Releases with Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:584
+#: ../root/statistics/stats.js:583
 msgid "Releases with Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:589
+#: ../root/statistics/stats.js:588
 msgid "Releases with no language set"
 msgstr ""
 
-#: ../root/statistics/stats.js:590
+#: ../root/statistics/stats.js:589
 msgid "Unknown Language"
 msgstr ""
 
-#: ../root/statistics/stats.js:595
+#: ../root/statistics/stats.js:594
 msgid "Count of all Releases not V.A."
 msgstr ""
 
-#: ../root/statistics/stats.js:596
+#: ../root/statistics/stats.js:595
 msgid "Releases not VA"
 msgstr ""
 
-#: ../root/statistics/stats.js:601
+#: ../root/statistics/stats.js:600
 msgid "Releases with no script set"
 msgstr ""
 
-#: ../root/statistics/stats.js:602
+#: ../root/statistics/stats.js:601
 msgid "Unknown Script"
 msgstr ""
 
-#: ../root/statistics/stats.js:607
+#: ../root/statistics/stats.js:606
 msgid "Count of all Releases by Various Artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:608
+#: ../root/statistics/stats.js:607
 msgid "Releases (VA)"
 msgstr ""
 
-#: ../root/statistics/stats.js:613
+#: ../root/statistics/stats.js:612
 msgid "Count of all release groups"
 msgstr ""
 
-#: ../root/statistics/stats.js:619
+#: ../root/statistics/stats.js:618
 msgid "Count of all series"
 msgstr ""
 
-#: ../root/statistics/stats.js:625
+#: ../root/statistics/stats.js:624
 msgid "Count of all Tags"
 msgstr ""
 
-#: ../root/statistics/stats.js:631
+#: ../root/statistics/stats.js:630
 msgid "Count of all Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:632
+#: ../root/statistics/stats.js:631
 msgid "Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:637
+#: ../root/statistics/stats.js:636
 msgid "Count of all Area Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:638
+#: ../root/statistics/stats.js:637
 msgid "Area Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:643
+#: ../root/statistics/stats.js:642
 msgid "Count of all Artist Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:644
+#: ../root/statistics/stats.js:643
 msgid "Artist Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:649
+#: ../root/statistics/stats.js:648
 msgid "Count of all Instrument Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:650
+#: ../root/statistics/stats.js:649
 msgid "Instrument Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:655
+#: ../root/statistics/stats.js:654
 msgid "Count of all Label Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:656
+#: ../root/statistics/stats.js:655
 msgid "Label Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:661
+#: ../root/statistics/stats.js:660
 msgid "Count of all Recording Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:662
+#: ../root/statistics/stats.js:661
 msgid "Recording Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:667
+#: ../root/statistics/stats.js:666
 msgid "Count of all Release Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:668
+#: ../root/statistics/stats.js:667
 msgid "Release Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:673
+#: ../root/statistics/stats.js:672
 msgid "Count of all Release Group Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:674
+#: ../root/statistics/stats.js:673
 msgid "Release Group Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:679
+#: ../root/statistics/stats.js:678
 msgid "Count of all Series Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:680
+#: ../root/statistics/stats.js:679
 msgid "Series Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:685
+#: ../root/statistics/stats.js:684
 msgid "Count of all Work Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:686
+#: ../root/statistics/stats.js:685
 msgid "Work Tags (raw)"
 msgstr ""
 
-#: ../root/statistics/stats.js:691
+#: ../root/statistics/stats.js:690
 msgid "Count of all Tracks"
 msgstr ""
 
-#: ../root/statistics/stats.js:692
+#: ../root/statistics/stats.js:691
 msgid "Tracks"
 msgstr ""
 
-#: ../root/statistics/stats.js:697
+#: ../root/statistics/stats.js:696
 msgid "Count of all votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:704
+#: ../root/statistics/stats.js:703
 msgid "Count of all Abstain votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:705
+#: ../root/statistics/stats.js:704
 msgid "Abstentions"
 msgstr ""
 
-#: ../root/statistics/stats.js:710
+#: ../root/statistics/stats.js:709
 msgid "Count of all No votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:711
+#: ../root/statistics/stats.js:710
 msgid "No Votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:716
+#: ../root/statistics/stats.js:715
 msgid "Count of votes per day"
 msgstr ""
 
-#: ../root/statistics/stats.js:718
+#: ../root/statistics/stats.js:717
 msgid "Votes per day"
 msgstr ""
 
-#: ../root/statistics/stats.js:723
+#: ../root/statistics/stats.js:722
 msgid "Count of votes per week"
 msgstr ""
 
-#: ../root/statistics/stats.js:724
+#: ../root/statistics/stats.js:723
 msgid "Votes per week"
 msgstr ""
 
-#: ../root/statistics/stats.js:729
+#: ../root/statistics/stats.js:728
 msgid "Count of all Yes votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:730
+#: ../root/statistics/stats.js:729
 msgid "Yes Votes"
 msgstr ""
 
-#: ../root/statistics/stats.js:735
+#: ../root/statistics/stats.js:734
 msgid "Count of all works"
 msgstr ""
 
-#: ../root/statistics/stats.js:738
+#: ../root/statistics/stats.js:737
 msgid "/day"
 msgstr ""
 
-#: ../root/statistics/stats.js:747
+#: ../root/statistics/stats.js:746
 msgid "Count of all Releases with {n} Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:748
+#: ../root/statistics/stats.js:747
 msgid "Releases with 1 Disc ID"
 msgid_plural "Releases with {n} Disc IDs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/statistics/stats.js:754
+#: ../root/statistics/stats.js:753
 msgid "Count of all Mediums with {n} Disc IDs"
 msgstr ""
 
-#: ../root/statistics/stats.js:755
+#: ../root/statistics/stats.js:754
 msgid "Mediums with 1 Disc ID"
 msgid_plural "Mediums with {n} Disc IDs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/statistics/stats.js:761
+#: ../root/statistics/stats.js:760
 msgid "Count of all Recordings with {n} Releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:762
+#: ../root/statistics/stats.js:761
 msgid "Recordings with 1 Release"
 msgid_plural "Recordings with {n} Releases"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/statistics/stats.js:768
+#: ../root/statistics/stats.js:767
 msgid "Count of all Release Groups with {n} Releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:769
+#: ../root/statistics/stats.js:768
 msgid "Release Groups with 1 Release"
 msgid_plural "Release Groups with {n} Releases"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../root/statistics/stats.js:807
+#: ../root/statistics/stats.js:806
 msgid "{country} artists"
 msgstr ""
 
-#: ../root/statistics/stats.js:814
+#: ../root/statistics/stats.js:813
 msgid "{country} labels"
 msgstr ""
 
-#: ../root/statistics/stats.js:821
+#: ../root/statistics/stats.js:820
 msgid "{country} releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:833
+#: ../root/statistics/stats.js:832
 msgid "{name} releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:840
+#: ../root/statistics/stats.js:839
 msgid "{name} mediums"
 msgstr ""
 
-#: ../root/statistics/stats.js:852
+#: ../root/statistics/stats.js:851
 msgid "{language} releases"
 msgstr ""
 
-#: ../root/statistics/stats.js:859
+#: ../root/statistics/stats.js:858
 msgid "l_{first}_{second} Relationships"
 msgstr ""
 
-#: ../root/statistics/stats.js:880
+#: ../root/statistics/stats.js:879
 msgid "{script} releases"
 msgstr ""

--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -7,7 +7,7 @@
     <fieldset>
       <legend>[%- l('Area Details') -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
-      [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
       [%- form_row_text_list(r, 'iso_3166_1', l('ISO 3166-1:'), l('ISO 3166-1')) -%]
       [%- form_row_text_list(r, 'iso_3166_2', l('ISO 3166-2:'), l('ISO 3166-2')) -%]

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -11,7 +11,7 @@
         [%- form_row_name_with_guesscase(r) -%]
         [%- form_row_sortname_with_guesscase(r) -%]
         [%- duplicate_entities_section() -%]
-        [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+        [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [%- form_row_select(r, 'gender_id', l('Gender:')) -%]

--- a/root/edit/details/add_instrument.tt
+++ b/root/edit/details/add_instrument.tt
@@ -13,7 +13,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_label.tt
+++ b/root/edit/details/add_label.tt
@@ -20,7 +20,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_place.tt
+++ b/root/edit/details/add_place.tt
@@ -13,7 +13,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_release.tt
+++ b/root/edit/details/add_release.tt
@@ -29,7 +29,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_release_group.tt
+++ b/root/edit/details/add_release_group.tt
@@ -18,7 +18,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</td>
+    <th>[% add_colon(l('Disambiguation')) %]</td>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_series.tt
+++ b/root/edit/details/add_series.tt
@@ -13,7 +13,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_standalone_recording.tt
+++ b/root/edit/details/add_standalone_recording.tt
@@ -18,7 +18,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</td>
+    <th>[% add_colon(l('Disambiguation')) %]</td>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/add_work.tt
+++ b/root/edit/details/add_work.tt
@@ -13,7 +13,7 @@
 
   [% IF edit.display_data.comment %]
   <tr>
-    <th>[% l('Disambiguation:') %]</th>
+    <th>[% add_colon(l('Disambiguation')) %]</th>
     <td>[% edit.display_data.comment | html %]</td>
   </tr>
   [% END %]

--- a/root/edit/details/change_release_data_quality.tt
+++ b/root/edit/details/change_release_data_quality.tt
@@ -4,7 +4,7 @@
     <td colspan="2">[% descriptive_link(edit.display_data.release) %]</td>
   </tr>
   <tr>
-    <th>[% l('Data Quality:') %]</th>
+    <th>[% add_colon(l('Data Quality')) %]</th>
     <td class="old">[% quality_name(edit.display_data.quality.old) %]</td>
     <td class="new">[% quality_name(edit.display_data.quality.new) %]</td>
   </tr>

--- a/root/edit/details/edit_area.tt
+++ b/root/edit/details/edit_area.tt
@@ -18,7 +18,7 @@
                         html_escape(edit.display_data.sort_name.new)) -%]
   [%- END -%]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_artist.tt
+++ b/root/edit/details/edit_artist.tt
@@ -18,7 +18,7 @@
                   html_escape(edit.display_data.sort_name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_event.tt
+++ b/root/edit/details/edit_event.tt
@@ -11,7 +11,7 @@
                   html_escape(edit.display_data.name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_instrument.tt
+++ b/root/edit/details/edit_instrument.tt
@@ -11,7 +11,7 @@
                   html_escape(edit.display_data.name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_label.tt
+++ b/root/edit/details/edit_label.tt
@@ -16,7 +16,7 @@
                   html_escape(edit.display_data.sort_name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_place.tt
+++ b/root/edit/details/edit_place.tt
@@ -11,7 +11,7 @@
                   html_escape(edit.display_data.name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_recording.tt
+++ b/root/edit/details/edit_recording.tt
@@ -14,7 +14,7 @@
                   html_escape(edit.display_data.name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_release.tt
+++ b/root/edit/details/edit_release.tt
@@ -22,7 +22,7 @@
                           descriptive_link(edit.display_data.group.old),
                           descriptive_link(edit.display_data.group.new)) -%]
 
-  [%- display_word_diff(l('Disambiguation:'),
+  [%- display_word_diff(add_colon(l('Disambiguation')),
                         html_escape(edit.display_data.comment.old),
                         html_escape(edit.display_data.comment.new)) -%]
 

--- a/root/edit/details/edit_release_group.tt
+++ b/root/edit/details/edit_release_group.tt
@@ -12,7 +12,7 @@
                         html_escape(edit.display_data.name.old),
                         html_escape(edit.display_data.name.new)) -%]
 
-  [%- display_word_diff(l('Disambiguation:'),
+  [%- display_word_diff(add_colon(l('Disambiguation')),
                         html_escape(edit.display_data.comment.old),
                         html_escape(edit.display_data.comment.new)) -%]
 

--- a/root/edit/details/edit_series.tt
+++ b/root/edit/details/edit_series.tt
@@ -11,7 +11,7 @@
                   html_escape(edit.display_data.name.new),
                   '\s+') %]
 
-  [% display_diff(l('Disambiguation:'),
+  [% display_diff(add_colon(l('Disambiguation')),
                   html_escape(edit.display_data.comment.old),
                   html_escape(edit.display_data.comment.new),
                   '\s+') %]

--- a/root/edit/details/edit_work.tt
+++ b/root/edit/details/edit_work.tt
@@ -12,7 +12,7 @@
                         html_escape(edit.display_data.name.old),
                         html_escape(edit.display_data.name.new)) -%]
 
-  [%- display_word_diff(l('Disambiguation:'),
+  [%- display_word_diff(add_colon(l('Disambiguation')),
                         html_escape(edit.display_data.comment.old),
                         html_escape(edit.display_data.comment.new)) -%]
 

--- a/root/edit/details/historic/change_artist_quality.tt
+++ b/root/edit/details/historic/change_artist_quality.tt
@@ -4,7 +4,7 @@
     <td colspan="2">[% link_entity(edit.display_data.artist) %]</td>
   </tr>
   <tr>
-    <th>[% l('Data Quality:') %]</th>
+    <th>[% add_colon(l('Data Quality')) %]</th>
     <td class="old">[% quality_name(edit.display_data.quality.old) %]</td>
     <td class="new">[% quality_name(edit.display_data.quality.new) %]</td>
   </tr>

--- a/root/edit/details/historic/change_release_quality.tt
+++ b/root/edit/details/historic/change_release_quality.tt
@@ -11,7 +11,7 @@
     </td>
   </tr>
   <tr>
-    <th>[% l('Data Quality:') %]</th>
+    <th>[% add_colon(l('Data Quality')) %]</th>
     <td class="old">[% quality_name(change.quality.old) %]</td>
     <td class="new">[% quality_name(change.quality.new) %]</td>
   </tr>

--- a/root/edit/list.tt
+++ b/root/edit/list.tt
@@ -62,7 +62,7 @@
                             [%-INCLUDE "edit/details/${edit.edit_template}.tt" %]
                           [% END %]
                         [% ELSE %]
-                           <p>[% l('An error occurred while loading this edit') %]</p>
+                           <p>[% l('An error occurred while loading this edit.') %]</p>
                         [% END %]
                     </div>
 

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -10,7 +10,7 @@
       <fieldset>
         <legend>[% l('Event Details') %]</legend>
         [%- form_row_name_with_guesscase(r) -%]
-        [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+        [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [% form_row_checkbox(r, 'cancelled', l('This event was cancelled.')) %]
         [% WRAPPER form_row %]

--- a/root/instrument/edit_form.tt
+++ b/root/instrument/edit_form.tt
@@ -7,7 +7,7 @@
     <fieldset>
       <legend>[%- l('Instrument Details') -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
-      [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
       [% WRAPPER form_row %]
           [%- r.label('description', l('Description:')) -%]

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -10,7 +10,7 @@
         <legend>[% l('Label Details') %]</legend>
         [%- form_row_name_with_guesscase(r) -%]
         [%- duplicate_entities_section() -%]
-        [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+        [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [% WRAPPER form_row %]

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -10,7 +10,7 @@
         <legend>[% l('Place Details') %]</legend>
         [%- form_row_name_with_guesscase(r) -%]
         [%- duplicate_entities_section() -%]
-        [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+        [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [%- form_row_text_long(r, 'address', l('Address:')) -%]

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -23,7 +23,7 @@
       <legend>[% l('Recording Details') %]</legend>
       [%- form_row_name_with_guesscase(r, { guessfeat => 1 }) -%]
       <div id="artist-credit-editor"></div>
-      [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- IF !form.used_by_tracks || form.field('length').has_errors;
             form_row_text_long(r, 'length', l('Length:'));
           END -%]

--- a/root/release/change_quality.tt
+++ b/root/release/change_quality.tt
@@ -2,7 +2,7 @@
    <h2>[% l('Change release data quality') %]</h2>
    <form method="post">
      [% USE r = FormRenderer(form) %]
-     [% form_row_select(r, 'quality', l('Data Quality:')) %]
+     [% form_row_select(r, 'quality', add_colon(l('Data Quality'))) %]
      [% INCLUDE 'forms/edit-note.tt' %]
      [% enter_edit() %]
    </form>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -246,7 +246,7 @@
       </tr>
 
       <tr>
-        <td><label for="comment">[% l('Disambiguation:') %]</label></td>
+        <td><label for="comment">[% add_colon(l('Disambiguation')) %]</label></td>
         <td>
           <input id="comment" type="text" maxlength="255" data-bind="value: comment, controlsBubble: $root.commentBubble" />
         </td>

--- a/root/release_group/edit_form.tt
+++ b/root/release_group/edit_form.tt
@@ -12,7 +12,7 @@
       <legend>[% l('Release Group Details') %]</legend>
       [%- form_row_name_with_guesscase(r, { guessfeat => 1 }) -%]
       <div id="artist-credit-editor"></div>
-      [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'primary_type_id', l('Primary Type:')) -%]
       [%- form_row_select(r, 'secondary_type_ids', l('Secondary Types:')) -%]
     </fieldset>

--- a/root/report/ArtistsThatMayBeGroups.js
+++ b/root/report/ArtistsThatMayBeGroups.js
@@ -34,7 +34,7 @@ const ArtistsThatMayBeGroups = ({
             than Group (or a subtype of Group) but may be a group,
             because they have other artists listed as members. If you find
             that an artist here is indeed a group, change its type. If it is
-            not, please make sure that the "member of" relationships are
+            not, please make sure that the “member of” relationships are
             in the right direction and are correct.`)}
       </li>
       <li>

--- a/root/report/DeprecatedRelationshipReleases.js
+++ b/root/report/DeprecatedRelationshipReleases.js
@@ -30,7 +30,7 @@ const DeprecatedRelationshipReleases = ({
 
     <ul>
       <li>
-        {l(`This report lists release which have relationships using
+        {l(`This report lists releases which have relationships using
             deprecated and grouping-only relationship types.`)}
       </li>
       <li>

--- a/root/report/PartOfSetRelationships.js
+++ b/root/report/PartOfSetRelationships.js
@@ -25,8 +25,8 @@ const PartOfSetRelationships = ({
   items,
   pager,
 }: ReportDataT<ReportReleaseT>) => (
-  <Layout fullWidth title={l('Releases with "part of set" relationships')}>
-    <h1>{l('Releases with "part of set" relationships')}</h1>
+  <Layout fullWidth title={l('Releases with “part of set” relationships')}>
+    <h1>{l('Releases with “part of set” relationships')}</h1>
 
     <ul>
       <li>

--- a/root/report/RecordingsWithVaryingTrackLengths.js
+++ b/root/report/RecordingsWithVaryingTrackLengths.js
@@ -25,8 +25,8 @@ const RecordingsWithVaryingTrackLengths = ({
   items,
   pager,
 }: ReportDataT<ReportRecordingT>) => (
-  <Layout fullWidth title={l('Recordings with varying track lengths')}>
-    <h1>{l('Recordings with varying track lengths')}</h1>
+  <Layout fullWidth title={l('Recordings with varying track times')}>
+    <h1>{l('Recordings with varying track times')}</h1>
 
     <ul>
       <li>

--- a/root/report/ReleasesWithDownloadRelationships.js
+++ b/root/report/ReleasesWithDownloadRelationships.js
@@ -36,7 +36,7 @@ const ReleasesWithDownloadRelationships = ({
     <ul>
       <li>
         {l(`This report shows releases that have download relationships, but
-            have media whose format is not "Digital Media".`)}
+            have media whose format is not “Digital Media”.`)}
       </li>
       <li>
         {texp.l('Total releases found: {count}',

--- a/root/report/UnlinkedPseudoReleases.js
+++ b/root/report/UnlinkedPseudoReleases.js
@@ -30,7 +30,7 @@ const UnlinkedPseudoReleases = ({
 
     <ul>
       <li>
-        {l(`This report shows releases with status Pseudo-Release that aren't
+        {l(`This report shows releases with status Pseudo-Release that aren’t
             linked via the translation/transliteration relationship to an
              original version. This could be because the original version is
              missing, or just because the release status is wrongly set.`)}

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -41,7 +41,7 @@ function buildResult(result, index) {
         {release.combined_format_name || l('[missing media]')}
       </td>
       <td>
-        {release.combined_track_count || '-'}
+        {release.combined_track_count || l('-')}
       </td>
       <td>
         <ReleaseDates events={release.events} />

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -10,7 +10,7 @@
         <legend>[% l('Series Details') %]</legend>
         [%- form_row_name_with_guesscase(r) -%]
         [%- duplicate_entities_section() -%]
-        [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+        [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
         [%- form_row_select(r, 'type_id', l('Type:')) -%]
         [%- form_row_select(r, 'ordering_type_id', l('Ordering Type:')) -%]

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -23,6 +23,7 @@ import SelectField from '../../../../components/SelectField';
 import DBDefs from '../../common/DBDefs-client';
 import Autocomplete from '../../common/components/Autocomplete';
 import Warning from '../../common/components/Warning';
+import {N_lp_attributes} from '../../common/i18n/attributes';
 import {pushCompoundField} from '../../edit/utility/pushField';
 import hydrate from '../../../../utility/hydrate';
 
@@ -65,9 +66,9 @@ type State = {|
 const genderOptions = {
   grouped: false,
   options: [
-    {label: N_l('Male'), value: 1},
-    {label: N_l('Female'), value: 2},
-    {label: N_l('Other'), value: 3},
+    {label: N_lp_attributes('Male', 'gender'), value: 1},
+    {label: N_lp_attributes('Female', 'gender'), value: 2},
+    {label: N_lp_attributes('Other', 'gender'), value: 3},
   ],
 };
 

--- a/root/static/scripts/common/i18n/attributes.js
+++ b/root/static/scripts/common/i18n/attributes.js
@@ -12,3 +12,7 @@ import * as wrapGettext from './wrapGettext';
 export const l_attributes = wrapGettext.dgettext('attributes');
 export const ln_attributes = wrapGettext.dngettext('attributes');
 export const lp_attributes = wrapGettext.dpgettext('attributes');
+
+export const N_lp_attributes = (key: string, context: string) => (
+  () => lp_attributes(key, context)
+);

--- a/root/statistics/Formats.js
+++ b/root/statistics/Formats.js
@@ -60,9 +60,9 @@ const Formats = ({$c, dateCollected, formatStats, stats}: FormatsStatsT) => (
           <td />
           <td>{l('Total')}</td>
           <td className="t">{formatCount($c, stats['count.release'])}</td>
-          <td className="t">{l('100%')}</td>
+          <td className="t">{formatPercentage($c, 1, 0)}</td>
           <td className="t">{formatCount($c, stats['count.medium'])}</td>
-          <td className="t">{l('100%')}</td>
+          <td className="t">{formatPercentage($c, 1, 0)}</td>
         </tr>
         {formatStats.map((formatStat, index) => {
           const entity = formatStat.entity;

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -28,7 +28,7 @@ const stats = {
     'edit-information': {hide: true, label: l('Edit Information')},
     'formats': {label: l('Formats')},
     'label-countries': {label: l('Label Countries')},
-    'other': {label: l('Other')},
+    'other': {label: lp('Other', 'stats category')},
     'ratings-tags': {label: l('Ratings and Tags')},
     'relationships': {hide: true, label: l('Relationships')},
     'release-countries': {label: l('Release Countries')},

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -97,10 +97,13 @@ const ReportUser = ({
       <strong>{addColonText(l('Note'))}</strong>
       {' '}
       {l(`Be sure to provide direct links to examples of the behaviour you’re
-          reporting (for example, use “https://musicbrainz.org/edit/23”
-          instead of “edit #23”, and use “https://musicbrainz.org/edit/42 and
-          https://musicbrainz.org/edit/43” instead of
-          “https://musicbrainz.org/user/SomeUser/edits”).
+          reporting (for example, use
+          “<code>https://musicbrainz.org/edit/23</code>”
+          instead of “edit #23”, and use
+          “<code>https://musicbrainz.org/edit/42</code> and
+          <code>https://musicbrainz.org/edit/43</code>”
+          instead of
+          “<code>https://musicbrainz.org/user/SomeUser/edits</code>”).
           Providing links makes it much easier for the recipients of the
           report to look into the issues; a report without links is
           unlikely to be acted on fast, since it will require a lot of

--- a/root/user/contact.tt
+++ b/root/user/contact.tt
@@ -8,7 +8,7 @@
         [% form_row_text_long(r, 'subject', l('Subject:')) %]
 
         [% WRAPPER form_row %]
-            [% r.label('body', l('Message:')) %]
+            [% r.label('body', add_colon(l('Message'))) %]
             [% r.textarea('body', { cols => 50, rows => 10 }) %]
             [% form_field_errors(form, 'body') %]
         [% END %]

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -10,7 +10,7 @@
     <fieldset>
       <legend>[%- l('Work Details') -%]</legend>
       [%- form_row_name_with_guesscase(r) -%]
-      [%- form_row_text_long(r, 'comment', l('Disambiguation:')) -%]
+      [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- form_row_select(r, 'type_id', l('Type:')) -%]
       <div id="work-languages-editor"></div>
       [%- form_row_text_list(r, 'iswcs', l('ISWCs:'), l('ISWC')) -%]


### PR DESCRIPTION
Updating localization files is usually done by pushing commits directly to `master` or `beta`, but this time I reviewed differences with v-2019-01-22 to `po/*.pot` files and fixed a lot of messages in `root/` before.