### PR TITLE
MBS-4091: Avoid breaking lists while trimming annotations

### DIFF
--- a/lib/MusicBrainz/Server/Form/Annotation.pm
+++ b/lib/MusicBrainz/Server/Form/Annotation.pm
@@ -7,6 +7,13 @@ has '+name' => (default => 'edit-annotation');
 
 has_field 'text' => (
     type     => 'Text',
+    trim => { transform => sub {
+        my $string = shift;
+        # Not trimming starting spaces to avoid breaking list formatting,
+        # consider trimming again once this uses Markdown 
+        $string =~ s/\s+$//;
+        return $string;
+    } }
 );
 
 has_field 'changelog' => (


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4091

From annotation formatting:
Lists: tab or 4 spaces and:
* bullets or 1., a., A., i., I. numbered items (rendered with 1.)

We are trimming all whitespace at the start and end of the annotation though (FormHandler's default), meaning if the annotation starts with a list the formatting for the first element will be broken. This overrides the default trim method with one that will leave one tab or four spaces if there's that or more than that at the start of the annotation.