### PR TITLE
Fix broken check digit i18n

### DIFF
--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -128,7 +128,7 @@ utils.withRelease(function (release) {
         return;
     }
 
-    var checkDigitText = N_l("The check digit is {checkdigit}.");
+    var checkDigitText = l("The check digit is {checkdigit}.");
     var doubleCheckText = l("Please double-check the barcode on the release.");
 
     if (barcode.length === 11) {


### PR DESCRIPTION
There's no reason to use `N_l` here, and it's causing an issue because we pass `checkDigitText` to `expand2text` below (which expects a string as the first argument, not a function).

Resolves https://sentry.metabrainz.org/metabrainz/musicbrainz-server/issues/57619/