### PR TITLE
MBS-9468: Missing check for remove rel edits in search

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
@@ -25,7 +25,7 @@ sub combine_with_query {
                                    (data#>>'{link,link_type,id}')::int,
                                    (data#>>'{old,link_type,id}')::int,
                                    (data#>>'{new,link_type,id}')::int,
-                                   (data#>>'{relationship,link_type,id}')::int
+                                   (data#>>'{relationship,link,type,id}')::int
                                ], NULL)",
         [ $self->sql_arguments ],
     ]);


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9468

The query currently checks for `(data#>>'{relationship,link_type,id}')::int`.
In the removal examples I checked, the type is loaded and we need `(data#>>'{relationship,link,type,id}')::int` (comma instead of underscore) instead.
Since I'm not 100% sure whether the previous check actually matches something too, not removing it at the moment (if you're confident it should be removed, let me know).