### PR TITLE
MBS-6791: Search for edits made by beginners

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
@@ -47,6 +47,7 @@ role {
         if ($self->operator eq 'me' || $self->operator eq 'not_me') {
             $query->add_where([ $sql, [ $self->user->id ] ]);
         } elsif ($self->operator eq 'limited') {
+            # Please keep the logic in sync with Report::LimitedEditors and Entity::Editor
             $sql = "
               edit.editor != ?
               AND (

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -178,6 +178,7 @@ has 'preferences' => (
 
 sub is_limited
 {
+    # Please keep the logic in sync with Report::LimitedEditors and EditSearch::Predicate::Role::User
     my $self = shift;
     return
         !($self->id == $EDITOR_MODBOT) &&

--- a/lib/MusicBrainz/Server/Report/LimitedEditors.pm
+++ b/lib/MusicBrainz/Server/Report/LimitedEditors.pm
@@ -5,6 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
 
 with 'MusicBrainz::Server::Report::EditorReport';
 
+# Please keep the logic in sync with EditSearch::Predicate::Role::User and Entity::Editor
+
 sub query { "
 SELECT id,
        row_number() OVER (ORDER BY id DESC)

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -326,6 +326,7 @@
                  [ 'not_me', l('is not me') ]
                  [ 'subscribed', l('is in my subscriptions') ]
                  [ 'not_subscribed', l('is not in my subscriptions') ]
+                 [ 'limited', l('is a beginner') ]
                ], field_contents) %]
   <span class="arg autocomplete editor">
     [% React.embed(c, 'static/scripts/common/components/SearchIcon') %]

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -24,7 +24,7 @@ $(function () {
             '=': 1
         },
         'user': {
-            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0
+            '=': 1, '!=': 1, 'me': 0, 'not_me': 0, 'subscribed': 0, 'not_subscribed': 0, 'beginner': 0
         },
     };
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-6791

The query checks for all the conditions of a beginner editor, except whether they have a confirmed email address, since you can't edit without a confirmed email address anyway.

Works great on my sample DB, hope it scales fine to a full DB :) 