### PR TITLE
Fix MBS-10366: Remove rather than renumber pregap track if DiscID is present

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -408,14 +408,32 @@
           <p style="margin-top: 0;">
             <label>
               <input class="has-pregap" type="checkbox" data-bind="checked: hasPregap" />
-              [% l('This disc has a hidden pregap track before track 1 ({info|more info})', { info => { href => doc_link('Hidden_Track'), target => '_blank' } }) %]
+              [% l('This disc has a hidden pregap track before track 1') %]
+              (<a href="#" data-bind="click: togglePregapTrackHelp">[% l('help') %]</a>)
             </label>
+            <div class="ar-descr" data-bind="visible: showPregapTrackHelp">
+              <p>
+                [% l('Some discs contain a hidden track in the pregap section that precedes track 1. Use this to add (or remove) the special pregap track section.') %]
+              </p>
+              <p>
+                [% l('Keep in mind that unselecting this will delete the track if the medium has a disc ID! If you unselect it by mistake, please readd the pregap track before submitting.') %]
+              </p>
+            </div>
           </p>
           <p style="margin-top: 0;">
             <label>
               <input class="has-data-tracks" type="checkbox" data-bind="checked: hasDataTracks" />
-              [% l('This disc contains data tracks at the end ({info|more info})', { info => { href => doc_link('Data_Track'), target => '_blank' } }) %]
+              [% l('This disc contains data tracks at the end') %]
+              (<a href="#" data-bind="click: toggleDataTracksHelp">[% l('help') %]</a>)
             </label>
+            <div class="ar-descr" data-bind="visible: showDataTracksHelp">
+              <p>
+                [% l('Some discs contain one or more data tracks after all audio tracks. Use this to add (or remove) the special data tracks section. You should only add data tracks that contain audio or video ({info|more info})', { info => { href => doc_link('Data_Track'), target => '_blank' } }) %]
+              </p>
+              <p>
+                [% l('Keep in mind that unselecting this will delete the tracks if the medium has a disc ID! If you unselect it by mistake, please readd the data tracks before submitting.') %]
+              </p>
+            </div>
           </p>
         <!-- /ko -->
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -339,7 +339,12 @@ class Medium {
                     const tracks = self.tracks.peek();
                     const pregap = tracks[0];
 
-                    if (pregap.id) {
+                    /*
+                     * If we have a discID, adding a new track 1 is
+                     * problematic, since the normal tracklist is
+                     * supposed to be frozen by the discID.
+                     */
+                    if (pregap.id && !self.hasToc()) {
                         releaseEditor.resetTrackPositions(tracks, 0, 1, -1);
                     } else {
                         self.tracks.shift();
@@ -365,6 +370,12 @@ class Medium {
                 if (oldValue && !newValue) {
                     var dataTracks = self.dataTracks();
 
+                    /*
+                     * If we have a discID, adding new normal tracks
+                     * at the end of the tracklist is problematic,
+                     * since the normal tracklist is supposed to be
+                     * frozen by the discID.
+                     */
                     if (self.hasToc()) {
                         self.tracks.removeAll(dataTracks);
                     } else {

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -319,6 +319,8 @@ class Medium {
         this.position = ko.observable(data.position || 1);
         this.formatID = ko.observable(data.format_id);
         this.formatUnknownToUser = ko.observable(Boolean(data.id && !data.format_id));
+        this.showPregapTrackHelp = ko.observable(false);
+        this.showDataTracksHelp = ko.observable(false);
 
         var tracks = data.tracks;
         this.tracks = ko.observableArray(utils.mapChild(this, tracks, Track));
@@ -471,6 +473,14 @@ class Medium {
         }
 
         this.tracks.push(new Track(data, this));
+    }
+
+    togglePregapTrackHelp() {
+        this.showPregapTrackHelp(!this.showPregapTrackHelp.peek());
+    }
+
+    toggleDataTracksHelp() {
+        this.showDataTracksHelp(!this.showDataTracksHelp.peek());
     }
 
     hasExistingTocs() {


### PR DESCRIPTION
MBS-10366

If a medium has a discID attached, the user shouldn't be able to move the pregap track to track 1 by unchecking the "has pregap" checkbox, since the number of "normal" tracks is frozen by the discID. This makes it so the pregap track is removed if there is a discID, but still renumbered otherwise, which is consistent with the way data tracks work.

I also added a toggleable help section with a second commit, that looks like this: 
![Screenshot from 2020-01-18 23-19-04](https://user-images.githubusercontent.com/1069224/72670717-7d740300-3a49-11ea-978f-3ee3b433f1b1.png)
