### PR TITLE
MBS-10141: Look at all area levels for Area tabs

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -105,7 +105,7 @@ sub find_by_area {
     my (
         $containment_query,
         @containment_query_args,
-    ) = get_area_containment_query('$2', 'any(array[area, begin_area, end_area])');
+    ) = get_area_containment_query('$2', 'any(array[area, begin_area, end_area])', check_all_levels => 1);
     my $query = "SELECT " . $self->_columns . "
                  FROM " . $self->_table . "
                  WHERE \$1 IN (area, begin_area, end_area) OR EXISTS (
@@ -398,23 +398,13 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 1;
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009 Lukas Lalinsky
 Copyright (C) 2011 MetaBrainz Foundation
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -170,7 +170,7 @@ sub find_by_area {
     my (
         $containment_query,
         @containment_query_args,
-    ) = get_area_containment_query('$2', 'area');
+    ) = get_area_containment_query('$2', 'area', check_all_levels => 1);
     my $query = "SELECT " . $self->_columns . "
                  FROM " . $self->_table . "
                  WHERE area = \$1 OR EXISTS (
@@ -661,24 +661,13 @@ Editors
 
 Provides support for fetching editors from the database
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009 Oliver Charles
 Copyright (C) 2010 MetaBrainz Foundation
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut
-

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -91,7 +91,7 @@ sub find_by_area {
     my (
         $containment_query,
         @containment_query_args,
-    ) = get_area_containment_query('$2', 'area');
+    ) = get_area_containment_query('$2', 'area', check_all_levels => 1);
     my $query = "SELECT " . $self->_columns . "
                  FROM " . $self->_table . "
                  WHERE area = \$1 OR EXISTS (
@@ -292,22 +292,12 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 1;
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009 Lukas Lalinsky
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -174,7 +174,7 @@ sub find_by_area {
     my (
         $containment_query,
         @containment_query_args,
-    ) = get_area_containment_query('$2', 'area');
+    ) = get_area_containment_query('$2', 'area', check_all_levels => 1);
     my $query = "SELECT " . $self->_columns . "
                  FROM " . $self->_table . "
                  WHERE area = \$1 OR EXISTS (
@@ -209,22 +209,12 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 1;
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2013-2015 MetaBrainz Foundation
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -236,9 +236,13 @@ sub generate_token
 }
 
 sub get_area_containment_query {
-    my ($link_type_param, $descendant_param) = @_;
+    my ($link_type_param, $descendant_param, %args) = @_;
 
-    return (qq{
+    my $levels_condition = $args{check_all_levels} 
+        ? '' 
+        : ' JOIN area a ON a.id = ad.parent WHERE a.type IN (1, 2, 3) ';
+
+    return ("
         WITH RECURSIVE area_descendants AS (
             SELECT entity0 AS parent, entity1 AS descendant, 1 AS depth
               FROM l_area_area laa
@@ -255,10 +259,9 @@ sub get_area_containment_query {
         )
         SELECT ad.descendant, ad.parent, ad.depth
           FROM area_descendants ad
-          JOIN area a ON a.id = ad.parent
-         WHERE a.type IN (1, 2, 3)
-         ORDER BY ad.descendant, ad.depth ASC
-    }, $PART_OF_AREA_LINK_TYPE_ID);
+         $levels_condition
+         ORDER BY ad.descendant, ad.depth ASC",
+        $PART_OF_AREA_LINK_TYPE_ID);
 }
 
 sub defined_hash
@@ -654,22 +657,13 @@ sub datetime_to_iso8601 {
 
 1;
 
-=head1 COPYRIGHT
+=head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2009 Lukas Lalinsky, 2009-2013 MetaBrainz Foundation
+Copyright (C) 2009 Lukas Lalinsky
+Copyright (C) 2009-2013 MetaBrainz Foundation
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
 
 =cut


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10141

get_area_containment_query only looks at area types:
1 (Country)
2 (Subdivision)
3 (City)

While this might make sense for listing containment while linking to the entity, it's quite confusing to skip levels when loading the contained entities in the different tabs of the Area page.