### PR TITLE
Link from guess case options to guess case documentation page

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -281,6 +281,7 @@
         <option value="French">[% l('French') %]</option>
         <option value="Turkish">[% l('Turkish') %]</option>
       </select>
+      (<a href="/doc/Guess_Case" target="_blank">[% l('help') %]</a>)
       <br />
       <label>
         <input type="checkbox" data-bind="checked: keepUpperCase" />
@@ -305,6 +306,7 @@
           <option value="French">[% l('French') %]</option>
           <option value="Turkish">[% l('Turkish') %]</option>
         </select>
+        (<a href="/doc/Guess_Case" target="_blank">[% l('help') %]</a>)
         <br />
         <label>
           <input type="checkbox" data-bind="checked: keepUpperCase" />

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -29,7 +29,6 @@ fieldset {
             padding: 1em;
             text-align: center;
         }
-        &.guesscase-options select { width: 100px; }
     }
 }
 

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -30,6 +30,8 @@ fieldset {
             text-align: center;
         }
     }
+
+    p.guesscase-options { display: inline-block; }
 }
 
 .warning { border-radius: 6px; }


### PR DESCRIPTION
Thanks to @reosarevok, https://musicbrainz.org/doc/Guess_Case is currently up-to-date.
This patch links to this page from guess case options dialog and tracklist guess case form.
It additionally slightly improves display of guess case options and removes unused style.