### PR TITLE
MBS-10420: Remove /all from /edits/all links

### DIFF
--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import _ from 'lodash';
 import React from 'react';
 
 import RequestLogin from '../../components/RequestLogin';

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -70,7 +70,7 @@ const DataMenu = ({user}: UserProp) => {
           <a href={userLink(userName, '/edits/open')}>{l('My Open Edits')}</a>
         </li>
         <li>
-          <a href={userLink(userName, '/edits/all')}>{l('All My Edits')}</a>
+          <a href={userLink(userName, '/edits')}>{l('All My Edits')}</a>
         </li>
         <li>
           <a href="/edit/subscribed">{l('Edits for Subscribed Entities')}</a>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10420

We have nothing that deals with /edits/all - this only works because the default for /edits/whatever is to ignore the whatever and load /edits (except for /edits/open)
