### PR TITLE
MBS-10209: Finetune instagram regex

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1227,7 +1227,17 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?instagram\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/([^?#]+[^\/?#])\/*(?:[?#].*)?$/, 'https://www.instagram.com/$1/');
+      // Ignore explore/photo URLs since we'll block them anyway
+      if (!(/^https:\/\/www\.instagram\.com\/(explore|p)\//.test(url))) {
+        // Point /stories/ sections to the main user profile instead
+        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/stories\/([^\/?#]+)\/?(?:[\/?#].*)?$/, 'https://www.instagram.com/$1/');
+        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/([^\/?#]+)\/?(?:[\/?#].*)?$/, 'https://www.instagram.com/$1/');
+      }
+      return url;
+    },
+    validate: function (url) {
+      // Block explore/photo URLs, which aren't really a social network link
+      return !(/^https:\/\/www\.instagram\.com\/(explore|p)\//.test(url));
     },
   },
   'irishtune': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1601,12 +1601,35 @@ const testData = [
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://www.instagram.com/deadmau5/',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
                      input_url: 'https://i.instagram.com/yorickvannorden/?ref=badge',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://www.instagram.com/yorickvannorden/',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.instagram.com/stories/nathanwpylestrangeplanet/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.instagram.com/nathanwpylestrangeplanet/',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.instagram.com/p/B3Mew-Cl2Z9/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.instagram.com/p/B3Mew-Cl2Z9/',
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://www.instagram.com/explore/locations/277133756/pacha-club-ibiza/',
+             input_entity_type: 'place',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.instagram.com/explore/locations/277133756/pacha-club-ibiza/',
+       only_valid_entity_types: [],
   },
   // Irish Traditional Music Tune Index (Alan Ng's Tunography)
   {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10209

The current instagram regex means that if a user starts typing the URL by hand, it will add the slash at the end and let the user keep typing, eventually leading to something like instagram.com/s/o/m/e/t/h/i/n/g/

This changes the regex so that it doesn't allow typing anything after the first slash in the user name section. While this means the user can't just type the whole URL in one go, it does avoid it turning into a mess, and the user can just move back to before the slash and finish typing.

It also redirects stories links to the main user page (those can easily be accessed from the user page anyway), and blocks posts (/p/) and post location (/explore/) pages, since those aren't correctly selected as "social network" and there's no particular reason to let them be added as anything else at the moment.