### PR TITLE
MBS-10196: backport IE7 XSS fix to knockout

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "imports-loader": "0.8.0",
     "jed": "git://github.com/mwiencek/Jed.git#cd3f71b",
     "jquery": "1.11.2",
-    "knockout": "git://github.com/mwiencek/knockout.git#cffd030",
+    "knockout": "git://github.com/mwiencek/knockout.git#a09f077",
     "knockout-arraytransforms": "git://github.com/mwiencek/knockout-arraytransforms.git#9673e91",
     "leaflet": "1.0.2",
     "leaflet.markercluster": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "2.1.1"
   resolved "git://github.com/mwiencek/knockout-arraytransforms.git#9673e91a4755b92ba4eea5ca03067790dbbd997b"
 
-"knockout@git://github.com/mwiencek/knockout.git#cffd030":
+"knockout@git://github.com/mwiencek/knockout.git#a09f077":
   version "3.1.0"
-  resolved "git://github.com/mwiencek/knockout.git#cffd030b9624d40122cd4a9a540c0b69b00f366f"
+  resolved "git://github.com/mwiencek/knockout.git#a09f0778844130a89af438971ad6229ab81e26b3"
 
 lazy-cache@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
Per WhiteSource, "Knockout, before 3.5.0-beta, has an XSS injection point in attr name binding for browser IE7 and older."

I've backported https://github.com/knockout/knockout/commit/86b06aa to our fork via https://github.com/mwiencek/knockout/commit/a09f077.