### PR TITLE
MBS-10134: Don't send bad browse queries to the search server

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
@@ -26,6 +26,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      area => {
+                         action   => '/ws/2/area/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags genres user-genres ratings user-ratings) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      artist => {
+                         action   => '/ws/2/artist/lookup',
                          method   => 'GET',
                          inc      => [ qw(recordings releases release-groups works
                                           aliases various-artists annotation

--- a/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          linked   => [ qw( area artist place collection ) ]
      },
      event => {
+                         action   => '/ws/2/event/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation _relations
                                           tags user-tags genres user-genres ratings user-ratings) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      label => {
+                         action   => '/ws/2/label/lookup',
                          method   => 'GET',
                          inc      => [ qw(releases aliases annotation
                                           _relations tags user-tags genres user-genres ratings user-ratings) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      place => {
+                         action   => '/ws/2/place/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation
                                           _relations tags user-tags genres user-genres) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
@@ -28,6 +28,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      recording => {
+                         action   => '/ws/2/recording/lookup',
                          method   => 'GET',
                          inc      => [ qw(artists releases artist-credits puids isrcs aliases
                                           _relations tags user-tags genres user-genres ratings user-ratings

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -31,6 +31,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      release => {
+                         action   => '/ws/2/release/lookup',
                          method   => 'GET',
                          inc      => [ qw(artists labels recordings release-groups aliases
                                           tags user-tags genres user-genres ratings user-ratings collections user-collections

--- a/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      "release-group" => {
+                         action   => '/ws/2/releasegroup/lookup',
                          method   => 'GET',
                          inc      => [ qw(artists releases artist-credits aliases annotation
                                           _relations tags user-tags genres user-genres ratings user-ratings) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
@@ -19,6 +19,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt limit offset) ],
      },
      series => {
+                         action   => '/ws/2/series/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation _relations tags user-tags genres user-genres) ],
                          optional => [ qw(fmt) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
@@ -18,6 +18,7 @@ my $ws_defs = Data::OptList::mkopt([
                          optional => [ qw(fmt) ],
      },
      url => {
+                         action   => '/ws/2/url/lookup',
                          method   => 'GET',
                          inc      => [ qw(_relations) ],
                          optional => [ qw(fmt) ],

--- a/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
@@ -20,6 +20,7 @@ my $ws_defs = Data::OptList::mkopt([
                          linked   => [ qw( artist collection ) ]
      },
      work => {
+                         action   => '/ws/2/work/lookup',
                          method   => 'GET',
                          inc      => [ qw(aliases annotation _relations
                                           tags user-tags genres user-genres ratings user-ratings) ],

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -266,6 +266,10 @@ role {
             next if ($resource ne $def->[0]);
             next if ($c->req->method ne $def->[1]->{method});
 
+            next if
+                defined $def->[1]->{action} &&
+                $c->req->action ne $def->[1]->{action};
+
             # Check to make sure that required arguments are present
             next unless validate_required($c, $def->[1]->{required});
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10134

Any browse request with an unsupported attribute will be understood as a search request. Since there's no good way of distinguishing those from an actual search request with "query=" (an empty query attribute), we need an error message that fits both options. 

It isn't useful to send either of these to the search service anyway, so we can just give a bad request error before we send them.