### PR TITLE
Updated the installation guide.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -383,16 +383,33 @@ If you intend to run a server with translations, there are a few steps to follow
 
 1.  Prerequisites
 
-    Make sure gettext is installed (you need msgmerge and msgfmt, at least),
-    and the transifex client 'tx'
-    (http://help.transifex.com/features/client/index.html):
+    Make sure gettext is installed (you need msgmerge and msgfmt, at least):
 
-        sudo apt-get install gettext transifex-client
+        sudo apt-get install gettext
 
-    You will need to make an account on transifex.com. Configure either a
-    username/password or an API key in ~/.transifexrc; see
-    (https://docs.transifex.com/client/client-configuration#-transifexrc) for
-    its contents.
+    This will enable you to compile and install the translations that are in
+    the source repository.
+    
+    If you want to get the latest translation files or partial work-in-progress
+    translations, or wish to work on translations yourself, you will need to
+    create a [Transifex](https://www.transifex.com/) account and install its
+    client software (`tx`):
+
+        sudo apt-get install transifex-client
+
+    More information (and alternative ways to install the client) can be found
+    at https://docs.transifex.com/client/introduction/.
+
+    Next, create an API token at https://www.transifex.com/user/settings/api/
+    and use it to configure your credentials in `~/.transifexrc`. Details at
+    https://docs.transifex.com/client/client-configuration#-transifexrc.
+    
+    Finally, you will need to join the
+    [MetaBrainz Foundation organization](https://www.transifex.com/musicbrainz/public/)
+    on Transifex to get access to the translations. If you wish to work on
+    translations, you will also need to join a language team at
+    (https://www.transifex.com/musicbrainz/musicbrainz/dashboard/); see also
+    https://musicbrainz.org/doc/Server_Internationalisation#Getting_started.
 
 2.  Change to the po directory
 
@@ -403,12 +420,16 @@ If you intend to run a server with translations, there are a few steps to follow
         tx pull -l {a list of languages you want to pull}
 
     This will download the .po files for your language(s) of choice to the po/
-    folder with the correct filenames.
-    If you want to get /all/ translations, you can also use `tx pull -a`.
+    folder with the correct filenames. Languages are written as an ISO language
+    code, optionally followed by an underscore and an ISO country code (e.g. `fr`
+    for French, `fr_CA` for Canadian French).
 
-    Note that you will need to join the MetaBrainz Foundation organization
-    (https://www.transifex.com/musicbrainz/public/) in order to be able to do
-    this, or you will get `Forbidden` errors from `tx pull`.
+    Or, if you want to get _all_ translations instead:
+
+        tx pull -a
+
+    If you get `Forbidden` errors from `tx pull`, you will need to make sure
+    you have joined the MusicBrainz organization and/or project (see point 1).
 
 4.  Install translations
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -251,8 +251,9 @@ Creating the database
     users (whoever your web server/crontabs run as), to one database (the
     MusicBrainz Database), as one PostgreSQL user. The PostgreSQL database name
     and user name are given in DBDefs.pm (look for the `READWRITE` key).  For
-    example, if you run your web server and crontabs as "www-user", the
-    following configuration recipe may prove useful:
+    example, if you run your web server and crontabs as "www-user", and you have
+    kept the default PostgreSQL user name ("musicbrainz"), the following
+    configuration recipe may prove useful:
 
         # in pg_hba.conf (Note: The order of lines is important!):
         local    musicbrainz_db    musicbrainz    ident    map=mb_map
@@ -267,12 +268,13 @@ Creating the database
 
         local   all    all    trust
 
-    You do not need to create this user in PostgreSQL yourself; the next step will
-    do so (using the password set in lib/DBDefs.pm) if it does not yet exist.
-
     Note that a running PostgreSQL will pick up changes to configuration files
     only when being told so via a `HUP` signal (or by using pg_ctlcluster,
     specifying `reload` as action).
+
+    You do not need to create the PostgreSQL user ("musicbrainz", or whatever
+    name you configured in DBDefs.pm) yourself; the next step will do so
+    (using the password from DBDefs.pm) if it does not exist yet.
 
 3.  Create the database
 
@@ -289,12 +291,12 @@ Creating the database
     2.  Import a database dump
 
         Our database dumps are provided twice a week and can be downloaded from
-        ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/
+        [from a variety of locations](https://musicbrainz.org/doc/MusicBrainz_Database/Download#Download).
+        That page also describes the contents of the various dump files.
 
         To get going, you need at least the mbdump.tar.bz2,
         mbdump-editor.tar.bz2 and mbdump-derived.tar.bz2 archives, but you can
-        grab whichever dumps suit your needs. The online documentation has a
-        [description of the various data dump files](https://musicbrainz.org/doc/MusicBrainz_Database/Download#File_Descriptions).
+        grab whichever dumps suit your needs.
 
         Assuming the dumps have been downloaded to /tmp/dumps/ you can verify
         that the data is correct by running:
@@ -327,8 +329,9 @@ Creating the database
         
         If a full dump is too large for your purposes, but you would like to have some
         real data to test with for development, you can download our database sample,
-        published once a month at 
-        ftp://ftp.musicbrainz.org/pub/musicbrainz/data/sample/
+        published once a month. This can be found at the same places the full dump is
+        found (see above), but using `sample` instead of `fullexport` in the URL.
+        For example: http://ftp.musicbrainz.org/pub/musicbrainz/data/sample/.
 
         You can import this sample dump in the same way as the full dump above.
 
@@ -398,18 +401,19 @@ If you intend to run a server with translations, there are a few steps to follow
         sudo apt-get install transifex-client
 
     More information (and alternative ways to install the client) can be found
-    at https://docs.transifex.com/client/introduction/.
+    [here](https://docs.transifex.com/client/introduction/).
 
-    Next, create an API token at https://www.transifex.com/user/settings/api/
-    and use it to configure your credentials in `~/.transifexrc`. Details at
-    https://docs.transifex.com/client/client-configuration#-transifexrc.
+    Next, [create an API token](https://www.transifex.com/user/settings/api/)
+    and use it to configure your credentials in
+    [`~/.transifexrc`](https://docs.transifex.com/client/client-configuration#-transifexrc).
     
     Finally, you will need to join the
     [MetaBrainz Foundation organization](https://www.transifex.com/musicbrainz/public/)
     on Transifex to get access to the translations. If you wish to work on
-    translations, you will also need to join a language team at
-    (https://www.transifex.com/musicbrainz/musicbrainz/dashboard/); see also
-    https://musicbrainz.org/doc/Server_Internationalisation#Getting_started.
+    translations, you will also need to
+    [join a language team](https://www.transifex.com/musicbrainz/musicbrainz/dashboard/).
+    More information on how to get started can be found on
+    [the MusicBrainz site](https://musicbrainz.org/doc/Server_Internationalisation).
 
 2.  Change to the po directory
 
@@ -436,25 +440,15 @@ If you intend to run a server with translations, there are a few steps to follow
         make install
 
     This will compile and install the files to
-    lib/LocaleData/{language}/LC\_MESSAGES/{domain}.mo
+    `lib/LocaleData/{language}/LC_MESSAGES/{domain}.mo`.
 
-5.  Add the languages to MB\_LANGUAGES in DBDefs.pm. These should be formatted
+5.  Add the languages to `MB_LANGUAGES` in DBDefs.pm. These should be formatted
     {lang}-{country}, e.g. 'es', or 'fr-ca', in a space-separated list.
 
-6.  Ensure you have a system locale for any languages you want to use, and for
-    some languages, be wary of https://rt.cpan.org/Public/Bug/Display.html?id=78341
-
-    For many languages, this will suffice:
+6.  Ensure you have a system locale for any languages you want to use. For many
+    languages, this will suffice:
 
         sudo apt-get install language-pack-{language code}
-
-    To work around the linked CPAN bug, you may need to edit the file for Locale::Util
-    to add entries to LANG2COUNTRY. Suggested ones include:
-
-    * es => 'ES'
-    * et => 'EE'
-    * el => 'GR'
-    * sl => 'SI' (this one is there in 1.20, but needs amendment)
 
 
 Troubleshooting

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -270,10 +270,13 @@ Creating the database
     By default, the password for the user musicbrainz should be "musicbrainz",
     as stated in lib/DBDefs.pm. You can change it with `psql`:
 
-        postgres=# ALTER USER musicbrainz UNENCRYPTED PASSWORD 'musicbrainz'
+        postgres=# ALTER USER musicbrainz UNENCRYPTED PASSWORD 'musicbrainz';
+
+    For PostgreSQL 10 or later, you will need to leave off the `UNENCRYPTED`.
 
     Note that a running PostgreSQL will pick up changes to configuration files
-    only when being told so via a `HUP` signal.
+    only when being told so via a `HUP` signal (or by using pg_ctlcluster,
+    specifying `reload` as action).
 
 3.  Create the database
 
@@ -330,9 +333,13 @@ Creating the database
         real data to test with for development, you can download our database sample,
         published once a month at 
         ftp://ftp.musicbrainz.org/pub/musicbrainz/data/sample/
-    
+
         You can import this sample dump in the same way as the full dump above.
-        
+
+    If this process gets interrupted or fails, you will need to manually drop the
+    musicbrainz_db database in order to be able to run `./admin/InitDb.pl --createdb`
+    again.
+
     MusicBrainz Server doesn't enforce any statement timeouts on any SQL it runs.
     If this is an issue in your setup, you may want to set a timeout at the
     database level:
@@ -386,8 +393,10 @@ If you intend to run a server with translations, there are a few steps to follow
 
         sudo apt-get install gettext transifex-client
 
-    Configure a username and password in ~/.transifexrc using the format listed
-    on the above page.
+    You will need to make an account on transifex.com. Configure either a
+    username/password or an API key in ~/.transifexrc; see
+    (https://docs.transifex.com/client/client-configuration#-transifexrc) for
+    its contents.
 
 2.  Change to the po directory
 
@@ -399,6 +408,11 @@ If you intend to run a server with translations, there are a few steps to follow
 
     This will download the .po files for your language(s) of choice to the po/
     folder with the correct filenames.
+    If you want to get /all/ translations, you can also use `tx pull -a`.
+
+    Note that you will need to join the MetaBrainz Foundation organization
+    (https://www.transifex.com/musicbrainz/public/) in order to be able to do
+    this, or you will get `Forbidden` errors from `tx pull`.
 
 4.  Install translations
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -267,12 +267,8 @@ Creating the database
 
         local   all    all    trust
 
-    By default, the password for the user musicbrainz should be "musicbrainz",
-    as stated in lib/DBDefs.pm. You can change it with `psql`:
-
-        postgres=# ALTER USER musicbrainz UNENCRYPTED PASSWORD 'musicbrainz';
-
-    For PostgreSQL 10 or later, you will need to leave off the `UNENCRYPTED`.
+    You do not need to create this user in PostgreSQL yourself; the next step will
+    do so (using the password set in lib/DBDefs.pm) if it does not yet exist.
 
     Note that a running PostgreSQL will pick up changes to configuration files
     only when being told so via a `HUP` signal (or by using pg_ctlcluster,


### PR DESCRIPTION
PostgreSQL changes:
- added a missing ';' to the ALTER USER
- note that for PostgreSQL 10 and later, UNENCRYPTED must be left
  off the ALTER USER
- explicitly note that the database must be dropped to restart an
  interrupted or failed run of InitDb --createdb

Translations:
- adjusted setup instructions, linking to .transifexrc docs
- noted that simply creating an account is not enough to be able
  to download the translations