### PR TITLE
MBS-10320: Only nag user if in prod or beta site

### DIFF
--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -83,7 +83,7 @@ sub nag_check
     my ($self, $c) = @_;
 
     # Never nag users in non-core MB servers
-    return 0 unless DBDefs->WEB_SERVER =~ /^(beta\.)?musicbrainz\.org$/;
+    return 0 unless DBDefs->WEB_SERVER =~ /^(?:beta\.)?musicbrainz\.org$/;
 
     # Always nag users who are not logged in
     return 1 unless $c->user_exists;

--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -82,6 +82,9 @@ sub nag_check
 {
     my ($self, $c) = @_;
 
+    # Never nag users in non-core MB servers
+    return 0 unless DBDefs->WEB_SERVER =~ /^(beta\.)?musicbrainz\.org$/;
+
     # Always nag users who are not logged in
     return 1 unless $c->user_exists;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/TagLookup.pm
@@ -18,6 +18,11 @@ with 't::Context', 't::Mechanize';
 test 'Can perform tag lookups with artist and release titles' => sub {
     my $test = shift;
 
+    # We want to make sure the nag will be shown on the main MB website
+    no warnings qw( redefine );
+    use DBDefs;
+    local *DBDefs::WEB_SERVER = sub { 'musicbrainz.org' };
+
     LWP::UserAgent::Mockable->set_record_pre_callback(sub {
         my $response = HTTP::Response->new;
         $response->code(200);


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10320

There's little reason to nag users in slave servers, test, and other non-core MB installs. The users are either already supporters, just testing for bugs (which is also a way of supporting us), or at the very least know enough to set up their own server, which also should mean they know we'd like them to donate without nagging them.
In many of these servers, there's no way to know if the user has donated or not, so we would risk annoying a user who has already donated by nagging them again locally.