### PR TITLE
MBS-10492: Display leading 0 in minute and second

### DIFF
--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -33,8 +33,8 @@ const patterns = {
   '%A': ['weekday', {weekday: 'long'}],
   '%B': ['month', {month: 'long'}],
   '%H': ['hour', {hour: '2-digit', hour12: false}],
-  '%M': ['minute', {minute: '2-digit'}],
-  '%S': ['second', {second: '2-digit'}],
+  '%M': ['minute', {minute: '2-digit', hour: '2-digit'}],
+  '%S': ['second', {second: '2-digit', minute: '2-digit'}],
   '%X': [null, {
     hour: 'numeric',
     minute: 'numeric',


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10492

Intl.DateTimeFormat resolves "2-digit" to "numeric" if minute or second are alone in the options object.
This works around it by adding hour/minute.

https://bugzilla.mozilla.org/show_bug.cgi?id=1284868