### PR TITLE
React autocomplete component

### DIFF
--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: a9b75804169260d49cda34b56dcfabe1
-// flow-typed version: e9dac1347c/lodash_v4.x.x/flow_>=v0.63.x
+// flow-typed signature: 978ec408ef4dc26808325571d235d3ca
+// flow-typed version: 9f33da9d84/lodash_v4.x.x/flow_>=v0.63.x
 
 declare module "lodash" {
   declare type Path = $ReadOnlyArray<string | number> | string | number;
@@ -265,7 +265,7 @@ declare module "lodash" {
     ): -1;
     // alias of _.head
     first<T>(array: ?$ReadOnlyArray<T>): T;
-    flatten<T, X>(array?: ?Array<Array<T> | X>): Array<T | X>;
+    flatten<T, X>(array?: ?$ReadOnlyArray<$ReadOnlyArray<T> | X>): Array<T | X>;
     flattenDeep<T>(array?: ?(any[])): Array<T>;
     flattenDepth(array?: ?(any[]), depth?: ?number): any[];
     fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
@@ -391,8 +391,8 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
-    take<T>(array?: ?Array<T>, n?: ?number): Array<T>;
-    takeRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
+    take<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
+    takeRight<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
     takeRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     takeWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     union<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
@@ -486,15 +486,15 @@ declare module "lodash" {
       a4: Array<T>,
       comparator?: Comparator<T>
     ): Array<T>;
-    zip<A, B>(a1?: ?(A[]), a2?: ?(B[])): Array<[A, B]>;
-    zip<A, B, C>(a1: A[], a2: B[], a3: C[]): Array<[A, B, C]>;
-    zip<A, B, C, D>(a1: A[], a2: B[], a3: C[], a4: D[]): Array<[A, B, C, D]>;
+    zip<A, B>(a1?: ?($ReadOnlyArray<A>), a2?: ?($ReadOnlyArray<B>)): Array<[A, B]>;
+    zip<A, B, C>(a1: $ReadOnlyArray<A>, a2: $ReadOnlyArray<B>, a3: $ReadOnlyArray<C>): Array<[A, B, C]>;
+    zip<A, B, C, D>(a1: $ReadOnlyArray<A>, a2: $ReadOnlyArray<B>, a3: $ReadOnlyArray<C>, a4: $ReadOnlyArray<D>): Array<[A, B, C, D]>;
     zip<A, B, C, D, E>(
-      a1: A[],
-      a2: B[],
-      a3: C[],
-      a4: D[],
-      a5: E[]
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
+      a3: $ReadOnlyArray<C>,
+      a4: $ReadOnlyArray<D>,
+      a5: $ReadOnlyArray<E>
     ): Array<[A, B, C, D, E]>;
 
     zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V };
@@ -675,7 +675,7 @@ declare module "lodash" {
       iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
       orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
     ): Array<T>;
