### PR TITLE
Fixed files so that objects do not use non-prototype-builtins, going along with the ESLint guidelines.

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -1048,7 +1048,7 @@ MB.Control.EntityAutocomplete = function (options) {
          * having a 'length' property.
          */
         for (const key in item) {
-            if (item.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(item, key)) {
                 $hidden.filter("input." + key)
                     .val(item[key]).trigger("change");
             }

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -67,7 +67,9 @@ class Autocomplete extends React.Component {
       autocomplete.element.val(next.name);
     }
 
-    if (Object.prototype.hasOwnProperty.call(nextProps, 'isLookupPerformed')) {
+    if (Object.prototype.hasOwnProperty.call(
+      nextProps, 'isLookupPerformed'
+    )) {
       autocomplete.element.toggleClass(
         'lookup-performed',
         !!nextProps.isLookupPerformed,

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -67,7 +67,7 @@ class Autocomplete extends React.Component {
       autocomplete.element.val(next.name);
     }
 
-    if (nextProps.hasOwnProperty('isLookupPerformed')) {
+    if (Object.prototype.hasOwnProperty.call(nextProps, 'isLookupPerformed')) {
       autocomplete.element.toggleClass(
         'lookup-performed',
         !!nextProps.isLookupPerformed,

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -68,7 +68,8 @@ class Autocomplete extends React.Component {
     }
 
     if (Object.prototype.hasOwnProperty.call(
-      nextProps, 'isLookupPerformed'
+      nextProps,
+      'isLookupPerformed',
     )) {
       autocomplete.element.toggleClass(
         'lookup-performed',

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -290,7 +290,9 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       };
 
       if (!this.state.positiveTagsOnly || isAlwaysVisible(t)) {
-        const isGenre = Object.prototype.hasOwnProperty.call(this.genreMap, t.tag.name);
+        const isGenre = Object.prototype.hasOwnProperty.call(
+          this.genreMap, t.tag.name
+        );
 
         const tagRow = (
           <TagRow

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -291,7 +291,8 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
       if (!this.state.positiveTagsOnly || isAlwaysVisible(t)) {
         const isGenre = Object.prototype.hasOwnProperty.call(
-          this.genreMap, t.tag.name
+          this.genreMap,
+          t.tag.name,
         );
 
         const tagRow = (

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -290,7 +290,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       };
 
       if (!this.state.positiveTagsOnly || isAlwaysVisible(t)) {
-        const isGenre = this.genreMap.hasOwnProperty(t.tag.name);
+        const isGenre = Object.prototype.hasOwnProperty.call(this.genreMap, t.tag.name);
 
         const tagRow = (
           <TagRow

--- a/root/static/scripts/common/utility/getCookie.js
+++ b/root/static/scripts/common/utility/getCookie.js
@@ -6,7 +6,7 @@ import _cookies from './_cookies';
 let defaultExport = getCookieFallback;
 
 function getCookieFallback(name, defaultValue = undefined) {
-  return _cookies.hasOwnProperty(name) ? _cookies[name] : defaultValue;
+  return Object.prototype.hasOwnProperty.call(_cookies, name) ? _cookies[name] : defaultValue;
 }
 
 function getCookieBrowser(name, defaultValue = undefined) {

--- a/root/static/scripts/common/utility/getCookie.js
+++ b/root/static/scripts/common/utility/getCookie.js
@@ -6,8 +6,9 @@ import _cookies from './_cookies';
 let defaultExport = getCookieFallback;
 
 function getCookieFallback(name, defaultValue = undefined) {
-  let cookieHasName = Object.prototype.hasOwnProperty.call(_cookies, name);
-  return cookieHasName ? _cookies[name] : defaultValue;
+  return Object.prototype.hasOwnProperty.call(_cookies, name)
+    ? _cookies[name]
+    : defaultValue;
 }
 
 function getCookieBrowser(name, defaultValue = undefined) {

--- a/root/static/scripts/common/utility/getCookie.js
+++ b/root/static/scripts/common/utility/getCookie.js
@@ -6,7 +6,7 @@ import _cookies from './_cookies';
 let defaultExport = getCookieFallback;
 
 function getCookieFallback(name, defaultValue = undefined) {
-  let cookieHasName = Object.prototype.hasOwnProperty.call(_cookies, name)
+  let cookieHasName = Object.prototype.hasOwnProperty.call(_cookies, name);
   return cookieHasName ? _cookies[name] : defaultValue;
 }
 

--- a/root/static/scripts/common/utility/getCookie.js
+++ b/root/static/scripts/common/utility/getCookie.js
@@ -6,7 +6,8 @@ import _cookies from './_cookies';
 let defaultExport = getCookieFallback;
 
 function getCookieFallback(name, defaultValue = undefined) {
-  return Object.prototype.hasOwnProperty.call(_cookies, name) ? _cookies[name] : defaultValue;
+  let cookieHasName = Object.prototype.hasOwnProperty.call(_cookies, name)
+  return cookieHasName ? _cookies[name] : defaultValue;
 }
 
 function getCookieBrowser(name, defaultValue = undefined) {


### PR DESCRIPTION
In accordance with ESLint, the files in musicbrainz-server have been edited to have no objects use non-prototype-builtins.

**Disambiguation:**
Instead of objects using the `.hasOwnProperty` method in the following way:
`object.hasOwnProperty('name')`
they would do it in the following way instead:
`Object.prototype.hasOwnProperty.call(object, 'name')`
where `object` is the object that the method is being called on.

**Command:** `./script/check_eslint_rule 'no-prototype-builtins: warn' root/`
