### PR TITLE
MBS-10256: Unescape description HTML in rels editor

### DIFF
--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -12,6 +12,7 @@ import '../../../lib/jquery-ui';
 
 import {ENTITY_NAMES, PART_OF_SERIES_LINK_TYPES} from '../../common/constants';
 import {compare} from '../../common/i18n';
+import expand2react from '../../common/i18n/expand2react';
 import linkedEntities from '../../common/linkedEntities';
 import MB from '../../common/MB';
 import * as URLCleanup from '../../edit/URLCleanup';
@@ -347,7 +348,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             if (linkType && linkType.description) {
                 description = ReactDOMServer.renderToStaticMarkup(
                     exp.l("{description} ({url|more documentation})", {
-                        description: l_relationships(linkType.description),
+                        description: expand2react(l_relationships(linkType.description)),
                         url: { href: "/relationship/" + linkType.gid, target: "_blank" }
                     })
                 );


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10256

React's renderToStaticMarkup seems to be sanitizing the HTML in a way that means what Knockout actually gets is not directly usable in a HTML binding. So I'm parsing it back into HTML before displaying it.