### PR TITLE
MBS-10430: Add "actions" class to fingerprints

### DIFF
--- a/root/static/scripts/common/components/FingerprintTable.js
+++ b/root/static/scripts/common/components/FingerprintTable.js
@@ -66,7 +66,7 @@ const FingerprintTable = ({recording}: {recording: RecordingT}) => {
                   </a>
                 </code>
               </td>
-              <td>
+              <td className="actions">
                 <a
                   className="external"
                   href={


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10430

This column is wrapping when translations are too long because I forgot to add the "actions" class to it.