### PR TITLE
MBS-5755: Improved unlikely language/script pairs

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
@@ -14,13 +14,17 @@ sub query {
             JOIN artist_credit ac ON r.artist_credit = ac.id
             JOIN script ON r.script = script.id
             JOIN language ON r.language = language.id
-        WHERE
-            script.iso_code != 'Latn' AND
+        WHERE (
+            script.iso_code NOT IN ('Kana', 'Latn', 'Qaaa') AND 
             language.iso_code_3 IN (
               'eng', 'spa', 'deu', 'fra', 'por', 'ita', 'swe', 'nor', 'fin',
               'est', 'lav', 'lit', 'pol', 'nld', 'cat', 'hun', 'ces', 'slk',
               'dan', 'ron', 'slv', 'hrv'
             )
+        ) OR (
+            language.iso_code_3 = 'jpn' AND 
+            script.iso_code NOT IN ('Hira', 'Hrkt', 'Kana', 'Jpan', 'Latn', 'Qaaa') 
+        ) 
     ";
 }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5755

All Western languages can also be transliterated into Katakana, and since a combination of Latin and Katakana is possible, [multiple scripts] should be accepted.
Additionally, Japanese is usually written in a specific number of scripts as well, so limiting it to Japanese scripts, Latin (for transliterations) and [multiple scripts].