### PR TITLE
MBS-10493: Better sizing for edit search selects

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -56,9 +56,9 @@
              CASE 'MusicBrainz::Server::EditSearch::Predicate::Set';
                SWITCH field.field_name;
                  CASE 'type';
-                   predicate_set(field.field_name, edit_types, field);
+                   predicate_set(field.field_name, edit_types, field, 15, 1);
                  CASE 'status';
-                   predicate_set(field.field_name, status, field);
+                   predicate_set(field.field_name, status, field, 8);
                END;
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality';
                predicate_set(field.field_name, quality, field);
@@ -181,11 +181,13 @@
   </span>
 [% END %]
 
-[% MACRO predicate_set(field, set_contents, field_contents) WRAPPER wfield predicate="set" %]
+[% MACRO predicate_set(field, set_contents, field_contents, size) WRAPPER wfield predicate="set" %]
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
 
-  <select name="args" multiple="multiple">
+  <select name="args" multiple="multiple"
+          [%~ ' size="' _ size _ '"' IF size ~%]
+          >
     [%- FOR item=set_contents %]
     <option value="[% html_escape(item.0) %]"
             [%~ ' selected="selected"' IF field_contents.find_argument(item.0).defined ~%]
@@ -198,7 +200,7 @@
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
 
-  <select name="args" multiple="multiple">
+  <select name="args" multiple="multiple" size="15">
     [%- FOR language=languages %]
     <option value="[% language.id %]"
             [%~ ' selected="selected"' IF field_contents.find_argument(language.id) ~%]
@@ -219,7 +221,7 @@
 [% MACRO predicate_link_type(field, field_contents) WRAPPER wfield predicate="set" %]
   [% operators([ [ '=', l('is') ] ], field_contents) %]
 
-  <select name="args" multiple="multiple">
+  <select name="args" multiple="multiple" size="15">
     [%- FOR type_group=relationship_type %]
     <optgroup label="[% type_group.name %]">
         [%- relationship_node(top_level, '', field_contents)
@@ -265,7 +267,7 @@
     [% add_colon(l('and voted')) %]
   </span>
 
-  <select name="args" multiple="multiple">
+  <select name="args" multiple="multiple" size="5">
     [%- FOR item=[ [  2,   lp('Approve', 'vote') ]
                 , [  1,   lp('Yes', 'vote') ]
                 , [  0,   lp('No', 'vote') ]
@@ -314,7 +316,7 @@
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
 
-  <select name="args" multiple="multiple">
+  <select name="args" multiple="multiple" size="15">
     [%- FOR country=countries %]
     <option value="[% country.id %]"
             [%- 'selected="selected"' IF field_contents.find_argument(country.id) %]>
@@ -407,8 +409,8 @@
   <div id="fields">
     [% predicate_id('id') %]
     [% predicate_date(field_name) FOR field_name=['open_time', 'expire_time', 'close_time'] %]
-    [% predicate_set('type', edit_types) %]
-    [% predicate_set('status', status) %]
+    [% predicate_set('type', edit_types, [], 15) %]
+    [% predicate_set('status', status, [], 8) %]
     [% predicate_set('release_quality', quality) %]
     [% predicate_vote_count('vote_count') %]
     [% predicate_user('edit_note_author') %]

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -219,6 +219,10 @@ div.searchform {
     margin-top: 24px;
 }
 
+#edit-search select[multiple=multiple] {
+    resize: vertical;
+}
+
 /* <table>-based forms to replace div.row-based stuff. */
 
 table.row-form {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10493

Some edit search multiple selects have *lots* of options, yet their default size is very, very small and they can't be resized.
This makes it so the largest selects (edit type, relationship type, release language and release country) start at size 15 and can be vertically resized, while two smaller selects that still were too big for the default size (edit status and vote type) get a size matching their number of entries to avoid pointless scrolling.

![Screenshot from 2019-11-27 12-39-25](https://user-images.githubusercontent.com/1069224/69716632-13a73f00-1113-11ea-9f27-4784baf0697f.png)
