### PR TITLE
MBS-5818 (SQL): Add integer position column to collection entries

### DIFF
--- a/admin/sql/CreateTables.sql
+++ b/admin/sql/CreateTables.sql
@@ -2267,72 +2267,84 @@ CREATE TABLE editor_collection_collaborator (
 CREATE TABLE editor_collection_area (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     area INTEGER NOT NULL, -- PK, references area.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_artist (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     artist INTEGER NOT NULL, -- PK, references artist.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_event (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     event INTEGER NOT NULL, -- PK, references event.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_instrument (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     instrument INTEGER NOT NULL, -- PK, references instrument.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_label (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     label INTEGER NOT NULL, -- PK, references label.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_place (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     place INTEGER NOT NULL, -- PK, references place.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_recording (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     recording INTEGER NOT NULL, -- PK, references recording.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_release (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     release INTEGER NOT NULL, -- PK, references release.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_release_group (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     release_group INTEGER NOT NULL, -- PK, references release_group.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_series (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     series INTEGER NOT NULL, -- PK, references series.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_work (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     work INTEGER NOT NULL, -- PK, references work.id
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 
 CREATE TABLE editor_collection_deleted_entity (
     collection INTEGER NOT NULL, -- PK, references editor_collection.id
     gid UUID NOT NULL, -- PK, references deleted_entity.gid
+    position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0),
     comment TEXT DEFAULT '' NOT NULL
 );
 

--- a/admin/sql/updates/20190422-mbs-5818-collection-position.sql
+++ b/admin/sql/updates/20190422-mbs-5818-collection-position.sql
@@ -1,0 +1,17 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+ALTER TABLE editor_collection_area ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_artist ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_event ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_instrument ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_label ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_place ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_recording ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_release ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_release_group ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_series ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_work ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_deleted_entity ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+
+COMMIT;

--- a/admin/sql/updates/schema-change/25.slave.sql
+++ b/admin/sql/updates/schema-change/25.slave.sql
@@ -2,6 +2,7 @@
 -- 20180503-mbs-9708-drop-area-containment-view.sql
 -- 20190422-mbs-7480.sql
 -- 20190422-mbs-9428-collection-collaborators.sql
+-- 20190422-mbs-5818-collection-position.sql
 -- 20190422-mbs-1658-collection-text.sql
 \set ON_ERROR_STOP 1
 BEGIN;
@@ -29,6 +30,22 @@ CREATE TABLE editor_collection_collaborator (
 );
 
 ALTER TABLE editor_collection_collaborator ADD CONSTRAINT editor_collection_collaborator_pkey PRIMARY KEY (collection, editor);
+
+--------------------------------------------------------------------------------
+SELECT '20190422-mbs-5818-collection-position.sql';
+
+ALTER TABLE editor_collection_area ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_artist ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_event ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_instrument ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_label ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_place ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_recording ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_release ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_release_group ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_series ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_work ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
+ALTER TABLE editor_collection_deleted_entity ADD COLUMN position INTEGER NOT NULL DEFAULT 0 CHECK (position >= 0);
 
 --------------------------------------------------------------------------------
 SELECT '20190422-mbs-1658-collection-text.sql';

--- a/upgrade.json
+++ b/upgrade.json
@@ -64,6 +64,7 @@
     "slave": ["20180503-mbs-9708-drop-area-containment-view.sql",
               "20190422-mbs-7480.sql",
               "20190422-mbs-9428-collection-collaborators.sql",
+              "20190422-mbs-5818-collection-position.sql",
               "20190422-mbs-1658-collection-text.sql"],
     "standalone": ["20170604-mbs-9365.sql",
                    "20170909-mbs-9462-missing-event-triggers.sql",


### PR DESCRIPTION
# Change schema to prepare for [MBS-5818](https://tickets.metabrainz.org/browse/MBS-5818): ordered collections

Add `position` column of `INTEGER` type to every `editor_collection_<entity_type>` table.

It will allow collection owner to manually order collection entries.

Default is still unordered collection, with positions set to `NULL`.