### PR TITLE
MBS-10422: Add ISRCs to release editor recording search

### DIFF
--- a/root/static/scripts/release-editor/utils.js
+++ b/root/static/scripts/release-editor/utils.js
@@ -137,6 +137,10 @@ utils.cleanWebServiceData = function (data) {
         clean.comment = data.disambiguation;
     }
 
+    if (data.isrcs) {
+        clean.isrcs = data.isrcs.map(cleanIsrc);
+    }
+
     return clean;
 };
 
@@ -150,6 +154,12 @@ function cleanArtistCreditName(data) {
         },
         name: data.name || data.artist.name,
         joinPhrase: data.joinphrase || ""
+    };
+}
+
+function cleanIsrc(data) {
+    return {
+        isrc: data,
     };
 }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10422

The recording search in the release editor takes ws/2 data and turns it into ws/js. This makes it so that the ws/2 formatted ISRCs also get converted to the ws/js format, so that we can actually display them in autocomplete.