### PR TITLE
Fix: Properly compare Entity::ArtistCredit missing artist_id

### DIFF
--- a/lib/MusicBrainz/Server/Entity/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistCredit.pm
@@ -45,7 +45,7 @@ sub is_equal {
         return 0 unless
             ($an->name eq $bn->name) &&
             (($an->join_phrase || '') eq ($bn->join_phrase || '')) &&
-            ($an->artist_id == $bn->artist_id);
+            (($an->artist_id || 0) == ($bn->artist_id || 0));
     }
 
     return 1;


### PR DESCRIPTION
Because some edits may create new entity only when applied, rendering open edits page may cause the following warning:

> Use of uninitialized value in numeric eq (==) at lib/MusicBrainz/Server/Entity/ArtistCredit.pm line 45.

This patch should mute this warning when comparing artist credits missing artist id.