-    orderBy<V, T: Object>(
+    orderBy<V, T: {}>(
       object: T,
       iteratees?: $ReadOnlyArray<OIteratee<*>> | string,
       orders?: $ReadOnlyArray<"asc" | "desc"> | string
@@ -1890,10 +1890,10 @@ declare module "lodash/fp" {
     sortedUniq<T>(array: Array<T>): Array<T>;
     sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
     tail<T>(array: Array<T>): Array<T>;
-    take<T>(n: number): (array: Array<T>) => Array<T>;
-    take<T>(n: number, array: Array<T>): Array<T>;
-    takeRight<T>(n: number): (array: Array<T>) => Array<T>;
-    takeRight<T>(n: number, array: Array<T>): Array<T>;
+    take<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    take<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    takeRight<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeRight<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
     takeLast<T>(n: number): (array: Array<T>) => Array<T>;
     takeLast<T>(n: number, array: Array<T>): Array<T>;
     takeRightWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;

--- a/root/components/FormRowRadio.js
+++ b/root/components/FormRowRadio.js
@@ -47,7 +47,7 @@ const FormRowRadio = ({
               value={option.value}
             />
             {' '}
-            {unwrapNl(option.label)}
+            {unwrapNl<string | React$MixedElement>(option.label)}
           </label>
           {index < options.length - 1 ? <br /> : null}
         </React.Fragment>

--- a/root/components/SelectField.js
+++ b/root/components/SelectField.js
@@ -14,7 +14,7 @@ import getSelectValue from '../utility/getSelectValue';
 
 const buildOption = (option: SelectOptionT, index: number) => (
   <option key={index} value={option.value}>
-    {unwrapNl(option.label)}
+    {unwrapNl<string>(option.label)}
   </option>
 );
 

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -1,0 +1,570 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import partition from 'lodash/partition';
+import unionBy from 'lodash/unionBy';
+import React, {useEffect, useMemo, useReducer, useRef} from 'react';
+
+import ENTITIES from '../../../../../entities';
+import useOutsideClickEffect from '../hooks/useOutsideClickEffect';
+import {unwrapNl} from '../i18n';
+import clean from '../utility/clean';
+
+import {
+  HIDE_MENU,
+  HIGHLIGHT_NEXT_ITEM,
+  HIGHLIGHT_PREVIOUS_ITEM,
+  SELECT_HIGHLIGHTED_ITEM,
+  SHOW_LOOKUP_ERROR,
+  SHOW_LOOKUP_TYPE_ERROR,
+  SHOW_MENU,
+  SHOW_SEARCH_ERROR,
+  STOP_SEARCH,
+} from './Autocomplete2/actions';
+import {
+  ARIA_LIVE_STYLE,
+  DISPLAY_NONE_STYLE,
+  EMPTY_ARRAY,
+  MBID_REGEXP,
+  MENU_ITEMS,
+  SEARCH_PLACEHOLDERS,
+} from './Autocomplete2/constants';
+import reducer from './Autocomplete2/reducer';
+import type {
+  Actions,
+  Item,
+  Props,
+  Instance,
+  State,
+} from './Autocomplete2/types';
+
+const INITIAL_STATE: State = {
+  highlightedIndex: 0,
+  indexedSearch: true,
+  inputTimeout: null,
+  inputValue: '',
+  isOpen: false,
+  items: EMPTY_ARRAY,
+  page: 1,
+  pendingSearch: null,
+  selectedItem: null,
+  statusMessage: '',
+  xhr: null,
+};
+
+/*
+ * If the autocomplete is provided an `items` prop, it's assumed that it
+ * contains the complete list of searchable options. In that case, we filter
+ * them based on a simple substring match via `doFilter`.
+ */
+function doFilter(
+  parent: Instance,
+  items: $ReadOnlyArray<Item>,
+  searchTerm: string,
+) {
+  let results = items;
+  let resultCount = results.length;
+
+  if (searchTerm) {
+    results = items.filter(item => (
+      unwrapNl<string>(item.name)
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase())
+    ));
+    resultCount = results.length;
+    if (!resultCount) {
+      results.push(MENU_ITEMS.NO_RESULTS);
+    }
+  }
+
+  parent.dispatch({
+    items: results,
+    page: 1,
+    resultCount,
+    type: 'show-results',
+  });
+}
+
+/*
+ * `doLookup` performs a direct MBID lookup (via /ws/js/entity) in case the
+ * the user pastes an MBID or some URL containing one.
+ */
+function doLookup(parent: Instance, mbid: string) {
+  parent.stopRequests();
+
+  const lookupXhr = new XMLHttpRequest();
+  parent.xhr = lookupXhr;
+
+  lookupXhr.addEventListener('load', () => {
+    parent.xhr = null;
+
+    if (lookupXhr.status !== 200) {
+      parent.dispatch(SHOW_LOOKUP_ERROR);
+      return;
+    }
+
+    const {entityType, onTypeChange} = parent.props;
+    const entity = JSON.parse(lookupXhr.responseText);
+
+    if (entity.entityType !== entityType &&
+        (!onTypeChange || onTypeChange(entity.entityType) === false)) {
+      parent.dispatch(SHOW_LOOKUP_TYPE_ERROR);
+    } else {
+      parent.dispatch({item: entity, type: 'select-item'});
+    }
+  });
+
+  lookupXhr.open('GET', '/ws/js/entity/' + mbid);
+  lookupXhr.send();
+}
+
+/*
+ * `doSearch` performs a direct or indexed search (via /ws/js). This is the
+ * default behavior if no `items` prop is given.
+ */
+function doSearch(instance: Instance) {
+  const searchXhr = new XMLHttpRequest();
+  instance.xhr = searchXhr;
+
+  searchXhr.addEventListener('load', () => {
+    instance.xhr = null;
+
+    if (searchXhr.status !== 200) {
+      instance.dispatch(SHOW_SEARCH_ERROR);
+      return;
+    }
+
+    const actions = [];
+    let newItems = JSON.parse(searchXhr.responseText);
+    const pager = newItems.pop();
+    const newPage = parseInt(pager.current, 10);
+    const totalPages = parseInt(pager.pages, 10);
+
+    if (newItems.length) {
+      if (newPage < totalPages) {
+        actions.push(MENU_ITEMS.SHOW_MORE);
+      }
+    } else if (newPage === 1) {
+      actions.push(MENU_ITEMS.NO_RESULTS);
+    }
+
+    actions.push(instance.state.indexedSearch
+      ? MENU_ITEMS.TRY_AGAIN_DIRECT
+      : MENU_ITEMS.TRY_AGAIN_INDEXED);
+
+    const [, prevItems] = partition(instance.state.items, hasAction);
+
+    newItems = newPage > 1
+      ? unionBy(prevItems, newItems, x => x.id)
+      : newItems;
+
+    instance.dispatch({
+      items: newItems.concat(actions),
+      page: newPage,
+      resultCount: newItems.length,
+      type: 'show-results',
+    });
+  });
+
+  const url = (
+    '/ws/js/' + ENTITIES[instance.props.entityType].url +
+    '/?q=' + encodeURIComponent(instance.state.inputValue || '') +
+    '&page=' + String(instance.state.page) +
+    '&direct=' + (instance.state.indexedSearch ? 'false' : 'true')
+  );
+
+  searchXhr.open('GET', url);
+  searchXhr.send();
+}
+
+function doSearchOrFilter(instance: Instance, searchTerm: string) {
+  if (instance.props.items) {
+    doFilter(instance, instance.props.items, searchTerm);
+  } else if (searchTerm) {
+    instance.dispatch({searchTerm, type: 'search-after-timeout'});
+  }
+}
+
+function findItem(instance: Instance, itemId: string) {
+  const items = instance.state.items;
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (String(item.id) === itemId) {
+      return [i, item];
+    }
+  }
+  return [-1, null];
+}
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function hasAction(x: Item) {
+  return hasOwnProperty.call(x, 'action');
+}
+
+function setScrollPosition(menuId: string, siblingAccessor: string) {
+  const menu = document.getElementById(menuId);
+  if (!menu) {
+    return;
+  }
+  // $FlowFixMe
+  const item = menu.querySelector('li[aria-selected=true]')[siblingAccessor];
+  if (!item) {
+    return;
+  }
+  const position =
+    (item.offsetTop + (item.offsetHeight / 2)) - menu.scrollTop;
+  const middle = menu.offsetHeight / 2;
+  if (position < middle) {
+    menu.scrollTop -= (middle - position);
+  }
+  if (position > middle) {
+    menu.scrollTop += (position - middle);
+  }
+}
+
+export default function Autocomplete2(props: Props) {
+  const {entityType, id} = props;
+
+  const [state, dispatch] = useReducer<State, Actions>(
+    reducer,
+    INITIAL_STATE,
+  );
+
+  let activeElementBeforeItemClick = null;
+  let itemClickInProgress = false;
+  let prevChildren = null;
+
+  /*
+   * The "instance" below, including associated methods, is created only once
+   * on initial render. This avoids unnecessary allocations and closures for
+   * each render by reusing the previous ones. It's important to note,
+   * however, that the `state` variable above (and `props` for that matter)
+   * should not be accessed in the closures below unless you know what you're
+   * doing (because it'll refer to the *original* state on the initial
+   * render). If access to the current state is needed in a callback or event
+   * handler, `instance.state` should be used instead, as it'll refer to the
+   * state of the last render.
+   */
+  const instanceRef = useRef<Instance | null>(null);
+  const instance: Instance = instanceRef.current || (instanceRef.current = {
+    container: {current: null},
+
+    dispatch,
+
+    handleBlur() {
+      if (itemClickInProgress) {
+        return;
+      }
+      setTimeout(() => {
+        const container = instance.container.current;
+        if (container && !container.contains(document.activeElement)) {
+          instance.stopRequests();
+          if (instance.state.isOpen) {
+            dispatch(HIDE_MENU);
+          }
+        }
+      }, 10);
+    },
+
+    handleButtonClick() {
+      const state = instance.state;
+
+      instance.stopRequests();
+
+      if (state.isOpen) {
+        instance.dispatch(HIDE_MENU);
+      } else if (state.items.length) {
+        instance.dispatch(SHOW_MENU);
+      } else if (state.inputValue) {
+        doSearchOrFilter(instance, state.inputValue);
+      }
+    },
+
+    handleInputChange(event: SyntheticKeyboardEvent<HTMLInputElement>) {
+      const newInputValue = event.currentTarget.value;
+      const newCleanInputValue = clean(newInputValue);
+
+      dispatch({type: 'type-value', value: newInputValue});
+
+      const mbidMatch = newCleanInputValue.match(MBID_REGEXP);
+      if (mbidMatch) {
+        doLookup(instance, mbidMatch[0]);
+      } else if (clean(instance.state.inputValue) !== newCleanInputValue) {
+        instance.stopRequests();
+        doSearchOrFilter(instance, newCleanInputValue);
+      }
+    },
+
+    handleInputKeyDown(
+      event: SyntheticKeyboardEvent<HTMLInputElement | HTMLButtonElement>,
+    ) {
+      const isInputNonEmpty = !!instance.state.inputValue;
+      const isMenuNonEmpty = instance.state.items.length > 0;
+      const isMenuOpen = instance.state.isOpen;
+      const menuId = instance.props.id + '-menu';
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+
+          if (isMenuOpen) {
+            setScrollPosition(menuId, 'nextElementSibling');
+            dispatch(HIGHLIGHT_NEXT_ITEM);
+          } else if (isMenuNonEmpty) {
+            dispatch(SHOW_MENU);
+          } else if (isInputNonEmpty) {
+            doSearchOrFilter(instance, instance.state.inputValue);
+          }
+          break;
+
+        case 'ArrowUp':
+          if (isMenuOpen) {
+            event.preventDefault();
+            setScrollPosition(menuId, 'previousElementSibling');
+            dispatch(HIGHLIGHT_PREVIOUS_ITEM);
+          }
+          break;
+
+        case 'Enter':
+          if (isMenuOpen) {
+            event.preventDefault();
+            dispatch(SELECT_HIGHLIGHTED_ITEM);
+          }
+          break;
+
+        case 'Escape':
+          instance.stopRequests();
+          if (isMenuOpen) {
+            dispatch(HIDE_MENU);
+          }
+          break;
+      }
+    },
+
+    handleItemClick(event: SyntheticMouseEvent<HTMLLIElement>) {
+      const active = activeElementBeforeItemClick;
+      if (active) {
+        setTimeout(() => {
+          active.focus();
+          itemClickInProgress = false;
+        }, 10);
+        activeElementBeforeItemClick = null;
+      }
+      const [, item] = findItem(instance, event.currentTarget.dataset.itemId);
+      item && instance.dispatch({item, type: 'select-item'});
+    },
+
+    handleItemMouseDown() {
+      activeElementBeforeItemClick = document.activeElement;
+      itemClickInProgress = true;
+    },
+
+    handleItemMouseOver(event: SyntheticMouseEvent<HTMLLIElement>) {
+      const [index] = findItem(instance, event.currentTarget.dataset.itemId);
+      index >= 0 && instance.dispatch({index, type: 'highlight-item'});
+    },
+
+    handleOuterClick() {
+      instance.stopRequests();
+      dispatch(HIDE_MENU);
+    },
+
+    inputTimeout: null,
+
+    props,
+
+    /*
+     * This needs to accept parameters for the state at the time of render.
+     * (The state outside this closure refers to the original component state,
+     * because the closure was created on the initial render; instance.state
+     * refers to the state of the last render, not the current one.)
+     */
+    renderItems(items, highlightedIndex, selectedItem) {
+      const children = new Map();
+
+      for (let index = 0; index < items.length; index++) {
+        const item = items[index];
+        const isHighlighted = index === highlightedIndex;
+        const isSelected = !!(selectedItem && item.id === selectedItem.id);
+        const itemMapKey = item.id + ',' +
+          String(isHighlighted) + ',' +
+          String(isSelected);
+        const style = item.level
+          ? {paddingLeft: String((item.level - 1) * 8) + 'px'}
+          : null;
+
+        children.set(
+          itemMapKey,
+          (prevChildren && prevChildren.get(itemMapKey)) || (
+            <li
+              aria-selected={isHighlighted ? 'true' : 'false'}
+              className={
+                (isHighlighted ? 'highlighted ' : '') +
+                (isSelected ? 'selected ' : '') +
+                (item.separator ? 'separator ' : '')
+              }
+              data-item-id={item.id}
+              id={`${id}-item-${item.id}`}
+              key={item.id}
+              onClick={instance.handleItemClick}
+              onMouseDown={instance.handleItemMouseDown}
+              onMouseOver={instance.handleItemMouseOver}
+              role="option"
+              style={style}
+            >
+              {unwrapNl(item.name)}
+            </li>
+          ),
+        );
+      }
+
+      prevChildren = children;
+      return children;
+    },
+
+    setContainer(node) {
+      instance.container.current = node;
+    },
+
+    state,
+
+    stopRequests() {
+      if (instance.xhr) {
+        instance.xhr.abort();
+        instance.xhr = null;
+      }
+
+      if (instance.inputTimeout) {
+        clearTimeout(instance.inputTimeout);
+        instance.inputTimeout = null;
+      }
+
+      dispatch(STOP_SEARCH);
+    },
+
+    xhr: null,
+  });
+
+  const activeDescendant = state.items.length
+    ? `${id}-item-${state.items[state.highlightedIndex].id}`
+    : null;
+  const inputId = `${id}-input`;
+  const labelId = `${id}-label`;
+  const menuId = `${id}-menu`;
+  const statusId = `${id}-status`;
+
+  const menuItems = useMemo(() => instance.renderItems(
+    state.items,
+    state.highlightedIndex,
+    state.selectedItem,
+  ), [state.items, state.highlightedIndex, state.selectedItem]);
+
+  useOutsideClickEffect(
+    instance.container,
+    instance.handleOuterClick,
+    instance.stopRequests,
+  );
+
+  useEffect(() => {
+    /*
+     * This gives event handlers access to the props and state of the most
+     * recent render. `useEffect` runs after a completed render; this does
+     * *not* allow access to props or state from any current, "in progress"
+     * render. This should generally be fine for events, since they're
+     * triggered through what's visible on screen, but care is advised.
+     */
+    instance.props = props;
+    instance.state = state;
+
+    if (
+      state.pendingSearch &&
+      !instance.inputTimeout &&
+      !instance.xhr &&
+      !props.items
+    ) {
+      instance.inputTimeout = setTimeout(() => {
+        instance.inputTimeout = null;
+
+        // Check if the input value has changed before proceeding.
+        if (clean(state.pendingSearch) === clean(instance.state.inputValue)) {
+          doSearch(instance);
+        }
+      }, 300);
+    }
+  });
+
+  return (
+    <div
+      className="autocomplete2"
+      ref={instance.setContainer}
+      style={props.width ? {width: props.width} : null}
+    >
+      <label htmlFor={inputId} id={labelId} style={DISPLAY_NONE_STYLE}>
+        {props.placeholder || SEARCH_PLACEHOLDERS[entityType]()}
+      </label>
+      <div
+        aria-expanded={state.isOpen ? 'true' : 'false'}
+        aria-haspopup="listbox"
+        aria-owns={menuId}
+        role="combobox"
+      >
+        <input
+          aria-activedescendant={activeDescendant}
+          aria-autocomplete="list"
+          aria-controls={menuId}
+          aria-labelledby={labelId}
+          autoComplete="off"
+          className={state.selectedItem ? 'lookup-performed' : ''}
+          id={inputId}
+          onBlur={instance.handleBlur}
+          onChange={instance.handleInputChange}
+          onKeyDown={instance.handleInputKeyDown}
+          placeholder={props.placeholder || l('Type to search, or paste an MBID')}
+          value={state.inputValue}
+        />
+        <button
+          aria-activedescendant={activeDescendant}
+          aria-autocomplete="list"
+          aria-controls={menuId}
+          aria-haspopup="true"
+          aria-label={l('Search')}
+          className={'search' + (state.pendingSearch ? ' loading' : '')}
+          data-toggle="true"
+          onBlur={instance.handleBlur}
+          onClick={instance.handleButtonClick}
+          onKeyDown={instance.handleInputKeyDown}
+          role="button"
+          title={l('Search')}
+          type="button"
+        />
+      </div>
+
+      <ul
+        aria-controls={statusId}
+        aria-labelledby={labelId}
+        id={menuId}
+        role="listbox"
+        style={{visibility: state.isOpen ? 'visible' : 'hidden'}}
+      >
+        {Array.from(menuItems.values())}
+      </ul>
+
+      <div
+        aria-live="assertive"
+        aria-relevant="additions text"
+        id={statusId}
+        role="status"
+        style={ARIA_LIVE_STYLE}
+      >
+        {state.statusMessage}
+      </div>
+    </div>
+  );
+}

--- a/root/static/scripts/common/components/Autocomplete2/actions.js
+++ b/root/static/scripts/common/components/Autocomplete2/actions.js
@@ -1,0 +1,62 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export const HIDE_MENU = {
+  type: 'set-menu-visibility',
+  value: false,
+};
+
+export const HIGHLIGHT_NEXT_ITEM = {
+  type: 'highlight-next-item',
+};
+
+export const HIGHLIGHT_PREVIOUS_ITEM = {
+  type: 'highlight-previous-item',
+};
+
+export const NOOP = {
+  type: 'noop',
+};
+
+export const SELECT_HIGHLIGHTED_ITEM = {
+  type: 'select-highlighted-item',
+};
+
+export const SHOW_MENU = {
+  type: 'set-menu-visibility',
+  value: true,
+};
+
+export const SHOW_MORE_RESULTS = {
+  type: 'show-more-results',
+};
+
+export const SEARCH_AGAIN = {
+  type: 'search-after-timeout',
+};
+
+export const SHOW_LOOKUP_ERROR = {
+  type: 'show-lookup-error',
+};
+
+export const SHOW_LOOKUP_TYPE_ERROR = {
+  type: 'show-lookup-type-error',
+};
+
+export const SHOW_SEARCH_ERROR = {
+  type: 'show-search-error',
+};
+
+export const STOP_SEARCH = {
+  type: 'stop-search',
+};
+
+export const TOGGLE_INDEXED_SEARCH = {
+  type: 'toggle-indexed-search',
+};

--- a/root/static/scripts/common/components/Autocomplete2/constants.js
+++ b/root/static/scripts/common/components/Autocomplete2/constants.js
@@ -1,0 +1,100 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {bracketedText} from '../../utility/bracketed';
+
+import {
+  NOOP,
+  SEARCH_AGAIN,
+  SHOW_MORE_RESULTS,
+  TOGGLE_INDEXED_SEARCH,
+} from './actions';
+import type {Item} from './types';
+
+export const ARIA_LIVE_STYLE = Object.seal({
+  height: '1px',
+  left: '-1px',
+  overflow: 'hidden',
+  position: 'absolute',
+  top: '-1px',
+  width: '1px',
+});
+
+export const DISPLAY_NONE_STYLE = {display: 'none'};
+
+export const EMPTY_ARRAY: $ReadOnlyArray<Item> = Object.freeze([]);
+
+export const MBID_REGEXP = /[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}/;
+
+export const MENU_ITEMS = {
+  ERROR_TRY_AGAIN_DIRECT: {
+    action: TOGGLE_INDEXED_SEARCH,
+    id: 'error-try-again-direct',
+    name: N_l('Try again with direct search.'),
+  },
+  ERROR_TRY_AGAIN_INDEXED: {
+    action: TOGGLE_INDEXED_SEARCH,
+    id: 'error-try-again-indexed',
+    name: N_l('Try again with indexed search.'),
+  },
+  LOOKUP_ERROR: {
+    action: NOOP,
+    id: 'lookup-error',
+    name: N_l('An error occurred while looking up the MBID you entered.'),
+  },
+  LOOKUP_TYPE_ERROR: {
+    action: NOOP,
+    id: 'lookup-type-error',
+    name: N_l('The type of entity you pasted isn’t supported here.'),
+  },
+  NO_RESULTS: {
+    action: NOOP,
+    id: 'no-results',
+    name: () => bracketedText(l('No results')),
+  },
+  SEARCH_ERROR: {
+    action: SEARCH_AGAIN,
+    id: 'try-again',
+    name: N_l('An error occurred while searching. Click here to try again.'),
+    separator: true,
+  },
+  SHOW_MORE: {
+    action: SHOW_MORE_RESULTS,
+    id: 'show-more',
+    name: N_l('Show more...'),
+    separator: true,
+  },
+  TRY_AGAIN_DIRECT: {
+    action: TOGGLE_INDEXED_SEARCH,
+    id: 'try-again-direct',
+    name: N_l('Not found? Try again with direct search.'),
+    separator: true,
+  },
+  TRY_AGAIN_INDEXED: {
+    action: TOGGLE_INDEXED_SEARCH,
+    id: 'try-again-indexed',
+    name: N_l('Slow? Switch back to indexed search.'),
+    separator: true,
+  },
+};
+
+export const SEARCH_PLACEHOLDERS = {
+  area: N_l('Search for an area'),
+  artist: N_l('Search for an artist'),
+  editor: N_l('Search for an editor'),
+  event: N_l('Search for an event'),
+  instrument: N_l('Search for an instrument'),
+  label: N_l('Search for a label'),
+  place: N_l('Search for a place'),
+  recording: N_l('Search for a recording'),
+  release: N_l('Search for a release'),
+  release_group: N_l('Search for a release group'),
+  series: N_l('Search for a series'),
+  work: N_l('Search for a work'),
+};

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -1,0 +1,235 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {unwrapNl} from '../../i18n';
+
+import {
+  SEARCH_AGAIN,
+  TOGGLE_INDEXED_SEARCH,
+} from './actions';
+import {EMPTY_ARRAY, MENU_ITEMS} from './constants';
+import type {
+  ActionItem,
+  Actions,
+  Item,
+  SearchAction,
+  State,
+} from './types';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function initSearch(state: State, action: SearchAction) {
+  if (action.indexed !== undefined) {
+    state.indexedSearch = action.indexed;
+  }
+
+  state.statusMessage = '';
+
+  let searchTerm;
+  if (hasOwnProperty.call(action, 'searchTerm')) {
+    searchTerm = action.searchTerm;
+  } else {
+    /*
+     * If we didn't provide a searchTerm, then that indicates we want to
+     * search again with the text we already have.
+     */
+    searchTerm = state.inputValue;
+  }
+
+  if (!searchTerm) {
+    return;
+  }
+
+  state.pendingSearch = searchTerm;
+}
+
+function resetPage(state: State) {
+  state.highlightedIndex = 0;
+  state.isOpen = false;
+  state.items = EMPTY_ARRAY;
+  state.page = 1;
+}
+
+function selectItem(state: State, item: Item) {
+  if (item.action) {
+    runReducer(state, item.action);
+    return;
+  }
+
+  state.isOpen = false;
+  state.selectedItem = item;
+  state.statusMessage = item.name;
+
+  if (item.name !== state.inputValue) {
+    state.inputValue = item.name;
+    resetPage(state);
+  }
+}
+
+function selectItemAtIndex(state: State, index: number) {
+  const item = state.items[index];
+  if (item) {
+    selectItem(state, item);
+  }
+}
+
+function showError(state: State, error: ActionItem) {
+  state.highlightedIndex = 0;
+  state.isOpen = true;
+  state.items = [error];
+  state.statusMessage = unwrapNl<string>(error.name);
+}
+
+// `runReducer` should only be run on a copy of the existing state.
+function runReducer(
+  state: State,
+  action: Actions,
+) {
+  switch (action.type) {
+    case 'highlight-item': {
+      state.highlightedIndex = action.index;
+      break;
+    }
+
+    case 'highlight-next-item': {
+      let index = state.highlightedIndex + 1;
+      if (index >= state.items.length) {
+        index = 0;
+      }
+      state.highlightedIndex = index;
+      break;
+    }
+
+    case 'highlight-previous-item': {
+      let index = state.highlightedIndex - 1;
+      if (index < 0) {
+        index = state.items.length - 1;
+      }
+      state.highlightedIndex = index;
+      break;
+    }
+
+    case 'noop':
+      break;
+
+    case 'search-after-timeout':
+      state.page = 1;
+      initSearch(state, action);
+      break;
+
+    case 'select-highlighted-item':
+      selectItemAtIndex(state, state.highlightedIndex);
+      break;
+
+    case 'select-item':
+      selectItem(state, action.item);
+      break;
+
+    case 'set-menu-visibility':
+      state.isOpen = action.value;
+      break;
+
+    case 'show-lookup-error': {
+      showError(state, MENU_ITEMS.LOOKUP_ERROR);
+      break;
+    }
+
+    case 'show-lookup-type-error': {
+      showError(state, MENU_ITEMS.LOOKUP_TYPE_ERROR);
+      break;
+    }
+
+    case 'show-results': {
+      const {items, page, resultCount} = action;
+
+      if (page === 1) {
+        state.highlightedIndex = 0;
+      } else if (state.highlightedIndex >= items.length) {
+        state.highlightedIndex = items.length - 1;
+      }
+
+      const highlightedItem = items[state.highlightedIndex];
+
+      state.isOpen = true;
+      state.items = items;
+      state.page = page;
+      state.pendingSearch = null;
+      state.statusMessage = items.length ? (
+        (highlightedItem
+          ? unwrapNl<string>(highlightedItem.name) + '. '
+          : '') +
+        texp.ln(
+          `1 result found.
+            Press enter to select, or
+            use the up and down arrow keys to navigate.`,
+          `{n} results found.
+            Press enter to select, or
+            use the up and down arrow keys to navigate.`,
+          items.length,
+          {n: resultCount},
+        )
+      ) : '';
+      break;
+    }
+
+    case 'show-search-error': {
+      showError(state, MENU_ITEMS.SEARCH_ERROR);
+      state.items = state.items.concat(
+        state.indexedSearch
+          ? MENU_ITEMS.ERROR_TRY_AGAIN_DIRECT
+          : MENU_ITEMS.ERROR_TRY_AGAIN_INDEXED
+      );
+      state.pendingSearch = null;
+      break;
+    }
+
+    case 'show-more-results':
+      state.page++;
+      initSearch(state, SEARCH_AGAIN);
+      break;
+
+    case 'stop-search':
+      state.pendingSearch = null;
+      break;
+
+    case 'toggle-indexed-search':
+      state.indexedSearch = !state.indexedSearch;
+      state.page = 1;
+      initSearch(state, SEARCH_AGAIN);
+      break;
+
+    case 'type-value':
+      state.inputValue = action.value;
+      state.pendingSearch = null;
+      state.selectedItem = null;
+      state.statusMessage = '';
+
+      if (!state.inputValue) {
+        resetPage(state);
+      }
+
+      break;
+
+    default:
+      throw new Error('Unknown action: ' + action.type);
+  }
+}
+
+export default function reducer(
+  state: State,
+  action: Actions,
+) {
+  if (action.type === 'noop') {
+    return state;
+  }
+
+  const nextState = {...state};
+  runReducer(nextState, action);
+  return nextState;
+}

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -1,0 +1,99 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export type Instance = {|
+  container: {|current: HTMLElement | null|},
+  dispatch: (Actions) => void,
+  handleBlur: () => void,
+  handleButtonClick: () => void,
+  handleInputChange: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
+  handleInputKeyDown: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
+  handleItemClick: (SyntheticMouseEvent<HTMLLIElement>) => void,
+  handleItemMouseDown: () => void,
+  handleItemMouseOver: (SyntheticMouseEvent<HTMLLIElement>) => void,
+  handleOuterClick: () => void,
+  inputTimeout: TimeoutID | null,
+  props: Props,
+  renderItems: (
+    $ReadOnlyArray<Item>,
+    number,
+    EntityItem | null,
+  ) => Map<string, React$Element<'li'>>,
+  setContainer: (HTMLDivElement | null) => void,
+  state: State,
+  stopRequests: () => void,
+  xhr: XMLHttpRequest | null,
+|};
+
+export type Props = {
+  entityType: string,
+  id: string,
+  items?: $ReadOnlyArray<EntityItem>,
+  onChange: () => void,
+  onTypeChange?: (string) => boolean,
+  placeholder?: string,
+  width?: string,
+};
+
+export type State = {
+  highlightedIndex: number,
+  indexedSearch: boolean,
+  inputValue: string,
+  isOpen: boolean,
+  items: $ReadOnlyArray<Item>,
+  page: number,
+  pendingSearch: string | null,
+  selectedItem: EntityItem | null,
+  statusMessage: string,
+};
+
+export type SearchAction = {|
+  +indexed?: boolean,
+  +searchTerm?: string,
+  +type: 'search-after-timeout',
+|};
+
+export type Actions =
+  | SearchAction
+  | {| +index: number, +type: 'highlight-item' |}
+  | {| +type: 'highlight-next-item' |}
+  | {| +type: 'highlight-previous-item' |}
+  | {| +type: 'noop' |}
+  | {| +type: 'select-highlighted-item' |}
+  | {| +item: Item, +type: 'select-item' |}
+  | {| +type: 'set-menu-visibility', +value: boolean |}
+  | {|
+      +items: $ReadOnlyArray<Item>,
+      +page: number,
+      +resultCount: number,
+      +type: 'show-results',
+    |}
+  | {| +type: 'show-lookup-error' |}
+  | {| +type: 'show-lookup-type-error' |}
+  | {| +type: 'show-more-results' |}
+  | {| +type: 'show-search-error' |}
+  | {| +type: 'stop-search' |}
+  | {| +type: 'toggle-indexed-search' |}
+  | {| +type: 'type-value', +value: string |}
+  ;
+
+export type ActionItem = {|
+  +action: Actions,
+  +id: number | string,
+  +name: string | () => string,
+  +separator?: boolean,
+|};
+
+export type EntityItem = {|
+  +id: number | string,
+  +level?: number,
+  +name: string,
+|};
+
+export type Item = ActionItem | EntityItem;

--- a/root/static/scripts/common/hooks/useOutsideClickEffect.js
+++ b/root/static/scripts/common/hooks/useOutsideClickEffect.js
@@ -1,0 +1,47 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import noop from 'lodash/noop';
+import {useEffect} from 'react';
+
+const EMPTY_ARRAY = [];
+
+const TARGET_REFS = new Map();
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('mouseup', function (event: MouseEvent) {
+    for (const [ref, action] of TARGET_REFS) {
+      const target = ref.current;
+      // $FlowFixMe
+      if (target && !target.contains(event.target)) {
+        action();
+      }
+    }
+  });
+}
+
+export default function useOutsideClickEffect(
+  targetRef: {|current: HTMLElement | null|},
+  action: () => void,
+  cleanup?: () => void,
+) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  useEffect(() => {
+    TARGET_REFS.set(targetRef, action);
+    return () => {
+      TARGET_REFS.delete(targetRef);
+      if (cleanup) {
+        cleanup();
+      }
+    };
+  }, EMPTY_ARRAY);
+}

