### PR TITLE
MBS-10495: Update Discourse API authentication method

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Discourse.pm
+++ b/lib/MusicBrainz/Server/Controller/Discourse.pm
@@ -22,6 +22,8 @@ has lwp => (
         $lwp->env_proxy;
         $lwp->timeout(5);
         $lwp->agent(DBDefs->LWP_USER_AGENT);
+        $lwp->default_header('Api-Key' => DBDefs->DISCOURSE_API_KEY);
+        $lwp->default_header('Api-Username' => DBDefs->DISCOURSE_API_USERNAME);
         $lwp;
     },
 );
@@ -46,8 +48,6 @@ sub _create_uri {
 
     my $uri = URI->new(DBDefs->DISCOURSE_SERVER);
     $uri->path($path);
-    $uri->query_param_append('api_key', DBDefs->DISCOURSE_API_KEY);
-    $uri->query_param_append('api_username', DBDefs->DISCOURSE_API_USERNAME);
     $uri;
 }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10495

Discourse’s SSO API has changed to use HTTP headers for authentication instead of URL parameters.

**Note:** This has not been tested in any way, shape, or form.

See:
* https://meta.discourse.org/t/discourse-api-documentation/22706
* https://docs.discourse.org/