### PR TITLE
MBS-10133: Clarify "empty query" bad request error

### DIFF
--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -205,7 +205,7 @@ sub xml_search
     if ($query =~ /^\s*$/)
     {
         return {
-            error => "Must specify a least one parameter (other than 'limit', 'offset' or empty 'query') for collections query.",
+            error => "You submitted a blank search query. You must include a non-blank 'query=' parameter with your search.",
             code  => HTTP_BAD_REQUEST
         };
     }

--- a/lib/MusicBrainz/Server/Data/WebService.pm
+++ b/lib/MusicBrainz/Server/Data/WebService.pm
@@ -201,8 +201,8 @@ sub xml_search
     }
 
     $query =~ s/^ AND //;
-    # In case we have a blank query
-    if ($query =~ /^\s*$/)
+    # In case we have a blank query (only whitespace, or whitespace surrounded by unescaped quotes)
+    if ($query =~ /^(?:\s*|"\s*")$/)
     {
         return {
             error => "You submitted a blank search query. You must include a non-blank 'query=' parameter with your search.",

--- a/lib/MusicBrainz/Server/Test/WS.pm
+++ b/lib/MusicBrainz/Server/Test/WS.pm
@@ -31,7 +31,7 @@ Readonly our $FORBIDDEN_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>You are not authorized to access this resource.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
 
@@ -39,7 +39,7 @@ Readonly our $UNAUTHORIZED_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>Your credentials could not be verified. Either you supplied the wrong credentials (e.g., bad password), or your client doesn't understand how to supply the credentials required.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
 
@@ -47,7 +47,7 @@ Readonly our $NOT_FOUND_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>Not Found</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
 
@@ -55,7 +55,7 @@ Readonly our $INVALID_MBID_XML_RESPONSE => <<'EOXML';
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>Invalid mbid.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
 

--- a/lib/MusicBrainz/Server/Test/WS.pm
+++ b/lib/MusicBrainz/Server/Test/WS.pm
@@ -21,10 +21,12 @@ our @EXPORT_OK = qw(
 
 Readonly our $FORBIDDEN_JSON_RESPONSE => {
     error => 'You are not authorized to access this resource.',
+    help => 'For usage, please see: https://musicbrainz.org/development/mmd',
 };
 
 Readonly our $UNAUTHORIZED_JSON_RESPONSE => {
     error => 'Your credentials could not be verified. Either you supplied the wrong credentials (e.g., bad password), or your client doesn\'t understand how to supply the credentials required.',
+    help => 'For usage, please see: https://musicbrainz.org/development/mmd',
 };
 
 Readonly our $FORBIDDEN_XML_RESPONSE => <<'EOXML';

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -129,7 +129,10 @@ sub autocomplete_editor {
 sub output_error {
     my ($self, $err) = @_;
 
-    return encode_json({ error => $err });
+    return encode_json({
+        error => $err,
+        help => 'For usage, please see: https://musicbrainz.org/development/mmd',
+    });
 }
 
 sub output_success {

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -1326,7 +1326,7 @@ sub output_error
 
     return '<?xml version="1.0" encoding="UTF-8"?>' .
         $gen->error($gen->text($err), $gen->text(
-           "For usage, please see: http://musicbrainz.org/development/mmd"));
+           "For usage, please see: https://musicbrainz.org/development/mmd"));
 }
 
 sub output_success

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -333,7 +333,7 @@ test "collection lookup errors" => sub {
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
   <text>This is not a collection for entity type $entity_type.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/BrowseReleases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/BrowseReleases.pm
@@ -21,7 +21,10 @@ test 'errors' => sub {
     $mech->get('/ws/2/release?recording=7b1f6e95-b523-43b6-a048-810ea5d463a8');
     is($mech->status, 404, 'browse releases via non-existent recording');
 
-    is_json($mech->content, encode_json({ error => "Not Found" }));
+    is_json($mech->content, encode_json({
+          error => "Not Found",
+          help => 'For usage, please see: https://musicbrainz.org/development/mmd',
+    }));
 };
 
 test 'browse releases via artist (paging)' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupArtist.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupArtist.pm
@@ -22,12 +22,16 @@ test 'errors' => sub {
     is($mech->status, 400);
 
     is_json($mech->content, encode_json({
-        error => "coffee is not a valid inc parameter for the artist resource."
+        error => "coffee is not a valid inc parameter for the artist resource.",
+        help => 'For usage, please see: https://musicbrainz.org/development/mmd',
     }));
 
     $mech->get('/ws/2/artist/00000000-1111-2222-3333-444444444444');
     is($mech->status, 404);
-    is_json($mech->content, encode_json({ error => "Not Found" }));
+    is_json($mech->content, encode_json({
+          error => "Not Found",
+          help => 'For usage, please see: https://musicbrainz.org/development/mmd',
+    }));
 };
 
 test 'basic artist lookup' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupArtist.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupArtist.pm
@@ -430,7 +430,7 @@ is($mech->status, 400);
 is_xml_same($mech->content, q{<?xml version="1.0"?>
 <error>
   <text>coffee is not a valid inc parameter for the artist resource.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>});
 
 ws_test 'artist lookup with works (using l_artist_work)',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupDiscID.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupDiscID.pm
@@ -186,7 +186,7 @@ subtest 'lookup of invalid discid with no toc parameter' => sub {
     is_xml_same($mech->content, q{<?xml version="1.0"?>
     <error>
       <text>Invalid discid.</text>
-      <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+      <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
     </error>});
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupEvent.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupEvent.pm
@@ -24,7 +24,7 @@ is($mech->status, 400);
 is_xml_same($mech->content, q{<?xml version="1.0"?>
 <error>
   <text>coffee is not a valid inc parameter for the event resource.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>});
 
 ws_test 'basic event lookup',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupInstrument.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupInstrument.pm
@@ -29,7 +29,7 @@ is($mech->status, 400);
 is_xml_same($mech->content, q{<?xml version="1.0"?>
 <error>
   <text>coffee is not a valid inc parameter for the instrument resource.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>});
 
 ws_test 'basic instrument lookup',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupSeries.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupSeries.pm
@@ -25,7 +25,7 @@ is($mech->status, 400);
 is_xml_same($mech->content, q{<?xml version="1.0"?>
 <error>
   <text>coffee is not a valid inc parameter for the series resource.</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>});
 
 ws_test 'basic series lookup',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/SubmitCollection.pm
@@ -156,7 +156,7 @@ EOXML
 <?xml version="1.0" encoding="UTF-8"?>
 <error>
     <text>PUT is not allowed on this endpoint.</text>
-    <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+    <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>
 EOXML
     };

--- a/t/lib/t/MusicBrainz/Server/WebService/Format.pm
+++ b/t/lib/t/MusicBrainz/Server/WebService/Format.pm
@@ -108,7 +108,7 @@ test 'webservice request format handling (errors)' => sub {
     my $expected = '<?xml version="1.0"?>
 <error>
   <text>Invalid format. Either set an Accept header (recognized mime types are application/json and application/xml), or include a fmt= argument in the query string (valid values for fmt are json and xml).</text>
-  <text>For usage, please see: http://musicbrainz.org/development/mmd</text>
+  <text>For usage, please see: https://musicbrainz.org/development/mmd</text>
 </error>';
 
     $Test->note('Accept: application/something-else');


### PR DESCRIPTION
Fix [MBS-10133](https://tickets.metabrainz.org/browse/MBS-10133)
----

Collections aren't searched through the search server at all, if https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2/Search is correct. As such, this should just say that the blank query was blank.

Also generalize what is seen as a blank query: given we can't have empty string or whitespaces as names, `""`, `''` or `"    "` should also be rejected as blank queries. *Escaped* quote marks, such as `query=\"`, should be allowed in order to allow searching for fields containing quote marks.