### PR TITLE
MBS-7256: Add "Expand all mediums" to release page

### DIFF
--- a/root/components/MediumToolbox.js
+++ b/root/components/MediumToolbox.js
@@ -1,0 +1,40 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+const MediumToolbox = ({
+  hasMultipleMedia,
+}: {hasMultipleMedia: boolean}): React.Element<'span'> => (
+  <span id="medium-toolbox">
+    {hasMultipleMedia ? (
+      <>
+        <button
+          className="btn-link"
+          id="expand-all-mediums"
+          type="button"
+        >
+          {l('Expand all mediums')}
+        </button>
+        {' | '}
+        <button
+          className="btn-link"
+          id="collapse-all-mediums"
+          type="button"
+        >
+          {l('Collapse all mediums')}
+        </button>
+        {' | '}
+      </>
+    ) : null}
+    <button className="btn-link" id="toggle-credits" type="button" />
+  </span>
+);
+
+export default MediumToolbox;

--- a/root/release/index.tt
+++ b/root/release/index.tt
@@ -2,6 +2,7 @@
     [%- INCLUDE 'annotation/summary.tt' -%]
 
     <h2 class="tracklist">[% l('Tracklist') %]</h2>
+
     [% has_any_credits = release.relationships.size OR release.release_group.relationships.size %]
 
     [% IF release.mediums.size == 0 %]
@@ -9,7 +10,7 @@
         [% l('The tracklist for this release is currently unknown.') %]
       </p>
     [% ELSE %]
-      <button type="button" id="toggle-credits" class="btn-link"></button>
+      [% React.embed(c, 'components/MediumToolbox', { hasMultipleMedia => release.mediums.size > 1 }) %]
 
       [%~ PROCESS 'components/medium.tt' ~%]
 

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -270,6 +270,7 @@ module.exports = {
   'collection/CollectionHeader': require('../collection/CollectionHeader'),
   'components/Aliases': require('../components/Aliases'),
   'components/GroupedTrackRelationships': require('../components/GroupedTrackRelationships'),
+  'components/MediumToolbox': require('../components/MediumToolbox'),
   'components/Relationships': require('../components/Relationships'),
   'components/RelationshipsTable': require('../components/RelationshipsTable'),
   'components/UserAccountTabs': require('../components/UserAccountTabs'),

--- a/root/static/scripts/common/MB/release.js
+++ b/root/static/scripts/common/MB/release.js
@@ -8,6 +8,7 @@
 
 import $ from 'jquery';
 
+import request from '../utility/request';
 import getBooleanCookie from '../utility/getBooleanCookie';
 import setCookie from '../utility/setCookie';
 
@@ -42,8 +43,8 @@ $(function () {
 
   bottomCreditsEnabled ? switchToBottomCredits() : switchToInlineCredits();
 
-  $(document).on('click', '.expand-medium', function () {
-    var $table = $(this).parents('table:first');
+  function expandOrCollapseMedium(element) {
+    var $table = $(element).parents('table:first');
     var $tbody = $table.children('tbody');
     var $triangle = $table.find('.expand-triangle');
 
@@ -61,9 +62,9 @@ $(function () {
       .addClass('loading-message')
       .text(l('Loading...'));
 
-    var mediumId = this.getAttribute('data-medium-id');
+    var mediumId = element.data('medium-id');
 
-    $.get('/medium/' + mediumId + '/fragments')
+    request({url: '/medium/' + mediumId + '/fragments', dataType: 'html'})
       .done(function (fragments) {
         var $fragments = $($.parseHTML(fragments));
 
@@ -99,6 +100,35 @@ $(function () {
           .text(l('Failed to load the medium.'));
       });
 
+    return false;
+  }
+
+  $(document).on('click', '.expand-medium', function () {
+    expandOrCollapseMedium($(this));
+    // Prevent browser from following link
+    return false;
+  });
+
+  $(document).on('click', '#expand-all-mediums', function () {
+    $('.expand-medium').each(function () {
+      const $table = $(this).parents('table:first');
+      const $tbody = $table.children('tbody');
+      if (!$tbody.length || $tbody.is(':hidden')) {
+        expandOrCollapseMedium($(this));
+      }
+    });
+    // Prevent browser from following link
+    return false;
+  });
+
+  $(document).on('click', '#collapse-all-mediums', function () {
+    $('.expand-medium').each(function () {
+      const $table = $(this).parents('table:first');
+      const $tbody = $table.children('tbody');
+      if ($tbody.is(':visible')) {
+        expandOrCollapseMedium($(this));
+      }
+    });
     // Prevent browser from following link
     return false;
   });

--- a/root/static/scripts/common/utility/request.js
+++ b/root/static/scripts/common/utility/request.js
@@ -13,7 +13,7 @@ var previousDeferred = null;
 var timeout = 1000;
 
 function makeRequest(args, context, deferred) {
-  deferred.jqXHR = $.ajax({...args, dataType: 'json'})
+  deferred.jqXHR = $.ajax({dataType: 'json', ...args})
     .done(function () {
       if (!deferred.aborted) {
         deferred.resolveWith(context, arguments);

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -750,7 +750,7 @@ table.tbl {
     }
 }
 
-#toggle-credits { float: right; }
+#medium-toolbox { float: right; }
 
 table.tbl.medium {
     /* Kills the 2px borders between collapsed discs on release pages. */


### PR DESCRIPTION
MBS-7256

If a release has, say, 20 mediums, expanding them all by hand is a huge pain. This makes it so that they can all be expanded and collapsed with one click.

![Screenshot from 2020-02-25 09-15-27](https://user-images.githubusercontent.com/1069224/75223559-6692a000-57af-11ea-839a-4da58551dba1.png)
