### PR TITLE
MBS-10345: Redirect away from /merge if not ready to merge

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -126,9 +126,13 @@ role {
             $c->model($merger->type)->get_by_ids($merger->all_entities)
         };
 
-        $c->detach
-            unless $merger->ready_to_merge;
-
+        unless ($merger->ready_to_merge) {
+            $c->response->redirect(
+                $c->req->referer ||
+                    $c->uri_for_action('/'));
+            $c->detach;
+        }
+        
         my $check_form = $c->form(form => 'Merge');
         if ($check_form->submitted_and_valid($c->req->params)) {
             # Ensure that we use the entities that appeared on the page and the right type,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10345

Currently going to /merge with just one entity in the queue loads a useless, semi-broken page. This changes it so that it just doesn't work, either sending the user back (if gone through a button, which can happen if the merge queue changed in another tab in the meantime), or just sending them to the front page if they typed /merge manually.

This also fixes https://tickets.metabrainz.org/browse/MBS-10344 by virtue of just not letting the user navigate there in the first place.