### PR TITLE
MBS-10274: Make sure to run postgres to listen on localhost

### DIFF
--- a/docker/musicbrainz-test-database/create_test_db.sh
+++ b/docker/musicbrainz-test-database/create_test_db.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pg_ctl -o "-c listen_addresses='localhost'" -w restart
 cd /home/musicbrainz/musicbrainz-server
 if [ "$MB_IMPORT_DUMPS" = "true" ]; then
     carton exec -- ./docker/scripts/import_db.sh


### PR DESCRIPTION
Run `postgres` and listen on localhost before trying to create database and setup schema. I think after changes due to https://github.com/docker-library/postgres/pull/440, during internal initialization, postgres only accepts connections over a unix domain socket. Please steer in the right direction if this issue should be handled differently :) (Ticket link: https://tickets.metabrainz.org/browse/MBS-10274)