### PR TITLE
MBS-10229: Block more shortened/“smart” URLs

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -212,7 +212,8 @@ export class ExternalLinksEditor
             } else if (!isValidURL(link.url)) {
               error = l('Enter a valid url e.g. "http://google.com/"');
             } else if (isShortened(link.url)) {
-              error = l("Please don't use shortened URLs.");
+              error = l(`Please don’t enter bundled/shortened URLs,
+                         enter the destination URL(s) instead.`);
             } else if (!link.type) {
               error = l(`Please select a link type for the URL
                          you’ve entered.`);
@@ -541,18 +542,37 @@ function isValidURL(url) {
 
 const URL_SHORTENERS = [
   'adf.ly',
+  'band.link',
+  'biglink.to',
   'bit.ly',
+  'bitly.com',
+  'bruit.app',
   'cli.gs',
   'deck.ly',
+  'distrokid.com',
+  'fanlink.to',
+  'ffm.to',
+  'fty.li',
   'fur.ly',
   'goo.gl',
+  'hyperurl.co',
   'is.gd',
   'kl.am',
+  'laburbain.com',
+  'linkco.re',
+  'linktr.ee',
+  'listen.lt',
+  'lnk.bio',
   'lnk.co',
+  'lnk.to',
   'mcaf.ee',
   'moourl.com',
   'owl.ly',
   'rubyurl.com',
+  'smarturl.it',
+  'song.link',
+  'songwhip.com',
+  'spread.link',
   'su.pr',
   't.co',
   'tiny.cc',

--- a/t/selenium/External_Links_Editor.html
+++ b/t/selenium/External_Links_Editor.html
@@ -72,7 +72,7 @@
 <tr>
 	<td>assertText</td>
 	<td>xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]</td>
-	<td>Please don't use shortened URLs.</td>
+	<td>Please don’t enter bundled/shortened URLs, enter the destination URL(s) instead.</td>
 </tr>
 <tr>
 	<td>click</td>


### PR DESCRIPTION
Do [MBS-10229](https://tickets.metabrainz.org/browse/MBS-10229) block 12 more URL shorteners
----

Throw error message “Please don't use shortened URLs.”