### PR TITLE
MBS-10571: Fix "localized" ModBot email display

### DIFF
--- a/lib/MusicBrainz/Server/Translation.pm
+++ b/lib/MusicBrainz/Server/Translation.pm
@@ -9,6 +9,7 @@ use I18N::LangTags::Detect;
 use List::UtilsBy qw( sort_by );
 use Locale::Messages qw( bindtextdomain LC_MESSAGES );
 use Locale::Util qw( web_set_locale );
+use POSIX qw( setlocale );
 use Text::Balanced qw( extract_bracketed );
 use Unicode::ICU::Collator qw( UCOL_NUMERIC_COLLATION UCOL_ON );
 
@@ -147,6 +148,16 @@ sub set_language
     else {
         return $set_lang;
     }
+}
+
+sub run_without_translations {
+    my ($self, $code) = @_;
+
+    my $prev_locale = setlocale(LC_MESSAGES);
+    $self->unset_language();
+    $code->();
+    setlocale(LC_MESSAGES, $prev_locale);
+    return;
 }
 
 sub unset_language


### PR DESCRIPTION
ModBot's notes can be localized since d2f9ced using a special syntax. Where it was used, the notes weren't being mailed correctly, instead exposing the internal syntax to the recipient.

This passes the ModBot note text through `Entity::EditNote::localize` before sending out the email. `editor_id` and `text` are the only attributes needed to run that method.

The message is sent in English (via a new `run_without_translations` method in `Server::Translation`) because we don't know the language of the recipient. This is the behavior it's always had, of course.