### PR TITLE
Only call AC macro if an AC exists (MBS-10182)

### DIFF
--- a/root/components/relationships-table.tt
+++ b/root/components/relationships-table.tt
@@ -64,7 +64,7 @@
                 [%- END %]
                 [%- IF has.artist %]
                 <td>
-                    [%~ artist_credit(rel.target.artist_credit) ~%]
+                    [%~ artist_credit(rel.target.artist_credit) IF rel.target.artist_credit ~%]
                 </td>
                 [%- END %]
                 [%- IF has.length %]


### PR DESCRIPTION
`rel.target.artist_credit` is empty, for example, if `rel.target` is a work or any other type of entity without an artist credit.

This didn't cause any issue until we changed the artist_credit macro to embed the `ArtistCreditLink` React component, which can't handle its `artistCredit` prop being an empty string.