### PR TITLE
MBS-10753: Use artist sort names for artist collection ordering

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -226,13 +226,13 @@ sub _order_by {
     my ($self, $order) = @_;
     my $order_by = order_by($order, "name", {
         "name" => sub {
-            return "musicbrainz_collate(name)"
+            return "musicbrainz_collate(sort_name)"
         },
         "gender" => sub {
-            return "gender, musicbrainz_collate(name)"
+            return "gender, musicbrainz_collate(sort_name)"
         },
         "type" => sub {
-            return "type, musicbrainz_collate(name)"
+            return "type, musicbrainz_collate(sort_name)"
         }
     });
 


### PR DESCRIPTION
### Implement MBS-10753

The reason we have a sort name is to sort by it, so when sorting collections by artist we should use the artist's sort names, not their names. 