### PR TITLE
MBS-10183: Fix double-encoding of artist credit in page title

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -186,10 +186,18 @@ END -%]
     [%- END -%]
 [%- END -%]
 
-[%~ MACRO artist_credit(ac, opts) BLOCK -%]
+[%~ MACRO artist_credit_plain(ac) BLOCK # Converted to React at root/static/scripts/common/immutable-entities.js with reduceArtistCredit
+-%]
+    [%- FOREACH name IN ac.names -%]
+        [%- name.name -%]
+        [%- name.join_phrase -%]
+    [%- END -%]
+[%- END -%]
+
+[%~ MACRO artist_credit(ac) BLOCK # Converted to React at root/static/scripts/common/components/ArtistCreditLink.js
+-%]
     [%- React.embed(c, 'static/scripts/common/components/ArtistCreditLink', {
       artistCredit => ac,
-      plain => opts.plain ? 1 : 0,
     }) -%]
 [%- END -%]
 

--- a/root/recording/layout.tt
+++ b/root/recording/layout.tt
@@ -1,4 +1,4 @@
-[%~ title_args = { artist => artist_credit(recording.artist_credit, plain => 1), name => recording.name } ~%]
+[%~ title_args = { artist => artist_credit_plain(recording.artist_credit), name => recording.name } ~%]
 
 [%~ main_title = recording.video ? l('Video “{name}” by {artist}', title_args) : l('Recording “{name}” by {artist}', title_args) ~%]
 [%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]

--- a/root/release/layout.tt
+++ b/root/release/layout.tt
@@ -1,5 +1,5 @@
 [%~ main_title = l('Release “{name}” by {artist}', {
-        artist => artist_credit(release.artist_credit, plain => 1),
+        artist => artist_credit_plain(release.artist_credit),
         name => release.name
 }) ~%]
 [%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]

--- a/root/release_group/layout.tt
+++ b/root/release_group/layout.tt
@@ -1,5 +1,5 @@
 [% main_title = l('Release group “{name}” by {artist}', {
-    artist => artist_credit(rg.artist_credit, plain => 1),
+    artist => artist_credit_plain(rg.artist_credit),
     name => rg.name
 }) %]
 [%- WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title -%]

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -74,27 +74,27 @@ const ArtistCreditLink = ({
   const parts = [];
   for (let i = 0; i < names.length; i++) {
     const credit = names[i];
-      const artist = credit.artist;
-      if (artist) {
-        parts.push(
-          <EntityLink
-            content={credit.name}
-            entity={artist}
-            key={`${artist.id}-${i}`}
-            showDeleted={showDeleted}
-            showEditsPending={!artistCredit.editsPending}
-            target={props.target}
-          />,
-        );
-      } else {
-        parts.push(
-          <DeletedLink
-            allowNew={false}
-            key={`deleted-${i}`}
-            name={credit.name}
-          />,
-        );
-      }
+    const artist = credit.artist;
+    if (artist) {
+      parts.push(
+        <EntityLink
+          content={credit.name}
+          entity={artist}
+          key={`${artist.id}-${i}`}
+          showDeleted={showDeleted}
+          showEditsPending={!artistCredit.editsPending}
+          target={props.target}
+        />,
+      );
+    } else {
+      parts.push(
+        <DeletedLink
+          allowNew={false}
+          key={`deleted-${i}`}
+          name={credit.name}
+        />,
+      );
+    }
     parts.push(credit.joinPhrase);
   }
   if (artistCredit.editsPending) {

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -15,7 +15,6 @@ import EntityLink, {DeletedLink} from './EntityLink';
 
 type Props = {
   +artistCredit: ArtistCreditT,
-  +plain?: boolean,
   +showDeleted?: boolean,
   +showEditsPending?: boolean,
   +target?: '_blank',
@@ -75,9 +74,6 @@ const ArtistCreditLink = ({
   const parts = [];
   for (let i = 0; i < names.length; i++) {
     const credit = names[i];
-    if (props.plain) {
-      parts.push(credit.name);
-    } else {
       const artist = credit.artist;
       if (artist) {
         parts.push(
@@ -99,7 +95,6 @@ const ArtistCreditLink = ({
           />,
         );
       }
-    }
     parts.push(credit.joinPhrase);
   }
   if (artistCredit.editsPending) {


### PR DESCRIPTION
## Fix [MBS-10183](https://tickets.metabrainz.org/browse/MBS-10183): Display bug in the title of page crediting the artist

Template Toolkit macro `artist_credit` has been correctly converted to React with `ArtistCreditLink` component, `plain` option included. But React.embed` call encodes HTML entities, TT macro `artist_credit` has a `plain` text mode option, which results in overencoding.

This patch creates a new TT macro `artist_credit_plain` to replace the 3 lasting template calls to `artist_credit` with `plain` option, and removes `plain` from `ArtistCreditLink` component properties.
Such calls can be replaced with `reduceArtistCredit` JS function calls (which is not a component though) when converting template to React.

It partly reverts commit 9493fe2f3ab73ae762052990d9672d28656018a4.