### PR TITLE
MBS-10356: Replace <b> with <strong>

### DIFF
--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -59,7 +59,7 @@ sub format_setlist_artist {
        [0-9a-f]{12})(?:\|([^\]]+))?\]
     /_make_link("artist",$1,$2)/eixg;
 
-    $line = "<b>Artist: $line</b>";
+    $line = "<strong>Artist: $line</strong>";
 
     return $line;
 }

--- a/root/instrument/edit_form.tt
+++ b/root/instrument/edit_form.tt
@@ -14,6 +14,16 @@
           [%- r.textarea('description', { rows => 5 }) -%]
           [%- field_errors(form, 'description') -%]
       [%- END -%]
+      [% WRAPPER form_row %]
+        <p>
+          [% # When converting to React, please move the list below to expand2react.js and import from there # %]
+          [% l('HTML tags allowed in the description: {tag_list}.', 
+            {tag_list => comma_only_list(
+              ['a', 'abbr', 'br', 'code', 'em', 'li', 'p', 'span', 'strong', 'ul'],
+            )}) %]
+        </p>
+      [%- END -%]
+
     </fieldset>
 
     [% PROCESS 'forms/relationship-editor.tt' %]

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -273,7 +273,7 @@
 
   <div class="bubble" data-bind="bubble: $root.dateBubble">
     <p data-bind="visible: target() && target().hasAmazonDate()">
-      [% l('Warning! "1990-10-25" is the bogus date that Amazon gives to all releases for which they don\'t know the actual date. <b>Please use this date only if you\'re certain this date is correct!</b>') %]
+      [% l('Warning! "1990-10-25" is the bogus date that Amazon gives to all releases for which they don\'t know the actual date. <strong>Please use this date only if you\'re certain this date is correct!</strong>') %]
     </p>
     <p data-bind="visible: target() && target().hasJanuaryFirstDate()">
       [% l('Note! If you do not know the month or day of release, please leave them empty.  January 1st is not often the actual release date, please double check that you have entered the release date correctly.') %]

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -53,7 +53,7 @@ if (places.length) {
         className: 'cluster-div-icon',
         html: '<img src="' + _.escape(iconURL) + '" />' +
               '<div class="cluster-div-text">' +
-              '<b>' + cluster.getChildCount() + '</b></div>',
+              '<strong>' + cluster.getChildCount() + '</strong></div>',
         iconSize: L.point(25, 41),
       });
     },

--- a/root/static/scripts/common/i18n/expand2.js
+++ b/root/static/scripts/common/i18n/expand2.js
@@ -16,6 +16,7 @@ import * as React from 'react';
  */
 export class NO_MATCH {
   static instance: ?NO_MATCH;
+
   constructor() {
     return NO_MATCH.instance || (NO_MATCH.instance = this);
   }
@@ -189,26 +190,26 @@ export const createTextContentParser = <+T, V>(
   textPattern: RegExp,
   mapValue: (string) => T,
 ): Parser<T | string | NO_MATCH, V> => () => {
-  const text = accept(textPattern);
-  if (typeof text !== 'string') {
-    return NO_MATCH_VALUE;
-  }
-  return mapValue(text);
-};
+    const text = accept(textPattern);
+    if (typeof text !== 'string') {
+      return NO_MATCH_VALUE;
+    }
+    return mapValue(text);
+  };
 
 const varSubst = /^\{([0-9A-z_]+)\}/;
 export const createVarSubstParser = <T, V>(
   argFilter: (V) => T,
 ): Parser<T | string | NO_MATCH, V> => saveMatch(function (args: VarArgs<V>) {
-  const name = accept(varSubst);
-  if (typeof name !== 'string') {
-    return NO_MATCH_VALUE;
-  }
-  if (args.has(name)) {
-    return argFilter(args.get(name));
-  }
-  return state.match;
-});
+    const name = accept(varSubst);
+    if (typeof name !== 'string') {
+      return NO_MATCH_VALUE;
+    }
+    if (args.has(name)) {
+      return argFilter(args.get(name));
+    }
+    return state.match;
+  });
 
 export const parseStringVarSubst =
   createVarSubstParser<string, mixed>(getString);
