### PR TITLE
Fix MBS-10572: Have one Jed bundle per language

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -37,6 +37,7 @@ module.exports = function (api) {
   const ignore = [
     'node_modules',
     'root/static/scripts/tests/typeInfo.js',
+    /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
   ];
 
   return {

--- a/root/account/EditProfile.js
+++ b/root/account/EditProfile.js
@@ -30,7 +30,6 @@ const EditProfile = ({$c, ...props}: Props) => {
   return (
     <UserAccountLayout
       entity={user}
-      gettextDomains={['attributes']}
       page="edit_profile"
       title={l('Edit Profile')}
     >

--- a/root/area/create.tt
+++ b/root/area/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Area') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Area') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Area') -%]</h1>
         [%- INCLUDE "area/edit_form.tt" -%]

--- a/root/artist/create.tt
+++ b/root/artist/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Artist') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Artist') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Artist') -%]</h1>
         [%- INCLUDE 'artist/edit_form.tt' -%]

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -17,7 +17,6 @@ import UserAccountTabs from './UserAccountTabs';
 type Props = {
   +children: React.Node,
   +entity: EditorT,
-  +gettextDomains?: $ReadOnlyArray<string>,
   +page: string,
   +title?: string,
 };

--- a/root/entity/edit.tt
+++ b/root/entity/edit.tt
@@ -1,3 +1,3 @@
-[%- WRAPPER "$entity_type/layout.tt" title=l('Edit') full_width=1 page='edit' gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER "$entity_type/layout.tt" title=l('Edit') full_width=1 page='edit' -%]
     [%- INCLUDE "$entity_type/edit_form.tt" -%]
 [%- END -%]

--- a/root/event/create.tt
+++ b/root/event/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Event') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Event') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Event') -%]</h1>
         [%- INCLUDE 'event/edit_form.tt' -%]

--- a/root/forms/dialog.tt
+++ b/root/forms/dialog.tt
@@ -8,11 +8,7 @@
       </script>
     </head>
   [% ELSE %]
-    [%- IF !gettext_domains;
-          SET gettext_domains = ['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'];
-        END;
-        React.embed(c, 'layout/components/Head', {
-            gettextDomains => gettext_domains,
+    [%- React.embed(c, 'layout/components/Head', {
             homepage => homepage,
             noIcons => boolean_to_json(no_icons),
             pager => pager,

--- a/root/instrument/create.tt
+++ b/root/instrument/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Instrument') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Instrument') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Instrument') -%]</h1>
         [%- INCLUDE 'instrument/edit_form.tt' new=1 -%]

--- a/root/label/create.tt
+++ b/root/label/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Label') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Label') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Label') -%]</h1>
         [%- INCLUDE 'label/edit_form.tt' -%]

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -5,7 +5,6 @@
             noIcons => boolean_to_json(no_icons),
             pager => pager,
             title => title,
-            gettextDomains => gettext_domains,
         })
     -%]
     <body>

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -18,7 +18,6 @@ import MetaDescription from './MetaDescription';
 
 export type HeadProps = {
   +$c: CatalystContextT,
-  +gettextDomains?: ?$ReadOnlyArray<string>,
   +homepage?: boolean,
   +noIcons?: boolean,
   +pager?: PagerT,
@@ -128,14 +127,9 @@ const Head = ({$c, ...props}: HeadProps) => (
 
     {manifest.js('jed-data')}
 
-    {$c.stash.current_language === 'en' ? null : (
-      ['mb_server']
-        .concat(props.gettextDomains || [])
-        .map(function (domain) {
-          const name ='jed-' + $c.stash.current_language + '-' + domain;
-          return manifest.js(name, {key: name});
-        })
-    )}
+    {$c.stash.current_language === 'en'
+      ? null
+      : manifest.js('jed-' + $c.stash.current_language)}
 
     {manifest.js('common', {
       'data-args': JSON.stringify({

--- a/root/place/create.tt
+++ b/root/place/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Place') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Place') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Place') -%]</h1>
         [%- INCLUDE 'place/edit_form.tt' -%]

--- a/root/recording/create.tt
+++ b/root/recording/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=lp('Add Standalone Recording', 'header') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] %]
+[% WRAPPER 'layout.tt' title=lp('Add Standalone Recording', 'header') full_width=1 %]
     <div id="content">
         <h1>[%- lp('Add Standalone Recording', 'header') -%]</h1>
         [% INCLUDE 'recording/edit_form.tt' %]

--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -1,6 +1,6 @@
 [%- PROCESS 'release/edit/macros.tt' -%]
 
-[%- WRAPPER 'layout.tt' full_width=1 edit=1 gettext_domains=['attributes', 'countries', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' full_width=1 edit=1 -%]
   [% IF release.name %]
     [%- React.embed(c, 'release/ReleaseHeader', { release => release, page => 'edit' }) -%]
   [% ELSE %]

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' full_width=1 title=l('Edit Relationships: {release}', {release => release.name}) -%]
     [% script_manifest('edit.js') %]
 
     [% PROCESS 'components/relationship-editor.tt' %]

--- a/root/release/index.tt
+++ b/root/release/index.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'release/layout.tt' gettext_domains=['countries'] page='index' -%]
+[%- WRAPPER 'release/layout.tt' page='index' -%]
     [%- INCLUDE 'annotation/summary.tt' -%]
 
     <h2 class="tracklist">[% l('Tracklist') %]</h2>

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -106,7 +106,6 @@ const ReleaseGroupIndex = ({
 }: Props) => (
   <ReleaseGroupLayout
     entity={releaseGroup}
-    gettextDomains={['countries']}
     page="index"
   >
     {eligibleForCleanup ? (

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -22,7 +22,6 @@ type Props = {
   +children: ReactNode,
   +entity: ReleaseGroupT,
   +fullWidth?: boolean,
-  +gettextDomains?: ?$ReadOnlyArray<string>,
   +page: string,
   +title?: string,
 };
@@ -31,7 +30,6 @@ const ReleaseGroupLayout = ({
   children,
   entity: releaseGroup,
   fullWidth,
-  gettextDomains,
   page,
   title,
 }: Props) => {
@@ -41,7 +39,6 @@ const ReleaseGroupLayout = ({
   });
   return (
     <Layout
-      gettextDomains={gettextDomains}
       title={title ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/release_group/create.tt
+++ b/root/release_group/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=l('Add Release Group') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] %]
+[% WRAPPER 'layout.tt' title=l('Add Release Group') full_width=1 %]
     <div id="content">
         <h1>[%- lp('Add Release Group', 'header') -%]</h1>
         [%~ javascript_required() ~%]

--- a/root/series/create.tt
+++ b/root/series/create.tt
@@ -1,4 +1,4 @@
-[%- WRAPPER 'layout.tt' title=l('Add Series') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] -%]
+[%- WRAPPER 'layout.tt' title=l('Add Series') full_width=1 -%]
     <div id="content">
         <h1>[%- l('Add Series') -%]</h1>
         [%- INCLUDE 'series/edit_form.tt' new=1 -%]

--- a/root/server/gettext.js
+++ b/root/server/gettext.js
@@ -11,7 +11,7 @@
 
 const Jed = require('jed');
 
-const {jedData} = require('../static/scripts/jed-data');
+const jedData = require('../static/scripts/jed-data');
 const poFile = require('./gettext/poFile');
 
 const jedInstance = new Jed(jedData.en);

--- a/root/static/scripts/common/i18n/wrapGettext.js
+++ b/root/static/scripts/common/i18n/wrapGettext.js
@@ -18,7 +18,7 @@ if (isNodeJS) {
   gettext = require('../../../../server/gettext');
   serverGettext = gettext;
 } else {
-  const {jedData} = require('../../jed-data');
+  const jedData = require('../../jed-data');
   // jedData contains all domains used by the client.
   gettext = new Jed(jedData[jedData.locale]);
 }

--- a/root/static/scripts/jed-data.js
+++ b/root/static/scripts/jed-data.js
@@ -89,18 +89,4 @@ const jedData /*: JedData */ = {
   "locale": "en"
 };
 
-function mergeData(
-  domain /*: GettextDomain */,
-  lang /*: string */,
-  newData /*: JedOptions */,
-) {
-  if (jedData[lang]) {
-    jedData[lang].locale_data[domain] = newData.locale_data[domain];
-  } else {
-    jedData[lang] = newData;
-  }
-  jedData.locale = lang;
-}
-
-exports.jedData = jedData;
-exports.mergeData = mergeData;
+module.exports = jedData;

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -99,7 +99,6 @@ const StatisticsLayout = ({
   return (
     <Layout
       fullWidth={fullWidth}
-      gettextDomains={['attributes', 'relationships', 'statistics']}
       title={htmlTitle}
     >
       <link

--- a/root/statistics/timeline.tt
+++ b/root/statistics/timeline.tt
@@ -22,7 +22,7 @@
     </div>
 [%~ END ~%]
 
-[%~ WRAPPER "statistics/layout.tt" title=l("Timeline Graph") sidebar=sidebar page='timeline' gettext_domains=['attributes', 'statistics'] ~%]
+[%~ WRAPPER "statistics/layout.tt" title=l("Timeline Graph") sidebar=sidebar page='timeline' ~%]
 [%~ PROCESS "statistics/macros-header.tt" ~%]
 
 <h2>[% l('Exact Values (items vs. day)') %]</h2>

--- a/root/work/create.tt
+++ b/root/work/create.tt
@@ -1,4 +1,4 @@
-[% WRAPPER 'layout.tt' title=lp('Add Work', 'header') full_width=1 gettext_domains=['attributes', 'countries', 'instruments', 'instrument_descriptions', 'languages', 'relationships'] %]
+[% WRAPPER 'layout.tt' title=lp('Add Work', 'header') full_width=1 %]
    <h1>[%- lp('Add Work', 'header') -%]</h1>
 
    [% INCLUDE 'work/edit_form.tt' %]


### PR DESCRIPTION
Prior to this patch, we had separate Jed data bundles per language per domain, and any page that used a domain other than mb_server had to specify that so it could be loaded. This was horrible, because we'd have to remember to update these domain lists on every change, and before we did, had to figure out what pages the change affected.

For example, re MBS-10572 an l_countries call was introduced into the ReleaseEvents component, which it turns out is used on a lot of pages that don't have the countries domain loaded.

This patch combines all domain-specific Jed data bundles into a single bundle per language. These new bundles are around 500KB before gzip and loaded on every page if a language is selected. Some unnecessary data will be loaded on some pages now, but on a lot of edit pages we had to load most or all of the domains anyway; this at least reduces the number of HTTP requests in those cases. In other cases, we don't have to worry about loading them now.

There is a potential for future work in reducing the size of these.