### PR TITLE
MBS-4826: Show RGs for recordings in artist list

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -426,6 +426,7 @@ sub recordings : Chained('load')
 
     $c->model('Recording')->load_meta(@$recordings);
 
+    my %release_group_appearances = $c->model('Recording')->appears_on($recordings, 10, 1);
     if ($c->user_exists) {
         $c->model('Recording')->rating->load_user_ratings($c->user->id, @$recordings);
     }
@@ -447,6 +448,7 @@ sub recordings : Chained('load')
             hasVideo => boolean_to_json($has_video),
             pager => serialize_pager($c->stash->{pager}),
             recordings => to_json_array($recordings),
+            releaseGroupAppearances => \%release_group_appearances,
             standaloneOnly => boolean_to_json($standalone_only),
             videoOnly => boolean_to_json($video_only),
         },

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -426,7 +426,7 @@ sub recordings : Chained('load')
 
     $c->model('Recording')->load_meta(@$recordings);
 
-    my %release_group_appearances = $c->model('Recording')->appears_on($recordings, 10, 1);
+    my $release_group_appearances = $c->model('Recording')->appears_on($recordings, 10, 1);
     if ($c->user_exists) {
         $c->model('Recording')->rating->load_user_ratings($c->user->id, @$recordings);
     }
@@ -448,7 +448,7 @@ sub recordings : Chained('load')
             hasVideo => boolean_to_json($has_video),
             pager => serialize_pager($c->stash->{pager}),
             recordings => to_json_array($recordings),
-            releaseGroupAppearances => \%release_group_appearances,
+            releaseGroupAppearances => $release_group_appearances,
             standaloneOnly => boolean_to_json($standalone_only),
             videoOnly => boolean_to_json($video_only),
         },

