### PR TITLE
Fix MBS-10567: Limit series types as per DB constraint

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -199,6 +199,7 @@
         "removal": {
             "automatic": {}
         },
+        "series": true,
         "tags": true,
         "type": {
             "simple": true
@@ -483,6 +484,7 @@
             "manual": true
         },
         "report_filter": true,
+        "series": true,
         "sitemaps_lastmod_table": true,
         "tags": true,
         "url": "recording"
@@ -528,6 +530,7 @@
             "manual": true
         },
         "report_filter": true,
+        "series": true,
         "sitemaps_lastmod_table": true,
         "tags": true,
         "url": "release"
@@ -576,6 +579,7 @@
             }
         },
         "report_filter": true,
+        "series": true,
         "sitemaps_lastmod_table": true,
         "tags": true,
         "type": {
@@ -741,6 +745,7 @@
             "automatic": {}
         },
         "report_filter": true,
+        "series": true,
         "sitemaps_lastmod_table": true,
         "tags": true,
         "type": {

--- a/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/Attributes.pm
@@ -52,8 +52,9 @@ sub options_parent_id {
 }
 
 sub options_item_entity_type {
-    my ($self) = @_;
-    return map { $_ => $_ } sort { $a cmp $b } entities_with('collections');
+    my ($self, $model) = @_;
+    my $entity_type = $self->ctx->stash->{model} eq 'SeriesType' ? 'series' : 'collections';
+    return map { $_ => $_ } sort { $a cmp $b } entities_with($entity_type);
 }
 
 1;


### PR DESCRIPTION
MBS-10567

When creating a new series type, you can currently select any entity type for the items that is allowed for collections. The list of types allowed for series is different though, meaning that the system will allow you to try to create an artist series type, then fail at the database level when it hits a constraint. This makes it so that only entity types allowed by the allowed_series_entity_type constraint are shown as options for new series types, mirroring the way it's done for collections.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1350