### PR TITLE
Update postgres base to 9.5.16 (and thus debian to stretch) in test-database docker image

### DIFF
--- a/docker/templates/Dockerfile.test-database.m4
+++ b/docker/templates/Dockerfile.test-database.m4
@@ -1,12 +1,7 @@
 m4_include(`macros.m4')m4_dnl
-FROM postgres:9.5.6
+FROM postgres:9.5.16
 
 ARG DEBIAN_FRONTEND=noninteractive
-
-# postgres:9.5.6 is based on debian:jessie
-# this acknowledges the removal of jessie-updates from mirrors
-# https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
 
 # install_extensions.sh removes certain build dependencies that we need, so we
 # can't install everything here.


### PR DESCRIPTION
Previous docker image for test-image was based on `postgres:9.5.6` which, in turn, was based on `debian:jessie`.

The recent removal of jessie-updates from mirrors broke sources.list
https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html

Rather than working around by hot-fixing `/etc/apt/sources.list`; this patch updates to `postgres:9.5.16` which is based on `debian:stretch`.

----

P.S. That should fix error at the bottom of https://ci.metabrainz.org/job/MusicBrainz%20Server%20Docker%20Images/274/console