### PR TITLE
MBS-5641: Show language/script in relevant reports

### DIFF
--- a/lib/MusicBrainz/Server/Report/NoLanguage.pm
+++ b/lib/MusicBrainz/Server/Report/NoLanguage.pm
@@ -4,6 +4,17 @@ use Moose;
 with 'MusicBrainz::Server::Report::ReleaseReport',
      'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
 
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $rows = $self->$orig(@_);
+    $self->c->model('Language')->load(map { $_->{release} } @$rows);
+    $self->c->model('Script')->load(map { $_->{release} } @$rows);
+
+    return $rows;
+};
+
 sub query {
     "
         SELECT

--- a/lib/MusicBrainz/Server/Report/NoScript.pm
+++ b/lib/MusicBrainz/Server/Report/NoScript.pm
@@ -4,6 +4,17 @@ use Moose;
 with 'MusicBrainz::Server::Report::ReleaseReport',
      'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
 
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $rows = $self->$orig(@_);
+    $self->c->model('Language')->load(map { $_->{release} } @$rows);
+    $self->c->model('Script')->load(map { $_->{release} } @$rows);
+
+    return $rows;
+};
+
 sub query {
     "
         SELECT

--- a/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
@@ -4,6 +4,17 @@ use Moose;
 with 'MusicBrainz::Server::Report::ReleaseReport',
      'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
 
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $rows = $self->$orig(@_);
+    $self->c->model('Language')->load(map { $_->{release} } @$rows);
+    $self->c->model('Script')->load(map { $_->{release} } @$rows);
+
+    return $rows;
+};
+
 sub query {
     "
         SELECT

--- a/root/report/NoLanguage.js
+++ b/root/report/NoLanguage.js
@@ -47,7 +47,7 @@ const NoLanguage = ({
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>
 
-    <ReleaseList items={items} pager={pager} />
+    <ReleaseList items={items} pager={pager} showLanguageAndScript />
 
   </Layout>
 );

--- a/root/report/NoScript.js
+++ b/root/report/NoScript.js
@@ -46,7 +46,7 @@ const NoScript = ({
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>
 
-    <ReleaseList items={items} pager={pager} />
+    <ReleaseList items={items} pager={pager} showLanguageAndScript />
 
   </Layout>
 );

--- a/root/report/ReleasesWithUnlikelyLanguageScript.js
+++ b/root/report/ReleasesWithUnlikelyLanguageScript.js
@@ -45,7 +45,7 @@ const ReleasesWithUnlikelyLanguageScript = ({
       {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
     </ul>
 
-    <ReleaseList items={items} pager={pager} />
+    <ReleaseList items={items} pager={pager} showLanguageAndScript />
 
   </Layout>
 );

--- a/root/report/components/ReleaseList.js
+++ b/root/report/components/ReleaseList.js
@@ -16,42 +16,73 @@ import type {ReportReleaseT} from '../types';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 
+type Props = {|
+  +items: $ReadOnlyArray<ReportReleaseT>,
+  +pager: PagerT,
+  +showLanguageAndScript?: boolean,
+|};
+
 const ReleaseList = ({
   items,
   pager,
-}: {items: $ReadOnlyArray<ReportReleaseT>, pager: PagerT}) => (
-  <PaginatedResults pager={pager}>
-    <table className="tbl">
-      <thead>
-        <tr>
-          <th>{l('Release')}</th>
-          <th>{l('Artist')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {items.map((item, index) => (
-          <tr className={loopParity(index)} key={item.release_id}>
-            {item.release ? (
-              <>
-                <td>
-                  <EntityLink entity={item.release} />
-                </td>
-                <td>
-                  <ArtistCreditLink
-                    artistCredit={item.release.artistCredit}
-                  />
-                </td>
-              </>
-            ) : (
-              <td colSpan="2">
-                {l('This release no longer exists.')}
-              </td>
-           )}
+  showLanguageAndScript,
+}: Props) => {
+  const colSpan = showLanguageAndScript ? 3 : 2;
+
+  return (
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Release')}</th>
+            <th>{l('Artist')}</th>
+            {showLanguageAndScript ? <th>{l('Language/Script')}</th> : null}
           </tr>
-        ))}
-      </tbody>
-    </table>
-  </PaginatedResults>
-);
+        </thead>
+        <tbody>
+          {items.map((item, index) => {
+            const language = item.release?.language;
+            const script = item.release?.script;
+            return (
+              <tr className={loopParity(index)} key={item.release_id}>
+                {item.release ? (
+                  <>
+                    <td>
+                      <EntityLink entity={item.release} />
+                    </td>
+                    <td>
+                      <ArtistCreditLink
+                        artistCredit={item.release.artistCredit}
+                      />
+                    </td>
+                    {showLanguageAndScript ? (
+                      <td>
+                        {language ? (
+                          <abbr title={l_languages(language.name)}>
+                            {language.iso_code_3}
+                          </abbr>
+                        ) : lp('-', 'missing data')}
+                        {' / '}
+                        {script ? (
+                          <abbr title={l_scripts(script.name)}>
+                            {script.iso_code}
+                          </abbr>
+                        ) : lp('-', 'missing data')}
+                      </td>
+                    ) : null}
+                  </>
+                ) : (
+                  <td colSpan={colSpan}>
+                    {l('This release no longer exists.')}
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </PaginatedResults>
+  );
+};
 
 export default ReleaseList;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5641

Mostly follows how it's done on release search results, but I chose to show "-" rather than nothing when language or script are missing, since I feel it makes *what* is missing more understandable.
Arguably could have been done so that the NoScript report only shows language and NoLanguage only script, but by showing both it also serves to show the editor whether some have already been fixed (since the language and script are loaded from the release entry and not from the saved report data).