### PR TITLE
Run chrome with disable-dev-shm-usage in tests

### DIFF
--- a/docker/musicbrainz-tests/chrome.service
+++ b/docker/musicbrainz-tests/chrome.service
@@ -2,6 +2,7 @@
 
 exec sudo -E -H -u musicbrainz google-chrome-stable \
     --headless \
+    --disable-dev-shm-usage \
     --disable-gpu \
     --no-sandbox \
     --remote-debugging-port=9222

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -125,6 +125,7 @@ const driver = (x => {
       new chrome.Options()
         .headless()
         .addArguments(
+          'disable-dev-shm-usage',
           'no-sandbox',
           'proxy-server=http://localhost:5050',
         )

--- a/t/selenium/release-editor/Duplicate_Selection.html
+++ b/t/selenium/release-editor/Duplicate_Selection.html
@@ -69,6 +69,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>pause</td>
+	<td>500</td>
+	<td></td>
+</tr>
+<tr>
 	<td>assertEval</td>
 	<td>Array.from(document.querySelectorAll('#duplicates-tab table.tbl > tbody > tr')).map(x => Array.from(x.querySelectorAll('td')).slice(1).map(x => x.textContent.trim()).join('\t')).join('\n')</td>
 	<td>Whatever It Takes	CD	2	2017-11-17	XE	Interscope RecordsKIDinaKORNER	06025671583940602567158394	0602567158394


### PR DESCRIPTION
We're starting to get page crashes in our Selenium tests since the Solr/sir integration was merged. This might have to do with /dev/shm being too small in the CircleCI container.