### PR TITLE
MBS-10584: Collapse work artists if too many

### DIFF
--- a/root/server/components.js
+++ b/root/server/components.js
@@ -289,6 +289,7 @@ module.exports = {
   'static/scripts/common/components/TaggerIcon': require('../static/scripts/common/components/TaggerIcon'),
   'static/scripts/common/components/WarningIcon': require('../static/scripts/common/components/WarningIcon'),
   'static/scripts/common/components/WikipediaExtract': require('../static/scripts/common/components/WikipediaExtract'),
+  'static/scripts/common/components/WorkArtists': require('../static/scripts/common/components/WorkArtists'),
   'static/scripts/edit/components/AddIcon': require('../static/scripts/edit/components/AddIcon'),
   'static/scripts/edit/components/GuessCaseIcon': require('../static/scripts/edit/components/GuessCaseIcon'),
   'static/scripts/edit/components/InformationIcon': require('../static/scripts/edit/components/InformationIcon'),

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -45,6 +45,7 @@ require("./common/i18n");
 require("./common/entity");
 require("./common/MB/Control/Autocomplete");
 require('./common/components/ReleaseEvents');
+require('./common/components/WorkArtists');
 require("./common/MB/Control/SelectAll");
 require("./common/components/TagEditor");
 

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -1,0 +1,101 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import React, {useCallback, useState} from 'react';
+
+import hydrate from '../../../../utility/hydrate';
+import {bracketedText} from '../utility/bracketed';
+
+import ArtistCreditLink from './ArtistCreditLink';
+
+const COLLAPSE_THRESHOLD = 4;
+
+const buildWorkArtistRow = (artistCredit: ArtistCreditT) => {
+  return (
+    <li key={artistCredit.id}>
+      <ArtistCreditLink artistCredit={artistCredit} />
+    </li>
+  );
+};
+
+type WorkArtistsProps = {
+  +artists: ?$ReadOnlyArray<ArtistCreditT>,
+};
+
+const WorkArtists = ({artists}: WorkArtistsProps) => {
+  const [expanded, setExpanded] = useState<boolean>(false);
+
+  const expand = useCallback(event => {
+    event.preventDefault();
+    setExpanded(true);
+  });
+
+  const collapse = useCallback(event => {
+    event.preventDefault();
+    setExpanded(false);
+  });
+
+  const containerProps = {
+    'aria-label': l('Work Artists'),
+    'className': 'work-artists',
+  };
+
+  const tooManyArtists = artists
+    ? artists.length > COLLAPSE_THRESHOLD
+    : false;
+
+  return (
+    (artists && artists.length) ? (
+      <>
+        {(tooManyArtists && !expanded) ? (
+          <>
+            <ul {...containerProps}>
+              {artists.slice(0, COLLAPSE_THRESHOLD).map(
+                artist => buildWorkArtistRow(artist),
+              )}
+              <li className="show-all" key="show-all">
+                <a
+                  href="#"
+                  onClick={expand}
+                  role="button"
+                  title={l('Show all artists')}
+                >
+                  {bracketedText(texp.l('show {n} more', {
+                    n: artists.length - COLLAPSE_THRESHOLD,
+                  }))}
+                </a>
+              </li>
+            </ul>
+          </>
+        ) : (
+          <ul {...containerProps}>
+            {artists.map(artist => buildWorkArtistRow(artist))}
+            {tooManyArtists && expanded ? (
+              <li className="show-less" key="show-less">
+                <a
+                  href="#"
+                  onClick={collapse}
+                  role="button"
+                  title={l('Show less artists')}
+                >
+                  {bracketedText(l('show less'))}
+                </a>
+              </li>
+            ) : null}
+          </ul>
+        )}
+      </>
+    ) : null
+  );
+};
+
+export default hydrate<WorkArtistsProps>(
+  'div.work-artists-container',
+  WorkArtists,
+);

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -13,11 +13,11 @@ import {withCatalystContext} from '../../../../context';
 import RatingStars from '../../../../components/RatingStars';
 import loopParity from '../../../../utility/loopParity';
 
-import ArtistCreditLink from './ArtistCreditLink';
 import ArtistRoles from './ArtistRoles';
 import CodeLink from './CodeLink';
 import AttributeList from './AttributeList';
 import EntityLink from './EntityLink';
+import WorkArtists from './WorkArtists';
 
 type WorkListRowProps = {
   ...SeriesItemNumbersRoleT,
@@ -69,13 +69,7 @@ export const WorkListRow = withCatalystContext<WorkListRowProps>(({
       <ArtistRoles relations={work.writers} />
     </td>
     <td>
-      <ul>
-        {work.artists.map((artist, i) => (
-          <li key={i}>
-            <ArtistCreditLink artistCredit={artist} />
-          </li>
-        ))}
-      </ul>
+      <WorkArtists artists={work.artists} />
     </td>
     {showIswcs ? (
       <td>

--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -96,6 +96,11 @@ p.subheader {
     margin: 1em 0;
 }
 
+.show-all, .show-less {
+    padding: 0.75em 0;
+    list-style: none;
+}
+
 div.release-events-container {
     ul.release-events {
         &.abbreviated {
@@ -131,8 +136,4 @@ div.release-events-container {
         }
     }
 
-    .show-all, .show-less {
-        padding: 0.75em 0;
-        list-style: none;
-    }
 }

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -30,6 +30,8 @@ import EventLocations
 import ReleaseEvents
   from '../static/scripts/common/components/ReleaseEvents';
 import TaggerIcon from '../static/scripts/common/components/TaggerIcon';
+import WorkArtists
+  from '../static/scripts/common/components/WorkArtists';
 import formatDate from '../static/scripts/common/utility/formatDate';
 import formatDatePeriod
   from '../static/scripts/common/utility/formatDatePeriod';
@@ -473,15 +475,7 @@ export const taggerColumn:
 
 export const workArtistsColumn:
   ColumnOptions<WorkT, $ReadOnlyArray<ArtistCreditT>> = {
-    Cell: ({cell: {value}}) => (
-      <ul>
-        {value.map((artistCredit, i) => (
-          <li key={i}>
-            <ArtistCreditLink artistCredit={artistCredit} />
-          </li>
-        ))}
-      </ul>
-    ),
+    Cell: ({cell: {value}}) => <WorkArtists artists={value} />,
     Header: N_l('Artists'),
     accessor: 'artists',
   };


### PR DESCRIPTION
MBS-10584

For some works (mostly classical) there can be dozens or hundreds of artists listed, making proper navigation of any work list including them pretty much impossible. This makes it so that only the top four artists are shown, with an option to see all, using the same general idea as MBS-10424 (https://github.com/metabrainz/musicbrainz-server/pull/1242).

For an example where this makes a huge difference:
![Screenshot from 2020-02-10 00-17-34](https://user-images.githubusercontent.com/1069224/74111106-c3c90780-4b9a-11ea-9403-105f980d287e.png)
