### PR TITLE
MBS-10521: Fix format in /ws/js/medium search

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -127,7 +127,7 @@ sub tracklist_results {
                 gid => $release->gid,
                 name => $release->name,
                 position => $medium->position,
-                format => $medium->format_name,
+                format => $medium->format ? $medium->format->TO_JSON : undef,
                 medium => $medium->name,
                 comment => $release->comment,
                 artist => $release->artist_credit->name,


### PR DESCRIPTION
c4f6823e4465fb7dff9a631250d19079a4b32238 changed the release editor to no longer treat format as a string, but the `tracklist_results` subroutine in WS::js wasn't changed to match the corresponding TO_JSON changes.