### PR TITLE
MBS-3112: Switch order of release editor buttons

### DIFF
--- a/root/components/ConfirmLayout.js
+++ b/root/components/ConfirmLayout.js
@@ -24,17 +24,19 @@ const ConfirmLayout = ({action, question, title}: Props) => (
     <form action={action} method="post">
       <span className="buttons">
         <button
+          name="confirm.submit"
+          type="submit"
+          value="1"
+        >
+          {l('Yes, I am sure')}
+        </button>
+        <button
           className="negative"
           name="confirm.cancel"
           type="submit"
           value="1"
-        >{l('Cancel')}
-        </button>
-        <button
-          name="confirm.submit"
-          type="submit"
-          value="1"
-        >{l('Yes, I am sure')}
+        >
+          {l('Cancel')}
         </button>
       </span>
     </form>

--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -55,7 +55,7 @@
     </div>
 
     <div class="buttons">
-      <button type="button" class="negative" data-click="cancelPage">[% l('Cancel') | html_entity %]</button>
+      <button type="button" id="enter-edit" class="positive" data-click="submitEdits" data-bind="visible: activeTabID() === '#edit-note', enable: allowsSubmission()">[% l('Enter edit') %]</button>
 
       <button type="button" data-bind="visible: activeTabIndex() > 0" data-click="previousTab">[% l('« Previous') | html_entity %]</button>
       <button type="button" data-bind="visible: activeTabIndex() < tabCount - 1" data-click="nextTab">[% l('Next »') | html_entity %]</button>
@@ -64,7 +64,7 @@
         <button type="button" data-click="open">[% l('Add Medium') %]</button>
       <!-- /ko -->
 
-      <button type="button" id="enter-edit" class="positive" data-click="submitEdits" data-bind="visible: activeTabID() === '#edit-note', enable: allowsSubmission()">[% l('Enter edit') %]</button>
+      <button type="button" class="negative" data-click="cancelPage">[% l('Cancel') | html_entity %]</button>
     </div>
   </div>
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-3112

Other menus (e.g. merge menus) have Enter first, Cancel second. This doesn't matter too much for normal clicking but it makes a lot of difference in the tab order (when navigating with the keyboard).

In the release editor, we generally want to submit the edits if we're in the edit note page, and otherwise navigate either forwards or backwards, much more often than we want to cancel the whole thing (which in my experience is easier done by closing the window anyway).