### PR TITLE
MBS-10262: Let user know if new RG will be created

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -47,6 +47,8 @@
         </td>
       </tr>
 
+      [% table_row_help_message(2, 'showMessageRightAway: willCreateReleaseGroup', l('If you don’t select an existing release group, a new one will be created with the types selected below.')) %]
+
       [% table_row_error(2, 'showErrorWhenTabIsSwitched: needsReleaseGroup', l('You must select an existing release group.')) %]
 
       <!-- ko with: releaseGroup -->

--- a/root/release/edit/macros.tt
+++ b/root/release/edit/macros.tt
@@ -7,6 +7,15 @@
   </tr>
 [%- END %]
 
+[% MACRO table_row_help_message(colspan, data_bind, message) BLOCK -%]
+  <tr data-bind="[% data_bind %]">
+    <td></td>
+    <td colspan="[% colspan %]">
+      [%~ message IF message ~%]
+    </td>
+  </tr>
+[%- END %]
+
 [% MACRO table_row_select_options(options) BLOCK -%]
   [%- FOR opt=options %]
   [%- matches = opt.label.match('^((?:&#xa0;)*)(.*)') -%]

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -835,6 +835,10 @@ class Release extends MB_entity.Release {
             }
         });
 
+        this.willCreateReleaseGroup = function () {
+            return releaseEditor.action === "add" && !self.releaseGroup().gid;
+        };
+
         this.needsReleaseGroup = errorField(function () {
             return releaseEditor.action === "edit" && !self.releaseGroup().gid;
         });

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -70,6 +70,7 @@ ko.bindingHandlers.showErrorRightAway = {
     })
 };
 
+ko.bindingHandlers.showMessageRightAway = ko.bindingHandlers.showErrorRightAway;
 
 ko.bindingHandlers.showErrorWhenTabIsSwitched = {
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10262

Users sometimes don't realize that a new release group will be created if they don't select an existing release group when adding a release. This adds a message to let them know, that gets hidden if they select an existing RG.