### PR TITLE
Eliminate warnings caused by eslint rule react/jsx-handler-names

### DIFF
--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -223,7 +223,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       this,
       'flushPendingVotes',
       'onBeforeUnload',
-      'handleAddTags',
+      'handleSubmit',
       'setTagsInput',
     );
 
@@ -329,7 +329,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
     return current.count + ((current.vote === -vote ? 2 : 1) * vote);
   }
 
-  handleAddTags(event: SyntheticEvent<HTMLFormElement>) {
+  handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const input = this.tagsInput;
@@ -562,7 +562,7 @@ export const MainTagEditor = hydrate<TagEditorProps>(
                   {tagdocs: '/doc/Folksonomy_Tagging'},
                 )}
               </p>
-              <form id="tag-form" onSubmit={this.handleAddTags}>
+              <form id="tag-form" onSubmit={this.handleSubmit}>
                 <p>
                   <textarea cols="50" ref={this.setTagsInput} rows="5" />
                 </p>
@@ -616,7 +616,7 @@ export const SidebarTagEditor = hydrate<TagEditorProps>(
             </p>
           ) : null}
 
-          <form id="tag-form" onSubmit={this.handleAddTags}>
+          <form id="tag-form" onSubmit={this.handleSubmit}>
             <div style={{display: 'flex'}}>
               <input
                 className="tag-input"

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -223,7 +223,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       this,
       'flushPendingVotes',
       'onBeforeUnload',
-      'addTags',
+      'handleAddTags',
       'setTagsInput',
     );
 
@@ -329,7 +329,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
     return current.count + ((current.vote === -vote ? 2 : 1) * vote);
   }
 
-  addTags(event: SyntheticEvent<HTMLFormElement>) {
+  handleAddTags(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const input = this.tagsInput;
@@ -562,7 +562,7 @@ export const MainTagEditor = hydrate<TagEditorProps>(
                   {tagdocs: '/doc/Folksonomy_Tagging'},
                 )}
               </p>
-              <form id="tag-form" onSubmit={this.addTags}>
+              <form id="tag-form" onSubmit={this.handleAddTags}>
                 <p>
                   <textarea cols="50" ref={this.setTagsInput} rows="5" />
                 </p>
@@ -616,7 +616,7 @@ export const SidebarTagEditor = hydrate<TagEditorProps>(
             </p>
           ) : null}
 
-          <form id="tag-form" onSubmit={this.addTags}>
+          <form id="tag-form" onSubmit={this.handleAddTags}>
             <div style={{display: 'flex'}}>
               <input
                 className="tag-input"

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -43,7 +43,7 @@ function renderDuplicates(name, duplicates, container) {
     <PossibleDuplicates
       name={name}
       duplicates={duplicates}
-      checkboxCallback={event => isConfirmed(event.target.checked)} />,
+      onCheckboxChange={event => isConfirmed(event.target.checked)} />,
     container
   );
 }

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -81,7 +81,7 @@ class ArtistCreditEditor extends React.Component {
     this.copyArtistCredit = this.copyArtistCredit.bind(this);
     this.done = this.done.bind(this);
     this.hide = this.hide.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
+    this.handleNameChange = this.handleNameChange.bind(this);
     this.pasteArtistCredit = this.pasteArtistCredit.bind(this);
     this.removeName = this.removeName.bind(this);
     this.handleBubbleToggle = this.handleBubbleToggle.bind(this);
@@ -116,7 +116,7 @@ class ArtistCreditEditor extends React.Component {
     });
   }
 
