### PR TITLE
MBS-2176: Add "Finish" button to go to last tab

### DIFF
--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -59,6 +59,8 @@
 
       <button type="button" data-bind="visible: activeTabIndex() > 0" data-click="previousTab">[% l('« Previous') | html_entity %]</button>
       <button type="button" data-bind="visible: activeTabIndex() < tabCount - 1" data-click="nextTab">[% l('Next »') | html_entity %]</button>
+      <!-- For release adds, we want to make sure the user at least sees release duplicates -->
+      <button type="button" data-bind="visible: (activeTabIndex() > 0 || action === 'edit') && (activeTabIndex() < tabCount - 1)" data-click="lastTab">[% l('Finish') | html_entity %]</button>
 
       <!-- ko template: { if: activeTabID() === "#tracklist", data: addDiscDialog } -->
         <button type="button" data-click="open">[% l('Add Medium') %]</button>

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -27,6 +27,12 @@ const actions = {
 
     previousTab: function () { this.adjacentTab(-1) },
 
+    lastTab: function () { 
+        this.uiTabs._setOption("active", this.tabCount - 1);
+        this.uiTabs.tabs.eq(this.tabCount - 1).focus();
+        return;
+     },
+
     adjacentTab: function (direction) {
         var index = this.activeTabIndex();
         var disabled = this.uiTabs.options.disabled;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-2176

This adds a "Finish" button that goes straight to the Edit Note tab, to make it more clear that a user can go to the Edit Note tab and enter the edit from any tab, without having to go through every single one.