### PR TITLE
MBS-10313: Reenable CAA image on homepage for Chrome

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -9,7 +9,7 @@ BEGIN { extends 'Catalyst::Controller' }
 use DBDefs;
 use MusicBrainz::Server::Constants qw( $VARTIST_GID $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::SSL qw( ensure_ssl );
-use MusicBrainz::Server::Data::Utils qw( boolean_to_json model_to_type );
+use MusicBrainz::Server::Data::Utils qw( model_to_type );
 use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Replication ':replication_type';
 use aliased 'MusicBrainz::Server::Translation';
@@ -55,7 +55,6 @@ sub index : Path Args(0)
         component_props => {
             blogEntries => $c->model('Blog')->get_latest_entries,
             newestReleases => \@newest_releases,
-            withSafeBrowsing => boolean_to_json(($c->req->user_agent // '') =~ /Chrome/),
         },
     );
 }

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import {omit} from 'lodash';
 import he from 'he';
 import React from 'react';
 
@@ -20,13 +19,11 @@ import entityHref from '../static/scripts/common/utility/entityHref';
 type Props = {|
   +blogEntries: $ReadOnlyArray<BlogEntryT> | null,
   +newestReleases: $ReadOnlyArray<ArtworkT>,
-  +withSafeBrowsing: boolean,
 |};
 
 const Homepage = ({
   blogEntries,
   newestReleases,
-  withSafeBrowsing,
 }: Props) => (
   <Layout fullWidth homepage title={l('MusicBrainz - The Open Music Encyclopedia')}>
     <div id="maincontent">
@@ -164,20 +161,11 @@ const Homepage = ({
 
     <div className="feature-column" style={{clear: 'both', paddingTop: '1%'}}>
       <h2>{l('Recent Additions')}</h2>
-      {withSafeBrowsing ? (
-        <div className="banner">
-          {exp.l('Cover art on the homepage is disabled for Chrome-based browsers, which are known to issue an incorrect phishing warning since the 11th of November 2018; see {ticket_link|ticket CAA-116} for follow-up.<br/>A phishing warning may show up on any other page with cover art. You are encouraged to {report_link|report errors to Google Safe Browsing}. Sorry for the inconvenience!', {
-            report_link: 'https://safebrowsing.google.com/safebrowsing/report_error/',
-            ticket_link: 'https://tickets.metabrainz.org/browse/CAA-116',
-          })}
-        </div>
-      ) : null}
       <div style={{height: '160px', overflow: 'hidden'}}>
         {newestReleases.map((artwork, index) => (
           <ReleaseArtwork
             artwork={artwork}
             key={index}
-            withSafeBrowsing={withSafeBrowsing}
           />
         ))}
       </div>
@@ -187,10 +175,8 @@ const Homepage = ({
 
 const ReleaseArtwork = ({
   artwork,
-  withSafeBrowsing,
 }: {|
   +artwork: ArtworkT,
-  +withSafeBrowsing: boolean,
 |}) => {
   const release = artwork.release;
   if (!release) {
@@ -207,14 +193,10 @@ const ReleaseArtwork = ({
           href={entityHref(release)}
           title={releaseDescription}
         >
-          {withSafeBrowsing ? (
-            <em>{releaseDescription}</em>
-          ) : (
-            <ArtworkImage
-              artwork={artwork}
-              fallback={release.cover_art_url || ''}
-            />
-          )}
+          <ArtworkImage
+            artwork={artwork}
+            fallback={release.cover_art_url || ''}
+          />
         </a>
       </div>
     </div>


### PR DESCRIPTION
# Complete task [MBS-10313](https://tickets.metabrainz.org/browse/MBS-10313)

Almost revert commit ef92e13639e62b4b26c78b865f94a5b6c287f1cf

See ticket and related tickets for details.