### PR TITLE
MBS-10150: Include CRITIQUEBRAINZ_SERVER in DBDefs-client

### DIFF
--- a/script/dbdefs_to_js.pl
+++ b/script/dbdefs_to_js.pl
@@ -49,6 +49,7 @@ Readonly our @QW_DEFS => qw(
 );
 
 Readonly our %CLIENT_DEFS => (
+    CRITIQUEBRAINZ_SERVER => 1,
     DB_STAGING_TESTING_FEATURES => 1,
     DEVELOPMENT_SERVER => 1,
     GIT_BRANCH => 1,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10150

https://github.com/metabrainz/musicbrainz-server/pull/1008 made it so the CB component uses DBDefs-client... but we didn't include the CB constant in that file. 