### PR TITLE
MBS-10502: Map 45cat/45worlds records with MB RGs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -339,7 +339,7 @@ const CLEANUPS = {
             return prefix === 'artist';
           case LINK_TYPES.otherdatabases.label:
             return prefix === 'label';
-          case LINK_TYPES.otherdatabases.release:
+          case LINK_TYPES.otherdatabases.release_group:
             return prefix === 'record';
         }
       }
@@ -366,7 +366,7 @@ const CLEANUPS = {
             return prefix === 'label';
           case LINK_TYPES.otherdatabases.place:
             return prefix === 'venue';
-          case LINK_TYPES.otherdatabases.release:
+          case LINK_TYPES.otherdatabases.release_group:
             return /^(album|cd|media|music|record)$/.test(prefix);
         }
       }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -30,10 +30,10 @@ const testData = [
   },
   {
                      input_url: 'http://45cat.com/record/vs1370&rc=365077#365077',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'http://www.45cat.com/record/vs1370',
-       only_valid_entity_types: ['release'],
+       only_valid_entity_types: ['release_group'],
   },
   {
                      input_url: 'http://www.45cat.com/45_composer.php?tc=Floyd+Hunt',
@@ -86,31 +86,31 @@ const testData = [
   },
   {
                      input_url: 'http://www.45worlds.com/vinyl/album/mfsl1100',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'http://www.45worlds.com/vinyl/album/mfsl1100',
-       only_valid_entity_types: ['release'],
+       only_valid_entity_types: ['release_group'],
   },
   {
                      input_url: 'http://www.45worlds.com/12single/record/fu2t',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'http://www.45worlds.com/12single/record/fu2t',
-       only_valid_entity_types: ['release'],
+       only_valid_entity_types: ['release_group'],
   },
   {
                      input_url: 'http://www.45worlds.com/cdsingle/cd/pwcd227',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'http://www.45worlds.com/cdsingle/cd/pwcd227',
-       only_valid_entity_types: ['release'],
+       only_valid_entity_types: ['release_group'],
   },
   {
                      input_url: 'http://www.45worlds.com/classical/music/asd264',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'http://www.45worlds.com/classical/music/asd264',
-       only_valid_entity_types: ['release'],
+       only_valid_entity_types: ['release_group'],
   },
   // 7digital (zdigital)
   {


### PR DESCRIPTION
## Fix MBS-10502: 45cat/45worlds URLs point to the wrong place

Prior to this patch, 45cat and 45worlds record URLs were wrongly mapped to MusicBrainz releases. But 45xxx records are identified with catalog number, thus grouping some releases together. This patch maps 45xxx records to MusicBrainz release groups instead.