### PR TITLE
MBS-10248: Show relationship types in instrument lists

### DIFF
--- a/root/components/InstrumentRelTypes.js
+++ b/root/components/InstrumentRelTypes.js
@@ -1,0 +1,42 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {commaOnlyListText} from '../static/scripts/common/i18n/commaOnlyList';
+import {bracketedText} from '../static/scripts/common/utility/bracketed';
+
+type Props = {
+  ...InstrumentCreditsAndRelTypesRoleT,
+  +entity: RecordingT | ReleaseT,
+};
+
+const InstrumentRelTypes = ({
+  entity,
+  instrumentCreditsAndRelTypes,
+}: Props) => (
+  <td>
+    {instrumentCreditsAndRelTypes &&
+      instrumentCreditsAndRelTypes[entity.gid] ? (
+        commaOnlyListText(
+          instrumentCreditsAndRelTypes[entity.gid].map(json => {
+            const relType = JSON.parse(json);
+            let listElement = l_relationships(relType.name);
+            if (relType.credit) {
+              listElement = listElement + ' ' +
+                bracketedText(texp.l('as “{credit}”', {credit: relType.credit}));
+            }
+            return listElement;
+          }),
+        )
+      ) : null}
+  </td>
+);
+
+export default InstrumentRelTypes;

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -11,7 +11,6 @@ import React from 'react';
 
 import {withCatalystContext} from '../../context';
 import loopParity from '../../utility/loopParity';
-import {commaListText} from '../../static/scripts/common/i18n/commaList';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 import CodeLink from '../../static/scripts/common/components/CodeLink';
@@ -20,13 +19,14 @@ import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
 import renderMergeCheckboxElement
   from '../../static/scripts/common/utility/renderMergeCheckboxElement';
