### PR TITLE
MBS-10531: Document and fix handling of maps service access token

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -374,6 +374,10 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/", shift) };
 # sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
+# Mapbox access token must be set to display area/place maps.
+# sub MAPBOX_MAP_ID { 'mapbox.streets' }
+# sub MAPBOX_ACCESS_TOKEN { '' }
+
 # Disallow OAuth2 requests over plain HTTP
 # sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
 

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -358,6 +358,7 @@ sub COVER_ART_ARCHIVE_SECRET_KEY { };
 sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/", shift) };
 sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
+# Mapbox access token must be set to display area/place maps.
 sub MAPBOX_MAP_ID { 'mapbox.streets' }
 sub MAPBOX_ACCESS_TOKEN { '' }
 

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -13,6 +13,7 @@ import {withCatalystContext} from '../context';
 import PlaceList from '../components/list/PlaceList';
 import PaginatedResults from '../components/PaginatedResults';
 import * as manifest from '../static/manifest';
+import * as DBDefs from '../static/scripts/common/DBDefs-client';
 
 import AreaLayout from './AreaLayout';
 
@@ -36,8 +37,19 @@ const AreaPlaces = ({
 
     {places?.length ? (
       <>
-        <div id="largemap" />
-        {manifest.js('area/places-map.js', {'data-args': mapDataArgs})}
+        {DBDefs.MAPBOX_ACCESS_TOKEN ? (
+          <>
+            <div id="largemap" />
+            {manifest.js('area/places-map.js', {'data-args': mapDataArgs})}
+          </>
+        ) : (
+          <p>
+            {l(
+              `A map cannot be shown because no maps service access token has
+               been set for this server.`,
+            )}
+          </p>
+        )}
         <form action="/place/merge_queue" method="post">
           <PaginatedResults pager={pager}>
             <PlaceList

--- a/root/place/PlaceMap.js
+++ b/root/place/PlaceMap.js
@@ -10,6 +10,7 @@
 import React from 'react';
 
 import * as manifest from '../static/manifest';
+import * as DBDefs from '../static/scripts/common/DBDefs-client';
 
 import PlaceLayout from './PlaceLayout';
 
@@ -30,10 +31,19 @@ const PlaceMap = ({
 }: Props) => (
   <PlaceLayout entity={place} page="map" title={l('Map')}>
     {place.coordinates ? (
-      <>
-        <div id="largemap" />
-        {manifest.js('place/map.js', {'data-args': mapDataArgs})}
-      </>
+      DBDefs.MAPBOX_ACCESS_TOKEN ? (
+        <>
+          <div id="largemap" />
+          {manifest.js('place/map.js', {'data-args': mapDataArgs})}
+        </>
+      ) : (
+        <p>
+          {l(
+            `A map cannot be shown because no maps service access token has
+             been set for this server.`,
+          )}
+        </p>
+      )
     ) : (
       <p>
         {l('A map cannot be shown because this place has no coordinates.')}


### PR DESCRIPTION
# Fix MBS-10531: Invalid requests are sent to maps service when access token is not set

- Document `MAPBOX_ACCESS_TOKEN` in sample config
- Prevent sending unauthorized requests to the maps service
- Display explanatory message instead of incomplete map