### PR TITLE
MBS-10562: Add phrases for future (sidebar) dates

### DIFF
--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -46,14 +46,17 @@ export function artistEndAreaLabel(typeId: ?number): string {
   }
 }
 
-export function artistEndLabel(typeId: ?number): string {
+export function artistEndLabel(
+  typeId: ?number,
+  future: boolean = false,
+): string {
   switch (typeId) {
     case 1:
       return l('Died:');
     case 2:
     case 5:
     case 6:
-      return l('Dissolved:');
+      return future ? addColonText(l('Dissolving')) : l('Dissolved:');
     default:
       return l('End date:');
   }

--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -14,7 +14,7 @@ export function artistBeginAreaLabel(typeId: ?number): string {
     case 2:
     case 5:
     case 6:
-      return l('Founded in:');
+      return addColonText(lp('Founded in', 'group artist'));
     default:
       return l('Begin area:');
   }
@@ -27,7 +27,7 @@ export function artistBeginLabel(typeId: ?number): string {
     case 2:
     case 5:
     case 6:
-      return l('Founded:');
+      return addColonText(lp('Founded', 'group artist'));
     default:
       return l('Begin date:');
   }
@@ -40,7 +40,7 @@ export function artistEndAreaLabel(typeId: ?number): string {
     case 2:
     case 5:
     case 6:
-      return l('Dissolved in:');
+      return addColonText(lp('Dissolved in', 'group artist'));
     default:
       return l('End area:');
   }
@@ -56,7 +56,9 @@ export function artistEndLabel(
     case 2:
     case 5:
     case 6:
-      return future ? addColonText(l('Dissolving')) : l('Dissolved:');
+      return future
+        ? addColonText(lp('Dissolving', 'group artist'))
+        : addColonText(lp('Dissolved', 'group artist'));
     default:
       return l('End date:');
   }

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -23,6 +23,7 @@ import entityHref from '../../../static/scripts/common/utility/entityHref';
 import isSpecialPurpose
   from '../../../static/scripts/common/utility/isSpecialPurpose';
 import * as age from '../../../utility/age';
+import isFutureDate from '../../../utility/isFutureDate';
 import ExternalLinks from '../ExternalLinks';
 
 import AnnotationLinks from './AnnotationLinks';
@@ -101,7 +102,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
         <SidebarEndDate
           age={artistAge}
           entity={artist}
-          label={artistEndLabel(artist.typeID)}
+          label={artistEndLabel(artist.typeID, isFutureDate(artist.end_date))}
         />
 
         {endArea ? (

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -60,8 +60,8 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
           entity={place}
           label={
             isFutureDate(place.begin_date)
-              ? addColonText(l('Opening'))
-              : l('Opened:')
+              ? addColonText(lp('Opening', 'place'))
+              : addColonText(lp('Opened', 'place'))
           }
         />
 
@@ -70,8 +70,8 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
           entity={place}
           label={
             isFutureDate(place.end_date)
-              ? addColonText(l('Closing'))
-              : l('Closed:')
+              ? addColonText(lp('Closing', 'place'))
+              : addColonText(lp('Closed', 'place'))
           }
         />
 

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -14,6 +14,7 @@ import CommonsImage
 import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink';
 import * as age from '../../../utility/age';
+import isFutureDate from '../../../utility/isFutureDate';
 import {formatCoordinates, osmUrl} from '../../../utility/coordinates';
 import ExternalLinks from '../ExternalLinks';
 
@@ -57,13 +58,21 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
         <SidebarBeginDate
           age={placeAge}
           entity={place}
-          label={l('Opened:')}
+          label={
+            isFutureDate(place.begin_date)
+              ? addColonText(l('Opening'))
+              : l('Opened:')
+          }
         />
 
         <SidebarEndDate
           age={placeAge}
           entity={place}
-          label={l('Closed:')}
+          label={
+            isFutureDate(place.end_date)
+              ? addColonText(l('Closing'))
+              : l('Closed:')
+          }
         />
 
         {place.address ? (

--- a/root/utility/isFutureDate.js
+++ b/root/utility/isFutureDate.js
@@ -1,0 +1,48 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function isFutureDate(
+  givenDate: PartialDateT | null,
+): boolean {
+  const givenYear = givenDate?.year;
+  if (givenDate == null || givenYear == null) {
+    return false;
+  }
+
+  const now = new Date();
+  const currentDate = {
+    day: now.getUTCDate(),
+    // Months in JavaScript are 0-based. (Days and years are not.)
+    month: now.getUTCMonth() + 1,
+    year: now.getUTCFullYear(),
+  };
+
+  if (givenYear > currentDate.year) {
+    return true;
+  }
+
+  if (givenYear === currentDate.year) {
+    if (givenDate.month == null) {
+      return false;
+    }
+    if (givenDate.month > currentDate.month) {
+      return true;
+    }
+    if (givenDate.month === currentDate.month) {
+      if (givenDate.day == null) {
+        return false;
+      }
+      if (givenDate.day > currentDate.day) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
MBS-10562

This only adds the option for cases that seem likely to happen and where we have custom phrases already. The opening and closing of a place can be announced ahead of time, and so can the dissolution of a group (but it would be strange to announce the foundation of a group before it happens, very dodgy to announce the death of a person and pretty much impossible to specify the birth of one).