### PR TITLE
MBS-9111: Stricter validation for empty edit notes

### DIFF
--- a/lib/MusicBrainz/Server/Form/Role/EditNote.pm
+++ b/lib/MusicBrainz/Server/Form/Role/EditNote.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Form::Role::EditNote;
 use HTML::FormHandler::Moose::Role;
 
 use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Validation qw( is_valid_edit_note );
 
 has 'requires_edit_note' => ( is => 'ro', default => 0 );
 
@@ -18,8 +19,12 @@ has_field 'make_votable' => (
 after validate => sub {
     my $self = shift;
 
-    if ($self->requires_edit_note && (!defined $self->field('edit_note')->value || $self->field('edit_note')->value eq '')) {
+    if ($self->requires_edit_note && (!defined $self->field('edit_note')->value)) {
         $self->field('edit_note')->add_error(l('You must provide an edit note'));
+    }
+
+    if ($self->requires_edit_note && (!is_valid_edit_note($self->field('edit_note')->value))) {
+        $self->field('edit_note')->add_error(l('Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!'));
     }
 };
 

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -56,6 +56,7 @@ require Exporter;
         is_valid_iso_3166_2
         is_valid_iso_3166_3
         is_valid_partial_date
+        is_valid_edit_note
         encode_entities
         normalise_strings
         is_nat
@@ -306,6 +307,20 @@ sub is_valid_partial_date
         # partial dates with year <= 0 are OK, but complete dates are not (don't ask)
         return 0 unless $year > 0;
     }
+
+    return 1;
+}
+
+sub is_valid_edit_note
+{
+    my $edit_note = shift;
+
+    # An edit note with only spaces and / or punctuation is useless
+    return 0 if $edit_note =~ /^[[:space:][:punct:]]+$/;
+
+    # An edit note with just one ASCII character is useless
+    # A one-character Japanese note (for example) might be useful, so limited to ASCII 
+    return 0 if $edit_note =~ /^[[:ascii:]]$/;
 
     return 1;
 }

--- a/root/components/EnterEditNote.js
+++ b/root/components/EnterEditNote.js
@@ -30,7 +30,13 @@ const EnterEditNote = ({
             note: {href: '/doc/Edit_Note', target: '_blank'},
           })}
         </p>
-        <p>{l('Even just providing a URL or two is helpful!')}</p>
+        <p>
+          {exp.l(
+            `Even just providing a URL or two is helpful!
+             For more suggestions, see {doc_how_to|our guide for writing good edit notes}.`,
+            {doc_how_to: {href: '/doc/How_to_Write_Edit_Notes', target: '_blank'}},
+          )}
+        </p>
       </>
     )}
     <FormRow>

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -29,7 +29,7 @@
     <p>
       [% l('Entering an {note|edit note} that describes where you got your information is highly recommended. Not only does it make it clear where you got your information, but it can also encourage other users to vote on your edit &#x2014; thus making your edit get applied faster.', { note => { href => doc_link('Edit_Note'), target => '_blank' } }) %]
     </p>
-    <p>[% l('Even just providing a URL or two is helpful!') %]</p>
+    <p>[% l('Even just providing a URL or two is helpful! For more suggestions, see {doc_how_to|our guide for writing good edit notes}.', { doc_how_to => { href => doc_link('How_to_Write_Edit_Notes'), target => '_blank' } }) %]</p>
   [% END %]
   [% WRAPPER form_row %]
     [% IF ko %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9111
Also https://tickets.metabrainz.org/browse/MBS-10373 as an addendum

We keep having issues with people adding edit notes with no content.
This blocks edit notes with only whitespace and (common) punctuation combinations, and asks the user to provide an edit note that will be useful to fellow editors.

It also blocks one-character ASCII notes, but not one-character notes in wider Unicode, since glyph languages (such as Japanese) might have a full meaningful word that is one character long.

People can obviously still enter just "á" or something, but at least it might block some of the bad edit notes while reminding users why a note is important.