@@ -220,38 +221,38 @@ export const createCondSubstParser = <T, V>(
   thenParser: Parser<T, V>,
   elseParser: Parser<T, V>,
 ): Parser<T | string | NO_MATCH, V> => saveMatch(function (args) {
-  const name = accept(condSubstStart);
-  if (typeof name !== 'string') {
-    return NO_MATCH_VALUE;
-  }
-
-  const savedReplacement = state.replacement;
-  if (args.has(name)) {
-    state.replacement = getVarSubstArg(args.get(name));
-  }
-
-  const thenChildren = thenParser(args);
-
-  let elseChildren = '';
-  if (gotMatch(accept(verticalPipe))) {
-    elseChildren = elseParser(args);
-  }
-
-  state.replacement = savedReplacement;
-
-  if (!gotMatch(accept(substEnd))) {
-    throw error('expected }');
-  }
-
-  if (args.has(name)) {
-    const value = args.get(name);
-    if (value) {
-      return thenChildren;
+    const name = accept(condSubstStart);
+    if (typeof name !== 'string') {
+      return NO_MATCH_VALUE;
     }
-    return elseChildren;
-  }
-  return state.match;
-});
+
+    const savedReplacement = state.replacement;
+    if (args.has(name)) {
+      state.replacement = getVarSubstArg(args.get(name));
+    }
+
+    const thenChildren = thenParser(args);
+
+    let elseChildren = '';
+    if (gotMatch(accept(verticalPipe))) {
+      elseChildren = elseParser(args);
+    }
+
+    state.replacement = savedReplacement;
+
+    if (!gotMatch(accept(substEnd))) {
+      throw error('expected }');
+    }
+
+    if (args.has(name)) {
+      const value = args.get(name);
+      if (value) {
+        return thenChildren;
+      }
+      return elseChildren;
+    }
+    return state.match;
+  });
 
 /*
  * This is not meant to be called directly, except by expand2react and

--- a/root/static/scripts/common/i18n/expand2html.js
+++ b/root/static/scripts/common/i18n/expand2html.js
@@ -16,6 +16,6 @@ export default function expand2html(
   args?: ?{+[string]: Expand2ReactInput},
 ) {
   return ReactDOMServer.renderToStaticMarkup(
-    expand2react(source, args)
+    expand2react(source, args),
   );
 }

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -46,7 +46,7 @@ const condSubstThenTextContent = /^[^<>{}|]+/;
 const percentSign = /(%)/;
 const linkSubstStart = /^\{([0-9A-z_]+)\|/;
 const htmlTagStart = /^<(?=[a-z])/;
-const htmlTagName = /^(a|abbr|b|br|code|em|li|p|span|strong|ul)(?=[\s\/>])/;
+const htmlTagName = /^(a|abbr|br|code|em|li|p|span|strong|ul)(?=[\s\/>])/;
 const htmlTagEnd = /^>/;
 const htmlSelfClosingTagEnd = /^\s*\/>/;
 const htmlAttrStart = /^\s+(?=[a-z])/;

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -10,13 +10,18 @@
 import he from 'he';
 import * as React from 'react';
 
+import {
+  l as lActual,
+  ln as lnActual,
+  lp as lpActual,
+} from '../i18n';
+
 import expand, {
   accept,
   createCondSubstParser,
   createTextContentParser,
   createVarSubstParser,
   error,
-  getString,
   getVarSubstArg,
   gotMatch,
   NO_MATCH_VALUE,
@@ -30,11 +35,6 @@ import expand, {
   type Parser,
   type VarArgs,
 } from './expand2';
-import {
-  l as lActual,
-  ln as lnActual,
-  lp as lpActual,
-} from '../i18n';
 
 type Input = Expand2ReactInput;
 type Output = Expand2ReactOutput;

--- a/root/static/scripts/tests/i18n/expand2.js
+++ b/root/static/scripts/tests/i18n/expand2.js
@@ -1,5 +1,6 @@
 import test from 'tape';
 import React from 'react';
+
 import {VarArgs} from '../../common/i18n/expand2';
 import expand2html from '../../common/i18n/expand2html';
 import expand2text from '../../common/i18n/expand2text';
@@ -92,25 +93,25 @@ test('expand2', function (t) {
 
   expandHtml(
     'A {apple_fruit|darn {apple}}',
-    {apple_fruit: 'http://www.apple.com', apple: 'pear'},
+    {apple: 'pear', apple_fruit: 'http://www.apple.com'},
     'A <a href="http://www.apple.com">darn pear</a>',
   );
 
   expandHtml(
     'A {apple_fruit|darn {apple}}',
-    {apple_fruit: 'http://www.apple.com', apple: React.createElement('i', null, 'pear')},
+    {apple: React.createElement('i', null, 'pear'), apple_fruit: 'http://www.apple.com'},
     'A <a href="http://www.apple.com">darn <i>pear</i></a>',
   );
 
   expandHtml(
     'A {apple_fruit|{apple}}',
     {
+      apple: 'pear',
       apple_fruit: {
         className: 'link',
         href: 'http://www.apple.com',
         target: '_blank',
       },
-      apple: 'pear',
     },
     'A <a class="link" href="http://www.apple.com" target="_blank">pear</a>',
   );
@@ -118,8 +119,8 @@ test('expand2', function (t) {
   expandHtml(
     'A {apple_fruit|{apple}}',
     {
-      apple_fruit: 'http://www.apple.com',
       apple: '<pears are="yellow, green & red">',
+      apple_fruit: 'http://www.apple.com',
     },
     'A <a href="http://www.apple.com">&lt;pears are=&quot;yellow, green &amp; red&quot;&gt;</a>',
   );
@@ -149,7 +150,7 @@ test('expand2', function (t) {
   expandText('{x:%|}', {x: ''}, '');
   expandText('{x:%|}', {x: '%'}, '%');
   expandText('{x:%|}', {x: '&percnt;'}, '&percnt;');
-  expandHtml('{x:%|}', {x: <p>hi</p>}, '<p>hi</p>');
+  expandHtml('{x:%|}', {x: <p>{'hi'}</p>}, '<p>hi</p>');
   expandText('{x:a%c|}', {x: 'b'}, 'abc');
   expandText('{x:a&percnt;c|}', {x: 'b'}, 'a&percnt;c');
   expandHtml('{x:a&percnt;c|}', {x: 'b'}, 'a%c');

--- a/root/static/scripts/tests/i18n/expand2.js
+++ b/root/static/scripts/tests/i18n/expand2.js
@@ -39,8 +39,8 @@ test('expand2', function (t) {
 
   expandHtml(
     'An {apple_fruit}',
-    {apple_fruit: React.createElement('b', null, 'apple')},
-    'An <b>apple</b>',
+    {apple_fruit: React.createElement('strong', null, 'apple')},
+    'An <strong>apple</strong>',
   );
 
   // Shouldn't interpolate React elements with expand2text.
@@ -131,15 +131,15 @@ test('expand2', function (t) {
   );
 
   expandHtml(
-    'A {apple_fruit|<b><strong>{prefix} APPLE!</strong></b>}',
+    'A {apple_fruit|<strong>{prefix} APPLE!</strong>}',
     {apple_fruit: 'http://www.apple.com', prefix: 'dang'},
-    'A <a href="http://www.apple.com"><b><strong>dang APPLE!</strong></b></a>',
+    'A <a href="http://www.apple.com"><strong>dang APPLE!</strong></a>',
   );
 
   expandText('{x:y|}', null, '{x:y|}');
   expandText('{x:y|}', {x: true}, 'y');
   expandText('{x:y|}', {x: false}, '');
-  expandHtml('{x:<b>|</b>|}', {x: true}, '<b>|</b>');
+  expandHtml('{x:<strong>|</strong>|}', {x: true}, '<strong>|</strong>');
 
   expandText('{x:|y}', null, '{x:|y}');
   expandText('{x:|y}', {x: true}, '');

--- a/root/taglookup/Nag.js
+++ b/root/taglookup/Nag.js
@@ -12,19 +12,34 @@ import * as React from 'react';
 const TagLookupNagSection = () => (
   <div className="nagpanel">
     <p>
-      {l("The users make MusicBrainz happen and we appreciate your help!")}
+      {l('The users make MusicBrainz happen and we appreciate your help!')}
     </p>
     <p>
-      {exp.l("However, we still have to pay the bills and hosting this site costs {finances|more than $1000 per month}. We need our users to help us make ends meet and hopefully have money left over to sponsor more development. The {metabrainz_foundation|MetaBrainz Foundation}, a California based 501(c)3 tax-exempt non-profit, operates the MusicBrainz project which makes all donations <strong>tax deductible</strong> for US taxpayers. And it's simply good karma everywhere else!", {
-        metabrainz_foundation: 'https://metabrainz.org',
-        finances: 'https://metabrainz.org/finances',
-      })}
+      {exp.l(
+        `However, we still have to pay the bills and hosting this site costs
+         {finances|more than $1000 per month}. We need our users to help us
+         make ends meet and hopefully have money left over to sponsor more
+         development. The {metabrainz_foundation|MetaBrainz Foundation}, a
+         California based 501(c)3 tax-exempt non-profit, operates the MusicBrainz
+         project which makes all donations <strong>tax deductible</strong>
+         for US taxpayers. And it's simply good karma everywhere else!`,
+        {
+          finances: 'https://metabrainz.org/finances',
+          metabrainz_foundation: 'https://metabrainz.org',
+        },
+      )}
     </p>
     <p>
-      {exp.l("If you donate <strong>$4</strong> you will not get this nag text for a <strong>month</strong>. We encourage people to donate $12 to make the nag screen disappear for 3 months. Or even better, sign up for a recurring donation every three months to not have to think about or see this nag again.")}
+      {exp.l(
+        `If you donate <strong>$4</strong> you will not get this nag text for 
+         a <strong>month</strong>. We encourage people to donate $12 to make
+         the nag screen disappear for 3 months. Or even better, sign up for a
+         recurring donation every three months to not have to think about or
+         see this nag again.`,
+      )}
     </p>
     <p className="naglinkpanel">
-      <a href="https://metabrainz.org/donate" className="naglink">
+      <a className="naglink" href="https://metabrainz.org/donate">
         {l('Make a donation now!')}
       </a>
       <br />

--- a/root/taglookup/Nag.js
+++ b/root/taglookup/Nag.js
@@ -21,7 +21,7 @@ const TagLookupNagSection = () => (
       })}
     </p>
     <p>
-      {exp.l("If you donate <b>$4</b> you will not get this nag text for a <b>month</b>. We encourage people to donate $12 to make the nag screen disappear for 3 months. Or even better, sign up for a recurring donation every three months to not have to think about or see this nag again.")}
+      {exp.l("If you donate <strong>$4</strong> you will not get this nag text for a <strong>month</strong>. We encourage people to donate $12 to make the nag screen disappear for 3 months. Or even better, sign up for a recurring donation every three months to not have to think about or see this nag again.")}
     </p>
     <p className="naglinkpanel">
       <a href="https://metabrainz.org/donate" className="naglink">


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10356

This replaces all of our `<b>` messages, including the ones not yet ported to JS, since we will eventually need them to be `<strong>` anyway. Ideally we should also fix the translations (which this will break, but can be reused by simply changing `<b>` to `<strong>` there as well). @yvanzo: any suggestions on how to do that? :) 

I added some eslint fixes to files I was touching anyway. I fixed all except no-weak-types, since I'm not sure what's the right fix for that one. We can either merge it as-is, or I can fix those too if you let me know how :)