### PR TITLE
MBS-10524: /account/change-password is broken unless logged in

### DIFF
--- a/root/account/change_password.tt
+++ b/root/account/change_password.tt
@@ -1,7 +1,4 @@
-[% WRAPPER "user/profile/layout.tt" page="change_password" title=l("Change Password") %]
-
-    <h2>[% l("Change Password") %]</h2>
-
+[% BLOCK page_content %]
     [%- IF mandatory -%]
     <p>[% l('Please change your password. Unfortunately we\'ve discovered that
              secure hashes user\'s passwords were temporarily available for
@@ -27,5 +24,16 @@
         [% form_submit(l('Change Password')) %]
         </div>
     </form>
-
 [% END %]
+
+[%- IF c.user_exists -%]
+    [% WRAPPER "user/profile/layout.tt" page="change_password" title=l("Change Password") %]
+        <h2>[% l("Change Password") %]</h2>
+        [% PROCESS page_content %]
+    [% END %]
+[%- ELSE -%]
+    [% WRAPPER "layout.tt" full_width=1 title=l("Change Password") %]
+        <h1>[% l("Change Password") %]</h1>
+        [% PROCESS page_content %]
+    [% END %]
+[%- END -%]


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10524

The issue is ultimately that `UserAccountTabs` requires a user to function. It doesn't make sense to use user/profile/layout.tt at all without a user, but it "worked" until the React conversion because TT allows magic behavior.

This patch uses the normal layout if the user isn't logged in.