### PR TITLE
Fix duplicate area-{url,work} relationship display

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -9,9 +9,10 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         cardinal    => ['edit'],
         default     => ['url'],
         subset      => {
-            show => [qw( area artist label place url work series instrument release release_group recording work url )],
+            show => [qw( area artist label place series instrument release release_group recording work url )],
         }
-    },};
+    },
+};
 with 'MusicBrainz::Server::Controller::Role::LoadWithRowID';
 with 'MusicBrainz::Server::Controller::Role::Annotation';
 with 'MusicBrainz::Server::Controller::Role::Alias';

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -120,7 +120,7 @@ sub get_by_ids
 sub _load
 {
     my ($self, $type, $target_types, $use_cardinality, @objs) = @_;
-    my @target_types = @$target_types;
+    my @target_types = uniq @$target_types;
     my @types = map { [ sort($type, $_) ] } @target_types;
     my @rels;
     foreach my $t (@types) {


### PR DESCRIPTION
area-url and area-work relationships were duplicated on area index pages, because 'url' and 'work' appeared twice in the type `subset` list passed to `Controller::Role::Load`, so they were loaded twice.

Besides removing the duplicate entries, I added a `uniq` call before it loops over the types.