### PR TITLE
MBS-3920: Add more matching to Featuring reports

### DIFF
--- a/lib/MusicBrainz/Server/Report/FeaturingRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingRecordings.pm
@@ -12,8 +12,8 @@ sub query {
         FROM recording r
             JOIN artist_credit ac ON r.artist_credit = ac.id
         WHERE
-            r.name ~ E' \\\\(feat\\\\. '
-    "
+            r.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
+    ";
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Report/FeaturingReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingReleaseGroups.pm
@@ -14,7 +14,7 @@ sub query {
             JOIN artist_credit ac ON rg.artist_credit = ac.id
             JOIN release_group_meta rm ON rg.id = rm.id
         WHERE
-            rg.name ~ E' \\\\(feat\\\\. '
+            rg.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
     ";
 }
 

--- a/lib/MusicBrainz/Server/Report/FeaturingReleases.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingReleases.pm
@@ -14,7 +14,7 @@ sub query {
             JOIN artist_credit ac ON r.artist_credit = ac.id
             JOIN release_meta rm ON r.id = rm.id
         WHERE
-            r.name ~ E' \\\\(feat\\\\. '
+            r.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
     ";
 }
 

--- a/root/report/FeaturingRecordings.js
+++ b/root/report/FeaturingRecordings.js
@@ -34,13 +34,13 @@ const FeaturingRecordings = ({
     <ul>
       <li>
         {exp.l(
-          `This report shows recordings with (feat. Artist) in the
-           title. For classical recordings, consult the
-           {CSG|classical style guidelines}. For non-classical recordings,
-           this is inherited from an older version of MusicBrainz
-           and should be fixed (both on the recordings and on the tracks!).
-           Consult the {featured_artists|page about featured artists}
-           to know more.`,
+          `This report shows recordings with “(feat. Artist)” 
+           (or similar) in the title. For classical recordings, 
+           consult the {CSG|classical style guidelines}. For 
+           non-classical recordings, this is usually inherited from an
+           older version of MusicBrainz and should be fixed  (both on 
+           the recordings and on the tracks!). Consult the
+           {featured_artists|page about featured artists} to know more.`,
           {
             CSG: '/doc/Style/Classical',
             featured_artists: '/doc/Style/Artist_Credits#Featured_artists',

--- a/root/report/FeaturingReleaseGroups.js
+++ b/root/report/FeaturingReleaseGroups.js
@@ -34,11 +34,11 @@ const FeaturingReleaseGroups = ({
     <ul>
       <li>
         {exp.l(
-          `This report shows release groups with (feat. Artist) in the
-           title. For classical release groups, consult the
-           {CSG|classical style guidelines}. For non-classical release
-           groups, this is inherited from an older version of MusicBrainz
-           and should be fixed. Consult the
+          `This report shows release groups with “(feat. Artist)” 
+           (or similar) in the title. For classical release groups, 
+           consult the {CSG|classical style guidelines}. For 
+           non-classical release groups, this is usually inherited from an
+           older version of MusicBrainz and should be fixed. Consult the
            {featured_artists|page about featured artists} to know more.`,
           {
             CSG: '/doc/Style/Classical',

--- a/root/report/FeaturingReleases.js
+++ b/root/report/FeaturingReleases.js
@@ -34,11 +34,15 @@ const FeaturingReleases = ({
     <ul>
       <li>
         {exp.l(
-          `This report shows releases with (feat. Artist) in the title. For
-          classical releases, consult the {CSG|classical style guidelines}.
-          For non-classical releases, this is inherited from an older
-          version of MusicBrainz and should be fixed. Consult the
-          {featured_artists|page about featured artists} to know more.`,
+          `This report shows releases with “(feat. Artist)”
+           (or similar) in the title. For classical releases, 
+           consult the {CSG|classical style guidelines}. For 
+           non-classical releases, this is usually inherited from an
+           older version of MusicBrainz and should be fixed. Consult the
+           {featured_artists|page about featured artists} to know more.
+           Don’t forget that the same generally applies to tracks, so if
+           the track titles also include featuring credits you can fix
+           them too while you edit the release!`,
           {
             CSG: '/doc/Style/Classical',
             featured_artists: '/doc/Style/Artist_Credits#Featured_artists',


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-3920

This extends the Featuring reports with more options that also mostly mean the artist needs to be fixed: "f/", "featuring", "ft.", "w/" and "duet with". It does not add other similar options (such as "con", "avec", "with") because they seem to cause too many false positives (mostly but not only related to classical music).