### PR TITLE
MBS-10184: Only call React component if artist credit has names

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -186,10 +186,18 @@ END -%]
     [%- END -%]
 [%- END -%]
 
-[%~ MACRO artist_credit(ac, opts) BLOCK -%]
+[%~ MACRO artist_credit_plain(ac) BLOCK # Converted to React at root/static/scripts/common/immutable-entities.js with reduceArtistCredit
+-%]
+    [%- FOREACH name IN ac.names -%]
+        [%- name.name -%]
+        [%- name.join_phrase -%]
+    [%- END -%]
+[%- END -%]
+
+[%~ MACRO artist_credit(ac) BLOCK # Converted to React at root/static/scripts/common/components/ArtistCreditLink.js
+-%]
     [%- React.embed(c, 'static/scripts/common/components/ArtistCreditLink', {
       artistCredit => ac,
-      plain => opts.plain ? 1 : 0,
     }) -%]
 [%- END -%]
 

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -196,9 +196,11 @@ END -%]
 
 [%~ MACRO artist_credit(ac) BLOCK # Converted to React at root/static/scripts/common/components/ArtistCreditLink.js
 -%]
-    [%- React.embed(c, 'static/scripts/common/components/ArtistCreditLink', {
-      artistCredit => ac,
-    }) -%]
+    [%- IF ac.names -%]
+        [%- React.embed(c, 'static/scripts/common/components/ArtistCreditLink', {
+            artistCredit => ac,
+        }) -%]
+    [%- END -%]
 [%- END -%]
 
 [%~ MACRO expanded_artist_credit(ac) IF ac -%]

--- a/root/recording/layout.tt
+++ b/root/recording/layout.tt
@@ -1,4 +1,4 @@
-[%~ title_args = { artist => artist_credit(recording.artist_credit, plain => 1), name => recording.name } ~%]
+[%~ title_args = { artist => artist_credit_plain(recording.artist_credit), name => recording.name } ~%]
 
 [%~ main_title = recording.video ? l('Video “{name}” by {artist}', title_args) : l('Recording “{name}” by {artist}', title_args) ~%]
 [%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]

--- a/root/release/layout.tt
+++ b/root/release/layout.tt
@@ -1,5 +1,5 @@
 [%~ main_title = l('Release “{name}” by {artist}', {
-        artist => artist_credit(release.artist_credit, plain => 1),
+        artist => artist_credit_plain(release.artist_credit),
         name => release.name
 }) ~%]
 [%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]

--- a/root/release_group/layout.tt
+++ b/root/release_group/layout.tt
@@ -1,5 +1,5 @@
 [% main_title = l('Release group “{name}” by {artist}', {
-    artist => artist_credit(rg.artist_credit, plain => 1),
+    artist => artist_credit_plain(rg.artist_credit),
     name => rg.name
 }) %]
 [%- WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title -%]

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -74,27 +74,27 @@ const ArtistCreditLink = ({
   const parts = [];
   for (let i = 0; i < names.length; i++) {
     const credit = names[i];
-      const artist = credit.artist;
-      if (artist) {
-        parts.push(
-          <EntityLink
-            content={credit.name}
-            entity={artist}
-            key={`${artist.id}-${i}`}
-            showDeleted={showDeleted}
-            showEditsPending={!artistCredit.editsPending}
-            target={props.target}
-          />,
-        );
-      } else {
-        parts.push(
-          <DeletedLink
-            allowNew={false}
-            key={`deleted-${i}`}
-            name={credit.name}
-          />,
-        );
-      }
+    const artist = credit.artist;
+    if (artist) {
+      parts.push(
+        <EntityLink
+          content={credit.name}
+          entity={artist}
+          key={`${artist.id}-${i}`}
+          showDeleted={showDeleted}
+          showEditsPending={!artistCredit.editsPending}
+          target={props.target}
+        />,
+      );
+    } else {
+      parts.push(
+        <DeletedLink
+          allowNew={false}
+          key={`deleted-${i}`}
+          name={credit.name}
+        />,
+      );
+    }
     parts.push(credit.joinPhrase);
   }
   if (artistCredit.editsPending) {

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -15,7 +15,6 @@ import EntityLink, {DeletedLink} from './EntityLink';
 
 type Props = {
   +artistCredit: ArtistCreditT,
-  +plain?: boolean,
   +showDeleted?: boolean,
   +showEditsPending?: boolean,
   +target?: '_blank',
@@ -75,9 +74,6 @@ const ArtistCreditLink = ({
   const parts = [];
   for (let i = 0; i < names.length; i++) {
     const credit = names[i];
-    if (props.plain) {
-      parts.push(credit.name);
-    } else {
       const artist = credit.artist;
       if (artist) {
         parts.push(
@@ -99,7 +95,6 @@ const ArtistCreditLink = ({
           />,
         );
       }
-    }
     parts.push(credit.joinPhrase);
   }
   if (artistCredit.editsPending) {


### PR DESCRIPTION
## Fix [MBS-10184](https://tickets.metabrainz.org/browse/MBS-10184): Regression: ISE on displaying merge edit

Original macro `artist_credit` was producing nothing if `ac.names` was undefined or empty, whereas its React replacement `ArtistCreditLink` expects a property of type `ArtistCreditT` and errors otherwise.

This patch checks artist credit `ac` matches `ArtistCreditT` type before calling `React.embed`.
It depends on PR #1073 (solely to avoid conflict, not a functional dependency).

It partly completes commit 9493fe2f3ab73ae762052990d9672d28656018a4. It is a more general fix for the same issue addressed in PR #1071.