### PR TITLE
MBS-10471: Add option to view edits by date closed

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -19,6 +19,10 @@
     [%- sort_select_block = '<select name="order">
       <option value="desc"' _ selected_if_matches('desc', query.order, 1) _ '>' _ l('newest first') _ '</option>
       <option value="asc"'  _ selected_if_matches('asc', query.order)  _ '>' _ l('oldest first') _ '</option>
+      <option value="closed_desc"' _ selected_if_matches('closed_desc', query.order) _ '>' _ l('recently closed first')     _ '</option>
+      <option value="closed_asc"' _ selected_if_matches('closed_asc', query.order) _ '>' _ l('earliest closed first')     _ '</option>
+      <option value="vote_closing_asc"' _ selected_if_matches('vote_closing_asc', query.order) _ '>' _ l('voting closing sooner first')     _ '</option>
+      <option value="vote_closing_desc"' _ selected_if_matches('vote_closing_desc', query.order) _ '>' _ l('voting closing later first')     _ '</option>
       <option value="rand"' _ selected_if_matches('rand', query.order) _ '>' _ l('randomly')     _ '</option>
     </select>' -%]
     [%- match_or_negation_block = '<select name="negation">

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -239,8 +239,6 @@ pre code {
             clear: both;
             font-size: @small-text;
             ul.menu {
-                li a {
-                }
                 li.language-selector {
                     float: right;
                     position: relative;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10471

Also adding an option for date applying.
For the closing date filter, filtering specifically for edits with a close_time set.  For the applying date filter, filtering specifically for open edits.