### PR TITLE
MBS-10565: Fix item_entity_type field name

### DIFF
--- a/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
@@ -7,7 +7,7 @@ use MusicBrainz::Server::Constants qw( entities_with );
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 
-sub edit_field_names { qw( parent_id child_order name description year has_discids free_text entity_type ) }
+sub edit_field_names { qw( parent_id child_order name description year has_discids free_text item_entity_type ) }
 
 has '+name' => ( default => 'attr' );
 
@@ -42,7 +42,7 @@ has_field 'free_text' => (
     type => 'Boolean',
 );
 
-has_field 'entity_type' => (
+has_field 'item_entity_type' => (
     type => 'Select',
 );
 
@@ -51,7 +51,7 @@ sub options_parent_id {
     return select_options_tree($self->ctx, $self->ctx->stash->{model}, accessor => 'name');
 }
 
-sub options_entity_type {
+sub options_item_entity_type {
     my ($self) = @_;
     return map { $_ => $_ } sort { $a cmp $b } entities_with('collections');
 }

--- a/root/admin/attributes/form.tt
+++ b/root/admin/attributes/form.tt
@@ -32,13 +32,13 @@
 
     [% ELSE %]
         [%~ IF model == "CollectionType" || model == "SeriesType" ~%]
-            [% form_row_select(r, 'entity_type', add_colon(l('Entity type'))) %]
+            [% form_row_select(r, 'item_entity_type', add_colon(l('Entity type'))) %]
             [%~ IF c.action.name == "edit" ~%]
                 <script>
                     $(function () {
-                        $('#id-attr\\.entity_type').prop('disabled', true);
+                        $('#id-attr\\.item_entity_type').prop('disabled', true);
                         $('form[action="[% c.req.uri %]"]').bind('submit', function () {
-                            $('#id-attr\\.entity_type').prop('disabled', false);
+                            $('#id-attr\\.item_entity_type').prop('disabled', false);
                         });
                     });
                 </script>


### PR DESCRIPTION
MBS-10565

The entity type for the items in a series (or collection) is expected to be item_entity_type. This renames the field in the form so that it actually sees and submits the item entity type correctly.