### PR TITLE
Fixed: E-mail verification is sometimes called confirmation

### DIFF
--- a/lib/MusicBrainz/Script/SubscriptionEmails.pm
+++ b/lib/MusicBrainz/Script/SubscriptionEmails.pm
@@ -122,7 +122,7 @@ sub run {
                                 %$data
                             );
                         } else { printf "... not sending email (dry run)\n" if $self->verbose; }
-                    } else { printf "... no confirmed email address, not sending\n" if $self->verbose; }
+                    } else { printf "... no verified email address, not sending\n" if $self->verbose; }
                 } else { printf "... no current edits found\n" if $self->verbose; }
 
             }

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -622,7 +622,7 @@ sub register : Path('/register') ForbiddenOnSlaves RequireSSL DenyWhenReadonly
 
 =head2 resend_verification
 
-Send out an email allowing users to confirm their email address, from the web
+Send out an email allowing users to verify their email address, from the web
 
 =cut
 
@@ -639,7 +639,7 @@ sub resend_verification : Path('/account/resend-verification') ForbiddenOnSlaves
 
 =head2 _send_confirmation_email
 
-Send out an email allowing users to confirm their email address
+Send out an email allowing users to verify their email address
 
 =cut
 
@@ -665,7 +665,7 @@ sub _send_confirmation_email
     }
     catch {
         $c->flash->{message} = l(
-            '<strong>We were unable to send a confirmation email to you.</strong><br/>Please confirm that you have entered a valid ' .
+            '<strong>We were unable to send a verification email to you.</strong><br/>Please confirm that you have entered a valid ' .
             'address by editing your {settings|account settings}. If the problem still persists, please contact us at ' .
             '{mail|support@musicbrainz.org}.',
             {

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -248,7 +248,7 @@ sub _check_for_confirmed_email {
     unless ($c->user->has_confirmed_email_address) {
         $c->stash(
             title    => l('Send Email'),
-            message  => l('You cannot contact other users because you have not {url|confirmed your email address}.',
+            message  => l('You cannot contact other users because you have not {url|verified your email address}.',
                           {url => $c->uri_for_action('/account/resend_verification')}),
             template => 'user/message.tt',
         );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
@@ -230,7 +230,7 @@ sub recording_submit : Private
     }
 
     if (!$c->user->has_confirmed_email_address) {
-        $self->_error($c, "You must have a confirmed email address to submit edits");
+        $self->_error($c, "You must have a verified email address to submit edits");
     }
 
     $c->model('MB')->with_transaction(sub {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -602,7 +602,7 @@ sub edit : Chained('/') PathPart('ws/js/edit') CaptureArgs(0) Edit {
     }]);
 
     unless ($c->user->has_confirmed_email_address) {
-        $c->forward('/ws/js/detach_with_error', ['a confirmed email address is required']);
+        $c->forward('/ws/js/detach_with_error', ['a verified email address is required']);
     }
     if ($c->user->is_editing_disabled) {
         $c->forward('/ws/js/detach_with_error', ['you are not allowed to enter edits']);

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -602,7 +602,7 @@ sub edit : Chained('/') PathPart('ws/js/edit') CaptureArgs(0) Edit {
     }]);
 
     unless ($c->user->has_confirmed_email_address) {
-        $c->forward('/ws/js/detach_with_error', ['a verified email address is required']);
+        $c->forward('/ws/js/detach_with_error', ['a confirmed email address is required']);
     }
     if ($c->user->is_editing_disabled) {
         $c->forward('/ws/js/detach_with_error', ['you are not allowed to enter edits']);

--- a/root/account/sso/DiscourseUnconfirmedEmailAddress.js
+++ b/root/account/sso/DiscourseUnconfirmedEmailAddress.js
@@ -12,8 +12,8 @@ import React from 'react';
 import Layout from '../../layout';
 
 const DiscourseUnconfirmedEmailAddress = () => (
-  <Layout fullWidth title={l('Unconfirmed Email Address')}>
-    <h2>{l('Unconfirmed Email Address')}</h2>
+  <Layout fullWidth title={l('Unverified Email Address')}>
+    <h2>{l('Unverified Email Address')}</h2>
     <p>
       {exp.l(
         `You must verify your email address before you can

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -60,7 +60,7 @@ function generateUserTypesList(user: EditorT) {
       <span
         className="tooltip"
         title={l(
-          `User accounts must be more than 2 weeks old, have a confirmed
+          `User accounts must be more than 2 weeks old, have a verified
            email address, and more than 10 accepted edits in order
            to vote on others' edits.`,
         )}
@@ -123,7 +123,7 @@ const UserProfileInformation = withCatalystContext(({
     $c.user && !$c.user.has_confirmed_email_address) ? (
       <strong>
         {l(`Your homepage and biography will not show
-            until you have confirmed your email.`)}
+            until you have verified your email.`)}
       </strong>
     ) : null;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -1054,7 +1054,7 @@ test 'Edits are rejected without a confirmed email address' => sub {
     post_json($mech, '/ws/js/edit/create', encode_json({ edits => [] }));
 
     my $response = from_json($mech->content);
-    is($response->{error}, 'a confirmed email address is required', 'error is returned for unconfirmed email');
+    is($response->{error}, 'a verified email address is required', 'error is returned for unconfirmed email');
 };
 
 


### PR DESCRIPTION

Jira Ticket: MBS-8699
Changed all instances of the usage of confirm in the context of emails to verify/verified/verification