### PR TITLE
MBS-9973 (part 2): Load and render collection items added date

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -92,9 +92,10 @@ sub show : Chained('load') PathPart('') {
     my $order = $c->req->params->{order};
 
     my $model = $c->model(type_to_model($entity_type));
-    my $entities = $self->_load_paged($c, sub {
-        $model->find_by_collection($collection->id, shift, shift, $order);
+    my $collection_items = $self->_load_paged($c, sub {
+        $model->find_items_by_collection($collection->id, shift, shift, $order);
     });
+    my $entities = map { $_->entity } @$collection_items;
 
     if ($model->can('load_related_info')) {
         $model->load_related_info(@$entities);
@@ -154,7 +155,7 @@ sub show : Chained('load') PathPart('') {
     my %props = (
         collection           => $collection,
         collectionEntityType => $entity_type,
-        entities             => $entities,
+        entities             => $collection_items,
         order                => $order,
         pager                => serialize_pager($c->stash->{pager}),
     );

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -106,7 +106,7 @@ sub merge_entities {
     my @ids = ($new_id, @old_ids);
 
     # Remove duplicate joins (ie, rows with entity from @old_ids and pointing to
-    # a collection that already contains $new_id)
+    # a collection that already contains $new_id), keep the earliest added row
     $self->sql->do(
         "DELETE FROM editor_collection_$type
                WHERE $type IN (" . placeholders(@ids) . ")
@@ -114,6 +114,7 @@ sub merge_entities {
                      SELECT DISTINCT ON (collection) collection, $type
                        FROM editor_collection_$type
                       WHERE $type IN (" . placeholders(@ids) . ")
+                      ORDER BY added ASC
                  )",
         @ids, @ids);
 

--- a/lib/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Collection.pm
@@ -29,6 +29,32 @@ sub find_by_collection {
     $self->query_to_list_limited($query, [$collection_id], $limit, $offset);
 }
 
+sub find_items_by_collection {
+    my ($self, $collection_id, $limit, $offset, $order) = @_;
+
+    my ($order_by, $extra_join, $also_select) = $self->_order_by($order);
+    $extra_join //= '';
+
+    my $table = $self->_table;
+    my $type = $self->_type;
+
+    my $query = "
+      SELECT *
+      FROM (
+      SELECT DISTINCT ON (" . $self->_id_column . ")
+        " . $self->_columns .
+          ($also_select ? ", $also_select" : "") . "
+        FROM $table
+        JOIN editor_collection_$type ec ON " . $self->_id_column . " = ec.$type
+        $extra_join
+        WHERE ec.collection = ?
+        ORDER BY id
+      ) $type
+      ORDER BY $order_by";
+
+    $self->query_to_list_limited($query, [$collection_id], $limit, $offset);
+}
+
 no Moose::Role;
 1;
 

--- a/lib/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Collection.pm
@@ -3,6 +3,9 @@ use Moose::Role;
 
 requires '_order_by', '_table', '_type', '_columns', '_new_from_row', 'c';
 
+use MusicBrainz::Server::Data::Utils qw( order_by );
+use MusicBrainz::Server::Entity::CollectionItem;
+
 sub find_by_collection {
     my ($self, $collection_id, $limit, $offset, $order) = @_;
 
@@ -32,7 +35,7 @@ sub find_by_collection {
 sub find_items_by_collection {
     my ($self, $collection_id, $limit, $offset, $order) = @_;
 
-    my ($order_by, $extra_join, $also_select) = $self->_order_by($order);
+    my ($order_by, $extra_join, $also_select) = $self->_order_collection_items_by($order);
     $extra_join //= '';
 
     my $table = $self->_table;
@@ -44,6 +47,7 @@ sub find_items_by_collection {
       SELECT DISTINCT ON (" . $self->_id_column . ")
         " . $self->_columns .
           ($also_select ? ", $also_select" : "") . "
+        , ec.added AS collection_item_added
         FROM $table
         JOIN editor_collection_$type ec ON " . $self->_id_column . " = ec.$type
         $extra_join
@@ -52,7 +56,43 @@ sub find_items_by_collection {
       ) $type
       ORDER BY $order_by";
 
-    $self->query_to_list_limited($query, [$collection_id], $limit, $offset);
+    $self->query_to_list_limited(
+        $query,
+        [$collection_id],
+        $limit,
+        $offset,
+        $self->_new_collection_item_from_row);
+}
+
+sub _order_collection_items_by {
+    my ($self, $order) = @_;
+
+    my ($order_by, $extra_join, $also_select) = $self->_order_by($order);
+
+    my $collection_items_ordering_map = {
+        'added' => sub {
+            return 'collection_item_added'
+        },
+    };
+
+    my $absolute_order = $order;
+    $absolute_order =~ s/^-// if defined $absolute_order;
+    if (defined $absolute_order &&
+      exists $collection_items_ordering_map->{$absolute_order}) {
+      $order_by = order_by($order, 'added', $collection_items_ordering_map);
+    }
+
+    return ($order_by, $extra_join, $also_select);
+}
+
+sub _new_collection_item_from_row {
+    my ($self, $row) = @_;
+    return unless $row;
+
+    return MusicBrainz::Server::Entity::CollectionItem->new(
+        entity => $self->_new_from_row($row),
+        added => $row->{collection_item_added}
+    );
 }
 
 no Moose::Role;

--- a/lib/MusicBrainz/Server/Entity/CollectionItem.pm
+++ b/lib/MusicBrainz/Server/Entity/CollectionItem.pm
@@ -1,0 +1,51 @@
+package MusicBrainz::Server::Entity::CollectionItem;
+use Moose;
+use namespace::autoclean;
+
+use DateTime::Format::Pg;
+
+use MusicBrainz::Server::Entity::Types;
+use MusicBrainz::Server::Types qw( PgDateStr );
+
+has 'entity' => (
+    is => 'rw',
+    isa => 'Entity',
+    required => 1,
+);
+
+has 'added' => (
+    is => 'rw',
+    isa => 'PgDateStr',
+);
+
+sub TO_JSON {
+    my $self = shift;
+
+    my $json = $self->entity->TO_JSON;
+    $json->{collection_item} = {
+        added => undef,
+    };
+
+    my $added = $self->added;
+    if (defined $added) {
+        $added = DateTime::Format::Pg->parse_datetime($self->added);
+        $added->set_time_zone('UTC');
+        $json->{collection_item}->{added} = $added->iso8601 . 'Z';
+    }
+
+    return $json;
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Entity/Types.pm
+++ b/lib/MusicBrainz/Server/Entity/Types.pm
@@ -6,7 +6,7 @@ for my $cls (qw(AggregatedTag AliasType Annotation Application
                 Area AreaAlias AreaType
                 Artist ArtistAlias ArtistCredit ArtistCreditName ArtistType
                 AutoEditorElection AutoEditorElectionVote
-                Barcode CDTOC CDStub Collection CollectionType Coordinates
+                Barcode CDTOC CDStub Collection CollectionItem CollectionType Coordinates
                 CoverArtType
                 CritiqueBrainz::Review CritiqueBrainz::User
                 Editor EditorOAuthToken

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -27,8 +27,30 @@ import PaginatedResults from '../components/PaginatedResults';
 import expand2react from '../static/scripts/common/i18n/expand2react';
 import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName';
+import formatUserDate from '../utility/formatUserDate';
 
 import CollectionLayout from './CollectionLayout';
+
+const buildCollectionHeaderCells = () => (
+  <th>{l('Date Added')}</th>
+);
+
+const buildCollectionDataCells = (
+  $c: CatalystContextT,
+  entity: CoreEntityT,
+) => {
+  const collectionItem = entity.collection_item;
+  if (!collectionItem) {
+    return null;
+  }
+  return (
+    <td>
+      {collectionItem.added
+        ? formatUserDate($c.user, collectionItem.added)
+        : l('Unknown')}
+    </td>
+  );
+};
 
 type PropsForEntity<T: CoreEntityT> = {
   +$c: CatalystContextT,
@@ -55,6 +77,8 @@ type Props =
 
 const listPicker = (props: Props, ownCollection: boolean) => {
   const sharedProps = {
+    buildExtraDataCells: buildCollectionDataCells,
+    buildExtraHeaderCells: buildCollectionHeaderCells,
     checkboxes: ownCollection ? 'remove' : '',
     order: props.order,
     sortable: true,

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -18,6 +18,11 @@ import SortableTableHeader from '../SortableTableHeader';
 type Props = {|
   +$c: CatalystContextT,
   +areas: $ReadOnlyArray<AreaT>,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +order?: string,
   +sortable?: boolean,
@@ -26,6 +31,8 @@ type Props = {|
 const AreaList = ({
   $c,
   areas,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   order,
   sortable,
@@ -60,6 +67,7 @@ const AreaList = ({
             )
             : l('Type')}
         </th>
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -82,6 +90,9 @@ const AreaList = ({
               ? lp_attributes(area.typeName, 'area_type')
               : null}
           </td>
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, area)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -17,6 +17,11 @@ import SortableTableHeader from '../SortableTableHeader';
 type Props = {|
   +$c: CatalystContextT,
   +artists: $ReadOnlyArray<ArtistT>,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +order?: string,
   +showBeginEnd?: boolean,
@@ -27,6 +32,8 @@ type Props = {|
 const ArtistList = ({
   $c,
   artists,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   order,
   showBeginEnd,
@@ -84,12 +91,14 @@ const ArtistList = ({
           </>
         ) : null}
         {showRatings ? <th>{l('Rating')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
       {artists.map((artist, index) => (
         <ArtistListEntry
           artist={artist}
+          buildExtraDataCells={buildExtraDataCells}
           checkboxes={checkboxes}
           index={index}
           key={artist.id}

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -29,6 +29,11 @@ type Props = {|
   +$c: CatalystContextT,
   +artist?: ArtistT,
   +artistRoles?: boolean,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +events: $ReadOnlyArray<EventT>,
   +order?: string,
@@ -43,6 +48,8 @@ const EventList = ({
   $c,
   artist,
   artistRoles,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   events,
   order,
@@ -102,6 +109,7 @@ const EventList = ({
         </th>
         <th>{l('Time')}</th>
         {showRatings ? <th>{l('Rating')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -157,6 +165,9 @@ const EventList = ({
               <RatingStars entity={event} />
             </td>
           ) : null}
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, event)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -16,6 +16,11 @@ import SortableTableHeader from '../SortableTableHeader';
 
 type Props = {|
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +instruments: $ReadOnlyArray<InstrumentT>,
   +order?: string,
@@ -24,6 +29,8 @@ type Props = {|
 
 const InstrumentList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   instruments,
   order,
@@ -60,11 +67,13 @@ const InstrumentList = ({
             : l('Type')}
         </th>
         <th>{l('Description')}</th>
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
       {instruments.map((instrument, index) => (
         <InstrumentListEntry
+          buildExtraDataCells={buildExtraDataCells}
           checkboxes={checkboxes}
           index={index}
           instrument={instrument}

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -21,6 +21,11 @@ import SortableTableHeader from '../SortableTableHeader';
 
 type Props = {|
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +labels: $ReadOnlyArray<LabelT>,
   +order?: string,
@@ -30,6 +35,8 @@ type Props = {|
 
 const LabelList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   labels,
   order,
@@ -109,6 +116,7 @@ const LabelList = ({
             : l('End')}
         </th>
         {showRatings ? <th>{l('Rating')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -144,6 +152,9 @@ const LabelList = ({
               <RatingStars entity={label} />
             </td>
           ) : null}
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, label)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -20,6 +20,11 @@ import formatDatePeriod
 
 type Props = {|
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +order?: string,
   +places: $ReadOnlyArray<PlaceT>,
@@ -28,6 +33,8 @@ type Props = {|
 
 const PlaceList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   order,
   places,
@@ -96,6 +103,7 @@ const PlaceList = ({
             )
             : l('Date')}
         </th>
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -123,6 +131,9 @@ const PlaceList = ({
             {place.area ? <DescriptiveLink entity={place.area} /> : null}
           </td>
           <td>{formatDatePeriod(place)}</td>
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, place)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -25,6 +25,11 @@ type Props = {|
   ...InstrumentCreditsRoleT,
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +lengthClass?: string,
   +merging?: boolean,
@@ -38,6 +43,8 @@ type Props = {|
 
 const RecordingList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   instrumentCredits,
   lengthClass,
@@ -94,6 +101,7 @@ const RecordingList = ({
             : l('Length')}
         </th>
         {showInstrumentCredits ? <th>{l('Instrument Credits')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -150,6 +158,9 @@ const RecordingList = ({
                 : null}
             </td>
           ) : null}
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, recording)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -24,6 +24,7 @@ import SortableTableHeader from '../SortableTableHeader';
 type ReleaseGroupListHeaderProps = {|
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +groupByType?: boolean,
   +order?: string,
@@ -34,6 +35,10 @@ type ReleaseGroupListHeaderProps = {|
 type ReleaseGroupListEntryProps = {|
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +groupByType?: boolean,
   +index: number,
@@ -44,6 +49,11 @@ type ReleaseGroupListEntryProps = {|
 type ReleaseGroupListProps = {|
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +groupByType?: boolean,
   +order?: string,
@@ -54,6 +64,7 @@ type ReleaseGroupListProps = {|
 
 const ReleaseGroupListHeader = ({
   $c,
+  buildExtraHeaderCells,
   checkboxes,
   groupByType,
   order,
@@ -107,12 +118,14 @@ const ReleaseGroupListHeader = ({
       )}
       {showRatings ? <th className="rating c">{l('Rating')}</th> : null}
       <th className="count c">{l('Releases')}</th>
+      {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
     </tr>
   </thead>
 );
 
 const ReleaseGroupListEntry = ({
   $c,
+  buildExtraDataCells,
   checkboxes,
   index,
   groupByType,
@@ -162,11 +175,16 @@ const ReleaseGroupListEntry = ({
       </td>
     ) : null}
     <td className="c">{releaseGroup.release_count}</td>
+    {buildExtraDataCells
+      ? buildExtraDataCells($c, releaseGroup)
+      : null}
   </tr>
 );
 
 const ReleaseGroupListTable = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   groupByType,
   order,
@@ -178,6 +196,7 @@ const ReleaseGroupListTable = ({
   <table className="tbl release-group-list">
     <ReleaseGroupListHeader
       $c={$c}
+      buildExtraHeaderCells={buildExtraHeaderCells}
       checkboxes={checkboxes}
       groupByType={groupByType}
       order={order}
@@ -189,6 +208,7 @@ const ReleaseGroupListTable = ({
       {releaseGroups.map((releaseGroup, index) => (
         <ReleaseGroupListEntry
           $c={$c}
+          buildExtraDataCells={buildExtraDataCells}
           checkboxes={checkboxes}
           groupByType={groupByType}
           index={index}
@@ -204,6 +224,8 @@ const ReleaseGroupListTable = ({
 
 const ReleaseGroupList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   groupByType,
   order,
@@ -227,6 +249,8 @@ const ReleaseGroupList = ({
             </h3>
             <ReleaseGroupListTable
               $c={$c}
+              buildExtraDataCells={buildExtraDataCells}
+              buildExtraHeaderCells={buildExtraHeaderCells}
               checkboxes={checkboxes}
               groupByType
               order={order}
@@ -242,6 +266,8 @@ const ReleaseGroupList = ({
       // TODO: When converting usages to React, please check MBS-10155.
       <ReleaseGroupListTable
         $c={$c}
+        buildExtraDataCells={buildExtraDataCells}
+        buildExtraHeaderCells={buildExtraHeaderCells}
         checkboxes={checkboxes}
         order={order}
         releaseGroups={releaseGroups}

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -30,6 +30,11 @@ type Props = {|
   ...InstrumentCreditsRoleT,
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +filterLabel?: LabelT,
   +order?: string,
@@ -41,6 +46,8 @@ type Props = {|
 
 const ReleaseList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   filterLabel,
   instrumentCredits,
@@ -164,6 +171,7 @@ const ReleaseList = ({
         {showRatings ? <th>{l('Rating')}</th> : null}
         {showInstrumentCredits ? <th>{l('Instrument Credits')}</th> : null}
         {$c.session && $c.session.tport ? <th>{l('Tagger')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -239,6 +247,9 @@ const ReleaseList = ({
               <TaggerIcon entity={release} />
             </td>
           ) : null}
+          {buildExtraDataCells
+            ? buildExtraDataCells($c, release)
+            : null}
         </tr>
       ))}
     </tbody>

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -18,6 +18,11 @@ import SortableTableHeader from '../SortableTableHeader';
 
 type Props = {|
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +order?: string,
   +series: $ReadOnlyArray<SeriesT>,
@@ -26,6 +31,8 @@ type Props = {|
 
 const SeriesList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   order,
   series,
@@ -62,6 +69,7 @@ const SeriesList = ({
             : l('Type')}
         </th>
         <th>{l('Ordering Type')}</th>
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
@@ -92,6 +100,9 @@ const SeriesList = ({
                 ? lp_attributes(orderingType.name, 'series_ordering_type')
                 : null}
             </td>
+            {buildExtraDataCells
+              ? buildExtraDataCells($c, thisSeries)
+              : null}
           </tr>
         );
       })}

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -17,6 +17,11 @@ import SortableTableHeader from '../SortableTableHeader';
 type Props = {|
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
+  +buildExtraHeaderCells?: () => AnyReactElem,
   +checkboxes?: string,
   +order?: string,
   +showRatings?: boolean,
@@ -26,6 +31,8 @@ type Props = {|
 
 const WorkList = ({
   $c,
+  buildExtraDataCells,
+  buildExtraHeaderCells,
   checkboxes,
   order,
   seriesItemNumbers,
@@ -70,11 +77,13 @@ const WorkList = ({
         <th>{l('Lyrics Languages')}</th>
         <th>{l('Attributes')}</th>
         {showRatings ? <th>{l('Rating')}</th> : null}
+        {buildExtraHeaderCells ? buildExtraHeaderCells() : null}
       </tr>
     </thead>
     <tbody>
       {works.map((work, index) => (
         <WorkListEntry
+          buildExtraDataCells={buildExtraDataCells}
           checkboxes={checkboxes}
           index={index}
           key={work.id}

--- a/root/static/scripts/common/components/ArtistListEntry.js
+++ b/root/static/scripts/common/components/ArtistListEntry.js
@@ -20,6 +20,10 @@ import DescriptiveLink from './DescriptiveLink';
 type ArtistListRowProps = {|
   +$c: CatalystContextT,
   +artist: ArtistT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +showBeginEnd?: boolean,
   +showRatings?: boolean,
@@ -28,6 +32,10 @@ type ArtistListRowProps = {|
 
 type ArtistListEntryProps = {|
   +artist: ArtistT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +index: number,
   +score?: number,
@@ -39,6 +47,7 @@ type ArtistListEntryProps = {|
 const ArtistListRow = withCatalystContext(({
   $c,
   artist,
+  buildExtraDataCells,
   checkboxes,
   showBeginEnd,
   showRatings,
@@ -92,11 +101,15 @@ const ArtistListRow = withCatalystContext(({
         <RatingStars entity={artist} />
       </td>
     ) : null}
+    {buildExtraDataCells
+      ? buildExtraDataCells($c, artist)
+      : null}
   </>
 ));
 
 const ArtistListEntry = ({
   artist,
+  buildExtraDataCells,
   checkboxes,
   index,
   score,

--- a/root/static/scripts/common/components/InstrumentListEntry.js
+++ b/root/static/scripts/common/components/InstrumentListEntry.js
@@ -16,12 +16,20 @@ import expand2react from '../i18n/expand2react';
 import DescriptiveLink from './DescriptiveLink';
 
 type InstrumentListRowProps = {|
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +$c: CatalystContextT,
   +checkboxes?: string,
   +instrument: InstrumentT,
 |};
 
 type InstrumentListEntryProps = {|
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +index: number,
   +instrument: InstrumentT,
@@ -30,6 +38,7 @@ type InstrumentListEntryProps = {|
 
 const InstrumentListRow = withCatalystContext(({
   $c,
+  buildExtraDataCells,
   checkboxes,
   instrument,
 }: InstrumentListRowProps) => (
@@ -56,10 +65,14 @@ const InstrumentListRow = withCatalystContext(({
         ? expand2react(l_instrument_descriptions(instrument.description))
         : null}
     </td>
+    {buildExtraDataCells
+      ? buildExtraDataCells($c, instrument)
+      : null}
   </>
 ));
 
 const InstrumentListEntry = ({
+  buildExtraDataCells,
   checkboxes,
   index,
   instrument,

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -22,6 +22,10 @@ import EntityLink from './EntityLink';
 type WorkListRowProps = {|
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +showAttributes?: boolean,
   +showIswcs?: boolean,
@@ -31,6 +35,10 @@ type WorkListRowProps = {|
 
 type WorkListEntryProps = {|
   ...SeriesItemNumbersRoleT,
+  +buildExtraDataCells?: (
+    $c: CatalystContextT,
+    entity: CoreEntityT,
+  ) => AnyReactElem | null,
   +checkboxes?: string,
   +index: number,
   +score?: number,
@@ -42,6 +50,7 @@ type WorkListEntryProps = {|
 
 export const WorkListRow = withCatalystContext(({
   $c,
+  buildExtraDataCells,
   checkboxes,
   seriesItemNumbers,
   showAttributes,
@@ -110,10 +119,14 @@ export const WorkListRow = withCatalystContext(({
         <RatingStars entity={work} />
       </td>
     ) : null}
+    {buildExtraDataCells
+      ? buildExtraDataCells($c, work)
+      : null}
   </>
 ));
 
 const WorkListEntry = ({
+  buildExtraDataCells,
   checkboxes,
   index,
   score,

--- a/root/types.js
+++ b/root/types.js
@@ -236,6 +236,14 @@ declare type CDStubT = {|
   +track_count: number,
 |};
 
+declare type CollectibleRoleT = {|
+  +collection_item?: CollectionItemT,
+|};
+
+declare type CollectionItemT = {|
+  +added: string | null,
+|};
+
 declare type CollectionT = {|
   ...EntityRoleT<'collection'>,
   ...TypeRoleT<CollectionTypeT>,
@@ -284,6 +292,7 @@ declare type ReadOnlyCompoundFieldT<+F> = {|
 declare type CoreEntityRoleT<+T> = {|
   ...EntityRoleT<T>,
   ...LastUpdateRoleT,
+  ...CollectibleRoleT,
   +gid: string,
   +name: string,
   +relationships?: $ReadOnlyArray<RelationshipT>,


### PR DESCRIPTION
## [MBS-9973](https://tickets.metabrainz.org/browse/MBS-9973): Date Added as sortable column in collection

* Create a proxy entity CollectionItem for entities that contains `added` date. (Other columns could be loaded on the same model.)
* JSON export of CollectionItem is the base entity with an extra `collection_item` attribute object that has an `added` attribute.
* New function `find_items_by_collection` is used for display only. (Web service endpoint keeps using `find_by_collection` for now.)
* Collection-specific columns display is implemented using callback functions so as to provision for comment display and for conditional hiding of empty extra columns.