### PR TITLE
MBS-10346: Remove unneeded <p> inside <td>

### DIFF
--- a/root/user/collections.tt
+++ b/root/user/collections.tt
@@ -79,7 +79,7 @@
                     <td>[% link_collection(collection) %]</td>
                     <td>[% collection.type.l_name %]</td>
                     <td>[% collection.entity_count %]</td>
-                    <td><p>[% collaborator_number(collection, c.user) %]</p></td>
+                    <td>[% collaborator_number(collection, c.user) %]</td>
                     [% IF viewing_own_profile %]
                         <td>[% yesno(collection.subscribed) %]</td>
                         <td>[% collection.public ? l('Public') : l('Private') %]</td>
@@ -121,7 +121,7 @@
                             <td>[% link_collection(collection) %]</td>
                             <td>[% collection.type.l_name %]</td>
                             <td>[% collection.entity_count %]</td>
-                            <td><p>[% collaborator_number(collection, c.user) %]</p></td>
+                            <td>[% collaborator_number(collection, c.user) %]</td>
                             [% IF viewing_own_profile %]
                                 <td>[% yesno(collection.subscribed) %]</td>
                             [% END %]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10346

For some reason I added a `<p>` around collaborator_number(). It seems wholly unnecessary and makes the table too high, so removing.