### PR TITLE
MBS-8915: Allow editors to choose delimiter in track parser

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -49,8 +49,13 @@
       </td>
     </tr>
     <tr>
-      <td></td>
       <td>
+        <label>
+        <input type="checkbox" name="use-custom-delimiter" data-bind="checked: useCustomDelimiter" />
+          [%= l('Use custom artist delimiter') %]
+        </label>
+       </td>
+       <td>
         <label>
           <input type="checkbox" name="use-titles" data-bind="checked: useTrackNames" />
           [%= l('Use track titles') %]
@@ -58,7 +63,19 @@
       </td>
     </tr>
     <tr>
-      <td></td>
+      <td style="padding-left: 2em">
+        <label data-bind="visible: useCustomDelimiter">
+          [%= add_colon(l('Custom delimiter')) %]
+          <input type="text" name="custom-delimiter" data-bind="value: customDelimiter" />
+          <span class="error" data-bind="text: customDelimiterError"></span>
+          (<a href="#" data-bind="click: toggleDelimiterHelp">[% l('help') %]</a>)
+          <p data-bind="visible: delimiterHelpVisible" style="max-width: 25em">
+            <i>[% l('Enter the delimiter that separates the track name from the artist name
+                     (valid {url|regular expressions} are accepted).',
+                     { url => 'https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions' }) %]</i>
+          </p>
+        </label>
+      </td>
       <td>
         <label>
           <input type="checkbox" name="use-lengths" data-bind="checked: useTrackLengths" />

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -66,10 +66,10 @@
       <td style="padding-left: 2em">
         <label data-bind="visible: useCustomDelimiter">
           [%= add_colon(l('Custom delimiter')) %]
-          <input type="text" name="custom-delimiter" data-bind="value: customDelimiter" />
-          <span class="error" data-bind="text: customDelimiterError"></span>
-          (<a href="#" data-bind="click: toggleDelimiterHelp">[% l('help') %]</a>)
-          <p data-bind="visible: delimiterHelpVisible" style="max-width: 25em">
+          <input type="text" name="custom-delimiter" data-bind="value: customDelimiter, valueUpdate: 'input'" />
+          (<a href="#" data-bind="click: $root.trackParser.toggleDelimiterHelp">[% l('help') %]</a>)
+          <p class="error" data-bind="text: $root.trackParser.customDelimiterError"></p>
+          <p data-bind="visible: $root.trackParser.delimiterHelpVisible" style="max-width: 25em">
             <i>[% l('Enter the delimiter that separates the track name from the artist name
                      (valid {url|regular expressions} are accepted).',
                      { url => 'https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions' }) %]</i>

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -40,10 +40,17 @@ releaseEditor.trackParser = {
         hasTrackNumbers: optionCookie("trackparser_tracknumbers", true),
         hasTrackArtists: optionCookie("trackparser_trackartists", true),
         hasVinylNumbers: optionCookie("trackparser_vinylnumbers", false),
+        customDelimiter: optionCookie("trackparser_customdelimiter", "", false),
+        customDelimiterError: ko.observable(''),
+        useCustomDelimiter: optionCookie("trackparser_usecustomdelimiter", false),
         useTrackNumbers: optionCookie("trackparser_usetracknumbers", true),
         useTrackNames: optionCookie("trackparser_usetracknames", true),
         useTrackArtists: optionCookie("trackparser_usetrackartists", true),
-        useTrackLengths: optionCookie("trackparser_tracktimes", true)
+        useTrackLengths: optionCookie("trackparser_tracktimes", true),
+        delimiterHelpVisible: ko.observable(false),
+        toggleDelimiterHelp: function () {
+          this.delimiterHelpVisible(!this.delimiterHelpVisible());
+        },
     },
 
     parse: function (str, medium) {
@@ -324,6 +331,16 @@ releaseEditor.trackParser = {
             return data;
         }
 
+        // Use custom delimiter as separator.
+        if (options.useCustomDelimiter && options.customDelimiter !== '') {
+            try {
+                this.separators = new RegExp('(' + options.customDelimiter + ')');
+                this.options.customDelimiterError('');
+            } catch(e) {
+                this.options.customDelimiterError(l('Invalid regular expression.'));
+            }
+        }
+
         // Split the string into parts, if there are any.
         var parts = line.split(this.separators),
             names = _.reject(parts, x => this.separatorOrBlank(x));
@@ -408,12 +425,18 @@ releaseEditor.trackParser = {
     }
 };
 
-function optionCookie(name, defaultValue) {
+function optionCookie(name, defaultValue, checkbox=true) {
     var existingValue = getCookie(name);
 
-    var observable = ko.observable(
-        defaultValue ? existingValue !== "false" : existingValue === "true"
-    );
+    if (checkbox) {
+      var observable = ko.observable(
+          defaultValue ? existingValue !== "false" : existingValue === "true"
+      );
+    } else {
+      var observable = ko.observable(
+          existingValue ? existingValue : defaultValue
+      );
+    }
 
     observable.subscribe(function (newValue) {
         setCookie(name, newValue);

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -276,6 +276,11 @@ div.changes div.warning { margin: 1em auto; }
         td:nth-child(2) {
             padding-left: 0.5em;
         }
+
+        input[type="text"] {
+          height: 1.5em;
+          width: 4em;
+        }
     }
 
     div.buttons { margin: 1em 0; float: left; width: 100%; }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-8915

Had to resubmit this since I couldn't push to https://github.com/metabrainz/musicbrainz-server/pull/774 - so it's still mostly @Ge0rg3's work.

Made a few changes as requested on the comments on the previous PR, and a change to move both components of the delimiter to the left column in a way that seems to make more sense to me.

Commit text: 
"This commit allows users to choose a custom delimiter, which can be any regular expression. This also required a change to the CSS to fit on, and a change to the optionCookie function to allow for strings as well as just boolean values."