### PR TITLE
MBS-10361: Move edit note help for better tabbing

### DIFF
--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -19,17 +19,16 @@
           <div class="add-edit-note edit-note"
               [% 'style="display: none"' IF hide -%]>
               <h3 class="owner">[% link_entity(c.user) %]</h3>
-              <div class="edit-note-text">
-                  <textarea class="edit-note" rows="5" placeholder="[% l('Add an edit note') %]"
-                      name="enter-vote.vote.[% index %].edit_note"></textarea>
-              </div>
-            <p>
+              <p class="edit-note-help">
                   [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}.
                         Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',
                        { doc_coc => { href => doc_link('Code_of_Conduct'), target = '_blank' },
                          doc_formatting => { href => doc_link('Edit_Note'), target => '_blank' } }) %]
-            </p>
-
+              </p>
+              <div class="edit-note-text">
+                  <textarea class="edit-note" rows="5" placeholder="[% l('Add an edit note') %]"
+                      name="enter-vote.vote.[% index %].edit_note"></textarea>
+              </div>
           </div>
       [% ELSE %]
           <p>

--- a/root/static/styles/common.less
+++ b/root/static/styles/common.less
@@ -1,5 +1,6 @@
 @import "variables.less";
 @import "colors.less";
+@import "help.less";
 
 @import "edit.less";
 @import "entity.less";

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -202,6 +202,14 @@ table.vote-tally {
         display: none;
         margin-top: 5px;
     }
+
+    .edit-note-help {
+        background: @effectively-white-bg;
+        border: dotted 1px @medium-border;
+        display: table;
+        margin-left: 1em;
+        padding: 4px;
+    }
 }
 
 /*

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -204,11 +204,8 @@ table.vote-tally {
     }
 
     .edit-note-help {
-        background: @effectively-white-bg;
-        border: dotted 1px @medium-border;
-        display: table;
+        .help-box();
         margin-left: 1em;
-        padding: 4px;
     }
 }
 

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -207,16 +207,11 @@ dl.properties label {
 }
 
 div.ar-descr, div.form-help {
-    background: @effectively-white-bg;
-    padding: 4px;
-    border: dotted 1px @medium-border;
+    .help-box();
     margin: 6px;
-    p:first-child { margin-top: 0; }
-    p:last-child { margin-bottom: 0; }
 }
 
 div.form-help {
-    display: table;
     margin-left: 1.4em;
 }
 

--- a/root/static/styles/help.less
+++ b/root/static/styles/help.less
@@ -1,0 +1,9 @@
+.help-box {
+    background: @effectively-white-bg;
+    border: dotted 1px @medium-border;
+    display: table;
+    padding: 4px;
+
+    p:first-child { margin-top: 0; }
+    p:last-child { margin-bottom: 0; }
+}

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -590,10 +590,6 @@ span.ac-mp {
     margin-left: -5px;
 }
 
-.edit-note-help {
-    font-style: italic;
-}
-
 span.video {
     background-image: data-uri('../images/icons/video.png');
     background-repeat: no-repeat;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -590,6 +590,10 @@ span.ac-mp {
     margin-left: -5px;
 }
 
+.edit-note-help {
+    font-style: italic;
+}
+
 span.video {
     background-image: data-uri('../images/icons/video.png');
     background-repeat: no-repeat;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10361

Users will want to tab directly to the submit button on edit pages, which the current position of the edit note help prevents (at least in Chrome). This moves it above the note field, but makes it .small to ensure the user doesn't confuse it with an existing edit note.