### PR TITLE
Bump Flow to 0.98.1

### DIFF
--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,8 +1,7 @@
-// flow-typed signature: ec7daead5cb4fec5ab25fedbedef29e8
-// flow-typed version: 2c04631d20/redux_v3.x.x/flow_>=v0.55.x
+// flow-typed signature: ed3e20936dd7b07b5487912b2d22f352
+// flow-typed version: 537401fe1b/redux_v3.x.x/flow_>=v0.89.x
 
 declare module 'redux' {
-
   /*
 
     S = State
@@ -12,48 +11,86 @@ declare module 'redux' {
   */
 
   declare export type DispatchAPI<A> = (action: A) => A;
-  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
-    dispatch: D;
-    getState(): S;
+    dispatch: D,
+    getState(): S,
   };
 
   declare export type Store<S, A, D = Dispatch<A>> = {
     // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
-    dispatch: D;
-    getState(): S;
-    subscribe(listener: () => void): () => void;
-    replaceReducer(nextReducer: Reducer<S, A>): void
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
   };
 
-  declare export type Reducer<S, A> = (state: S, action: A) => S;
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
 
-  declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
 
-  declare export type Middleware<S, A, D = Dispatch<A>> =
-    (api: MiddlewareAPI<S, A, D>) =>
-      (next: D) => D;
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
 
   declare export type StoreCreator<S, A, D = Dispatch<A>> = {
-    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
   };
 
-  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
 
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
 
-  declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
 
   declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
-  declare export type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
 
-  declare export function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
-  declare export function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
 
-  declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 
   declare export var compose: $Compose;
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-react": "7.12.4",
     "file-url": "2.0.2",
-    "flow-bin": "0.96.0",
+    "flow-bin": "0.98.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.16.2",
     "jsdom": "13.2.0",

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -59,11 +59,11 @@ type AttrValue<T> = Array<T | string> | T | string;
 class PhraseVarArgs<T> extends VarArgs<AttrValue<T>> {
   +usedAttributes: Array<string>;
 
-  +makeCommaList: (Array<T | string>) => T | string;
+  +makeCommaList: ($ReadOnlyArray<T | string>) => T | string;
 
   constructor(
     args: ?VarArgsObject<AttrValue<T>>,
-    makeCommaList: (Array<T | string>) => T | string,
+    makeCommaList: ($ReadOnlyArray<T | string>) => T | string,
   ) {
     super(args || EMPTY_OBJECT);
     this.usedAttributes = [];
@@ -89,8 +89,8 @@ class PhraseVarArgs<T> extends VarArgs<AttrValue<T>> {
 
 type I18n<T, V> = {
   cache: WeakMap<RelationshipInfoT, CachedResult<T>>,
-  commaList: (Array<T>) => T,
-  commaOnlyList: (Array<T>) => T,
+  commaList: ($ReadOnlyArray<T>) => T,
+  commaOnlyList: ($ReadOnlyArray<T>) => T,
   expand: (string, PhraseVarArgs<T>) => T,
   getAttributeValue: (LinkAttrTypeT, string) => T,
   l: (string, VarArgsObject<T | V>) => T,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,10 +2715,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.96.0:
-  version "0.96.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.96.0.tgz#3b0379d97304dc1879ae6db627cd2d6819998661"
-  integrity sha512-OSxERs0EdhVxEVCst/HmlT/RcnXsQQIRqcfK9J9wC8/93JQj+xQz4RtlsmYe1PSRYaozuDLyPS5pIA81Zwzaww==
+flow-bin@0.98.1:
+  version "0.98.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.1.tgz#a8d781621c91703df69928acc83c9777e2fcbb49"
+  integrity sha512-y1YzQgbFUX4EG6h2EO8PhyJeS0VxNgER8XsTwU8IXw4KozfneSmGVgw8y3TwAOza7rVhTlHEoli1xNuNW1rhPw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Updates flow-typed/npm/redux_v3.x.x.js to remove the deprecated `$Subtype` utility (though they replaced it with `*` which is also deprecated, though Flow doesn't complain about it, so...).

Fixes an issue where Flow now expects a `$ReadOnlyArray` from `PhraseVarArgs.get`. Not sure which bit in the changelog correlates to that, but perhaps "mixed refined to an array produces a read-only array" now.