### PR TITLE
MBS-2905: Make CD Stub submission always include release artist

### DIFF
--- a/lib/MusicBrainz/Server/Form/CDStub.pm
+++ b/lib/MusicBrainz/Server/Form/CDStub.pm
@@ -24,6 +24,7 @@ has_field 'barcode' => (
 );
 
 has_field 'artist' => (
+    required => 1,
     type => '+MusicBrainz::Server::Form::Field::Text',
     maxlength => 255
 );
@@ -79,7 +80,7 @@ sub validate
     my $self = shift;
     if ($self->field('multiple_artists')->value) {
         $self->field('artist')->add_error(l('You may not specify a release artist while also specifying track artists.'))
-            if $self->field('artist')->value;
+            if $self->field('artist')->value && $self->field('artist')->value ne "Various Artists";
 
         for my $field ($self->field('tracks')->fields) {
             $field = $field->field('artist');
@@ -88,7 +89,6 @@ sub validate
         }
     }
     else {
-        $self->field('artist')->required(1);
         $self->field('artist')->validate_field;
 
         for my $field ($self->field('tracks')->fields) {

--- a/root/cdstub/edit_form.tt
+++ b/root/cdstub/edit_form.tt
@@ -35,11 +35,11 @@
                 artist_value = artist_field.value;
                 artist_field.value = "Various Artists";
                 track_artists(true);
-                artist_field.disabled = true;
+                artist_field.setAttribute("readonly", true);
             } else {
                 artist_field.value = artist_value;
                 track_artists(false);
-                artist_field.disabled = false;
+                artist_field.removeAttribute("readonly");
             }
         };
 

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -21,7 +21,7 @@ input::-webkit-input-placeholder { // webkit
     color: @dark-text;
 }
 input[disabled].lookup-performed,
-input[disabled] { background: @medium-bg; cursor: default; }
+input[disabled], input[readonly] { background: @medium-bg; cursor: default; }
 
 /* this is to ensure input/select/textarea elements are all the same
    width if you set the same width on them. (without this a <select>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-2905

For some weird reason, we have historically added a null release artist for various artists CD stubs. This changes it so that various artists CD stubs instead get a hardcoded "Various Artists" release artist.