### PR TITLE
MBS-10291: Add "、" as a separator in guessFeat

### DIFF
--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -19,7 +19,7 @@ import {
 import getSimilarity from './similarity';
 
 var featRegex = /(?:^\s*|[,，－\-]\s*|\s+)((?:ft|feat|ｆｔ|ｆｅａｔ)(?:[.．]|(?=\s))|(?:featuring|ｆｅａｔｕｒｉｎｇ)(?=\s))\s*/i;
-var collabRegex = /([,，]?\s+(?:&|and|et|＆|ａｎｄ|ｅｔ)\s+|[,，;；]\s+|\s*[\/／]\s*|\s+(?:vs|ｖｓ)[.．]\s+)/i;
+var collabRegex = /([,，]?\s+(?:&|and|et|＆|ａｎｄ|ｅｔ)\s+|、|[,，;；]\s+|\s*[\/／]\s*|\s+(?:vs|ｖｓ)[.．]\s+)/i;
 var bracketPairs = [['(', ')'], ['[', ']'], ['（', '）'], ['［', '］']];
 
 function extractNonBracketedFeatCredits(str, artists, isProbablyClassical) {

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -10,7 +10,7 @@ import guessFeat from '../edit/utility/guessFeat';
 import fields from '../release-editor/fields';
 
 test('guessing feat. artists', function (t) {
-    t.plan(21);
+    t.plan(22);
 
     var trackTests = [
         {
@@ -296,7 +296,23 @@ test('guessing feat. artists', function (t) {
                     ],
                 },
             }
-        }
+        },
+        {
+            input: {
+                name: 'Coast To Coast feat. 漢、般若',
+                artistCredit: {names: [{name: 'DJ Baku', joinPhrase: ''}]},
+            },
+            output: {
+                name: 'Coast To Coast',
+                artistCredit: {
+                    names: [
+                        {name: 'DJ Baku', joinPhrase: ' feat. '},
+                        {name: '漢', joinPhrase: '、'},
+                        {name: '般若', joinPhrase: ''},
+                    ],
+                },
+            }
+        },
     ];
 
     var releaseTests = [


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10291

In Japanese "、" is sometimes used to separate multiple artists in a feat. credit. As such, we should allow splitting collab artists by "、".