### PR TITLE
MBS-6539: Allow resolving MBIDs of unknown type

### DIFF
--- a/lib/MusicBrainz/Server/Controller/MBID.pm
+++ b/lib/MusicBrainz/Server/Controller/MBID.pm
@@ -1,0 +1,45 @@
+package MusicBrainz::Server::Controller::MBID;
+use Moose;
+
+use MusicBrainz::Server::Constants qw( entities_with );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
+use MusicBrainz::Server::Validation qw( is_guid );
+
+BEGIN { extends 'MusicBrainz::Server::Controller'; }
+
+sub base : Path('/mbid') CaptureArgs(0) { }
+
+sub show : Path('/mbid') CaptureArgs(1) {
+    my ($self, $c, $gid) = @_;
+
+    my $is_guid = is_guid($gid);
+
+    if ($is_guid) {
+        for my $model (entities_with('mbid', take => 'model')) {
+            my $entity = $c->model($model)->get_by_gid($gid) or next;
+            $c->response->redirect(
+                $c->uri_for_action(
+                    $c->controller($model)->action_for('show'),
+                    [ $gid ]));
+            $c->detach;
+        }
+    }
+
+    $c->stash(
+        component_path => 'mbid/NotFound',
+        component_props => {isGuid => boolean_to_json($is_guid), mbid => $gid},
+        current_view => 'Node',
+    );
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Controller/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/OtherLookup.pm
@@ -60,16 +60,7 @@ lookup_handler 'barcode' => sub {
 lookup_handler 'mbid' => sub {
     my ($self, $c, $gid) = @_;
 
-    for my $model (entities_with('mbid', take => 'model')) {
-        my $entity = $c->model($model)->get_by_gid($gid) or next;
-        $c->response->redirect(
-            $c->uri_for_action(
-                $c->controller($model)->action_for('show'),
-                [ $gid ]));
-        $c->detach;
-    }
-
-    $self->not_found($c);
+    $c->forward('/mbid/show', [$gid]);
 };
 
 lookup_handler 'url' => sub {

--- a/root/mbid/NotFound.js
+++ b/root/mbid/NotFound.js
@@ -1,0 +1,51 @@
+/*
+ * @flow
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React from 'react';
+
+import NotFound from '../components/NotFound';
+
+const MbidNotFound = ({isGuid, mbid}: {+isGuid: boolean, +mbid?: string}) => (
+  <NotFound title={isGuid ? l('MBID Not Found') : l('Invalid MBID')}>
+    <p>
+      {mbid && isGuid ? (
+        exp.l(
+          `No MusicBrainz {entity_doc|entities} match the {mbid_doc|MBID}
+           {mbid}. Either it’s incorrect, it was for an entity that has since
+           been deleted, or it is an ID for something else than an entity
+           (for example, a {rel_type_table|relationship type}).`,
+          {
+            entity_doc: '/doc/MusicBrainz_Entity',
+            mbid: mbid,
+            mbid_doc: '/doc/MusicBrainz_Identifier',
+            rel_type_table: '/relationships',
+          },
+        )
+      ) : (
+        mbid ? (
+          exp.l(
+            '{mbid} is not a valid {mbid_doc|MBID}.',
+            {
+              mbid: mbid,
+              mbid_doc: '/doc/MusicBrainz_Identifier',
+            },
+          )
+        ) : (
+          exp.l(
+            'No {mbid_doc|MBID} selected.',
+            {mbid_doc: '/doc/MusicBrainz_Identifier'},
+          )
+
+        )
+      )}
+    </p>
+  </NotFound>
+);
+
+export default MbidNotFound;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -80,6 +80,7 @@ module.exports = {
   'label/LabelRelationships': require('../label/LabelRelationships'),
   'main/404': require('../main/404'),
   'main/index': require('../main/index'),
+  'mbid/NotFound': require('../mbid/NotFound'),
   'oauth2/OAuth2Authorize': require('../oauth2/OAuth2Authorize'),
   'oauth2/OAuth2Error': require('../oauth2/OAuth2Error'),
   'oauth2/OAuth2Oob': require('../oauth2/OAuth2Oob'),

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -218,6 +218,8 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Label::withdraw_tags",
   "Controller::Label::tags",
   "Controller::Label::wikipedia_extract",
+  "Controller::MBID::base",
+  "Controller::MBID::show",
   "Controller::Medium::base",
   "Controller::Medium::fragments",
   "Controller::OAuth2::authorize",


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-6539

This takes the quite hidden MBID "search" in the /search page and makes it possible to do /mbid/$mbid to redirect to the entity that MBID represents, whatever its type. The /search page option now just forwards to this.