### PR TITLE
MBS-4090: Report: non-matching recording/track titles

### DIFF
--- a/lib/MusicBrainz/Server/Report/RecordingTrackDifferentName.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingTrackDifferentName.pm
@@ -1,0 +1,34 @@
+package MusicBrainz::Server::Report::RecordingTrackDifferentName;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
+
+sub query {
+    "
+        SELECT
+            r.id AS recording_id, t.name AS track_name,
+            row_number() OVER (ORDER BY musicbrainz_collate(r.name), musicbrainz_collate(t.name))
+        FROM
+            recording r
+            JOIN track t 
+            ON r.id = t.recording
+        WHERE (SELECT COUNT(*) FROM track WHERE recording = r.id) = 1
+          AND r.name != t.name
+    "
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -66,6 +66,7 @@ use MusicBrainz::Server::PagedReport;
     RecordingsWithEarliestReleaseRelationships
     RecordingsWithVaryingTrackLengths
     RecordingsSameNameDifferentArtistsSameName
+    RecordingTrackDifferentName
     ReleasedTooEarly
     ReleaseGroupsWithoutVACredit
     ReleaseGroupsWithoutVALink
@@ -146,6 +147,7 @@ use MusicBrainz::Server::Report::RecordingsWithoutVALink;
 use MusicBrainz::Server::Report::RecordingsWithEarliestReleaseRelationships;
 use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
 use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;
+use MusicBrainz::Server::Report::RecordingTrackDifferentName;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;

--- a/root/report/RecordingTrackDifferentName.js
+++ b/root/report/RecordingTrackDifferentName.js
@@ -1,0 +1,95 @@
+/*
+ * @flow
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {withCatalystContext} from '../context';
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+import PaginatedResults from '../components/PaginatedResults';
+import loopParity from '../utility/loopParity';
+import ArtistCreditLink
+  from '../static/scripts/common/components/ArtistCreditLink';
+import EntityLink from '../static/scripts/common/components/EntityLink';
+
+import FilterLink from './FilterLink';
+import type {ReportDataT, ReportRecordingTrackT} from './types';
+
+const RecordingTrackDifferentName = ({
+  $c,
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingTrackT>) => (
+  <Layout
+    fullWidth
+    title={l('Recordings with a different name than their only track')}
+  >
+    <h1>
+      {l('Recordings with a different name than their only track')}
+    </h1>
+
+    <ul>
+      <li>
+        {l(`This report shows recordings that are linked to only one track,
+            yet have a different name than the track. This might mean
+            one of the two needs to be renamed to match the other.`)}
+      </li>
+      <li>
+        {texp.l('Total recordings found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+
+      {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
+    </ul>
+
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Artist')}</th>
+            <th>{l('Recording')}</th>
+            <th>{l('Track')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <tr className={loopParity(index)} key={item.recording_id}>
+              {item.recording ? (
+                <>
+                  <td>
+                    <ArtistCreditLink
+                      artistCredit={item.recording.artistCredit}
+                    />
+                  </td>
+                  <td>
+                    <EntityLink entity={item.recording} />
+                  </td>
+                </>
+              ) : (
+                <td colSpan="2">
+                  {l('This recording no longer exists.')}
+                </td>
+              )}
+              <td>{item.track_name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </PaginatedResults>
+  </Layout>
+);
+
+export default withCatalystContext(RecordingTrackDifferentName);

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -455,6 +455,11 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
                 with the same name`)}
           </a>
         </li>
+        <li>
+          <a href="/report/RecordingTrackDifferentName">
+            {l('Recordings with a different name than their only track')}
+          </a>
+        </li>
       </ul>
 
       <h2>{l('Places')}</h2>

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -163,6 +163,13 @@ export type ReportRecordingT = {
   +row_number: number,
 };
 
+export type ReportRecordingTrackT = {
+  +recording: ?RecordingT,
+  +recording_id: number,
+  +row_number: number,
+  +track_name: string,
+};
+
 export type ReportReleaseAnnotationT = {
   +created: string,
   +release: ?ReleaseT,

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -152,6 +152,7 @@ module.exports = {
   'report/PartOfSetRelationships': require('../report/PartOfSetRelationships'),
   'report/PlacesWithoutCoordinates': require('../report/PlacesWithoutCoordinates'),
   'report/PossibleCollaborations': require('../report/PossibleCollaborations'),
+  'report/RecordingTrackDifferentName': require('../report/RecordingTrackDifferentName'),
   'report/RecordingsSameNameDifferentArtistsSameName': require('../report/RecordingsSameNameDifferentArtistsSameName'),
   'report/RecordingsWithEarliestReleaseRelationships': require('../report/RecordingsWithEarliestReleaseRelationships'),
   'report/RecordingsWithVaryingTrackLengths': require('../report/RecordingsWithVaryingTrackLengths'),


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4090

To avoid false positives (which would be quite likely otherwise), only recordings linked to just one track are checked for this report.

The original request also asked for differences in artist credits, but that would make almost all classical recordings false positives, and titles-only will still probably catch most cases that need fixing.
