### PR TITLE
MBS-4538: Prevent years with less than 4 digits

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/PartialDate.pm
+++ b/lib/MusicBrainz/Server/Form/Field/PartialDate.pm
@@ -7,7 +7,8 @@ use Date::Calc ();
 extends 'HTML::FormHandler::Field::Compound';
 
 has_field 'year' => (
-    type => '+MusicBrainz::Server::Form::Field::Integer'
+    type => '+MusicBrainz::Server::Form::Field::Integer',
+    deflate_method => sub { defined $_[1] ? sprintf '%.4d', $_[1] : undef },
 );
 
 has_field 'month' => (

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -36,6 +36,7 @@
             [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
         </p>
         [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+        [% too_short_year_error('too_short_begin_year') %]
         [% WRAPPER form_row %]
           [% begin_area_field = form.field('begin_area.name') %]
           <label id="label-id-edit-artist.begin_area.name" for="id-edit-artist.begin_area.name">[% l('Begin Area:') %]</label>
@@ -48,6 +49,7 @@
           [% field_errors(r.form, 'begin_area.name') %]
         [% END %]
         [% form_row_date(r, 'period.end_date', l('End date:')) %]
+        [% too_short_year_error('too_short_end_year') %]
         [% form_row_checkbox(r, 'period.ended', l('This artist has ended.')) %]
         [% WRAPPER form_row %]
           [% end_area_field = form.field('end_area.name') %]
@@ -112,5 +114,7 @@
     [%- END %]
 
     MB.initializeDuplicateChecker('artist');
+
+    [% too_short_year_js('artist') %]
   }());
 </script>

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -187,6 +187,36 @@
     [% END %]
 [%- END -%]
 
+[%- MACRO too_short_year_js(type) BLOCK -%]
+  function blockTooShortBeginYear() {
+    var beginYear = $('#id-edit-[% type %]\\\.period\\\.begin_date\\\.year').val();
+    var allowed = (!beginYear || beginYear.trim().length === 4);
+    $('.submit').prop('disabled', !allowed);
+    $('#too_short_begin_year').toggle(!allowed);
+  }
+
+  function blockTooShortEndYear() {
+    var endYear = $('#id-edit-[% type %]\\\.period\\\.end_date\\\.year').val();
+    var allowed = (endYear === null || endYear === '' || endYear.length === 4);
+    $('.submit').prop('disabled', !allowed);
+    $('#too_short_end_year').toggle(!allowed);
+  }
+
+  $('#id-edit-[% type %]\\\.period\\\.begin_date\\\.year').keyup(_.debounce(blockTooShortBeginYear, 500)).change(_.debounce(blockTooShortBeginYear, 500));
+  blockTooShortBeginYear();
+
+  $('#id-edit-[% type %]\\\.period\\\.end_date\\\.year').keyup(_.debounce(blockTooShortEndYear, 500)).change(_.debounce(blockTooShortEndYear, 500));
+  blockTooShortEndYear();
+[%- END -%]
+
+[%- MACRO too_short_year_error(id) BLOCK -%]
+  <div class="error field-error" id="[% id %]" style="display: none">
+    <div class="row no-label"> 
+      [%- l('The year should have four digits. If you want to enter a year earlier than 1000 CE, please pad with zeros, such as “0123”.') -%]
+    </div>
+  </div>
+[%- END -%]
+
 [%- MACRO date_range_fieldset(r, type, ended_label) BLOCK -%]
     <fieldset>
       <legend>[% l('Date Period') %]</legend>
@@ -194,11 +224,14 @@
         [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
       </p>
       [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+      [% too_short_year_error('too_short_begin_year') %]
       [% form_row_date(r, 'period.end_date', l('End date:')) %]
+      [% too_short_year_error('too_short_end_year') %]
       [% form_row_checkbox(r, 'period.ended', ended_label) %]
     </fieldset>
     <script type="text/javascript">
       MB.initializeToggleEnded('id-edit-[% type %]');
+      [% too_short_year_js(type) %] 
     </script>
 [%- END -%]
 

--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -126,6 +126,7 @@
       --><input type="text" data-bind="value: date.month, valueUpdate: 'afterkeydown'" maxlength="2" placeholder="[% l('MM') %]" size="2" />-<!--
       --><input type="text" data-bind="value: date.day, valueUpdate: 'afterkeydown'" maxlength="2" placeholder="[% l('DD') %]" size="2" />
       <div class="error" data-bind="text: $parent.dateError(date)"></div>
+      <div class="error" data-bind="text: isBeginDate ? $parent.tooShortBeginYearError() : $parent.tooShortEndYearError()"></div>
     </td>
   </tr>
 </script>
@@ -149,11 +150,11 @@
   <!-- ko if: relationship().hasDates() -->
     <!-- ko template: {
               name: "template.dialog-date",
-              data: { label: "[% l('Begin date:') | html | js %]", date: relationship().begin_date }
+              data: { label: "[% l('Begin date:') | html | js %]", date: relationship().begin_date, isBeginDate: true }
             } --><!-- /ko -->
     <!-- ko template: {
               name: "template.dialog-date",
-              data: { label: "[% l('End date:') | html | js %]", date: relationship().end_date }
+              data: { label: "[% l('End date:') | html | js %]", date: relationship().end_date, isBeginDate: false }
             } --><!-- /ko -->
     <!-- ko with: datePeriodError() -->
     <tr>

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -31,7 +31,9 @@
             [%- l('Dates are in the format YYYY-MM-DD. Partial dates such as YYYY-MM or just YYYY are OK, or you can omit the date entirely.') -%]
         </p>
         [% form_row_date(r, 'period.begin_date', l('Begin date:')) %]
+        [% too_short_year_error('too_short_begin_year') %]
         [% form_row_date(r, 'period.end_date', l('End date:')) %]
+        [% too_short_year_error('too_short_end_year') %]
         [%- form_row_time(r, 'time', l('Time:')) -%]
       </fieldset>
 
@@ -58,5 +60,7 @@
 <script type="text/javascript">
   (function () {
     MB.Control.initialize_guess_case("event", "id-edit-event");
+
+    [% too_short_year_js("event") %]
   }());
 </script>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -153,6 +153,7 @@
       </tr>
 
       [% table_row_error(4, 'showErrorRightAway: hasInvalidDate', l('The date you\'ve entered is not valid.')) %]
+      [% table_row_error(4, 'showErrorRightAway: hasTooShortYear', l('The year should have four digits. If you want to enter a year earlier than 1000 CE, please pad with zeros, such as “0123”.')) %]
       [% table_row_error(4, 'showErrorRightAway: isDuplicate', l('You cannot use the same country more than once.')) %]
     <!-- /ko -->
 

--- a/root/static/scripts/edit/utility/dates.js
+++ b/root/static/scripts/edit/utility/dates.js
@@ -31,6 +31,10 @@ export const isDateValid = function (y, m, d) {
     return true;
 };
 
+export const isYearFourDigits = function (y) {
+    return (y === null || y === '' || y.length === 4);
+};
+
 export const isDatePeriodValid = function (a, b) {
     var y1 = a.year, m1 = a.month, d1 = a.day;
     var y2 = b.year, m2 = b.month, d2 = b.day;

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -18,6 +18,7 @@ import MB from '../../common/MB';
 import clean from '../../common/utility/clean';
 import formatDate from '../../common/utility/formatDate';
 import formatDatePeriod from '../../common/utility/formatDatePeriod';
+import nonEmpty from '../../common/utility/nonEmpty';
 import request from '../../common/utility/request';
 import MB_edit from '../../edit/MB/edit';
 import * as linkPhrase from '../../edit/utility/linkPhrase';
@@ -57,7 +58,16 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             this.linkTypeID.isDifferent = linkTypeComparer;
             this.linkTypeID.subscribe(this.linkTypeIDChanged, this);
 
+            if (data.begin_date && nonEmpty(data.begin_date.year)) {
+                data.begin_date.year = _.padStart(String(data.begin_date.year), 4, '0');
+            }
+
             this.begin_date = setPartialDate({}, data.begin_date || {});
+
+            if (data.end_date && nonEmpty(data.end_date.year)) {
+                data.end_date.year = _.padStart(String(data.end_date.year), 4, '0');
+            }
+
             this.end_date = setPartialDate({}, data.end_date || {});
             this.ended = ko.observable(!!data.ended);
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -16,7 +16,9 @@ import {
 } from '../common/immutable-entities';
 import MB from '../common/MB';
 import clean from '../common/utility/clean';
+import debounce from '../common/utility/debounce';
 import formatTrackLength from '../common/utility/formatTrackLength';
+import nonEmpty from '../common/utility/nonEmpty';
 import isBlank from '../common/utility/isBlank';
 import request from '../common/utility/request';
 import MB_edit from '../edit/MB/edit';
@@ -609,6 +611,10 @@ class ReleaseEvent {
     constructor(data, release) {
         var date = data.date || {};
 
+        if (nonEmpty(date.year)) {
+            date.year = _.padStart(String(date.year), 4, '0');
+        }
+        
         this.date = {
             year:   ko.observable(date.year == null ? null : date.year),
             month:  ko.observable(date.month == null ? null : date.month),
@@ -624,6 +630,11 @@ class ReleaseEvent {
         this.hasInvalidDate = ko.computed(function () {
             var date = self.unwrapDate();
             return !dates.isDateValid(date.year, date.month, date.day);
+        });
+
+        this.hasTooShortYear = debounce(function () {
+            var date = self.unwrapDate();
+            return !dates.isYearFourDigits(date.year);
         });
     }
 
@@ -802,6 +813,7 @@ class Release extends MB_entity.Release {
 
         this.hasDuplicateCountries = errorField(this.events.any("isDuplicate"));
         this.hasInvalidDates = errorField(this.events.any("hasInvalidDate"));
+        this.hasTooShortYears = errorField(this.events.any("hasTooShortYear"));
 
         this.labels = ko.observableArray(
             utils.mapChild(this, data.labels, ReleaseLabel)


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4538

Cases where years before 1000 are correct are rare. This requires the user to enter padding zeroes for those cases, which is not too problematic yet avoids all the cases where a too short year is added accidentally (for example because the user thought this was the day field).

After a chat with @mwiencek we decided not to try to implement this also on the Perl side. 