### PR TITLE
MBS-10488: Fix profile subscription links

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -354,7 +354,7 @@ const UserProfileStatistics = withCatalystContext(({
             <th colSpan="2">
               {exp.l(
                 'Edits ({view_url|view})',
-                {view_url: `/user/${encodedName}/edits/all`},
+                {view_url: `/user/${encodedName}/edits`},
               )}
             </th>
           </tr>

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -254,13 +254,13 @@ const UserProfileInformation = withCatalystContext(({
               {bracketed(
                 subscribed ? (
                   <a href={
-                    `/account/subscriptions/editor/remove?id=${encodedName}`}
+                    `/account/subscriptions/editor/remove?id=${user.id}`}
                   >
                     {l('unsubscribe')}
                   </a>
                 ) : (
                   <a href={
-                    `account/subscriptions/editor/add?id=${encodedName}`}
+                    `/account/subscriptions/editor/add?id=${user.id}`}
                   >
                     {l('subscribe')}
                   </a>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10488

When converting to React, I apparently changed these to use user name instead of ID by mistake, and we missed it on review.

https://tickets.metabrainz.org/browse/MBS-10485

Also removing the useless /all in /edits/all link.