### PR TITLE
MBS-10604: Remove allowNew from Add Place edit

### DIFF
--- a/root/edit/details/AddPlace.js
+++ b/root/edit/details/AddPlace.js
@@ -40,7 +40,7 @@ const AddPlace = ({edit}: {edit: AddPlaceEditT}) => {
         <tbody>
           <tr>
             <th>{addColonText(l('Place'))}</th>
-            <td><DescriptiveLink allowNew entity={place} /></td>
+            <td><DescriptiveLink entity={place} /></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
MBS-10604

An Add Place edit always creates the place immediately, so there is no case where the "This entity will be created by this edit" message applies. As such, we don't even need to check whether it applies on a specific edit, we can just never allow it.