### PR TITLE
Code style: eslint consistent-return (2)

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -589,6 +589,8 @@ $.widget("ui.menu", $.ui.menu, {
              */
             event.stopPropagation();
             event.preventDefault();
+
+            return true;
         }
     },
 

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -554,6 +554,7 @@ $.widget("mb.entitylookup", $.ui.autocomplete, {
         if (arguments.length) {
             recentEntities[entityType] = _.take(arguments[0], MAX_RECENT_ENTITIES);
             localStorage("recentAutocompleteEntities", JSON.stringify(recentEntities));
+            return undefined;
         } else {
             return recentEntities[entityType] || [];
         }
@@ -591,6 +592,8 @@ $.widget("ui.menu", $.ui.menu, {
 
             return true;
         }
+
+        return false;
     },
 
     _create: function () {

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -592,6 +592,8 @@ $.widget("ui.menu", $.ui.menu, {
 
             return true;
         }
+
+        return undefined;
     },
 
     _create: function () {

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -1050,6 +1050,8 @@ MB.Control.EntityAutocomplete = function (options) {
                 options.entity = entity;
                 return true;
             }
+
+            return false;
         });
     }
 

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -589,8 +589,6 @@ $.widget("ui.menu", $.ui.menu, {
              */
             event.stopPropagation();
             event.preventDefault();
-
-            return true;
         }
     },
 

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -590,10 +590,10 @@ $.widget("ui.menu", $.ui.menu, {
             event.stopPropagation();
             event.preventDefault();
 
-            return true;
+            return false;
         }
 
-        return undefined;
+        return true;
     },
 
     _create: function () {
@@ -602,7 +602,7 @@ $.widget("ui.menu", $.ui.menu, {
     },
 
     select: function (event) {
-        if (!this._selectAction(event)) {
+        if (this._selectAction(event)) {
             this._super(event);
         }
         /*

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -592,8 +592,6 @@ $.widget("ui.menu", $.ui.menu, {
 
             return true;
         }
-
-        return false;
     },
 
     _create: function () {

--- a/root/static/scripts/common/MB/release.js
+++ b/root/static/scripts/common/MB/release.js
@@ -83,8 +83,9 @@ $(function () {
 
               if (position > $other.data('position')) {
                 insertAfter = $other;
+                return true;
               } else {
-                return false;
+                return false; // prematurely stop iterating
               }
             });
 

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -271,7 +271,7 @@ function bubbleControlHandler(event) {
                 bubble.hide(false);
             }
         }
-        return;
+        return true;
     }
 
     var isButton = $(control).is(":button");

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -273,7 +273,7 @@ function bubbleControlHandler(event) {
                 bubble.hide(false);
             }
         }
-        return true;
+        return undefined;
     }
 
     var isButton = $(control).is(":button");

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -190,6 +190,8 @@ import request from '../../common/utility/request';
                 if (_(event.date).values().some(nonEmpty) || event.country_id !== null) {
                     return event;
                 }
+
+                return null;
             }).compact().value();
 
             return {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -436,7 +436,7 @@ const CLEANUPS = {
         return 'https://www.amazon.' + tld + '/gp/product/' + asin;
       }
 
-      return undefined;
+      return null;
     },
     validate: function (url) {
       return /^https:\/\/www\.amazon\.(com|ca|co\.uk|fr|at|de|it|co\.jp|jp|cn|es|in|com\.br|com\.mx|com\.au)\//.test(url);

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -435,6 +435,8 @@ const CLEANUPS = {
       if (tld !== '' && asin !== '') {
         return 'https://www.amazon.' + tld + '/gp/product/' + asin;
       }
+
+      return undefined;
     },
     validate: function (url) {
       return /^https:\/\/www\.amazon\.(com|ca|co\.uk|fr|at|de|it|co\.jp|jp|cn|es|in|com\.br|com\.mx|com\.au)\//.test(url);
@@ -2395,6 +2397,8 @@ function testAll(tests, text) {
       return true;
     }
   }
+
+  return false;
 }
 
 export const validationRules = {};

--- a/root/static/scripts/edit/confirmNavigationFallback.js
+++ b/root/static/scripts/edit/confirmNavigationFallback.js
@@ -41,11 +41,15 @@ MB.confirmNavigationFallback = function () {
                 return false;
             }
         }
+
+        return true;
     };
 
     document.onkeypress = function () {
         if (prevented) {
             return (prevented = false);
         }
+
+        return true;
     };
 };

--- a/root/static/scripts/edit/confirmNavigationFallback.js
+++ b/root/static/scripts/edit/confirmNavigationFallback.js
@@ -42,7 +42,7 @@ MB.confirmNavigationFallback = function () {
             }
         }
 
-        return true;
+        return undefined;
     };
 
     document.onkeypress = function () {
@@ -50,6 +50,6 @@ MB.confirmNavigationFallback = function () {
             return (prevented = false);
         }
 
-        return true;
+        return undefined;
     };
 };

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -129,6 +129,7 @@ function bestArtistMatch(artists, name) {
             if (similarity >= MIN_NAME_SIMILARITY) {
                 return {similarity: similarity, artist: a, name: name};
             }
+            return null;
         })
         .compact()
         .sortBy('similarity')
@@ -216,6 +217,7 @@ MB.Control.initGuessFeatButton = function (formName) {
             name: function () {
                 if (arguments.length) {
                     nameInput.value = arguments[0];
+                    return undefined;
                 } else {
                     return nameInput.value;
                 }

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -166,7 +166,7 @@ MB.GuessCase.Handler.Artist = function (gc) {
                 return utils.trim(_.compact(names).join(" ") + (append || ""));
             }
 
-            return null;
+            return '';
         });
     };
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -165,6 +165,8 @@ MB.GuessCase.Handler.Artist = function (gc) {
 
                 return utils.trim(_.compact(names).join(" ") + (append || ""));
             }
+
+            return null;
         });
     };
 

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -71,6 +71,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                             }
 
                             dialog.targetType(type);
+                            return true;
                         },
 
                         resultHook: function (items) {
@@ -404,6 +405,8 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                             linkType.gid !== PART_OF_SERIES_LINK_TYPES[itemType]) {
                         return true;
                     }
+
+                    return false;
                 });
             }
 
@@ -423,6 +426,8 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                     if (self.linkTypeOptions(key).length) {
                         return true;
                     }
+
+                    return false;
                 })
             }
 

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -306,7 +306,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
 
         keydownEvent(data, event) {
             if (event.isDefaultPrevented()) {
-                return;
+                return false;
             }
 
             var nodeName = event.target.nodeName.toLowerCase();

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -795,6 +795,8 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 return id;
             }
         }
+
+        return null;
     }
 
     function isCreditable(attribute) {

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -29,6 +29,8 @@ function getDirection(relationship, source) {
   if (source === entities[1]) {
     return 'backward';
   }
+
+  return null;
 }
 
 const RE = MB.relationshipEditor = MB.relationshipEditor || {};

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -30,7 +30,7 @@ function getDirection(relationship, source) {
     return 'backward';
   }
 
-  return null;
+  throw 'source should be in the entities array (which has length 2)';
 }
 
 const RE = MB.relationshipEditor = MB.relationshipEditor || {};

--- a/root/static/scripts/relationship-editor/common/entity.js
+++ b/root/static/scripts/relationship-editor/common/entity.js
@@ -30,7 +30,7 @@ function getDirection(relationship, source) {
     return 'backward';
   }
 
-  throw 'source should be in the entities array (which has length 2)';
+  throw 'source not in the entities array';
 }
 
 const RE = MB.relationshipEditor = MB.relationshipEditor || {};

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -541,6 +541,8 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             if (entity === entities[1]) {
                 return this.entity1_credit;
             }
+
+            return null;
         }
     }
 

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -542,7 +542,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 return this.entity1_credit;
             }
 
-            return null;
+            throw 'entity should be in the entities array (which has length 2)';
         }
     }
 

--- a/root/static/scripts/relationship-editor/common/fields.js
+++ b/root/static/scripts/relationship-editor/common/fields.js
@@ -542,7 +542,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                 return this.entity1_credit;
             }
 
-            throw 'entity should be in the entities array (which has length 2)';
+            throw 'entity not in the entities array';
         }
     }
 

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -232,7 +232,7 @@ function getRelationshipEditor(data, source) {
 
     if ((target && target.entityType === 'url') ||
         (linkType && (linkType.type0 === 'url' || linkType.type1 === 'url'))) {
-        return; // handled by the external links editor
+        return null; // handled by the external links editor
     }
 
     if (MB.releaseRelationshipEditor) {
@@ -242,6 +242,8 @@ function getRelationshipEditor(data, source) {
     if (source === MB.sourceRelationshipEditor.source) {
         return MB.sourceRelationshipEditor;
     }
+
+    return null;
 }
 
 function addSubmittedRelationship(data, source) {

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -220,6 +220,8 @@ MB.getRelationship = function (data, source) {
         var relationship = new viewModel.relationshipClass(data, source, viewModel);
         return data.id ? (viewModel.cache[cacheKey] = relationship) : relationship;
     }
+
+    return null;
 };
 
 function getRelationshipEditor(data, source) {

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -68,7 +68,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
 
             window.addEventListener('beforeunload', function (event) {
                 if (self.redirecting) {
-                    return true;
+                    return undefined;
                 }
                 var $changes = $(".link-phrase")
                     .filter(".rel-edit:eq(0), .rel-add:eq(0), .rel-remove:eq(0)");
@@ -78,7 +78,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                     return event.returnValue;
                 }
 
-                return true;
+                return undefined;
             });
         }
 

--- a/root/static/scripts/relationship-editor/release.js
+++ b/root/static/scripts/relationship-editor/release.js
@@ -68,7 +68,7 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
 
             window.addEventListener('beforeunload', function (event) {
                 if (self.redirecting) {
-                    return;
+                    return true;
                 }
                 var $changes = $(".link-phrase")
                     .filter(".rel-edit:eq(0), .rel-add:eq(0), .rel-remove:eq(0)");
@@ -77,6 +77,8 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
                     event.returnValue = l("All of your changes will be lost if you leave this page.");
                     return event.returnValue;
                 }
+
+                return true;
             });
         }
 

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -73,6 +73,8 @@ class RecordingBubble extends MB.Control.BubbleDoc {
             this.moveToTrack(track, stealFocus === true);
             return true;
         }
+
+        return false;
     }
 
     nextTrack(data, event, stealFocus) {
@@ -84,6 +86,8 @@ class RecordingBubble extends MB.Control.BubbleDoc {
             this.moveToTrack(track, stealFocus === true);
             return true;
         }
+
+        return false;
     }
 
     submit() {

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -212,6 +212,7 @@ class SearchTab {
     keydownEvent(data, event) {
         if (event.keyCode === 13) { // Enter
             this.search(data, event);
+            return false;
         }
         else {
             /*

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -523,7 +523,7 @@ class Medium {
 
     hasInvalidPregapLength() {
         if (!this.hasPregap() || !this.hasToc()) {
-            return;
+            return false;
         }
 
         var maxLength = -Infinity;

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -325,7 +325,7 @@ releaseEditor.releaseLoaded = function (data) {
 releaseEditor.createExternalLinksEditor = function (data, mountPoint) {
     if (!mountPoint) {
         // XXX undefined in some tape tests
-        return;
+        return null;
     }
 
     var self = this;

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -244,6 +244,8 @@ releaseEditor.init = function (options) {
             event.returnValue = l("All of your changes will be lost if you leave this page.");
             return event.returnValue;
         }
+
+        return true;
     });
 
     // Intialize release data/view model.

--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -315,7 +315,7 @@ function setSuggestedRecordings(track, recordings) {
 
 function matchAgainstRecordings(track, recordings) {
     if (!recordings || !recordings.length) {
-        return;
+        return null;
     }
 
     var trackLength = track.length();
@@ -334,6 +334,8 @@ function matchAgainstRecordings(track, recordings) {
             if (utils.similarNames(trackName, recordingWithoutETI)) {
                 return true;
             }
+            
+            return false;
         })
         .sortBy(function (recording) {
             var appearsOn = recording.appearsOn;
@@ -360,6 +362,8 @@ function matchAgainstRecordings(track, recordings) {
             return MB.entity(match, "recording");
         });
     }
+
+    return null;
 }
 
 

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -451,8 +451,10 @@ const trackParser = releaseEditor.trackParser = {
     },
 
     matchDataWithTrack: function (data, track) {
-        // The result of this function will be fed into _.compact so that
-        // null and undefined return values will be stripped.
+        /*
+         * The result of this function will be fed into _.compact so that
+         * null and undefined return values will be stripped.
+         */
         if (!track) {
             return null;
         }

--- a/root/static/scripts/release-editor/trackParser.js
+++ b/root/static/scripts/release-editor/trackParser.js
@@ -92,11 +92,11 @@ const trackParser = releaseEditor.trackParser = {
 
             /*
              * We should've parsed at least some values, otherwise something
-             * went wrong. Returning undefined removes this result from
-             * newTracks.
+             * went wrong. Returning undefined or null removes this result from
+             * newTracks because $.map discards it.
              */
             if (!_.some(_.values(data))) {
-                return;
+                return null;
             }
 
             currentPosition += 1;
@@ -451,8 +451,10 @@ const trackParser = releaseEditor.trackParser = {
     },
 
     matchDataWithTrack: function (data, track) {
+        // The result of this function will be fed into _.compact so that
+        // null and undefined return values will be stripped.
         if (!track) {
-            return;
+            return null;
         }
 
         var similarity = getSimilarity(data.name, track.name.peek());
@@ -460,6 +462,8 @@ const trackParser = releaseEditor.trackParser = {
         if (similarity >= MIN_NAME_SIMILARITY) {
             return { similarity: similarity, track: track, data: data };
         }
+
+        return null;
     }
 };
 


### PR DESCRIPTION
The eslint rule [consistent-return](https://eslint.org/docs/rules/consistent-return) asks that all functions should either:
- Always return a value explicitly (using `return value;` and even `return undefined;`) or
- Never return a value explicitly (using only `return;` or simply by omission)

This means that a function which sometimes returns a value and sometimes doesn't (e.g. it depends on an `if` statement) will be in violation of this rule.

<hr>

I would say that it is possible to categorise when a rewrite in a function occurred as follows:
- *Event listener*: Boolean return value decides whether the default action should be taken by the browser. **Solution: explicitly return the 'default' Boolean)**
- *Undefined indicates that the result should be discarded*. This would often occur in a `_.map` which would be fed into a `_.compact`. **Solution: return `null` to show it's intentional**
- *Unintentional*. If code expects that it is either in state X or in state Y, then `if (X) return 1; if (B) return 2;` should be sufficient. Ideally, this would be rewritten into an `else` construct. If we are not in state A or B, we should throw an error rather than silently return `undefined`. **See review comments**