### PR TITLE
Install pkg-config to probe ICU headers/libraries

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -172,7 +172,8 @@ Below outlines how to setup MusicBrainz server with local::lib.
             libpq-dev \
             libxml2 \
             libxml2-dev \
-            cpanminus
+            cpanminus \
+            pkg-config
 
 2.  Enable local::lib
 
@@ -228,7 +229,7 @@ Creating the database
     To build our collate extension you will need libicu and its development
     headers, to install these run:
 
-        sudo apt-get install libicu-dev
+        sudo apt-get install libicu-dev pkg-config
 
     With libicu installed, you can build and install the collate extension by
     running:

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -64,6 +64,7 @@ RUN apt-get update && \
         openjdk-8-jre \
         openssh-client \
         perl \
+        pkg-config \
         postgresql \
         postgresql-10-pgtap \
         postgresql-contrib \

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -53,7 +53,8 @@ libicu-dev m4_dnl
 libperl-dev m4_dnl
 libpq-dev m4_dnl
 libssl-dev m4_dnl
-libxml2-dev')
+libxml2-dev m4_dnl
+pkg-config')
 
 # postgresql-server-dev-9.5 provides pg_config, which is needed by InitDb.pl
 # at run-time.


### PR DESCRIPTION
Anticipate postgresql-musicbrainz-collate's switch to pkg-config at https://github.com/metabrainz/postgresql-musicbrainz-collate/pull/5.

Unicode::ICU::Collator 0.004 already uses pkg-config if available, see https://rt.cpan.org/Public/Bug/Display.html?id=86373