### PR TITLE
Fix relationship edit credit display

### DIFF
--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -88,28 +88,28 @@ const RelationshipDiff = ({
 
   const oldSourceLink = (
     <DescriptiveLink
-      credit={oldRelationship.entity0_credit}
+      content={oldRelationship.entity0_credit}
       entity={oldSource}
     />
   );
 
   const newSourceLink = (
     <DescriptiveLink
-      credit={newRelationship.entity0_credit}
+      content={newRelationship.entity0_credit}
       entity={newSource}
     />
   );
 
   const oldTargetLink = (
     <DescriptiveLink
-      credit={oldRelationship.entity1_credit}
+      content={oldRelationship.entity1_credit}
       entity={oldTarget}
     />
   );
 
   const newTargetLink = (
     <DescriptiveLink
-      credit={newRelationship.entity1_credit}
+      content={newRelationship.entity1_credit}
       entity={newTarget}
     />
   );


### PR DESCRIPTION
`DescriptiveLink` accepts a `content` prop to change the link content, not `credit`.

I noticed this by accident in #1224. Since `DescriptiveLinkProps` is an inexact object, Flow didn't care about the extra `credit` prop (`content` is optional).

Random edit ID you can test against: 33386803