### PR TITLE
MBS-4486: Remove parentheses around disambiguation

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -37,6 +37,7 @@ use MusicBrainz::Server::Data::Utils qw(
     split_relationship_by_attributes
     sanitize
     trim
+    trim_comment
     non_empty
 );
 use MusicBrainz::Server::Renderer qw( render_component );
@@ -216,7 +217,7 @@ sub process_entity {
     }
 
     if ($data->{comment}) {
-        trim_string($data, 'comment');
+        $data->{comment} = trim_comment($data->{comment});
         # MBS-7963
         $data->{comment} = substr($data->{comment}, 0, 255);
     }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -70,6 +70,7 @@ our @EXPORT_OK = qw(
     sanitize
     take_while
     trim
+    trim_comment
     type_to_model
     split_relationship_by_attributes
 );
@@ -339,6 +340,14 @@ sub trim {
     $t = Text::Trim::trim($t);
 
     return $t;
+}
+
+sub trim_comment {
+    my $t = shift;
+
+    $t =~ s/^\s*\(([^()]+)\)\s*$/$1/;
+
+    return trim($t);
 }
 
 sub remove_direction_marks {

--- a/lib/MusicBrainz/Server/Form/Field/Comment.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Comment.pm
@@ -1,9 +1,16 @@
 package MusicBrainz::Server::Form::Field::Comment;
-use Moose;
+use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Data::Utils;
 
-extends 'MusicBrainz::Server::Form::Field::Text';
+extends 'HTML::FormHandler::Field::Text';
 
 has '+maxlength' => ( default => 255 );
 has '+not_nullable' => ( default => 1 );
+
+apply ([
+    {
+        transform => sub { MusicBrainz::Server::Data::Utils::trim_comment(shift) }
+    }
+]);
 
 1;

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -339,7 +339,7 @@
 
   <div class="bubble" data-bind="bubble: $root.commentBubble">
     <p>
-      [% l('The comment field is used to help users distinguish between identically named releases.') %]
+      [% l('The disambiguation field is used to help users distinguish between identically named releases.') %]
     </p>
     <p>
       [% l('This field is not a place to store general background information about the release: that kind of information should go in the annotation field.') %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4486

Disambiguation is already presented in parentheses everywhere, but people sometimes add it *in* parentheses,leading to stuff being shown as ((disambiguation)). This drops parentheses if the disambiguation comment both starts and ends with them.