### PR TITLE
Beta: MBS-10348: Open edit note help links in a new tab

### DIFF
--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -24,8 +24,10 @@
                       name="enter-vote.vote.[% index %].edit_note"></textarea>
               </div>
             <p>
-                  [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}. Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',
-                     { doc_coc => { href => doc_link('Code_of_Conduct'), target = '_blank' }, doc_formatting => { href => doc_link('Edit_Note'), target => '_blank' } }) %]
+                  [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}.
+                        Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',
+                       { doc_coc => { href => doc_link('Code_of_Conduct'), target = '_blank' },
+                         doc_formatting => { href => doc_link('Edit_Note'), target => '_blank' } }) %]
             </p>
 
           </div>

--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -25,7 +25,7 @@
               </div>
             <p>
                   [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}. Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',
-                     { doc_coc => doc_link('Code_of_Conduct'), doc_formatting => doc_link('Edit_Note') }) %]
+                     { doc_coc => { href => doc_link('Code_of_Conduct'), target = '_blank' }, doc_formatting => { href => doc_link('Edit_Note'), target => '_blank' } }) %]
             </p>
 
           </div>


### PR DESCRIPTION
## Fix [MBS-10348](https://tickets.metabrainz.org/browse/MBS-10348): Beta: new edit page link should open in new tab

It amends https://github.com/metabrainz/musicbrainz-server/pull/1184 which is currently in beta.