### PR TITLE
MBS-10347: Make action columns take only needed space

### DIFF
--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -29,7 +29,7 @@ const AliasTable = (props: Props) => (
         <th>{l('Type')}</th>
         <th>{l('Locale')}</th>
         {props.allowEditing
-          ? <th className="actions actions-header">{l('Actions')}</th>
+          ? <th className="actions">{l('Actions')}</th>
           : null}
       </tr>
     </thead>

--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -29,7 +29,7 @@ const AliasTable = (props: Props) => (
         <th>{l('Type')}</th>
         <th>{l('Locale')}</th>
         {props.allowEditing
-          ? <th className="actions-header">{l('Actions')}</th>
+          ? <th className="actions actions-header">{l('Actions')}</th>
           : null}
       </tr>
     </thead>

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -49,7 +49,7 @@ const AliasTableRow = ({alias, allowEditing, entity, row}: Props) => (
         )
         : null}
     </td>
-    <td>
+    <td className="actions">
       {allowEditing
         ? (
           <>

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -44,7 +44,7 @@ const ArtistCreditList = ({$c, artistCredits, entity}: Props) => {
               {l('Name')}
             </th>
             {$c.user_exists ? (
-              <th className="actions-header">
+              <th className="actions actions-header">
                 {l('Actions')}
               </th>
             ) : null}
@@ -57,7 +57,7 @@ const ArtistCreditList = ({$c, artistCredits, entity}: Props) => {
                 <ArtistCreditLink artistCredit={credit} />
               </td>
               {$c.user_exists ? (
-                <td>
+                <td className="actions">
                   <a href={`/artist/${entity.gid}/credit/${credit.id}/edit`}>
                     {credit.editsPending
                       ? <span className="mp">{l('Edit')}</span>

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -44,7 +44,7 @@ const ArtistCreditList = ({$c, artistCredits, entity}: Props) => {
               {l('Name')}
             </th>
             {$c.user_exists ? (
-              <th className="actions actions-header">
+              <th className="actions">
                 {l('Actions')}
               </th>
             ) : null}

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -1015,6 +1015,11 @@ a.tagger-icon {
     min-width: 10em;
 }
 
+.actions {
+    white-space: nowrap;
+    width: 1px;
+}
+
 dl.ars, dl.ars dd, dl.ars dt {
     padding: 0;
     margin: 0;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -1011,10 +1011,6 @@ a.tagger-icon {
     display: block;
 }
 
-.actions-header {
-    min-width: 10em;
-}
-
 .actions {
     white-space: nowrap;
     width: 1px;

--- a/root/user/collections.tt
+++ b/root/user/collections.tt
@@ -69,7 +69,7 @@
                 [% IF viewing_own_profile %]
                     <th>[% l('Subscribed') %]</th>
                     <th>[% l('Privacy') %]</th>
-                    <th class="actions actions-header">[% l('Actions') %]</th>
+                    <th class="actions">[% l('Actions') %]</th>
                 [% END %]
             </tr>
         </thead>

--- a/root/user/collections.tt
+++ b/root/user/collections.tt
@@ -69,7 +69,7 @@
                 [% IF viewing_own_profile %]
                     <th>[% l('Subscribed') %]</th>
                     <th>[% l('Privacy') %]</th>
-                    <th class="actions-header">[% l('Actions') %]</th>
+                    <th class="actions actions-header">[% l('Actions') %]</th>
                 [% END %]
             </tr>
         </thead>
@@ -83,7 +83,7 @@
                     [% IF viewing_own_profile %]
                         <td>[% yesno(collection.subscribed) %]</td>
                         <td>[% collection.public ? l('Public') : l('Private') %]</td>
-                        <td>
+                        <td class="actions">
                             [% link_collection(collection, 'edit', l('Edit')) %] |
                             [% link_collection(collection, 'delete', l('Remove')) %]
                         </td>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10347

Actions columns are never the main focus of a table, so they should take as little space as they need for "Remove", "Edit", or whatever else goes in them. There's already a min-width of 10em, so they won't look too tiny anyway.