### PR TITLE
MBS-9762: Standardize Songkick URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1937,7 +1937,7 @@ const CLEANUPS = {
           case LINK_TYPES.songkick.event:
             return prefix === 'concerts' || prefix === 'festivals';
           case LINK_TYPES.songkick.place:
-            return prefix === 'venues' || prefix === 'festivals';
+            return prefix === 'venues';
         }
       }
       return false;

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1920,12 +1920,17 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?songkick\\.com', 'i')],
     type: LINK_TYPES.songkick,
     clean: function (url) {
-      return url.replace(/^http:\/\//, 'https://');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?songkick\.com\//, 'https://www.songkick.com/');
+      url = url.replace(/^(https:\/\/www\.songkick\.com\/[a-z]+\/[0-9]+)(?:-[\w-]*)?(\/id\/[0-9]+)?(?:[-\/?#].*)?$/, '$1$2');
+      return url;
     },
     validate: function (url, id) {
-      const m = /songkick\.com\/([a-z]+)\//.exec(url);
+      const m = /^https:\/\/www\.songkick\.com\/([a-z]+)\/[0-9]+(?:\/(id)\/[0-9]+)?$/.exec(url);
       if (m) {
         const prefix = m[1];
+        if ((m[2] === 'id') !== (prefix === 'festivals')) {
+          return false;
+        }
         switch (id) {
           case LINK_TYPES.songkick.artist:
             return prefix === 'artists';

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2700,17 +2700,24 @@ const testData = [
   },
   // Songkick
   {
+                     input_url: 'https://www.songkick.com/artists/3909026-courtney-barnett/calendar',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'songkick',
+            expected_clean_url: 'https://www.songkick.com/artists/3909026',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://www.songkick.com/festivals/74586-ruhrpott-rodeo/id/19803209-ruhrpott-rodeo-festival-2014',
              input_entity_type: 'event',
     expected_relationship_type: 'songkick',
-            expected_clean_url: 'https://www.songkick.com/festivals/74586-ruhrpott-rodeo/id/19803209-ruhrpott-rodeo-festival-2014',
+            expected_clean_url: 'https://www.songkick.com/festivals/74586/id/19803209',
        only_valid_entity_types: ['event', 'place'],
   },
   {
-                     input_url: 'http://www.songkick.com/venues/1141041-flugplatz-schwarze-heide',
+                     input_url: 'http://www.songkick.com/venues/1141041-flugplatz-schwarze-heide#calendar-summary',
              input_entity_type: 'place',
     expected_relationship_type: 'songkick',
-            expected_clean_url: 'https://www.songkick.com/venues/1141041-flugplatz-schwarze-heide',
+            expected_clean_url: 'https://www.songkick.com/venues/1141041',
        only_valid_entity_types: ['place'],
   },
   // SoundCloud

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2711,7 +2711,7 @@ const testData = [
              input_entity_type: 'event',
     expected_relationship_type: 'songkick',
             expected_clean_url: 'https://www.songkick.com/festivals/74586/id/19803209',
-       only_valid_entity_types: ['event', 'place'],
+       only_valid_entity_types: ['event'],
   },
   {
                      input_url: 'http://www.songkick.com/venues/1141041-flugplatz-schwarze-heide#calendar-summary',


### PR DESCRIPTION
# Resolves [MBS-9762](https://tickets.metabrainz.org/browse/MBS-9762): Standardize Songkick URLs

1. Replace songkick.com with www.songkick.com and deny other domains

2. Remove slug, subpath, query, fragment, and deny unclean URLs
   * It helps with preventing duplicates (with/without slug)
   * Only festivals have mandatory `/id/<edition id>` subpath
   * Songkick accepts URLs without slug and auto-add slug to it

Update tests accordingly, and add artist test with unneeded subpath.

Edit: Additionally disallow linking Songkick festivals to places (which was an unexploited bug).