### PR TITLE
Fix for updating track ACs with the release AC

### DIFF
--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -157,6 +157,9 @@ releaseEditor.init = function (options) {
                     _.each(medium.tracks(), function (track) {
                         if (reduceArtistCredit(track.artistCredit()) === reduceArtistCredit(savedReleaseAC)) {
                             track.artistCredit(artistCreditFromArray(releaseAC));
+                            track.artistCreditEditorInst.setState({
+                                artistCredit: track.artistCredit.peek(),
+                            });
                         }
                     });
                 });


### PR DESCRIPTION
This is a hack, but fixes an issue where the track artist credits would not appear to be updated when the matching release artist credit was changed. It achieves this by setting the component state directly, similar to how we do inside `doneCallback` in bindingHandlers.js.

I don't know if it's related to [MBS-10115](https://tickets.metabrainz.org/browse/MBS-10115) without specific steps to reproduce that.

Also, I saw some talk on IRC about the "Change all artists on this release that match ..." feature not working, but I can't reproduce any issue with that (and don't see any tickets related to it). It was recently fixed with https://github.com/metabrainz/musicbrainz-server/pull/795 so if anyone has more details about how to break it (again), please open a ticket with steps! :)