--- a/root/static/scripts/common/i18n.js
+++ b/root/static/scripts/common/i18n.js
@@ -23,9 +23,9 @@ export const N_lp = (key: string, context: string) => (
   () => lp(key, context)
 );
 
-export const unwrapNl = (
-  value: React$MixedElement | string | (() => React$MixedElement | string),
-) => (
+export const unwrapNl = <T: React$MixedElement | string>(
+  value: T | (() => T),
+): T => (
   typeof value === 'function' ? value() : value
 );
 

--- a/root/static/scripts/tests/autocomplete2.html
+++ b/root/static/scripts/tests/autocomplete2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Autocomplete2 Test</title>
+    <link rel="stylesheet/less" type="text/css" href="../../../static/styles/autocomplete2.less" />
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
+  </head>
+  <body>
+    <script src="../../build/autocomplete2.js"></script>
+  </body>
+</html>

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -1,0 +1,74 @@
+// IE 11 support.
+require('core-js/modules/es6.object.assign');
+require('core-js/modules/es6.array.from');
+require('core-js/modules/es6.array.iterator');
+require('core-js/modules/es6.string.iterator');
+require('core-js/es6/set');
+require('core-js/es6/map');
+require('core-js/es6/promise');
+require('core-js/es6/symbol');
+
+const $ = require('jquery');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Autocomplete2 = require('../common/components/Autocomplete2').default;
+
+const vocals = [
+  {id: 3, name: 'vocal', level: 1},
+  {id: 4, name: 'lead vocals', level: 2},
+  {id: 5, name: 'alto vocals', level: 3},
+  {id: 6, name: 'baritone vocals', level: 3},
+  {id: 7, name: 'bass vocals', level: 3},
+  {id: 8, name: 'countertenor vocals', level: 3},
+  {id: 9, name: 'mezzo-soprano vocals', level: 3},
+  {id: 10, name: 'soprano vocals', level: 3},
+  {id: 11, name: 'tenor vocals', level: 3},
+  {id: 230, name: 'contralto vocals', level: 3},
+  {id: 231, name: 'bass-baritone vocals', level: 3},
+  {id: 834, name: 'treble vocals', level: 3},
+  {id: 1060, name: 'meane vocals', level: 3},
+  {id: 12, name: 'background vocals', level: 2},
+  {id: 13, name: 'choir vocals', level: 2},
+  {id: 461, name: 'other vocals', level: 2},
+  {id: 561, name: 'spoken vocals', level: 3},
+];
+
+$(function () {
+  const container = document.createElement('div');
+  document.body.insertBefore(container, document.getElementById('page'));
+
+  function render(entityType) {
+    ReactDOM.render(
+      <>
+        <div>
+          <h2>Entity autocomplete</h2>
+          <p>
+            Current entity type: {entityType}.
+            Paste an MBID to change it.
+          </p>
+          <Autocomplete2
+            entityType={entityType}
+            id="entity-test"
+            onChange={console.log}
+            onTypeChange={render}
+            width="200px"
+          />
+        </div>
+        <div>
+          <h2>Vocal autocomplete</h2>
+          <Autocomplete2
+            entityType={entityType}
+            id="vocal-test"
+            items={vocals}
+            onChange={console.log}
+            placeholder="Choose a vocal"
+            width="200px"
+          />
+        </div>
+      </>,
+      container,
+    );
+  }
+
+  render('artist');
+});

--- a/root/static/styles/autocomplete2.less
+++ b/root/static/styles/autocomplete2.less
@@ -1,0 +1,15 @@
+@import "variables.less";
+@import "colors.less";
+@import "forms.less";
+@import "layout.less";
+@import "widgets.less";
+
+html {
+  height: 100%;
+}
+
+body {
+  padding: 1em;
+  width: 100%;
+  height: 100%;
+}

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -286,3 +286,67 @@ div.g-recaptcha {
     width: 100%;
     height: 100%;
 }
+
+/* Autocomplete2 */
+
+div.autocomplete2 {
+    display: inline-block;
+    position: relative;
+
+    div[role="combobox"] {
+        display: flex;
+        flex-direction: row;
+
+        input {
+            flex-grow: 1;
+        }
+
+        button.search {
+            background-color: transparent;
+            background-image: data-uri('../images/icons/search.svg');
+            background-repeat: no-repeat;
+            background-size: contain;
+            border: none;
+            height: 20px;
+            vertical-align: top;
+            width: 20px;
+
+            &.loading {
+                background-image: data-uri('../images/icons/loading.gif');
+            }
+        }
+    }
+
+    ul {
+        border: 1px @musicbrainz-orange solid;
+        list-style: none;
+        margin: 0;
+        max-width: 150%;
+        max-height: 400px;
+        overflow-y: auto;
+        padding: 0;
+        position: absolute;
+        width: max-content;
+        z-index: 100;
+
+        li {
+            background: @text-white;
+            border-width: 1px 0 1px 0;
+            border-color: @text-white;
+            border-style: solid;
+            cursor: pointer;
+            padding: 4px;
+            &.highlighted {
+                background: lighten(@musicbrainz-orange, 30%);
+                border-color: lighten(@musicbrainz-orange, 20%);
+            }
+            &.selected {
+                font-weight: bold;
+            }
+            &.separator {
+                border-top-color: @medium-grey;
+                margin-top: 0px;
+            }
+        }
+    }
+}

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -33,7 +33,9 @@ type TabPropsT = {
 
 const LinkStatisticsTab = ({link, title, page, selected}: TabPropsT) => (
   <li className={page === selected ? 'sel' : ''}>
-    <a href={link}>{unwrapNl(title)}</a>
+    <a href={link}>
+      {unwrapNl<string | React$MixedElement>(title)}
+    </a>
   </li>
 );
 

--- a/webpack.tests.config.js
+++ b/webpack.tests.config.js
@@ -29,6 +29,7 @@ const baseTestsConfig = {
 
 const webTestsConfig = {
   entry: {
+    'autocomplete2': path.resolve(dirs.SCRIPTS, 'tests', 'autocomplete2.js'),
     'web-tests': path.resolve(dirs.SCRIPTS, 'tests', 'browser-runner.js'),
   },
 


### PR DESCRIPTION
This is a basic implementation that just shows a list of names; the entity-specific formatters which display more details will be converted later.

To test this, run `./script/compile_resources.sh tests` and navigate to http://localhost:5000/static/scripts/tests/autocomplete2.html.

I'd like if we could check that the basic functionality and controls work as we'd like here (I tried to keep them almost identical to the existing autocomplete), and if they do, merge this mostly as-is plus any requested changes. We could then convert the entity formatters in a followup-PR, and soon after open a PR to replace the jQuery UI one with this.