### PR TITLE
MBS-4776: Require confirmation for VA track artist

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -338,6 +338,13 @@
           <strong>[% l('Warning:') | html_entity %]</strong>
           [% l('You’ve used the {valink|Various Artists} special purpose artist on some tracks below. {valink|Various Artists} should very rarely be used on tracks; please make sure the artists have been entered correctly.', { valink => va_doc_link }) %]
         </p>
+        <label>
+          <input id="confirm-va" type="checkbox" data-bind="checked: confirmedVariousArtists" />
+          [% l('I confirm this is an intentional use of Various Artists on tracks.') %]
+        </label>
+        <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: hasUnconfirmedVariousArtists">
+          [%~ l('If you’re sure the use of Various Artists is correct, confirm it above. Otherwise, please fix the data.') %]
+        </p>
       </div>
     <!-- /ko -->
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -382,6 +382,7 @@ class Medium {
         this.needsRecordings = this.tracks.any("needsRecording");
         this.hasTrackInfo = this.tracks.all("hasNameAndArtist");
         this.hasVariousArtistTracks = this.tracks.any("hasVariousArtists");
+        this.confirmedVariousArtists = ko.observable(this.hasVariousArtistTracks());
         this.needsTrackInfo = ko.computed(function () { return !self.hasTrackInfo() });
 
         if (data.id != null) {
@@ -423,6 +424,16 @@ class Medium {
 
         this.needsFormat = ko.computed(function () {
             return !(self.formatID() || self.formatUnknownToUser());
+        });
+
+        this.hasUnconfirmedVariousArtists = ko.computed(function() {
+            return (self.hasVariousArtistTracks() && !self.confirmedVariousArtists());
+        });
+
+        this.hasVariousArtistTracks.subscribe(function (value) {
+            if (!value) {
+                self.confirmedVariousArtists(false);
+            }
         });
 
         this.formatID.subscribe(function (value) {
@@ -576,6 +587,7 @@ class Medium {
         this.loaded(true);
         this.loading(false);
         this.collapsed(false);
+        this.confirmedVariousArtists(this.hasVariousArtistTracks());
     }
 
     hasTracks() { return this.tracks().length > 0 }
@@ -887,6 +899,7 @@ class Release extends MB_entity.Release {
         this.hasUnknownTracklist = ko.observable(!this.mediums().length && releaseEditor.action === "edit");
         this.needsRecordings = errorField(this.mediums.any("needsRecordings"));
         this.hasInvalidFormats = errorField(this.mediums.any("hasInvalidFormat"));
+        this.hasUnconfirmedVariousArtists = errorField(this.mediums.any("hasUnconfirmedVariousArtists"));
         this.needsMediums = errorField(function () { return !(self.mediums().length || self.hasUnknownTracklist()) });
         this.needsFormat = errorField(this.mediums.any("needsFormat"));
         this.needsTracks = errorField(this.mediums.any("needsTracks"));

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -360,8 +360,12 @@ div.warning {
     width: 60em;
     background: @warning-background;
 
-    p {
+    p, label {
         margin: 1em;
+    }
+
+    label {
+        display: block;
     }
 }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-4776

We have a warning for Various Artists used as a track artist, but people keep wrongly selecting it. This adds a checkbox so that they have to explicitly confirm they want to use VA, which hopefully will make them think twice about it (we can't disallow it completely since it *is* correct in some rare cases).