### PR TITLE
MBS-8566: Reuse release AC when importing CD stubs

### DIFF
--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -123,8 +123,16 @@ class SearchResult {
         if (track.artistCredit) {
             track.artist = reduceArtistCredit(track.artistCredit);
         } else {
+            // If the track artist matches the release artist, reuse the AC
+            const release = releaseEditor.rootField.release();
+            const releaseArtistCredit = release.artistCredit();
+            const releaseArtistName = reduceArtistCredit(releaseArtistCredit);
             track.artist = track.artist || this.artist || "";
-            track.artistCredit = {names: [{ name: track.artist }]};
+            if (track.artist === releaseArtistName) {
+                track.artistCredit = releaseArtistCredit;
+            } else {
+                track.artistCredit = {names: [{ name: track.artist }]};
+            }
         }
     }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-8566

If a CD stub is being imported that has track artists matching the release artist already selected, it's very unlikely that the user actually wants a different artist for the tracks. This assigns the release AC to the tracks if the track artist name matches the reduced artist credit for the release.