### PR TITLE
MBS-4787: Redirect WS namespace to WS docs

### DIFF
--- a/admin/nginx/mbserver-rewrites.conf
+++ b/admin/nginx/mbserver-rewrites.conf
@@ -83,6 +83,7 @@ rewrite ^/list\.html$                            $mb_server/doc/Communication/Ma
 rewrite ^/mod_faq\.html$                         $mb_server/doc/Editing_FAQ                  permanent;
 rewrite ^/mod_intro\.html$                       $mb_server/doc/How_Editing_Works            permanent;
 rewrite ^/news/licenses\.html$                   $mb_server/doc/About/Data_License           permanent;
+rewrite ^/ns/mmd-2\.0$                           $mb_server/doc/Development/XML_Web_Service  permanent;
 rewrite ^/press\.html$                           $mb_server/doc/About/Press                  permanent;
 rewrite ^/products/libdiscid$                    $mb_server/doc/libdiscid                    permanent;
 rewrite ^/products/libmusicbrainz$               $mb_server/doc/libmusicbrainz               permanent;


### PR DESCRIPTION
# Implements [MBS-4787](https://tickets.metabrainz.org/browse/MBS-4787)

While the namespace URI doesn't have to point to anything to be valid, it seems sensible to point it to the documentation to give users a quick link to the docs rather than a kinda frustrating 404.
This was apparently also the pre-NGS behaviour.