### PR TITLE
REFACTOR: Eliminate usage of variables outside their context

### DIFF
--- a/root/static/scripts/edit/forms.js
+++ b/root/static/scripts/edit/forms.js
@@ -136,7 +136,7 @@ ko.bindingHandlers.loop = {
                 items = observableArray.peek(),
                 removals = [];
 
-            for (var i = 0, change, j, node; (change = changes[i]); i++) {
+            for (let i = 0, change, node; (change = changes[i]); i++) {
                 var status = change.status;
 
                 if (status === "retained") {
@@ -160,7 +160,7 @@ ko.bindingHandlers.loop = {
                              */
                             tmpElementContainer = document.createElement("div");
 
-                            for (j = 0; (node = template[j]); j++) {
+                            for (let j = 0; (node = template[j]); j++) {
                                 tmpElementContainer.appendChild(node.cloneNode(true));
                             }
 
@@ -172,7 +172,7 @@ ko.bindingHandlers.loop = {
                     }
                 } else if (status === "deleted") {
                     if (change.moved === undefined) {
-                        for (j = 0; (node = currentElements[j]); j++) {
+                        for (let j = 0; (node = currentElements[j]); j++) {
                             /*
                              * If the node is already removed for some unknown
                              * reason, don't outright explode. It's possible
@@ -199,7 +199,7 @@ ko.bindingHandlers.loop = {
                     elementsToInsert = currentElements[0];
                 } else {
                     elementsToInsert = document.createDocumentFragment();
-                    for (j = 0; (node = currentElements[j]); j++) {
+                    for (let j = 0; (node = currentElements[j]); j++) {
                         elementsToInsert.appendChild(node);
                     }
                 }

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -844,7 +844,7 @@ MB.GuessCase.Handler.Base = function (gc) {
                     const pos = gc.i.getPos();
                     const len = gc.i.getLength();
                     let currPos = pos;
-                    while(currPos < len) {
+                    while (currPos < len) {
                         if (gc.i.getWordAtIndex(currPos) == "(") {
                             break;
                         }

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -841,20 +841,22 @@ MB.GuessCase.Handler.Base = function (gc) {
                      *    though :]
                      * Blah (feat. Erroll Flynn Some Remixname) (remix)
                      */
-                    var pos = gc.i.getPos();
-                    var len = gc.i.getLength();
-                    for (var i = pos; i < len; i++) {
-                        if (gc.i.getWordAtIndex(i) == "(") {
+                    const pos = gc.i.getPos();
+                    const len = gc.i.getLength();
+                    let currPos = pos;
+                    while(currPos < len) {
+                        if (gc.i.getWordAtIndex(currPos) == "(") {
                             break;
                         }
+                        currPos++;
                     }
 
                     /*
                      * We got a part, but not until the end of the string
                      * close feat. part, and add space to next set of brackets
                      */
-                    if (i != pos && i < len-1) {
-                        gc.i.insertWordsAtIndex(i, [")", " "]);
+                    if (currPos != pos && currPos < len-1) {
+                        gc.i.insertWordsAtIndex(currPos, [")", " "]);
                     }
                     gc.i.updateCurrentWord("(");
                     self.doOpeningBracket();

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -67,8 +67,8 @@ MB.GuessCase = MB.GuessCase || {};
              * a special case, fetch the correct format, if the
              * returned case is indeed a special case.
              */
-            let num = handler.checkSpecialCase(is);
-            let os = handler.isSpecialCase(num) 
+            const num = handler.checkSpecialCase(is);
+            const os = handler.isSpecialCase(num) 
                 ? handler.getSpecialCaseFormatted(is, num)
                 // if it was not a special case, start Guessing
                 : handler[method].apply(handler, arguments);

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -48,7 +48,7 @@ MB.GuessCase = MB.GuessCase || {};
     // Member functions
 
     function guess(handlerName, method) {
-        var handler;
+        let handler;
 
         /*
          * Guesses the name (e.g. capitalization) or sort name (for aliases)
@@ -67,13 +67,11 @@ MB.GuessCase = MB.GuessCase || {};
              * a special case, fetch the correct format, if the
              * returned case is indeed a special case.
              */
-            var num = handler.checkSpecialCase(is);
-            if (handler.isSpecialCase(num)) {
-                var os = handler.getSpecialCaseFormatted(is, num);
-            } else {
+            let num = handler.checkSpecialCase(is);
+            let os = handler.isSpecialCase(num) 
+                ? handler.getSpecialCaseFormatted(is, num)
                 // if it was not a special case, start Guessing
-                var os = handler[method].apply(handler, arguments);
-            }
+                : handler[method].apply(handler, arguments);
 
             return os;
         };

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -399,9 +399,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
         }
 
         paddedSeriesNumber() {
-            var attributes = this.attributes(), numberAttribute;
+            const attributes = this.attributes();
+            let numberAttribute;
 
-            for (var i = 0; (numberAttribute = attributes[i]); i++) {
+            for (let i = 0; (numberAttribute = attributes[i]); i++) {
                 if (numberAttribute.type.gid === SERIES_ORDERING_ATTRIBUTE) {
                     break;
                 }
@@ -411,10 +412,10 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 return "";
             }
 
-            var parts = _.compact(numberAttribute.textValue().split(/(\d+)/)),
-                integerRegex = /^\d+$/;
+            const integerRegex = /^\d+$/;
+            let parts = _.compact(numberAttribute.textValue().split(/(\d+)/));
 
-            for (var i = 0, part; (part = parts[i]); i++) {
+            for (let i = 0, part; (part = parts[i]); i++) {
                 if (integerRegex.test(part)) {
                     parts[i] = _.padStart(part, 10, "0");
                 }

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -413,7 +413,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             }
 
             const integerRegex = /^\d+$/;
-            let parts = _.compact(numberAttribute.textValue().split(/(\d+)/));
+            const parts = _.compact(numberAttribute.textValue().split(/(\d+)/));
 
             for (let i = 0, part; (part = parts[i]); i++) {
                 if (integerRegex.test(part)) {

--- a/root/static/scripts/relationship-editor/common/multiselect.js
+++ b/root/static/scripts/relationship-editor/common/multiselect.js
@@ -194,7 +194,7 @@ import deferFocus from '../../edit/utility/deferFocus';
                     break;
                 case 38: // up arrow
                     if (menuItemActive) {
-                        var nextItem = activeElement.previousSibling;
+                        let nextItem = activeElement.previousSibling;
 
                         while (nextItem && nextItem.style.display === "none") {
                             nextItem = nextItem.previousSibling;
@@ -206,7 +206,7 @@ import deferFocus from '../../edit/utility/deferFocus';
                     break;
                 case 40: // down arrow
                     if (menuItemActive) {
-                        var nextItem = activeElement.nextSibling;
+                        let nextItem = activeElement.nextSibling;
 
                         while (nextItem && nextItem.style.display === "none") {
                             nextItem = nextItem.nextSibling;

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -194,11 +194,11 @@ MB.initRelationshipEditors = function (args) {
 };
 
 MB.getRelationship = function (data, source) {
-    var target = data.target;
+    const target = data.target;
 
     data = _.clone(data);
 
-    var backward = source.entityType > target.entityType;
+    let backward = source.entityType > target.entityType;
 
     if (source.entityType === target.entityType) {
         backward = (data.direction === "backward");
@@ -206,19 +206,21 @@ MB.getRelationship = function (data, source) {
 
     data.entities = backward ? [target, source] : [source, target];
 
-    var viewModel = getRelationshipEditor(data, source);
+    const viewModel = getRelationshipEditor(data, source);
 
     if (viewModel) {
-        if (data.id) {
-            var cacheKey = _.map(data.entities, "entityType").concat(data.id).join("-");
-            var cached = viewModel.cache[cacheKey];
+        const relationship = new viewModel.relationshipClass(data, source, viewModel);
+        if (data.id) {      
+            const cacheKey = _.map(data.entities, "entityType").concat(data.id).join("-");
+            let cached = viewModel.cache[cacheKey];
 
             if (cached) {
                 return cached;
             }
+
+            return (viewModel.cache[cacheKey] = relationship);
         }
-        var relationship = new viewModel.relationshipClass(data, source, viewModel);
-        return data.id ? (viewModel.cache[cacheKey] = relationship) : relationship;
+        return relationship;
     }
 };
 

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -212,7 +212,7 @@ MB.getRelationship = function (data, source) {
         let cacheKey;
         if (data.id) {      
             cacheKey = _.map(data.entities, "entityType").concat(data.id).join("-");
-            let cached = viewModel.cache[cacheKey];
+            const cached = viewModel.cache[cacheKey];
 
             if (cached) {
                 return cached;

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -209,18 +209,17 @@ MB.getRelationship = function (data, source) {
     const viewModel = getRelationshipEditor(data, source);
 
     if (viewModel) {
-        const relationship = new viewModel.relationshipClass(data, source, viewModel);
+        let cacheKey;
         if (data.id) {      
-            const cacheKey = _.map(data.entities, "entityType").concat(data.id).join("-");
+            cacheKey = _.map(data.entities, "entityType").concat(data.id).join("-");
             let cached = viewModel.cache[cacheKey];
 
             if (cached) {
                 return cached;
             }
-
-            return (viewModel.cache[cacheKey] = relationship);
         }
-        return relationship;
+        const relationship = new viewModel.relationshipClass(data, source, viewModel);
+        return data.id ? (viewModel.cache[cacheKey] = relationship) : relationship;
     }
 };
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -759,10 +759,11 @@ class Barcode {
             return false;
         }
 
-        for (var i = 0, calc = 0; i < 12; i++) {
+        let calc = 0;
+        for (let i = 0; i < 12; i++) {
             calc += parseInt(barcode[i]) * this.weights[i];
         }
-
+        
         var digit = 10 - (calc % 10);
         return digit === 10 ? 0 : digit;
     }

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -763,7 +763,7 @@ class Barcode {
         for (let i = 0; i < 12; i++) {
             calc += parseInt(barcode[i]) * this.weights[i];
         }
-        
+
         var digit = 10 - (calc % 10);
         return digit === 10 ? 0 : digit;
     }

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -485,19 +485,19 @@ trackParser.customDelimiterError = debounce(function () {
 })
 
 function optionCookie(name, defaultValue, checkbox=true) {
-    let existingValue = getCookie(name);
+    const existingValue = getCookie(name);
 
-    let observable = checkbox  
-        ? ko.observable(
-            defaultValue  
-                ? existingValue !== "false"
-                : existingValue === "true"
-          )
-        : ko.observable(
-            existingValue 
-                ? existingValue 
-                : defaultValue
-          )
+    const observable = checkbox  
+          ? ko.observable(
+              defaultValue  
+                  ? existingValue !== "false"
+                  : existingValue === "true"
+            )
+          : ko.observable(
+              existingValue 
+                  ? existingValue 
+                  : defaultValue
+            )
 
     observable.subscribe(function (newValue) {
         setCookie(name, newValue);

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -485,17 +485,19 @@ trackParser.customDelimiterError = debounce(function () {
 })
 
 function optionCookie(name, defaultValue, checkbox=true) {
-    var existingValue = getCookie(name);
+    let existingValue = getCookie(name);
 
-    if (checkbox) {
-      var observable = ko.observable(
-          defaultValue ? existingValue !== "false" : existingValue === "true"
-      );
-    } else {
-      var observable = ko.observable(
-          existingValue ? existingValue : defaultValue
-      );
-    }
+    let observable = checkbox  
+        ? ko.observable(
+            defaultValue  
+                ? existingValue !== "false"
+                : existingValue === "true"
+          )
+        : ko.observable(
+            existingValue 
+                ? existingValue 
+                : defaultValue
+          )
 
     observable.subscribe(function (newValue) {
         setCookie(name, newValue);

--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -612,10 +612,11 @@ class TimelineLine {
                 }
 
                 var plot = $.plot($(element), _.map(lines, function (line) {
+                    let data;
                     if (graph === 'main' || graph === 'overview') {
-                        var data = line.data();
+                        data = line.data();
                     } else if (graph === 'rate') {
-                        var data = line.rateData().data;
+                        data = line.rateData().data;
                     }
                     return {
                         data: data,


### PR DESCRIPTION
*Submitted as part of the Google Code-in (GCI) competition*

This pull request aims to make js files in `/root` directory follows [ESLint](https://eslint.org/) rule [block-scoped-var](https://eslint.org/docs/rules/block-scoped-var). 

**Description** 
 Ensure that variables are not used outside the block where they were defined. Change any usage of "var" to its block-scoped variant "let" (or "const" if the variable is constant, i.e. never reassigned). If a variable is simply repurposed later on, make that second use a new, different variable.