### PR TITLE
MBS-5083: Display recording artist on release view

### DIFF
--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -329,6 +329,7 @@ sub load_related_info {
     $self->c->model('ArtistCredit')->load(@tracks);
 
     my @recordings = $self->c->model('Recording')->load(@tracks);
+    $self->c->model('ArtistCredit')->load(@recordings);
     $self->c->model('Recording')->load_meta(@recordings);
     $self->c->model('Recording')->load_gid_redirects(@recordings);
     $self->c->model('Recording')->rating->load_user_ratings($user_id, @recordings) if $user_id;

--- a/root/components/medium.tt
+++ b/root/components/medium.tt
@@ -48,7 +48,13 @@
     </td>
     <td>
       [%- link_recording(track.recording, 'show', track.name) -%]
-      <br/>
+      [% # Show recording artist only to logged in users to avoid confusing visitors with recordings -%]
+      [% IF c.user_exists && track.artist_credit_id != track.recording.artist_credit_id %]
+          <div class="small">
+          [% l('Recording artist:') %]
+          [% artist_credit(track.recording.artist_credit) %]
+        </div>
+      [% END %]
       <div class="ars" style="display: none;">
         [% grouped_relationships(track.recording) %]
       </div>

--- a/t/selenium/release-editor/The_Downward_Spiral.html
+++ b/t/selenium/release-editor/The_Downward_Spiral.html
@@ -2543,6 +2543,7 @@ Nothing Records</td>
 	</td>
 </tr>
 <!-- Reset the track numbers. -->
+<tr>
 	<td>clickAndWait</td>
 	<td>css=.tabs a[href$="/edit"]</td>
 	<td></td>

--- a/t/selenium/release-editor/The_Downward_Spiral.html
+++ b/t/selenium/release-editor/The_Downward_Spiral.html
@@ -508,10 +508,10 @@ A7 The Becoming - nin 5:32</td>
 </tr>
 <tr>
 	<td>assertEval</td>
-	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim()).join('\t')).join('\n')</td>
+	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim().replace(/\s*(Recording artist:)\s*([^\n]+)/, '\t$1 $2')).join('\t')).join('\n')</td>
 	<td>0	Pregap	Nine Inch Nails	?:??
-A1	Mr Self Destruct	nin	4:31
-A2	Piggy	nin	4:24
+A1	Mr Self Destruct	Recording artist: Nine Inch Nails	nin	4:31
+A2	Piggy	Recording artist: Nine Inch Nails	nin	4:24
 A3	Heresy	nin	3:54
 A4	March of the Pigs	nin	2:58
 A5	Closer	nin	6:13
@@ -1448,14 +1448,14 @@ B4. Eraser (4:54)
 </tr>
 <tr>
 	<td>assertEval</td>
-	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim()).join('\t')).join('\n')</td>
+	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim().replace(/\s*(Recording artist:)\s*([^\n]+)/, '\t$1 $2')).join('\t')).join('\n')</td>
 	<td>A1	Mr Self Destruct	4:31
 A2	Piggy	4:24
-A3	Heresy	3:54
-A4	March of the Pigs	2:58
-A5	Closer	6:13
-A6	Ruiner	4:59
-A7	The Becoming	5:32
+A3	Heresy	Recording artist: nin	3:54
+A4	March of the Pigs	Recording artist: nin	2:58
+A5	Closer	Recording artist: nin	6:13
+A6	Ruiner	Recording artist: nin	4:59
+A7	The Becoming	Recording artist: nin	5:32
 B1	I Do Not Want This	5:41
 B2	Big Man With a Gun	1:36
 B3	A Warm Place	3:23
@@ -2575,14 +2575,14 @@ Nothing Records</td>
 <!-- Check that the submitted release information is correct. -->
 <tr>
 	<td>assertEval</td>
-	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim()).join('\t')).join('\n')</td>
+	<td>Array.from(document.querySelectorAll('table.medium > tbody > tr')).slice(1).map(x => Array.from(x.querySelectorAll('td')).filter(x => !x.classList.contains('rating')).map(x => x.textContent.trim().replace(/\s*(Recording artist:)\s*([^\n]+)/, '\t$1 $2')).join('\t')).join('\n')</td>
 	<td>1	Mr Self Destruct	4:31
 2	Piggy	4:24
-3	Heresy	3:54
-4	March of the Pigs	2:58
-5	Closer	6:13
-6	Ruiner	4:59
-7	The Becoming	5:32
+3	Heresy	Recording artist: nin	3:54
+4	March of the Pigs	Recording artist: nin	2:58
+5	Closer	Recording artist: nin	6:13
+6	Ruiner	Recording artist: nin	4:59
+7	The Becoming	Recording artist: nin	5:32
 8	I Do Not Want This	5:41
 9	Big Man With a Gun	1:36
 10	A Warm Place	3:23


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5083

There's currently no good way of telling if the  recording artist is different from the track artist from a release page without actually opening the recording page for each recording.

This patch makes it so that if the track and recording ACs differ, the recording AC is displayed under the track name (since the track artist column, which might seem like a more obvious choice, doesn't appear at all if all track artists match the release artist).

This is particularly useful in two cases:
a) when a user has fixed a track artist but forgotten to fix the recording artist, or vice versa.
b) for classical music, where the recording artist should usually be different from the track artist.