### PR TITLE
Fix MBS-10576: Support errors with HTML

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -28,6 +28,7 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Log qw( log_debug );
 use MusicBrainz::Server::Translation qw( comma_list N_l );
+use MusicBrainz::Server::Validation qw( encode_entities );
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Data::CoreEntity';
@@ -936,7 +937,7 @@ sub _link_recording {
     MusicBrainz::Server::Translation->expand(
         '{url|{name}}',
         url => '/recording/' . $recording_info->{gid},
-        name => $recording_info->{name},
+        name => encode_entities($recording_info->{name}),
     );
 }
 

--- a/root/components/FieldErrors.js
+++ b/root/components/FieldErrors.js
@@ -9,17 +9,24 @@
 
 import React from 'react';
 
+import expand2react from '../static/scripts/common/i18n/expand2react';
 import subfieldErrors, {type FieldShape} from '../utility/subfieldErrors';
 
-const buildErrorListItem = (error, index) => (
-  <li key={index}>{error}</li>
-);
+const buildErrorListItem = (error, hasHtmlErrors, index) => {
+  if (hasHtmlErrors) {
+    return (
+      <li key={index}>{expand2react(error)}</li>
+    );
+  }
+  return <li key={index}>{error}</li>;
+};
 
 type Props = {
   +field: FieldShape,
+  +hasHtmlErrors?: boolean,
 };
 
-const FieldErrors = ({field}: Props) => {
+const FieldErrors = ({field, hasHtmlErrors}: Props) => {
   if (!field) {
     return null;
   }
@@ -27,7 +34,9 @@ const FieldErrors = ({field}: Props) => {
   if (errors.length) {
     return (
       <ul className="errors">
-        {errors.map(buildErrorListItem)}
+        {errors.map(function (error, index) {
+          return buildErrorListItem(error, hasHtmlErrors, index);
+        })}
       </ul>
     );
   }

--- a/root/components/FieldErrors.js
+++ b/root/components/FieldErrors.js
@@ -12,6 +12,7 @@ import React from 'react';
 import expand2react from '../static/scripts/common/i18n/expand2react';
 import subfieldErrors, {type FieldShape} from '../utility/subfieldErrors';
 
+// FIXME: Use expandable object instead of HTML string for safety (MBS-10632)
 const buildErrorListItem = (error, hasHtmlErrors, index) => {
   if (hasHtmlErrors) {
     return (

--- a/root/components/FormRowSelect.js
+++ b/root/components/FormRowSelect.js
@@ -20,6 +20,7 @@ type Props = {
   +allowEmpty?: boolean,
   +field: ReadOnlyFieldT<number | string>,
   +frozen?: boolean,
+  +hasHtmlErrors?: boolean,
   +helpers?: React.Node,
   +label: string,
   +onChange?: (event: SyntheticEvent<HTMLSelectElement>) => void,
@@ -36,6 +37,7 @@ const FormRowSelect = ({
   allowEmpty = false,
   frozen = false,
   field,
+  hasHtmlErrors,
   helpers,
   label,
   onChange,
@@ -61,7 +63,7 @@ const FormRowSelect = ({
       />
       {frozen ? <HiddenField field={field} /> : null}
       {helpers}
-      <FieldErrors field={field} />
+      <FieldErrors field={field} hasHtmlErrors={hasHtmlErrors} />
     </FormRow>
   );
 };

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -53,17 +53,25 @@
     </div>
 [%- END -%]
 
-[%- MACRO field_errors(form, field_name) BLOCK # Converted to React at root/components/FieldErrors.js
+[%- MACRO field_errors(form, field_name, has_html_errors) BLOCK # Converted to React at root/components/FieldErrors.js
 -%]
     [% field = form.field(field_name) || field_name %]
     [%- IF field.has_errors OR field.error_fields -%]
         <ul class="errors">
           [%- FOR err IN field.errors -%]
-            <li>[% err | html %]</li>
+            [%- IF has_html_errors -%]
+              <li>[% err %]</li>
+            [% ELSE %]
+              <li>[% err | html %]</li>
+            [% END %]
           [%- END -%]
           [%- FOR field IN field.error_fields -%]
             [% FOR err IN field.errors %]
-            <li>[% err | html %]</li>
+              [%- IF has_html_errors -%]
+                <li>[% err %]</li>
+              [% ELSE %]
+                <li>[% err | html %]</li>
+              [% END %]
             [% END %]
           [%- END -%]
         </ul>
@@ -135,13 +143,13 @@
     </div>
 [%- END -%]
 
-[%- MACRO form_row_select(r, field_name, label, class, attributes) BLOCK # Converted to React at root/components/FormRowSelect.js
+[%- MACRO form_row_select(r, field_name, label, class, attributes, has_html_errors) BLOCK # Converted to React at root/components/FormRowSelect.js
 -%]
     [% attributes = attributes || {}; attributes.class = class %]
     [% WRAPPER form_row %]
       [% r.label(field_name, label || r.form.field(field_name).label, { class => class }) %]
       [% r.select(field_name, attributes) -%]
-      [% field_errors(r.form, field_name) %]
+      [% field_errors(r.form, field_name, has_html_errors) %]
     [% END %]
 [%- END -%]
 

--- a/root/release/merge.tt
+++ b/root/release/merge.tt
@@ -53,7 +53,7 @@
         [% field_errors(form, 'target') %]
 
         [% USE r = FormRenderer(form) %]
-        [% form_row_select(r, 'merge_strategy', l('Merge strategy:')) %]
+        [% form_row_select(r, 'merge_strategy', l('Merge strategy:'), '', {}, 1) %]
 
         <div id="merge-strategy-1" class="merge-strategy">
           <p>


### PR DESCRIPTION
MBS-10576

This allows passing forms errors containing HTML. We interpret the errors as HTML only when specifically requested to ensure we still escape the appropriate characters otherwise.

For now, this changes only form_row_select since that's the one that already has one error using HTML, but we might want to expand it in the future (if we add links to documentation in error texts, for example).

Even though this isn't yet needed anywhere that uses the React components, I'm adding it there already for parity - we'll need it once we convert release/merge anyway.