### PR TITLE
Bump Flow to 0.100.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-react": "7.12.4",
     "file-url": "2.0.2",
-    "flow-bin": "0.98.1",
+    "flow-bin": "0.100.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.16.2",
     "jsdom": "13.2.0",

--- a/root/components/FormRowRadio.js
+++ b/root/components/FormRowRadio.js
@@ -30,7 +30,6 @@ type Props = {|
 const FormRowRadio = ({
   field,
   label,
-  onChange,
   options,
   required = false,
 }: Props) => (

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -40,7 +40,7 @@ type WorkListEntryProps = {|
   +work: WorkT,
 |};
 
-export const WorkListRow = withCatalystContext(({
+export const WorkListRow = withCatalystContext<WorkListRowProps>(({
   $c,
   checkboxes,
   seriesItemNumbers,

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -102,15 +102,15 @@ class WorkAttribute {
 
   allowedValuesByTypeID: {[number]: OptionListT};
 
-  attributeValue: (?string) => string;
+  attributeValue: KnockoutObservable<string>;
 
-  errors: (?$ReadOnlyArray<string>) => $ReadOnlyArray<string>;
+  errors: KnockoutObservableArray<string>;
 
   parent: ViewModel;
 
-  typeHasFocus: (?boolean) => boolean;
+  typeHasFocus: KnockoutObservable<boolean>;
 
-  typeID: (?number) => number;
+  typeID: KnockoutObservable<number>;
 
   constructor(
     data: WorkAttributeField,
@@ -167,8 +167,7 @@ class ViewModel {
 
   allowedValuesByTypeID: {[number]: OptionListT};
 
-  attributes: (?$ReadOnlyArray<WorkAttribute>) =>
-    $ReadOnlyArray<WorkAttribute>;
+  attributes: KnockoutObservableArray<WorkAttribute>;
 
   constructor(
     attributeTypes: WorkAttributeTypeTreeRootT,

--- a/root/types.js
+++ b/root/types.js
@@ -547,6 +547,19 @@ declare type IswcT = {|
   +work_id: number,
 |};
 
+declare type KnockoutObservable<T> = {
+  [[call]]: (() => T) & ((T) => empty),
+  peek: () => T,
+  subscribe: ((T) => void) => {dispose: () => empty},
+};
+
+declare type KnockoutObservableArray<T> =
+  & KnockoutObservable<$ReadOnlyArray<T>>
+  & {
+      push: (T) => empty,
+      remove: (T) => empty,
+    };
+
 declare type LabelT = {|
   ...AnnotationRoleT,
   ...CommentRoleT,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,10 +2712,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.98.1:
-  version "0.98.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.1.tgz#a8d781621c91703df69928acc83c9777e2fcbb49"
-  integrity sha512-y1YzQgbFUX4EG6h2EO8PhyJeS0VxNgER8XsTwU8IXw4KozfneSmGVgw8y3TwAOza7rVhTlHEoli1xNuNW1rhPw==
+flow-bin@0.100.0:
+  version "0.100.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.100.0.tgz#729902726658cfa0a81425d6401f9625cf9f5534"
+  integrity sha512-jcethhgrslBJukH7Z7883ohFFpzLrdsOEwHxvn5NwuTWbNaE71GAl55/PEBRJwYpDvYkRlqgcNkANTv0x5XjqA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
The main items from the changelog (https://github.com/facebook/flow/releases) that required fixing were:

 * "The statics of function types used to be any but are now typed as an empty object."
 * "Fix an issue where Flow would not catch certain errors involving React function components with unannotated props."
 * "Destructuring patterns could previously include missing properties if the resulting binding was unused. This is now an error even when unused."