### PR TITLE
MBS-9976: Check work is defined before loading stuff

### DIFF
--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -51,6 +51,8 @@ sub load
 sub load_for_works {
     my ($self, @objs) = @_;
 
+    @objs = grep { defined $_ } @objs;
+
     $self->c->model('Work')->language->load_for(@objs);
 
     load_subobjects($self, 'language', map { $_->all_languages } @objs);

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -320,7 +320,7 @@ sub load_writers
 {
     my ($self, @works) = @_;
 
-    @works = grep { scalar $_->all_writers == 0 } @works;
+    @works = grep { defined $_ && scalar $_->all_writers == 0 } @works;
     my @ids = map { $_->id } @works;
     return () unless @ids;
 
@@ -374,7 +374,7 @@ sub load_recording_artists
 {
     my ($self, @works) = @_;
 
-    @works = grep { scalar $_->all_artists == 0 } @works;
+    @works = grep { defined $_ && scalar $_->all_artists == 0 } @works;
     my @ids = map { $_->id } @works;
     return () unless @ids;
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9976

In the ISWC report (at least) we sometimes get works that have been merged away since, and the work not being defined causes an ISE. This patch fixes that by ensuring writers, artists and language are only loaded for works that are defined.