### PR TITLE
MBS-4980: Use catnos to sort releases in RG page

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -302,17 +302,24 @@ sub find_by_release_group
       SELECT *
       FROM (
         SELECT DISTINCT ON (release.id) " . $self->_columns . ",
-          date_year, date_month, date_day, area.name AS country_name
+          date_year, date_month, date_day, area.name AS country_name,
+          rl.catalog_numbers AS catalog_numbers
         FROM " . $self->_table . "
         " . join(' ', @$extra_joins) . "
         LEFT JOIN release_event ON release_event.release = release.id
         LEFT JOIN area ON area.id = release_event.country
+        LEFT JOIN (
+          SELECT
+            array_agg(catalog_number ORDER BY catalog_number) AS catalog_numbers, release
+            FROM release_label
+            GROUP BY release
+        ) rl ON release.id = rl.release
         WHERE " . join(" AND ", @$conditions) . "
         ORDER BY release.id, date_year, date_month, date_day,
-          country_name, barcode
+          rl.catalog_numbers, country_name, barcode
       ) s
       ORDER BY date_year, date_month, date_day,
-        country_name, barcode
+        catalog_numbers, country_name, barcode
     ";
 
     $self->query_to_list_limited($query, $params, $limit, $offset);


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4980

https://github.com/metabrainz/musicbrainz-server/pull/29 was originally rejected because it didn't work in PG 8.4. We don't have that problem anymore, and the general idea makes sense, so I just changed it a bit to fit in our current query.