### PR TITLE
MBS-5460/MBS-5572: Add shift-click selecting to more places

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -72,7 +72,7 @@
       </fieldset>
 
       [% IF artist_credits.size %]
-      <fieldset>
+      <fieldset id="artist-credit-renamer">
         <legend>[% l('Artist Credits') %]</legend>
         <p>
             [%- l('Please select the {doc|artist credits} that you want to rename to follow the new artist name.', {doc => doc_link('Artist Credits')}) -%]

--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -15,7 +15,7 @@
     <fieldset>
       <legend data-bind="text: formattedName()"></legend>
 
-      <table data-bind="if: loaded">
+      <table id="track-recording-assignation" data-bind="if: loaded">
         <thead>
           <tr>
             <th></th>

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -45,13 +45,13 @@ require("./common/i18n");
 require("./common/entity");
 require("./common/MB/Control/Autocomplete");
 require('./common/components/ReleaseEvents');
+require("./common/MB/Control/SelectAll");
 require("./common/components/TagEditor");
 
 import(/* webpackChunkName: "common-artwork-viewer" */ "./common/artworkViewer");
 import(/* webpackChunkName: "common-dialogs" */ "./common/dialogs");
 import(/* webpackChunkName: "common-filter" */ "./common/components/Filter");
 import(/* webpackChunkName: "common-menu" */ "./common/MB/Control/Menu");
-import(/* webpackChunkName: "common-select-all" */ "./common/MB/Control/SelectAll");
 import(/* webpackChunkName: "common-edit-search" */ "./common/MB/edit_search");
 import(/* webpackChunkName: "common-release" */ "./common/MB/release");
 import(/* webpackChunkName: "common-ratings" */ "./common/ratings");

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -10,25 +10,33 @@ import $ from 'jquery';
 
 import MB from '../../MB';
 
