### PR TITLE
MBS-9491: Update genre list to use database genres

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -224,6 +224,25 @@
         },
         "model": "Gender"
     },
+    "genre": {
+        "cache": {
+            "id": 333
+        },
+        "disambiguation": true,
+        "edit_table": false,
+        "mbid": {
+            "indexable": true,
+            "multiple": false
+        },
+        "merging": false,
+        "model": "Genre",
+        "plural": "genres",
+        "plural_url": "genres",
+        "removal": {
+            "manual": true
+        },
+        "url": "genre"
+    },
     "instrument": {
         "aliases": {
             "add_edit_type": 136,

--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -1,21 +1,21 @@
 package MusicBrainz::Server::Controller::Genre;
 use Moose;
 
-use MusicBrainz::Server::Constants qw( %ENTITIES );
-
 BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+use List::UtilsBy qw( sort_by );
 
 sub list : Path('/genres') Args(0) {
     my ($self, $c) = @_;
 
-    my $genres = $ENTITIES{tag}{genres};
+    my @genres = $c->model('Genre')->get_all;
+    my $coll = $c->get_collator();
+    my @sorted_genres = sort_by { $coll->getSortKey($_->name) } @genres;
 
     $c->stash(
         current_view => 'Node',
         component_path => 'genre/List',
-        component_props => {
-            genres => $genres,
-        },
+        component_props => { genres => \@sorted_genres },
     );
 }
 
@@ -23,7 +23,7 @@ sub list : Path('/genres') Args(0) {
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2018 MetaBrainz Foundation
+Copyright (C) 2019 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -14,7 +14,7 @@ sub list : Path('/genres') Args(0) {
 
     $c->stash(
         current_view => 'Node',
-        component_path => 'genre/List',
+        component_path => 'genre/GenreListPage',
         component_props => { genres => \@sorted_genres },
     );
 }

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -1,0 +1,78 @@
+package MusicBrainz::Server::Data::Genre;
+
+use Moose;
+use MusicBrainz::Server::Data::Utils qw(
+    hash_to_row
+    load_subobjects
+);
+use MusicBrainz::Server::Entity::Genre;
+
+extends 'MusicBrainz::Server::Data::CoreEntity';
+with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'genre' };
+with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::SelectAll';
+with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'genre' };
+
+sub _type { 'genre' }
+
+sub _columns {
+    return 'genre.id, genre.gid, genre.name,
+            genre.comment, genre.edits_pending, genre.last_updated';
+}
+
+sub _column_mapping {
+    return {
+        id => 'id',
+        gid => 'gid',
+        name => 'name',
+        comment => 'comment',
+        edits_pending => 'edits_pending',
+        last_updated => 'last_updated',
+    };
+}
+
+sub _id_column {
+    return 'genre.id';
+}
+
+sub load {
+    my ($self, @objs) = @_;
+    load_subobjects($self, 'genre', @objs);
+}
+
+sub update {
+    my ($self, $genre_id, $update) = @_;
+    return unless %{ $update // {} };
+    my $row = $self->_hash_to_row($update);
+    $self->sql->update_row('genre', $row, { id => $genre_id });
+}
+
+sub delete {
+    my ($self, $genre_id) = @_;
+
+    $self->delete_returning_gids($genre_id);
+    return;
+}
+
+sub _hash_to_row {
+    my ($self, $genre) = @_;
+    my $row = hash_to_row($genre, {
+        map { $_ => $_ } qw( comment name )
+    });
+
+    return $row;
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -348,6 +348,10 @@ my %stats = (
             };
         },
     },
+    "count.genre" => {
+        DESC => "Count of all genres",
+        SQL => "SELECT COUNT(*) FROM genre",
+    },
     "count.instrument" => {
         DESC => "Count of all instruments",
         SQL => "SELECT COUNT(*) FROM instrument",

--- a/lib/MusicBrainz/Server/Entity/Genre.pm
+++ b/lib/MusicBrainz/Server/Entity/Genre.pm
@@ -1,0 +1,24 @@
+package MusicBrainz::Server::Entity::Genre;
+
+use Moose;
+use MusicBrainz::Server::Entity::Types;
+
+extends 'MusicBrainz::Server::Entity::CoreEntity';
+with 'MusicBrainz::Server::Entity::Role::Comment';
+with 'MusicBrainz::Server::Entity::Role::LastUpdate';
+
+sub entity_type { 'genre' }
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/genre/GenreListPage.js
+++ b/root/genre/GenreListPage.js
@@ -1,6 +1,6 @@
 /*
  * @flow
- * Copyright (C) 2018 MetaBrainz Foundation
+ * Copyright (C) 2019 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
  * and is licensed under the GPL version 2, or (at your option) any
@@ -16,12 +16,13 @@ type PropsT = {|
   +genres: $ReadOnlyArray<GenreT>,
 |};
 
-const GenreList = ({genres}: PropsT) => (
+const GenreListPage = ({genres}: PropsT) => (
   <Layout fullWidth title={l('Genre List')}>
     <div id="content">
       <h1>{l('Genre List')}</h1>
       <p>
-        {l('These are all the tags that will be understood as genres by the tag system.')}
+        {l(`These are all the tags that will be understood 
+            as genres by the tag system.`)}
       </p>
       <ul>
         {genres.map(genre => (
@@ -31,13 +32,14 @@ const GenreList = ({genres}: PropsT) => (
         ))}
       </ul>
       <p>
-        {exp.l('Is a genre missing from the list? Request it by {link|adding a style ticket}.', {
-          link: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!&components=10699',
-        })}
+        {exp.l(`Is a genre missing from the list?
+                Request it by {link|adding a style ticket}.`,
+               {
+                 link: 'https://tickets.metabrainz.org/secure/CreateIssueDetails!init.jspa?pid=10032&issuetype=2&summary=Enter%20the%20genre%20name%20here!&components=10699',
+               })}
       </p>
     </div>
   </Layout>
 );
 
-
-export default GenreList;
+export default GenreListPage;

--- a/root/genre/List.js
+++ b/root/genre/List.js
@@ -13,7 +13,7 @@ import Layout from '../layout';
 import TagLink from '../static/scripts/common/components/TagLink';
 
 type PropsT = {|
-  +genres: $ReadOnlyArray<string>,
+  +genres: $ReadOnlyArray<GenreT>,
 |};
 
 const GenreList = ({genres}: PropsT) => (
@@ -25,8 +25,8 @@ const GenreList = ({genres}: PropsT) => (
       </p>
       <ul>
         {genres.map(genre => (
-          <li key={genre}>
-            <TagLink tag={genre} />
+          <li key={genre.id}>
+            <TagLink tag={genre.name} />
           </li>
         ))}
       </ul>
@@ -38,5 +38,6 @@ const GenreList = ({genres}: PropsT) => (
     </div>
   </Layout>
 );
+
 
 export default GenreList;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -54,7 +54,7 @@ module.exports = {
   'elections/NotFound': require('../elections/NotFound'),
   'elections/Show': require('../elections/Show'),
   'event/NotFound': require('../event/NotFound'),
-  'genre/List': require('../genre/List'),
+  'genre/GenreListPage': require('../genre/GenreListPage'),
   'instrument/List': require('../instrument/List'),
   'instrument/NotFound': require('../instrument/NotFound'),
   'isrc/Index': require('../isrc/Index'),

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -132,6 +132,10 @@ const Index = ({
             <th>{l('Events:')}</th>
             <td colSpan="3">{formatCount($c, stats['count.event'])}</td>
           </tr>
+          <tr>
+            <th>{addColonText(l('Genres'))}</th>
+            <td colSpan="3">{formatCount($c, stats['count.genre'])}</td>
+          </tr>
         </tbody>
         <tbody>
           <tr className="thead">

--- a/root/types.js
+++ b/root/types.js
@@ -287,6 +287,7 @@ declare type CoreEntityT =
   | AreaT
   | ArtistT
   | EventT
+  | GenreT
   | InstrumentT
   | LabelT
   | PlaceT
@@ -301,6 +302,7 @@ declare type CoreEntityTypeT =
   | 'area'
   | 'artist'
   | 'event'
+  | 'genre'
   | 'instrument'
   | 'label'
   | 'place'
@@ -477,6 +479,11 @@ declare type FormT<+F> = {|
 |};
 
 declare type GenderT = OptionTreeT<'gender'>;
+
+declare type GenreT = {|
+  ...CommentRoleT,
+  ...CoreEntityRoleT<'genre'>,
+|};
 
 /*
  * See MusicBrainz::Server::Form::Utils::build_grouped_options


### PR DESCRIPTION
First step of genres-in-DB, creates Data::Genre and Entity::Genre.

Also: I haven't added a new entity nor data page since I think 2013, so comments on those would be very appreciated.