### PR TITLE
MBS-5049: Link to edit note syntax from edit pages

### DIFF
--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -23,6 +23,11 @@
                   <textarea class="edit-note" rows="5" placeholder="[% l('Add an edit note') %]"
                       name="enter-vote.vote.[% index %].edit_note"></textarea>
               </div>
+            <p>
+                  [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}. Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',
+                     { doc_coc => doc_link('Code_of_Conduct'), doc_formatting => doc_link('Edit_Note') }) %]
+            </p>
+
           </div>
       [% ELSE %]
           <p>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5049

We currently only show some info about edit note syntax when entering an edit, but not when voting on it. The info is equally useful there.

While at it, added a reminder to follow the CoC while voting: if we're going to have text, we might as well remind people to be nice!