### PR TITLE
MBS-975: 301 redirect from track/ to recording/

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Track.pm
+++ b/lib/MusicBrainz/Server/Controller/Track.pm
@@ -37,6 +37,8 @@ sub show : Chained('load') PathPart('')
     if (defined ($c->stash->{recording}))
     {
         $uri = $c->uri_for_action('/recording/show', [ $c->stash->{recording}->gid ]);
+        # The track link is now a recording link: this should be considered a permanent move
+        $c->response->redirect($uri, 301);
     }
     else
     {
@@ -47,9 +49,10 @@ sub show : Chained('load') PathPart('')
         $uri = $c->uri_for_action('/release/show', [ $release_gid ]);
         $uri->path($uri->path . '/disc/' . $medium->position);
         $uri->fragment($track->gid);
+
+        $c->response->redirect($uri, 303);
     }
 
-    $c->response->redirect($uri, 303);
     $c->detach;
 }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-975

When we redirect an (old, pre-NGS) track link to a recording link, we should 301, not 303, since this is not a "see other" situation (such as with tracks in release tracklists) but a "this track permanently turned into this recording" situation. 

This was decided in a dev meeting in 2014, but never implemented (see jira comments)