### PR TITLE
MBS-2250: Go back when cancelling merge

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -56,7 +56,7 @@ role {
             if ($merger->ready_to_merge) {
                 $c->response->redirect(
                     $c->uri_for_action(
-                        $self->action_for('merge')));
+                        $self->action_for('merge'), { returnto => $c->req->referer }));
                 $c->detach;
             }
         }
@@ -86,7 +86,7 @@ role {
         my ($self, $c) = @_;
         delete $c->session->{merger};
         $c->res->redirect(
-            $c->req->referer || $c->uri_for('/'));
+            $c->req->query_params->{returnto} || $c->uri_for('/'));
         $c->detach;
     };
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-2250

The code already attempted to do this, but because the merge goes through a redirect (merge_queue -> merge) the referer was /merge itself, and it always redirected the user to the main page.
I don't see a less ugly way to do this than a returnto parameter, but we already use these elsewhere so it should be ok.