### PR TITLE
MBS-7097: Avoid listing releases multiple times

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithDownloadRelationships.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithDownloadRelationships.pm
@@ -6,17 +6,23 @@ with 'MusicBrainz::Server::Report::ReleaseReport',
 
 sub query {
     "
-        SELECT
-            DISTINCT r.id AS release_id,
-            row_number() OVER (ORDER BY musicbrainz_collate(ac.name), musicbrainz_collate(r.name))
-        FROM
-            release r
-            JOIN artist_credit ac ON r.artist_credit = ac.id
-            JOIN l_release_url lru ON lru.entity0 = r.id
-            JOIN link ON lru.link = link.id
-            JOIN medium ON r.id = medium.release
-        WHERE link.link_type IN (74, 75)
-          AND medium.format != 12
+        SELECT DISTINCT r.id AS release_id,
+        row_number() OVER (ORDER BY musicbrainz_collate(ac.name), musicbrainz_collate(r.name))
+          FROM release r
+          JOIN artist_credit ac ON r.artist_credit = ac.id
+        WHERE EXISTS (
+            SELECT TRUE
+                FROM medium
+            WHERE medium.release = r.id
+                AND medium.format != 12
+        )
+        AND EXISTS (
+            SELECT TRUE
+                FROM l_release_url lru
+                JOIN link ON lru.link = link.id
+            WHERE lru.entity0 = r.id 
+                AND link.link_type IN (74, 75)
+        )
     ";
 }
 

--- a/lib/MusicBrainz/Server/Report/ReleasesWithDownloadRelationships.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithDownloadRelationships.pm
@@ -6,22 +6,24 @@ with 'MusicBrainz::Server::Report::ReleaseReport',
 
 sub query {
     "
-        SELECT DISTINCT r.id AS release_id,
-        row_number() OVER (ORDER BY musicbrainz_collate(ac.name), musicbrainz_collate(r.name))
-          FROM release r
-          JOIN artist_credit ac ON r.artist_credit = ac.id
+        SELECT
+            DISTINCT r.id AS release_id,
+            row_number() OVER (ORDER BY musicbrainz_collate(ac.name), musicbrainz_collate(r.name))
+        FROM
+            release r
+            JOIN artist_credit ac ON r.artist_credit = ac.id
         WHERE EXISTS (
             SELECT TRUE
-                FROM medium
+            FROM medium
             WHERE medium.release = r.id
-                AND medium.format != 12
-        )
-        AND EXISTS (
+              AND medium.format != 12
+        ) AND EXISTS (
             SELECT TRUE
-                FROM l_release_url lru
+            FROM
+                l_release_url lru
                 JOIN link ON lru.link = link.id
             WHERE lru.entity0 = r.id 
-                AND link.link_type IN (74, 75)
+              AND link.link_type IN (74, 75)
         )
     ";
 }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-7097

The old query had one line for each non-digital medium, and one line for each download relationship. We only need one line per release, so the two conditions are moved to subqueries. We check that at least one medium is non-digital, since if the whole thing isn't digital then it follows you can't just download the whole thing.