-MB.Control.RangeSelect = function ($checkboxes) {
+MB.Control.RangeSelect = function (selector, parent) {
   let lastChecked = null;
-  $checkboxes.click(function (event) {
-    const nowChecked = event.currentTarget;
+  $(parent || 'body').on(
+    'click',
+    selector,
+    function (event) {
+      const thisChecked = event.currentTarget;
+      const $checkboxes = $(selector);
 
-    if (event.shiftKey && lastChecked && lastChecked !== nowChecked) {
-      const first = $checkboxes.index(lastChecked);
-      const last = $checkboxes.index(nowChecked);
+      if (event.shiftKey && lastChecked && lastChecked !== thisChecked) {
+        const lastIndex = $checkboxes.index(lastChecked);
+        const thisIndex = $checkboxes.index(thisChecked);
+        const thisIsChecked = $(thisChecked).is(':checked');
 
-      if (first > last) {
-        $checkboxes.slice(last, first + 1)
-          .prop('checked', nowChecked.checked);
-      } else if (last > first) {
-        $checkboxes.slice(first, last + 1)
-          .prop('checked', nowChecked.checked);
+        if (lastIndex > thisIndex) {
+          $checkboxes.slice(thisIndex, lastIndex + 1)
+            .filter(thisIsChecked ? ':not(:checked)' : ':checked')
+            .trigger('click');
+        } else if (thisIndex > lastIndex) {
+          $checkboxes.slice(lastIndex, thisIndex + 1)
+            .filter(thisIsChecked ? ':not(:checked)' : ':checked')
+            .trigger('click');
+        }
       }
-    }
-    lastChecked = nowChecked;
-  });
+      lastChecked = thisChecked;
+    },
+  );
 };
 
 MB.Control.SelectAll = function (table) {
@@ -44,7 +52,7 @@ MB.Control.SelectAll = function (table) {
     $checkboxes.prop('checked', $input.prop('checked'));
   });
 
-  MB.Control.RangeSelect($checkboxes);
+  MB.Control.RangeSelect('td input[type="checkbox"]', $table);
 };
 
 $(function () {

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -10,39 +10,41 @@ import $ from 'jquery';
 
 import MB from '../../MB';
 
-MB.Control.SelectAll = function (table) {
-  const self = {};
+MB.Control.RangeSelect = function ($checkboxes) {
+  let lastChecked = null;
+  $checkboxes.click(function (event) {
+    const nowChecked = event.currentTarget;
 
-  self.$table = $(table);
-  self.$checkboxes = self.$table.find('td input[type="checkbox"]');
-  self.lastChecked = null;
-
-  self.$selector = self.$table.find('th input[type="checkbox"]');
-
-  self.$selector.toggle(self.$checkboxes.length > 0);
-
-  self.$selector.change(function () {
-    const $input = $(this);
-    self.$checkboxes.prop('checked', $input.prop('checked'));
-  });
-
-  self.$checkboxes.click(function (event) {
-    if (event.shiftKey && self.lastChecked && self.lastChecked != this) {
-      const first = self.$checkboxes.index(self.lastChecked);
-      const last = self.$checkboxes.index(this);
+    if (event.shiftKey && lastChecked && lastChecked !== nowChecked) {
+      const first = $checkboxes.index(lastChecked);
+      const last = $checkboxes.index(nowChecked);
 
       if (first > last) {
-        self.$checkboxes.slice(last, first + 1)
-          .prop('checked', this.checked);
+        $checkboxes.slice(last, first + 1)
+          .prop('checked', nowChecked.checked);
       } else if (last > first) {
-        self.$checkboxes.slice(first, last + 1)
-          .prop('checked', this.checked);
+        $checkboxes.slice(first, last + 1)
+          .prop('checked', nowChecked.checked);
       }
     }
-    self.lastChecked = this;
+    lastChecked = nowChecked;
+  });
+};
+
+MB.Control.SelectAll = function (table) {
+  const $table = $(table);
+  const $checkboxes = $table.find('td input[type="checkbox"]');
+
+  const $selector = $table.find('th input[type="checkbox"]');
+
+  $selector.toggle($checkboxes.length > 0);
+
+  $selector.change(function () {
+    const $input = $(this);
+    $checkboxes.prop('checked', $input.prop('checked'));
   });
 
-  return self;
+  MB.Control.RangeSelect($checkboxes);
 };
 
 $(function () {

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -11,42 +11,42 @@ import $ from 'jquery';
 import MB from '../../MB';
 
 MB.Control.SelectAll = function (table) {
-    var self = {};
+  var self = {};
 
-    self.$table = $(table);
-    self.$checkboxes = self.$table.find('td input[type="checkbox"]');
-    self.lastChecked = null;
+  self.$table = $(table);
+  self.$checkboxes = self.$table.find('td input[type="checkbox"]');
+  self.lastChecked = null;
 
-    self.$selector = self.$table.find('th input[type="checkbox"]');
+  self.$selector = self.$table.find('th input[type="checkbox"]');
 
-    self.$selector.toggle(self.$checkboxes.length > 0);
+  self.$selector.toggle(self.$checkboxes.length > 0);
 
-    self.$selector.change(function () {
-        var $input = $(this);
-        self.$checkboxes.prop('checked', $input.prop('checked'));
-    });
+  self.$selector.change(function () {
+    var $input = $(this);
+    self.$checkboxes.prop('checked', $input.prop('checked'));
+  });
 
-    self.$checkboxes.click(function (event) {
-        if (event.shiftKey && self.lastChecked && self.lastChecked != this) {
-            const first = self.$checkboxes.index(self.lastChecked);
-            const last = self.$checkboxes.index(this);
+  self.$checkboxes.click(function (event) {
+    if (event.shiftKey && self.lastChecked && self.lastChecked != this) {
+      const first = self.$checkboxes.index(self.lastChecked);
+      const last = self.$checkboxes.index(this);
 
-            if (first > last) {
-                self.$checkboxes.slice(last, first + 1)
-                    .prop('checked', this.checked);
-            } else if (last > first) {
-                self.$checkboxes.slice(first, last + 1)
-                    .prop('checked', this.checked);
-            }
-        }
-        self.lastChecked = this;
-    });
+      if (first > last) {
+        self.$checkboxes.slice(last, first + 1)
+          .prop('checked', this.checked);
+      } else if (last > first) {
+        self.$checkboxes.slice(first, last + 1)
+          .prop('checked', this.checked);
+      }
+    }
+    self.lastChecked = this;
+  });
 
-    return self;
+  return self;
 };
 
 $(function () {
-    $('table.tbl').each(function () {
-        MB.Control.SelectAll(this);
-    });
+  $('table.tbl').each(function () {
+    MB.Control.SelectAll(this);
+  });
 });

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -11,7 +11,7 @@ import $ from 'jquery';
 import MB from '../../MB';
 
 MB.Control.SelectAll = function (table) {
-  var self = {};
+  const self = {};
 
   self.$table = $(table);
   self.$checkboxes = self.$table.find('td input[type="checkbox"]');
@@ -22,7 +22,7 @@ MB.Control.SelectAll = function (table) {
   self.$selector.toggle(self.$checkboxes.length > 0);
 
   self.$selector.change(function () {
-    var $input = $(this);
+    const $input = $(this);
     self.$checkboxes.prop('checked', $input.prop('checked'));
   });
 

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -126,6 +126,10 @@ MB.Control.ArtistEdit = function () {
         });
     };
 
+    self.$checkboxes = $('#artist-credit-renamer')
+        .find('span.rename-artist-credit input[type="checkbox"]');
+    MB.Control.RangeSelect(self.$checkboxes);
+
     MB.Control.initializeGuessCase('artist', 'id-edit-artist');
 
     MB.Control.Area("#area", "#begin_area", "#end_area");

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -126,9 +126,9 @@ MB.Control.ArtistEdit = function () {
         });
     };
 
-    self.$checkboxes = $('#artist-credit-renamer')
-        .find('span.rename-artist-credit input[type="checkbox"]');
-    MB.Control.RangeSelect(self.$checkboxes);
+    MB.Control.RangeSelect(
+        '#artist-credit-renamer span.rename-artist-credit input[type="checkbox"]',
+    );
 
     MB.Control.initializeGuessCase('artist', 'id-edit-artist');
 

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -54,11 +54,22 @@ releaseEditor.init = function (options) {
     });
 
     /*
+     * Allow using range-select (shift-click) on the change recording artist
+     * and change recording title checkboxes in the Recordings page.
+     */
+    MB.Control.RangeSelect(
+        '#track-recording-assignation input.update-recording-title[type="checkbox"]',
+    );
+
+    MB.Control.RangeSelect(
+        '#track-recording-assignation input.update-recording-artist[type="checkbox"]',
+    );
+
+    /*
      * Allow pressing enter to advance to the next tab. The listener is added
      * to the document and not #release-editor so that other events can call
      * preventDefault if necessary.
      */
-
     $(document).on("keydown", "#release-editor :input:not(:button, textarea)",
         function (event) {
             if (event.which === 13 && !event.isDefaultPrevented()) {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5460
https://tickets.metabrainz.org/browse/MBS-5572

The patch extends the support for shift-click (de)selecting of checkboxes to the release editor recording tab and to the artist credit list on artist/edit.

This has a bunch of eslint fixes included. I didn't fix all of the issues, just some that were annoying me, but I feel that's still better than before. If preferred, I can drop the eslint commits or split them into a separate PR.