### PR TITLE
Complete GitHub docs to welcome contributors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://metabrainz.org/donate']

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+    Hello! Thanks for submitting a pull request to MusicBrainz Server.
+    We appreciate your time and interest in helping our project!
+
+    Please use this template to help us review your change.
+
+    Depending on your change, some sections may be unneeded, just remove these.
+    For example, small pull requests usually don’t need the section “Action”.
+
+    Remember that the more helpful info your pull request includes,
+    the easier it is for us to understand and review your changes.
+
+    Ensure that you’ve read through and followed the Contributing Guidelines, at
+    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
+-->
+
+# Problem
+<!--
+    Anything that helps us understand why you are making this change goes here.
+    What problem are you trying to fix? What does this change address?
+-->
+
+:beginner: Reference related tickets with MBS-XXX at least.
+
+
+# Solution
+<!--
+    Talk about technical details, considerations, or other interesting points.
+-->
+
+:beginner: If you have a lot to say, be more detailed in this section.
+
+
+# Checklist for author
+<!--
+    The tasks you have to do to get your change ready for review. Use this if
+    you draft a pull request. Mark done tasks with an [x] as you progress. See
+    https://github.blog/2019-02-14-introducing-draft-pull-requests/
+-->
+
+* [x] Read the [Contributing Guidelines](https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md)
+* [ ] Delete irrelevant parts of this template
+* [ ] Update the [WikiDocs pages](https://wiki.musicbrainz.org/Category:WikiDocs_Page)
+  * [ ] :beginner: Page...
+* [ ] :beginner: Task...
+
+
+# Action
+<!--
+    Other than merging your change, do you want / need us to do anything else
+    with your change? This could include reviewing a specific part of your PR.
+-->
+
+1. Make updated WikiDocs pages visible on MusicBrainz website
+2. :beginner: Action...

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,14 @@
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: |
+  Thanks for opening your first pull request for MusicBrainz Server, and welcome to our community! :tada:
+  If you haven’t yet, please check out our [contributing guidelines](https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md).
+  Someone will be reviewing your PR soon; just hang in there!
+  In the meantime, if you’re wondering what to do next, you can have a look at our [issue tracker](https://tickets.metabrainz.org/browse/MBS).
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: |
+  Congratulations on your first merged pull request for MusicBrainz Server! :tada:
+  We’re very thankful for your work, and happy to count you as part of our community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to MusicBrainz Server
+
+Thank you for considering contributing to MusicBrainz Server.
+
+Get started with <https://musicbrainz.org/doc/Development> first,
+then continue reading the additional guidelines below.
+
+Some more general guidelines (not complete yet) are available at
+<https://github.com/metabrainz/guidelines/> too.
+
+## Submitting changes
+
+### Commit message
+
+Please follow the generally accepted [seven rules of a great Git
+commit message](https://chris.beams.io/posts/git-commit/#seven-rules):
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain _what_ and _why_ vs. _how_
+
+Additionally, start the subject line with a ticket reference if applicable.
+
+### Pull request
+
+#### Ticket
+
+If your change is large or relevant to users, it should have a ticket
+in [our issue tracker](https://tickets.metabrainz.org/browse/MBS).
+Create one if necessary.
+Reference it with its key `MBS-XXX`.
+It will be used to follow the progress of the change and to generate
+the release notes that are made available to users on the blog.
+
+Untracked changes are typos, comments, coding style changes, automated
+dependency updates, unnoticeable refactoring, and so on.
+
+#### Title
+
+Describe your change with a short imperative title, e.g.
+
+> Change small unnoticeable bits
+
+If your change resolves a ticket (see [above](#ticket)), please make sure you
+prefix your pull request title with `MBS-XXX: ` in order for our issue tracker
+to link your pull request to that ticket, e.g.
+
+> MBS-1234567: Change things relevant to users
+
+If it **partially resolves** a ticket, use parenthesis, e.g.
+
+> MBS-1234567 (I): Make first part of needed changes
+
+If your change relate to **several tickets**, separate these with commas, e.g.
+
+> MBS-1234567, MBS-2345678: Change two related things at once
+
+#### Comment
+
+Just follow our [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
+
+If your change relates to a ticket, make sure to mention it in the comment, e.g.
+
+```Markdown
+# Summary
+
+Fix MBS-1234567: Change things relevant to users
+```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Contributing
 ------------
 
 Please submit all patches to [GitHub](https://github.com/metabrainz/musicbrainz-server/pulls) for review.
+See the [contributing guidelines](CONTRIBUTING.md).
 
 License
 -------
 
 MusicBrainz Server is released under the GPLv2 or later.
-See the [licenses notice](COPYING.md).
+See the [license notice](COPYING.md).
 
 Further reading
 ---------------

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Please submit all patches to [GitHub](https://github.com/metabrainz/musicbrainz-
 License
 -------
 
-MusicBrainz Server is released under the GPLv2 or later. See COPYING.
+MusicBrainz Server is released under the GPLv2 or later.
+See the [licenses notice](COPYING.md).
 
 Further reading
 ---------------


### PR DESCRIPTION
# Complete GitHub docs

Attempt to follow https://opensource.guide/best-practices/#be-proactive by adding a `CONTRIBUTING.md` file (essentially linking to our development docs for now), a pull request template and a funding link.

Note: Most of our development docs should ultimately be moved to `CONTRIBUTING.md` or other file in the repository itself. Additional hints are a link that has been [shared on `#metabrainz`](https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/4506987/) already, and common practices coupled with keywords that could be used to automate ticket’s transition on submission/merge/beta/release.