### PR TITLE
MBS-2614: Clearer message for edits waiting for ModBot

### DIFF
--- a/root/components/VotingPeriod.js
+++ b/root/components/VotingPeriod.js
@@ -51,7 +51,7 @@ const VotingPeriod = ({closingDate, user}: PropsT) => {
       {exactdate: userDate, num: duration.minutes()},
     );
   }
-  return l('Already closed');
+  return l('About to close');
 };
 
 export default VotingPeriod;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-2614

While the closing period for voting is exactly 7 days after the edit is entered (or more if extended), ModBot only applies them on the full hour mark (more or less). That means there's a fair amount of edits already past their "closing time", but still open and votable.

The current message "Already closed" suggests that no more votes will be accepted, but that is not the case: any votes entered before ModBot looks at the edit will still be as valid as the older ones. As such, changing it to "About to close" (without a specific time) seems like the easiest way to not have a misleading message anymore.