### PR TITLE
MBS-10137: Fix guess feat. on recording pages

### DIFF
--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -360,7 +360,15 @@ class ArtistCreditEditor extends React.Component {
 
     return (
       <>
-        <table key="artist-credit-editor" className="artist-credit-editor">
+        <table
+          key="artist-credit-editor"
+          className="artist-credit-editor"
+          ref={node => {
+            if (node) {
+              $(node).data('componentInst', this);
+            }
+          }}
+        >
           <tbody>
             <tr>
               <td>

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -3,6 +3,7 @@
 // Licensed under the GPL version 2, or (at your option) any later version:
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
+import ko from 'knockout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -28,10 +29,17 @@ export const FormRowArtistCredit = ({form, entity}) => (
 
 MB.initializeArtistCredit = function (form, initialArtistCredit) {
   let source = MB.sourceEntity || {name: ''};
-  source.artistCredit = initialArtistCredit;
+  source.artistCredit = ko.observable(initialArtistCredit);
 
+  const container = document.getElementById('artist-credit-editor');
   ReactDOM.render(
     <FormRowArtistCredit entity={source} form={form} />,
-    document.getElementById('artist-credit-editor')
+    container,
   );
+
+  source.artistCredit.subscribe((artistCredit) => {
+    $('table.artist-credit-editor', container)
+      .data('componentInst')
+      .setState({artistCredit});
+  });
 };


### PR DESCRIPTION
Fix [MBS-10137](https://tickets.metabrainz.org/browse/MBS-10137): Guess feat button doesn't change AC on recording pages
----

The `guessFeat` function expects an entity's `artistCredit` to be an observable, which was previously only true on release pages. This is now made true on the other entity forms.

We also need a way to update the `ArtistCreditEditor` component when the observable changes. This is done by storing the component instance on the table node, and later calling `setState` on it. (Unfortunately, we can't just render `FormRowArtistCredit` again using a different key, because `ArtistCreditEditor` does some extremely bad things with `ArtistCreditBubble` that leave behind stale state. These components should hopefully be rewritten and changed to be fully controlled in the future.)