### PR TITLE
MBS-10250: Distinguish Spotify links sidebar name

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
@@ -7,7 +7,15 @@ use MusicBrainz::Server::Translation qw( l );
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
-sub sidebar_name { l('Stream at Spotify') }
+sub sidebar_name {
+    my $self = shift;
+
+    if ($self->url =~ m{^(?:https?:)?//(?:[^/]+.)?spotify.com/user/[^/?&#]+/?}i) {
+        return l('Playlists at Spotify');
+    } else {
+        return l('Stream at Spotify');
+    }
+};
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
@@ -2,10 +2,12 @@ package MusicBrainz::Server::Entity::URL::Spotify;
 
 use Moose;
 
+use MusicBrainz::Server::Translation qw( l );
+
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
-sub sidebar_name { 'Stream at Spotify' }
+sub sidebar_name { l('Stream at Spotify') }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
### Fix [MBS-10250](https://tickets.metabrainz.org/browse/MBS-10250): User profile link on Spotify shows up as "Stream at Spotify"

See commit message for details.
Additionally localize Spotify URLs sidebar name.