### PR TITLE
MBS-10292: Normalize and validate QIM URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1698,7 +1698,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www22\\.)?big\\.or\\.jp', 'i'),
       new RegExp('^(https?://)?(www\\.)?japanesemetal\\.gooside\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?d-nb\\.info', 'i'),
-      new RegExp('^(https?://)?(www\\.)?qim\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?mainlynorfolk\\.info', 'i'),
       new RegExp('^(https?://)?(www\\.)?tedcrane\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?thedancegypsy\\.com', 'i'),
@@ -1795,6 +1794,39 @@ const CLEANUPS = {
   'purevolume': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?purevolume\\.com', 'i')],
     type: LINK_TYPES.purevolume,
+  },
+  'quebecinfomusique': {
+    match: [new RegExp('^(https?://)?(www\\.)?(qim|quebecinfomusique)\\.com', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(
+        /^(?:https?:\/\/)?(?:www\.)?(?:qim|quebecinfomusique)\.com\/([^#]+).*$/i,
+        'http://www.qim.com/$1',
+      );
+      url = url.replace(
+        /^(http:\/\/www\.qim\.com\/artistes)\/(?:albums|oeuvres)\b/,
+        '$1/biographie',
+      );
+      return url;
+    },
+    validate: function (url, id) {
+      const m = /^http:\/\/www\.qim\.com\/(\w+)\/(\w+)\.asp\?(.+)$/.exec(url);
+      if (m) {
+        const [/* matched string */, type, page, query] = m;
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return type === 'artistes' && page === 'biographie' &&
+              /^artistid=\d+$/.test(query);
+          case LINK_TYPES.otherdatabases.release_group:
+            return type === 'albums' && page === 'description' &&
+              /^albumid=\d+$/.test(query);
+          case LINK_TYPES.otherdatabases.work:
+            return type === 'oeuvres' && page === 'oeuvre' &&
+              /^oeuvreid=\d+&albumid=\d+$/.test(query);
+        }
+      }
+      return false;
+    },
   },
   'recochoku': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?recochoku\\.jp', 'i')],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2428,9 +2428,47 @@ const testData = [
   },
   // QIM (Québec Info Musique)
   {
-                     input_url: 'http://www.qim.com/artistes/biographie.asp?artistid=47',
+                     input_url: 'http://QIM.com/artistes/biographie.asp?artistid=47',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.qim.com/artistes/biographie.asp?artistid=47',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://QuebecInfoMusique.com/artistes/albums.asp?artistid=47',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.qim.com/artistes/biographie.asp?artistid=47',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'http://www.quebecinfomusique.com/artistes/oeuvres.asp?artistid=47#',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.qim.com/artistes/biographie.asp?artistid=47',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'http://www.qim.com/artistes/nawak.asp?artistid=47',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'http://www.qim.com/artistes/nawak.asp?artistid=47',
+       input_relationship_type: 'otherdatabases',
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'http://www.qim.com/albums/description.asp?albumid=16',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.qim.com/albums/description.asp?albumid=16',
+       only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'http://www.qim.com/oeuvres/oeuvre.asp?oeuvreid=716&albumid=16',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.qim.com/oeuvres/oeuvre.asp?oeuvreid=716&albumid=16',
+       only_valid_entity_types: ['work'],
   },
   // RecoChoku
   {


### PR DESCRIPTION
# Implement MBS-10292: Improve QIM URLs matching, add cleanup and validation

## Match
`quebecinfomusique.com` (additionally to `qim.com`)

## Normalize
- protocol to `http` (as `https` is not available)
- domain name to `www.qim.com` (which has the best SEO)
- `artistes/` subpage to `biography` (which exists for every entry)

## Allow linking
- QIM "artistes" with MB artist
- QIM "albums" with MB release group
- QIM "oeuvres" with MB work