### PR TITLE
MBS-10309: Updated URL cleanup for musik-sammler

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1539,7 +1539,9 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?musik-sammler\\.de/', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/(album|artist|media)\/([0-9a-z-]+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/$1/$2/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/artist\/([0-9a-zA-Z-%]+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/artist/$1/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/album\/(?:[^\/]+-(?=[\d\/]))?(\d+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/album/$1/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?musik-sammler\.de\/(?:media|release)\/(?:[^\/]+-(?=[\d\/]))?(\d+)(?:[\/?#].*)?$/, 'https://www.musik-sammler.de/release/$1/');
       return url;
     },
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2097,31 +2097,28 @@ const testData = [
   },
   // Musik-Sammler.de
   {
-                     input_url: 'http://www.musik-sammler.de/artist/100743',
+                     input_url: 'http://musik-sammler.de/artist/strafe-f%C3%BCr-rebellion/',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.musik-sammler.de/artist/strafe-f%C3%BCr-rebellion/',
   },
   {
-                     input_url: 'http://www.musik-sammler.de/artist/end-of-a-year/#',
+                     input_url: 'https://www.musik-sammler.de/artist/210311/?view=compact#disco-header',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://www.musik-sammler.de/artist/end-of-a-year/',
-  },
-  {
-                     input_url: 'https://musik-sammler.de/artist/100743?test',
-             input_entity_type: 'artist',
-    expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://www.musik-sammler.de/artist/100743/',
+            expected_clean_url: 'https://www.musik-sammler.de/artist/210311/',
   },
   {
                      input_url: 'http://www.musik-sammler.de/media/594158',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.musik-sammler.de/release/594158/',
   },
   {
-                     input_url: 'http://www.musik-sammler.de/album/364515',
+                     input_url: 'https://www.musik-sammler.de/album/terrorgruppe-melodien-f%C3%BCr-milliarden-56725/',
              input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.musik-sammler.de/album/56725/',
   },
   {
                      input_url: 'https://www.musik-sammler.de/album/804508/review/rain/',
@@ -2130,10 +2127,10 @@ const testData = [
             expected_clean_url: 'https://www.musik-sammler.de/album/804508/',
   },
   {
-                     input_url: 'musik-sammler.de/media/594158',
+                     input_url: 'musik-sammler.de/release/594158',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://www.musik-sammler.de/media/594158/',
+            expected_clean_url: 'https://www.musik-sammler.de/release/594158/',
   },
   // Musixmatch
   {


### PR DESCRIPTION
Since musik-sammler changed the URL format for releases a tiny bit, I have updated the cleanup URL along with the suggested changes by chaban. See https://tickets.metabrainz.org/browse/MBS-10309