### PR TITLE
MBS-9491: List genre on tag search results

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -178,6 +178,10 @@ sub direct : Private
             $c->model('Event')->load_related_info(@entities);
             $c->model('Event')->load_areas(@entities);
         }
+        when ('tag') {
+            #TODO: add support for genre aliases when finishing MBS-10062
+            $c->model('Genre')->load(@entities);
+        }
     }
 
     if ($type =~ /(recording|release|release_group)/)

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -301,9 +301,10 @@ sub search
 
     elsif ($type eq "tag") {
         $query = "
-            SELECT id, name, ts_rank_cd(to_tsvector('mb_simple', name), query, 2) AS rank
-            FROM tag, plainto_tsquery('mb_simple', ?) AS query
-            WHERE to_tsvector('mb_simple', name) @@ query OR name = ?
+            SELECT tag.id, tag.name, genre.id as genre_id,
+                   ts_rank_cd(to_tsvector('mb_simple', tag.name), query, 2) AS rank
+            FROM tag LEFT JOIN genre USING (name), plainto_tsquery('mb_simple', ?) AS query
+            WHERE to_tsvector('mb_simple', tag.name) @@ query OR tag.name = ?
             ORDER BY rank DESC, tag.name
             OFFSET ?
         ";

--- a/root/search/components/TagResults.js
+++ b/root/search/components/TagResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import EntityLink from '../../static/scripts/common/components/EntityLink';
 import TagLink from '../../static/scripts/common/components/TagLink';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsT} from '../types';
@@ -24,6 +25,11 @@ function buildResult(result, index) {
     <tr className={loopParity(index)} data-score={score} key={tag.name}>
       <td>
         <TagLink tag={tag.name} />
+      </td>
+      <td>
+        {tag.genre ? (
+          <EntityLink entity={tag.genre} />
+        ) : null}
       </td>
     </tr>
   );
@@ -42,6 +48,7 @@ const TagResults = ({
       columns={
         <>
           <th>{l('Name')}</th>
+          <th>{l('Genre')}</th>
         </>
       }
       pager={pager}


### PR DESCRIPTION
Goes after https://github.com/metabrainz/musicbrainz-server/pull/1062

It makes sense to show genres for tags - it will make even more sense once we have aliases and the genre associated to a tag can have a different name than the tag itself.