### PR TITLE
MBS-10223: Use relationship credits in ArtistRoles

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -711,9 +711,11 @@ sub schema_fixup
                 map {
                     my @relationships = @{ $relationship_map{$_} };
                     {
+                        # TODO: Pass the actual credit when SEARCH-585 is fixed
+                        credit => '',
                         entity => $relationships[0]->entity1,
-                            roles  => [ map { $_->link->type->name } grep { $_->link->type->entity1_type eq 'artist' } @relationships ]
-                        }
+                        roles  => [ map { $_->link->type->name } grep { $_->link->type->entity1_type eq 'artist' } @relationships ]
+                    }
                 } grep {
                     my @relationships = @{ $relationship_map{$_} };
                     any { $_->link->type->entity1_type eq 'artist' } @relationships;

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -51,6 +51,7 @@ has 'performers' => (
     is => 'ro',
     isa => ArrayRef[
         Dict[
+            credit => Str,
             roles => ArrayRef[Str],
             entity => Object
         ]
@@ -115,6 +116,7 @@ around TO_JSON => sub {
         }, $self->all_areas],
         cancelled => boolean_to_json($self->cancelled),
         performers => [map +{
+            credit => $_->{credit},
             entity => $_->{entity},
             roles => $_->{roles},
         }, $self->all_performers],

--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -45,6 +45,7 @@ has 'writers' => (
     is => 'ro',
     isa => ArrayRef[
         Dict[
+            credit => Str,
             roles => ArrayRef[Str],
             entity => Object
         ]
@@ -99,6 +100,7 @@ around TO_JSON => sub {
         iswcs => [map { $_->TO_JSON } $self->all_iswcs],
         artists => [map { $_->TO_JSON } $self->all_artists],
         writers => [map +{
+            credit => $_->{credit},
             entity => $_->{entity},
             roles => $_->{roles},
         }, $self->all_writers],

--- a/root/static/scripts/common/components/ArtistRoles.js
+++ b/root/static/scripts/common/components/ArtistRoles.js
@@ -16,6 +16,7 @@ import EntityLink from './EntityLink';
 
 type Props = {
   +relations: $ReadOnlyArray<{
+    +credit: string,
     +entity: ArtistT,
     +roles: $ReadOnlyArray<string>,
   }>,
@@ -26,7 +27,7 @@ const ArtistRoles = ({relations}: Props) => (
     {relations.map(r => (
       <li key={r.entity.id}>
         {exp.l('{artist} ({roles})', {
-          artist: <EntityLink entity={r.entity} />,
+          artist: <EntityLink content={r.credit} entity={r.entity} />,
           roles: commaOnlyList(localizeArtistRoles(r.roles)),
         })}
       </li>

--- a/root/types.js
+++ b/root/types.js
@@ -482,6 +482,7 @@ declare type EventT = $ReadOnly<{
   +areas: $ReadOnlyArray<{+entity: AreaT}>,
   +cancelled: boolean,
   +performers: $ReadOnlyArray<{
+    +credit: string,
     +entity: ArtistT,
     +roles: $ReadOnlyArray<string>,
   }>,
@@ -1101,6 +1102,7 @@ declare type WorkT = $ReadOnly<{
   +iswcs: $ReadOnlyArray<IswcT>,
   +languages: $ReadOnlyArray<WorkLanguageT>,
   +writers: $ReadOnlyArray<{
+    +credit: string,
     +entity: ArtistT,
     +roles: $ReadOnlyArray<string>,
   }>,

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -92,12 +92,14 @@ export function defineArtistCreditColumn<D>(
 
 export function defineArtistRolesColumn<D>(
   getRoles: (D) => $ReadOnlyArray<{
+    +credit: string,
     +entity: ArtistT,
     +roles: $ReadOnlyArray<string>,
   }>,
   columnName: string,
   title: string,
 ): ColumnOptions<D, $ReadOnlyArray<{
+      +credit: string,
       +entity: ArtistT,
       +roles: $ReadOnlyArray<string>,
 }>> {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10223

This makes it so that if a relationship used in ArtistRoles (work writers or event performers) has a relationship credit for the artist, the credit is also displayed in the ArtistRoles display.

The search results for works don't include credits for work relationships, so in search results the credits will be missing until SOLR-110 is fixed.