### PR TITLE
MBS-10579: Unbreak es-es/el-gr translations

### DIFF
--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -62,16 +62,6 @@ function langToPosix(lang) {
   return lang.replace(/^([a-zA-Z]+)-([a-zA-Z]+)$/, function (match, l, c) {
     l = l.toLowerCase();
     c = c.toUpperCase();
-
-    /*
-     * Handle symlinks (see under po/). We want to keep the the result here
-     * consistent regardless of whether someone has el or el-gr in their
-     * MB_LANGUAGE setting, for example.
-     */
-    if (/^(?:el_GR|es_ES)$/.test(`${l}_${c}`)) {
-      return l;
-    }
-
     return l + '_' + c.toUpperCase();
   });
 }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10579

The code and associated comment here don't make sense to me. The language used in the Jed files should match what's in DBDefs, since that's what gets set in the lang cookie and is what's used to fetch the file.

I'd also be in favor of changing these to es/el (without country codes) in `MB_LANGUAGES` in production and removing the symlinks - they were to work around a bug in `Locale::Util` that's been fixed for years. But in that case we'd still remove this code as unused.