### PR TITLE
MBS-10511: Regression: Modbot edit references are no longer linkified

### DIFF
--- a/lib/MusicBrainz/Server/Entity/EditNote.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNote.pm
@@ -8,6 +8,7 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
 use MusicBrainz::Server::Entity::Types;
+use MusicBrainz::Server::Filters qw( format_editnote );
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Types qw( DateTime );
 
@@ -58,6 +59,9 @@ sub _localize_text {
         } keys %{$source_args};
 
         $text = l($source->{message} // '', \%args);
+    } else {
+        # Otherwise, assume this message uses edit note syntax.
+        $text = format_editnote($text);
     }
 
     return $text;


### PR DESCRIPTION
# Fix MBS-10511 in beta branch

This was broken in d2f9ced19a20a45e25b5a7e5beb0b7fdb4b726a4 due to all ModBot notes no longer being passed to `format_editnote`. (We don't need to do that if the note is actually localized, because it should be using our translated string syntax to link/format things in that case.)