### PR TITLE
Allow showing tracklists everywhere when attaching/viewing discIDs

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -42,6 +42,9 @@ sub _load_releases
     my ($self, $c, $cdtoc) = @_;
     my @medium_cdtocs = $c->model('MediumCDTOC')->find_by_discid($cdtoc->discid);
     my @mediums = $c->model('Medium')->load(@medium_cdtocs);
+    $c->model('Track')->load_for_mediums(@mediums);
+    my @tracks = map { $_->all_tracks } @mediums;
+    $c->model('Recording')->load(@tracks);
     my @releases = $c->model('Release')->load(@mediums);
     my @rgs = $c->model('ReleaseGroup')->load(@releases);
     $c->model('ReleaseGroup')->load_meta(@rgs);
@@ -58,10 +61,6 @@ sub show : Chained('load') PathPart('')
 
     my $cdtoc = $c->stash->{cdtoc};
     my $medium_cdtocs = $self->_load_releases($c, $cdtoc);
-
-    $c->model('Track')->load_for_mediums(
-        map { $_->medium } @{$medium_cdtocs}
-    );
 
     $c->stash(
         medium_cdtocs => $medium_cdtocs,

--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -314,7 +314,13 @@ sub _attach_list {
                 $initial_release ||= $cdstub->title;
 
                 my @mediums = $c->model('Medium')->find_for_cdstub($cdstub);
-                $c->model('ArtistCredit')->load(map { $_->release } @mediums);
+                $c->model('MediumFormat')->load(@mediums);
+                $c->model('Track')->load_for_mediums(@mediums);
+                my @tracks = map { $_->all_tracks } @mediums;
+                $c->model('Recording')->load(@tracks);
+                my @releases = map { $_->release } @mediums;
+                $c->model('Release')->load_related_info(@releases);
+                $c->model('ArtistCredit')->load(@releases);
                 $c->stash(
                     possible_mediums => [ @mediums  ],
                     cdstub => $cdstub

--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -1,8 +1,4 @@
-[% MACRO attach_list_row(release, show_artists) BLOCK %]
-  <tr[% ' class="even"' IF zebra % 2 == 0 %]>
-    <td colspan="2">
-      [%~ link_entity(release) ~%]
-    </td>
+[% MACRO release_info(show_artists) BLOCK %]
     [% IF show_artists %]
       <td>[% artist_credit(release.artist_credit) %]</td>
     [% END %]
@@ -15,6 +11,29 @@
     [%- IF c.try_get_session('tport') -%]
       <td>[% tagger_icon(release) %]</td>
     [%- END -%]
+[% END %]
+
+[% MACRO tracklist_toggle BLOCK %]
+  <small>(<a class="toggle" style="cursor:pointer;">[% l('show tracklist') %]</a>)</small>
+[% END %]
+
+[% MACRO tracklist_block BLOCK %]
+  <tr class="tracklist" style="display:none">
+    <td></td>
+    <td colspan="6">
+      <table style="border-collapse: collapse;">
+      [% INCLUDE 'medium/tracklist.tt' tracks=medium.tracks hide_rating = 1%]
+      </table>
+    </td>
+  </tr>
+[% END %]
+
+[% MACRO attach_list_row(release, show_artists) BLOCK %]
+  <tr[% ' class="even"' IF zebra % 2 == 0 %]>
+    <td colspan="2">
+      [%~ link_entity(release) ~%]
+    </td>
+    [% release_info(show_artists) %]
   </tr>
   [%-
     attachable_mediums = [];
@@ -42,21 +61,14 @@
                [% medium.name | html %]
             [% END %]
           </label>
-          <small>(<a class="toggle" style="cursor:pointer;">[% l('show tracklist') %]</a>)</small>
+          [% tracklist_toggle %]
           [% IF this_medium_has_cdtoc %]
             <div class="error">[% l('This CDTOC is already attached to this medium.') %]</div>
           [% END %]
         </td>
         <td colspan="6"></td>
       </tr>
-      <tr class="tracklist" style="display:none">
-        <td></td>
-        <td colspan="6">
-          <table style="border-collapse: collapse;">
-          [% INCLUDE 'medium/tracklist.tt' tracks=medium.tracks hide_rating = 1%]
-          </table>
-        </td>
-      </tr>
+      [% tracklist_block %]
     </tr>
   [% END %]
   [% IF was_mbid_search && !attachable_mediums.size %]

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -1,3 +1,5 @@
+[%- PROCESS 'cdtoc/attach_list.tt' -%]
+
 <table class="tbl">
     <thead>
         <tr>
@@ -25,7 +27,10 @@
            classes.push(loop.parity);
            classes.push('mp') IF medium_cdtoc.edits_pending > 0; %]
         <tr class="[% classes.join(' ') %]">
-            <td>[% medium.position %]/[% release.medium_count %]</td>
+            <td>
+              [% medium.position %]/[% release.medium_count %]
+              [% tracklist_toggle %]
+            </td>
             <td>[% link_entity(release) %]</td>
             <td>[% artist_credit(release.artist_credit) %]</td>
             <td>[% medium_format_name(medium) %]</td>
@@ -59,6 +64,24 @@
             </td>
             [% END %]
         </tr>
-        [%- END -%]
+        [% tracklist_block %]
+      [%- END -%]
+      [% attach_list_script() %]
     </tbody>
 </table>
+
+[% MACRO cdtoc_list_script BLOCK %]
+  <script>
+    $(".tracklist").hide();
+
+    $(document).on("click", ".toggle", function () {
+      var $tracklist = $(this).closest("tr").next(".tracklist").toggle();
+
+      if ($tracklist.is(":hidden")) {
+        $(this).text("[% l('show tracklist') | js %]");
+      } else {
+        $(this).text("[% l('hide tracklist') | js %]");
+      }
+    });
+  </script>
+[% END %]

--- a/root/cdtoc/lookup.tt
+++ b/root/cdtoc/lookup.tt
@@ -1,3 +1,5 @@
+[%- PROCESS 'cdtoc/attach_list.tt' -%]
+
 [% WRAPPER 'layout.tt' title=l('Lookup CD') full_width=1 %]
 <h1>[% l('Lookup CD') %]</h1>
 [% IF c.user_exists %]
@@ -37,16 +39,27 @@
         <th>[% l('Release') %]</th>
         <th>[% l('Medium') %]</th>
         <th>[% l('Artist') %]</th>
+        <th>[% l('Date') %]</th>
+        <th>[% l('Country') %]</th>
+        <th>[% l('Label') %]</th>
+        <th>[% l('Catalog#') %]</th>
+        <th>[% l('Barcode') %]</th>
       </thead>
       <tbody>
         [% FOR medium=possible_mediums %]
-        <tr class="[% loop.parity %]">
-          <td><input type="radio" name="medium" value="[% medium.id %]" /></td>
-          <td>[% link_entity(medium.release) %]</td>
-          <td>[% medium.position %]</td>
-          <td>[% artist_credit(medium.release.artist_credit) %]</td>
-        </tr>
+          [% release=medium.release %]
+          <tr class="[% loop.parity %]">
+            <td><input type="radio" name="medium" value="[% medium.id %]" /></td>
+            <td>[% link_entity(release) %]</td>
+            <td>
+              [% medium.format_name %] [% medium.position %]
+              [% tracklist_toggle %]
+            </td>
+            [% release_info(1) %]
+          </tr>
+          [% tracklist_block %]
         [% END %]
+        [% attach_list_script() %]
       </tbody>
     </table>
     <p>[% form_submit(l('Attach Disc ID')) %]</p>


### PR DESCRIPTION
 ### Implement MBS-5225

When importing a discID normally, you get given a nice table with a lot of data, including tracklist (see cdtoc/attach_list.tt). 
When importing it from a CDStub, a list of "Possible Mediums" was given, with only release title, artist, and medium number, forcing users to choose semi-blindly.

This patch changes the table to be more similar to the one in attach_list, with both more info and collapsible tracklists. attach_list itself can't directly be reused without changing the way we look for the possible mediums, but this reuses as many components as possible.

The second commit allows seeing tracklists both on the list of "Matching CDs" shown in Lookup CD, and on the list of mediums attached to a discid on cdtoc/index.
