### PR TITLE
Add typeInfo.js to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 root/static/build/**/*.js
 root/static/lib/**/*.js
+root/static/scripts/tests/typeInfo.js


### PR DESCRIPTION
root/static/scripts/tests/typeInfo.js is usually an empty file, unless tests have been generated. This makes eslint error on it all the time.