--- a/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
@@ -48,11 +48,11 @@ after _load_entities => sub {
 
 around _format_output => sub {
     my ($orig, $self, $c, @entities) = @_;
-    my %appears_on = $c->model('Recording')->appears_on(\@entities, 3);
+    my $appears_on = $c->model('Recording')->appears_on(\@entities, 3);
 
     return map +{
         %$_,
-        appearsOn => $appears_on{$_->{entity}->id}
+        appearsOn => $appears_on->{$_->{entity}->id}
     }, $self->$orig($c, @entities);
 };
 

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Data::Recording;
 use Moose;
 use namespace::autoclean;
 use List::MoreUtils qw( uniq );
-use List::UtilsBy qw( rev_nsort_by sort_by uniq_by );
+use List::UtilsBy qw( nsort_by sort_by uniq_by );
 use MusicBrainz::Server::Constants qw(
     $EDIT_RECORDING_CREATE
     $EDIT_HISTORIC_ADD_TRACK
@@ -416,7 +416,7 @@ sub appears_on
     {
         # A crude ordering of importance.
         my $rgs = [ uniq_by { $_->name }
-                  rev_nsort_by { $_->primary_type_id // -1 }
+                  nsort_by { $_->primary_type_id // 999 }
                   sort_by { $_->name  }
                   @{ $map{$rec_id} } ];
 

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -390,7 +390,7 @@ sub appears_on
 {
     my ($self, $recordings, $limit, $return_json) = @_;
 
-    return () unless scalar @$recordings;
+    return {} unless scalar @$recordings;
 
     my @ids = map { $_->id } @$recordings;
 
@@ -430,7 +430,7 @@ sub appears_on
         }
     }
 
-    return %map;
+    return \%map;
 }
 
 sub has_materialized_recording_first_release_date_data {

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -29,6 +29,7 @@ type FooterSwitchProps = {
 };
 
 type Props = {
+  ...ReleaseGroupAppearancesRoleT,
   +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
@@ -132,6 +133,7 @@ const ArtistRecordings = ({
   hasVideo,
   pager,
   recordings,
+  releaseGroupAppearances,
   standaloneOnly,
   videoOnly,
 }: Props): React.Element<typeof ArtistLayout> => (
@@ -156,7 +158,9 @@ const ArtistRecordings = ({
           <RecordingList
             checkboxes="add-to-merge"
             recordings={recordings}
+            releaseGroupAppearances={releaseGroupAppearances}
             showRatings
+            showReleaseGroups
           />
         </PaginatedResults>
         {$c.user ? (

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -8,9 +8,12 @@
  */
 
 import * as React from 'react';
+import type {ColumnOptions} from 'react-table';
 
 import {SanitizedCatalystContext} from '../../context';
 import Table from '../Table';
+import ReleaseGroupAppearances
+  from '../../static/scripts/common/components/ReleaseGroupAppearances';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
 import {
@@ -29,6 +32,7 @@ import hydrate from '../../utility/hydrate';
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
+  ...ReleaseGroupAppearancesRoleT,
   ...SeriesItemNumbersRoleT,
   +checkboxes?: string,
   +lengthClass?: string,
@@ -39,8 +43,24 @@ type Props = {
   +showExpandedArtistCredits?: boolean,
   +showInstrumentCreditsAndRelTypes?: boolean,
   +showRatings?: boolean,
+  +showReleaseGroups?: boolean,
   +sortable?: boolean,
 };
+
+function defineReleaseGroupAppearancesColumn(
+  releaseGroupAppearances,
+): ColumnOptions<RecordingT, ReleaseGroupAppearancesT> {
+  return {
+    Cell: ({row: {original}}) => releaseGroupAppearances &&
+      releaseGroupAppearances[original.id] ? (
+        <ReleaseGroupAppearances
+          appearances={releaseGroupAppearances[original.id]}
+        />
+      ) : null,
+    Header: l('Release Groups'),
+    id: 'appearances',
+  };
+}
 
 const RecordingList = ({
   checkboxes,
@@ -49,11 +69,13 @@ const RecordingList = ({
   mergeForm,
   order,
   recordings,
+  releaseGroupAppearances,
   seriesItemNumbers,
   showAcoustIds = false,
   showExpandedArtistCredits = false,
   showInstrumentCreditsAndRelTypes = false,
   showRatings = false,
+  showReleaseGroups = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
   const $c = React.useContext(SanitizedCatalystContext);
@@ -95,6 +117,9 @@ const RecordingList = ({
         sortable: sortable,
         title: l('Length'),
       });
+      const releaseGroupAppearancesColumn = showReleaseGroups
+        ? defineReleaseGroupAppearancesColumn(releaseGroupAppearances)
+        : null;
       const instrumentUsageColumn = showInstrumentCreditsAndRelTypes
         ? defineInstrumentUsageColumn({
           instrumentCreditsAndRelTypes: instrumentCreditsAndRelTypes,
@@ -110,6 +135,9 @@ const RecordingList = ({
         ...(showRatings ? [ratingsColumn] : []),
         ...(acoustIdsColumn ? [acoustIdsColumn] : []),
         lengthColumn,
+        ...(releaseGroupAppearancesColumn
+          ? [releaseGroupAppearancesColumn]
+          : []),
         ...(instrumentUsageColumn ? [instrumentUsageColumn] : []),
         ...(mergeForm && recordings.length > 2
           ? [removeFromMergeColumn]
@@ -124,11 +152,13 @@ const RecordingList = ({
       mergeForm,
       order,
       recordings,
+      releaseGroupAppearances,
       seriesItemNumbers,
       acoustIdsColumn,
       showExpandedArtistCredits,
       showInstrumentCreditsAndRelTypes,
       showRatings,
+      showReleaseGroups,
       sortable,
     ],
   );

--- a/root/static/scripts/common/components/ReleaseGroupAppearances.js
+++ b/root/static/scripts/common/components/ReleaseGroupAppearances.js
@@ -1,0 +1,50 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import EntityLink from './EntityLink';
+
+const buildAppearancesRow = (releaseGroup: ReleaseGroupT) => (
+  <li key={releaseGroup.id}>
+    <EntityLink entity={releaseGroup} />
+  </li>
+);
+
+type ReleaseGroupAppearancesProps = {
+  +appearances: ReleaseGroupAppearancesT,
+};
+
+const ReleaseGroupAppearances = (
+  {appearances}: ReleaseGroupAppearancesProps,
+): React.Element<'ul'> | null => {
+  const releaseGroups = appearances.results;
+  const unloadedReleaseGroupCount = appearances.hits - releaseGroups.length;
+  return (
+    (appearances && releaseGroups.length > 0) ? (
+      <ul>
+        {releaseGroups.map(
+          releaseGroup => buildAppearancesRow(releaseGroup),
+        )}
+        {unloadedReleaseGroupCount ? (
+          <li>
+            {exp.ln(
+              'and another {num} release group',
+              'and another {num} release groups',
+              unloadedReleaseGroupCount,
+              {num: unloadedReleaseGroupCount},
+            )}
+          </li>
+        ) : null}
+      </ul>
+    ) : null
+  );
+};
+
+export default ReleaseGroupAppearances;

--- a/root/types/recording.js
+++ b/root/types/recording.js
@@ -26,3 +26,13 @@ declare type RecordingT = $ReadOnly<{
 
 declare type RecordingWithArtistCreditT =
   $ReadOnly<{...RecordingT, +artistCredit: ArtistCreditT}>;
+
+declare type ReleaseGroupAppearancesT = {
+  +hits: number,
+  +results: $ReadOnlyArray<ReleaseGroupT>,
+};
+
+declare type ReleaseGroupAppearancesRoleT = {
+  +releaseGroupAppearances?:
+    {+[recordingId: number]: ReleaseGroupAppearancesT},
+};

--- a/t/lib/t/MusicBrainz/Server/Data/Recording.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Recording.pm
@@ -117,11 +117,11 @@ ok(!defined $rec);
 
 my @entities = map { $rec_data->get_by_id($_) } qw(1 8 14);
 
-my %appears = $rec_data->appears_on(\@entities, 2);
-$results = $appears{1}->{results};
+my $appears = $rec_data->appears_on(\@entities, 2);
+$results = $appears->{1}->{results};
 
-is ($appears{8}->{results}->[0]->name, "Aerial", "recording 8 appears on Aerial");
-is ($appears{1}->{hits}, 4, "recording 1 appears on four release groups");
+is ($appears->{8}->{results}->[0]->name, "Aerial", "recording 8 appears on Aerial");
+is ($appears->{1}->{hits}, 4, "recording 1 appears on four release groups");
 is (scalar @$results, 2, " ... of which two have been returned");
 is ($results->[0]->name, "King of the Mountain", "recording 1 appears on King of the Mountain");
 is ($results->[1]->name, "Aerial", "recording 1 appears on Aerial");

--- a/t/lib/t/MusicBrainz/Server/Data/Recording.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Recording.pm
@@ -123,9 +123,8 @@ $results = $appears->{1}->{results};
 is ($appears->{8}->{results}->[0]->name, "Aerial", "recording 8 appears on Aerial");
 is ($appears->{1}->{hits}, 4, "recording 1 appears on four release groups");
 is (scalar @$results, 2, " ... of which two have been returned");
-is ($results->[0]->name, "King of the Mountain", "recording 1 appears on King of the Mountain");
-is ($results->[1]->name, "Aerial", "recording 1 appears on Aerial");
-
+is ($results->[0]->name, "Aerial", "recording 1 appears on Aerial");
+is ($results->[1]->name, "エアリアル", "recording 1 appears on エアリアル");
 
 };
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4826
https://tickets.metabrainz.org/browse/MBS-4881

A popular artist's recording list is usually a lot of the same name with only a length to differentiate them. This makes it so that the release groups each recording appears in are also shown, making it easier to figure out if they're different recordings (e.g. album vs live bootleg) or whether maybe they should be looked into for merging.