### PR TITLE
Flow 0.112

### DIFF
--- a/flow-typed/npm/cookie_v0.4.x.js
+++ b/flow-typed/npm/cookie_v0.4.x.js
@@ -1,0 +1,21 @@
+declare module 'cookie' {
+  declare type CookeParseOptions = {
+    +decode?: (string) => string,
+  };
+
+  declare type CookieSerializeOptions = {
+    +domain?: string,
+    +encode?: (string) => string,
+    +expires?: Date,
+    +httpOnly?: boolean,
+    +maxAge?: number,
+    +path?: string,
+    +sameSite?: boolean | 'lax' | 'none' | 'strict',
+    +secure?: boolean,
+  };
+
+  declare module.exports: {
+    parse: (str: string, options?: CookeParseOptions) => {[string]: string, ...},
+    serialize: (name: string, value: string, options?: CookieSerializeOptions) => string,
+  };
+}

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -495,12 +495,9 @@ sub TO_JSON {
         current_language
         current_language_html
         entity
-        hide_merge_helper
         jsonld_data
         last_replication_date
-        makes_no_changes
         more_tags
-        new_edit_notes
         new_edit_notes_mtime
         number_of_collections
         number_of_revisions
@@ -515,9 +512,20 @@ sub TO_JSON {
         user_tags
     );
 
+    my @boolean_stash_keys = qw(
+        hide_merge_helper
+        makes_no_changes
+        new_edit_notes
+    );
+
     my %stash;
     for (@stash_keys) {
         $stash{$_} = $self->stash->{$_} if exists $self->stash->{$_};
+    }
+
+    for (@boolean_stash_keys) {
+        $stash{$_} = boolean_to_json($self->stash->{$_})
+            if exists $self->stash->{$_};
     }
 
     if (my $entity = delete $stash{entity}) {

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -499,7 +499,6 @@ sub TO_JSON {
         jsonld_data
         last_replication_date
         makes_no_changes
-        merge_link
         more_tags
         new_edit_notes
         new_edit_notes_mtime

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -48,6 +48,7 @@ __PACKAGE__->config(
     encoding => 'UTF-8',
     "View::Default" => {
         expose_methods => [qw(
+            boolean_to_json
             comma_list
             comma_only_list
         )],

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -9,7 +9,7 @@ BEGIN { extends 'Catalyst::Controller' }
 use DBDefs;
 use MusicBrainz::Server::Constants qw( $VARTIST_GID $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::SSL qw( ensure_ssl );
-use MusicBrainz::Server::Data::Utils qw( model_to_type );
+use MusicBrainz::Server::Data::Utils qw( type_to_model );
 use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Replication ':replication_type';
 use aliased 'MusicBrainz::Server::Translation';
@@ -328,23 +328,21 @@ sub begin : Private
 
     # Merging
     if (my $merger = $c->try_get_session('merger')) {
-        my $model = $c->model($merger->type);
+        my $model = $c->model(type_to_model($merger->type));
         my @merge = values %{
             $model->get_by_ids($merger->all_entities)
         };
         $c->model('ArtistCredit')->load(@merge);
 
         my @areas = ();
-        push @areas, @merge if $merger->type eq 'Area';
-        push @areas, $c->model('Area')->load(@merge) if $merger->type eq 'Place';
+        push @areas, @merge if $merger->type eq 'area';
+        push @areas, $c->model('Area')->load(@merge) if $merger->type eq 'place';
         $c->model('Area')->load_containment(@areas);
 
         $c->stash(
             to_merge => [ @merge ],
             merger => $merger,
-            merge_link => $c->uri_for_action(
-                model_to_type($merger->type) . '/merge',
-            )
+            merge_link => $c->uri_for_action($merger->type . '/merge'),
         );
     }
 

--- a/lib/MusicBrainz/Server/View/Default.pm
+++ b/lib/MusicBrainz/Server/View/Default.pm
@@ -5,6 +5,7 @@ use base 'Catalyst::View::TT';
 use DBDefs;
 use MRO::Compat;
 use Digest::MD5 qw( md5_hex );
+use MusicBrainz::Server::Data::Utils;
 use MusicBrainz::Server::Translation;
 use MusicBrainz::Server::View::Base;
 
@@ -17,6 +18,11 @@ sub process {
     MusicBrainz::Server::View::Base::process($self, @_) or return 0;
     $self->next::method(@_) or return 0;
     MusicBrainz::Server::View::Base::_post_process($self, @_);
+}
+
+sub boolean_to_json {
+    my ($self, $c, $bool) = @_;
+    MusicBrainz::Server::Data::Utils::boolean_to_json($bool);
 }
 
 sub comma_list {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "8.0.5",
     "balanced-match": "0.2.0",
     "canonical-json": "0.0.4",
-    "cookie": "0.2.3",
+    "cookie": "0.4.0",
     "copy-webpack-plugin": "4.6.0",
     "detect-node": "2.0.3",
     "file-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-react": "7.16.0",
     "file-url": "2.0.2",
-    "flow-bin": "0.111.3",
+    "flow-bin": "0.112.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.0",
     "jsdom": "13.2.0",

--- a/root/account/EditProfile.js
+++ b/root/account/EditProfile.js
@@ -30,7 +30,7 @@ const EditProfile = ({$c, ...props}: Props) => {
   return (
     <UserAccountLayout
       entity={user}
-      gettext_domains={['attributes']}
+      gettextDomains={['attributes']}
       page="edit_profile"
       title={l('Edit Profile')}
     >

--- a/root/account/LostPassword.js
+++ b/root/account/LostPassword.js
@@ -41,11 +41,13 @@ const LostPassword = (props: Props) => (
         field={props.form.field.username}
         label={l('Username:')}
         required
+        uncontrolled
       />
       <FormRowEmailLong
         field={props.form.field.email}
         label={addColonText(l('Email'))}
         required
+        uncontrolled
       />
       <FormRow hasNoLabel>
         <FormSubmit label={l('Reset Password')} />

--- a/root/account/LostUsername.js
+++ b/root/account/LostUsername.js
@@ -34,6 +34,7 @@ const LostUsername = (props: Props) => (
         field={props.form.field.email}
         label={addColonText(l('Email'))}
         required
+        uncontrolled
       />
       <FormRow hasNoLabel>
         <FormSubmit label={l('Send Email')} />

--- a/root/components/FormRowEmailLong.js
+++ b/root/components/FormRowEmailLong.js
@@ -9,15 +9,10 @@
 
 import React from 'react';
 
+import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowTextLong from './FormRowTextLong';
 
-type Props = {
-  +field: ReadOnlyFieldT<string>,
-  +label: string,
-  +required?: boolean,
-};
-
-const FormRowEmailLong = (props: Props) => (
+const FormRowEmailLong = (props: FormRowTextProps) => (
   <FormRowTextLong type="email" {...props} />
 );
 

--- a/root/components/FormRowText.js
+++ b/root/components/FormRowText.js
@@ -16,17 +16,19 @@ import FormLabel from './FormLabel';
 type Props = {
   +field: ReadOnlyFieldT<?string>,
   +label: string,
+  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
   +required?: boolean,
+  +size?: number,
   +type?: string,
-  ...
 };
 
 const FormRowText = ({
   field,
   label,
+  onChange,
   required = false,
+  size,
   type = 'text',
-  ...inputProps
 }: Props) => (
   <FormRow>
     <FormLabel forField={field} label={label} required={required} />
@@ -34,9 +36,10 @@ const FormRowText = ({
       defaultValue={field.value || ''}
       id={'id-' + field.html_name}
       name={field.html_name}
+      onChange={onChange}
       required={required}
+      size={size}
       type={type}
-      {...inputProps}
     />
     <FieldErrors field={field} />
   </FormRow>

--- a/root/components/FormRowText.js
+++ b/root/components/FormRowText.js
@@ -13,36 +13,66 @@ import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';
 import FormLabel from './FormLabel';
 
-type Props = {
+type InputOnChange = (SyntheticEvent<HTMLInputElement>) => void;
+
+type InputProps = {
+  defaultValue?: string,
+  +id: string,
+  +name: string,
+  onChange?: InputOnChange,
+  +required: boolean,
+  +size: ?number,
+  +type: string,
+  value?: string,
+};
+
+type CommonProps = {
   +field: ReadOnlyFieldT<?string>,
   +label: string,
-  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
   +required?: boolean,
   +size?: number,
   +type?: string,
 };
 
-const FormRowText = ({
-  field,
-  label,
-  onChange,
-  required = false,
-  size,
-  type = 'text',
-}: Props) => (
-  <FormRow>
-    <FormLabel forField={field} label={label} required={required} />
-    <input
-      defaultValue={field.value || ''}
-      id={'id-' + field.html_name}
-      name={field.html_name}
-      onChange={onChange}
-      required={required}
-      size={size}
-      type={type}
-    />
-    <FieldErrors field={field} />
-  </FormRow>
-);
+export type Props =
+  | $ReadOnly<{
+      ...CommonProps,
+      onChange: InputOnChange,
+      uncontrolled?: false,
+    }>
+  | $ReadOnly<{
+      ...CommonProps,
+      uncontrolled: true,
+    }>;
+
+const FormRowText = (props: Props) => {
+  const field = props.field;
+  const required = props.required ?? false;
+
+  const inputProps: InputProps = {
+    id: 'id-' + field.html_name,
+    name: field.html_name,
+    required: required,
+    size: props.size,
+    type: props.type ?? 'text',
+  };
+
+  const inputValue = field.value ?? '';
+
+  if (props.uncontrolled) {
+    inputProps.defaultValue = inputValue;
+  } else {
+    inputProps.onChange = props.onChange;
+    inputProps.value = inputValue;
+  }
+
+  return (
+    <FormRow>
+      <FormLabel forField={field} label={props.label} required={required} />
+      <input {...inputProps} />
+      <FieldErrors field={field} />
+    </FormRow>
+  );
+};
 
 export default FormRowText;

--- a/root/components/FormRowTextLong.js
+++ b/root/components/FormRowTextLong.js
@@ -9,17 +9,10 @@
 
 import React from 'react';
 
+import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowText from './FormRowText';
 
-type Props = {
-  +field: ReadOnlyFieldT<string>,
-  +label: string,
-  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
-  +required?: boolean,
-  +type?: string,
-};
-
-const FormRowTextLong = (props: Props) => (
+const FormRowTextLong = (props: FormRowTextProps) => (
   <FormRowText size={47} {...props} />
 );
 

--- a/root/components/FormRowTextLong.js
+++ b/root/components/FormRowTextLong.js
@@ -14,6 +14,7 @@ import FormRowText from './FormRowText';
 type Props = {
   +field: ReadOnlyFieldT<string>,
   +label: string,
+  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
   +required?: boolean,
   +type?: string,
 };

--- a/root/components/FormRowURLLong.js
+++ b/root/components/FormRowURLLong.js
@@ -9,16 +9,10 @@
 
 import React from 'react';
 
+import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowTextLong from './FormRowTextLong';
 
-type Props = {
-  +field: ReadOnlyFieldT<string>,
-  +label: string,
-  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
-  +required?: boolean,
-};
-
-const FormRowURLLong = (props: Props) => (
+const FormRowURLLong = (props: FormRowTextProps) => (
   <FormRowTextLong type="url" {...props} />
 );
 

--- a/root/components/FormRowURLLong.js
+++ b/root/components/FormRowURLLong.js
@@ -14,8 +14,8 @@ import FormRowTextLong from './FormRowTextLong';
 type Props = {
   +field: ReadOnlyFieldT<string>,
   +label: string,
+  +onChange?: (SyntheticEvent<HTMLInputElement>) => void,
   +required?: boolean,
-  ...
 };
 
 const FormRowURLLong = (props: Props) => (

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -17,9 +17,9 @@ import UserAccountTabs from './UserAccountTabs';
 type Props = {
   +children: React.Node,
   +entity: EditorT,
+  +gettextDomains?: $ReadOnlyArray<string>,
   +page: string,
   +title?: string,
-  ...
 };
 
 const UserAccountLayout = ({

--- a/root/context.js
+++ b/root/context.js
@@ -17,6 +17,7 @@ const defaultContext = {
   action: {
     name: '',
   },
+  flash: {},
   relative_uri: '',
   req: {
     headers: {},

--- a/root/doc/DocPage.js
+++ b/root/doc/DocPage.js
@@ -52,7 +52,7 @@ const DocPage = ({
     </a>
   );
   return (
-    <Layout fullWidth no_icons title={page.title}>
+    <Layout fullWidth noIcons title={page.title}>
       <div className="wikicontent" id="content">
         {useGoogleCustomSearch ? <DocSearchBox /> : null}
 

--- a/root/forms/dialog.tt
+++ b/root/forms/dialog.tt
@@ -12,9 +12,9 @@
           SET gettext_domains = ['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'];
         END;
         React.embed(c, 'layout/components/Head', {
-            gettext_domains => gettext_domains,
+            gettextDomains => gettext_domains,
             homepage => homepage,
-            no_icons => no_icons,
+            noIcons => boolean_to_json(no_icons),
             pager => pager,
             title => title,
         })

--- a/root/genre/GenreEditForm.js
+++ b/root/genre/GenreEditForm.js
@@ -29,10 +29,12 @@ const GenreEditForm = ({$c, form}: Props) => (
           field={form.field.name}
           label={addColonText(l('Name'))}
           required
+          uncontrolled
         />
         <FormRowTextLong
           field={form.field.comment}
           label={addColonText(l('Disambiguation'))}
+          uncontrolled
         />
       </fieldset>
     </div>

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -2,10 +2,10 @@
     [%- DEFAULT no_icons = homepage -%]
     [%- React.embed(c, 'layout/components/Head', {
             homepage => homepage,
-            no_icons => no_icons,
+            noIcons => boolean_to_json(no_icons),
             pager => pager,
             title => title,
-            gettext_domains => gettext_domains,
+            gettextDomains => gettext_domains,
         })
     -%]
     <body>

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -16,7 +16,7 @@ import escapeClosingTags from '../../utility/escapeClosingTags';
 
 import MetaDescription from './MetaDescription';
 
-type HeadProps = {
+export type HeadProps = {
   +$c: CatalystContextT,
   +gettextDomains?: $ReadOnlyArray<string>,
   +homepage?: boolean,

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -1,4 +1,5 @@
 /*
+ * @flow
  * Copyright (C) 2015 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -14,6 +15,15 @@ import * as DBDefs from '../../static/scripts/common/DBDefs';
 import escapeClosingTags from '../../utility/escapeClosingTags';
 
 import MetaDescription from './MetaDescription';
+
+type HeadProps = {
+  +$c: CatalystContextT,
+  +gettextDomains?: $ReadOnlyArray<string>,
+  +homepage?: boolean,
+  +noIcons?: boolean,
+  +pager?: PagerT,
+  +title: string,
+};
 
 const canonRegexp = new RegExp('^(https?:)?//' + DBDefs.WEB_SERVER);
 function canonicalize(url) {
@@ -51,7 +61,7 @@ const CanonicalLink = ({requestUri}) => {
   return null;
 };
 
-const Head = ({$c, ...props}) => (
+const Head = ({$c, ...props}: HeadProps) => (
   <head>
     <meta charSet="utf-8" />
     <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
@@ -68,7 +78,7 @@ const Head = ({$c, ...props}) => (
       type="text/css"
     />
 
-    {props.no_icons
+    {props.noIcons
       ? null
       : <link
           href={require('../../static/styles/icons.less')}
@@ -119,7 +129,7 @@ const Head = ({$c, ...props}) => (
 
     {$c.stash.current_language !== 'en' ? (
       ['mb_server']
-        .concat(props.gettext_domains || [])
+        .concat(props.gettextDomains || [])
         .map(function (domain) {
           const name ='jed-' + $c.stash.current_language + '-' + domain;
           return manifest.js(name, {key: name});

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -1,4 +1,5 @@
 /*
+ * @flow
  * Copyright (C) 2015 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -12,15 +13,20 @@ import {withCatalystContext} from '../../context';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 
-const MergeHelper = ({$c}) => (
+type Props = {
+  +$c: CatalystContextT,
+  +merger: MergeQueueT,
+};
+
+const MergeHelper = ({$c, merger}: Props) => (
   <div id="current-editing">
-    <form action={$c.stash.merge_link} method="get">
+    <form action={`/${merger.type}/merge`} method="get">
       <h2>{l('Merge Process')}</h2>
       <p>
         {l('You currently have the following entities selected for merging:')}
       </p>
       <ul>
-        {$c.stash.to_merge.map(entity => (
+        {$c.stash.to_merge && $c.stash.to_merge.map(entity => (
           <li key={entity.id}>
             <input
               id={`remove.${entity.id}`}
@@ -35,7 +41,7 @@ const MergeHelper = ({$c}) => (
         ))}
       </ul>
       <p>
-        {$c.session.merger.ready_to_merge
+        {merger.ready_to_merge
           ? l(
             `When you are ready to merge these, just click the Merge button.
              You may still add more to this merge queue by simply browsing to
@@ -48,7 +54,7 @@ const MergeHelper = ({$c}) => (
         }
       </p>
       <div className="buttons" style={{display: 'table-cell'}}>
-        {$c.session.merger.ready_to_merge &&
+        {merger.ready_to_merge &&
           <button
             className="positive"
             name="submit"

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -10,8 +10,6 @@
 import React from 'react';
 
 import {artistBeginLabel, artistEndLabel} from '../../artist/utils';
-import {commaOnlyListText}
-  from '../../static/scripts/common/i18n/commaOnlyList';
 import formatBarcode from '../../static/scripts/common/utility/formatBarcode';
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import formatTrackLength
@@ -28,7 +26,7 @@ function entityDescription(entity) {
 function pushTypeName(desc, entity) {
   const typeName = entity.typeName;
   if (typeName) {
-    desc.push(l('Type:') + ' ' + typeName);
+    desc.push('Type: ' + typeName);
   }
 }
 
@@ -39,7 +37,7 @@ function artistDescription(artist) {
   const endDate = formatDate(artist.end_date);
   const gender = artist.gender;
   if (gender) {
-    desc.push(l('Gender:') + ' ' + gender.name);
+    desc.push('Gender: ' + gender.name);
   }
   if (beginDate || artist.begin_area) {
     desc.push(
@@ -57,7 +55,7 @@ function artistDescription(artist) {
   }
   const area = artist.area;
   if (area) {
-    desc.push(l('Area:') + ' ' + area.name);
+    desc.push('Area: ' + area.name);
   }
   return desc;
 }
@@ -68,10 +66,10 @@ function eventDescription(event) {
   const beginDate = formatDate(event.begin_date);
   const endDate = formatDate(event.end_date);
   if (beginDate) {
-    desc.push(l('Start:') + ' ' + beginDate);
+    desc.push('Start: ' + beginDate);
   }
   if (endDate) {
-    desc.push(l('End:') + ' ' + endDate);
+    desc.push('End: ' + endDate);
   }
   if (event.time) {
     desc.push(event.time);
@@ -83,7 +81,7 @@ function instrumentDescription(instrument) {
   const desc = entityDescription(instrument);
   pushTypeName(desc, instrument);
   if (instrument.description) {
-    desc.push(l('Description:') + ' ' + instrument.description);
+    desc.push('Description: ' + instrument.description);
   }
   return desc;
 }
@@ -94,17 +92,17 @@ function labelDescription(label) {
   const beginDate = formatDate(label.begin_date);
   const endDate = formatDate(label.end_date);
   if (label.label_code) {
-    desc.push(l('Label Code:') + ' ' + label.label_code);
+    desc.push('Label Code: ' + label.label_code);
   }
   if (beginDate) {
-    desc.push(l('Founded:') + ' ' + beginDate);
+    desc.push('Founded: ' + beginDate);
   }
   if (endDate) {
-    desc.push(l('Defunct:') + ' ' + endDate);
+    desc.push('Defunct: ' + endDate);
   }
   const area = label.area;
   if (area) {
-    desc.push(l('Area:') + ' ' + area.name);
+    desc.push('Area: ' + area.name);
   }
   return desc;
 }
@@ -115,10 +113,10 @@ function placeDescription(place) {
   const beginDate = formatDate(place.begin_date);
   const endDate = formatDate(place.end_date);
   if (beginDate) {
-    desc.push(l('Opened:') + ' ' + beginDate);
+    desc.push('Opened: ' + beginDate);
   }
   if (endDate) {
-    desc.push(l('Closed:') + ' ' + endDate);
+    desc.push('Closed: ' + endDate);
   }
   return desc;
 }
@@ -127,14 +125,14 @@ function releaseDescription(release) {
   const desc = entityDescription(release);
   const combinedFormatName = release.combined_format_name;
   if (combinedFormatName) {
-    desc.push(l('Format:') + ' ' + combinedFormatName);
+    desc.push('Format: ' + combinedFormatName);
   }
   let year;
   if (release.events && release.events.length) {
     year = release.events[0].date?.year;
   }
   if (year) {
-    desc.push(l('Year:') + ' ' + year);
+    desc.push('Year: ' + year);
   }
   if (release.labels && release.labels.length) {
     const labels = release.labels.map(function (rl) {
@@ -144,20 +142,20 @@ function releaseDescription(release) {
       );
     });
     desc.push(
-      (labels.length > 1 ? l('Labels:') : l('Label:')) + ' ' +
-      commaOnlyListText(labels),
+      (labels.length > 1 ? 'Labels:' : 'Label:') + ' ' +
+      labels.join(', '),
     );
   }
   if (release.barcode) {
-    desc.push(l('Barcode:') + ' ' + formatBarcode(release.barcode));
+    desc.push('Barcode: ' + formatBarcode(release.barcode));
   }
   if (release.length) {
-    desc.push(l('Length:') + ' ' + formatTrackLength(release.length));
+    desc.push('Length: ' + formatTrackLength(release.length));
   }
   return desc;
 }
 
-const getLanguageName = wl => l_languages(wl.language.name);
+const getLanguageName = wl => wl.language.name;
 
 const getEntityName = x => x.entity.name;
 
@@ -168,19 +166,19 @@ function workDescription(work) {
   pushTypeName(desc, work);
   if (work.languages.length) {
     desc.push(
-      addColonText(l('Lyrics Languages')) + ' ' +
-      commaOnlyListText(work.languages.map(getLanguageName)),
+      'Lyrics Languages: ' +
+      work.languages.map(getLanguageName).join(', '),
     );
   }
   if (work.writers) {
     desc.push(
-      l('Writers:') + ' ' +
-      commaOnlyListText(work.writers.map(getEntityName)),
+      'Writers: ' +
+      work.writers.map(getEntityName).join(', '),
     );
   }
   if (work.iswcs) {
     desc.push(
-      l('ISWCs:') + ' ' + commaOnlyListText(work.iswcs.map(getIswc)),
+      'ISWCs: ' + work.iswcs.map(getIswc).join(', '),
     );
   }
   return desc;
@@ -219,7 +217,7 @@ const MetaDescription = ({entity}: Props) => {
       break;
   }
   if (desc && desc.length) {
-    return <meta content={commaOnlyListText(desc)} name="description" />;
+    return <meta content={desc.join(', ')} name="description" />;
   }
   return null;
 };

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -157,6 +157,8 @@ function releaseDescription(release) {
   return desc;
 }
 
+const getLanguageName = wl => l_languages(wl.language.name);
+
 const getEntityName = x => x.entity.name;
 
 const getIswc = x => x.iswc;
@@ -167,9 +169,7 @@ function workDescription(work) {
   if (work.languages.length) {
     desc.push(
       addColonText(l('Lyrics Languages')) + ' ' +
-      commaOnlyListText(
-        work.languages.map(wl => l_languages(wl.language.name)),
-      ),
+      commaOnlyListText(work.languages.map(getLanguageName)),
     );
   }
   if (work.writers) {

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -180,7 +180,7 @@ const Layout = ({$c, ...props}) => (
       </div>
 
       {($c.session && $c.session.merger && !$c.stash.hide_merge_helper) &&
-        <MergeHelper />}
+        <MergeHelper merger={$c.session.merger} />}
 
       <Footer {...props} />
     </body>

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -1,4 +1,5 @@
 /*
+ * @flow
  * Copyright (C) 2015 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -16,7 +17,7 @@ import * as DBDefs from '../static/scripts/common/DBDefs';
 
 import Footer from './components/Footer';
 import Header from './components/Header';
-import Head from './components/Head';
+import Head, {type HeadProps} from './components/Head';
 import MergeHelper from './components/MergeHelper';
 
 const DismissBannerButton = ({bannerName}) => (
@@ -99,7 +100,13 @@ const ServerDetailsBanner = () => {
   return null;
 };
 
-const Layout = ({$c, ...props}) => (
+export type Props = $ReadOnly<{
+  ...HeadProps,
+  children: React$Node,
+  fullWidth?: boolean,
+}>;
+
+const Layout = ({$c, ...props}: Props) => (
   <html lang={$c.stash.current_language_html}>
     <Head {...props} />
 
@@ -109,8 +116,8 @@ const Layout = ({$c, ...props}) => (
       {!getRequestCookie($c.req, 'server_details_dismissed_mtime') &&
         <ServerDetailsBanner />}
 
-      {!!($c.stash.alert && $c.stash.alert_mtime >
-        getRequestCookie($c.req, 'alert_dismissed_mtime', 0)) &&
+      {!!($c.stash.alert && ($c.stash.alert_mtime ?? Infinity) >
+        Number(getRequestCookie($c.req, 'alert_dismissed_mtime', '0'))) &&
         <div className="banner warning-header">
           <p dangerouslySetInnerHTML={{__html: $c.stash.alert}} />
           <DismissBannerButton bannerName="alert" />
@@ -139,9 +146,11 @@ const Layout = ({$c, ...props}) => (
         </div>}
 
       {!!($c.stash.new_edit_notes &&
-          $c.stash.new_edit_notes_mtime >
-          getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', 0) &&
-          ($c.user.is_limited ||
+          ($c.stash.new_edit_notes_mtime ?? Infinity) >
+          Number(
+            getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', '0'),
+          ) &&
+          (($c.user && $c.user.is_limited) ||
           getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !==
           'false')) &&
           <div className="banner new-edit-notes">

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import noop from 'lodash/noop';
 import React from 'react';
 
 import * as DBDefs from '../../static/scripts/common/DBDefs';
@@ -78,14 +77,12 @@ const SearchForm = ({form}: Props) => (
         <FormRowSelect
           field={form.field.type}
           label={l('Type:')}
-          onChange={noop}
           options={typeOptions}
           uncontrolled
         />
         <FormRowSelect
           field={form.field.limit}
           label={l('Results per page:')}
-          onChange={noop}
           options={limitOptions}
           uncontrolled
         />

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -73,18 +73,21 @@ const SearchForm = ({form}: Props) => (
           field={form.field.query}
           label={l('Query:')}
           required
+          uncontrolled
         />
         <FormRowSelect
           field={form.field.type}
           label={l('Type:')}
           onChange={noop}
           options={typeOptions}
+          uncontrolled
         />
         <FormRowSelect
           field={form.field.limit}
           label={l('Results per page:')}
           onChange={noop}
           options={limitOptions}
+          uncontrolled
         />
         <FormRowRadio
           field={form.field.method}

--- a/root/static/scripts/account/components/ApplicationForm.js
+++ b/root/static/scripts/account/components/ApplicationForm.js
@@ -78,6 +78,7 @@ class ApplicationForm extends React.Component<Props, State> {
           field={this.state.form.field.name}
           label={addColonText(l('Name'))}
           required
+          uncontrolled
         />
         <FormRowSelect
           field={this.state.form.field.oauth_type}

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -189,6 +189,7 @@ class EditProfileForm extends React.Component<Props, State> {
         <FormRowEmailLong
           field={field.email}
           label={addColonText(l('Email'))}
+          uncontrolled
         />
         <FormRow hasNoLabel>
           {l(
@@ -200,6 +201,7 @@ class EditProfileForm extends React.Component<Props, State> {
         <FormRowURLLong
           field={field.website}
           label={addColonText(l('Website'))}
+          uncontrolled
         />
 
         <FormRowSelect

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -75,6 +75,7 @@ const CollectionEditForm = ({$c, collectionTypes, form}: Props) => {
           field={form.field.name}
           label={addColonText(l('Name'))}
           required
+          uncontrolled
         />
         <FormRowSelect
           field={form.field.type_id}

--- a/root/static/scripts/common/utility/parseCookie.js
+++ b/root/static/scripts/common/utility/parseCookie.js
@@ -17,8 +17,8 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 function parseCookie(
   cookie /*: mixed */,
   name /*: string */,
-  defaultValue /*: mixed */ = undefined,
-) {
+  defaultValue /*: string */ = '',
+) /*: string */ {
   if (typeof cookie === 'string') {
     const values = parse(cookie);
     if (hasOwnProperty.call(values, name)) {

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -99,7 +99,7 @@ const StatisticsLayout = ({
   return (
     <Layout
       fullWidth={fullWidth}
-      gettext_domains={['attributes', 'relationships', 'statistics']}
+      gettextDomains={['attributes', 'relationships', 'statistics']}
       title={htmlTitle}
     >
       <link

--- a/root/taglookup/Form.js
+++ b/root/taglookup/Form.js
@@ -22,26 +22,32 @@ const TagLookupForm = ({form}: {+form: TagLookupFormT}) => (
       <FormRowTextLong
         field={form.field.artist}
         label={addColonText(l('Artist'))}
+        uncontrolled
       />
       <FormRowTextLong
         field={form.field.release}
         label={addColonText(l('Release'))}
+        uncontrolled
       />
       <FormRowText
         field={form.field.tracknum}
         label={addColonText(l('Track number'))}
+        uncontrolled
       />
       <FormRowTextLong
         field={form.field.track}
         label={addColonText(l('Track'))}
+        uncontrolled
       />
       <FormRowText
         field={form.field.duration}
         label={addColonText(l('Duration'))}
+        uncontrolled
       />
       <FormRowTextLong
         field={form.field.filename}
         label={addColonText(l('Filename'))}
+        uncontrolled
       />
       <FormRow hasNoLabel>
         <FormSubmit label={l('Search')} />

--- a/root/types.js
+++ b/root/types.js
@@ -182,6 +182,9 @@ type CatalystActionT = {
 
 type CatalystContextT = {
   +action: CatalystActionT,
+  +flash: {
+    +message?: string,
+  },
   +relative_uri: string,
   +req: CatalystRequestContextT,
   +session: CatalystSessionT | null,
@@ -204,6 +207,8 @@ type CatalystSessionT = {
 };
 
 type CatalystStashT = {
+  +alert?: string,
+  +alert_mtime?: number | null,
   +collaborative_collections?: $ReadOnlyArray<CollectionT>,
   +commons_image?: CommonsImageT | null,
   +containment?: {
@@ -212,8 +217,12 @@ type CatalystStashT = {
   +current_language: string,
   +current_language_html: string,
   +entity?: CoreEntityT,
+  +hide_merge_helper?: boolean,
   +jsonld_data?: {...},
+  +makes_no_changes?: boolean,
   +more_tags?: boolean,
+  +new_edit_notes?: boolean,
+  +new_edit_notes_mtime?: number | null,
   +number_of_collections?: number,
   +number_of_revisions?: number,
   +own_collections?: $ReadOnlyArray<CollectionT>,

--- a/root/types.js
+++ b/root/types.js
@@ -210,6 +210,8 @@ type CatalystStashT = {
   },
   +current_language: string,
   +current_language_html: string,
+  +entity?: CoreEntityT,
+  +jsonld_data?: {...},
   +more_tags?: boolean,
   +number_of_collections?: number,
   +number_of_revisions?: number,

--- a/root/types.js
+++ b/root/types.js
@@ -200,6 +200,7 @@ type CatalystRequestContextT = {
 
 type CatalystSessionT = {
   +tport?: number,
+  +merger?: MergeQueueT,
 };
 
 type CatalystStashT = {
@@ -220,6 +221,7 @@ type CatalystStashT = {
   +release_artwork_count?: number,
   +server_languages?: $ReadOnlyArray<ServerLanguageT>,
   +subscribed?: boolean,
+  +to_merge?: $ReadOnlyArray<CoreEntityT>,
   +top_tags?: $ReadOnlyArray<AggregatedTagT>,
   +user_tags?: $ReadOnlyArray<UserTagT>,
 };
@@ -703,6 +705,12 @@ declare type MergeFormT = FormT<{
   +rename: FieldT<boolean>,
   +target: FieldT<number>,
 }>;
+
+declare type MergeQueueT = {
+  +type: CoreEntityTypeT,
+  +entities: $ReadOnlyArray<number>,
+  +ready_to_merge: boolean,
+};
 
 declare type MinimalCoreEntityT = {
   +entityType: string,

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -7,7 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import noop from 'lodash/noop';
 import * as React from 'react';
 
 import UserAccountLayout from '../components/UserAccountLayout';
@@ -116,8 +115,8 @@ const ReportUser = ({
       <FormRowSelect
         field={form.field.reason}
         label={addColonText(l('Reason'))}
-        onChange={noop}
         options={reportReasonOptions}
+        uncontrolled
       />
 
       <FormRowTextArea

--- a/root/utility/getRequestCookie.js
+++ b/root/utility/getRequestCookie.js
@@ -15,8 +15,8 @@ const parseCookie = require('../static/scripts/common/utility/parseCookie');
 function getRequestCookie(
   req /*: CatalystRequestContextT */,
   name /*: string */,
-  defaultValue /*: mixed */ = undefined,
-) {
+  defaultValue /*: string */ = '',
+) /*: string */ {
   const headers = req.headers;
   const cookie = (
     headers.cookie ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,10 +3074,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.111.3:
-  version "0.111.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.111.3.tgz#8653a413400ebc966097a47c81fb4e6b722a5921"
-  integrity sha512-Gn27aRTjSFicukZ/pq3raRERmSk9UWszhIK9eNtj6843L54YtK+jk2OkQWV70+VKi9LmWyfItCkhwoIVy7L2lA==
+flow-bin@0.112.0:
+  version "0.112.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
+  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,15 +2100,15 @@ convert-source-map@^1.6.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.2.3.tgz#1a59536af68537a21178a01346f87cb059d2ae5c"
-  integrity sha1-GllTavaFN6IReKATRvh8sFnSrlw=
-
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
https://github.com/facebook/flow/releases/tag/v0.112.0

From the changelog: "JSX expressions now use the new spread semantics added in v0.111.0." This caused new errors for us in some of the `FormRowText` and layout components, which I've fixed here.

I've also added Flow types to more of the components under root/layout (to make sure my changes elsewhere were correct), and fixed `FormRowText` to only use `defaultValue` when `uncontrolled` is specified.