### PR TITLE
Adding flow/require-indexer-name to eslintrc

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -310,6 +310,7 @@ rules:
   flowtype/no-weak-types: warn
   flowtype/object-type-delimiter: [warn, comma]
   flowtype/require-exact-type: off
+  flowtype/require-indexer-name: [warn, always]
   flowtype/require-parameter-type: off
   flowtype/require-return-type: off
   flowtype/require-valid-file-annotation: off


### PR DESCRIPTION
The flow/require-indexer-name rule seems like it would be really nice
to help document what our flow object indexers actually stand for.
See "An indexer can be optionally named, for documentation purposes"
in https://flow.org/en/docs/types/objects/ 

https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-require-indexer-name