### PR TITLE
MBS-10268: Use DescriptiveLink for the RG bubble

### DIFF
--- a/root/edit/details/AddArtist.js
+++ b/root/edit/details/AddArtist.js
@@ -42,6 +42,9 @@ type AddArtistEditT = {|
 
 const AddArtist = ({edit}: {edit: AddArtistEditT}) => {
   const display = edit.display_data;
+  const area = display.area;
+  const beginArea = display.begin_area;
+  const endArea = display.end_area;
   const gender = display.gender;
   const type = display.type;
 
@@ -90,12 +93,12 @@ const AddArtist = ({edit}: {edit: AddArtistEditT}) => {
           </tr>
         ) : null}
 
-        {display.area ? (
+        {area ? (
           <tr>
             <th>{addColon(l('Area'))}</th>
             <td>
               <DescriptiveLink
-                entity={display.area}
+                entity={area}
               />
             </td>
           </tr>
@@ -108,12 +111,12 @@ const AddArtist = ({edit}: {edit: AddArtistEditT}) => {
           </tr>
         )}
 
-        {display.begin_area ? (
+        {beginArea ? (
           <tr>
             <th>{artistBeginAreaLabel(type ? type.id : null)}</th>
             <td>
               <DescriptiveLink
-                entity={display.begin_area}
+                entity={beginArea}
               />
             </td>
           </tr>
@@ -126,12 +129,12 @@ const AddArtist = ({edit}: {edit: AddArtistEditT}) => {
           </tr>
         )}
 
-        {display.end_area ? (
+        {endArea ? (
           <tr>
             <th>{artistEndAreaLabel(type ? type.id : null)}</th>
             <td>
               <DescriptiveLink
-                entity={display.end_area}
+                entity={endArea}
               />
             </td>
           </tr>

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -17,14 +17,16 @@ type DescriptiveLinkProps = {
   +content?: React.Node,
   +entity: CoreEntityT,
   +showDeletedArtists?: boolean,
+  +target?: '_blank',
 };
 
 const DescriptiveLink = ({
   content,
   entity,
   showDeletedArtists = true,
+  target,
 }: DescriptiveLinkProps) => {
-  const props = {content, showDisambiguation: true};
+  const props = {content, showDisambiguation: true, target};
 
   if (entity.entityType === 'area' && entity.gid) {
     return <AreaWithContainmentLink area={entity} {...props} />;

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -1,4 +1,5 @@
 /*
+ * @flow
  * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015—2016 MetaBrainz Foundation
  * Licensed under the GPL version 2, or (at your option) any later version:
@@ -6,20 +7,29 @@
  */
 
 import ko from 'knockout';
-import React from 'react';
+import * as React from 'react';
 
 import AreaWithContainmentLink from './AreaWithContainmentLink';
 import ArtistCreditLink from './ArtistCreditLink';
 import EntityLink from './EntityLink';
 
-const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
+type DescriptiveLinkProps = {
+  +content?: React.Node,
+  +entity: CoreEntityT,
+  +showDeletedArtists?: boolean,
+};
+
+const DescriptiveLink = ({
+  content,
+  entity,
+  showDeletedArtists = true,
+}: DescriptiveLinkProps) => {
   const props = {content, showDisambiguation: true};
 
   if (entity.entityType === 'area' && entity.gid) {
     return <AreaWithContainmentLink area={entity} {...props} />;
   }
 
-  props.key = 0;
   const link = <EntityLink entity={entity} {...props} />;
 
   if (entity.artistCredit) {
@@ -27,7 +37,6 @@ const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
       artist: (
         <ArtistCreditLink
           artistCredit={ko.unwrap(entity.artistCredit)}
-          key={1}
           showDeleted={showDeletedArtists}
         />
       ),
@@ -37,7 +46,7 @@ const DescriptiveLink = ({entity, content, showDeletedArtists = true}) => {
 
   if (entity.entityType === 'place' && entity.area) {
     return exp.l('{place} in {area}', {
-      area: <AreaWithContainmentLink area={entity.area} key="area" />,
+      area: <AreaWithContainmentLink area={entity.area} />,
       place: link,
     });
   }

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -11,6 +11,7 @@ import ReactDOMServer from 'react-dom/server';
 import ArtistCreditLink from './components/ArtistCreditLink';
 import EditorLink from './components/EditorLink';
 import EntityLink from './components/EntityLink';
+import DescriptiveLink from './components/DescriptiveLink';
 import {
   ENTITY_NAMES,
   PART_OF_SERIES_LINK_TYPES,
@@ -317,7 +318,7 @@ import formatTrackLength from './utility/formatTrackLength';
         selectionMessage() {
             return ReactDOMServer.renderToStaticMarkup(
                 exp.l('You selected {releasegroup}.', {
-                    releasegroup: this.reactElement({target: '_blank'}),
+                    releasegroup: <DescriptiveLink entity={this} />,
                 })
             );
         }

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -318,7 +318,7 @@ import formatTrackLength from './utility/formatTrackLength';
         selectionMessage() {
             return ReactDOMServer.renderToStaticMarkup(
                 exp.l('You selected {releasegroup}.', {
-                    releasegroup: <DescriptiveLink entity={this} />,
+                    releasegroup: <DescriptiveLink entity={this} target="_blank" />,
                 })
             );
         }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10268

Knowing the release group artist(s) is quite useful, so this changes the release group bubble in the release editor to use DescriptiveLink, which shows both title and AC rather than just title as before.