### PR TITLE
MBS-5479: Add an "Edit Relationships" tab

### DIFF
--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -105,6 +105,10 @@ function buildLinks(
     }
   }
 
+  if (entity.entityType === 'release') {
+    links.push(buildLink(l('Edit Relationships'), entity, 'edit-relationships', page));
+  }
+
   return links;
 }
 

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -4,7 +4,7 @@
     [% PROCESS 'components/relationship-editor.tt' %]
 
     <div id="content" class="rel-editor" data-bind="delegatedHandler: 'click'">
-      [%- React.embed(c, 'release/ReleaseHeader', { release => release, page => 'edit_relationships' }) -%]
+      [%- React.embed(c, 'release/ReleaseHeader', { release => release, page => 'edit-relationships' }) -%]
 
       <p>
         [% l('Relationships highlighted <span class="rel-edit">yellow</span> will be edited,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-5479

This adds an "Edit Relationships" tab to releases by the "Edit" tab, in order to make the relationship editor easier to find for everyone.

Since most users are currently used to click the link on the sidebar and it also makes sense in that context, this leaves it in there as well - we certainly can use as big a chance as possible for people
to add relationships anyway.