### PR TITLE
MBS-10467: whitelist new_edit_notes_mtime stash key

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -501,6 +501,7 @@ sub TO_JSON {
         merge_link
         more_tags
         new_edit_notes
+        new_edit_notes_mtime
         number_of_collections
         number_of_revisions
         own_collections


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10467

How did this work before????