### PR TITLE
MBS-4326: Show DiscID edits in RG and artist history

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
@@ -11,6 +11,8 @@ sub edit_name { N_l('Add disc ID') }
 sub edit_kind { 'add' }
 sub edit_type { $EDIT_MEDIUM_ADD_DISCID }
 
+sub medium_id { shift->data->{medium_id} }
+
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 use aliased 'MusicBrainz::Server::Entity::Medium';
 use aliased 'MusicBrainz::Server::Entity::MediumCDTOC';
@@ -19,6 +21,7 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Role::Insert';
 with 'MusicBrainz::Server::Edit::Medium';
+with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
 with 'MusicBrainz::Server::Edit::Role::Preview';
 with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
@@ -66,13 +69,6 @@ sub _edit_hash {
 
     delete $data->{medium_position};
     return $data;
-}
-
-method _build_related_entities
-{
-    return {
-        release => [ $self->release_id ]
-    }
 }
 
 method foreign_keys {

--- a/lib/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
@@ -65,8 +65,20 @@ sub alter_edit_pending
 sub _build_related_entities
 {
     my $self = shift;
+    my @releases = values %{
+        $self->c->model('Release')->get_by_ids($self->release_ids)
+    };
+    $self->c->model('ReleaseGroup')->load(@releases);
+    my @release_groups = map { $_->release_group } @releases;
+
+    $self->c->model('ArtistCredit')->load(@releases, @release_groups);
     return {
-        release => [ $self->release_ids ],
+        artist => [
+            map { $_->artist_id } map { $_->artist_credit->all_names }
+                @releases, @release_groups
+        ],
+        release_group => [ map { $_->id } @release_groups ],
+        release => [ $self->release_ids ]
     }
 }
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
@@ -17,7 +17,6 @@ test all => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+cdtoc');
     MusicBrainz::Server::Test->prepare_test_database($c, <<'SQL');
         SET client_min_messages TO warning;
-        TRUNCATE artist CASCADE;
         DELETE FROM medium_cdtoc WHERE id = 2;
 SQL
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4326

DiscID edits seem relevant enough to both the release group the release is in and the artists in release and release group to be displayed in those's edit histories as well.

Remove Disc ID was already being shown in the relevant places: this changes Add and Move to do the same.