### PR TITLE
MBS-10363: Go back to referer on merge cancel

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -86,7 +86,7 @@ role {
         my ($self, $c) = @_;
         delete $c->session->{merger};
         $c->res->redirect(
-            $c->req->query_params->{returnto} || $c->uri_for('/'));
+            $c->req->query_params->{returnto} || $c->req->referer || $c->uri_for('/'));
         $c->detach;
     };
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10363

My commit 7ea117feea2df13f0a4478c39fa5f5e55ad6b5db made things better on the /merge page but inadvertently made them worse on the merge helper. This changes it so that it does still try to go to referer if there's no returnto set, so that it will stay in the same page when canceling a merge from the merge helper.