### PR TITLE
MBS-10369: Count descendant countries in stats

### DIFF
--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -929,7 +929,11 @@ my %stats = (
                     ON l.area = ac.descendant
                     AND ac.parent IN (SELECT area FROM country_area)
                 FULL OUTER JOIN iso_3166_1 iso
-                    ON iso.area = COALESCE(ac.parent, l.area)
+                    ON iso.area = COALESCE(
+                        (SELECT area FROM country_area WHERE area = ac.descendant),
+                        ac.parent,
+                        l.area
+                    )
                 GROUP BY iso.code
             }, @containment_query_args);
 
@@ -1369,7 +1373,11 @@ my %stats = (
                     ON a.area = ac.descendant
                     AND ac.parent IN (SELECT area FROM country_area)
                 FULL OUTER JOIN iso_3166_1 iso
-                    ON iso.area = COALESCE(ac.parent, a.area)
+                    ON iso.area = COALESCE(
+                        (SELECT area FROM country_area WHERE area = ac.descendant),
+                        ac.parent,
+                        a.area
+                    )
                 GROUP BY iso.code
             }, @containment_query_args);
 


### PR DESCRIPTION
# Fix [MBS-10369](https://tickets.metabrainz.org/browse/MBS-10369)

Adjusts the `count.artist.country` and `count.label.country` stat queries to count those entities as part of a descendant area if the descendant is itself a country.

Here's the artist stats before/after:
Before: https://gist.github.com/mwiencek/00b0657ce8d9c377a22a85b1f6e9ea23
After: https://gist.github.com/mwiencek/0cf9efe9d523677110d7c327913dce20
