### PR TITLE
MBS-10497: Limit the number of cache locks

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -121,8 +121,6 @@ author_requires 'Test::NoTabs';
 
 test_requires 'Cache::Null';
 test_requires 'Catalyst::Plugin::Static::Simple';
-# Broken in Perl >= 5.22; the one test that requires it is disabled for now.
-# test_requires 'Coro';
 test_requires 'HTML::HTML5::Parser';
 test_requires 'HTML::HTML5::Sanity';
 test_requires 'HTML::Selector::XPath';

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -4,8 +4,10 @@ use DBDefs;
 use Moose::Role;
 use List::MoreUtils qw( natatime uniq );
 use MusicBrainz::Server::Constants qw( %ENTITIES );
+use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Validation qw( is_database_row_id );
 use Readonly;
+use Time::HiRes qw( time );
 
 requires '_type';
 
@@ -81,8 +83,15 @@ sub _create_cache_entries {
         # deleted in a concurrent transaction. (This is non-blocking;
         # if we fail to acquire the lock for a particular id, we skip
         # the key.)
+        #
+        # MBS-10497: `id % 50` is used to limit the number of locks
+        # obtained per entity type per transaction to be within
+        # PostgreSQL's default configuration value for
+        # max_locks_per_transaction, 64. Note that 64 is not a hard
+        # limit, just an average. A transaction can have as many locks
+        # as will fit in the lock table.
         my $locks = $self->c->sql->select_list_of_hashes(
-            'SELECT id, pg_try_advisory_xact_lock(?, id) AS got_lock ' .
+            'SELECT id, pg_try_advisory_xact_lock(?, id % 50) AS got_lock ' .
             '  FROM unnest(?::integer[]) AS id',
             $cache_id,
             \@next_ids,
@@ -114,13 +123,31 @@ sub _delete_from_cache {
     # MBS-7241: Lock cache deletions from `_create_cache_entries`
     # above, so that these keys can't be repopulated until after the
     # database transaction commits.
-    my @row_ids = grep { is_database_row_id($_) } @ids;
-    $self->c->sql->do(
-        'SELECT pg_advisory_xact_lock(?, id) ' .
-        '  FROM unnest(?::integer[]) AS id',
-        $cache_id,
-        \@row_ids,
-    ) if @row_ids;
+    my @row_ids = uniq
+        # MBS-10497: Limit the number of locks obtained per cache id
+        # per transaction to 50; see the comment in
+        # `_create_cache_entries` above. This increases the chance of
+        # contention, but invalidating cache entries is infrequent
+        # enough that it shouldn't matter.
+        map { $_ % 50 }
+        grep { is_database_row_id($_) } @ids;
+    if (@row_ids) {
+        my $start_time = time;
+        $self->c->sql->do(
+            'SELECT pg_advisory_xact_lock(?, id) ' .
+            '  FROM unnest(?::integer[]) AS id',
+            $cache_id,
+            \@row_ids,
+        );
+        my $elapsed_time = (time - $start_time);
+        if ($elapsed_time > 0.01) {
+            log_debug {
+                "[$start_time] _delete_from_cache: waited $elapsed_time" .
+                ' seconds for ' . (scalar @row_ids) .
+                " locks with cache id $cache_id"
+            };
+        }
+    }
 
     my $cache_prefix = $self->_type . ':';
     my @keys = map { $cache_prefix . $_ } @ids;

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -73,6 +73,7 @@ sub _create_cache_entries {
         @ids = @ids[0..$MAX_CACHE_ENTRIES];
     }
 
+    my $ttl = DBDefs->ENTITY_CACHE_TTL;
     my $it = natatime 100, @ids;
     while (my @next_ids = $it->()) {
         # MBS-7241
@@ -84,7 +85,7 @@ sub _create_cache_entries {
         );
         push @entries, map {
             my $id = $_->{id};
-            [$cache_prefix . $id, $data->{$id}, DBDefs->ENTITY_CACHE_TTL]
+            [$cache_prefix . $id, $data->{$id}, ($ttl ? $ttl : ())]
         } grep { $_->{got_lock} } @$locks;
     }
 


### PR DESCRIPTION
This limits the number of cache locks we have open per entity type per transaction by mapping entity IDs to locks IDs with `% 50`.

This may increase contention, but cache deletions are relatively infrequent compared to reads. If desired we could add some logging in cases where it waits longer than 10ms or so for a lock.