### PR TITLE
MBS-10411: Force coordinates as floats in JSON WS

### DIFF
--- a/lib/MusicBrainz/Server/Test.pm
+++ b/lib/MusicBrainz/Server/Test.pm
@@ -389,7 +389,7 @@ sub _build_ws_test_json {
                 $mech->clear_credentials;
             }
 
-            $Test->plan(tests => 2);
+            $Test->plan(tests => 2 + ($opts->{extra_plan} // 0));
 
             $mech->get($end_point . $url, 'fetching');
             if ($opts->{response_code}) {
@@ -399,6 +399,9 @@ sub _build_ws_test_json {
             }
 
             cmp_deeply(decode_json($mech->content), $expected);
+
+            my $cb = $opts->{content_cb};
+            $cb->($mech->content) if $cb;
         });
     };
 }

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Place.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Place.pm
@@ -15,8 +15,8 @@ sub serialize
     $body{area} = $entity->area ? serialize_entity($entity->area) : JSON::null;
     $body{coordinates} = $entity->coordinates ?
             {
-                latitude => $entity->coordinates->latitude,
-                longitude => $entity->coordinates->longitude,
+                latitude => $entity->coordinates->latitude + 0.0,
+                longitude => $entity->coordinates->longitude + 0.0,
             }
         : JSON::null;
 

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Place.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Place.pm
@@ -16,8 +16,8 @@ around serialize => sub {
     $ret->{'@type'} = 'Place';
     $ret->{geo} = {
         '@type'   => 'GeoCoordinates',
-        latitude  => $entity->coordinates->latitude,
-        longitude => $entity->coordinates->longitude
+        latitude  => $entity->coordinates->latitude + 0.0,
+        longitude => $entity->coordinates->longitude + 0.0,
     } if $entity->coordinates;
 
     return $ret;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupPlace.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupPlace.pm
@@ -1,0 +1,54 @@
+package t::MusicBrainz::Server::Controller::WS::2::JSON::LookupPlace;
+
+use utf8;
+use JSON;
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test ws_test_json => {
+    version => 2
+};
+
+with 't::Mechanize', 't::Context';
+
+test 'basic place lookup' => sub {
+
+    MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
+
+    ws_test_json 'basic place lookup', '/place/df9269dd-0470-4ea2-97e8-c11e46080edd' => {
+        'address' => 'An Address',
+        'area' => {
+            'disambiguation' => '',
+            'id' => '89a675c2-3e37-3518-b83c-418bad59a85a',
+            'iso-3166-1-codes' => ['XE'],
+            'name' => 'Europe',
+            'sort-name' => 'Europe',
+        },
+        'coordinates' => {
+            'latitude' => 0.323,
+            'longitude' => 1.234,
+        },
+        'disambiguation' => 'A PLACE!',
+        'id' => 'df9269dd-0470-4ea2-97e8-c11e46080edd',
+        'life-span' => {
+            'begin' => '2013',
+            'end' => JSON::null,
+            'ended' => JSON::false,
+        },
+        'name' => 'A Test Place',
+        'type' => 'Venue',
+        'type-id' => 'cd92781a-a73f-30e8-a430-55d7521338db',
+    }, {
+        content_cb => sub {
+            my $content = shift;
+
+            like $content, qr{"longitude":\s*1.234},
+                'longitude is outputted as a float';
+
+            like $content, qr{"latitude":\s*0.323},
+                'latitude is outputted as a float';
+        },
+        extra_plan => 2,
+    };
+};
+
+1;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10411

When serializing the JSON for places, we want latitude and longitude to always be outputted as floats. Perl doesn't have explicit "string" or "number" types; the conversion between them is done automatically depending on context in which they're used. Thus adding 0 to these values changes the context, and forces Perl to change its internal representation of the values to numbers. The JSON serializer follows suit.