### PR TITLE
Eslint fixes for multiline-comment-style

### DIFF
--- a/contrib/slowdown.psgi
+++ b/contrib/slowdown.psgi
@@ -8,7 +8,7 @@ use feature "switch";
 # This script simulates the 503 Slow Down response we occassionally get
 # from the archive.org servers.
 
-# Copyright (c) 2013  MetaBrainz Foundation
+# Copyright (C) 2013  MetaBrainz Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/contrib/ssssss.psgi
+++ b/contrib/ssssss.psgi
@@ -12,7 +12,7 @@ use feature "switch";
 # ----------------------------------------------------------------------
 
 # ssssss.psgi version 2
-# Copyright (c) 2012  MetaBrainz Foundation
+# Copyright (C) 2012  MetaBrainz Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import * as React from 'react';

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/main/404.js
+++ b/root/main/404.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/server.js
+++ b/root/server.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server.js
+++ b/root/server.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */

--- a/root/server/buffer.js
+++ b/root/server/buffer.js
@@ -1,17 +1,21 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 
-// Buffer.from apparently exists in some Nodes <= 4.5.0, but is broken,
-// throwing "this is not a typed array" if you pass it a string.
-//
-// Buffer.from doesn't exist at all in versions <= 0.12.
-//
-// Buffer.allocUnsafe is not known to be broken in any versions, but doesn't
-// exist before v5.10 according to the documentation.
+/*
+ * Buffer.from apparently exists in some Nodes <= 4.5.0, but is broken,
+ * throwing "this is not a typed array" if you pass it a string.
+ *
+ * Buffer.from doesn't exist at all in versions <= 0.12.
+ *
+ * Buffer.allocUnsafe is not known to be broken in any versions, but doesn't
+ * exist before v5.10 according to the documentation.
+ */
 
 try {
   Buffer.from('');

--- a/root/server/buffer.js
+++ b/root/server/buffer.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */

--- a/root/server/createServer.js
+++ b/root/server/createServer.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server/createServer.js
+++ b/root/server/createServer.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */

--- a/root/server/gettext.js
+++ b/root/server/gettext.js
@@ -1,8 +1,10 @@
-// Copyright (C) 2018 MetaBrainz Foundation
-//
-// This file is part of MusicBrainz, the open internet music database,
-// and is licensed under the GPL version 2, or (at your option) any
-// later version: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server/gettext/poFile.js
+++ b/root/server/gettext/poFile.js
@@ -1,8 +1,10 @@
-// Copyright (C) 2015-2018 MetaBrainz Foundation
-//
-// This file is part of MusicBrainz, the open internet music database,
-// and is licensed under the GPL version 2, or (at your option) any
-// later version: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * Copyright (C) 2015-2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server/response.js
+++ b/root/server/response.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015-2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015-2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server/response.js
+++ b/root/server/response.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015-2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */

--- a/root/server/utils.js
+++ b/root/server/utils.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 /* eslint-disable import/no-commonjs */
 

--- a/root/server/utils.js
+++ b/root/server/utils.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -1,9 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 Jérôme Roy
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import 'leaflet.markercluster/dist/leaflet.markercluster-src';

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -1,6 +1,8 @@
-// Needed by root/release/cover_art_uploader.tt, which uses the
-// css_manifest TT macro that requires common.less to exist in
-// rev-manifest.json.
+/*
+ * Needed by root/release/cover_art_uploader.tt, which uses the
+ * css_manifest TT macro that requires common.less to exist in
+ * rev-manifest.json.
+ */
 require('../styles/common.less');
 
 // IE 11 support.
@@ -17,8 +19,10 @@ const DBDefs = require('./common/DBDefs-client');
 import MB from './common/MB';
 
 if (DBDefs.DEVELOPMENT_SERVER) {
-  // Used by the Selenium tests under /t/selenium/ to make sure that no errors
-  // occurred on the page.
+  /*
+   * Used by the Selenium tests under /t/selenium/ to make sure that no errors
+   * occurred on the page.
+   */
   MB.js_errors = [];
   window.onerror = function (message, source, lineno, colno, error) {
     MB.js_errors.push(error && error.stack ? error.stack : message);

--- a/root/static/scripts/common/MB.js
+++ b/root/static/scripts/common/MB.js
@@ -1,20 +1,21 @@
-/* @flow
-   Copyright (C) 2009 Oliver Charles
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-*/
+/*
+ * @flow
+ * Copyright (C) 2009 Oliver Charles
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
 
 'use strict';
 

--- a/root/static/scripts/common/MB.js
+++ b/root/static/scripts/common/MB.js
@@ -2,19 +2,9 @@
  * @flow
  * Copyright (C) 2009 Oliver Charles
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 'use strict';

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';
@@ -42,8 +44,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         minLength: 1,
         allowEmpty: true,
 
-        // default to showing error and lookup-performed status by adding
-        // those classes (red/green background) to lookup fields.
+        /*
+         * default to showing error and lookup-performed status by adding
+         * those classes (red/green background) to lookup fields.
+         */
         showStatus: true,
 
         // Prevent menu item focus from changing the input value
@@ -116,9 +120,11 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
 
         var self = this;
 
-        // The following callbacks are triggered by jQuery UI. They're defined
-        // here, and not in the "options" definition above, because they need
-        // access to current instance.
+        /*
+         * The following callbacks are triggered by jQuery UI. They're defined
+         * here, and not in the "options" definition above, because they need
+         * access to current instance.
+         */
 
         this.options.open = function (event) {
             // Automatically focus the first item in the menu.
@@ -131,8 +137,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
             self.currentSelection(entity);
             self.element.trigger("lookup-performed", [entity]);
 
-            // Returning false prevents the search input's text from changing.
-            // We've already changed it in setSelection.
+            /*
+             * Returning false prevents the search input's text from changing.
+             * We've already changed it in setSelection.
+             */
             return false;
         };
 
@@ -141,22 +149,26 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         this.element.on("input", function (event) {
             var selection = self.currentSelection.peek();
 
-            // XXX The condition shouldn't be necessary, because the input
-            // event should only fire if the value has changed. But Opera
-            // doesn't fire an input event if you paste text into a field,
-            // only if you type it [1]. Pressing enter after pasting an MBID,
-            // then, has the effect of firing the input event too late, and
-            // clearing the field. Checking the current selection against the
-            // current value is done to prevent this.
-            // [1] https://developer.mozilla.org/en-US/docs/Web/Reference/Events/input
+            /*
+             * XXX The condition shouldn't be necessary, because the input
+             * event should only fire if the value has changed. But Opera
+             * doesn't fire an input event if you paste text into a field,
+             * only if you type it [1]. Pressing enter after pasting an MBID,
+             * then, has the effect of firing the input event too late, and
+             * clearing the field. Checking the current selection against the
+             * current value is done to prevent this.
+             * [1] https://developer.mozilla.org/en-US/docs/Web/Reference/Events/input
+             */
             if (selection && selection.name !== this.value) {
                 self.clearSelection(false);
             }
         });
 
         this.element.on("blur", function (event) {
-            // Stop searching if someone types something and then tabs out of
-            // the field.
+            /*
+             * Stop searching if someone types something and then tabs out of
+             * the field.
+             */
             self.cancelSearch = true;
 
             var selection = self.currentSelection.peek();
@@ -179,8 +191,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
             var recent = self.recentEntities();
 
             if (!this.value && recent && recent.length && !self.menu.active) {
-                // setting ac.term to "" prevents the autocomplete plugin
-                // from running its own search, which closes our menu.
+                /*
+                 * Setting ac.term to "" prevents the autocomplete plugin
+                 * from running its own search, which closes our menu.
+                 */
                 self.term = "";
 
                 recent.push({
@@ -223,8 +237,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         }
     },
 
-    // Overrides $.ui.autocomplete.prototype.close
-    // Reset the currentPage and currentResults on menu close.
+    /*
+     * Overrides $.ui.autocomplete.prototype.close
+     * Reset the currentPage and currentResults on menu close.
+     */
     close: function (event) {
         this._super(event);
         this._resetPage();
@@ -239,10 +255,12 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         var name = clearAction ? "" : this._value();
         var currentSelection = this.currentSelection.peek();
 
-        // If the current entity doesn't have an id, it's already "blank" and
-        // we don't need to unnecessarily create a new one. Doing so can even
-        // have unintended effects, e.g. wiping other useful data on the
-        // entity (like release group types).
+        /*
+         * If the current entity doesn't have an id, it's already "blank" and
+         * we don't need to unnecessarily create a new one. Doing so can even
+         * have unintended effects, e.g. wiping other useful data on the
+         * entity (like release group types).
+         */
 
         if (currentSelection.id) {
             this.currentSelection(this._dataToEntity({ name: name }));
@@ -339,8 +357,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
 
         var oldTerm = this.term;
 
-        // Support pressing <space> to trigger a search, but ignore it if the
-        // menu is already open.
+        /*
+         * Support pressing <space> to trigger a search, but ignore it if the
+         * menu is already open.
+         */
         if (this.menu.element.is(':visible')) {
             newTerm = clean(newTerm);
             oldTerm = clean(oldTerm);
@@ -380,8 +400,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
                 var currentEntityType = self.entity.replace("-", "_");
 
                 if (data.entityType !== currentEntityType) {
-                    // Only RelateTo boxes and relationship-editor dialogs
-                    // support changing the entity type.
+                    /*
+                     * Only RelateTo boxes and relationship-editor dialogs
+                     * support changing the entity type.
+                     */
                     var setEntity = self.options.setEntity;
 
                     if (!setEntity || setEntity(data.entityType) === false) {
@@ -403,9 +425,11 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
 
         data = this.options.resultHook(_.initial(data));
 
-        // "currentResults" will contain action items that aren't results,
-        // e.g. ShowMore, SwitchToDirectSearch, etc. Filter these actions out
-        // before appending the new results (we re-add them below).
+        /*
+         * "currentResults" will contain action items that aren't results,
+         * e.g. ShowMore, SwitchToDirectSearch, etc. Filter these actions out
+         * before appending the new results (we re-add them below).
+         */
 
         var results = this.currentResults = _.filter(
             this.currentResults, function (item) {
@@ -460,8 +484,10 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         response(results);
 
         this._delay(function () {
-            // Once everything's rendered, jump to the first item that was
-            // added. This makes the menu scroll after hitting "Show More."
+            /*
+             * Once everything's rendered, jump to the first item that was
+             * added. This makes the menu scroll after hitting "Show More."
+             */
             var menu = this.menu;
             var $ul = menu.element;
 
@@ -534,14 +560,16 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
 
 $.widget("ui.menu", $.ui.menu, {
 
-    // When a result is normally selected from an autocomplete menu, the menu
-    // is closed and the text of the search input is changed. This is not what
-    // we want to happen for menu items associated with an action (e.g. show
-    // more, switch to indexed search, clear artist, etc.). To support the
-    // desired behavior, the "select" method for jQuery UI menus is overridden
-    // below to check if an action function is associated with the selected
-    // item. If it is, the action is executed. Otherwise we fall back to the
-    // default menu behavior.
+    /*
+     * When a result is normally selected from an autocomplete menu, the menu
+     * is closed and the text of the search input is changed. This is not what
+     * we want to happen for menu items associated with an action (e.g. show
+     * more, switch to indexed search, clear artist, etc.). To support the
+     * desired behavior, the "select" method for jQuery UI menus is overridden
+     * below to check if an action function is associated with the selected
+     * item. If it is, the action is executed. Otherwise we fall back to the
+     * default menu behavior.
+     */
 
     _selectAction: function (event) {
         var active = this.active || $(event.target).closest(".ui-menu-item");
@@ -550,9 +578,11 @@ $.widget("ui.menu", $.ui.menu, {
         if (item && $.isFunction(item.action)) {
             item.action();
 
-            // If this is a click event on the <a>, make sure the event
-            // doesn't reach the parent <li>, or the select action will
-            // close the menu.
+            /*
+             * If this is a click event on the <a>, make sure the event
+             * doesn't reach the parent <li>, or the select action will
+             * close the menu.
+             */
             event.stopPropagation();
             event.preventDefault();
 
@@ -569,9 +599,11 @@ $.widget("ui.menu", $.ui.menu, {
         if (!this._selectAction(event)) {
             this._super(event);
         }
-        // When mouseHandled is true, $.ui ignores future mouse events. It only
-        // gets reset to false if you click outside of the menu, but we want
-        // it to be false no matter what.
+        /*
+         * When mouseHandled is true, $.ui ignores future mouse events. It only
+         * gets reset to false if you click outside of the menu, but we want
+         * it to be false no matter what.
+         */
         this.mouseHandled = false;
     }
 });
@@ -980,27 +1012,27 @@ function renderContainingAreas(area) {
 }
 
 /*
-   MB.Control.EntityAutocomplete is a helper class which simplifies using
-   Autocomplete to look up entities.  It takes care of setting id and gid
-   values on related hidden inputs.
-
-   It expects to see html looking like this:
-
-       <span class="ENTITY autocomplete">
-          <img class="search" src="search.png" />
-          <input type="text" class="name" />
-          <input type="hidden" class="id" />
-          <input type="hidden" class="gid" />
-       </span>
-
-   Do a lookup of the span with jQuery and pass it into EntityAutocomplete
-   as options.inputs, for example, for a release group do this:
-
-       MB.Control.EntityAutocomplete({ inputs: $('span.release-group.autocomplete') });
-
-   The 'lookup-performed' and 'cleared' events will be triggered on the input.name
-   element (though you can just bind on the span, as events will bubble up).
-*/
+ * MB.Control.EntityAutocomplete is a helper class which simplifies using
+ * Autocomplete to look up entities.  It takes care of setting id and gid
+ * values on related hidden inputs.
+ *
+ * It expects to see html looking like this:
+ *
+ *   <span class="ENTITY autocomplete">
+ *     <img class="search" src="search.png" />
+ *     <input type="text" class="name" />
+ *     <input type="hidden" class="id" />
+ *     <input type="hidden" class="gid" />
+ *   </span>
+ *
+ * Do a lookup of the span with jQuery and pass it into EntityAutocomplete
+ * as options.inputs, for example, for a release group do this:
+ *
+ *   MB.Control.EntityAutocomplete({inputs: $('span.release-group.autocomplete')});
+ *
+ * The 'lookup-performed' and 'cleared' events will be triggered on the input.name
+ * element (though you can just bind on the span, as events will bubble up).
+ */
 
 MB.Control.EntityAutocomplete = function (options) {
     var $inputs = options.inputs || $();
@@ -1029,8 +1061,10 @@ MB.Control.EntityAutocomplete = function (options) {
     autocomplete.currentSelection.subscribe(function (item) {
         var $hidden = $inputs.find("input[type=hidden]").val("");
 
-        // We need to do this manually, rather than using $.each, due to recordings
-        // having a 'length' property.
+        /*
+         * We need to do this manually, rather than using $.each, due to recordings
+         * having a 'length' property.
+         */
         for (let key in item) {
             if (item.hasOwnProperty(key)) {
                 $hidden.filter("input." + key)

--- a/root/static/scripts/common/MB/Control/EditList.js
+++ b/root/static/scripts/common/MB/Control/EditList.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/MB/Control/EditList.js
+++ b/root/static/scripts/common/MB/Control/EditList.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 
@@ -38,8 +40,10 @@ MB.Control.EditList = function (container) {
             $('<div>').text(l("Vote on all edits:"))
         );
 
-        // :nth-child would make more sense, but I couldn't get it working
-        // - ocharles
+        /*
+         * :nth-child would make more sense, but I couldn't get it working
+         * - ocharles
+         */
         $voteOptions.find('input').each(function (i) {
             $(this).click(function () {
                     $container.find('div.voteopts').each(function () {

--- a/root/static/scripts/common/MB/Control/EditSummary.js
+++ b/root/static/scripts/common/MB/Control/EditSummary.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/MB/Control/EditSummary.js
+++ b/root/static/scripts/common/MB/Control/EditSummary.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/common/MB/Control/Menu.js
+++ b/root/static/scripts/common/MB/Control/Menu.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2011 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/MB/Control/Menu.js
+++ b/root/static/scripts/common/MB/Control/Menu.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2011 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2011 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import $ from 'jquery';
 
@@ -49,8 +49,10 @@ MB.Control.HeaderMenu = function () {
     });
 
     $('body').on('click', function (event) {
-        // clicks outside of the menu (anything that reaches the body) should
-        // close the menu
+        /*
+         * Clicks outside of the menu (anything that reaches the body) should
+         * close the menu.
+         */
         $('.header ul.menu li ul').css('left', '-10000px');
         $('.header .menu-header').parent().removeClass('fake-active');
     });

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/common/MB/Control/SelectAll.js
+++ b/root/static/scripts/common/MB/Control/SelectAll.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/MB/release.js
+++ b/root/static/scripts/common/MB/release.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/common/MB/release.js
+++ b/root/static/scripts/common/MB/release.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/artworkViewer.js
+++ b/root/static/scripts/common/artworkViewer.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/artworkViewer.js
+++ b/root/static/scripts/common/artworkViewer.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2013 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';
@@ -24,9 +26,11 @@ $.widget("mb.artworkViewer", $.ui.dialog, {
 
         // Only display prev/next buttons if there's >1 image.
         if (this.$artwork.length > 1) {
-            // jQuery UI dialogs have a buttons API, but it's difficult to
-            // style them like our other ones without duplicating CSS. And
-            // it doesn't save a whole lotta code anyway.
+            /*
+             * jQuery UI dialogs have a buttons API, but it's difficult to
+             * style them like our other ones without duplicating CSS. And
+             * it doesn't save a whole lotta code anyway.
+             */
 
             this.$prev = $("<button>").attr("type", "button")
                             .text(l("Previous"))
@@ -73,11 +77,13 @@ $.widget("mb.artworkViewer", $.ui.dialog, {
 
         this._super();
 
-        // Only size the dialog based on the preview image's aspect ratio if
-        // the dialog was just opened. If the dialog is already open and the
-        // user is simply loading a previous/next image, it'll get resized
-        // later, once the image actually loads. But if we were to resize
-        // *now*, the current image would get clipped.
+        /*
+         * Only size the dialog based on the preview image's aspect ratio if
+         * the dialog was just opened. If the dialog is already open and the
+         * user is simply loading a previous/next image, it'll get resized
+         * later, once the image actually loads. But if we were to resize
+         * *now*, the current image would get clipped.
+         */
 
         if (wasClosed) {
             this._sizeAndPosition($preview.width() / $preview.height());
@@ -156,8 +162,10 @@ $.widget("mb.artworkViewer", $.ui.dialog, {
             nonContentHeight = this.uiDialog.outerHeight() - this.element.height(),
             nonContentWidth = this.uiDialog.outerWidth() - this.element.width();
 
-        // Don't stretch the image beyond its original dimensions, and don't
-        // exceed maxDialogHeight or maxDialogWidth.
+        /*
+         * Don't stretch the image beyond its original dimensions, and don't
+         * exceed maxDialogHeight or maxDialogWidth.
+         */
         var imageHeight = maxDialogHeight - nonContentHeight;
 
         if (imageElement && imageElement.height < imageHeight) {
@@ -187,8 +195,10 @@ $.widget("mb.artworkViewer", $.ui.dialog, {
 $(function () {
     var $activeDialog = $();
 
-    // Create separate dialogs for the sidebar and content, so that the
-    // image "albums" are logically grouped.
+    /*
+     * Create separate dialogs for the sidebar and content, so that the
+     * image "albums" are logically grouped.
+     */
     $("#sidebar, #content").each(function (index, container) {
         var $artwork = $("a.artwork-image", container);
         if ($artwork.length === 0) return;

--- a/root/static/scripts/common/banner.js
+++ b/root/static/scripts/common/banner.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015–2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015–2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React, {useState} from 'react';

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015—2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015–2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/common/coverart.js
+++ b/root/static/scripts/common/coverart.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/common/coverart.js
+++ b/root/static/scripts/common/coverart.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/dialogs.js
+++ b/root/static/scripts/common/dialogs.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/dialogs.js
+++ b/root/static/scripts/common/dialogs.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';
@@ -39,9 +41,11 @@ import MB from './MB';
             this.element.remove();
             event.preventDefault();
 
-            // XXX Returning focus to the "opener" element is handled by $.ui,
-            // but it doesn't always work in Opera. This trys to focus again
-            // after a small delay, if it hasn't already.
+            /*
+             * XXX Returning focus to the "opener" element is handled by $.ui,
+             * but it doesn't always work in Opera. This trys to focus again
+             * after a small delay, if it hasn't already.
+             */
             _.defer(function () {
                 if (self.opener[0] !== document.activeElement) {
                     self.opener.focus();
@@ -110,8 +114,10 @@ import MB from './MB';
     });
 
 
-    // Make sure click events within the dialog don't bubble and cause
-    // side-effects.
+    /*
+     * Make sure click events within the dialog don't bubble and cause
+     * side-effects.
+     */
 
     $(function () {
         $("body").on("click", ".ui-dialog", function (event) {

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -28,9 +30,11 @@ import formatTrackLength from './utility/formatTrackLength';
 
 (function () {
 
-    // Base class that both core and non-core entities inherit from. The only
-    // purpose this really serves is allowing the `data instanceof Entity`
-    // check in MB.entity() to work.
+    /*
+     * Base class that both core and non-core entities inherit from. The only
+     * purpose this really serves is allowing the `data instanceof Entity`
+     * check in MB.entity() to work.
+     */
     class Entity {
 
         constructor(data) {
@@ -79,13 +83,15 @@ import formatTrackLength from './utility/formatTrackLength';
         }
     }
 
-    // Usually, this function should be called to create new entities instead
-    // of directly instantiating any of the classes below. MB.entity() caches
-    // everything with a GID, so if you pass in the same entity twice, you get
-    // the same object back (which is ideal, because otherwise there could be a
-    // lot of duplication for things like track artists). This also allows
-    // comparing entities for equality with a simple `===` instead of having to
-    // compare the GIDs.
+    /*
+     * Usually, this function should be called to create new entities instead
+     * of directly instantiating any of the classes below. MB.entity() caches
+     * everything with a GID, so if you pass in the same entity twice, you get
+     * the same object back (which is ideal, because otherwise there could be
+     * a lot of duplication for things like track artists). This also allows
+     * comparing entities for equality with a simple `===` instead of having
+     * to compare the GIDs.
+     */
 
     MB.entity = function (data, type) {
         if (!data) {
@@ -251,9 +257,11 @@ import formatTrackLength from './utility/formatTrackLength';
 
             // Returned from the /ws/js/recording search.
             if (this.appearsOn) {
-                // Depending on where we're getting the data from (search
-                // server, /ws/js...) we may have either releases or release
-                // groups here. Assume the latter by default.
+                /*
+                 * Depending on where we're getting the data from (search
+                 * server, /ws/js...) we may have either releases or release
+                 * groups here. Assume the latter by default.
+                 */
                 var appearsOnType = this.appearsOn.entityType || "release_group";
 
                 this.appearsOn.results = _.map(this.appearsOn.results, function (appearance) {
@@ -458,8 +466,10 @@ import formatTrackLength from './utility/formatTrackLength';
         });
     }
 
-    // Used by MB.entity() to look up classes. JSON from the web service
-    // usually includes a lower-case type name, which is used as the key.
+    /*
+     * Used by MB.entity() to look up classes. JSON from the web service
+     * usually includes a lower-case type name, which is used as the key.
+     */
 
     var coreEntityMapping = {
         artist:        Artist,

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/common/i18n/cleanMsgid.js
+++ b/root/static/scripts/common/i18n/cleanMsgid.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2018 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 const newLines = /[\r\n]/g;

--- a/root/static/scripts/common/i18n/wrapGettext.js
+++ b/root/static/scripts/common/i18n/wrapGettext.js
@@ -1,9 +1,11 @@
-// @flow
-// Copyright (C) 2015 MetaBrainz Foundation
-//
-// This file is part of MusicBrainz, the open internet music database,
-// and is licensed under the GPL version 2, or (at your option) any
-// later version: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow
+ * Copyright (C) 2015 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import isNodeJS from 'detect-node';
 

--- a/root/static/scripts/common/immutable-entities.js
+++ b/root/static/scripts/common/immutable-entities.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import {VARTIST_GID} from './constants';
 import nonEmpty from './utility/nonEmpty';

--- a/root/static/scripts/common/immutable-entities.js
+++ b/root/static/scripts/common/immutable-entities.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import {VARTIST_GID} from './constants';

--- a/root/static/scripts/common/leaflet.js
+++ b/root/static/scripts/common/leaflet.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import L from 'leaflet/dist/leaflet-src';

--- a/root/static/scripts/common/leaflet.js
+++ b/root/static/scripts/common/leaflet.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import L from 'leaflet/dist/leaflet-src';
 

--- a/root/static/scripts/common/ratings.js
+++ b/root/static/scripts/common/ratings.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/ratings.js
+++ b/root/static/scripts/common/ratings.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2013 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/common/raven.js
+++ b/root/static/scripts/common/raven.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import Raven from 'raven-js';
 

--- a/root/static/scripts/common/raven.js
+++ b/root/static/scripts/common/raven.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import Raven from 'raven-js';

--- a/root/static/scripts/common/utility/bugTrackerURL.js
+++ b/root/static/scripts/common/utility/bugTrackerURL.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 function bugTrackerURL(description) {

--- a/root/static/scripts/common/utility/bugTrackerURL.js
+++ b/root/static/scripts/common/utility/bugTrackerURL.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 function bugTrackerURL(description) {
   return (

--- a/root/static/scripts/common/utility/debounce.js
+++ b/root/static/scripts/common/utility/debounce.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 

--- a/root/static/scripts/common/utility/debounce.js
+++ b/root/static/scripts/common/utility/debounce.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/common/utility/displayLinkAttribute.js
+++ b/root/static/scripts/common/utility/displayLinkAttribute.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2019 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import * as React from 'react';

--- a/root/static/scripts/common/utility/formatBarcode.js
+++ b/root/static/scripts/common/utility/formatBarcode.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 function formatBarcode(code) {

--- a/root/static/scripts/common/utility/formatBarcode.js
+++ b/root/static/scripts/common/utility/formatBarcode.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 function formatBarcode(code) {
   if (code == null) {

--- a/root/static/scripts/common/utility/formatDatePeriod.js
+++ b/root/static/scripts/common/utility/formatDatePeriod.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015–2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/common/utility/formatDatePeriod.js
+++ b/root/static/scripts/common/utility/formatDatePeriod.js
@@ -1,8 +1,10 @@
-// @flow
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015–2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015–2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 

--- a/root/static/scripts/common/utility/formatTrackLength.js
+++ b/root/static/scripts/common/utility/formatTrackLength.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2011 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2011 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 export default function formatTrackLength(milliseconds, placeholder='?:??') {
     if (!milliseconds) {

--- a/root/static/scripts/common/utility/formatTrackLength.js
+++ b/root/static/scripts/common/utility/formatTrackLength.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2011 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 export default function formatTrackLength(milliseconds, placeholder='?:??') {

--- a/root/static/scripts/common/utility/getBooleanCookie.js
+++ b/root/static/scripts/common/utility/getBooleanCookie.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import getCookie from './getCookie';
 

--- a/root/static/scripts/common/utility/getBooleanCookie.js
+++ b/root/static/scripts/common/utility/getBooleanCookie.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import getCookie from './getCookie';

--- a/root/static/scripts/common/utility/getScriptArgs.js
+++ b/root/static/scripts/common/utility/getScriptArgs.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 function getCurrentScript() {

--- a/root/static/scripts/common/utility/getScriptArgs.js
+++ b/root/static/scripts/common/utility/getScriptArgs.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 function getCurrentScript() {
   let currentScript = document.currentScript;

--- a/root/static/scripts/common/utility/request.js
+++ b/root/static/scripts/common/utility/request.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/common/utility/request.js
+++ b/root/static/scripts/common/utility/request.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/edit/MB/Control/Area.js
+++ b/root/static/scripts/edit/MB/Control/Area.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/MB/Control/Area.js
+++ b/root/static/scripts/edit/MB/Control/Area.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 
@@ -31,14 +33,15 @@ MB.Control.ArtistEdit = function () {
         self.$endarea.text(end);
     };
 
-    /* Sets the label descriptions depending upon the artist type:
-
-           Unknown: 0
-           Person: 1
-           Group: 2
-           Orchestra: 5
-           Choir: 6
-    */
+    /*
+     * Sets the label descriptions depending upon the artist type:
+     *
+     *   Unknown: 0
+     *   Person: 1
+     *   Group: 2
+     *   Orchestra: 5
+     *   Choir: 6
+     */
     self.typeChanged = function () {
         switch (self.$type.val()) {
             default:

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -1,6 +1,8 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2013 MetaBrainz Foundation
-// Released under the GPLv2 license: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ * Released under the GPLv2 license: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';
@@ -11,8 +13,10 @@ import deferFocus from '../../utility/deferFocus';
 
 class BubbleBase {
 
-    // The default observable equality comparer returns false if the values
-    // aren't primitive, even if the values are equal.
+    /*
+     * The default observable equality comparer returns false if the values
+     * aren't primitive, even if the values are equal.
+     */
     targetEqualityComparer(a, b) { return a === b }
 
     constructor(group) {
@@ -82,9 +86,11 @@ class BubbleBase {
 
     redraw(stealFocus) {
         if (this.visible.peek()) {
-            // It's possible that the control we're pointing at has been
-            // removed, hence why MutationObserver has triggered a redraw. If
-            // that's the case, we want to hide the bubble, not show it.
+            /*
+             * It's possible that the control we're pointing at has been
+             * removed, hence why MutationObserver has triggered a redraw. If
+             * that's the case, we want to hide the bubble, not show it.
+             */
 
             if ($(this.control).parents("html").length === 0) {
                 this.hide(false);
@@ -100,17 +106,22 @@ class BubbleBase {
     }
 }
 
-// Organized by group, where only one bubble from each group can be
-// visible on the page at once.
+/*
+ * Organized by group, where only one bubble from each group can be
+ * visible on the page at once.
+ */
 BubbleBase.prototype.activeBubbles = {};
 
-// Whether the bubble should close when we click outside of it. Used for
-// track artist credit bubbles.
+/*
+ * Whether the bubble should close when we click outside of it. Used for
+ * track artist credit bubbles.
+ */
 BubbleBase.prototype.closeWhenFocusIsLost = false;
 
-/* BubbleDoc turns a documentation div into a bubble pointing at an
-   input to the left of it.
-*/
+/*
+ * BubbleDoc turns a documentation div into a bubble pointing at an
+ * input to the left of it.
+ */
 class BubbleDoc extends BubbleBase {
 
     show(control) {
@@ -134,10 +145,12 @@ class BubbleDoc extends BubbleBase {
 
 MB.Control.BubbleDoc = BubbleDoc;
 
-// Knockout's visible binding only toggles the display style between "none"
-// and "". When it's an empty string, the display falls back to whatever
-// overriding CSS rule is in place, which in our case is "display: none".
-// This explicitly sets it to "block".
+/*
+ * Knockout's visible binding only toggles the display style between "none"
+ * and "". When it's an empty string, the display falls back to whatever
+ * overriding CSS rule is in place, which in our case is "display: none".
+ * This explicitly sets it to "block".
+ */
 
 ko.bindingHandlers.show = {
 
@@ -174,8 +187,10 @@ ko.bindingHandlers.controlsBubble = {
         element.bubbleDoc = bubble;
         viewModel["bubbleControl" + bubble.group] = element;
 
-        // We may be here because a template was redrawn. Since the old control
-        // we pointed at is gone, we have to update it to the new one.
+        /*
+         * We may be here because a template was redrawn. Since the old
+         * control we pointed at is gone, we have to update it to the new one.
+         */
         if (bubble.visible.peek() && bubble.targetIs(viewModel)) {
             bubble.control = element;
         }
@@ -196,11 +211,13 @@ ko.bindingHandlers.controlsBubble = {
 };
 
 
-// Used to watch for DOM changes, so that doc bubbles stay pointed at the
-// correct position.
-//
-// See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-// for browser support.
+/*
+ * Used to watch for DOM changes, so that doc bubbles stay pointed at the
+ * correct position.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+ * for browser support.
+ */
 
 ko.bindingHandlers.affectsBubble = {
 
@@ -222,10 +239,12 @@ ko.bindingHandlers.affectsBubble = {
 };
 
 
-// Handle click and focus events that might cause a bubble to be shown or
-// hidden. This event could be attached individually in controlsBubble, but
-// since there can be a lot of bubble controls on the page, event
-// delegation is better for performance.
+/*
+ * Handle click and focus events that might cause a bubble to be shown or
+ * hidden. This event could be attached individually in controlsBubble, but
+ * since there can be a lot of bubble controls on the page, event
+ * delegation is better for performance.
+ */
 
 function bubbleControlHandler(event) {
     var control = event.target;
@@ -241,8 +260,10 @@ function bubbleControlHandler(event) {
             if (bubble && bubble.closeWhenFocusIsLost &&
                 !event.isDefaultPrevented() &&
 
-                // Close unless focus was moved to a dialog above this
-                // one, i.e. when adding a new entity.
+                /*
+                 * Close unless focus was moved to a dialog above this
+                 * one, i.e. when adding a new entity.
+                 */
                 !$(event.target).parents(".ui-dialog").length) {
 
                 bubble.hide(false);
@@ -256,8 +277,10 @@ function bubbleControlHandler(event) {
     var inputFocused = !isButton && event.type === "focusin";
     var viewModel = ko.dataFor(control);
 
-    // If this is false, the bubble should already be hidden. See the
-    // computed in controlsBubble.
+    /*
+     * If this is false, the bubble should already be hidden. See the
+     * computed in controlsBubble.
+     */
     if (bubble.canBeShown(viewModel)) {
         var wasOpen = bubble.visible() && bubble.targetIs(viewModel);
 
@@ -273,8 +296,10 @@ function bubbleControlHandler(event) {
 }
 
 
-// Pressing enter should close the bubble or perform a custom action (i.e.
-// going to the next track). Pressing escape should always close it.
+/*
+ * Pressing enter should close the bubble or perform a custom action (i.e.
+ * going to the next track). Pressing escape should always close it.
+ */
 
 function bubbleKeydownHandler(event) {
     if (event.isDefaultPrevented()) {
@@ -295,11 +320,13 @@ function bubbleKeydownHandler(event) {
     if (pressedEsc || (pressedEnter && $target.is(":not(:button)"))) {
         event.preventDefault();
 
-        // This causes any "value" binding on the input to update its
-        // associated observable. e.g. if the user types something in a
-        // join phrase field and hits esc., the join phrase in the view
-        // model should update. This should run before the code below,
-        // because the view model for the bubble may change.
+        /*
+         * This causes any "value" binding on the input to update its
+         * associated observable. e.g. if the user types something in a
+         * join phrase field and hits esc., the join phrase in the view
+         * model should update. This should run before the code below,
+         * because the view model for the bubble may change.
+         */
         $target.trigger("change");
 
         if (pressedEsc) {

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -1,7 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
- * Released under the GPLv2 license: http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/MB/CoverArt.js
+++ b/root/static/scripts/edit/MB/CoverArt.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import filesize from 'filesize';

--- a/root/static/scripts/edit/MB/CoverArt.js
+++ b/root/static/scripts/edit/MB/CoverArt.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2013 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import filesize from 'filesize';
 import $ from 'jquery';
@@ -58,10 +58,12 @@ MB.CoverArt.image_error = function ($img, image) {
     }
     else
     {
-        /* image doesn't exist at all, perhaps it was removed
-           between requesting the index and loading the image.
-           FIXME: start over if this happens?  obviously the
-           data in the index is incorrect. */
+        /*
+         * image doesn't exist at all, perhaps it was removed
+         * between requesting the index and loading the image.
+         * FIXME: start over if this happens?  obviously the
+         * data in the index is incorrect.
+         */
         $img.attr("src", require('../../../images/image404-125.png'));
     }
 };
@@ -114,9 +116,11 @@ MB.CoverArt.reorder_position = function () {
         }
     );
 
-    /* moving <script> elements around with insertBefore() and
+    /*
+     * Moving <script> elements around with insertBefore() and
      * insertAfter() will rerun them.  The script bits for these
-     * images should NOT be ran again, so remove those nodes. */
+     * images should NOT be ran again, so remove those nodes.
+     */
     $('div.editimage script').remove();
 };
 
@@ -136,17 +140,17 @@ MB.CoverArt.cover_art_types = function () {
 };
 
 /*
-   For each image the upload process is:
-
-   1. validating   Validate the file the user has selected.
-   2. waiting      Wait for the user to make their selections and submit the edit.
-   3. signing      Request postfields from /ws/js/cover-art-upload/:mbid.
-   4. uploading    Upload image to postfields.action.
-   5. submitting   POST edit to /release/:mbid/add-cover-art.
-   6. done         All actions completed successfully.
-
-   most of these have an accompanying error state.
-*/
+ * For each image the upload process is:
+ *
+ * 1. validating   Validate the file the user has selected.
+ * 2. waiting      Wait for the user to make selections and submit the edit.
+ * 3. signing      Request postfields from /ws/js/cover-art-upload/:mbid.
+ * 4. uploading    Upload image to postfields.action.
+ * 5. submitting   POST edit to /release/:mbid/add-cover-art.
+ * 6. done         All actions completed successfully.
+ *
+ * most of these have an accompanying error state.
+ */
 
 MB.CoverArt.upload_status_enum = {
     'validating':     'validating',
@@ -168,8 +172,10 @@ MB.CoverArt.validate_file = function (file) {
     reader.addEventListener("loadend", function () {
         var uint32view = new Uint32Array(reader.result);
 
-        /* JPEG signature is usually FF D8 FF E0 (JFIF), or FF D8 FF E1 (EXIF).
-           Some cameras and phones write a different fourth byte. */
+        /*
+         * JPEG signature is usually FF D8 FF E0 (JFIF), or FF D8 FF E1 (EXIF).
+         * Some cameras and phones write a different fourth byte. 
+         */
 
         if ((uint32view[0] & 0x00FFFFFF) === 0x00FFD8FF)
         {
@@ -264,8 +270,10 @@ MB.CoverArt.upload_image = function (postfields, file) {
     /* IE10 and older don't have overrideMimeType. */
     if (typeof (xhr.overrideMimeType) === 'function')
     {
-        /* prevent firefox from parsing a 204 No Content response as XML.
-           https://bugzilla.mozilla.org/show_bug.cgi?id=884693 */
+        /*
+         * Prevent firefox from parsing a 204 No Content response as XML.
+         * https://bugzilla.mozilla.org/show_bug.cgi?id=884693
+         */
         xhr.overrideMimeType('text/plain');
     }
     xhr.addEventListener("error", function (event) {
@@ -378,8 +386,10 @@ MB.CoverArt.FileUpload = function (file) {
 
         if (self.status() === 'done' || self.busy())
         {
-            /* This file is currently being uploaded or has already
-               been uploaded. */
+            /*
+             * This file is currently being uploaded or has already
+             * been uploaded.
+             */
             deferred.reject();
             return deferred.promise();
         }
@@ -433,13 +443,13 @@ MB.CoverArt.FileUpload = function (file) {
 
     self.updateProgress = function (step, value) {
         /*
-          To make the progress bar show progress for the entire process each of
-          the three requests get a chunk of the progress bar:
-
-          step 1. Signing       0% to  10%
-          step 2. Upload       10% to  90%
-          step 3. Create edit  90% to 100%
-        */
+         * To make the progress bar show progress for the entire process each of
+         * the three requests get a chunk of the progress bar:
+         *
+         * step 1. Signing       0% to  10%
+         * step 2. Upload       10% to  90%
+         * step 3. Create edit  90% to 100%
+         */
 
         switch (step) {
         case 1:
@@ -520,8 +530,10 @@ MB.CoverArt.add_cover_art = function (gid) {
     {
         File.prototype.slice = File.prototype.webkitSlice || File.prototype.mozSlice || File.prototype.slice;
 
-        /* FormData is supported, so we can present the multifile ajax
-         * upload form. */
+        /*
+         * FormData is supported, so we can present the multifile ajax
+         * upload form. 
+         */
 
         $('.with-formdata').show();
 
@@ -604,16 +616,17 @@ MB.CoverArt.add_cover_art = function (gid) {
     }
 };
 
-/* This takes a list of asynchronous functions (i.e. functions which
-   return a jquery promise) and runs them in sequence.  It in turn
-   returns a promise which is only resolved when all promises in the
-   queue have been resolved.  If one of the promises is rejected, the
-   rest of the queue is still processed (but the returned promise will
-   be rejected).
-
-   Note that any results are currently ignored, it is assumed you are
-   interested in the side effects of the functions executed.
-*/
+/*
+ * This takes a list of asynchronous functions (i.e. functions which
+ * return a jquery promise) and runs them in sequence.  It in turn
+ * returns a promise which is only resolved when all promises in the
+ * queue have been resolved.  If one of the promises is rejected, the
+ * rest of the queue is still processed (but the returned promise will
+ * be rejected).
+ *
+ * Note that any results are currently ignored, it is assumed you are
+ * interested in the side effects of the functions executed.
+ */
 function iteratePromises(promises) {
     var deferred = $.Deferred();
     var failed = false;

--- a/root/static/scripts/edit/MB/TextList.js
+++ b/root/static/scripts/edit/MB/TextList.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2012 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2012 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/edit/MB/TextList.js
+++ b/root/static/scripts/edit/MB/TextList.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2012 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2010 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -107,8 +109,10 @@ function getSelectedArea() {
 function isPlaceCommentRequired(duplicates) {
   var selectedArea = ko.unwrap(getSelectedArea()) || {};
 
-  // We require a disambiguation comment if no area is given, or if there
-  // is a possible duplicate in the same area or lacking area information.
+  /*
+   * We require a disambiguation comment if no area is given, or if there
+   * is a possible duplicate in the same area or lacking area information.
+   */
   if (!selectedArea.gid) {
     return true;
   }
@@ -231,8 +235,10 @@ MB.initializeDuplicateChecker = function (type) {
     }
   }, 300);
 
-  // Initiate the duplicate checker on the existing name, which may have been
-  // seeded via query parameters.
+  /*
+   * Initiate the duplicate checker on the existing name, which may have been
+   * seeded via query parameters.
+   */
   handleNameChange(currentName, true);
   $(nameInput).on('input', function () {
     handleNameChange(this.value, false);

--- a/root/static/scripts/edit/common.js
+++ b/root/static/scripts/edit/common.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 
@@ -17,17 +19,21 @@ ko.components.loaders.unshift({
 });
 
 
-// See http://knockoutjs.com/documentation/custom-bindings-disposal.html
-// We don't need external data cleaned, so this just slows things down.
+/*
+ * See http://knockoutjs.com/documentation/custom-bindings-disposal.html
+ * We don't need external data cleaned, so this just slows things down.
+ */
 ko.utils.domNodeDisposal.cleanExternalData = function () {};
 
 
-// By default, knockout limits the number of items it'll loop through before
-// giving up finding any moves in an arrayChange sequence, presumably to
-// limit its polynomial time complexity in the case of really large arrays.
-// But the loop bindingHandler which we use depends on moves always being
-// detected, so we must disable this limit by passing a falsy value as the
-// third argument.
+/*
+ * By default, knockout limits the number of items it'll loop through before
+ * giving up finding any moves in an arrayChange sequence, presumably to
+ * limit its polynomial time complexity in the case of really large arrays.
+ * But the loop bindingHandler which we use depends on moves always being
+ * detected, so we must disable this limit by passing a falsy value as the
+ * third argument.
+ */
 ko.utils.__findMovesInArrayComparison = ko.utils.findMovesInArrayComparison;
 
 ko.utils.findMovesInArrayComparison = function (left, right) {

--- a/root/static/scripts/edit/common.js
+++ b/root/static/scripts/edit/common.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -184,9 +186,11 @@ class ArtistCreditEditor extends React.Component {
         .end()
       .show()
       .position(position)
-      // For some reason this needs to be called twice...
-      // Steps to reproduce: open the release AC bubble, switch to the
-      // tracklist tab, open a track AC bubble.
+      /*
+       * For some reason this needs to be called twice...
+       * Steps to reproduce: open the release AC bubble, switch to the
+       * tracklist tab, open a track AC bubble.
+       */
       .position(position);
   }
 
@@ -205,8 +209,10 @@ class ArtistCreditEditor extends React.Component {
       return;
     }
 
-    // Don't hijack the bubble unless show = true or this is for the
-    // currently-open entity.
+    /*
+     * Don't hijack the bubble unless show = true or this is for the
+     * currently-open entity.
+     */
     if (!show && $bubble.data('target') !== this.props.entity) {
       return;
     }
@@ -296,8 +302,10 @@ class ArtistCreditEditor extends React.Component {
             $bubble.is(':visible') &&
             $target.is(':not(.open-ac)') &&
             !$bubble.has($target).length &&
-            // Close unless focus was moved to a dialog above this one, e.g.
-            // when adding a new entity.
+            /*
+             * Close unless focus was moved to a dialog above this one, e.g.
+             * when adding a new entity.
+             */
             !$target.parents('.ui-dialog').length) {
           $bubble.data('componentInst').done(false);
         }
@@ -353,8 +361,10 @@ class ArtistCreditEditor extends React.Component {
     let entity = _.clone(this.props.entity);
     entity.artistCredit = {names: _.filter(ac.names, n => hasArtist(n))};
 
-    // The single-artist lookup changes the credit boxes in the doc bubble,
-    // and the credit boxes change the single-artist lookup.
+    /*
+     * The single-artist lookup changes the credit boxes in the doc bubble,
+     * and the credit boxes change the single-artist lookup.
+     */
     const complex = isComplexArtistCredit(ac);
     let singleArtistSelection = {name: ''};
     let singleArtistIsEditable = true;

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import React from 'react';

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import React from 'react';
 

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import React from 'react';
 

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import React from 'react';
 

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import React from 'react';

--- a/root/static/scripts/edit/components/Tooltip.js
+++ b/root/static/scripts/edit/components/Tooltip.js
@@ -1,12 +1,16 @@
-// @flow
-// Copyright (C) 2014 Khan Academy
-// Copyright (C) 2015 MetaBrainz Foundation
+/*
+ * @flow
+ * Copyright (C) 2014 Khan Academy
+ * Copyright (C) 2015 MetaBrainz Foundation
+ */
 
-// The source code contained in this file was originally derived from
-// https://raw.githubusercontent.com/Khan/react-components/9984740/js/info-tip.jsx
-// which is released under the MIT license. The full terms of this license can
-// be found in the original source code repository at
-// https://raw.githubusercontent.com/Khan/react-components/9984740/LICENSE
+/*
+ * The source code contained in this file was originally derived from
+ * https://raw.githubusercontent.com/Khan/react-components/9984740/js/info-tip.jsx
+ * which is released under the MIT license. The full terms of this license can
+ * be found in the original source code repository at
+ * https://raw.githubusercontent.com/Khan/react-components/9984740/LICENSE
+ */
 
 import * as React from 'react';
 import ReactDOM from 'react-dom';

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import React from 'react';

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/edit/confirmNavigationFallback.js
+++ b/root/static/scripts/edit/confirmNavigationFallback.js
@@ -1,14 +1,17 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import MB from '../common/MB';
 
 MB.confirmNavigationFallback = function () {
-    /* Every major browser supports onbeforeunload expect Opera. (This says
-       Opera 12 supports it, but it doesn't, at least not <= 12.10.)
-       https://developer.mozilla.org/en-US/docs/DOM/window.onbeforeunload
+    /*
+     * Every major browser supports onbeforeunload expect Opera. (This says
+     * Opera 12 supports it, but it doesn't, at least not <= 12.10.)
+     * https://developer.mozilla.org/en-US/docs/DOM/window.onbeforeunload
      */
     if (window.onbeforeunload !== undefined) {
         return;
@@ -16,14 +19,15 @@ MB.confirmNavigationFallback = function () {
 
     var prevented = false;
 
-    /* This catches the backspace key and asks the user whether they want to
-       navigate back.
-
-       Opera < 12.10 fires both keydown and keypress events, but keypress
-       must return false. Opera >= 12.10 doesn't fire keypress for special
-       keys, so keydown must return false. Regular event listeners and/or
-       preventDefault don't work for this, they must be assigned directly
-       to document.onkeydown and document.onkeypress.
+    /*
+     * This catches the backspace key and asks the user whether they want to
+     * navigate back.
+     *
+     * Opera < 12.10 fires both keydown and keypress events, but keypress
+     * must return false. Opera >= 12.10 doesn't fire keypress for special
+     * keys, so keydown must return false. Regular event listeners and/or
+     * preventDefault don't work for this, they must be assigned directly
+     * to document.onkeydown and document.onkeypress.
      */
     document.onkeydown = function (event) {
         if (event.keyCode == 8) {

--- a/root/static/scripts/edit/confirmNavigationFallback.js
+++ b/root/static/scripts/edit/confirmNavigationFallback.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../common/MB';

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2013 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -91,9 +93,11 @@ ko.bindingHandlers.loop = {
     ) {
         var options = valueAccessor(), observableArray = options.items;
 
-        // The way this binding handler works is by using the "arrayChange"
-        // event found on observableArrays, which notifies a list of changes
-        // we can apply to the UI.
+        /*
+         * The way this binding handler works is by using the "arrayChange"
+         * event found on observableArrays, which notifies a list of changes
+         * we can apply to the UI.
+         */
 
         if (!ko.isObservable(observableArray) ||
             !observableArray.cacheDiffForKnownOperation) {
@@ -111,8 +115,10 @@ ko.bindingHandlers.loop = {
             }
         });
 
-        // For regular DOM nodes this is the same as parentNode; if parentNode
-        // is a virtual element, this will be the parentNode of the comment.
+        /*
+         * For regular DOM nodes this is the same as parentNode; if parentNode
+         * is a virtual element, this will be the parentNode of the comment.
+         */
         var actualParentNode = parentNode;
         while (actualParentNode.nodeType !== ELEMENT_NODE) {
             actualParentNode = actualParentNode.parentNode;
@@ -143,9 +149,11 @@ ko.bindingHandlers.loop = {
                         var newContext = bindingContext.createChildContext(item);
 
                         if (!currentElements) {
-                            // Would simplify things to use a documentFragment,
-                            // but knockout doesn't support them.
-                            // https://github.com/knockout/knockout/pull/1432
+                            /*
+                             * Using a documentFragment would simplify things,
+                             * but knockout doesn't support them.
+                             * https://github.com/knockout/knockout/pull/1432
+                             */
                             tmpElementContainer = document.createElement("div");
 
                             for (j = 0; node = template[j]; j++) {
@@ -161,20 +169,24 @@ ko.bindingHandlers.loop = {
                 } else if (status === "deleted") {
                     if (change.moved === undefined) {
                         for (j = 0; node = currentElements[j]; j++) {
-                            // If the node is already removed for some unknown
-                            // reason, don't outright explode. It's possible
-                            // an exception occurred somewhere in the middle
-                            // of an arrayChange notification, causing
-                            // knockout to send duplicate changes afterward.
+                            /*
+                             * If the node is already removed for some unknown
+                             * reason, don't outright explode. It's possible
+                             * an exception occurred somewhere in the middle
+                             * of an arrayChange notification, causing
+                             * knockout to send duplicate changes afterward.
+                             */
                             if (node.parentNode) {
                                 node.parentNode.removeChild(node);
                             }
                             removals.push({ node: node, itemID: itemID });
                         }
                     }
-                    // When knockout detects a moved item, it sends both "added"
-                    // and "deleted" changes for it. We only need to handle the
-                    // former.
+                    /*
+                     * When knockout detects a moved item, it sends both
+                     * "added" and "deleted" changes for it. We only need
+                     * to handle the former.
+                     */
                     continue;
                 }
 
@@ -188,27 +200,33 @@ ko.bindingHandlers.loop = {
                     }
                 }
 
-                // Find where to insert the elements associated with this
-                // item. The final result should be in the same order as the
-                // items are in their containing array.
+                /*
+                 * Find where to insert the elements associated with this
+                 * item. The final result should be in the same order as the
+                 * items are in their containing array.
+                 */
                 var prevItem;
 
-                // Loop through the items before the current one, and find one
-                // that actually has elements on the page (i.e. something we
-                // can insertAfter). It doesn't matter if we don't insert
-                // after the *immediate* prevItem, because when *that* item
-                // is dealt with it'll be inserted after the same item we
-                // used (thus settling before us). prevItem will be undefined
-                // when it's past the first item in the array, and the for-
-                // loop will end; insertAfter handles that by just prepending
-                // the elements to parentNode.
+                /*
+                 * Loop through the items before the current one, and find one
+                 * that actually has elements on the page (i.e. something we
+                 * can insertAfter). It doesn't matter if we don't insert
+                 * after the *immediate* prevItem, because when *that* item
+                 * is dealt with it'll be inserted after the same item we
+                 * used (thus settling before us). prevItem will be undefined
+                 * when it's past the first item in the array, and the for-
+                 * loop will end; insertAfter handles that by just prepending
+                 * the elements to parentNode.
+                 */
 
                 for (var j = change.index - 1; prevItem = items[j]; j--) {
                     elementsToInsertAfter = elements[prevItem[idAttribute]];
 
-                    // prevItem's elements won't exist on the page if they
-                    // were previously removed, but haven't been purged from
-                    // `elements` yet (below).
+                    /*
+                     * prevItem's elements won't exist on the page if they
+                     * were previously removed, but haven't been purged from
+                     * `elements` yet (below).
+                     */
                     if (elementsToInsertAfter) {
                         if (actualParentNode.contains(elementsToInsertAfter[0])) {
                             break;
@@ -255,30 +273,31 @@ ko.bindingHandlers.loop = {
 ko.virtualElements.allowedBindings.loop = true;
 
 
-/* Helper binding that matches an input and label (assuming a table layout)
-   together in a foreach loop, by assigning an id composed of a prefix
-   concatenated with the index of the item in the loop.
-
-   So if you have something like this in the template:
-
-    <!-- ko foreach: items -->
-    <tr>
-      <td><label>Foo</label></td>
-      <td><input data-bind="withLabel: 'foo'" /></td>
-    <tr>
-    <!-- /ko -->
-
-   It'll result in this markup once rendered (assuming two items):
-
-    <tr>
-      <td><label for="foo-0">Foo</label></td>
-      <td><input id="foo-0" data-bind="withLabel: 'foo'" /></td>
-    <tr>
-    <tr>
-      <td><label for="foo-1">Foo</label></td>
-      <td><input id="foo-1" data-bind="withLabel: 'foo'" /></td>
-    <tr>
-*/
+/*
+ * Helper binding that matches an input and label (assuming a table layout)
+ * together in a foreach loop, by assigning an id composed of a prefix
+ * concatenated with the index of the item in the loop.
+ *
+ * So if you have something like this in the template:
+ *
+ * <!-- ko foreach: items -->
+ * <tr>
+ *   <td><label>Foo</label></td>
+ *   <td><input data-bind="withLabel: 'foo'" /></td>
+ * <tr>
+ * <!-- /ko -->
+ *
+ * It'll result in this markup once rendered (assuming two items):
+ *
+ * <tr>
+ *   <td><label for="foo-0">Foo</label></td>
+ *   <td><input id="foo-0" data-bind="withLabel: 'foo'" /></td>
+ * <tr>
+ * <tr>
+ *   <td><label for="foo-1">Foo</label></td>
+ *   <td><input id="foo-1" data-bind="withLabel: 'foo'" /></td>
+ * <tr>
+ */
 ko.bindingHandlers.withLabel = {
 
     update: function (element, valueAccessor, allBindings,

--- a/root/static/scripts/edit/notes-received.js
+++ b/root/static/scripts/edit/notes-received.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/notes-received.js
+++ b/root/static/scripts/edit/notes-received.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/edit/utility/dates.js
+++ b/root/static/scripts/edit/utility/dates.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2012-2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2012-2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import getDaysInMonth from '../../../../utility/getDaysInMonth';
 import nonEmpty from '../../common/utility/nonEmpty';

--- a/root/static/scripts/edit/utility/dates.js
+++ b/root/static/scripts/edit/utility/dates.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2012-2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import getDaysInMonth from '../../../../utility/getDaysInMonth';

--- a/root/static/scripts/edit/utility/deferFocus.js
+++ b/root/static/scripts/edit/utility/deferFocus.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/utility/deferFocus.js
+++ b/root/static/scripts/edit/utility/deferFocus.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import balanced from 'balanced-match';
@@ -136,11 +138,13 @@ function bestArtistMatch(artists, name, isProbablyClassical) {
 function expandCredit(fullName, artists, isProbablyClassical) {
     fullName = cleanCredit(fullName, isProbablyClassical);
 
-    // See which produces a better match to an existing artist: the full
-    // credit, or the individual credits as split by collabRegex. Some artist
-    // names legitimately contain characters in collabRegex, so this stops
-    // those from getting split (assuming the artist appears in a relationship
-    // or artist credit).
+    /*
+     * See which produces a better match to an existing artist: the full
+     * credit, or the individual credits as split by collabRegex. Some artist
+     * names legitimately contain characters in collabRegex, so this stops
+     * those from getting split (assuming the artist appears in a relationship
+     * or artist credit).
+     */
     var bestFullMatch = bestArtistMatch(artists, fullName, isProbablyClassical);
 
     var fixJoinPhrase = function (existing) {
@@ -215,9 +219,11 @@ MB.Control.initGuessFeatButton = function (formName) {
                     return nameInput.value;
                 }
             },
-            // Confusingly, the artistCredit object used to generated hidden input
-            // fields is also different from MB.sourceRelationshipEditor.source's,
-            // so we have to replace this field too.
+            /*
+             * Confusingly, the artistCredit object used to generated hidden input
+             * fields is also different from MB.sourceRelationshipEditor.source's,
+             * so we have to replace this field too.
+             */
             artistCredit: MB.sourceEntity.artistCredit
         }
     );

--- a/root/static/scripts/edit/utility/linkPhrase.js
+++ b/root/static/scripts/edit/utility/linkPhrase.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import * as React from 'react';

--- a/root/static/scripts/edit/utility/similarity.js
+++ b/root/static/scripts/edit/utility/similarity.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import leven from 'leven';
 
@@ -11,13 +13,17 @@ function stripSpacesAndPunctuation(str) {
     return (str || "").replace(punctuation, "").toLowerCase();
 }
 
-// Compares two names, considers them equivalent if there are only case
-// changes, changes in punctuation and/or changes in whitespace between
-// the two strings.
+/*
+ * Compares two names, considers them equivalent if there are only case
+ * changes, changes in punctuation and/or changes in whitespace between
+ * the two strings.
+ */
 
 export default function similarity(a, b) {
-    // If a track title is all punctuation, we'll end up with an empty
-    // string, so just fall back to the original for comparison.
+    /*
+     * If a track title is all punctuation, we'll end up with an empty
+     * string, so just fall back to the original for comparison.
+     */
     a = stripSpacesAndPunctuation(a) || a || '';
     b = stripSpacesAndPunctuation(b) || b || '';
 

--- a/root/static/scripts/edit/utility/similarity.js
+++ b/root/static/scripts/edit/utility/similarity.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import leven from 'leven';

--- a/root/static/scripts/edit/utility/toggleEnded.js
+++ b/root/static/scripts/edit/utility/toggleEnded.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/edit/utility/toggleEnded.js
+++ b/root/static/scripts/edit/utility/toggleEnded.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 

--- a/root/static/scripts/edit/validation.js
+++ b/root/static/scripts/edit/validation.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 const ko = require('knockout');
 
@@ -49,8 +51,10 @@ if (typeof document !== 'undefined') {
         $('#page form :input[required]').each(function () {
             var $input = $(this);
 
-            // XXX We can't handle artist credit fields here. They have separate
-            // hidden inputs that are injected by knockout.
+            /*
+             * XXX We can't handle artist credit fields here. They have
+             * separate hidden inputs that are injected by knockout.
+             */
             if ($input.is('.artist-credit-input')) {
                 return;
             }

--- a/root/static/scripts/edit/validation.js
+++ b/root/static/scripts/edit/validation.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 const ko = require('knockout');

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/guess-case/MB/Control/GuessCase.js
+++ b/root/static/scripts/guess-case/MB/Control/GuessCase.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Area.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2013 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../../common/MB';
 import * as flags from '../../../flags';
@@ -25,27 +25,22 @@ import * as utils from '../../../utils';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Area specific GuessCase functionality
- **/
+// Area specific GuessCase functionality
 MB.GuessCase.Handler.Area = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
-     * Checks special cases
-     **/
+    // Checks special cases
     self.checkSpecialCase = function (is) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
      *
      * - Handles DiscNumberStyle (DiscNumberWithNameStyle)
      * - Handles FeaturingArtistStyle
-     *
-     **/
+     */
     self.doWord = function () {
         if (self.doIgnoreWords()) {
         } else if (self.doFeaturingArtistStyle()) {
@@ -57,9 +52,7 @@ MB.GuessCase.Handler.Area = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for areas
-     **/
+    // Guesses the sortname for areas
     self.guessSortName = function (is) {
         return utils.trim(is);
     };

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import _ from 'lodash';
 
@@ -28,31 +28,29 @@ import * as utils from '../../../utils';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Artist specific GuessCase functionality
- **/
+// Artist specific GuessCase functionality
 MB.GuessCase.Handler.Artist = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
+    /*
      * Checks special cases of artists
      * - empty, unknown -> [unknown]
      * - none, no artist, not applicable, n/a -> [no artist]
-     **/
+     */
     self.checkSpecialCase = function (is) {
         if (is) {
             if (!gc.re.ARTIST_EMPTY) {
-                // match empty
+                // Match empty
                 gc.re.ARTIST_EMPTY = /^\s*$/i;
-                // match "unknown" and variants
+                // Match "unknown" and variants
                 gc.re.ARTIST_UNKNOWN = /^[\(\[]?\s*Unknown\s*[\)\]]?$/i;
-                // match "none" and variants
+                // Match "none" and variants
                 gc.re.ARTIST_NONE = /^[\(\[]?\s*none\s*[\)\]]?$/i;
-                // match "no artist" and variants
+                // Match "no artist" and variants
                 gc.re.ARTIST_NOARTIST = /^[\(\[]?\s*no[\s-]+artist\s*[\)\]]?$/i;
-                // match "not applicable" and variants
+                // Match "not applicable" and variants
                 gc.re.ARTIST_NOTAPPLICABLE = /^[\(\[]?\s*not[\s-]+applicable\s*[\)\]]?$/i;
-                // match "n/a" and variants
+                // Match "n/a" and variants
                 gc.re.ARTIST_NA = /^[\(\[]?\s*n\s*[\\\/]\s*a\s*[\)\]]?$/i;
             }
             var os = is;
@@ -78,10 +76,10 @@ MB.GuessCase.Handler.Artist = function (gc) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
-     **/
+     */
     self.doWord = function () {
         gc.o.appendSpaceIfNeeded();
         gc.i.capitalizeCurrentWord();
@@ -94,16 +92,14 @@ MB.GuessCase.Handler.Artist = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for artists
-     **/
+    // Guesses the sortname for artists
     self.guessSortName = function (is, person) {
         return self.sortCompoundName(is, function (artist) {
             if (artist) {
                 artist = utils.trim(artist);
                 var append = "";
 
-                // strip Jr./Sr. from the string, and append at the end.
+                // Strip Jr./Sr. from the string, and append at the end.
                 if (!gc.re.SORTNAME_SR) {
                     gc.re.SORTNAME_SR = /,\s*Sr[\.]?$/i;
                     gc.re.SORTNAME_JR = /,\s*Jr[\.]?$/i;
@@ -118,8 +114,10 @@ MB.GuessCase.Handler.Artist = function (gc) {
                 }
                 var names = artist.split(" ");
 
-                // handle some special cases, like DJ, The, Los which
-                // are sorted at the end.
+                /*
+                 * Handle some special cases, like DJ, The, Los which
+                 * are sorted at the end.
+                 */
                 var reorder = false;
                 if (!gc.re.SORTNAME_DJ) {
                     gc.re.SORTNAME_DJ = /^DJ$/i; // match DJ
@@ -158,16 +156,20 @@ MB.GuessCase.Handler.Artist = function (gc) {
                             // >> firstnames,middlenames one pos right
                             if (i == names.length-2 && names[i] == "St.") {
                                 names[i+1] = names[i] + " " + names[i+1];
-                            // handle St. because it belongs
-                            // to the lastname
+                            /*
+                             * Handle St. because it belongs
+                             * to the lastname
+                             */
                             } else if (names[i]) {
                                 reOrderedNames[i+1] = names[i];
                             }
                         }
                         reOrderedNames[0] = names[names.length-1]; // lastname,firstname
                         if (reOrderedNames.length > 1) {
-                            // only append comma if there was more than 1
-                            // non-empty word (and therefore switched)
+                            /*
+                             * Only append comma if there was more than 1
+                             * non-empty word (and therefore switched)
+                             */
                             reOrderedNames[0] += ",";
                         }
                         names = reOrderedNames;

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../../common/MB';
 import * as flags from '../../../flags';
@@ -26,7 +26,7 @@ import * as utils from '../../../utils';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
+/*
  * Base class of the type specific handlers
  *
  * @see GcArtistHandler
@@ -37,20 +37,18 @@ MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 MB.GuessCase.Handler.Base = function (gc) {
     var self = {};
 
-    // ----------------------------------------------------------------------------
-    // member variables
-    // ---------------------------------------------------------------------------
+    // Member variables
 
     // Values of the specialcases defined in
     self.NOT_A_SPECIALCASE = -1;
 
-    // artist cases
+    // Artist cases
     self.SPECIALCASE_UNKNOWN = 10;          // [unknown]
 
-    // release cases
+    // Release cases
     self.SPECIALCASE_DATA_TRACK = 20;       // [data track]
 
-    // track cases
+    // Track cases
     self.SPECIALCASE_DATA_TRACK = 30;       // [data track]
     self.SPECIALCASE_SILENCE = 31;          // [silence]
     self.SPECIALCASE_UNTITLED = 32;         // [untitled]
@@ -58,22 +56,18 @@ MB.GuessCase.Handler.Base = function (gc) {
     self.SPECIALCASE_GUITAR_SOLO = 34;      // [guitar solo]
     self.SPECIALCASE_DIALOGUE= 35;          // [dialogue]
 
-    // ----------------------------------------------------------------------------
-    // member functions
-    // ---------------------------------------------------------------------------
+    // Member functions
 
-    /**
-     * Returns true if the number corresponds to a special case.
-     **/
+    // Returns true if the number corresponds to a special case.
     self.isSpecialCase = function (num) {
         return (num != self.NOT_A_SPECIALCASE);
     };
 
-    /**
+    /*
      * Returns the correctly formatted string of the
      * special case, or the input string if num
      * does not correspond to a special case
-     **/
+     */
     self.getSpecialCaseFormatted = function (is, num) {
         switch (num) {
             case self.SPECIALCASE_DATA_TRACK:
@@ -114,20 +108,22 @@ MB.GuessCase.Handler.Base = function (gc) {
         return gc.mode.runPostProcess(gc.o.getOutput());
     };
 
-    /**
+    /*
      * Processes the next word from the GuessCaseInput
      * returns true, if there are more words, else false.
-     **/
+     */
     self.processWord = function () {
         if (self.doWhiteSpace()) {
         } else {
-            // dump information if in debug mode.
+            // Dump information if in debug mode.
 
-            // try to decide if we need to check all the special cases,
-            // or if it's possibly just a plain word. this should improve
-            // performance a bit, since we don't have to go through all
-            // the regex expressions to find that we didn't have to
-            // check them.
+            /*
+             * Try to decide if we need to check all the special cases,
+             * or if it's possibly just a plain word. This should improve
+             * performance a bit, since we don't have to go through all
+             * the regex expressions to find that we didn't have to
+             * check them.
+             */
             var handled = false;
             if (!gc.re.SPECIALCASES) {
                 gc.re.SPECIALCASES = /(&|¿|¡|\?|\!|;|:|'|‘|’|"|\-|\+|,|\*|\.|#|%|\/|\(|\)|\{|\}|\[|\])/;
@@ -166,9 +162,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         gc.i.nextIndex();
     };
 
-    /**
-     * Delegate function for Artist/Release/Track specific handlers
-     **/
+    // Delegate function for Artist/Release/Track specific handlers
     self.doWord = function () {};
 
     self.doNormalWord = function () {
@@ -180,10 +174,10 @@ MB.GuessCase.Handler.Base = function (gc) {
         flags.context.spaceNextWord = true;
     };
 
-    /**
+    /*
      * Deal with whitespace (\t)
-     * primarily we only look at whitespace for context purposes
-     **/
+     * Primarily we only look at whitespace for context purposes
+     */
     self.doWhiteSpace = function () {
         if (!gc.re.WHITESPACE) {
             gc.re.WHITESPACE = " ";
@@ -199,18 +193,20 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with colons (:)
      * Colons are used as a sub-title split,and also for disc/box name splits
-     **/
+     */
     self.doColon = function () {
         if (!gc.re.COLON) {
             gc.re.COLON = ":";
         }
 
         if (gc.i.matchCurrentWord(gc.re.COLON)) {
-            // capitalize the last word before the colon (it's a line stop)
-            // -- handle special case feat. "role" lowercase.
+            /*
+             * Capitalize the last word before the colon (it's a line stop)
+             * -- handle special case feat. "role" lowercase.
+             */
             var featIndex = gc.o.getLength()-3;
             var role;
             if (flags.context.slurpExtraTitleInformation &&
@@ -220,8 +216,10 @@ MB.GuessCase.Handler.Base = function (gc) {
 
                 gc.o.setWordAtIndex(gc.o.getLength()-1, role.toLowerCase());
             } else {
-                // force capitalization of the last word,
-                // because we are starting a new subtitle
+                /*
+                 * Force capitalization of the last word,
+                 * because we are starting a new subtitle
+                 */
                 gc.o.capitalizeLastWord(!gc.mode.isSentenceCaps());
             }
 
@@ -244,7 +242,7 @@ MB.GuessCase.Handler.Base = function (gc) {
                 }
             }
             if (!skip) {
-                // no whitespace before colons
+                // No whitespace before colons
                 gc.o.appendCurrentWord();
                 flags.resetContext();
                 flags.context.forceCaps = true;
@@ -256,9 +254,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Deal with asterix (*)
-     **/
+    // Deal with asterisk (*)
     self.doAsterix = function () {
         if (!gc.re.ASTERIX) {
             gc.re.ASTERIX = "*";
@@ -271,9 +267,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Deal with diamond (#)
-     **/
+    // Deal with diamond (#)
     self.doDiamond = function () {
         if (!gc.re.DIAMOND) {
             gc.re.DIAMOND = "#";
@@ -286,10 +280,10 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with percent signs (%)
      * TODO: lots of methods for special chars look the same, combine?
-     **/
+     */
     self.doPercent = function () {
         if (!gc.re.PERCENT) {
             gc.re.PERCENT = "%";
@@ -302,9 +296,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Deal with ampersands (&)
-     **/
+    // Deal with ampersands (&)
     self.doAmpersand = function () {
         if (!gc.re.AMPERSAND) {
             gc.re.AMPERSAND = "&";
@@ -312,18 +304,15 @@ MB.GuessCase.Handler.Base = function (gc) {
         if (gc.i.matchCurrentWord(gc.re.AMPERSAND)) {
             flags.resetContext();
             flags.context.forceCaps = true;
-            gc.o.appendSpace(); // add a space,and remember to
-            flags.context.spaceNextWord = true; // add one before the next word
+            gc.o.appendSpace(); // Add a space,and remember to
+            flags.context.spaceNextWord = true; // Add one before the next word
             gc.o.appendCurrentWord();
             return true;
         }
         return false;
     };
 
-    /**
-     * Deal with line terminators (?!;)
-     * (other than the period).
-     **/
+    // Deal with line terminators other than the period (?!;)
     self.doLineStop = function () {
         if (!gc.re.LINESTOP) {
             gc.re.LINESTOP = /[\?\!\;]/;
@@ -331,8 +320,10 @@ MB.GuessCase.Handler.Base = function (gc) {
         if (gc.i.matchCurrentWord(gc.re.LINESTOP)) {
             flags.resetContext();
 
-            // force caps on word before the colon, if
-            // the mode is not sentencecaps
+            /*
+             * Force caps on word before the colon, if
+             * the mode is not sentencecaps
+             */
             gc.o.capitalizeLastWord(!gc.mode.isSentenceCaps());
 
             flags.context.forceCaps = true;
@@ -343,13 +334,13 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with hyphens (-)
-     * if a hyphen has a space near it,then it should be spaced out and treated
-     * similar to a sentence pause,otherwise it's a part of a hyphenated word.
-     * unfortunately it's not practical to implement real em-dashes,however we'll
-     * treat a spaced hyphen as an em-dash for the purposes of caps.
-     **/
+     * If a hyphen has a space near it, it should be spaced out and treated
+     * similar to a sentence pause, if not it's a part of a hyphenated word.
+     * Unfortunately it's not practical to implement real em-dashes, however
+     * we'll treat a spaced hyphen as an em-dash for the purposes of caps.
+     */
     self.doHyphen = function () {
         if (!gc.re.HYPHEN) {
             gc.re.HYPHEN = "-";
@@ -358,7 +349,7 @@ MB.GuessCase.Handler.Base = function (gc) {
             gc.o.appendWordPreserveWhiteSpace({apply: true, capslast: true});
             flags.resetContext();
 
-            // don't capitalize next word after hyphen in sentence mode.
+            // Don't capitalize next word after hyphen in sentence mode.
             flags.context.forceCaps = !gc.mode.isSentenceCaps();
             flags.context.hypen = true;
             return true;
@@ -366,9 +357,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Deal with inverted question (¿) and exclamation marks (¡).
-     **/
+    // Deal with inverted question (¿) and exclamation marks (¡).
     self.doInvertedMarks = function () {
         if (!gc.re.INVERTEDMARKS) {
             gc.re.INVERTEDMARKS = /(¿|¡)/;
@@ -377,16 +366,14 @@ MB.GuessCase.Handler.Base = function (gc) {
             gc.o.appendWordPreserveWhiteSpace({apply: true, capslast: false});
             flags.resetContext();
 
-            // next word is start of a new sentence.
+            // Next word is start of a new sentence.
             flags.context.forceCaps = true;
             return true;
         }
         return false;
     };
 
-    /**
-     * Deal with plus symbol    (+)
-     **/
+    // Deal with plus symbol    (+)
     self.doPlus = function () {
         if (!gc.re.PLUS) {
             gc.re.PLUS = "+";
@@ -399,10 +386,10 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with slashes (/,\)
      * If a slash has a space near it, pad it out, otherwise leave as is.
-     **/
+     */
     self.doSlash = function () {
         if (!gc.re.SLASH) {
             gc.re.SLASH = /[\\\/]/;
@@ -416,18 +403,16 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Deal with double quotes (")
-     **/
+    // Deal with double quotes (")
     self.doDoubleQuote = function () {
         if (!gc.re.DOUBLEQUOTE) {
             gc.re.DOUBLEQUOTE = "\"";
         }
         if (gc.i.matchCurrentWord(gc.re.DOUBLEQUOTE)) {
-            // changed 05/2006: do not force capitalization before quotes
+            // Changed 05/2006: do not force capitalization before quotes
             gc.o.appendWordPreserveWhiteSpace({apply: true, capslast: false});
 
-            // changed 05/2006: do not force capitalization after quotes
+            // Changed 05/2006: do not force capitalization after quotes
             flags.resetContext();
             flags.context.forceCaps = !gc.i.isNextWord(" ");
             return true;
@@ -435,13 +420,13 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with single quotes (')
-     * * need to keep context on whether gc.re.inside quotes or not.
+     * * Need to keep context on whether gc.re.inside quotes or not.
      * * Look for contractions (see contractions_words for a list of
-     *   Contractions that are handled,and format the right part (after)
+     *   contractions that are handled), and format the right part (after)
      *   the (') as lowercase.
-     **/
+     */
     self.doSingleQuote = function () {
         if (!gc.re.SINGLEQUOTE) {
             gc.re.SINGLEQUOTE = /['‘’]/;
@@ -453,14 +438,16 @@ MB.GuessCase.Handler.Base = function (gc) {
             var b = gc.i.isNextWord(" ");
             var state = flags.context.openedSingleQuote;
 
-            // preserve whitespace before opening singlequote.
-            // -- if it's a "Asdf 'Text in Quotes'"
+            /*
+             * Preserve whitespace before opening singlequote.
+             * -- if it's a "Asdf 'Text in Quotes'"
+             */
             if (a && !b) {
                 gc.o.appendSpace();
                 flags.context.openedSingleQuote = true;
                 flags.context.forceCaps = true;
 
-            // preserve whitespace after closing singlequote.
+            // Preserve whitespace after closing singlequote.
             } else if (!a && b) {
                 if (state) {
                     flags.context.forceCaps = true;
@@ -473,13 +460,18 @@ MB.GuessCase.Handler.Base = function (gc) {
             flags.context.spaceNextWord = b; // and keep whitespace intact
             gc.o.appendCurrentWord(); // append current word
 
-            // if there is a space after the ' assume its a closing singlequote
-            // do not force capitalization per default, else for "Rollin' on",
-            // the "On" will be titled.
+            /*
+             * If there is a space after the '
+             * then assume its a closing singlequote
+             * Do not force capitalization per default, else for "Rollin' on",
+             * the "On" will be titled.
+             */
             flags.resetContext();
 
-            // default, if singlequote state was not modified, is
-            // not forcing caps.
+            /*
+             * Default, if singlequote state was not modified, is
+             * not forcing caps.
+             */
             if (state == flags.context.openedSingleQuote) {
                 flags.context.forceCaps = false;
             }
@@ -489,18 +481,20 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with opening parenthesis    (([{<)
-     * Knowing whether gc.re.inside parenthesis (and multiple levels thereof) is
-     * important for determining what words should be capped or not.
-     **/
+     * Knowing whether gc.re.inside parenthesis (and multiple levels thereof)
+     * is important for determining what words should be capped or not.
+     */
     self.doOpeningBracket = function () {
         if (!gc.re.OPENBRACKET) {
             gc.re.OPENBRACKET = /[\(\[\{\<]/;
         }
         if (gc.i.matchCurrentWord(gc.re.OPENBRACKET)) {
-            // force caps on last word before the opending bracket,
-            // if the current mode is not sentence mode.
+            /*
+             * Force caps on last word before the opending bracket,
+             * if the current mode is not sentence mode.
+             */
             gc.o.capitalizeLastWord(!gc.mode.isSentenceCaps());
 
             // register current bracket as openening bracket
@@ -524,7 +518,7 @@ MB.GuessCase.Handler.Base = function (gc) {
                     }
                 }
             }
-            gc.o.appendSpace(); // always space brackets
+            gc.o.appendSpace(); // Always space brackets
             flags.resetContext();
             flags.context.spaceNextWord = false;
             flags.context.openingBracket = true;
@@ -535,18 +529,20 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with closing parenthesis    (([{<)
-     * knowing whether gc.re.inside parenthesis (and multiple levels thereof) is
-     * important for determining what words should be capped or not.
-     **/
+     * Knowing whether gc.re.inside parenthesis (and multiple levels thereof)
+     * is important for determining what words should be capped or not.
+     */
     self.doClosingBracket = function () {
         if (!gc.re.CLOSEBRACKET) {
             gc.re.CLOSEBRACKET = /[\)\]\}\>]/;
         }
         if (gc.i.matchCurrentWord(gc.re.CLOSEBRACKET)) {
-            // capitalize the last word, if forceCaps was
-            // set, else leave it like it is.
+            /*
+             * Capitalize the last word, if forceCaps was
+             * set, else leave it like it is.
+             */
             gc.o.capitalizeLastWord();
 
             if (flags.isInsideBrackets()) {
@@ -562,24 +558,26 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with commas.            (,)
-     * commas can mean two things: a sentence pause,or a number split. We
-     * need context to guess which one it's meant to be, thus the digit
+     * Commas can mean two things: a sentence pause or a number split.
+     * We need context to guess which one it's meant to be, thus the digit
      * triplet checking later on. Multiple commas are removed.
-     **/
+     */
     self.doComma = function () {
         if (!gc.re.COMMA) {
             gc.re.COMMA = ",";
         }
         if (gc.i.matchCurrentWord(gc.re.COMMA)) {
-            // skip duplicate commas.
+            // Skip duplicate commas.
             if (gc.o.getLastWord() != ",") {
-                // capitalize the last word before the colon.
-                // -- do words before comma need to be titled?
-                // -- see http://bugs.musicbrainz.org/ticket/1317
+                /*
+                 * Capitalize the last word before the colon.
+                 * -- Do words before comma need to be titled?
+                 * -- See http://bugs.musicbrainz.org/ticket/1317
+                 */
 
-                // handle comma
+                // Handle comma
                 flags.resetContext();
                 flags.context.spaceNextWord = true;
                 flags.context.forceCaps = false;
@@ -590,7 +588,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Deal with periods.         (.)
      * Periods can also mean four things:
      *   * a sentence break (full stop);
@@ -598,7 +596,7 @@ MB.GuessCase.Handler.Base = function (gc) {
      *   * part of an ellipsis (...)
      *   * an acronym split.
      * We flag digits and digit triplets in the words routine.
-     **/
+     */
     self.doPeriod = function () {
         if (!gc.re.PERIOD) {
             gc.re.PERIOD = ".";
@@ -609,22 +607,24 @@ MB.GuessCase.Handler.Base = function (gc) {
                 if (!flags.context.ellipsis) {
                     gc.o.appendWord("..");
                     while (gc.i.isNextWord(".")) {
-                        gc.i.nextIndex(); // skip trailing (.)
+                        gc.i.nextIndex(); // Skip trailing (.)
                     }
                     flags.resetContext();
                     flags.context.ellipsis = true;
                 }
-                flags.context.forceCaps = true; // capitalize next word in any case.
+                flags.context.forceCaps = true; // Capitalize next word in any case.
                 flags.context.spaceNextWord = true;
             } else {
                 if (!gc.i.hasMoreWords() || gc.i.getNextWord() != ".") {
-                    // capitalize the last word, if forceCaps was
-                    // set, else leave it like it is.
+                    /*
+                     * Capitalize the last word, if forceCaps was
+                     * set, else leave it like it is.
+                     */
                     gc.o.capitalizeLastWord();
                 }
                 gc.o.appendWord(".");
                 flags.resetContext();
-                flags.context.forceCaps = true; // force caps on next word
+                flags.context.forceCaps = true; // Force caps on next word
                 flags.context.spaceNextWord = (gc.i.isNextWord(" "));
             }
             return true;
@@ -632,52 +632,52 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
-     * Check for an acronym
-     **/
+    // Check for an acronym
     self.doAcronym = function () {
         if (!gc.re.ACRONYM) {
             gc.re.ACRONYM = /^\w$/;
         }
 
-        // acronym handling was made less strict to
-        // fix broken acronyms which look like this: "A. B. C."
-        // the variable flags.context.gotPeriod,is used such that such
-        // cases do not yield false positives:
-        // The method works as follows:
-        // "A.B.C. I Love You"          => "A.B.C. I Love You"
-        // "A. B. C. I Love You"        => "A.B.C. I Love You"
-        // "A.B.C I Love You"           => "A.B. C I Love You"
-        // "P.S I Love You"             => "P. S I Love You"
+        /*
+         * Acronym handling was made less strict to
+         * fix broken acronyms which look like this: "A. B. C."
+         * The variable flags.context.gotPeriod is used such that such
+         * cases do not yield false positives:
+         * The method works as follows:
+         * "A.B.C. I Love You"          => "A.B.C. I Love You"
+         * "A. B. C. I Love You"        => "A.B.C. I Love You"
+         * "A.B.C I Love You"           => "A.B. C I Love You"
+         * "P.S I Love You"             => "P. S I Love You"
+         */
         var subIndex, tmp = [];
         if (gc.i.matchCurrentWord(gc.re.ACRONYM)) {
             var cw = gc.i.getCurrentWord();
-            tmp.push(cw.toUpperCase()); // add current word
+            tmp.push(cw.toUpperCase()); // Add current word
             flags.context.expectWord = false;
             flags.context.gotPeriod = false;
 
             acronymloop:
             for (subIndex = gc.i.getPos() + 1; subIndex < gc.i.getLength();) {
-                cw = gc.i.getWordAtIndex(subIndex); // remember current word.
+                cw = gc.i.getWordAtIndex(subIndex); // Remember current word.
 
                 if (flags.context.expectWord && cw.match(gc.re.ACRONYM)) {
-                    tmp.push(cw.toUpperCase()); // do character
+                    tmp.push(cw.toUpperCase()); // Do character
                     flags.context.expectWord = false;
                     flags.context.gotPeriod = false;
                 } else {
                     if (cw == "." && !flags.context.gotPeriod) {
-                        tmp[tmp.length] = "."; // do dot
+                        tmp[tmp.length] = "."; // Do dot
                         flags.context.gotPeriod = true;
                         flags.context.expectWord = true;
                     } else {
                         if (flags.context.gotPeriod && cw == " ") {
-                            flags.context.expectWord = true; // do a single whitespace
+                            flags.context.expectWord = true; // Do a single whitespace
                         } else {
                             if (tmp[tmp.length-1] != ".") {
-                                tmp.pop(); // loose last of the acronym
-                                subIndex--; // its for example "P.S. I" love you
+                                tmp.pop(); // Lose last of the acronym
+                                subIndex--; // It's for example "P.S. I" love you
                             }
-                            break acronymloop; // found something which is not part of the acronym
+                            break acronymloop; // Vound something which is not part of the acronym
                         }
                     }
                 }
@@ -686,8 +686,8 @@ MB.GuessCase.Handler.Base = function (gc) {
         }
 
         if (tmp.length > 2) {
-            var s = tmp.join(""); // yes,we have an acronym, get string
-            s = s.replace(/(\.)*$/,"."); // replace any number of trailing "." with ". "
+            var s = tmp.join(""); // Yes, we have an acronym, get string
+            s = s.replace(/(\.)*$/,"."); // Replace any number of trailing "." with ". "
 
             gc.o.appendSpaceIfNeeded();
             gc.o.appendWord(s);
@@ -696,15 +696,13 @@ MB.GuessCase.Handler.Base = function (gc) {
             flags.context.acronym = true;
             flags.context.spaceNextWord = true;
             flags.context.forceCaps = false;
-            gc.i.setPos(subIndex-1); // set pointer to after acronym
+            gc.i.setPos(subIndex-1); // Set pointer to after acronym
             return true;
         }
         return false;
     };
 
-    /**
-     * Check for a digit only string
-     **/
+    // Check for a digit only string
     self.doDigits = function () {
         if (!gc.re.DIGITS) {
             gc.re.DIGITS = /^\d+$/;
@@ -723,26 +721,28 @@ MB.GuessCase.Handler.Base = function (gc) {
             for (subIndex = gc.i.getPos() + 1; subIndex < gc.i.getLength();) {
                 if (flags.context.numberSplitExpect) {
                     if (gc.i.matchWordAtIndex(subIndex, gc.re.DIGITS_NUMBERSPLIT)) {
-                        tmp.push(gc.i.getWordAtIndex(subIndex)); // found a potential number split
+                        tmp.push(gc.i.getWordAtIndex(subIndex)); // Found a potential number split
                         flags.context.numberSplitExpect = false;
                     } else {
                         break numberloop;
                     }
                 } else {
-                    // look for a group of 3 digits
+                    // Look for a group of 3 digits
                     if (gc.i.matchWordAtIndex(subIndex, gc.re.DIGITS_TRIPLE)) {
                         if (flags.context.numberSplitChar == null) {
-                            flags.context.numberSplitChar = tmp[tmp.length - 1]; // confirmed number split
+                            flags.context.numberSplitChar = tmp[tmp.length - 1]; // Confirmed number split
                         }
                         tmp.push(gc.i.getWordAtIndex(subIndex));
                         flags.context.numberSplitExpect = true;
                     } else {
                         if (gc.i.matchWordAtIndex(subIndex, gc.re.DIGITS_DUPLE)) {
                             if (tmp.length > 2 && flags.context.numberSplitChar != tmp[tmp.length - 1]) {
-                                // check for the opposite number splitter (,or .)
-                                // because numbers are generally either
-                                // 1,000,936.00 or 1.300.402,00 depending on
-                                // the country
+                                /*
+                                 * Check for the opposite number splitter (, or .)
+                                 * because numbers are generally either
+                                 * 1,000,936.00 or 1.300.402,00 depending on
+                                 * the country
+                                 */
                                 tmp.push(gc.i.getWordAtIndex(subIndex++));
                             } else {
                                 tmp.pop(); // stand-alone number pair
@@ -750,11 +750,13 @@ MB.GuessCase.Handler.Base = function (gc) {
                             }
                         } else {
                             if (gc.i.matchWordAtIndex(subIndex, gc.re.DIGITS_NTUPLE)) {
-                                // big number at the end,probably a decimal point,
-                                // end of number in any case
+                                /*
+                                 * Big number at the end, probably a decimal point,
+                                 * end of number in any case
+                                 */
                                 tmp.push(gc.i.getWordAtIndex(subIndex++));
                             } else {
-                                tmp.pop(); // last number split was not
+                                tmp.pop(); // Last number split was not
                                 subIndex--; // actually a number split
                             }
                         }
@@ -777,11 +779,11 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     };
 
-    /**
+    /*
      * Do not change the caps of certain words
      * ---------------------------------------------------
      * warp        2011-08-13        first version
-     **/
+     */
     self.doIgnoreWords = function () {
         // deciBel
         if (gc.i.getCurrentWord() === 'dB') {
@@ -792,60 +794,66 @@ MB.GuessCase.Handler.Base = function (gc) {
         return false;
     }
 
-    /**
+    /*
      * Detect featuring,f., ft[.], feat[.] and add parentheses as needed.
      * keschte        2005-11-10        added ^f\.$ to cases
      *                                  which are added converted to feat.
      * ---------------------------------------------------
-     **/
+     */
     self.doFeaturingArtistStyle = function () {
         if (!gc.re.FEAT) {
             gc.re.FEAT = /^featuring$|^f$|^ft$|^feat$/i;
-            gc.re.FEAT_F = /^f$/i; // match word "f"
-            gc.re.FEAT_FEAT = /^feat$/i; // match word "feat"
+            gc.re.FEAT_F = /^f$/i; // Match word "f"
+            gc.re.FEAT_FEAT = /^feat$/i; // Match word "feat"
         }
         if (gc.i.matchCurrentWord(gc.re.FEAT)) {
-            // special cases (f.) and (f/), have to check if next word is a "." or a "/"
+            // Special cases (f.) and (f/), have to check if next word is a "." or a "/"
             if ((gc.i.matchCurrentWord(gc.re.FEAT_F)) &&
                 !gc.i.getNextWord().match(/^[\/.]$/)) {
                     return false;
             }
 
-            // only try to convert to feat. if there are
-            // enough words after the keyword
+            /*
+             * Only try to convert to feat. if there are
+             * enough words after the keyword
+             */
             if (gc.i.getPos() < gc.i.getLength() - 2) {
 
                 const featWord = gc.i.getCurrentWord() + (
                     gc.i.isNextWord(".") || gc.i.isNextWord("/") ? gc.i.getNextWord() :
-                    // special case (feat), fix typo by adding a "." if missing
+                    // Special case (feat), fix typo by adding a "." if missing
                     gc.i.matchCurrentWord(gc.re.FEAT_FEAT) ? "." : ""
                 );
 
                 if (!flags.context.openingBracket && !flags.isInsideBrackets()) {
                     if (flags.isInsideBrackets()) {
-                        // close open parentheses before the feat. part.
+                        // Close open parentheses before the feat. part.
                         var closebrackets = new Array();
                         while (flags.isInsideBrackets()) {
-                            // close brackets that were opened before
+                            // Close brackets that were opened before
                             var cb = flags.popBracket();
                             gc.o.appendWord(cb);
                             if (gc.i.getWordAtIndex(gc.i.getLength()-1) == cb) {
                                 gc.i.dropLastWord();
-                                // get rid of duplicate bracket at the end (will be
-                                // added again by closeOpenBrackets if they wern't
-                                // closed before (e.g. using feat.)
+                                /*
+                                 * Get rid of duplicate bracket at the end (will be
+                                 * added again by closeOpenBrackets if they wern't
+                                 * closed before (e.g. using feat.)
+                                 */
                             }
                         }
                     }
 
-                    // handle case:
-                    // Blah ft. Erroll Flynn Some Remixname remix
-                    // -> pre-processor added parentheses such that the string is:
-                    // Blah ft. erroll flynn Some Remixname (remix)
-                    // -> now there are parentheses needed before remix, we can't
-                    //    guess where the artist name ends, and the remixname starts
-                    //    though :]
-                    // Blah (feat. Erroll Flynn Some Remixname) (remix)
+                    /*
+                     * Handle case:
+                     * Blah ft. Erroll Flynn Some Remixname remix
+                     * -> pre-processor added parentheses such that the string is:
+                     * Blah ft. erroll flynn Some Remixname (remix)
+                     * -> now there are parentheses needed before remix, we can't
+                     *    guess where the artist name ends, and the remixname starts
+                     *    though :]
+                     * Blah (feat. Erroll Flynn Some Remixname) (remix)
+                     */
                     var pos = gc.i.getPos();
                     var len = gc.i.getLength();
                     for (var i = pos; i < len; i++) {
@@ -854,8 +862,10 @@ MB.GuessCase.Handler.Base = function (gc) {
                         }
                     }
 
-                    // we got a part, but not until the end of the string
-                    // close feat. part, and add space to next set of brackets
+                    /*
+                     * We got a part, but not until the end of the string
+                     * close feat. part, and add space to next set of brackets
+                     */
                     if (i != pos && i < len-1) {
                         gc.i.insertWordsAtIndex(i, [")", " "]);
                     }

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Label.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../../common/MB';
 import * as flags from '../../../flags';
@@ -25,31 +25,29 @@ import * as flags from '../../../flags';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Label specific GuessCase functionality
- **/
+// Label specific GuessCase functionality
 MB.GuessCase.Handler.Label = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
+    /*
      * Checks special cases of labels
      * - empty, unknown -> [unknown]
      * - none, no label, not applicable, n/a -> [no label]
-     **/
+     */
     self.checkSpecialCase = function (is) {
         if (is) {
             if (!gc.re.LABEL_EMPTY) {
-                // match empty
+                // Match empty
                 gc.re.LABEL_EMPTY = /^\s*$/i;
-                // match "unknown" and variants
+                // Match "unknown" and variants
                 gc.re.LABEL_UNKNOWN = /^[\(\[]?\s*Unknown\s*[\)\]]?$/i;
-                // match "none" and variants
+                // Match "none" and variants
                 gc.re.LABEL_NONE = /^[\(\[]?\s*none\s*[\)\]]?$/i;
-                // match "no label" and variants
+                // Match "no label" and variants
                 gc.re.LABEL_NOLABEL = /^[\(\[]?\s*no[\s-]+label\s*[\)\]]?$/i;
-                // match "not applicable" and variants
+                // Match "not applicable" and variants
                 gc.re.LABEL_NOTAPPLICABLE = /^[\(\[]?\s*not[\s-]+applicable\s*[\)\]]?$/i;
-                // match "n/a" and variants
+                // Match "n/a" and variants
                 gc.re.LABEL_NA = /^[\(\[]?\s*n\s*[\\\/]\s*a\s*[\)\]]?$/i;
             }
             var os = is;
@@ -75,10 +73,10 @@ MB.GuessCase.Handler.Label = function (gc) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
-     **/
+     */
     self.doWord = function () {
         gc.o.appendSpaceIfNeeded();
         gc.i.capitalizeCurrentWord();
@@ -91,9 +89,7 @@ MB.GuessCase.Handler.Label = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for label aliases
-     **/
+    // Guesses the sortname for label aliases
     self.guessSortName = function (is) {
         return self.sortCompoundName(is, self.moveArticleToEnd);
     };

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
@@ -1,21 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Place.js
@@ -1,22 +1,22 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (C) 2013 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2013 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../../common/MB';
 import * as flags from '../../../flags';
@@ -24,23 +24,19 @@ import * as flags from '../../../flags';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Place specific GuessCase functionality
- **/
+// Place specific GuessCase functionality
 MB.GuessCase.Handler.Place = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
-     * Checks special cases
-     **/
+    // Checks special cases
     self.checkSpecialCase = function (is) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
-     **/
+     */
     self.doWord = function () {
         if (self.doIgnoreWords()) {
         } else if (gc.mode.doWord()) {
@@ -51,9 +47,7 @@ MB.GuessCase.Handler.Place = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for place aliases
-     **/
+    // Guesses the sortname for place aliases
     self.guessSortName = function (is) {
         return self.sortCompoundName(is, self.moveArticleToEnd);
     };

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import _ from 'lodash';
 
@@ -27,19 +27,15 @@ import * as flags from '../../../flags';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Release specific GuessCase functionality
- **/
+// Release specific GuessCase functionality
 MB.GuessCase.Handler.Release = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
-     * Checks special cases of releases
-     **/
+    // Checks special cases of releases
     self.checkSpecialCase = function (is) {
         if (is) {
             if (!gc.re.RELEASE_UNTITLED) {
-                // untitled
+                // Untitled
                 gc.re.RELEASE_UNTITLED = /^([\(\[]?\s*untitled\s*[\)\]]?)$/i;
             }
             if (is.match(gc.re.RELEASE_UNTITLED)) {
@@ -49,13 +45,13 @@ MB.GuessCase.Handler.Release = function (gc) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Guess the releasename given in string is, and
      * returns the guessed name.
      *
      * @param    is        the inputstring
      * @returns os        the processed string
-     **/
+     */
     self.process = _.wrap(self.process, function (process, os) {
         return gc.mode.fixVinylSizes(process(os));
     });
@@ -65,14 +61,13 @@ MB.GuessCase.Handler.Release = function (gc) {
         return gc.mode.prepExtraTitleInfo(gc.i.splitWordsAndPunctuation(is));
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
      *
      * - Handles DiscNumberStyle (DiscNumberWithNameStyle)
      * - Handles FeaturingArtistStyle
-     *
-     **/
+     */
     self.doWord = function () {
         if (self.doFeaturingArtistStyle()) {
         } else if (gc.mode.doWord()) {
@@ -83,9 +78,7 @@ MB.GuessCase.Handler.Release = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for releases (for aliases)
-     **/
+    // Guesses the sortname for releases (for aliases)
     self.guessSortName = self.moveArticleToEnd;
 
     return self;

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Release.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Track.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import _ from 'lodash';
 
@@ -27,9 +27,7 @@ import * as flags from '../../../flags';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Track specific GuessCase functionality
- **/
+// Track specific GuessCase functionality
 MB.GuessCase.Handler.Track = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
@@ -39,13 +37,13 @@ MB.GuessCase.Handler.Track = function (gc) {
             .replace(/[\(\[]?retail(\s+version)?\s*[\)\]]?$/i, "");
     };
 
-    /**
+    /*
      * Guess the trackname given in string is, and
      * returns the guessed name.
      *
-     * @param    is        the inputstring
+     * @param    is       the inputstring
      * @returns os        the processed string
-     **/
+     */
 
     self.process = _.wrap(self.process, function (process, os) {
         return gc.mode.fixVinylSizes(process(os));
@@ -56,7 +54,7 @@ MB.GuessCase.Handler.Track = function (gc) {
         return gc.mode.prepExtraTitleInfo(gc.i.splitWordsAndPunctuation(is));
     };
 
-    /**
+    /*
      * Detect if UntitledTrackStyle and DataTrackStyle needs
      * to be applied.
      *
@@ -64,19 +62,19 @@ MB.GuessCase.Handler.Track = function (gc) {
      * - silence|silent [track]    -> [silence]
      * - untitled [track]        -> [untitled]
      * - unknown|bonus [track]    -> [unknown]
-     **/
+     */
     self.checkSpecialCase = function (is) {
         if (is) {
             if (!gc.re.TRACK_DATATRACK) {
-                // data tracks
+                // Data tracks
                 gc.re.TRACK_DATATRACK = /^([\(\[]?\s*data(\s+track)?\s*[\)\]]?$)/i;
-                // silence
+                // Silence
                 gc.re.TRACK_SILENCE = /^([\(\[]?\s*(silen(t|ce)|blank)(\s+track)?\s*[\)\]]?)$/i;
-                // untitled
+                // Untitled
                 gc.re.TRACK_UNTITLED = /^([\(\[]?\s*untitled(\s+track)?\s*[\)\]]?)$/i;
-                // unknown
+                // Unknown
                 gc.re.TRACK_UNKNOWN = /^([\(\[]?\s*(unknown|bonus|hidden)(\s+track)?\s*[\)\]]?)$/i;
-                // any number of question marks
+                // Any number of question marks
                 gc.re.TRACK_MYSTERY = /^\?+$/i;
             }
             if (is.match(gc.re.TRACK_DATATRACK)) {
@@ -98,13 +96,12 @@ MB.GuessCase.Handler.Track = function (gc) {
         return self.NOT_A_SPECIALCASE;
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
      *
      * - Handles FeaturingArtistStyle
-     *
-     **/
+     */
     self.doWord = function () {
         if (self.doIgnoreWords()) {
         } else if (self.doFeaturingArtistStyle()) {
@@ -123,7 +120,7 @@ MB.GuessCase.Handler.Track = function (gc) {
                 flags.context.spaceNextWord = false;
                 flags.context.forceCaps = false;
             } else {
-                // handle other cases (e.g. normal words)
+                // Handle other cases (e.g. normal words)
                 gc.o.appendSpaceIfNeeded();
                 gc.i.capitalizeCurrentWord();
 
@@ -137,9 +134,7 @@ MB.GuessCase.Handler.Track = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for recordings (for aliases)
-     **/
+    // Guesses the sortname for recordings (for aliases)
     self.guessSortName = self.moveArticleToEnd;
 
     return self;

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../../common/MB';
 import * as flags from '../../../flags';
@@ -25,19 +25,15 @@ import * as flags from '../../../flags';
 MB.GuessCase = (MB.GuessCase) ? MB.GuessCase : {};
 MB.GuessCase.Handler = (MB.GuessCase.Handler) ? MB.GuessCase.Handler : {};
 
-/**
- * Work specific GuessCase functionality
- **/
+// Work specific GuessCase functionality
 MB.GuessCase.Handler.Work = function (gc) {
     var self = MB.GuessCase.Handler.Base(gc);
 
-    /**
-     * Checks special cases of releases
-     **/
+    // Checks special cases of releases
     self.checkSpecialCase = function (is) {
         if (is) {
             if (!gc.re.RELEASE_UNTITLED) {
-                // untitled
+                // Untitled
                 gc.re.RELEASE_UNTITLED = /^([\(\[]?\s*untitled\s*[\)\]]?)$/i;
             }
             if (is.match(gc.re.RELEASE_UNTITLED)) {
@@ -52,14 +48,13 @@ MB.GuessCase.Handler.Work = function (gc) {
         return gc.mode.prepExtraTitleInfo(gc.i.splitWordsAndPunctuation(is));
     };
 
-    /**
+    /*
      * Delegate function which handles words not handled
      * in the common word handlers.
      *
      * - Handles DiscNumberStyle (DiscNumberWithNameStyle)
      * - Handles FeaturingArtistStyle
-     *
-     **/
+     */
     self.doWord = function () {
         if (self.doIgnoreWords()) {
         } else if (self.doFeaturingArtistStyle()) {
@@ -71,9 +66,7 @@ MB.GuessCase.Handler.Work = function (gc) {
         return null;
     };
 
-    /**
-     * Guesses the sortname for works
-     **/
+    // Guesses the sortname for works
     self.guessSortName = self.moveArticleToEnd;
 
     return self;

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Work.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import _ from 'lodash';
 
@@ -27,27 +27,21 @@ import * as utils from '../../utils';
 
 MB.GuessCase = MB.GuessCase ? MB.GuessCase : {};
 
-/**
+/*
  * Holds the input variables
- **/
+ */
 MB.GuessCase.Input = function (gc) {
     var self = {};
 
-    // ----------------------------------------------------------------------------
-    // member variables
-    // ---------------------------------------------------------------------------
+    // Member variables
     self._source = "";
     self._w = [];
     self._l = 0;
     self._wi = 0;
 
-    // ----------------------------------------------------------------------------
-    // member functions
-    // ---------------------------------------------------------------------------
+    // Member functions
 
-    /**
-     * Initialise the GcInput object
-     **/
+    // Initialise the GcInput object
     self.init = function (is, w) {
         self._source = (is || "");
         self._w = (w || []);
@@ -55,40 +49,30 @@ MB.GuessCase.Input = function (gc) {
         self._wi = 0;
     };
 
-    /**
-     * Returns the length of the wordlist
-     **/
+    // Returns the length of the wordlist
     self.getLength = function () {
         return self._l;
     };
 
-    /**
-     * Returns true if the lenght==0
-     **/
+    // Returns true if the lenght==0
     self.isEmpty = function () {
         var f = (self.getLength() == 0);
         return f;
     };
 
-    /**
-     * Get the cursor position
-     **/
+    // Get the cursor position
     self.getPos = function () {
         return self._wi;
     };
 
-    /**
-     * Set the cursor to a new position
-     **/
+    // Set the cursor to a new position
     self.setPos = function (index) {
         if (index >= 0 && index < self.getLength()) {
             self._wi = index;
         }
     };
 
-    /**
-     * Accessors for strings at certain positions.
-     **/
+    // Accessors for strings at certain positions.
     self.getWordAtIndex = function (index) {
         return (self._w[index] || null);
     };
@@ -105,9 +89,7 @@ MB.GuessCase.Input = function (gc) {
         return self.getWordAtIndex(self._wi-1);
     };
 
-    /**
-     * Test methods
-     **/
+    // Test methods
     self.isFirstWord = function () {
         return (0 == self._wi);
     };
@@ -124,18 +106,18 @@ MB.GuessCase.Input = function (gc) {
         return (!self.isFirstWord() && self.getPreviousWord() == s);
     };
 
-    /**
+    /*
      * Match the word at the current index against the
      * regular expression or string given
-     **/
+     */
     self.matchCurrentWord = function (re) {
         return self.matchWordAtIndex(self.getPos(), re);
     };
 
-    /**
+    /*
      * Match the word at index wi against the
      * regular expression or string given
-     **/
+     */
     self.matchWordAtIndex = function (index, re) {
         var cw = (self.getWordAtIndex(index) || "");
         var f;
@@ -147,9 +129,7 @@ MB.GuessCase.Input = function (gc) {
         return f;
     };
 
-    /**
-     * Index methods
-     **/
+    // Index methods
     self.hasMoreWords = function () {
         return (self._wi == 0 && self.getLength() > 0 || self._wi-1 < self.getLength());
     };
@@ -162,9 +142,7 @@ MB.GuessCase.Input = function (gc) {
         self._wi++;
     };
 
-    /**
-     * Returns the last word of the wordlist
-     **/
+    // Returns the last word of the wordlist
     self.dropLastWord = function () {
         if (self.getLength() > 0) {
             self._w.pop();
@@ -174,9 +152,7 @@ MB.GuessCase.Input = function (gc) {
         }
     };
 
-    /**
-     * Capitalize the word at the current position
-     **/
+    // Capitalize the word at the current position
     self.insertWordsAtIndex = function (index, w) {
         var part1 = self._w.slice(0,index);
         var part2 = self._w.slice(index, self._w.length);
@@ -184,9 +160,7 @@ MB.GuessCase.Input = function (gc) {
         self._l = self._w.length;
     };
 
-    /**
-     * Capitalize the word at the current position
-     **/
+    // Capitalize the word at the current position
     self.capitalizeCurrentWord = function () {
         var w;
         if ((w = self.getCurrentWord()) != null) {
@@ -199,9 +173,7 @@ MB.GuessCase.Input = function (gc) {
         return null;
     };
 
-    /**
-     * Update the word at the current position
-     **/
+    // Update the word at the current position
     self.updateCurrentWord = function (o) {
         var w = self.getCurrentWord();
         if (w != null) {
@@ -209,24 +181,24 @@ MB.GuessCase.Input = function (gc) {
         }
     };
 
-    /**
-     * Insert a word at the end of the wordlist
-     **/
+    // Insert a word at the end of the wordlist
     self.insertWordAtEnd = function (w) {
         self._w[self._w.length] = w;
         self._l++;
     };
 
-    /**
+    /*
      * This function returns an array of all the words, punctuation and
      * spaces of the input string
      *
-     * Before splitting the string into the different candidates,the following actions are taken:
-     *  * remove leading and trailing whitespace
-     *  * compress whitespace,e.g replace all instances of multiple space with a single space
-     * @param   is      the un-processed input string
-     * @returns         sets the GLOBAL array of words and puctuation characters
-     **/
+     * Before splitting the string into the different candidates,
+     * the following actions are taken:
+     * 1) remove leading and trailing whitespace
+     * 2) compress whitespace, e.g replace all instances
+     *    of multiple space with a single space
+     * @param is the un-processed input string
+     * @returns sets the GLOBAL array of words and puctuation characters
+     */
     self.splitWordsAndPunctuation = function (is) {
         is = is.replace(/^\s\s*/,""); // delete leading space
         is = is.replace(/\s\s*$/,""); // delete trailing space
@@ -239,8 +211,10 @@ MB.GuessCase.Input = function (gc) {
         }
         for (var i = 0; i < chars.length; i++) {
             if (chars[i].match(gc.re.SPLITWORDSANDPUNCTUATION)) {
-                // see http://www.codingforums.com/archive/index.php/t-49001
-                // for reference (escaping the sequence)
+                /*
+                 * See http://www.codingforums.com/archive/index.php/t-49001
+                 * for reference (escaping the sequence)
+                 */
                 word.push(chars[i]); // greedy match anything except our stop characters
             } else {
                 if (word.length > 0) {

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../common/MB';
 import getCookie from '../../../common/utility/getCookie';
@@ -38,20 +38,16 @@ import './Handler/Work';
 
 MB.GuessCase = MB.GuessCase || {};
 
-/**
- * Main class of the GC functionality
- **/
+// Main class of the GC functionality
     var self = {};
 
     self.modeName = getCookie("guesscase_mode") || "English";
     self.mode = modes[self.modeName];
 
-    /* config. */
+    // Config
     self.CFG_UC_UPPERCASED = getCookie("guesscase_keepuppercase") !== "false";
 
-    // ----------------------------------------------------------------------------
-    // member variables
-    // ----------------------------------------------------------------------------
+    // Member variables
     self.i = Input(self);
     self.o = Output(self);
 
@@ -61,28 +57,28 @@ MB.GuessCase = MB.GuessCase || {};
         SERIES_NUMBER: /^(\d+|[ivx]+)$/i
     }; // holder for the regular expressions
 
-    // ----------------------------------------------------------------------------
-    // member functions
-    // ---------------------------------------------------------------------------
+    // Member functions
 
     function guess(handlerName, method) {
         var handler;
 
-        /**
+        /*
          * Guesses the name (e.g. capitalization) or sort name (for aliases)
          * of a given entity.
          * @param {string} is The unprocessed input string.
          * @return {string} The processed string.
-         **/
+         */
         return function (is) {
             // Initialise flags for another run.
             flags.init();
 
             handler = handler || MB.GuessCase.Handler[handlerName](self);
 
-            // we need to query the handler if the input string is
-            // a special case, fetch the correct format, if the
-            // returned case is indeed a special case.
+            /*
+             * We need to query the handler if the input string is
+             * a special case, fetch the correct format, if the
+             * returned case is indeed a special case.
+             */
             var num = handler.checkSpecialCase(is);
             if (handler.isSpecialCase(num)) {
                 var os = handler.getSpecialCaseFormatted(is, num);
@@ -135,8 +131,10 @@ MB.GuessCase = MB.GuessCase || {};
         sortname: guess("Work", "guessSortName")
     };
 
-    // Series and Event don't have their own handler, and they use the
-    // work handler because additional behavior isn't needed.
+    /*
+     * Series and Event don't have their own handler, and they use the
+     * work handler because additional behavior isn't needed.
+     */
     MB.GuessCase.series = MB.GuessCase.work;
     MB.GuessCase.event = MB.GuessCase.work;
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -1,23 +1,23 @@
 /*
-   This file is part of MusicBrainz, the open internet music database.
-   Copyright (c) 2005 Stefan Kestenholz (keschte)
-   Copyright (C) 2010 MetaBrainz Foundation
-
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2 of the License, or
-   (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-*/
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
 
 import MB from '../../../common/MB';
 import * as flags from '../../flags';
@@ -25,48 +25,36 @@ import * as utils from '../../utils';
 
 MB.GuessCase = MB.GuessCase ? MB.GuessCase : {};
 
-/**
- * Holds the output variables
- **/
+// Holds the output variables
 MB.GuessCase.Output = function (gc) {
     var self = {};
 
-    // ----------------------------------------------------------------------------
-    // member variables
-    // ---------------------------------------------------------------------------
+    // Member variables
     self._w = [];
 
-    // ----------------------------------------------------------------------------
-    // member functions
-    // ---------------------------------------------------------------------------
+    // Member functions
 
-    /**
-     * Initialise the GcOutput object for another run
-     **/
+    // Initialise the GcOutput object for another run
     self.init = function () {
         self._w = [];
         self._output = "";
     };
 
-    /**
-     * @returns the length
-     **/
+    // @returns the length
     self.getLength = function () {
        return self._w.length;
     };
 
-    /**
-     * @returns if the array is empty
-     **/
+    // @returns if the array is empty
     self.isEmpty = function () {
         var f = (self.getLength() == 0);
         return f;
     };
 
-    /**
+    /*
      * Fetches the current word from the GcInput
      * object, and appends it to the wordlist.
-     **/
+     */
     self.appendCurrentWord = function () {
         var w;
         if ((w = gc.i.getCurrentWord()) != null) {
@@ -74,11 +62,11 @@ MB.GuessCase.Output = function (gc) {
         }
     };
 
-    /**
+    /*
      * Append the word w to the worlist
      *
-     * @param w        the word
-     **/
+     * @param w the word
+     */
     self.appendWord = function (w) {
         if (w == " ") {
             gc.o.appendSpace();
@@ -87,26 +75,22 @@ MB.GuessCase.Output = function (gc) {
         }
     };
 
-    /**
-     * Adds a space to the processed wordslist
-     **/
+    // Adds a space to the processed wordslist
     self.appendSpace = function () {
        self._w[self._w.length] = " ";
     };
 
-    /**
+    /*
      * Checks the global flag spaceNextWord and adds a space to the
      * processed wordlist if needed. The flag is *NOT* reset.
-     **/
+     */
     self.appendSpaceIfNeeded = function () {
         if (flags.context.spaceNextWord) {
             gc.o.appendSpace();
         }
     };
 
-    /**
-     * Returns the word at the index, or null if index outside bounds
-     **/
+    // Returns the word at the index, or null if index outside bounds
     self.getWordAtIndex = function (index) {
         if (self._w[index]) {
             return self._w[index];
@@ -115,18 +99,14 @@ MB.GuessCase.Output = function (gc) {
         }
     };
 
-    /**
-     * Returns the word at the index, or null if index outside bounds
-     **/
+    // Returns the word at the index, or null if index outside bounds
     self.setWordAtIndex = function (index, word) {
         if (self.getWordAtIndex(index)) {
             self._w[index] = word;
         }
     };
 
-    /**
-     * Returns the last word of the wordlist
-     **/
+    // Returns the last word of the wordlist
     self.getLastWord = function () {
         if (!self.isEmpty()) {
             return self._w[self._w.length-1];
@@ -135,9 +115,7 @@ MB.GuessCase.Output = function (gc) {
         }
     };
 
-    /**
-     * Returns the last word of the wordlist
-     **/
+    // Returns the last word of the wordlist
     self.dropLastWord = function () {
         if (!self.isEmpty()) {
             return self._w.pop();
@@ -145,21 +123,19 @@ MB.GuessCase.Output = function (gc) {
         return null;
     };
 
-    /**
-     * Capitalize the word at the current cursor position.
-     **/
+    // Capitalize the word at the current cursor position.
     self.capitalizeWordAtIndex = function (index, overrideCaps) {
         overrideCaps = (overrideCaps != null ? overrideCaps : flags.context.forceCaps);
         if ((!gc.mode.isSentenceCaps() || overrideCaps) &&
             (!self.isEmpty()) &&
             (self.getWordAtIndex(index) != null)) {
 
-            // don't capitalize last word before puncuation/end of string in sentence mode.
+            // Don't capitalize last word before puncuation/end of string in sentence mode.
             var w = self.getWordAtIndex(index), o = w;
 
-            // check that last word is NOT an acronym.
+            // Check that last word is NOT an acronym.
             if (w.match(/^\w\..*/) == null) {
-                // some words that were manipulated might have space padding
+                // Some words that were manipulated might have space padding
                 var probe = utils.trim(w.toLowerCase());
 
                 // If inside brackets, do nothing.
@@ -169,16 +145,16 @@ MB.GuessCase.Output = function (gc) {
 
                     // If it is an UPPERCASE word,do nothing.
                 } else if (!overrideCaps && gc.mode.isUpperCaseWord(probe)) {
-                    // else capitalize the current word.
+                    // Else capitalize the current word.
                 } else {
-                    // rewind pos pointer on input
+                    // Rewind pos pointer on input
                     var bef = gc.i.getPos(), pos = bef-1;
                     while (pos >= 0 && utils.trim(gc.i.getWordAtIndex(pos).toLowerCase()) != probe) {
                         pos--;
                     }
                     gc.i.setPos(pos);
                     o = utils.titleString(gc, w, overrideCaps);
-                    // restore pos pointer on input
+                    // Restore pos pointer on input
                     gc.i.setPos(bef);
                     if (w != o) {
                         self.setWordAtIndex(index, o);
@@ -188,22 +164,20 @@ MB.GuessCase.Output = function (gc) {
         }
     };
 
-    /**
+    /*
      * Capitalize the word at the current cursor position.
      * Modifies the last element of the processed wordlist
      *
      * @param    overrideCaps    can be used to override
      *                            the flags.context.forceCaps parameter.
-     **/
+     */
     self.capitalizeLastWord = function (overrideCaps) {
         self.capitalizeWordAtIndex(self.getLength()-1, overrideCaps);
     };
 
-    /**
-     * Apply post-processing, and return the string
-     **/
+    // Apply post-processing, and return the string
     self.getOutput = function () {
-        // if *not* sentence mode, force caps on last word.
+        // If *not* sentence mode, force caps on last word.
         flags.context.forceCaps = !gc.mode.isSentenceCaps();
         self.capitalizeLastWord();
 
@@ -211,19 +185,17 @@ MB.GuessCase.Output = function (gc) {
         return utils.trim(self._w.join(""));
     };
 
-    /**
-     * Work through the stack of opened parentheses and close them
-     **/
+    // Work through the stack of opened parentheses and close them
     self.closeOpenBrackets = function () {
         var parts = new Array();
         while (flags.isInsideBrackets()) {
-            // close brackets that were opened before
+            // Close brackets that were opened before
             parts[parts.length] = flags.popBracket();
         }
         self.appendWord(parts.join(""));
     };
 
-    /**
+    /*
      * This function checks the wordlist for spaces before
      * and after the current cursor position, and modifies
      * the spaces of the input string.
@@ -231,13 +203,15 @@ MB.GuessCase.Output = function (gc) {
      * @param c        configuration wrapper
      *                c.apply:     if true, apply changes
      *                c.capslast: if true, capitalize word before
-     **/
+     */
     self.appendWordPreserveWhiteSpace = function (c) {
         if (c) {
             var ws = { before: gc.i.isPreviousWord(" "), after: gc.i.isNextWord(" ") };
             if (c.apply) {
-                // do not register method, such that this message appears as
-                // it were sent from the calling method.
+                /*
+                 * Do not register method, such that this message appears as
+                 * it were sent from the calling method.
+                 */
                 if (c.capslast) {
                     // capitalize last word before current
                     self.capitalizeLastWord(!gc.mode.isSentenceCaps());

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -1,22 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (c) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import MB from '../../../common/MB';

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/guess-case/flags.js
+++ b/root/static/scripts/guess-case/flags.js
@@ -1,9 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2010 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 // Holds the state of the current GC operation.

--- a/root/static/scripts/guess-case/flags.js
+++ b/root/static/scripts/guess-case/flags.js
@@ -1,8 +1,10 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2005 Stefan Kestenholz (keschte)
-// Copyright (C) 2010 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2005 Stefan Kestenholz (keschte)
+ * Copyright (C) 2010 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 // Holds the state of the current GC operation.
 export const context = {
@@ -65,8 +67,10 @@ export function getCurrentCloseBracket() {
 
 // Initialise flags for another run.
 export function init() {
-    // Flag to force the next word to capitalize the first letter. Set to true
-    // because the first word is always capitalized.
+    /*
+     * Flag to force the next word to capitalize the first letter. Set to true
+     * because the first word is always capitalized.
+     */
     context.forceCaps = true;
 
     // Flag to force a space before the next word.
@@ -84,10 +88,12 @@ export function init() {
     // Flag used for the number splitting routine (i.e. 10,000,000).
     context.number = false;
 
-    // Defines the current number split. Note that this will not be cleared,
-    // which has the side-effect of forcing the first type of number split
-    // encountered to be the only one used for the entire string, assuming that
-    // people aren't going to be mixing grammars in titles.
+    /*
+     * Defines the current number split. Note that this will not be cleared,
+     * which has the side-effect of forcing the first type of number split
+     * encountered to be the only one used for the entire string, assuming
+     * people aren't going to be mixing grammars in titles.
+     */
     context.numberSplitChar = null;
     context.numberSplitExpect = false;
 }

--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -1,9 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import {assign, capitalize} from 'lodash';

--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -1,9 +1,10 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2005 Stefan Kestenholz (keschte)
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import clean from '../common/utility/clean';

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import L from 'leaflet/dist/leaflet-src';
@@ -22,8 +24,11 @@ initializeDuplicateChecker('place');
 
 var bubble = initializeBubble('#coordinates-bubble', 'input[name=edit-place\\.coordinates]');
 
-// The map is hidden by default, which means it can't position itself correctly.
-// This tells it to update its position once it's visible.
+/*
+ * The map is hidden by default, which means it can't
+ * position itself correctly.
+ * This tells it to update its position once it's visible.
+ */
 const afterBubbleShow = _.once(function () {
     map.invalidateSize();
 });

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/place/map.js
+++ b/root/static/scripts/place/map.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import {createMap, L} from '../common/leaflet';

--- a/root/static/scripts/place/map.js
+++ b/root/static/scripts/place/map.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import {createMap, L} from '../common/leaflet';
 import getScriptArgs from '../common/utility/getScriptArgs';

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -250,10 +252,12 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                         var targetCredit = relationship.creditField(target)();
                         var relationshipFilter = this.selectedRelationshipCredits[role]();
 
-                        // XXX HACK XXX
-                        // MB.entityCache isn't supposed to be exposed outside of
-                        // whatever module it's defined in, but there's no easier
-                        // way to iterate over all entities on the page.
+                        /*
+                         * XXX HACK XXX
+                         * MB.entityCache isn't supposed to be exposed outside of
+                         * whatever module it's defined in, but there's no easier
+                         * way to iterate over all entities on the page.
+                         */
 
                         _.each(MB.entityCache, function (entity, gid) {
                             if (gid === target.gid) {
@@ -307,17 +311,21 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             var nodeName = event.target.nodeName.toLowerCase();
             var self = this;
 
-            // Firefox needs a small delay in order to allow for the change
-            // event to trigger on <select> menus, and Opera 12.0* needs it
-            // triggered explicitly, so do that first.
+            /*
+             * Firefox needs a small delay in order to allow for the change
+             * event to trigger on <select> menus, and Opera 12.0* needs it
+             * triggered explicitly, so do that first.
+             */
 
             if (event.keyCode === 13 && /^input|select$/.test(nodeName)) {
                 $(event.target).trigger('change');
 
                 if (!this.hasErrors()) {
-                    // Opera 12.0* also has a bug where the pencil icon is
-                    // clicked if the dialog is closed too fast, which makes
-                    // it immediately reopen, hence the added delay here.
+                    /*
+                     * Opera 12.0* also has a bug where the pencil icon is
+                     * clicked if the dialog is closed too fast, which makes
+                     * it immediately reopen, hence the added delay here.
+                     */
                     _.defer(function () { self.accept() });
                 }
             } else if (event.keyCode === 27 && nodeName !== "select") {
@@ -438,11 +446,13 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             var data = currentRelationship.editData();
             data.target = MB.entity({ name: currentTarget.name }, newType);
 
-            // Always keep any existing dates, even if the new relationship
-            // doesn't support them. If they're not supported they'll be
-            // hidden/ignored anyway, but if the user changes the target type
-            // or link type again (to something that does support them), we
-            // want to preserve what they previously entered.
+            /*
+             * Always keep any existing dates, even if the new relationship
+             * doesn't support them. If they're not supported they'll be
+             * hidden/ignored anyway, but if the user changes the target type
+             * or link type again (to something that does support them), we
+             * want to preserve what they previously entered.
+             */
             data.begin_date = MB.edit.fields.partialDate(currentRelationship.begin_date);
             data.end_date = MB.edit.fields.partialDate(currentRelationship.end_date);
             data.ended = !!currentRelationship.ended();
@@ -457,8 +467,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
 
             this.relationship(newRelationship);
 
-            // XXX knockout is stupid and unsets the linkTypeID for no apparent
-            // reason, so do it again...
+            /*
+             * XXX knockout is stupid and unsets the linkTypeID for no apparent
+             * reason, so do it again...
+             */
             newRelationship.linkTypeID(data.linkTypeID);
 
             currentRelationship.remove();
@@ -639,9 +651,11 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
     export class EditDialog extends Dialog {
 
         constructor(options) {
-            // originalRelationship is a copy of the relationship when the dialog
-            // was opened, i.e. before the user edits it. if they cancel the
-            // dialog, this is what gets copied back to revert their changes.
+            /*
+             * originalRelationship is a copy of the relationship when the dialog
+             * was opened, i.e. before the user edits it. if they cancel the
+             * dialog, this is what gets copied back to revert their changes.
+             */
             const relationship = options.relationship;
             options.relationship = relationship.clone();
             super(options);

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -154,8 +156,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             return addColon(key);
         },
 
-        // searches this entity's relationships for potential duplicate "rel"
-        // if it is a duplicate, remove and merge it
+        /*
+         * Searches this entity's relationships for potential duplicate "rel"
+         * if it is a duplicate, remove and merge it
+         */
 
         mergeRelationship: function (rel) {
             var relationships = this.relationships();
@@ -179,11 +183,13 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         },
 
         getRelationshipGroup: function (relationship, viewModel) {
-            // Returns all relationships that belong to the same 'ordering'
-            // group as `relationship`, i.e. that have the same link type and
-            // direction. Used in fields.js to recalculate link orders when an
-            // item is moved. Since displayableRelationships is used, it should
-            // be in the same order as it appears in the UI.
+            /*
+             * Returns all relationships that belong to the same 'ordering'
+             * group as `relationship`, i.e. that have the same link type and
+             * direction. Used in fields.js to recalculate link orders when an
+             * item is moved. Since displayableRelationships is used,
+             * it should be in the same order as it appears in the UI.
+             */
             let linkTypeID = String(relationship.linkTypeID());
             let direction = getDirection(relationship, this);
 

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -99,16 +101,19 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 });
             }
 
-            // XXX Sigh. This whole subscription shouldn't be necessary, because
-            // we already filter out invalid attributes in linkTypeIDChanged.
-            // But knockout's 'checked' binding is annoying and reverts any removals
-            // if it sees that the previous attributes are still checked (they
-            // haven't been removed from the template yet; that probably happens
-            // in a later subscription). That's why the _.defer is needed; we need
-            // to wait for it to idiotically add the attributes back. The proper
-            // solution would be to use a writable computed observable that filters
-            // out invalid values upon writing, but there's already a bunch of code
-            // that depends on 'attributes' being an observableArray.
+            /*
+             * XXX Sigh. This whole subscription shouldn't be necessary, since
+             * we already filter out invalid attributes in linkTypeIDChanged.
+             * But knockout's 'checked' binding is annoying and reverts any
+             * removals if it sees that the previous attributes are still
+             * checked (they haven't been removed from the template yet; that
+             * probably happens in a later subscription). That's why the
+             * _.defer is needed; we need to wait for it to idiotically add
+             * the attributes back. The proper solution would be to use a
+             * writable computed observable that filters out invalid values
+             * upon writing, but there's already a bunch of code
+             * that depends on 'attributes' being an observableArray.
+             */
             var removingInvalidAttributes = false;
             this.attributes.subscribe(function (newAttributes) {
                 if (!removingInvalidAttributes) {
@@ -174,8 +179,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 return;
             }
 
-            // This should really only change if the relationship was initially
-            // seeded without any link type.
+            /*
+             * This should really only change if the relationship was
+             * initially seeded without any link type.
+             */
             this.entityTypes = linkType.type0 + '-' + linkType.type1;
 
             var typeAttributes = linkType.attributes,
@@ -358,10 +365,12 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             return !!(linkType && linkType.orderable_direction > 0);
         }
 
-        // Same as linkPhrase, but if the link type is orderable, then
-        // also stripped of non-required attributes so that `groupBy` keeps
-        // ordered relationships together even if they have different
-        // attributes.
+        /*
+         * Same as linkPhrase, but if the link type is orderable, then
+         * also stripped of non-required attributes so that `groupBy` keeps
+         * ordered relationships together even if they have different
+         * attributes.
+         */
         groupingLinkPhrase(source) {
             return this._linkPhrase(source, this.hasOrderableLinkType());
         }

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/relationship-editor/common/mergeDates.js
+++ b/root/static/scripts/relationship-editor/common/mergeDates.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';

--- a/root/static/scripts/relationship-editor/common/mergeDates.js
+++ b/root/static/scripts/relationship-editor/common/mergeDates.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -174,8 +176,10 @@ const actions = {
         var tracks = medium.tracks,
             underlyingTracks = tracks.peek(),
             offset = medium.hasPregap() ? 0 : 1,
-            // Use _.indexOf instead of .position()
-            // http://tickets.metabrainz.org/browse/MBS-7227
+            /*
+             * Use _.indexOf instead of .position()
+             * http://tickets.metabrainz.org/browse/MBS-7227
+             */
             position1 = _.indexOf(underlyingTracks, track1) + offset,
             position2 = _.indexOf(underlyingTracks, track2) + offset,
             number1 = track1.number(),

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -54,9 +56,11 @@ ko.bindingHandlers.artistCreditEditor = {
         const prev = entity.medium.tracks()[entity.position() - 2];
         if (prev) {
             entity.artistCreditEditorInst.runDoneCallback();
-            // Defer until the setState calls in doneCallback finish,
-            // since initialArtistText (which is set in updateBubble)
-            // depends on the artist credit state.
+            /*
+             * Defer until the setState calls in doneCallback finish,
+             * since initialArtistText (which is set in updateBubble)
+             * depends on the artist credit state.
+             */
             _.defer(() => {
                 prev.artistCreditEditorInst.updateBubble(true, this.uncheckChangeMatchingArtists);
             });
@@ -96,8 +100,10 @@ ko.bindingHandlers.artistCreditEditor = {
     update: function (element, valueAccessor) {
         const bindingHandler = ko.bindingHandlers.artistCreditEditor;
         const entity = valueAccessor();
-        // Subscribe to the artistCredit observable so that we
-        // re-render the ArtistCreditEditor when it changes.
+        /*
+         * Subscribe to the artistCredit observable so that we
+         * re-render the ArtistCreditEditor when it changes.
+         */
         entity.artistCredit();
         const props = {
             entity: entity,

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import ko from 'knockout';
@@ -62,9 +64,11 @@ class RecordingBubble extends MB.Control.BubbleDoc {
         var track = this.currentTrack().previous();
 
         if (track) {
-            // If the user initiates this action from the UI by explicitly
-            // pressing the previous button, stealFocus will be undefined,
-            // so default to not stealing the focus unless it's true.
+            /*
+             * If the user initiates this action from the UI by explicitly
+             * pressing the previous button, stealFocus will be undefined,
+             * so default to not stealing the focus unless it's true.
+             */
 
             this.moveToTrack(track, stealFocus === true);
             return true;
@@ -83,9 +87,11 @@ class RecordingBubble extends MB.Control.BubbleDoc {
     }
 
     submit() {
-        // stealFocus set to true causes the bubble to move focus to the
-        // first input in the bubble. This is useful here, but not if the
-        // user explicitly presses a next/previous button.
+        /*
+         * stealFocus set to true causes the bubble to move focus to the
+         * first input in the bubble. This is useful here, but not if the
+         * user explicitly presses a next/previous button.
+         */
 
         if (!this.nextTrack(null, null, true /* stealFocus */)) {
             this.hide();

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -209,8 +211,10 @@ class SearchTab {
             this.search(data, event);
         }
         else {
-            // Knockout calls preventDefault unless you return true. Allows
-            // people to actually enter text.
+            /*
+             * Knockout calls preventDefault unless you return true. Allows
+             * people to actually enter text.
+             */
             return true;
         }
     }

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -71,8 +73,10 @@ releaseEditor.findReleaseDuplicates = function () {
     debounce(utils.withRelease(function (release) {
         var name = release.name();
 
-        // If a release group is selected, just show the releases from
-        // there without searching.
+        /*
+         * If a release group is selected, just show the releases from
+         * there without searching.
+         */
         var rgReleases = releaseGroupReleases();
 
         if (rgReleases.length > 0) {

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -142,11 +144,13 @@ releaseEditor.edits = {
     medium: function (release) {
         var edits = [];
 
-        // oldPositions are the original positions for all the original
-        // mediums (as they exist in the database). newPositions are all
-        // the new positions for the new mediums (as they exist on the
-        // page). tmpPositions stores any positions we use to avoid
-        // conflicts between oldPositions/newPositions.
+        /*
+         * oldPositions are the original positions for all the original
+         * mediums (as they exist in the database). newPositions are all
+         * the new positions for the new mediums (as they exist on the
+         * page). tmpPositions stores any positions we use to avoid
+         * conflicts between oldPositions/newPositions.
+         */
 
         var oldPositions = _.map(release.mediums.original(), function (m) {
             return m.original().position;
@@ -196,15 +200,17 @@ releaseEditor.edits = {
                     edits.push(MB.edit.mediumEdit(newNoPosition, oldNoPosition));
                 }
             } else if (medium.hasTracks()) {
-                // With regards to the medium position, make sure that:
-                //
-                //  (1) The position doesn't conflict with an existing
-                //      medium as present in the database. If it does,
-                //      pick a position that doesn't and enter a reorder
-                //      edit.
-                //
-                //  (2) The position doesn't conflict with the new
-                //      position of any moved medium, unless they swap.
+                /*
+                 * With regards to the medium position, make sure that:
+                 *
+                 *  (1) The position doesn't conflict with an existing
+                 *      medium as present in the database. If it does,
+                 *      pick a position that doesn't and enter a reorder
+                 *      edit.
+                 *
+                 *  (2) The position doesn't conflict with the new
+                 *      position of any moved medium, unless they swap.
+                 */
 
                 var newPosition = newMediumData.position;
 
@@ -220,9 +226,11 @@ releaseEditor.edits = {
                         }
 
                         if (_.includes(newPositions, attempt)) {
-                            // Another medium is being moved to the
-                            // position we want. Avoid this *unless* we're
-                            // swapping with that medium.
+                            /*
+                             * Another medium is being moved to the
+                             * position we want. Avoid this *unless* we're
+                             * swapping with that medium.
+                             */
 
                             var possibleSwap = _.find(
                                 newMediums,
@@ -282,8 +290,10 @@ releaseEditor.edits = {
             );
 
             if (oldPosition !== newPosition) {
-                // A removed medium is already in the position we want, so
-                // make sure we swap with it to avoid conflicts.
+                /*
+                 * A removed medium is already in the position we want, so
+                 * make sure we swap with it to avoid conflicts.
+                 */
                 var removedMedium;
                 if (removedMedium = removedMediums[newPosition]) {
                     newOrder.push({
@@ -611,9 +621,11 @@ releaseEditor.orderedEditSubmissions = [
 
                     var currentData = MB.edit.fields.medium(medium);
 
-                    // mediumReorder edits haven't been submitted yet, so
-                    // we must keep the position the medium was added in
-                    // (i.e. tmpPosition).
+                    /*
+                     * mediumReorder edits haven't been submitted yet, so
+                     * we must keep the position the medium was added in
+                     * (i.e. tmpPosition).
+                     */
                     currentData.position = addedData.position;
 
                     medium.original(currentData);

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -82,9 +84,11 @@ class Track {
             new MB_entity.Recording({ name: data.name })
         );
 
-        // Custom write function is needed around recordingValue because
-        // when it's written to there's certain values we need to save
-        // beforehand (see methods below).
+        /*
+         * Custom write function is needed around recordingValue because
+         * when it's written to there's certain values we need to save
+         * beforehand (see methods below).
+         */
         this.recording = ko.computed({
             read: this.recordingValue,
             write: this.setRecordingValue,
@@ -173,9 +177,11 @@ class Track {
             return;
         }
 
-        // If the length being changed is for a pregap track and the medium
-        // has cdtocs attached, make sure the new length doesn't exceed the
-        // maximum possible allowed by any of the tocs.
+        /*
+         * If the length being changed is for a pregap track and the medium
+         * has cdtocs attached, make sure the new length doesn't exceed the
+         * maximum possible allowed by any of the tocs.
+         */
         const $ = require('jquery');
 
         var $lengthInput = $("input.track-length", "#track-row-" + this.uniqueID);
@@ -217,9 +223,11 @@ class Track {
     artistDiffersFromRecording() {
         const recording = this.recording();
 
-        // This function is used to determine whether we can update the
-        // recording AC, so if there's no recording, then there's nothing
-        // to compare against.
+        /*
+         * This function is used to determine whether we can update the
+         * recording AC, so if there's no recording, then there's nothing
+         * to compare against.
+         */
         if (!recording || !recording.gid) {
             return false;
         }
@@ -245,11 +253,13 @@ class Track {
         var currentValue = this.recording.peek();
         if (value.gid === currentValue.gid) return;
 
-        // Save the current track values to allow for comparison when they
-        // change. If they change too much, we unset the recording and find
-        // a new suggestion. Only save these if there's a recording to
-        // revert back to - it doesn't make sense to save these values for
-        // comparison if there's no recording.
+        /*
+         * Save the current track values to allow for comparison when they
+         * change. If they change too much, we unset the recording and find
+         * a new suggestion. Only save these if there's a recording to
+         * revert back to - it doesn't make sense to save these values for
+         * comparison if there's no recording.
+         */
         if (value.gid) {
             this.name.saved = this.name.peek();
             this.length.saved = this.length.peek();
@@ -381,8 +391,10 @@ class Medium {
             this.originalID = data.originalID;
         }
 
-        // The medium is considered to be loaded if it has tracks, or if
-        // there's no ID to load tracks from.
+        /*
+         * The medium is considered to be loaded if it has tracks, or if
+         * there's no ID to load tracks from.
+         */
         var loaded = !!(this.tracks().length || !(this.id || this.originalID));
 
         if (data.cdtocs) {
@@ -548,10 +560,12 @@ class Medium {
             }
         }
 
-        // We already have the original name, format, and position data,
-        // which we don't want to overwrite - it could have been changed
-        // by the user before they loaded the medium. We just need the
-        // tracklist data, now that it's loaded.
+        /*
+         * We already have the original name, format, and position data,
+         * which we don't want to overwrite - it could have been changed
+         * by the user before they loaded the medium. We just need the
+         * tracklist data, now that it's loaded.
+         */
         var currentEditData = MB_edit.fields.medium(this);
         var originalEditData = this.original();
 
@@ -703,9 +717,11 @@ class Barcode {
             owner: this
         });
 
-        // Always notify of changes, so that when non-digits are stripped,
-        // the text in the input element will update even if the stripped
-        // value is identical to the old value.
+        /*
+         * Always notify of changes, so that when non-digits are stripped,
+         * the text in the input element will update even if the stripped
+         * value is identical to the old value.
+         */
         this.barcode.equalityComparer = null;
         this.value.equalityComparer = null;
 
@@ -915,9 +931,11 @@ class Release extends MB_entity.Release {
     }
 
     existingMediumData() {
-        // This function should return the mediums on the release as they
-        // hopefully exist in the DB, so including ones removed from the
-        // page (as long as they have an id, i.e. were attached before).
+        /*
+         * This function should return the mediums on the release as they
+         * hopefully exist in the DB, so including ones removed from the
+         * page (as long as they have an id, i.e. were attached before).
+         */
 
         var mediums = _.union(this.mediums(), this.mediums.original());
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -39,27 +41,33 @@ releaseEditor.init = function (options) {
 
     $.extend(this, _.pick(options, "action", "returnTo", "redirectURI"));
 
-    // Setup guess case buttons for the title field. Do this every time the
-    // release changes, since the old fields get removed and the events no
-    // longer exist.
+    /*
+     * Setup guess case buttons for the title field. Do this every time the
+     * release changes, since the old fields get removed and the events no
+     * longer exist.
+     */
     utils.withRelease(function (release) {
         _.defer(function () {
             MB.Control.initialize_guess_case("release");
         });
     });
 
-    // Allow pressing enter to advance to the next tab. The listener is added
-    // to the document and not #release-editor so that other events can call
-    // preventDefault if necessary.
+    /*
+     * Allow pressing enter to advance to the next tab. The listener is added
+     * to the document and not #release-editor so that other events can call
+     * preventDefault if necessary.
+     */
 
     $(document).on("keydown", "#release-editor :input:not(:button, textarea)",
         function (event) {
             if (event.which === 13 && !event.isDefaultPrevented()) {
-                // The _.defer is entirely for <select> elements in Firefox,
-                // which don't have their change events triggered until after
-                // enter is hit. Additionally, if we switch tabs before the
-                // change event is handled, it doesn't seem to even register
-                // (probably because the <select> is hidden by then).
+                /*
+                 * The _.defer is entirely for <select> elements in Firefox,
+                 * which don't have their change events triggered until after
+                 * enter is hit. Additionally, if we switch tabs before the
+                 * change event is handled, it doesn't seem to even register
+                 * (probably because the <select> is hidden by then).
+                 */
                 _.defer(function () {
                     self.activeTabID() === "#edit-note" ? self.submitEdits() : self.nextTab();
                 });
@@ -84,10 +92,12 @@ releaseEditor.init = function (options) {
             self.activeTabID(panel.selector)
                 .activeTabIndex(self.uiTabs.panels.index(panel));
 
-            // jQuery UI's position() function doesn't work on hidden
-            // elements. So if any bubble was open in the tab we just
-            // switched to, we have to trigger its position to update,
-            // now that it's visible.
+            /*
+             * jQuery UI's position() function doesn't work on hidden
+             * elements. So if any bubble was open in the tab we just
+             * switched to, we have to trigger its position to update,
+             * now that it's visible.
+             */
 
             var $bubble = panel.find("div.bubble:visible:eq(0)");
             if ($bubble.length) {
@@ -112,17 +122,21 @@ releaseEditor.init = function (options) {
 
     $pageContent.find(".ui-tabs-nav a").tooltip();
 
-    // Enable or disable the recordings tab depending on whether there are
-    // tracks or if the tracks have errors.
+    /*
+     * Enable or disable the recordings tab depending on whether there are
+     * tracks or if the tracks have errors.
+     */
 
     utils.withRelease(function (release) {
         var addingRelease = self.action === "add";
         var tabEnabled = addingRelease ? release.hasTracks() : true;
 
         if (tabEnabled) {
-            // If we're editing a release and the mediums aren't loaded
-            // (because there are many discs), we should still allow the
-            // user to edit the recordings if that's all they want to do.
+            /*
+             * If we're editing a release and the mediums aren't loaded
+             * (because there are many discs), we should still allow the
+             * user to edit the recordings if that's all they want to do.
+             */
             tabEnabled = release.hasTrackInfo();
         }
 
@@ -134,8 +148,10 @@ releaseEditor.init = function (options) {
         var tooltipEnabled = !tabEnabled;
         var $tab = self.uiTabs.tabs.eq(tabNumber).find("a");
 
-        // XXX Don't disable the tooltip twice.
-        // http://bugs.jqueryui.com/ticket/9719
+        /*
+         * XXX Don't disable the tooltip twice.
+         * http://bugs.jqueryui.com/ticket/9719
+         */
 
         if ($tab.tooltip("option", "disabled") === tooltipEnabled) {
             $tab.tooltip(tooltipEnabled ? "enable" : "disable");
@@ -183,8 +199,10 @@ releaseEditor.init = function (options) {
         }
     });
 
-    // Handle showing/hiding the AddDisc dialog when the user switches to/from
-    // the tracklist tab.
+    /*
+     * Handle showing/hiding the AddDisc dialog when the user switches to/from
+     * the tracklist tab.
+     */
 
     utils.withRelease(function (release) {
         self.autoOpenTheAddDiscDialog(release);
@@ -202,16 +220,20 @@ releaseEditor.init = function (options) {
             recordingAssociation.getReleaseGroupRecordings(releaseGroup, 0, []);
         }
 
-        // Refresh our list of recordings every 10 minutes, in case the user
-        // leaves the tab open and comes back later, potentially leaving us
-        // with stale data.
+        /*
+         * Refresh our list of recordings every 10 minutes, in case the user
+         * leaves the tab open and comes back later, potentially leaving us
+         * with stale data.
+         */
         releaseGroupTimer = setTimeout(getRecordings, 10 * 60 * 1000);
 
         getRecordings();
     });
 
-    // Make sure the user actually wants to close the page/tab if they've made
-    // any changes.
+    /*
+     * Make sure the user actually wants to close the page/tab if they've made
+     * any changes.
+     */
     var hasEdits = ko.computed(function () {
         return releaseEditor.allEdits().length > 0;
     });
@@ -313,10 +335,12 @@ releaseEditor.createExternalLinksEditor = function (data, mountPoint) {
         errorObservable: this.hasInvalidLinks
     });
 
-    // XXX Since there's no notion of observable data in React, we need to
-    // override componentDidUpdate to watch for changes to the external links.
-    // externalLinksEditData is hooked into the edit generation code and will
-    // create corresponding edits for the new link data.
+    /*
+     * XXX Since there's no notion of observable data in React, we need to
+     * override componentDidUpdate to watch for changes to the external links.
+     * externalLinksEditData is hooked into the edit generation code and will
+     * create corresponding edits for the new link data.
+     */
     this.externalLinks.componentDidUpdate = function () {
         self.externalLinksEditData(self.externalLinks.getEditData());
     };

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -21,21 +23,23 @@ const recordingAssociation = {};
 
 releaseEditor.recordingAssociation = recordingAssociation;
 
-// This file contains code for finding suggested recording associations
-// in the release editor.
-//
-// Levenshtein is used to compare track & recording titles, and track
-// lengths are checked to be within 10s of recording lengths.
-//
-// Recordings from the same release group are preferred. Since there are
-// usually less than 50 recordings in a release group, we request and cache
-// all of them as soon as the release group changes. If there is no release
-// group (i.e. one isn't selected), all recordings of the selected track's
-// artists are searched using the web service.
-//
-// Direct database search is terrible at matching titles (a single
-// apostrophe changes the entire set of results), so indexed search is
-// used.
+/*
+ * This file contains code for finding suggested recording associations
+ * in the release editor.
+ *
+ * Levenshtein is used to compare track & recording titles, and track
+ * lengths are checked to be within 10s of recording lengths.
+ *
+ * Recordings from the same release group are preferred. Since there are
+ * usually less than 50 recordings in a release group, we request and cache
+ * all of them as soon as the release group changes. If there is no release
+ * group (i.e. one isn't selected), all recordings of the selected track's
+ * artists are searched using the web service.
+ *
+ * Direct database search is terrible at matching titles (a single
+ * apostrophe changes the entire set of results), so indexed search is
+ * used.
+ */
 
 var releaseGroupRecordings = ko.observable(),
     etiRegex = /(\([^)]+\) ?)*$/;
@@ -102,8 +106,10 @@ function cleanRecordingData(data) {
 
     var appearsOn = _(data.releases)
         .map(function (release) {
-            // The webservice doesn't include the release group title, so
-            // we have to use the release title instead.
+            /*
+             * The webservice doesn't include the release group title, so
+             * we have to use the release title instead.
+             */
             return {
                 name: release.title,
                 gid: release.id,
@@ -118,10 +124,12 @@ function cleanRecordingData(data) {
         entityType: "release"
     };
 
-    // Recording entities will have already been created and cached for
-    // any existing recordings on the release. However, /ws/js/release does
-    // not provide any appearsOn data. So now that we have it, we can add
-    // it in.
+    /*
+     * Recording entities will have already been created and cached for
+     * any existing recordings on the release. However, /ws/js/release does
+     * not provide any appearsOn data. So now that we have it, we can add
+     * it in.
+     */
     var recording = MB.entityCache[clean.gid];
 
     if (recording && !recording.appearsOn) {
@@ -164,9 +172,11 @@ function searchTrackArtistRecordings(track) {
 }
 
 
-// Allow the recording search autocomplete to also get better results.
-// The standard /ws/js indexed search doesn't support sending artist or
-// length info.
+/*
+ * Allow the recording search autocomplete to also get better results.
+ * The standard /ws/js indexed search doesn't support sending artist or
+ * length info.
+ */
 
 recordingAssociation.autocompleteHook = function (track) {
     return function (args) {
@@ -206,14 +216,18 @@ function watchTrackForChanges(track) {
     var name = track.name();
     var length = track.length();
 
-    // We don't compare any artist credit changes, but we use the track
-    // artists when searching the web service. If there are track changes
-    // below but the AC is not complete, the ko.computed this is inside of
-    // will re-evaluate once the user fixes the artist.
+    /*
+     * We don't compare any artist credit changes, but we use the track
+     * artists when searching the web service. If there are track changes
+     * below but the AC is not complete, the ko.computed this is inside of
+     * will re-evaluate once the user fixes the artist.
+     */
     var completeAC = isCompleteArtistCredit(track.artistCredit());
 
-    // Only proceed if we need a recording, and the track has information
-    // we can search for - this tab should be disabled otherwise, anyway.
+    /*
+     * Only proceed if we need a recording, and the track has information
+     * we can search for - this tab should be disabled otherwise, anyway.
+     */
     if (!name || !completeAC) return;
 
     var similarTo = function (prop) {
@@ -274,9 +288,11 @@ recordingAssociation.findRecordingSuggestions = function (track) {
 };
 
 
-// Sets track.suggestedRecordings. If the track currently does not have
-// a recording selected, it shifts the last used recording to the top of
-// the suggestions list (if there is one).
+/*
+ * Sets track.suggestedRecordings. If the track currently does not have
+ * a recording selected, it shifts the last used recording to the top of
+ * the suggestions list (if there is one).
+ */
 
 function setSuggestedRecordings(track, recordings) {
     var lastRecording = track.recording.saved;
@@ -315,8 +331,10 @@ function matchAgainstRecordings(track, recordings) {
         })
         .reverse()
         .sortBy(function (recording) {
-            // Prefer that recordings with a length be at the top of the
-            // suggestions list.
+            /*
+             * Prefer that recordings with a length be at the top of the
+             * suggestions list.
+             */
             if (!recording.length) {
                 return MAX_LENGTH_DIFFERENCE + 1;
             }

--- a/root/static/scripts/release-editor/seeding.js
+++ b/root/static/scripts/release-editor/seeding.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -96,9 +98,11 @@ releaseEditor.seedRelease = function (release, data) {
     }
 
     if (data.releaseGroup) {
-        // Need to convert secondary type IDs into strings because
-        // Knockout.js will do a strict comparison when rendering the
-        // input. See MBS-7828.
+        /*
+         * Need to convert secondary type IDs into strings because
+         * Knockout.js will do a strict comparison when rendering the
+         * input. See MBS-7828.
+         */
         data.releaseGroup.secondaryTypeIDs = data.releaseGroup.secondaryTypeIDs.map(String);
         release.releaseGroup(new fields.ReleaseGroup(data.releaseGroup));
     }

--- a/root/static/scripts/release-editor/seeding.js
+++ b/root/static/scripts/release-editor/seeding.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2010-2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2010-2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -75,8 +77,10 @@ const trackParser = releaseEditor.trackParser = {
             hasTocs = medium.hasToc();
             releaseAC = medium.release.artistCredit();
 
-            // Don't add more tracks than the CDTOC allows. If there are data
-            // tracks, then more can be added at the end.
+            /*
+             * Don't add more tracks than the CDTOC allows. If there are data
+             * tracks, then more can be added at the end.
+             */
             if (hasTocs && !medium.hasDataTracks()) {
                 lines = lines.slice(0, currentTracks.length);
             }
@@ -85,9 +89,11 @@ const trackParser = releaseEditor.trackParser = {
         var newTracksData = $.map(lines, function (line) {
             var data = self.parseLine(line, options);
 
-            // We should've parsed at least some values, otherwise something
-            // went wrong. Returning undefined removes this result from
-            // newTracks.
+            /*
+             * We should've parsed at least some values, otherwise something
+             * went wrong. Returning undefined removes this result from
+             * newTracks.
+             */
             if (!_.some(_.values(data))) return;
 
             currentPosition += 1;
@@ -99,16 +105,20 @@ const trackParser = releaseEditor.trackParser = {
 
             if (!currentTracks || !currentTracks.length) return data;
 
-            // Check for tracks with similar names to existing tracks, so that
-            // we can reuse them if possible. If the medium has a CDTOC, don't
-            // do this because we can't move tracks around. Also don't do this
-            // if the user says not to use track names.
+            /*
+             * Check for tracks with similar names to existing tracks, so that
+             * we can reuse them if possible. If the medium has a CDTOC, don't
+             * do this because we can't move tracks around. Also don't do this
+             * if the user says not to use track names.
+             */
 
             if (hasTocs || !options.useTrackNames) {
                 data.matchedTrack = currentTracks.shift();
             } else {
-                // Pair every parsed track object with every existing track,
-                // along with their similarity.
+                /*
+                 * Pair every parsed track object with every existing track,
+                 * along with their similarity.
+                 */
                 dataTrackPairs = dataTrackPairs.concat(
                     _(currentTracks)
                         .map(function (track) {
@@ -138,8 +148,10 @@ const trackParser = releaseEditor.trackParser = {
             var matchedTrackAC = matchedTrack && matchedTrack.artistCredit();
             var previousTrackAC = previousTrack && previousTrack.artistCredit();
 
-            // See if we can re-use the AC from the matched track, the previous
-            // track at this position, or the release.
+            /*
+             * See if we can re-use the AC from the matched track, the previous
+             * track at this position, or the release.
+             */
             var matchedAC = _.find([ matchedTrackAC, previousTrackAC, releaseAC ],
                 function (ac) {
                     if (!ac || hasVariousArtists(ac)) {
@@ -160,10 +172,12 @@ const trackParser = releaseEditor.trackParser = {
             data.artistCredit = data.artistCredit ||
                 {names: [{ name: data.artist || "" }]};
 
-            // If the AC has just a single artist, we can re-use the parsed
-            // artist text as the credited name for that artist. Otherwise we
-            // can't easily do anything with it because the parsed text likely
-            // contains bits for every artist.
+            /*
+             * If the AC has just a single artist, we can re-use the parsed
+             * artist text as the credited name for that artist. Otherwise we
+             * can't easily do anything with it because the parsed text likely
+             * contains bits for every artist.
+             */
             if (data.artist && data.artistCredit.names.length === 1) {
                 data.artistCredit.names[0].name = data.artist;
             }
@@ -205,16 +219,20 @@ const trackParser = releaseEditor.trackParser = {
                 var dataTracksEnded = false;
 
                 _.each(newTracks.slice(0).reverse(), function (t, index) {
-                    // Don't touch the data track boundary if the total number
-                    // of tracks is >= the previous number. The user can edit
-                    // things manually if it needs fixing. Since we're
-                    // iterating backwards, the condition is checking that we
-                    // don't exceed the point where the audio tracks end.
+                    /*
+                     * Don't touch the data track boundary if the total number
+                     * of tracks is >= the previous number. The user can edit
+                     * things manually if it needs fixing. Since we're
+                     * iterating backwards, the condition is checking that we
+                     * don't exceed the point where the audio tracks end.
+                     */
                     if (difference >= 0) {
                         t.isDataTrack(index < (newTracks.length - oldAudioTrackCount));
-                    // Otherwise, keep isDataTrack true for ones that stayed at
-                    // the end, but unset it if they somehow moved up in the
-                    // tracklist and are no longer contiguous.
+                    /*
+                     * Otherwise, keep isDataTrack true for ones that stayed
+                     * at the end, but unset it if they somehow moved up in
+                     * the tracklist and are no longer contiguous.
+                     */
                     } else if (dataTracksEnded) {
                         t.isDataTrack(false);
                     } else if (!t.isDataTrack()) {
@@ -246,17 +264,21 @@ const trackParser = releaseEditor.trackParser = {
             }
         }
 
-        // MBS-7719: make sure the "Reuse previous recordings" button is
-        // available for new tracks by saving any unset recordings onto the
-        // new track instances.
+        /*
+         * MBS-7719: Make sure the "Reuse previous recordings" button is
+         * available for new tracks by saving any unset recordings onto the
+         * new track instances.
+         */
         if (previousTracks && previousTracks.length) {
             _.each(newTracks, function (track, index) {
                 delete track.previousTrackAtThisPosition;
 
                 var previousTrack = previousTracks[index];
 
-                // Don't save the recording that was at this position if the
-                // *track* that was at this position was moved/reused.
+                /*
+                 * Don't save the recording that was at this position if the
+                 * *track* that was at this position was moved/reused.
+                 */
                 if (previousTrack && !matchedTracks[previousTrack.uniqueID]) {
                     var previousRecording = previousTrack.recording.peek();
 
@@ -291,8 +313,10 @@ const trackParser = releaseEditor.trackParser = {
 
         if (line === "") return data;
 
-        // Parse track times first, because they could be confused with track
-        // numbers if the line only contains a time.
+        /*
+         * Parse track times first, because they could be confused with track
+         * numbers if the line only contains a time.
+         */
 
         // Assume the track time is at the end.
         var match = line.match(this.trackTime);
@@ -341,8 +365,10 @@ const trackParser = releaseEditor.trackParser = {
         var parts = line.split(this.separators),
             names = _.reject(parts, x => this.separatorOrBlank(x));
 
-        // Only parse an artist if there's more than one name. Assume the
-        // artist is the last name.
+        /*
+         * Only parse an artist if there's more than one name. Assume the
+         * artist is the last name.
+         */
 
         if (names.length > 1) {
             var artist = names.pop();
@@ -363,8 +389,10 @@ const trackParser = releaseEditor.trackParser = {
             data.name = clean(line);
         }
 
-        // Either of these could be the artist name (they may have to be
-        // swapped by the user afterwards), so run `cleanArtistName` on both.
+        /*
+         * Either of these could be the artist name (they may have to be
+         * swapped by the user afterwards), so run `cleanArtistName` on both.
+         */
 
         if (options.useTrackNames) {
             data.name = this.cleanArtistName(data.name || "");

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2010-2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -1,12 +1,14 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2011-2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
-//
-// The 'base64' function contained in this file is derived from:
-// http://stringencoders.googlecode.com/svn-history/r210/trunk/javascript/base64.js
-// Original version Copyright (C) 2010 Nick Galbreath, and released under
-// the MIT license: http://opensource.org/licenses/MIT
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2011-2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * The 'base64' function contained in this file is derived from:
+ * http://stringencoders.googlecode.com/svn-history/r210/trunk/javascript/base64.js
+ * Original version Copyright (C) 2010 Nick Galbreath, and released under
+ * the MIT license: http://opensource.org/licenses/MIT
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';
@@ -112,8 +114,10 @@ utils.reuseExistingMediumData = function (data) {
 };
 
 
-// Converts JSON from /ws/2 into /ws/js-formatted data. Hopefully one day
-// we'll have a standard MB data format and this won't be needed.
+/*
+ * Converts JSON from /ws/2 into /ws/js-formatted data. Hopefully one day
+ * we'll have a standard MB data format and this won't be needed.
+ */
 
 utils.cleanWebServiceData = function (data) {
     var clean = { gid: data.id, name: data.title };
@@ -164,8 +168,10 @@ utils.similarNames = function (oldName, newName) {
 };
 
 utils.similarLengths = function (oldLength, newLength) {
-    // If either of the lengths are empty, we can't compare them, so we
-    // consider them to be "similar" for recording association purposes.
+    /*
+     * If either of the lengths are empty, we can't compare them, so we
+     * consider them to be "similar" for recording association purposes.
+     */
     return !oldLength || !newLength || lengthsAreWithin10s(oldLength, newLength);
 };
 
@@ -188,8 +194,10 @@ function paddedHex(str, length) {
     return _.padStart((parseInt(str, 10) || 0).toString(16).toUpperCase(), length, '0');
 }
 
-// The alphabet has been modified and does not conform to RFC822.
-// For an explanation, see http://wiki.musicbrainz.org/Disc_ID_Calculation
+/*
+ * The alphabet has been modified and does not conform to RFC822.
+ * For an explanation, see http://wiki.musicbrainz.org/Disc_ID_Calculation
+ */
 
 var padchar = "-";
 var alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._";

--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2011-2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  *
  * The 'base64' function contained in this file is derived from:
  * http://stringencoders.googlecode.com/svn-history/r210/trunk/javascript/base64.js

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/release-editor/validation.js
+++ b/root/static/scripts/release-editor/validation.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';
@@ -21,8 +23,10 @@ releaseEditor.validation = validation;
 validation.errorsExist = errorsExist;
 
 function markTabWithErrors($panel) {
-    // Don't mark the edit note tab, because it's the last one and only
-    // can have one error, so the user will always see it anyway.
+    /*
+     * Don't mark the edit note tab, because it's the last one and only
+     * can have one error, so the user will always see it anyway.
+     */
     if ($panel.attr("id") === "edit-note") {
         return;
     }
@@ -93,8 +97,10 @@ ko.bindingHandlers.showErrorWhenTabIsSwitched = {
 $(function () {
     $("#release-editor").on("tabsbeforeactivate", function (event, ui) {
 
-        // Show errors on and mark all tabs between the one we just
-        // clicked on, including the one we left.
+        /*
+         * Show errors on and mark all tabs between the one we just
+         * clicked on, including the one we left.
+         */
         var oldPanel = ui.oldPanel;
         var newPanel = ui.newPanel;
 

--- a/root/static/scripts/release-editor/viewModel.js
+++ b/root/static/scripts/release-editor/viewModel.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 

--- a/root/static/scripts/release-editor/viewModel.js
+++ b/root/static/scripts/release-editor/viewModel.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/CoverArt.js
+++ b/root/static/scripts/tests/CoverArt.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/tests/CoverArt.js
+++ b/root/static/scripts/tests/CoverArt.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2013 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/autocomplete.js
+++ b/root/static/scripts/tests/autocomplete.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/tests/autocomplete.js
+++ b/root/static/scripts/tests/autocomplete.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/tests/common/immutable-entities.js
+++ b/root/static/scripts/tests/common/immutable-entities.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import test from 'tape';
 

--- a/root/static/scripts/tests/common/immutable-entities.js
+++ b/root/static/scripts/tests/common/immutable-entities.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/edit.js
+++ b/root/static/scripts/tests/edit.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import test from 'tape';

--- a/root/static/scripts/tests/edit.js
+++ b/root/static/scripts/tests/edit.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/tests/entity.js
+++ b/root/static/scripts/tests/entity.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/entity.js
+++ b/root/static/scripts/tests/entity.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import test from 'tape';
 

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import test from 'tape';
@@ -207,8 +209,10 @@ test('guessing feat. artists', function (t) {
                 },
             }
         },
-        // "Slash & Ol' Dirty Bastard" should be split even though it's above
-        // the similarity threshold to "Ol' Dirty Bastard" alone.
+        /*
+         * "Slash & Ol' Dirty Bastard" should be split even though it's above
+         * the similarity threshold to "Ol' Dirty Bastard" alone.
+         */
         {
             input: {
                 name: 'Fix (Main Mix) (feat. Slash & Ol\' Dirty Bastard)',

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/i18n.js
+++ b/root/static/scripts/tests/i18n.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/i18n.js
+++ b/root/static/scripts/tests/i18n.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import test from 'tape';
 

--- a/root/static/scripts/tests/react-macros.js
+++ b/root/static/scripts/tests/react-macros.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2016 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 'use strict';

--- a/root/static/scripts/tests/react-macros.js
+++ b/root/static/scripts/tests/react-macros.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2016 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2016 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 'use strict';
 

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import './typeInfo';

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import './typeInfo';
 
@@ -143,9 +145,11 @@ function relationshipEditorTest(name, callback) {
                 .append('<div id="content"></div><div id="dialog"></div></div>')
                 .appendTo('body');
 
-        // _.defer makes its target functions asynchronous. It is redefined
-        // here to call its target right away, so that we don't have to deal
-        // with writing async tests.
+        /*
+         * _.defer makes its target functions asynchronous. It is redefined
+         * here to call its target right away, so that we don't have to deal
+         * with writing async tests.
+         */
         var _defer = _.defer;
 
         _.defer = function (func) {

--- a/root/static/scripts/tests/release-editor/actions.js
+++ b/root/static/scripts/tests/release-editor/actions.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/release-editor/actions.js
+++ b/root/static/scripts/tests/release-editor/actions.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import test from 'tape';

--- a/root/static/scripts/tests/release-editor/common.js
+++ b/root/static/scripts/tests/release-editor/common.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import ko from 'knockout';
 import _ from 'lodash';

--- a/root/static/scripts/tests/release-editor/common.js
+++ b/root/static/scripts/tests/release-editor/common.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import ko from 'knockout';

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import _ from 'lodash';

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import '../typeInfo';
 

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import '../typeInfo';

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import $ from 'jquery';

--- a/root/static/scripts/tests/release-editor/fields.js
+++ b/root/static/scripts/tests/release-editor/fields.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import $ from 'jquery';
 import ko from 'knockout';

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/release-editor/trackParser.js
+++ b/root/static/scripts/tests/release-editor/trackParser.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import test from 'tape';

--- a/root/static/scripts/tests/release-editor/utils.js
+++ b/root/static/scripts/tests/release-editor/utils.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import test from 'tape';

--- a/root/static/scripts/tests/release-editor/utils.js
+++ b/root/static/scripts/tests/release-editor/utils.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import test from 'tape';
 

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import test from 'tape';

--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2014 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import _ from 'lodash';

--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2014 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2014 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import _ from 'lodash';
 import test from 'tape';

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -59,8 +59,10 @@ class TimelineViewModel {
             rate: ko.observable(false),
             events: ko.observable(true)
         };
-        // rateLimit so they'll all be updated before zoomHashPart is recalculated,
-        // and to ensure graph doesn't need repeated redrawing
+        /*
+         * rateLimit so they'll all be updated before zoomHashPart is
+         * recalculated, and to ensure graph doesn't need repeated redrawing
+         */
         self.zoom = {
             xaxis: { min: debounce(ko.observable(null), 50),
                      max: debounce(ko.observable(null), 50) },
@@ -174,9 +176,11 @@ class TimelineViewModel {
             return optionParts.concat(categoryParts, lineParts).join('+');
         }, 1000);
 
-        // Ignore hashchange events that are the result of the user fiddling
-        // with options. We only need to call _getLocationHashSettings again
-        // if it's directly changed in the address bar.
+        /*
+         * Ignore hashchange events that are the result of the user fiddling
+         * with options. We only need to call _getLocationHashSettings again
+         * if it's directly changed in the address bar.
+         */
         var ignoreHashChange = false;
 
         self.hash.subscribe(function (newHash) {

--- a/root/static/scripts/voting.js
+++ b/root/static/scripts/voting.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2015 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2015 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 import querystring from 'querystring';
 

--- a/root/static/scripts/voting.js
+++ b/root/static/scripts/voting.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import querystring from 'querystring';

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -2,19 +2,9 @@
  * Copyright (C) 2011 Ian McEwen
  * Copyright (C) 2018 MetaBrainz Foundation
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import padStart from 'lodash/padStart';

--- a/root/utility/escapeClosingTags.js
+++ b/root/utility/escapeClosingTags.js
@@ -1,7 +1,9 @@
-// This file is part of MusicBrainz, the open internet music database.
-// Copyright (C) 2017 MetaBrainz Foundation
-// Licensed under the GPL version 2, or (at your option) any later version:
-// http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2017 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 function escapeClosingTags(jsonText) {
   return jsonText.replace(/<\//g, '<\\/');

--- a/root/utility/escapeClosingTags.js
+++ b/root/utility/escapeClosingTags.js
@@ -1,8 +1,9 @@
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2017 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 function escapeClosingTags(jsonText) {

--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2015 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import parseIsoDate from './parseIsoDate';

--- a/root/utility/ratingTooltip.js
+++ b/root/utility/ratingTooltip.js
@@ -1,9 +1,11 @@
-// @flow strict
-// Copyright (C) 2013 MetaBrainz Foundation
-//
-// This file is part of MusicBrainz, the open internet music database,
-// and is licensed under the GPL version 2, or (at your option) any
-// later version: http://www.gnu.org/licenses/gpl-2.0.txt
+/*
+ * @flow strict
+ * Copyright (C) 2013 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
 
 const ratingTooltip = (rating: number) => (
   rating === 0

--- a/root/utility/relationshipDateText.js
+++ b/root/utility/relationshipDateText.js
@@ -1,9 +1,10 @@
 /*
  * @flow
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2019 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 import {bracketedText} from '../static/scripts/common/utility/bracketed';

--- a/script/xgettext.js
+++ b/script/xgettext.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /*
- * This file is part of MusicBrainz, the open internet music database.
  * Copyright (C) 2018 MetaBrainz Foundation
- * Licensed under the GPL version 2, or (at your option) any later version:
- * http://www.gnu.org/licenses/gpl-2.0.txt
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
 /* eslint-disable import/no-commonjs */


### PR DESCRIPTION
Mostly autofixes, but went through it to make a few additional changes: fix too long lines, start with caps when I noticed them missing (no doubt I missed a few) and make unnecessarily multiline comments single-line.

In separate commits, replaced some long copyright blurbs by the shorter version and some (c) by (C).

I will now stop sending huge eslint patches for a while :p