### PR TITLE
Generate source maps in production

### DIFF
--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -203,7 +203,7 @@ plugins.push.apply(plugins, [
 module.exports = {
   context: dirs.CHECKOUT,
 
-  devtool: DBDefs.DEVELOPMENT_SERVER ? 'cheap-source-map' : undefined,
+  devtool: 'source-map',
 
   entry: entries,
 
@@ -250,6 +250,7 @@ if (String(process.env.WATCH_MODE) === '1') {
 if (!DBDefs.DEVELOPMENT_SERVER) {
   module.exports.optimization.minimizer = [
     new TerserPlugin({
+      sourceMap: true,
       terserOptions: {
         safari10: true,
       },


### PR DESCRIPTION
This generates source maps (mapped to the original source) in production, to be hosted on StaticBrainz. Sentry can use these to display better stack traces.

For development, I checked the difference in build time between source-map and cheap-source-map, and it was negligible (less than a second or two for me). Didn't check for rebuilds, though.

I don't see any issue with exposing these publicly since it doesn't contain any private data and the code is open source.