### PR TITLE
MBS-10235: Drop format when reusing mediums

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -108,6 +108,7 @@
 
   <!-- ko if: searchResults() && searchResults().length > 0 -->
   <p>[% l('Select a medium from the search results below and then click "Add Medium".') %]</p>
+  <p>[% l('The tracklist for the medium (including the track/recording associations, but not other data such as medium format) will be loaded as a medium on this release.') %]</p>
   <!-- /ko -->
 
   <!-- ko if: totalPages() > 1 -->

--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -96,11 +96,14 @@ utils.search = function (resource, query, limit, offset) {
 
 
 utils.reuseExistingMediumData = function (data) {
-    // When reusing an existing medium, we don't want to keep its id or
-    // its cdtocs, since neither of those will be shared. However, if we
-    // haven't loaded the tracks yet, we retain the id as originalID so we
-    // can request them later.
-    var newData = _.omit(data, "id", "cdtocs");
+    /*
+     * When reusing an existing medium, we don't want to keep its id or
+     * its cdtocs, since neither of those will be shared. However, if we
+     * haven't loaded the tracks yet, we retain the id as originalID so we
+     * can request them later. We also drop the format, since it'll often
+     * be different.
+     */
+    var newData = _.omit(data, "id", "cdtocs", "format", "formatID");
 
     if (data.id) newData.originalID = data.id;
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10235

The medium format being kept when reusing a medium causes a lot of problems (when editors forget to unset it) yet it rarely is of any use: a tracklist being the same doesn't imply the format will be and in fact it's often the opposite, with the same release having CD, vinyl and digital versions, for example. This drops the format when reusing a medium, so that the user will have to either select a format or select the "I don't know" checkbox for it.