-  onNameChange(i, update) {
+  handleNameChange(i, update) {
     this.setState(state => mutate(state, newState => {
       newState.artistCredit.names[i] =
         {...state.artistCredit.names[i], ...update};
@@ -234,7 +234,7 @@ class ArtistCreditEditor extends React.Component {
         copyArtistCredit={this.copyArtistCredit}
         done={this.done}
         hide={this.hide}
-        onNameChange={this.onNameChange}
+        onNameChange={this.handleNameChange}
         pasteArtistCredit={this.pasteArtistCredit}
         removeName={this.removeName}
         {...this.props}

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -84,7 +84,7 @@ class ArtistCreditEditor extends React.Component {
     this.handleNameChange = this.handleNameChange.bind(this);
     this.pasteArtistCredit = this.pasteArtistCredit.bind(this);
     this.removeName = this.removeName.bind(this);
-    this.handleToggleBubble = this.handleToggleBubble.bind(this);
+    this.handleBubbleToggle = this.handleBubbleToggle.bind(this);
   }
 
   addName() {
@@ -138,7 +138,7 @@ class ArtistCreditEditor extends React.Component {
     this.setState({artistCredit: {names}});
   }
 
-  handleToggleBubble() {
+  handleBubbleToggle() {
     const $bubble = $('#artist-credit-bubble');
     if ($bubble.is(':visible')) {
       const inst = $bubble.data('componentInst');
@@ -424,7 +424,7 @@ class ArtistCreditEditor extends React.Component {
                   className="open-ac"
                   ref={button => this._editButton = button}
                   type="button"
-                  onClick={this.handleToggleBubble}>
+                  onClick={this.handleBubbleToggle}>
                   {l('Edit')}
                 </button>
               </td>

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -81,7 +81,7 @@ class ArtistCreditEditor extends React.Component {
     this.copyArtistCredit = this.copyArtistCredit.bind(this);
     this.done = this.done.bind(this);
     this.hide = this.hide.bind(this);
-    this.handleNameChange = this.handleNameChange.bind(this);
+    this.onNameChange = this.onNameChange.bind(this);
     this.pasteArtistCredit = this.pasteArtistCredit.bind(this);
     this.removeName = this.removeName.bind(this);
     this.handleBubbleToggle = this.handleBubbleToggle.bind(this);
@@ -116,7 +116,7 @@ class ArtistCreditEditor extends React.Component {
     });
   }
 
-  handleNameChange(i, update) {
+  onNameChange(i, update) {
     this.setState(state => mutate(state, newState => {
       newState.artistCredit.names[i] =
         {...state.artistCredit.names[i], ...update};
@@ -234,7 +234,7 @@ class ArtistCreditEditor extends React.Component {
         copyArtistCredit={this.copyArtistCredit}
         done={this.done}
         hide={this.hide}
-        onNameChange={this.handleNameChange}
+        onNameChange={this.onNameChange}
         pasteArtistCredit={this.pasteArtistCredit}
         removeName={this.removeName}
         {...this.props}

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -84,7 +84,7 @@ class ArtistCreditEditor extends React.Component {
     this.handleNameChange = this.handleNameChange.bind(this);
     this.pasteArtistCredit = this.pasteArtistCredit.bind(this);
     this.removeName = this.removeName.bind(this);
-    this.toggleBubble = this.toggleBubble.bind(this);
+    this.handleToggleBubble = this.handleToggleBubble.bind(this);
   }
 
   addName() {
@@ -138,7 +138,7 @@ class ArtistCreditEditor extends React.Component {
     this.setState({artistCredit: {names}});
   }
 
-  toggleBubble() {
+  handleToggleBubble() {
     const $bubble = $('#artist-credit-bubble');
     if ($bubble.is(':visible')) {
       const inst = $bubble.data('componentInst');
@@ -424,7 +424,7 @@ class ArtistCreditEditor extends React.Component {
                   className="open-ac"
                   ref={button => this._editButton = button}
                   type="button"
-                  onClick={this.toggleBubble}>
+                  onClick={this.handleToggleBubble}>
                   {l('Edit')}
                 </button>
               </td>

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -81,7 +81,7 @@ class ArtistCreditEditor extends React.Component {
     this.copyArtistCredit = this.copyArtistCredit.bind(this);
     this.done = this.done.bind(this);
     this.hide = this.hide.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
+    this.handleNameChange = this.handleNameChange.bind(this);
     this.pasteArtistCredit = this.pasteArtistCredit.bind(this);
     this.removeName = this.removeName.bind(this);
     this.toggleBubble = this.toggleBubble.bind(this);
@@ -116,7 +116,7 @@ class ArtistCreditEditor extends React.Component {
     });
   }
 
-  onNameChange(i, update) {
+  handleNameChange(i, update) {
     this.setState(state => mutate(state, newState => {
       newState.artistCredit.names[i] =
         {...state.artistCredit.names[i], ...update};
@@ -234,7 +234,7 @@ class ArtistCreditEditor extends React.Component {
         copyArtistCredit={this.copyArtistCredit}
         done={this.done}
         hide={this.hide}
-        onNameChange={this.onNameChange}
+        onNameChange={this.handleNameChange}
         pasteArtistCredit={this.pasteArtistCredit}
         removeName={this.removeName}
         {...this.props}

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -20,7 +20,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.artistName = _.get(props.name, ['artist', 'name'], '');
     this.handleArtistChange = this.handleArtistChange.bind(this);
     this.handleNameBlur = this.handleNameBlur.bind(this);
-    this.handleNameChange = this.handleNameChange.bind(this);
+    this.onNameChange = this.onNameChange.bind(this);
     this.handleJoinPhraseBlur = this.handleJoinPhraseBlur.bind(this);
     this.handleJoinPhraseChange = this.handleJoinPhraseChange.bind(this);
   }
@@ -48,7 +48,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.props.onChange({name: newName});
   }
 
-  handleNameChange(event) {
+  onNameChange(event) {
     this.props.onChange({name: event.target.value});
   }
 
@@ -113,7 +113,7 @@ class ArtistCreditNameEditor extends React.Component {
           <input
             id={`${id}-credited-as-${index}`}
             onBlur={this.handleNameBlur}
-            onChange={this.handleNameChange}
+            onChange={this.onNameChange}
             type="text"
             value={nonEmpty(name.name) ? name.name : ''} />
         </td>

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -20,7 +20,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.artistName = _.get(props.name, ['artist', 'name'], '');
     this.handleArtistChange = this.handleArtistChange.bind(this);
     this.handleNameBlur = this.handleNameBlur.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
+    this.handleNameChange = this.handleNameChange.bind(this);
     this.handleJoinPhraseBlur = this.handleJoinPhraseBlur.bind(this);
     this.handleJoinPhraseChange = this.handleJoinPhraseChange.bind(this);
   }
@@ -48,7 +48,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.props.onChange({name: newName});
   }
 
-  onNameChange(event) {
+  handleNameChange(event) {
     this.props.onChange({name: event.target.value});
   }
 
@@ -113,7 +113,7 @@ class ArtistCreditNameEditor extends React.Component {
           <input
             id={`${id}-credited-as-${index}`}
             onBlur={this.handleNameBlur}
-            onChange={this.onNameChange}
+            onChange={this.handleNameChange}
             type="text"
             value={nonEmpty(name.name) ? name.name : ''} />
         </td>

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -52,7 +52,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.props.onChange({name: event.target.value});
   }
 
-  hanldeJoinPhraseBlur(event) {
+  handleJoinPhraseBlur(event) {
     if (!this.props.name.automaticJoinPhrase) {
       return;
     }

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -18,14 +18,14 @@ class ArtistCreditNameEditor extends React.Component {
     super(props);
 
     this.artistName = _.get(props.name, ['artist', 'name'], '');
-    this.onArtistChange = this.onArtistChange.bind(this);
-    this.onNameBlur = this.onNameBlur.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
-    this.onJoinPhraseBlur = this.onJoinPhraseBlur.bind(this);
-    this.onJoinPhraseChange = this.onJoinPhraseChange.bind(this);
+    this.handleArtistChange = this.handleArtistChange.bind(this);
+    this.handleNameBlur = this.handleNameBlur.bind(this);
+    this.handleNameChange = this.handleNameChange.bind(this);
+    this.handleJoinPhraseBlur = this.handleJoinPhraseBlur.bind(this);
+    this.handleJoinPhraseChange = this.handleJoinPhraseChange.bind(this);
   }
 
-  onArtistChange(artist) {
+  handleArtistChange(artist) {
     const update = {artist};
     const artistName = artist ? artist.name : '';
 
@@ -37,7 +37,7 @@ class ArtistCreditNameEditor extends React.Component {
     this.props.onChange(update);
   }
 
-  onNameBlur(event) {
+  handleNameBlur(event) {
     let newName = clean(event.target.value);
 
     const artist = this.props.name.artist;
@@ -48,11 +48,11 @@ class ArtistCreditNameEditor extends React.Component {
     this.props.onChange({name: newName});
   }
 
-  onNameChange(event) {
+  handleNameChange(event) {
     this.props.onChange({name: event.target.value});
   }
 
-  onJoinPhraseBlur(event) {
+  hanldeJoinPhraseBlur(event) {
     if (!this.props.name.automaticJoinPhrase) {
       return;
     }
@@ -87,7 +87,7 @@ class ArtistCreditNameEditor extends React.Component {
     }
   }
 
-  onJoinPhraseChange(event) {
+  handleJoinPhraseChange(event) {
     // The join phrase has been changed, it should no longer be automatic.
     this.props.onChange({
       automaticJoinPhrase: false,
@@ -107,21 +107,21 @@ class ArtistCreditNameEditor extends React.Component {
             currentSelection={name.artist || {name: name.name}}
             entity="artist"
             inputID={`${id}-artist-${index}`}
-            onChange={this.onArtistChange} />
+            onChange={this.handleArtistChange} />
         </td>
         <td>
           <input
             id={`${id}-credited-as-${index}`}
-            onBlur={this.onNameBlur}
-            onChange={this.onNameChange}
+            onBlur={this.handleNameBlur}
+            onChange={this.handleNameChange}
             type="text"
             value={nonEmpty(name.name) ? name.name : ''} />
         </td>
         <td>
           <input
             id={`${id}-join-phrase-${index}`}
-            onBlur={this.onJoinPhraseBlur}
-            onChange={this.onJoinPhraseChange}
+            onBlur={this.handleJoinPhraseBlur}
+            onChange={this.handleJoinPhraseChange}
             type="text"
             value={nonEmpty(name.joinPhrase) ? name.joinPhrase : ''} />
         </td>

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -25,7 +25,7 @@ class PossibleDuplicates extends React.Component {
         </ul>
         <p>
           <label>
-            <input type="checkbox" onChange={this.props.checkboxCallback} />
+            <input type="checkbox" onChange={this.props.onCheckboxChange} />
             {' '}
             {texp.l(
               'Yes, I still want to enter “{entity_name}”.',

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -13,7 +13,7 @@ class RemoveButton extends React.Component {
     return (
       <button
         className="nobutton icon remove-item"
-        onClick={this.props.callback}
+        onClick={this.props.onButtonRemoved}
         title={this.props.title}
         type="button"
       />

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -13,7 +13,7 @@ class RemoveButton extends React.Component {
     return (
       <button
         className="nobutton icon remove-item"
-        onClick={this.props.onButtonRemoved}
+        onClick={this.props.onClick}
         title={this.props.title}
         type="button"
       />

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -278,7 +278,7 @@ export class ExternalLinksEditor
                 }
                 isOnlyLink={this.state.links.length === 1}
                 key={link.relationship}
-                removeCallback={_.bind(this.removeLink, this, index)}
+                handleRemoveCallback={_.bind(this.removeLink, this, index)}
                 type={link.type}
                 typeChangeCallback={
                   _.bind(this.handleTypeChange, this, index)
@@ -329,7 +329,7 @@ type LinkProps = {
   handleVideoChange:
     (number, SyntheticEvent<HTMLInputElement>) => void,
   isOnlyLink: boolean,
-  removeCallback: (number) => void,
+  handleRemoveCallback: (number) => void,
   type: number | null,
   typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
   typeOptions: Array<React.Element<'option'>>,
@@ -441,7 +441,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           {typeDescription && <HelpIcon content={typeDescription} />}
           {isEmpty(props) ||
             <RemoveButton
-              callback={props.removeCallback}
+              callback={handleRemoveCallback}
               title={l('Remove Link')}
             />}
         </td>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -441,7 +441,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           {typeDescription && <HelpIcon content={typeDescription} />}
           {isEmpty(props) ||
             <RemoveButton
-              onButtonRemoved={handleRemoveCallback}
+              onButtonRemoved={props.handleRemoveCallback}
               title={l('Remove Link')}
             />}
         </td>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -278,7 +278,7 @@ export class ExternalLinksEditor
                 }
                 isOnlyLink={this.state.links.length === 1}
                 key={link.relationship}
-                handleRemoveCallback={_.bind(this.removeLink, this, index)}
+                onRemove={_.bind(this.removeLink, this, index)}
                 type={link.type}
                 typeChangeCallback={
                   _.bind(this.handleTypeChange, this, index)
@@ -329,7 +329,7 @@ type LinkProps = {
   handleVideoChange:
     (number, SyntheticEvent<HTMLInputElement>) => void,
   isOnlyLink: boolean,
-  handleRemoveCallback: (number) => void,
+  onRemove: (number) => void,
   type: number | null,
   typeChangeCallback: (number, SyntheticEvent<HTMLSelectElement>) => void,
   typeOptions: Array<React.Element<'option'>>,
@@ -441,7 +441,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           {typeDescription && <HelpIcon content={typeDescription} />}
           {isEmpty(props) ||
             <RemoveButton
-              onButtonRemoved={props.handleRemoveCallback}
+              onClick={props.onRemove}
               title={l('Remove Link')}
             />}
         </td>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -441,7 +441,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           {typeDescription && <HelpIcon content={typeDescription} />}
           {isEmpty(props) ||
             <RemoveButton
-              callback={handleRemoveCallback}
+              onButtonRemoved={handleRemoveCallback}
               title={l('Remove Link')}
             />}
         </td>

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -66,7 +66,8 @@ $(function () {
             entityType={entityType}
             id="entity-test"
             key={entityType + '-autocomplete'}
-            onChange={console.log} // eslint-disable-line react/jsx-handler-names
+            // eslint-disable-next-line react/jsx-handler-names
+            onChange={console.log}
             onTypeChange={render}
             width="200px"
           />
@@ -77,7 +78,8 @@ $(function () {
             entityType={entityType}
             id="vocal-test"
             items={vocals}
-            onChange={console.log} // eslint-disable-line react/jsx-handler-names
+            // eslint-disable-next-line react/jsx-handler-names
+            onChange={console.log}
             placeholder="Choose a vocal"
             width="200px"
           />

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -66,7 +66,7 @@ $(function () {
             entityType={entityType}
             id="entity-test"
             key={entityType + '-autocomplete'}
-            onChange={console.log}
+            onChange={console.log} // eslint-disable-line react/jsx-handler-names
             onTypeChange={render}
             width="200px"
           />
@@ -77,7 +77,7 @@ $(function () {
             entityType={entityType}
             id="vocal-test"
             items={vocals}
-            onChange={console.log}
+            onChange={console.log} // eslint-disable-line react/jsx-handler-names
             placeholder="Choose a vocal"
             width="200px"
           />


### PR DESCRIPTION
*Submitted as part of the Google Code-in (GCI) competition*

The eslint rule **react/jsx-handler-names** requires that prop methods which handle events are prefixed so that their purpose is clear (that is, it imposes a simple naming convention on event handlers appearing in JSX). [Specifically](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md), their names must start with "handle" (or in some cases, "on").

This pull request does this in a few different ways:
  - In some cases, such as where the event handler is `console.log`, eslint is simply disabled for that line because the code is in its most readable and understandable form
  - Often, a callback is simply renamed from `x` to `handlerX`
  - In some cases, the callback is renamed to something vastly different to its original name, in an attempt to make it clearer what it does

I have verified that eslint no longer complains about this particular error message, by running
```bash
./script/check_eslint_rule 'react/jsx-handler-names: warn' root/
```
However, I have added one commit (unrelated to lint) afterwards so it may be an outdated result. I will re-run as soon as I can.