### PR TITLE
Fix JS to follow the no-cond-assign eslint rule

### DIFF
--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -33,7 +33,7 @@ MB.forms = {
             if (!children) { return; }
 
             const childOptions = [];
-            while (child = children[i++]) {
+            while ((child = children[i++])) {
                 var opt = {};
 
                 opt.value = child[valueAttr];
@@ -132,7 +132,7 @@ ko.bindingHandlers.loop = {
                 items = observableArray.peek(),
                 removals = [];
 
-            for (var i = 0, change, j, node; change = changes[i]; i++) {
+            for (var i = 0, change, j, node; (change = changes[i]); i++) {
                 var status = change.status;
 
                 if (status === "retained") {
@@ -157,7 +157,7 @@ ko.bindingHandlers.loop = {
                              */
                             tmpElementContainer = document.createElement("div");
 
-                            for (j = 0; node = template[j]; j++) {
+                            for (j = 0; (node = template[j]); j++) {
                                 tmpElementContainer.appendChild(node.cloneNode(true));
                             }
 
@@ -169,7 +169,7 @@ ko.bindingHandlers.loop = {
                     }
                 } else if (status === "deleted") {
                     if (change.moved === undefined) {
-                        for (j = 0; node = currentElements[j]; j++) {
+                        for (j = 0; (node = currentElements[j]); j++) {
                             /*
                              * If the node is already removed for some unknown
                              * reason, don't outright explode. It's possible
@@ -196,7 +196,7 @@ ko.bindingHandlers.loop = {
                     elementsToInsert = currentElements[0];
                 } else {
                     elementsToInsert = document.createDocumentFragment();
-                    for (j = 0; node = currentElements[j]; j++) {
+                    for (j = 0; (node = currentElements[j]); j++) {
                         elementsToInsert.appendChild(node);
                     }
                 }
@@ -220,7 +220,7 @@ ko.bindingHandlers.loop = {
                  * the elements to parentNode.
                  */
 
-                for (var j = change.index - 1; prevItem = items[j]; j--) {
+                for (var j = change.index - 1; (prevItem = items[j]); j--) {
                     elementsToInsertAfter = elements[prevItem[idAttribute]];
 
                     /*
@@ -241,7 +241,7 @@ ko.bindingHandlers.loop = {
 
             // Brief timeout in case a removed item gets re-added.
             setTimeout(function () {
-                for (var i = 0, removal; removal = removals[i]; i++) {
+                for (var i = 0, removal; (removal = removals[i]); i++) {
                     if (!document.body.contains(removal.node)) {
                         ko.cleanNode(removal.node);
                         delete elements[removal.itemID];

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -781,7 +781,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
     function defaultLinkType(root) {
         var child, id, i = 0;
 
-        while (child = root.children[i++]) {
+        while ((child = root.children[i++])) {
             if (child.description && !child.deprecated) {
                 return child.id;
             }

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -295,7 +295,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         getAttribute(typeGID) {
             var attributes = this.attributes();
 
-            for (var i = 0, linkAttribute; linkAttribute = attributes[i]; i++) {
+            for (var i = 0, linkAttribute; (linkAttribute = attributes[i]); i++) {
                 if (linkAttribute.type.gid === typeGID) return linkAttribute;
             }
             return new fields.LinkAttribute({ type: { gid: typeGID }});
@@ -387,7 +387,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         paddedSeriesNumber() {
             var attributes = this.attributes(), numberAttribute;
 
-            for (var i = 0; numberAttribute = attributes[i]; i++) {
+            for (var i = 0; (numberAttribute = attributes[i]); i++) {
                 if (numberAttribute.type.gid === SERIES_ORDERING_ATTRIBUTE) {
                     break;
                 }
@@ -400,7 +400,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             var parts = _.compact(numberAttribute.textValue().split(/(\d+)/)),
                 integerRegex = /^\d+$/;
 
-            for (var i = 0, part; part = parts[i]; i++) {
+            for (var i = 0, part; (part = parts[i]); i++) {
                 if (integerRegex.test(part)) {
                     parts[i] = _.padStart(part, 10, "0");
                 }
@@ -602,10 +602,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         if (attributesA.length !== attributesB.length) {
             return false;
         }
-        for (var i = 0, a; a = attributesA[i]; i++) {
+        for (var i = 0, a; (a = attributesA[i]); i++) {
             var match = false;
 
-            for (var j = i, b; b = attributesB[j]; j++) {
+            for (var j = i, b; (b = attributesB[j]); j++) {
                 if (a.identity() === b.identity()) {
                     match = true;
                     break;

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -50,7 +50,7 @@ import deferFocus from '../../edit/utility/deferFocus';
             var options = params.options;
             var optionNodes = [];
 
-            for (var i = 0, node, option; option = options[i]; i++) {
+            for (var i = 0, node, option; (option = options[i]); i++) {
                 node = document.createElement("a")
                 node.href = "#";
                 node.style.paddingLeft = option.depth + "em";
@@ -130,7 +130,7 @@ import deferFocus from '../../edit/utility/deferFocus';
                 return node.optionData.value === typeGID;
             });
 
-            while (node = nodes[++nextIndex]) {
+            while ((node = nodes[++nextIndex])) {
                 if (node.style.display === "block") {
                     ++nextIndex;
                     break;

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -341,7 +341,7 @@ function parseQueryString(queryString) {
     var fields = {};
     var subField, match, parts;
 
-    while (match = queryStringRegex.exec(queryString)) {
+    while ((match = queryStringRegex.exec(queryString))) {
         subField = fields;
         parts = match[1].split('.');
 

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -236,7 +236,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         $("#page form button[type=submit]").prop("disabled", true);
         $("input[type=hidden]", "#relationship-editor").remove();
 
-        if (vm = MB.sourceRelationshipEditor) {
+        if ((vm = MB.sourceRelationshipEditor)) {
             addHiddenInputs(pushInput, vm, formName);
             submitted = submitted.concat(source.relationshipsInViewModel(vm)());
         }
@@ -258,7 +258,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             ));
         }
 
-        if (vm = MB.sourceExternalLinksEditor) {
+        if ((vm = MB.sourceExternalLinksEditor)) {
             vm.getFormData(formName + '.url', fieldCount, pushInput);
 
             if (hasSessionStorage && vm.state.links.length) {

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -112,7 +112,7 @@ const actions = {
         mediums.remove(medium);
         mediums = mediums.peek();
 
-        for (var i = index; medium = mediums[i]; i++) {
+        for (var i = index; (medium = mediums[i]); i++) {
             if (medium.position() === position + 1) {
                 medium.position(position);
             }
@@ -203,7 +203,7 @@ const actions = {
 
     resetTrackPositions: function (tracks, start, offset, removed) {
         let track;
-        for (let i = start; track = tracks[i]; i++) {
+        for (let i = start; (track = tracks[i]); i++) {
             track.position(i + offset);
 
             if (track.number.peek() == (i + offset + removed)) {

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -219,7 +219,7 @@ releaseEditor.edits = {
                     var lastAttempt = (_.last(tmpPositions) + 1) || 1;
                     var attempt;
 
-                    while (attempt = lastAttempt++) {
+                    while ((attempt = lastAttempt++)) {
                         if (_.includes(oldPositions, attempt) ||
                             _.includes(tmpPositions, attempt)) {
                             // This position is taken.
@@ -296,7 +296,7 @@ releaseEditor.edits = {
                  * make sure we swap with it to avoid conflicts.
                  */
                 var removedMedium;
-                if (removedMedium = removedMediums[newPosition]) {
+                if ((removedMedium = removedMediums[newPosition])) {
                     newOrder.push({
                         medium_id:  removedMedium.id,
                         "old":      newPosition,

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -212,13 +212,26 @@ class TimelineViewModel {
 
         _.forEach(parts, function (part) {
             var match;
-            if (match = part.match(/^(-)?([rv])-?$/)) { // trailing - for backwards-compatibility
+
+            /** Please correct me if i'm misunderstanding this
+             * if(match = part.match(RegExp) {
+             *    // Do sth!!
+             * }
+             * 
+             * is equivalent to
+             * 
+             * if(part.match(RegExp)) {
+             *    match = part.match(RegExp);
+             *    // Do sth!!
+             * }
+             *  */ 
+            if ((match = part.match(/^(-)?([rv])-?$/))) { // trailing - for backwards-compatibility
                 var meth = match[2] === 'r' ? 'rate' : 'events';
                 self.options[meth](!(match[1] === '-'));
-            } else if (match = part.match(/^(-)?(c-.*)$/)) {
+            } else if ((match = part.match(/^(-)?(c-.*)$/))) {
                 var category = _.find(self.categories(), { hashIdentifier: match[2] });
                 if (category) { category.enabled(!(match[1] === '-')) }
-            } else if (match = part.match(/^g\/.*$/)) {
+            } else if ((match = part.match(/^g\/.*$/))) {
                 self.zoomHashPart(part);
             } else {
                 match = part.match(/^(-)?(.*)$/);

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -213,18 +213,6 @@ class TimelineViewModel {
         _.forEach(parts, function (part) {
             var match;
 
-            /** Please correct me if i'm misunderstanding this
-             * if(match = part.match(RegExp) {
-             *    // Do sth!!
-             * }
-             * 
-             * is equivalent to
-             * 
-             * if(part.match(RegExp)) {
-             *    match = part.match(RegExp);
-             *    // Do sth!!
-             * }
-             *  */ 
             if ((match = part.match(/^(-)?([rv])-?$/))) { // trailing - for backwards-compatibility
                 var meth = match[2] === 'r' ? 'rate' : 'events';
                 self.options[meth](!(match[1] === '-'));


### PR DESCRIPTION
*Submitted as part of the Google Code-in (GCI) competition*

This pull request aims to make JS files in `/root` directory follows [ESLint](https://eslint.org/) rule [no-cond-assign](https://eslint.org/docs/rules/no-cond-assign). 

**Description:** 
If the assignment is intentional then wrap it with parentheses to signals readers that assigning a new value to the variable (using =) was intended, rather than it being an equality comparison (which should use == or ===) that was wrongly written.

For example: 
`while(foo = bar) // Intentional assignment` 
becomes 
`while((foo = bar)) // Wrap it with parentheses`.
