### PR TITLE
MBS-4299: Show expanded AC in merge release warning

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -203,8 +203,7 @@ END -%]
     [%- END -%]
 [%- END -%]
 
-[%~ MACRO expanded_artist_credit(ac) IF ac -%]
-  [%- artist_credit(ac) -%]<br />
+[%~ MACRO expanded_artist_credit_list(ac) IF ac -%]
   [%- IF ac.name != ac.names.0.artist.name || ac.names.size > 1 || ac.names.0.artist.comment -%]
     [%- SET artist_list = [];
         SET show_list = 0;
@@ -221,6 +220,11 @@ END -%]
         END; -%]
     [%- IF show_list -%]<span class="expanded-ac-list">[%- comma_only_list(artist_list) -%]</span>[%- END -%]
   [% END %]
+[%- END -%]
+
+[%~ MACRO expanded_artist_credit(ac) IF ac -%]
+  [%- artist_credit(ac) -%]<br />
+  [%- expanded_artist_credit_list(ac) -%]<br />
 [%- END -%]
 
 [%~ MACRO entity_exists(entity) BLOCK; entity.gid.defined; END -%]

--- a/root/release/merge.tt
+++ b/root/release/merge.tt
@@ -118,7 +118,10 @@
             [% FOR bad_recordings IN bad_recording_merges %]
                 <ul>
                 [% FOR bad_recording IN bad_recordings %]
-                    <li>[% descriptive_link(bad_recording) %]</li>
+                    <li>
+                      [% descriptive_link(bad_recording) %]<br />
+                      [% expanded_artist_credit_list(bad_recording.artist_credit) %]
+                    </li>
                 [% END %]
                 </ul>
             [% END %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4299

When merging releases and recordings, if the recording artists differ, the user is shown the recordings with different artists, so that they can make sure the merge seems correct. This does not show disambiguations, which can lead to a confusing situation where a user is told "these recordings have different artists" but the only info shown is "Foo by Bar" for both recordings.

This changes the display to use the list we already use for edit medium edits, where every artist in an AC is shown separately under the line if they have a disambiguation.