### PR TITLE
Fix MBS-10522: Save subscriptions to merge destination

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -313,7 +313,6 @@ sub merge
     $self->isni->merge($new_id, @$old_ids) unless is_special_artist($new_id);
     $self->tags->merge($new_id, @$old_ids);
     $self->rating->merge($new_id, @$old_ids);
-    $self->subscription->merge_entities($new_id, @$old_ids);
     $self->annotation->merge($new_id, @$old_ids);
     $self->c->model('ArtistCredit')->merge_artists($new_id, $old_ids, %opts);
     $self->c->model('Edit')->merge_entities('artist', $new_id, @$old_ids);

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -210,7 +210,6 @@ sub _merge_impl
     $self->isni->merge($new_id, @old_ids);
     $self->tags->merge($new_id, @old_ids);
     $self->rating->merge($new_id, @old_ids);
-    $self->subscription->merge_entities($new_id, @old_ids);
     $self->annotation->merge($new_id, @old_ids);
     $self->c->model('Collection')->merge_entities('label', $new_id, @old_ids);
     $self->c->model('ReleaseLabel')->merge_labels($new_id, @old_ids);

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -93,7 +93,6 @@ sub _merge_impl {
 
     $self->alias->merge($new_id, @old_ids);
     $self->tags->merge($new_id, @old_ids);
-    $self->subscription->merge_entities($new_id, @old_ids);
     $self->annotation->merge($new_id, @old_ids);
     $self->c->model('Collection')->merge_entities('series', $new_id, @old_ids);
     $self->c->model('Edit')->merge_entities('series', $new_id, @old_ids);

--- a/lib/MusicBrainz/Server/Data/Subscription.pm
+++ b/lib/MusicBrainz/Server/Data/Subscription.pm
@@ -209,7 +209,7 @@ sub merge
               $edit_id, @ids);
 }
 
-sub merge_entities
+sub transfer_to_merge_target
 {
     my ($self, $new_id, @old_ids) = @_;
 

--- a/lib/MusicBrainz/Server/Edit/Role/MergeSubscription.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/MergeSubscription.pm
@@ -9,7 +9,7 @@ requires 'subscription_model', '_entity_ids', 'do_merge', '_merge_model';
 around do_merge => sub {
     my ($orig, $self, @args) = @_;
 
-    $self->subscription_model->merge_entities($self->new_entity->{id}, $self->_old_ids);
+    $self->subscription_model->transfer_to_merge_target($self->new_entity->{id}, $self->_old_ids);
     my $editors = $self->subscription_model->delete($self->_old_ids);
     my $entities = $self->c->model($self->_merge_model)->get_by_ids($self->_old_ids);
 

--- a/lib/MusicBrainz/Server/Edit/Role/MergeSubscription.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/MergeSubscription.pm
@@ -9,6 +9,7 @@ requires 'subscription_model', '_entity_ids', 'do_merge', '_merge_model';
 around do_merge => sub {
     my ($orig, $self, @args) = @_;
 
+    $self->subscription_model->merge_entities($self->new_entity->{id}, $self->_old_ids);
     my $editors = $self->subscription_model->delete($self->_old_ids);
     my $entities = $self->c->model($self->_merge_model)->get_by_ids($self->_old_ids);
 


### PR DESCRIPTION
MBS-10522

This was supposed to happen already, but merge_entities was running after the around do_merge code deleted the subscriptions, so there was nothing left for merge_entities to move. This moves it to run as part of the around do_merge section of MergeSubscription, which seems sensible given it's as much part of the subscription merge as the deletion is.
