### PR TITLE
MBS-10591: Enable Disc IDs tab in release editor

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -75,6 +75,7 @@ after 'load' => sub {
 
     # Load release group
     $c->model('ReleaseGroup')->load($release);
+    $c->model('ReleaseGroupType')->load($release->release_group);
 
     unless ($returning_jsonld) {
         $c->model('ReleaseGroup')->load_meta($release->release_group);
@@ -94,20 +95,14 @@ after 'load' => sub {
     my $cdtoc_count = $c->model('MediumCDTOC')->find_count_by_release($release->id);
     $c->stash->{release_cdtoc_count} = $cdtoc_count;
 
-    # We need to load more artist credits in 'show'
-    if ($c->action->name ne 'show') {
-        $c->model('ArtistCredit')->load($release);
-    }
+    $c->model('ArtistCredit')->load($release, $release->release_group);
+    $c->model('ReleasePackaging')->load($release);
+    $c->model('ReleaseStatus')->load($release);
+    $c->model('Language')->load($release);
+    $c->model('Script')->load($release);
+    $c->model('Release')->load_related_info($release);
 
-    # The release editor loads this stuff on its own
     if ($c->action->name ne 'edit') {
-        $c->model('ReleaseStatus')->load($release);
-        $c->model('ReleasePackaging')->load($release);
-        $c->model('Language')->load($release);
-        $c->model('Script')->load($release);
-        $c->model('ReleaseGroupType')->load($release->release_group);
-        $c->model('Release')->load_related_info($release);
-
         # Only needed by pages showing the sidebar
         $c->model('CritiqueBrainz')->load_display_reviews($release->release_group)
             unless $returning_jsonld;
@@ -169,7 +164,6 @@ sub show : Chained('load') PathPart('') {
         $c->model('Medium')->load_related_info($user_id, @mediums);
     }
 
-    $c->model('ArtistCredit')->load($release);
     $c->stash->{template} = 'release/index.tt';
 }
 

--- a/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
@@ -70,9 +70,15 @@ sub edit : Chained('/release/load') PathPart('edit') Edit RequireAuth
 
     my $release = $c->stash->{release};
 
+    my @mediums = $release->all_mediums;
+    $c->model('MediumCDTOC')->load_for_mediums(@mediums);
+    $c->model('CDTOC')->load(map { $_->all_cdtocs } @mediums);
+    $c->model('Relationship')->load_cardinal($release->release_group, $release);
+
     $self->_init_release_editor(
         $c,
-        return_to => $c->uri_for_action('/release/show', [ $release->gid ])
+        return_to => $c->uri_for_action('/release/show', [ $release->gid ]),
+        release_json => $c->json->encode($release),
     );
 }
 

--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -87,7 +87,7 @@
 
     MB.releaseEditor.init({
     [%- IF release.gid %]
-      gid: "[% release.gid | js %]",
+      release: [% closing_tag_escape(release_json) %],
       action: "edit",
     [%- ELSE %]
       action: "add",

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -268,7 +268,7 @@ releaseEditor.init = function (options) {
     this.seed(options.seed);
 
     if (this.action === "edit") {
-        this.loadRelease(options.gid);
+        this.releaseLoaded(options.release);
     } else {
         releaseEditor.createExternalLinksEditor(
             { entityType: 'release' },

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -26,6 +26,12 @@ test all => sub {
         },
         'releaseOf' => {
             'albumReleaseType' => 'http://schema.org/AlbumRelease',
+            'byArtist' => {
+                '@id' => 'https://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
+                '@type' => ['Person', 'MusicGroup'],
+                'name' => 'Kate Bush',
+            },
+            'creditedTo' => 'Kate Bush',
             'name' => 'Aerial',
             '@type' => 'MusicAlbum',
             '@id' => 'https://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
@@ -21,6 +21,12 @@ test all => sub {
         'releaseOf' => {
             '@type' => 'MusicAlbum',
             'albumProductionType' => 'http://schema.org/StudioAlbum',
+            'byArtist' => {
+                'name' => 'Artist',
+                '@id' => 'https://musicbrainz.org/artist/945c079d-374e-4436-9448-da92dedef3cf',
+                '@type' => 'MusicGroup',
+            },
+            'creditedTo' => 'Artist',
             '@id' => 'https://musicbrainz.org/release-group/54b9d183-7dab-42ba-94a3-7388a66604b8',
             'name' => 'Release'
         },

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
@@ -29,6 +29,12 @@ page_test_jsonld $mech => {
     '@id' => 'https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
     'releaseOf' => {
         'name' => 'Aerial',
+        'byArtist' => {
+            '@id' => 'https://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
+            '@type' => ['Person', 'MusicGroup'],
+            'name' => 'Kate Bush',
+        },
+        'creditedTo' => 'Kate Bush',
         'albumReleaseType' => 'http://schema.org/AlbumRelease',
         'albumProductionType' => 'http://schema.org/StudioAlbum',
         '@id' => 'https://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',


### PR DESCRIPTION
The EntityTabs component accesses `entity.may_have_discids` to toggle the Disc IDs tab, but this property requires mediums loaded to be computed on the server. Since loading mediums twice isn't a good use of resources, I've change the release editor controller to directly seed release and medium data to the page (still without tracks) rather than requesting it asynchronously.