### PR TITLE
Define eslint globals and set no-undef: error

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -106,6 +106,7 @@ rules:
   no-else-return: warn
   no-eq-null: off
   no-floating-decimal: warn
+  no-global-assign: error
   no-multi-spaces: [error, {ignoreEOLComments: true}]
   no-useless-catch: warn
   radix: warn

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,6 +12,49 @@ env:
   browser: true
   node: true
 
+globals:
+  # Real globals
+  $: readonly
+  jQuery: readonly
+
+  # Fake globals; these are auto-imported upon use by Webpack's
+  # ProvidePlugin, but look like real globals to eslint
+  addColon: readonly
+  addColonText: readonly
+  hyphenateTitle: readonly
+  l: readonly
+  ln: readonly
+  lp: readonly
+  N_l: readonly
+  N_ln: readonly
+  N_lp: readonly
+  exp: readonly
+  texp: readonly
+  l_attributes: readonly
+  ln_attributes: readonly
+  lp_attributes: readonly
+  l_countries: readonly
+  ln_countries: readonly
+  lp_countries: readonly
+  l_instrument_descriptions: readonly
+  ln_instrument_descriptions: readonly
+  lp_instrument_descriptions: readonly
+  l_instruments: readonly
+  ln_instruments: readonly
+  lp_instruments: readonly
+  l_languages: readonly
+  ln_languages: readonly
+  lp_languages: readonly
+  l_relationships: readonly
+  ln_relationships: readonly
+  lp_relationships: readonly
+  l_scripts: readonly
+  ln_scripts: readonly
+  lp_scripts: readonly
+  l_statistics: readonly
+  ln_statistics: readonly
+  lp_statistics: readonly
+
 settings:
   flowtype:
     onlyFilesWithFlowAnnotation: true

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -72,6 +72,7 @@ rules:
   strict: off
 
   # Variables
+  no-undef: error
   no-use-before-define: off
 
   # Stylistic Issues

--- a/root/types.js
+++ b/root/types.js
@@ -613,6 +613,7 @@ declare type IswcT = {
 };
 
 declare type KnockoutObservable<T> = {
+  // eslint-disable-next-line no-undef
   [[call]]: (() => T) & ((T) => empty),
   peek: () => T,
   subscribe: ((T) => void) => {dispose: () => empty},

--- a/root/types.js
+++ b/root/types.js
@@ -15,8 +15,6 @@
  * how data is serialized for us.
  */
 
-/* eslint-disable no-unused-vars */
-
 declare type AggregatedTagT = {
   +count: number,
   +tag: TagT,
@@ -178,7 +176,7 @@ declare type BlogEntryT = {
   +url: string,
 };
 
-type CatalystActionT = {
+declare type CatalystActionT = {
   +name: string,
 };
 
@@ -196,19 +194,19 @@ declare type CatalystContextT = {
   +user_exists: boolean,
 };
 
-type CatalystRequestContextT = {
+declare type CatalystRequestContextT = {
   +headers: {+[header: string]: string},
   +query_params: {+[param: string]: string},
   +secure: boolean,
   +uri: string,
 };
 
-type CatalystSessionT = {
+declare type CatalystSessionT = {
   +merger?: MergeQueueT,
   +tport?: number,
 };
 
-type CatalystStashT = {
+declare type CatalystStashT = {
   +alert?: string,
   +alert_mtime?: number | null,
   +collaborative_collections?: $ReadOnlyArray<CollectionT>,
@@ -239,7 +237,7 @@ type CatalystStashT = {
   +user_tags?: $ReadOnlyArray<UserTagT>,
 };
 
-type CatalystUserT = EditorT;
+declare type CatalystUserT = EditorT;
 
 declare type CDStubT = $ReadOnly<{
   ...EntityRoleT<'cdstub'>,
@@ -275,7 +273,7 @@ declare type CollectionTypeT = {
   item_entity_type: string,
 };
 
-type CommentRoleT = {
+declare type CommentRoleT = {
   +comment: string,
 };
 
@@ -582,7 +580,7 @@ declare type InstrumentT = $ReadOnly<{
 
 declare type InstrumentTypeT = OptionTreeT<'instrument_type'>;
 
-type IpiCodesRoleT = {
+declare type IpiCodesRoleT = {
   +ipi_codes: $ReadOnlyArray<IpiCodeT>,
 };
 
@@ -591,7 +589,7 @@ declare type IpiCodeT = {
   +ipi: string,
 };
 
-type IsniCodesRoleT = {
+declare type IsniCodesRoleT = {
   +isni_codes: $ReadOnlyArray<IsniCodeT>,
 };
 
@@ -653,7 +651,7 @@ declare type LanguageT = {
   +name: string,
 };
 
-type LastUpdateRoleT = {
+declare type LastUpdateRoleT = {
   +last_updated: string | null,
 };
 

--- a/root/vars.js
+++ b/root/vars.js
@@ -12,8 +12,6 @@
  * See /webpack/providePluginConfig.js.
  */
 
-/* eslint-disable no-unused-vars */
-
 declare var addColon: (variable: Expand2ReactInput) => Expand2ReactOutput;
 declare var addColonText: (variable: StrOrNum) => string;
 declare var hyphenateTitle: (title: string, subtitle: string) => string;

--- a/script/check_eslint_rule
+++ b/script/check_eslint_rule
@@ -49,5 +49,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../"
     --global lp_statistics:readonly \
     --rule 'react/jsx-uses-react: warn' \
     --rule 'react/jsx-uses-vars: warn' \
+    --rule 'flowtype/define-flow-type: warn' \
+    --rule 'flowtype/use-flow-type: warn' \
     --rule \
     "$@"

--- a/script/check_eslint_rule
+++ b/script/check_eslint_rule
@@ -10,6 +10,43 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../"
     --plugin flowtype \
     --plugin import \
     --plugin react-hooks \
+    --global '$':readonly \
+    --global jQuery:readonly \
+    --global addColon:readonly \
+    --global addColonText:readonly \
+    --global hyphenateTitle:readonly \
+    --global l:readonly \
+    --global ln:readonly \
+    --global lp:readonly \
+    --global N_l:readonly \
+    --global N_ln:readonly \
+    --global N_lp:readonly \
+    --global exp:readonly \
+    --global texp:readonly \
+    --global l_attributes:readonly \
+    --global ln_attributes:readonly \
+    --global lp_attributes:readonly \
+    --global l_countries:readonly \
+    --global ln_countries:readonly \
+    --global lp_countries:readonly \
+    --global l_instrument_descriptions:readonly \
+    --global ln_instrument_descriptions:readonly \
+    --global lp_instrument_descriptions:readonly \
+    --global l_instruments:readonly \
+    --global ln_instruments:readonly \
+    --global lp_instruments:readonly \
+    --global l_languages:readonly \
+    --global ln_languages:readonly \
+    --global lp_languages:readonly \
+    --global l_relationships:readonly \
+    --global ln_relationships:readonly \
+    --global lp_relationships:readonly \
+    --global l_scripts:readonly \
+    --global ln_scripts:readonly \
+    --global lp_scripts:readonly \
+    --global l_statistics:readonly \
+    --global ln_statistics:readonly \
+    --global lp_statistics:readonly \
     --rule 'react/jsx-uses-react: warn' \
     --rule 'react/jsx-uses-vars: warn' \
     --rule \


### PR DESCRIPTION
This wasn't enabled before because all of these real/fake globals would trigger the error, rendering it useless.

I've also set `no-global-assign: error`, which is good to have. (Our code doesn't have any such issues.)

https://eslint.org/docs/rules/no-undef
https://eslint.org/docs/rules/no-global-assign