### PR TITLE
MBS-10421: Update schema_fixup of ReleasePackaging

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -520,10 +520,29 @@ sub schema_fixup
                 name => delete $data->{status}
             )
         }
-        if ($data->{packaging}) {
-            $data->{packaging} = MusicBrainz::Server::Entity::ReleasePackaging->new(
-                name => delete $data->{packaging}
-            )
+
+        my $packaging = delete $data->{packaging};
+        my $packaging_id = delete $data->{'packaging-id'};
+
+        if ($packaging) {
+            if (ref($packaging) eq 'HASH') {
+                # MB Solr search server v3.1
+                $data->{packaging} = MusicBrainz::Server::Entity::ReleasePackaging->new(
+                    name => $packaging->{name},
+                    gid => $packaging->{id}
+                )
+            } elsif ($packaging_id) {
+                # MB Solr search server v3.2? (SOLR-121)
+                $data->{packaging} = MusicBrainz::Server::Entity::ReleasePackaging->new(
+                    name => $packaging,
+                    gid => $packaging_id
+                )
+            } else {
+                # MB Lucene search server
+                $data->{packaging} = MusicBrainz::Server::Entity::ReleasePackaging->new(
+                    name => $packaging
+                )
+            }
         }
     }
     if ($type eq 'release-group') {


### PR DESCRIPTION
# Fix critical regression MBS-10421

After having added release packaging id to MMD schema for MBS-8978, and having updated search indexer/server to follow this new schema, this patch updates MusicBrainz Server to handle the new JSON format returned by MB Solr search server to instantiate ReleasePackaging.

It keeps compatibility with former Lucene-based search server.

Since JSON WS 2 lookup/browse requests use 'packaging-id' instead of 'id' subkey to 'packaging' to preserve backward-compatibility, this patch also anticipates further fix to SOLR-121 search server issue.