### PR TITLE
REFACTOR: Make line breaks inside parentheses more consistent

### DIFF
--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -43,7 +43,11 @@ const PaginatedResults = ({
               'Found {n} result for "{q}"',
               'Found {n} results for "{q}"',
               pager.total_entries,
-              {n: Number(pager.total_entries).toLocaleString(), q: query})
+              {
+                n: Number(pager.total_entries).toLocaleString(),
+                q: query,
+              },
+            )
           )}
         </p>
       ) : null}

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -433,9 +433,11 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
          */
 
         var results = this.currentResults = _.filter(
-            this.currentResults, function (item) {
+            this.currentResults,
+            function (item) {
                 return !item.action;
-            });
+            },
+        );
 
         results.push.apply(results, data);
 

--- a/root/static/scripts/edit/ExampleRelationships.js
+++ b/root/static/scripts/edit/ExampleRelationships.js
@@ -37,7 +37,8 @@ ERE.init = function (config) {
     ERE.viewModel.availableEntityTypes(
         _.uniq([ type0, type1 ]).map(function (value) {
             return { 'value': value, 'text': ENTITY_NAMES[value]() };
-        }));
+        }),
+    );
 
     ko.bindingHandlers.checkObject = {
         init: function (element, valueAccessor, all, vm, bindingContext) {
@@ -85,7 +86,8 @@ ViewModel = function () {
                 var ce = this.currentExample;
 
                 this.examples.push(
-                    new ERE.Example(ce.name(), ce.relationship()));
+                    new ERE.Example(ce.name(), ce.relationship()),
+                );
 
                 ce.name('');
                 ce.relationship(null);

--- a/root/static/scripts/edit/MB/CoverArt.js
+++ b/root/static/scripts/edit/MB/CoverArt.js
@@ -410,7 +410,11 @@ MB.CoverArt.FileUpload = function (file) {
                     self.updateProgress(2, 100);
 
                     var submitting = MB.CoverArt.submit_edit(
-                        self, postfields, mime_type, position);
+                        self,
+                        postfields, 
+                        mime_type, 
+                        position,
+                    );
 
                     submitting.fail(function (msg) {
                         self.status(statuses.submit_error);
@@ -593,7 +597,10 @@ MB.CoverArt.add_cover_art = function (gid) {
             if (mime_type)
             {
                 $('iframe')[0].contentWindow.upload(
-                    gid, $('#id-add-cover-art\\.id').val(), mime_type);
+                    gid, 
+                    $('#id-add-cover-art\\.id').val(),
+                    mime_type,
+                );
             }
             else
             {

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -17,11 +17,11 @@ class PossibleDuplicates extends React.Component {
         <h3>{l('Possible Duplicates')}</h3>
         <p>{l('We found the following entities with very similar names:')}</p>
         <ul>
-          {this.props.duplicates.map(dupe =>
+          {this.props.duplicates.map(dupe => (
             <li key={dupe.gid}>
               <EntityLink entity={dupe} target="_blank" />
             </li>
-          )}
+          ))}
         </ul>
         <p>
           <label>

--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -60,8 +60,12 @@ MB.forms = {
 
     linkTypeOptions: function (root, backward) {
         function getText(data) {
-            return stripAttributes(data, l_relationships(
-                backward ? data.reverse_link_phrase : data.link_phrase));
+            return stripAttributes(
+                data, 
+                l_relationships(
+                    backward ? data.reverse_link_phrase : data.link_phrase,
+                ),
+            );
         }
 
         var options = MB.forms.buildOptionsTree(root, getText, 'id');

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -275,7 +275,8 @@ recordingAssociation.findRecordingSuggestions = function (track) {
                         delete releaseGroupRecordings.loading;
 
                         recordingAssociation.findRecordingSuggestions(track);
-                    });
+                    },
+                );
             }
             return;
         }

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -157,7 +157,8 @@ const trackParser = releaseEditor.trackParser = {
              * See if we can re-use the AC from the matched track, the previous
              * track at this position, or the release.
              */
-            var matchedAC = _.find([ matchedTrackAC, previousTrackAC, releaseAC ],
+            var matchedAC = _.find(
+                [ matchedTrackAC, previousTrackAC, releaseAC ],
                 function (ac) {
                     if (!ac || hasVariousArtists(ac)) {
                         return false;
@@ -167,7 +168,7 @@ const trackParser = releaseEditor.trackParser = {
                         !data.artist ||
                         utils.similarNames(data.artist, reduceArtistCredit(ac))
                     );
-                }
+                },
             );
 
             if (matchedAC) {

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -128,7 +128,11 @@ class TimelineViewModel {
                     var rateBounds = line.calculateRateBounds(
                         line.rateData().data,
                         line.rateData().thresholds,
-                        {min: self.zoom.xaxis.min(), max: self.zoom.xaxis.max()});
+                        {
+                          min: self.zoom.xaxis.min(),
+                          max: self.zoom.xaxis.max(),
+                        },
+                    );
                     if (accum.min == null || rateBounds.min < accum.min) {
                         accum.min = rateBounds.min;
                     }


### PR DESCRIPTION
*Submitted as part of the Google Code-in (GCI) competition*

This pull request aims to make js files in `/root` directory follows [ESLint](https://eslint.org/) rule [function-paren-newline](https://eslint.org/docs/rules/function-paren-newline) (with 'consistent' option).  

**Description** 
This rule enforces consistent line breaks inside parentheses of function parameters or arguments.

For example: 
 ```
foo(
  bar,
  baz);
```
becomes 
 ```
foo(
  bar,
  baz
);
```
