### PR TITLE
MBS-10423: Handle missing ID of release packaging

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -529,7 +529,7 @@ sub schema_fixup
                 # MB Solr search server v3.1
                 $data->{packaging} = MusicBrainz::Server::Entity::ReleasePackaging->new(
                     name => $packaging->{name},
-                    gid => $packaging->{id}
+                    defined $packaging->{id} ? (gid => $packaging->{id}) : ()
                 )
             } elsif ($packaging_id) {
                 # MB Solr search server v3.2? (SOLR-121)


### PR DESCRIPTION
# Fix regression MBS-10423

Search server may sometimes return release packaging without any ID associated with.
This patch enables MusicBrainz Server to handle this corner case.