### PR TITLE
MBS-10536: Remove span.name-variation around "see all" releases link

### DIFF
--- a/root/release/ReleaseHeader.js
+++ b/root/release/ReleaseHeader.js
@@ -41,7 +41,6 @@ const ReleaseHeader = ({release, page}: Props) => {
             <EntityLink
               content={rgLink}
               entity={release.releaseGroup}
-              nameVariation
             />,
           )}
         </span>


### PR DESCRIPTION
This should only be used if a different entity name (credited name) is being used.