### PR TITLE
Fix issues relating to eslint rule no-negated-condition

### DIFF
--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -127,14 +127,14 @@ const Head = ({$c, ...props}: HeadProps) => (
 
     {manifest.js('jed-data')}
 
-    {$c.stash.current_language !== 'en' ? (
+    {$c.stash.current_language === 'en' ? null : (
       ['mb_server']
         .concat(props.gettextDomains || [])
         .map(function (domain) {
           const name ='jed-' + $c.stash.current_language + '-' + domain;
           return manifest.js(name, {key: name});
         })
-    ) : null}
+    )}
 
     {manifest.js('common', {
       'data-args': JSON.stringify({

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -239,7 +239,7 @@ const ReleaseSidebar = ({$c, release}: Props) => {
         heading={l('Release group rating')}
       />
 
-      {releaseGroup.review_count != null ? (
+      {releaseGroup.review_count == null ? null : (
         <>
           <h2 className="reviews">
             {l('Release group reviews')}
@@ -248,7 +248,7 @@ const ReleaseSidebar = ({$c, release}: Props) => {
             <CritiqueBrainzLinks releaseGroup={releaseGroup} />
           </p>
         </>
-      ) : null}
+      )}
 
       <SidebarTags
         aggregatedTags={$c.stash.top_tags}

--- a/root/static/scripts/edit/ExampleRelationships.js
+++ b/root/static/scripts/edit/ExampleRelationships.js
@@ -130,11 +130,7 @@ RelationshipSearcher = function () {
             var relationships =
                 _.filter(data.relationships, { linkTypeID: linkTypeID });
 
-            if (!relationships.length) {
-                self.error(
-                    'No ' + linkTypeName + ' relationships found for ' + data.name,
-                );
-            } else {
+            if (relationships.length) {
                 self.error(null);
 
                 _.each(relationships, function (rel) {
@@ -158,6 +154,10 @@ RelationshipSearcher = function () {
                         }
                     })
                 });
+            } else {
+                self.error(
+                    'No ' + linkTypeName + ' relationships found for ' + data.name,
+                );
             }
         });
     };

--- a/root/static/scripts/edit/MB/CoverArt.js
+++ b/root/static/scripts/edit/MB/CoverArt.js
@@ -40,11 +40,7 @@ MB.CoverArt.get_image_mime_type = function () {
 };
 
 MB.CoverArt.image_error = function ($img, image) {
-    if ($img.attr("src") !== image.image)
-    {
-        $img.attr("src", image.image)
-    }
-    else
+    if ($img.attr("src") === image.image)
     {
         /*
          * image doesn't exist at all, perhaps it was removed
@@ -53,6 +49,10 @@ MB.CoverArt.image_error = function ($img, image) {
          * data in the index is incorrect.
          */
         $img.attr("src", require('../../../images/image404-125.png'));
+    }
+    else
+    {
+        $img.attr("src", image.image)
     }
 };
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -892,8 +892,8 @@ MB.GuessCase.Handler.Base = function (gc) {
         is = utils.trim(is);
 
         var joinPhrase = " and ";
-        joinPhrase = (is.indexOf(" + ") != -1 ? " + " : joinPhrase);
-        joinPhrase = (is.indexOf(" & ") != -1 ? " & " : joinPhrase);
+        joinPhrase = (is.indexOf(" + ") == -1 ? joinPhrase : " + ");
+        joinPhrase = (is.indexOf(" & ") == -1 ? joinPhrase : " & ");
 
         return is.split(joinPhrase).map(callback).join(joinPhrase);
     };

--- a/root/static/scripts/guess-case/MB/GuessCase/Output.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Output.js
@@ -96,10 +96,10 @@ MB.GuessCase.Output = function (gc) {
 
     // Returns the last word of the wordlist
     self.getLastWord = function () {
-        if (!self.isEmpty()) {
-            return self._w[self._w.length-1];
-        } else {
+        if (self.isEmpty()) {
             return null;
+        } else {
+            return self._w[self._w.length-1];
         }
     };
 
@@ -113,7 +113,7 @@ MB.GuessCase.Output = function (gc) {
 
     // Capitalize the word at the current cursor position.
     self.capitalizeWordAtIndex = function (index, overrideCaps) {
-        overrideCaps = (overrideCaps != null ? overrideCaps : flags.context.forceCaps);
+        overrideCaps = (overrideCaps == null ? flags.context.forceCaps : overrideCaps);
         if ((!gc.mode.isSentenceCaps() || overrideCaps) &&
             (!self.isEmpty()) &&
             (self.getWordAtIndex(index) != null)) {


### PR DESCRIPTION
*Submitted as part of the Google Code In competition*

This pull request makes stylistic changes only. Where there is a negated condition, like the one below:
```javascript
!boolExpr ? "a" : "b"
```
it is rewritten to not be negated:
```javascript
boolExpr ? "b" : "a"
```

This is to comply with the eslint rule *no-negated-condition*, to make it easier to reason about branching.

<hr>

This pull request is not intended to change any program behaviour, so all I did was negate any conditionals.
