### PR TITLE
MBS-10212: Display artist name for SoundCloud URL with trailing slash

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/SoundCloud.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/SoundCloud.pm
@@ -13,9 +13,11 @@ sub sidebar_name {
     my $name = $self->decoded_local_part;
     # e.g. "/someartist/somesong" -> "someartist/somesong"
     $name =~ s{^/}{};
+    # e.g. "someartist/" -> "someartist"
+    $name =~ s{/$}{};
     # only show "SoundCloud" for URI parts containing slashes (e.g. songs),
     # since they are too long for the sidebar
-    return 'SoundCloud' if $name =~ /\//;
+    return 'SoundCloud' if $name =~ /\/.+/;
 
     return $name;
 }


### PR DESCRIPTION
Fix [MBS-10212](https://tickets.metabrainz.org/browse/MBS-10212): SoundCloud URL with trailing slash is not displayed with user name in artist sidebar
----
SoundCloud artist URL ending with a slash `/` was wrongly treated as SoundCloud song URL and displayed with generic 'SoundCloud' instead of artist name.