### PR TITLE
MBS-10112: Support instrument descriptions that contain HTML

### DIFF
--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import Layout from '../layout';
 import EntityLink from '../static/scripts/common/components/EntityLink';
+import expand2react from '../static/scripts/common/i18n/expand2react';
 
 type PropsT = {|
   +instrument_types: $ReadOnlyArray<InstrumentTypeT>,
@@ -27,7 +28,7 @@ const Instrument = ({instrument}) => (
       ? (
         <>
           {' — '}
-          {l_instrument_descriptions(instrument.description)}
+          {expand2react(l_instrument_descriptions(instrument.description))}
         </>
       )
       : null}

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsT} from '../types';
 
@@ -25,10 +26,13 @@ function buildResult(result, index) {
       <td>
         <EntityLink entity={instrument} />
       </td>
-      <td>{instrument.typeName ? lp_attributes(instrument.typeName, 'instrument_type') : null}</td>
+      <td>
+        {instrument.typeName
+          ? lp_attributes(instrument.typeName, 'instrument_type') : null}
+      </td>
       <td>
         {instrument.description
-          ? l_instrument_descriptions(instrument.description)
+          ? expand2react(l_instrument_descriptions(instrument.description))
           : null}
       </td>
     </tr>

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -894,8 +894,11 @@ MB.Control.autocomplete_formatters = {
         }
 
         if (item.description) {
+            // We want to strip html from the non-clickable description
             a.append('<br /><span class="autocomplete-comment">' +
-                      _.escape(l_instrument_descriptions(item.description)) +
+                      _.escape($('<div/>').html(
+                        l_instrument_descriptions(item.description),
+                      ).text()) +
                       '</span>');
         }
 


### PR DESCRIPTION
In most cases we want to read and use this html.
For Autocomplete, the description should just be text, so we just drop the html tags. I've done that with jquery since that file is already using jquery anyway and it seems to be the simplest way, but eventually we might want a better way or our own function.

The autocomplete error is already there in prod. The other two are beta only.