### PR TITLE
MBS-4478: Improve messages for edits that create entities

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -264,7 +264,7 @@ END -%]
       SET text = html_escape(entity.name) IF text == '';
       SET text = html_escape(l('[removed]')) IF text == '';
       caption = allow_new
-        ? l("This entity will be created when edits are entered.")
+        ? l("This entity will be created by this edit.")
         : l("This entity has been removed, and cannot be displayed correctly.");
       '<span class="' _ (!allow_new && ('deleted' _ ' ')) _ 'tooltip" title="' _ html_escape(caption) _ '">' _
         '<bdi>' _ text _ '</bdi>' _

--- a/root/edit/details/edit_medium.tt
+++ b/root/edit/details/edit_medium.tt
@@ -101,10 +101,14 @@
             </td>
             <td>
               [%~ data_track_icon IF new_track.is_data_track %]
+              [% # If no recording_id exists, it's creating a recording
+                SET allow_new = 1 IF !new_track.recording_id
+              %]
               [%= link_entity(
                      new_track.recording, 'show',
                      new_name_diff, undef, 1
                    ) ~%]
+              [% SET allow_new = 0 IF !new_track.recording_id %]
             </td>
             <td>
               [% artist_credit_differences.new %]
@@ -190,7 +194,15 @@
                    [% new_track.number %]
                  </td>
                  <td><span class="diff-only-a">[% IF old_track.recording; descriptive_link(old_track.recording); END %]</span></td>
-                 <td><span class="diff-only-b">[% SET allow_new = 1; descriptive_link(new_track.recording); SET allow_new = 0; %]</span></td>
+                 <td>
+                   <span class="diff-only-b">
+                     [% # If no recording_id exists, it's creating a recording
+                       SET allow_new = 1 IF !new_track.recording_id
+                     %]
+                     [% descriptive_link(new_track.recording) %]
+                     [% SET allow_new = 0 IF !new_track.recording_id %]
+                   </span>
+                 </td>
                </tr>
           [% END %]
         </tbody>

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -23,7 +23,7 @@ export const DeletedLink = ({
   name,
 }: {|+allowNew: boolean, +name: React.Node|}) => {
   const caption = allowNew
-    ? l('This entity will be created when edits are entered.')
+    ? l('This entity will be created by this edit.')
     : l('This entity has been removed, and cannot be displayed correctly.');
 
   return (

--- a/t/lib/t/TemplateMacros.pm
+++ b/t/lib/t/TemplateMacros.pm
@@ -211,7 +211,7 @@ test all => sub {
             "allow_new=1; link_entity(entity)",
             "React.createElement(EntityLink, {entity: entity, allowNew: true})",
 
-            '<span class="tooltip" title="This entity will be created when edits are entered.">' .
+            '<span class="tooltip" title="This entity will be created by this edit.">' .
                 '<bdi>[removed]</bdi>' .
             '</span>',
 
@@ -289,7 +289,7 @@ test all => sub {
             "allow_new=1; link_entity(entity)",
             "React.createElement(EntityLink, {entity: entity, allowNew: true})",
 
-            '<span class="tooltip" title="This entity will be created when edits are entered.">' .
+            '<span class="tooltip" title="This entity will be created by this edit.">' .
                 '<bdi>Flying Nun Records</bdi>' .
             '</span>',
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4478

When editing a medium and using a new recording, the current tooltip claims that the entity will be created once the edit is entered (both in the preview and... once the edit is entered). This is not really true: it is created once the edit is *applied*. Tooltip changed accordingly.

Additionally, it doesn't really make a difference when a recording in the new column has been removed or is being created, but we do have that information (the former has a recording_id but the latter does not), so I'm changing the code to actually check what is the case.

There's a third issue where the "will be created" message is never replaced by a link to the actual recording (MBS-7814), but that's a much less straightforward fix, so let's start with this.