+import InstrumentRelTypes from '../InstrumentRelTypes';
 import RatingStars from '../RatingStars';
 import RemoveFromMergeTableCell from '../RemoveFromMergeTableCell';
 import RemoveFromMergeTableHeader from '../RemoveFromMergeTableHeader';
 import SortableTableHeader from '../SortableTableHeader';
 
 type Props = {
-  ...InstrumentCreditsRoleT,
+  ...InstrumentCreditsAndRelTypesRoleT,
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
   +checkboxes?: string,
@@ -34,7 +34,7 @@ type Props = {
   +mergeForm?: MergeFormT,
   +order?: string,
   +recordings: $ReadOnlyArray<RecordingT>,
-  +showInstrumentCredits?: boolean,
+  +showInstrumentCreditsAndRelTypes?: boolean,
   +showRatings?: boolean,
   +sortable?: boolean,
 };
@@ -42,13 +42,13 @@ type Props = {
 const RecordingList = ({
   $c,
   checkboxes,
-  instrumentCredits,
+  instrumentCreditsAndRelTypes,
   lengthClass,
   mergeForm,
   order,
   recordings,
   seriesItemNumbers,
-  showInstrumentCredits,
+  showInstrumentCreditsAndRelTypes,
   showRatings,
   sortable,
 }: Props) => (
@@ -96,7 +96,9 @@ const RecordingList = ({
             )
             : l('Length')}
         </th>
-        {showInstrumentCredits ? <th>{l('Instrument Credits')}</th> : null}
+        {showInstrumentCreditsAndRelTypes
+          ? <th>{l('Relationship Types')}</th>
+          : null}
         {mergeForm
           ? <RemoveFromMergeTableHeader toMerge={recordings} />
           : null}
@@ -149,12 +151,11 @@ const RecordingList = ({
             {/* Show nothing rather than ?:?? for recordings merged away */}
             {recording.gid ? formatTrackLength(recording.length) : null}
           </td>
-          {showInstrumentCredits ? (
-            <td>
-              {instrumentCredits && instrumentCredits[recording.gid]
-                ? commaListText(instrumentCredits[recording.gid])
-                : null}
-            </td>
+          {showInstrumentCreditsAndRelTypes ? (
+            <InstrumentRelTypes
+              entity={recording}
+              instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+            />
           ) : null}
           {mergeForm ? (
             <RemoveFromMergeTableCell

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -11,11 +11,11 @@ import React from 'react';
 
 import {withCatalystContext} from '../../context';
 import loopParity from '../../utility/loopParity';
+import InstrumentRelTypes from '../InstrumentRelTypes';
 import ReleaseCatnoList from '../ReleaseCatnoList';
 import ReleaseCountries from '../ReleaseCountries';
 import ReleaseDates from '../ReleaseDates';
 import ReleaseLabelList from '../ReleaseLabelList';
-import commaList from '../../static/scripts/common/i18n/commaList';
 import filterReleaseLabels
   from '../../static/scripts/common/utility/filterReleaseLabels';
 import formatBarcode from '../../static/scripts/common/utility/formatBarcode';
@@ -27,14 +27,14 @@ import RatingStars from '../RatingStars';
 import SortableTableHeader from '../SortableTableHeader';
 
 type Props = {
-  ...InstrumentCreditsRoleT,
+  ...InstrumentCreditsAndRelTypesRoleT,
   ...SeriesItemNumbersRoleT,
   +$c: CatalystContextT,
   +checkboxes?: string,
   +filterLabel?: LabelT,
   +order?: string,
   +releases: $ReadOnlyArray<ReleaseT>,
-  +showInstrumentCredits?: boolean,
+  +showInstrumentCreditsAndRelTypes?: boolean,
   +showRatings?: boolean,
   +sortable?: boolean,
 };
@@ -43,11 +43,11 @@ const ReleaseList = ({
   $c,
   checkboxes,
   filterLabel,
-  instrumentCredits,
+  instrumentCreditsAndRelTypes,
   order,
   releases,
   seriesItemNumbers,
-  showInstrumentCredits,
+  showInstrumentCreditsAndRelTypes,
   showRatings,
   sortable,
 }: Props) => (
@@ -162,7 +162,7 @@ const ReleaseList = ({
             : l('Barcode')}
         </th>
         {showRatings ? <th>{l('Rating')}</th> : null}
-        {showInstrumentCredits ? <th>{l('Instrument Credits')}</th> : null}
+        {showInstrumentCreditsAndRelTypes ? <th>{l('Relationship Types')}</th> : null}
         {$c.session && $c.session.tport ? <th>{l('Tagger')}</th> : null}
       </tr>
     </thead>
@@ -227,12 +227,11 @@ const ReleaseList = ({
               ) : null}
             </td>
           ) : null}
-          {showInstrumentCredits ? (
-            <td>
-              {instrumentCredits && instrumentCredits[release.gid]
-                ? commaList(instrumentCredits[release.gid])
-                : null}
-            </td>
+          {showInstrumentCreditsAndRelTypes ? (
+            <InstrumentRelTypes
+              entity={release}
+              instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+            />
           ) : null}
           {$c.session && $c.session.tport ? (
             <td>

--- a/root/instrument/recordings.tt
+++ b/root/instrument/recordings.tt
@@ -4,7 +4,7 @@
     [%- IF recordings.size -%]
         <form action="[% c.uri_for_action('/recording/merge_queue') %]"
             method="post">
-            [% React.embed(c, 'components/list/RecordingList', { recordings => recordings, checkboxes => 'add-to-merge', showRatings => 1, showInstrumentCredits => 1, instrumentCredits => instrument_credits })
+            [% React.embed(c, 'components/list/RecordingList', { recordings => recordings, checkboxes => 'add-to-merge', showRatings => 1, showInstrumentCreditsAndRelTypes => 1, instrumentCreditsAndRelTypes => instrument_credits_and_rel_types })
                 WRAPPER 'components/with-pager.tt' -%]
             [% form_submit(l('Add selected recordings for merging')) WRAPPER form_row IF c.user_exists %]
         </form>

--- a/root/instrument/releases.tt
+++ b/root/instrument/releases.tt
@@ -4,7 +4,7 @@
     [%- IF releases.size -%]
       <form action="[% c.uri_for_action('/release/merge_queue') %]"
             method="post">
-        [% React.embed(c, 'components/list/ReleaseList', { releases => releases, checkboxes => 'add-to-merge', showInstrumentCredits => 1, instrumentCredits => instrument_credits})
+        [% React.embed(c, 'components/list/ReleaseList', { releases => releases, checkboxes => 'add-to-merge', showInstrumentCreditsAndRelTypes => 1, instrumentCreditsAndRelTypes => instrument_credits_and_rel_types})
             WRAPPER 'components/with-pager.tt' -%]
         [% form_submit(l('Add selected releases for merging')) WRAPPER form_row IF c.user_exists %]
       </form>

--- a/root/types.js
+++ b/root/types.js
@@ -552,8 +552,10 @@ declare type GroupedOptionsT = $ReadOnlyArray<{
   +options: SelectOptionsT,
 }>;
 
-declare type InstrumentCreditsRoleT = {
-  +instrumentCredits?: {+[string]: $ReadOnlyArray<string>},
+declare type InstrumentCreditsAndRelTypesRoleT = {
+  +instrumentCreditsAndRelTypes?: {
+    +[string]: $ReadOnlyArray<string>,
+  },
 };
 
 declare type InstrumentT = {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10248

Sometimes it can be useful to distinguish whether an artist played an instrument in a recording, or programmed it, or arranged it.
This changes the credit column to a roles column, with the credit also shown when it exists.