### PR TITLE
Set source attribute in load_entities, if unset

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -250,7 +250,10 @@ sub load_entities
 
                 if ($rel->direction == $MusicBrainz::Server::Entity::Relationship::DIRECTION_BACKWARD) {
                     $rel->target($obj);
-                    $rel->target_type($obj->entity_type);
+                    $rel->target_type($type);
+                } elsif (!defined $rel->source) {
+                    $rel->source($obj);
+                    $rel->source_type($type);
                 }
             }
         }
@@ -263,7 +266,10 @@ sub load_entities
 
                 if ($rel->direction == $MusicBrainz::Server::Entity::Relationship::DIRECTION_FORWARD) {
                     $rel->target($obj);
-                    $rel->target_type($obj->entity_type);
+                    $rel->target_type($type);
+                } elsif (!defined $rel->source) {
+                    $rel->source($obj);
+                    $rel->source_type($type);
                 }
             }
         }


### PR DESCRIPTION
With 42ad9a5, we have to set the source attribute explicitly now. `load_entities` was modified to set the target, but not the source.

Fixes [MBS-10418](https://tickets.metabrainz.org/browse/MBS-10418) and possibly other cases where we have a relationship fetched via `get_by_id` which then has `load_entities` invoked on it. (This is likely not many other places, if any. The vast majority of places we load relationships use the form `$c->model('Relationship')->load($source)` for obvious reasons, which does set the source attribute on the loaded relationships correctly.)