### PR TITLE
MBS-1921: Display edit link under annotations

### DIFF
--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -92,14 +92,18 @@ const Annotation = ({
                 date: formatUserDate($c, annotation.creation_date),
                 user: <EditorLink editor={annotation.editor} />,
               })}
+              {' '}
               {numberOfRevisions && numberOfRevisions > 1 ? (
                 <>
-                  {' '}
                   <a href={entityHref(entity, '/annotations')}>
                     {l('View annotation history')}
                   </a>
+                  {' | '}
                 </>
               ) : null}
+              <a href={entityHref(entity, 'edit_annotation')}>
+                {l('Edit annotation')}
+              </a>
             </>
           ) : (
             exp.l(

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -29,7 +29,7 @@ type Props = {
   +annotation: ?$ReadOnly<{
     ...AnnotationT,
     +editor: EditorT | SanitizedEditorT | null,
-    ...
+    ...,
   }>,
   +collapse?: boolean,
   +entity: AnnotatedEntityT | MinimalAnnotatedEntityT,
@@ -41,10 +41,10 @@ type WritableProps = {
   annotation: ?{
     ...AnnotationT,
     editor: EditorT | SanitizedEditorT | null,
-    ...
+    ...,
   },
   entity: MinimalAnnotatedEntityT,
-  ...
+  ...,
 };
 
 const Annotation = ({


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-1921

This adds an extra "Edit annotation" link under annotations.
This link will make it clearer to users that they can edit the current annotation, which isn't always that clear at the moment since the only edit link is on the sidebar, very far away from the text.

Because the "View annotation history" link is already there sometimes, I'm separating them with a slash when that's the case. Seems cleaner than using brackets or periods.