### PR TITLE
Restore instrument type name in instrument page title

### DIFF
--- a/root/instrument/InstrumentLayout.js
+++ b/root/instrument/InstrumentLayout.js
@@ -31,11 +31,18 @@ const InstrumentLayout = ({
   fullWidth,
   page,
   title,
-}: Props) => (
+}: Props) => {
+  const nameWithType = texp.l('{type} “{instrument}”', {
+    instrument: localizeInstrumentName(instrument),
+    type: instrument.typeName
+      ? lp_attributes(instrument.typeName, 'instrument_type')
+      : l('Instrument'),
+  });
+  return (
   <Layout
     title={title
-      ? hyphenateTitle(localizeInstrumentName(instrument), title)
-      : localizeInstrumentName(instrument)}
+      ? hyphenateTitle(nameWithType, title)
+      : nameWithType}
   >
     <div id="content">
       <InstrumentHeader instrument={instrument} page={page} />
@@ -44,6 +51,6 @@ const InstrumentLayout = ({
     {fullWidth ? null : <InstrumentSidebar instrument={instrument} />}
   </Layout>
 );
-
+};
 
 export default InstrumentLayout;

--- a/root/instrument/InstrumentLayout.js
+++ b/root/instrument/InstrumentLayout.js
@@ -39,18 +39,18 @@ const InstrumentLayout = ({
       : l('Instrument'),
   });
   return (
-  <Layout
-    title={title
-      ? hyphenateTitle(nameWithType, title)
-      : nameWithType}
-  >
-    <div id="content">
-      <InstrumentHeader instrument={instrument} page={page} />
-      {children}
-    </div>
-    {fullWidth ? null : <InstrumentSidebar instrument={instrument} />}
-  </Layout>
-);
+    <Layout
+      title={title
+        ? hyphenateTitle(nameWithType, title)
+        : nameWithType}
+    >
+      <div id="content">
+        <InstrumentHeader instrument={instrument} page={page} />
+        {children}
+      </div>
+      {fullWidth ? null : <InstrumentSidebar instrument={instrument} />}
+    </Layout>
+  );
 };
 
 export default InstrumentLayout;

--- a/root/instrument/layout.tt
+++ b/root/instrument/layout.tt
@@ -2,7 +2,8 @@
         type => instrument.l_type_name or l('Instrument'),
         instrument => instrument.l_name
 }) ~%]
-[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title ~%]
+[%~ WRAPPER "layout.tt" title=title ? main_title _ " - ${title}" : main_title # Converted to React at root/instrument/InstrumentLayout.js
+~%]
     <div id="content">
         [%~ React.embed(c, 'instrument/InstrumentHeader', { instrument => instrument, page => page }) ~%]
         [%~ content ~%]


### PR DESCRIPTION
Restore instrument type name in instrument page title
----

Fix a small regression from https://github.com/metabrainz/musicbrainz-server/pull/869 noticed in https://github.com/metabrainz/musicbrainz-server/pull/1006#pullrequestreview-241396314: During React conversion (commit https://github.com/metabrainz/musicbrainz-server/commit/d2507d6d4ad41106833d8122ceac34e0c9c3587d for [MBS-10005](https://tickets.metabrainz.org/browse/MBS-10005)), instrument type name has been lost from instrument page title, this patch restores it.
