### PR TITLE
MBS-2663 (II): Search edits by non-subscribed editor

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Voter.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Voter.pm
@@ -30,6 +30,7 @@ sub operator_cardinality_map {
         'me' => undef,
         'not_me' => undef,
         'subscribed' => undef,
+        'not_subscribed' => undef,
     );
 };
 
@@ -45,6 +46,12 @@ sub voter_clause {
 
     if ($self->operator eq 'subscribed') {
         $sql .= "IN (
+             SELECT subscribed_editor
+               FROM editor_subscribe_editor
+              WHERE editor = ?
+        )";
+    } elsif ($self->operator eq 'not_subscribed') {
+        $sql .= "NOT IN (
              SELECT subscribed_editor
                FROM editor_subscribe_editor
               WHERE editor = ?

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -246,7 +246,9 @@
                  [ '!=', l('is not') ]
                  [ 'me', l('is me') ]
                  [ 'not_me', l('is not me') ]
-                 [ 'subscribed', l('is in my subscriptions') ] ], field_contents) %]
+                 [ 'subscribed', l('is in my subscriptions') ]
+                 [ 'not_subscribed', l('is not in my subscriptions') ]
+               ], field_contents) %]
 
   <span class="arg autocomplete editor">
     [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
@@ -322,8 +324,9 @@
                  [ '!=', l('is not') ]
                  [ 'me', l('is me') ]
                  [ 'not_me', l('is not me') ]
-                 [ 'subscribed', l('is in my subscriptions') ] ], field_contents) %]
-
+                 [ 'subscribed', l('is in my subscriptions') ]
+                 [ 'not_subscribed', l('is not in my subscriptions') ]
+               ], field_contents) %]
   <span class="arg autocomplete editor">
     [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]
     <input type="text" class="name" name="name" value="[% html_escape(field_contents.name) %]" style="width: 170px;" />

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -15,7 +15,7 @@ $(function () {
             '=': 1, '!=': 1 // Not directly true, but it here it means "show one argument control"
         },
         'voter': {
-            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0 // Not directly true, but it here it means "show one argument control"
+            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0
         },
         'subscription': {
             '=': 1, '!=': 1, 'subscribed': 0, 'not_subscribed': 0

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -15,7 +15,7 @@ $(function () {
             '=': 1, '!=': 1 // Not directly true, but it here it means "show one argument control"
         },
         'voter': {
-            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0 // Not directly true, but it here it means "show one argument control"
+            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0 // Not directly true, but it here it means "show one argument control"
         },
         'subscription': {
             '=': 1, '!=': 1, 'subscribed': 0, 'not_subscribed': 0
@@ -24,7 +24,7 @@ $(function () {
             '=': 1
         },
         'user': {
-            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0
+            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0
         },
     };
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-2663

As a follow-up to https://github.com/metabrainz/musicbrainz-server/pull/1119 - I just realized that I didn't implement it for editors. Same general idea.