### PR TITLE
MBS-10349: New, more clear headers for rel stats

### DIFF
--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -88,8 +88,8 @@ const Relationships = ({
         <tbody>
           <tr className="thead">
             <th />
-            <th>{l('Exclusive')}</th>
-            <th>{l('Inclusive')}</th>
+            <th>{lp('This type only', 'relationships')}</th>
+            <th>{lp('Including subtypes', 'relationships')}</th>
             <th />
           </tr>
           <tr>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10349

It's not particularly obvious what "Exclusive" vs "Inclusive" mean on the relationship stats. This changes the headers to actually specify what the numbers mean.