### PR TITLE
MBS-10324: Make "takes" ETI (since "take" is)

### DIFF
--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -57,6 +57,7 @@ const preBracketSingleWordsList = [
   'session',
   'short',
   'take',
+  'takes',
   'techno',
   'trance',
   'version',


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10324

This will cause issues with a title like "Fight (Whatever It Takes)" or something like that, but I guess that's not worse than the existing "take", which can also be used in the same way.