### PR TITLE
MBS-10108: Allow linking tweets to recordings only

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2094,7 +2094,15 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?twitter\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\/@?([^\/?#]+)(?:[\/?#].*)?$/, 'https://twitter.com/$1');
+      url = url.replace(
+        /^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\//,
+        'https://twitter.com/'
+      );
+      url = url.replace(
+        /^(https:\/\/twitter\.com)\/@?([^\/?#]+)(?:[\/?#].*)?$/,
+        '$1/$2'
+      );
+      return url;
     },
   },
   'unwelcomeimages': { // Block images from sites that don't allow deeplinking

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2092,17 +2092,32 @@ const CLEANUPS = {
   },
   'twitter': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?twitter\\.com/', 'i')],
-    type: LINK_TYPES.socialnetwork,
+    type: _.defaults(
+      {},
+      LINK_TYPES.socialnetwork,
+      LINK_TYPES.streamingmusic,
+    ),
     clean: function (url) {
       url = url.replace(
         /^(?:https?:\/\/)?(?:(?:www|mobile)\.)?twitter\.com(?:\/#!)?\//,
         'https://twitter.com/'
       );
       url = url.replace(
-        /^(https:\/\/twitter\.com)\/@?([^\/?#]+)(?:[\/?#].*)?$/,
+        /^(https:\/\/twitter\.com)\/@?([^\/?#]+(?:\/status\/\d+)?)(?:[\/?#].*)?$/,
         '$1/$2'
       );
       return url;
+    },
+    validate: function (url, id) {
+      const m = /^https:\/\/twitter\.com\/[^\/?#]+(\/status\/\d+)?$/.exec(url);
+      if (m) {
+        const isATweet = !!m[1];
+        if (_.includes(LINK_TYPES.streamingmusic, id)) {
+          return isATweet && (id === LINK_TYPES.streamingmusic.recording);
+        }
+        return !isATweet;
+      }
+      return false;
     },
   },
   'unwelcomeimages': { // Block images from sites that don't allow deeplinking

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3022,13 +3022,13 @@ const testData = [
   },
   {
                      input_url: 'https://twitter.com/@UNIVERSAL_D',
-             input_entity_type: 'artist',
+             input_entity_type: 'label',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://twitter.com/UNIVERSAL_D',
   },
   {
                      input_url: 'https://twitter.com/@UNIVERSAL_D#content-main-heading',
-             input_entity_type: 'artist',
+             input_entity_type: 'label',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://twitter.com/UNIVERSAL_D',
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3032,6 +3032,13 @@ const testData = [
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://twitter.com/UNIVERSAL_D',
   },
+  {
+                     input_url: 'https://twitter.com/mountain_goats/status/1062342708470132738',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingmusic',
+            expected_clean_url: 'https://twitter.com/mountain_goats/status/1062342708470132738',
+       only_valid_entity_types: ['recording'],
+  },
   // Universal Music
   {
                      input_url: 'http://www.universal-music.co.jp/sweety/products/umca-59007/',


### PR DESCRIPTION
[MBS-10108](https://tickets.metabrainz.org/browse/MBS-10108): Allow linking tweets to recordings only
----

Handle Twitter update permalinks such as `https://twitter.com/user/status/123`:

* auto-select “stream music for free” relationship type,
* same cleanup as for linking to Twitter accounts,
* validate linking Twitter updates to recordings only.

See https://blog.twitter.com/en_us/a/2006/twitter-has-permalinks-and-rss-feeds.html