### PR TITLE
Implement MBS-9477, MBS-10568, MBS-10569: DiscID tab improvements

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -510,7 +510,6 @@
         },
         "collections": true,
         "cover_art": true,
-        "custom_tabs": ["discids"],
         "disambiguation": true,
         "edit_table": true,
         "last_updated_column": true,

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -502,6 +502,7 @@ sub TO_JSON {
         own_collections
         release_artwork
         release_artwork_count
+        release_cdtoc_count
         server_details
         server_languages
         subscribed

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -91,6 +91,9 @@ after 'load' => sub {
     my $artwork_count = $c->model('Artwork')->find_count_by_release($release->id);
     $c->stash->{release_artwork_count} = $artwork_count;
 
+    my $cdtoc_count = $c->model('MediumCDTOC')->find_count_by_release($release->id);
+    $c->stash->{release_cdtoc_count} = $cdtoc_count;
+
     # We need to load more artist credits in 'show'
     if ($c->action->name ne 'show') {
         $c->model('ArtistCredit')->load($release);

--- a/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
@@ -75,6 +75,19 @@ sub find_by_discid
     $self->query_to_list($query, [$discid]);
 }
 
+sub find_count_by_release
+{
+    my ($self, $release_id) = @_;
+
+    return unless $release_id; # nothing to do
+    my $query = 'SELECT count(*)
+        FROM ' . $self->_table . '
+          JOIN medium ON medium = medium.id
+        WHERE medium.release = ?';
+
+    return $self->sql->select_single_value($query, $release_id);
+}
+
 sub get_by_medium_cdtoc
 {
     my ($self, $medium_id, $cdtoc_id) = @_;

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -1,11 +1,13 @@
 package MusicBrainz::Server::Entity::Release;
 use Moose;
 
+use List::AllUtils qw( any );
 use List::MoreUtils qw( uniq );
 use MusicBrainz::Server::Entity::Barcode;
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Translation qw( l );
 
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_name );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
@@ -202,6 +204,12 @@ sub may_have_cover_art {
     return shift->cover_art_presence ne 'darkened';
 }
 
+sub may_have_discids {
+    my $self = shift;
+
+    return any { $_->may_have_discids } $self->all_mediums;
+}
+
 sub find_medium_for_recording {
     my ($self, $recording) = @_;
     for my $medium ($self->all_mediums) {
@@ -275,6 +283,7 @@ around TO_JSON => sub {
         status      => $self->status,
         cover_art_presence => $self->cover_art_presence,
         cover_art_url => $self->cover_art_url,
+        may_have_discids => boolean_to_json($self->may_have_discids),
     };
 
     if (my $language = $self->language) {

--- a/root/components/EntityTabLink.js
+++ b/root/components/EntityTabLink.js
@@ -13,13 +13,22 @@ import EntityLink from '../static/scripts/common/components/EntityLink';
 
 type Props = {
   +content: string,
+  +disabled?: boolean,
   +entity: CoreEntityT | CollectionT,
   +selected: boolean,
   +subPath: string,
 };
 
-const EntityTabLink = ({selected, ...linkProps}: Props) => (
-  <li className={selected ? 'sel' : null}>
+const EntityTabLink = ({disabled, selected, ...linkProps}: Props) => (
+  <li
+    className={
+      selected || disabled
+        ? (selected ? 'sel' : '') +
+          (selected && disabled ? ' ' : '') +
+          (disabled ? 'disabled' : '')
+        : null
+    }
+  >
     <EntityLink {...linkProps} />
   </li>
 );

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -18,7 +18,7 @@ import Tabs from './Tabs';
 import EntityTabLink from './EntityTabLink';
 
 const tabLinkNames = {
-  'artists': N_l('Artists'),
+  artists: N_l('Artists'),
   discids: N_l('Disc IDs'),
   events: N_l('Events'),
   fingerprints: N_l('Fingerprints'),

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -19,7 +19,6 @@ import EntityTabLink from './EntityTabLink';
 
 const tabLinkNames = {
   artists: N_l('Artists'),
-  discids: N_l('Disc IDs'),
   events: N_l('Events'),
   fingerprints: N_l('Fingerprints'),
   labels: N_l('Labels'),
@@ -37,10 +36,12 @@ const buildLink = (
   entity,
   subPath,
   page,
+  disabled = false,
   pageName = subPath,
 ) => (
   <EntityTabLink
     content={content}
+    disabled={disabled}
     entity={entity}
     key={subPath}
     selected={pageName === page}
@@ -71,7 +72,7 @@ function buildLinks(
   page: string,
   editTab: ?React.Node,
 ): React.Node {
-  const links = [buildLink(l('Overview'), entity, '', page, 'index')];
+  const links = [buildLink(l('Overview'), entity, '', page, false, 'index')];
   const user = $c.user;
 
   const entityProperties = ENTITIES[entity.entityType];
@@ -84,6 +85,16 @@ function buildLinks(
 
   if (entityProperties.mbid.relatable === 'dedicated') {
     links.push(buildLink(l('Relationships'), entity, 'relationships', page));
+  }
+
+  if (entity.entityType === 'release') {
+    links.push(buildLink(
+      l('Disc IDs'),
+      entity,
+      'discids',
+      page,
+      !entity.may_have_discids /* disable if can't have discids */,
+    ));
   }
 
   if (entityProperties.cover_art) {

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -89,7 +89,12 @@ function buildLinks(
 
   if (entity.entityType === 'release') {
     links.push(buildLink(
-      l('Disc IDs'),
+      entity.may_have_discids
+        ? texp.l(
+          'Disc IDs ({num})',
+          {num: $c.stash.release_cdtoc_count || 0},
+        )
+        : l('Disc IDs'),
       entity,
       'discids',
       page,

--- a/root/release/discids.tt
+++ b/root/release/discids.tt
@@ -46,7 +46,11 @@
             </tbody>
         </table>
     [% ELSE %]
+      [% IF release.may_have_discids %]
         <p>[% l('There are no disc IDs attached to this release; to find out more about how to add one, see {doc|How to Add Disc IDs}.', { doc => doc_link('How_to_Add_Disc_IDs') }) %]</p>
+      [% ELSE %]
+        <p>[% l('This release has no mediums that can have disc IDs.') %]</p>
+      [% END %]
     [% END %]
 
 [%- END -%]

--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -43,6 +43,19 @@ div.tabs {
                     cursor: default;
                 }
             }
+            &.disabled a {
+                &,
+                &:hover,
+                &:focus {
+                    color: @text-black;
+                    background-color: @very-light-grey;
+                    border-color: @very-light-grey;
+                    border-bottom-color: transparent;
+                    cursor: default;
+                    pointer-events: none;
+                }
+            }
+
 
         }
     }

--- a/root/types.js
+++ b/root/types.js
@@ -231,6 +231,7 @@ type CatalystStashT = {
   +own_collections?: $ReadOnlyArray<CollectionT>,
   +release_artwork?: ArtworkT,
   +release_artwork_count?: number,
+  +release_cdtoc_count?: number,
   +server_languages?: $ReadOnlyArray<ServerLanguageT>,
   +subscribed?: boolean,
   +to_merge?: $ReadOnlyArray<CoreEntityT>,

--- a/root/types.js
+++ b/root/types.js
@@ -879,6 +879,7 @@ declare type ReleaseT = $ReadOnly<{
   +language: LanguageT | null,
   +languageID: number | null,
   +length?: number,
+  +may_have_discids?: boolean,
   +packagingID: number | null,
   +quality: QualityT,
   +releaseGroup?: ReleaseGroupT,

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -278,6 +278,7 @@ test 'previewing/creating/editing a release group and release' => sub {
             editsPending => JSON::false,
             cover_art_presence => undef,
             cover_art_url => undef,
+            may_have_discids => JSON::false,
             quality => 1,
         },
         response => $WS_EDIT_RESPONSE_OK,


### PR DESCRIPTION
MBS-9477, MBS-10568, MBS-10569

See commit messages for details. Screenshots:

![Screenshot from 2020-01-14 22-43-05](https://user-images.githubusercontent.com/1069224/72381097-6e2a4800-371f-11ea-9f3e-aec04d36aeba.png)
![Screenshot from 2020-01-14 22-43-08](https://user-images.githubusercontent.com/1069224/72381108-73879280-371f-11ea-9cab-d343101a3610.png)
![Screenshot from 2020-01-14 22-43-10](https://user-images.githubusercontent.com/1069224/72381113-76828300-371f-11ea-93c4-c01bc4ba940f.png)
