### PR TITLE
MBS-10468: Stop breaking Bandcamp merch links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -526,7 +526,7 @@ const CLEANUPS = {
       if (/^https:\/\/daily\.bandcamp\.com/.test(url)) {
         url = url.replace(/^https:\/\/daily\.bandcamp\.com\/(\d+\/\d+\/\d+\/[\w-]+)(?:\/.*)?$/, 'https://daily.bandcamp.com/$1/');
       } else {
-        url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
+        url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|merch|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
       }
       return url;
     },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -403,6 +403,14 @@ const testData = [
        only_valid_entity_types: ['recording', 'release'],
   },
   {
+                     input_url: 'https://non-serviam-records.bandcamp.com/merch/the-howling-void-megaliths-of-the-abyss-digipak',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://non-serviam-records.bandcamp.com/merch/the-howling-void-megaliths-of-the-abyss-digipak',
+       input_relationship_type: 'mailorder',
+       only_valid_entity_types: ['release'],
+  },
+  {
                      input_url: 'daily.bandcamp.com/2018/05/30/brownout-fear-of-a-brown-planet-album-review/#more-90177',
              input_entity_type: 'release_group',
     expected_relationship_type: 'review',


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10468

Merch links are sometimes used to sell music releases, with or without other merch, such as https://non-serviam-records.bandcamp.com/merch/the-howling-void-megaliths-of-the-abyss-digipak
As such, we should avoid breaking those links by cleaning them up into the main Bandcamp page URL.