### PR TITLE
MBS-9654: Show expanded ACs on recording merges 

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -199,7 +199,7 @@ END -%]
     [%- END -%]
 [%- END -%]
 
-[%~ MACRO expanded_artist_credit_list(ac) IF ac -%]
+[%~ MACRO expanded_artist_credit_list(ac) IF ac -%] [% # Converted to React at root/static/scripts/common/components/ExpandedArtistCredit.js %]
   [%- IF ac.name != ac.names.0.artist.name || ac.names.size > 1 || ac.names.0.artist.comment -%]
     [%- SET artist_list = [];
         SET show_list = 0;
@@ -218,7 +218,7 @@ END -%]
   [% END %]
 [%- END -%]
 
-[%~ MACRO expanded_artist_credit(ac) IF ac -%]
+[%~ MACRO expanded_artist_credit(ac) IF ac -%] [% # Converted to React at root/static/scripts/common/components/ExpandedArtistCredit.js %]
   [%- artist_credit(ac) -%]<br />
   [%- expanded_artist_credit_list(ac) -%]<br />
 [%- END -%]

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -15,6 +15,8 @@ import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 import CodeLink from '../../static/scripts/common/components/CodeLink';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import ExpandedArtistCredit
+  from '../../static/scripts/common/components/ExpandedArtistCredit';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
 import renderMergeCheckboxElement
@@ -34,6 +36,7 @@ type Props = {
   +mergeForm?: MergeFormT,
   +order?: string,
   +recordings: $ReadOnlyArray<RecordingT>,
+  +showExpandedArtistCredits?: boolean,
   +showInstrumentCreditsAndRelTypes?: boolean,
   +showRatings?: boolean,
   +sortable?: boolean,
@@ -48,6 +51,7 @@ const RecordingList = ({
   order,
   recordings,
   seriesItemNumbers,
+  showExpandedArtistCredits,
   showInstrumentCreditsAndRelTypes,
   showRatings,
   sortable,
@@ -129,9 +133,13 @@ const RecordingList = ({
             <EntityLink entity={recording} />
           </td>
           <td>
-            {recording.artistCredit
-              ? <ArtistCreditLink artistCredit={recording.artistCredit} />
-              : null}
+            {recording.artistCredit ? (
+              showExpandedArtistCredits ? (
+                <ExpandedArtistCredit artistCredit={recording.artistCredit} />
+              ) : (
+                <ArtistCreditLink artistCredit={recording.artistCredit} />
+              )
+            ) : null}
           </td>
           <td>
             <ul>

--- a/root/edit/details/merge_recordings.tt
+++ b/root/edit/details/merge_recordings.tt
@@ -2,13 +2,13 @@
   <tr>
     <th>[% l('Merge:') %]</th>
     <td>
-      [% React.embed(c, 'components/list/RecordingList', { recordings => edit.display_data.old, lengthClass => (edit.display_data.large_spread ? 'warn-lengths' : '') }) %]
+      [% React.embed(c, 'components/list/RecordingList', { recordings => edit.display_data.old, lengthClass => (edit.display_data.large_spread ? 'warn-lengths' : ''), showExpandedArtistCredits => 1 }) %]
     </td>
   </tr>
   <tr>
     <th>[% l('Into:') %]</th>
     <td>
-      [% React.embed(c, 'components/list/RecordingList', { recordings => [edit.display_data.new], lengthClass => (edit.display_data.large_spread ? 'warn-lengths' : '') }) %]
+      [% React.embed(c, 'components/list/RecordingList', { recordings => [edit.display_data.new], lengthClass => (edit.display_data.large_spread ? 'warn-lengths' : ''), showExpandedArtistCredits => 1 }) %]
     </td>
   </tr>
 </table>

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -50,6 +50,7 @@ const RecordingMerge = ({$c, form, isrcsDiffer, toMerge}: Props) => (
         <RecordingList
           mergeForm={form}
           recordings={toMerge}
+          showExpandedArtistCredits
         />
         <FieldErrors field={form.field.target} />
 

--- a/root/static/scripts/common/components/ExpandedArtistCredit.js
+++ b/root/static/scripts/common/components/ExpandedArtistCredit.js
@@ -1,0 +1,60 @@
+/*
+ * @flow
+ * This file is part of MusicBrainz, the open internet music database.
+ * Copyright (C) 2019 MetaBrainz Foundation
+ * Licensed under the GPL version 2, or (at your option) any later version:
+ * http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React from 'react';
+
+import commaOnlyList from '../i18n/commaOnlyList';
+
+import ArtistCreditLink from './ArtistCreditLink';
+import DescriptiveLink from './DescriptiveLink';
+
+export const ExpandedArtistCreditList = ({
+  artistCredit,
+}: {artistCredit: ArtistCreditT}) => {
+  if (!artistCredit) {
+    return null;
+  }
+
+  const names = artistCredit.names;
+  let artistList = [];
+
+  if (names.some(x => x.artist.name !== x.name || x.artist.comment)) {
+    artistList = names.map(name => {
+      if (name.artist.name === name.name) {
+        return <DescriptiveLink entity={name.artist} />;
+      }
+      return exp.l(
+        '{artist} as {name}',
+        {
+          artist: <DescriptiveLink entity={name.artist} />,
+          name: name.name,
+        },
+      );
+    });
+  }
+
+  if (artistList.length) {
+    return (
+      <span className="expanded-ac-list">{commaOnlyList(artistList)}</span>
+    );
+  }
+
+  return null;
+};
+
+const ExpandedArtistCredit = ({
+  artistCredit,
+}: {artistCredit: ArtistCreditT}) => (
+  <>
+    <ArtistCreditLink artistCredit={artistCredit} />
+    <br />
+    <ExpandedArtistCreditList artistCredit={artistCredit} />
+  </>
+);
+
+export default ExpandedArtistCredit;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9654

When merging recordings, it's pretty useful to be able to see whether, say, the same artist credit name hides a different artist (and the disambiguation comment for the artist).

This makes the merge page and the edit display show expanded artist credits in the artist cell to make these things more visible than just on hover.

This is on top of https://github.com/metabrainz/musicbrainz-server/pull/1162 and should probably be reviewed after it.

Examples:
_**Edit page**_
![Screenshot from 2019-11-08 17-40-42](https://user-images.githubusercontent.com/1069224/68489456-cc363d00-024f-11ea-9857-119b2c0cff06.png)

**_Merge page_**
![Screenshot from 2020-01-07 19-55-32](https://user-images.githubusercontent.com/1069224/71916952-b7125780-3187-11ea-9aaf-d65468857151.png)
