### PR TITLE
MBS-10139 (fixup): Make the doc link open in a new tab

### DIFF
--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -31,7 +31,7 @@
           <label>[% l('Length:') %]</label>
           [% l('{recording_length} ({length_info|derived} from the associated track lengths)',
                 recording_length => format_length(form.field('length').value),
-                length_info => doc_link('Recording') ) %]
+                length_info => { href => doc_link('Recording'), target => '_blank' } ) %]
         [%- END -%]
       [%- END -%]
       [%- form_row_checkbox(r, 'video', l('Video')) -%]


### PR DESCRIPTION
Amendment to https://github.com/metabrainz/musicbrainz-server/pull/1037 - because this is in an editor page, and we don't want opening the link to mess up a user's changes.