### PR TITLE
Fix DBDefs import in CritiqueBrainzReview

### DIFF
--- a/root/static/scripts/common/components/CritiqueBrainzReview.js
+++ b/root/static/scripts/common/components/CritiqueBrainzReview.js
@@ -12,7 +12,7 @@ import React from 'react';
 import {withCatalystContext} from '../../../../context';
 import formatUserDate from '../../../../utility/formatUserDate';
 import hydrate from '../../../../utility/hydrate';
-import * as DBDefs from '../DBDefs';
+import * as DBDefs from '../DBDefs-client';
 
 import Collapsible from './Collapsible';
 


### PR DESCRIPTION
'DBDefs' can't be imported in scripts that run in the browser. It can contain sensitive configuration values, so is specifically excluded from the build by Webpack.

'DBDefs-client' must be used instead, as it's available in the browser and specifically includes only the %CLIENT_DEFS listed in script/dbdefs_to_js.pl.

Resolves https://sentry.metabrainz.org/metabrainz/musicbrainz-server/issues/52114/