### PR TITLE
MBS-10240: Allow seeding "release has no barcode"

### DIFF
--- a/root/static/scripts/release-editor/seeding.js
+++ b/root/static/scripts/release-editor/seeding.js
@@ -75,7 +75,11 @@ releaseEditor.seedRelease = function (release, data) {
     }
 
     if (data.barcode) {
-        release.barcode.value(data.barcode);
+        if (data.barcode === 'none') {
+            release.barcode.none(true);
+        } else {
+            release.barcode.value(data.barcode);
+        }
     }
 
     if (data.artistCredit) {

--- a/t/selenium/release-editor/Seeding.html
+++ b/t/selenium/release-editor/Seeding.html
@@ -464,6 +464,22 @@
     <td>document.querySelector('tr.track td.title input').value</td>
     <td>foo</td>
 </tr>
+<!-- seeding barcode = none -->
+<tr>
+    <td>openFile</td>
+    <td>./seeds/no_barcode.html</td>
+    <td></td>
+</tr>
+<tr>
+    <td>clickAndWait</td>
+    <td>css=button[type=submit]</td>
+    <td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.document.getElementById('barcode').disabled</td>
+	<td>true</td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/t/selenium/release-editor/seeds/no_barcode.html
+++ b/t/selenium/release-editor/seeds/no_barcode.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form action="http://localhost:5000/release/add" method="POST">
+      <input type="hidden" name="barcode" value="none" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10240

Needs updating the barcode section of https://musicbrainz.org/doc/Development/Release_Editor_Seeding to "The barcode of the release. May be any valid barcode without whitespace. To indicate there is no barcode, seed "none"" if it gets merged.