### PR TITLE
MBS-10308: Clean up and validate maniadb URLs

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Maniadb.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Maniadb.pm
@@ -5,7 +5,7 @@ use Moose;
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
-sub sidebar_name { 'Maniadb' }
+sub sidebar_name { 'maniadb' }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1501,6 +1501,26 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.lyrics,
   },
+  'maniadb': {
+    match: [new RegExp('^(https?://)?(www\\.)?maniadb\\.com', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?maniadb\.com\/(?:index.php\/)?(album|artist)(?:\/|\.asp[?][ap]=)([0-9]+).*$/, 'http://www.maniadb.com/$1/$2');
+    },
+    validate: function (url, id) {
+      const m = /^http:\/\/www\.maniadb\.com\/(album|artist)\/[0-9]+$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix === 'artist';
+          case LINK_TYPES.otherdatabases.release_group:
+            return prefix === 'album';
+        }
+      }
+      return false;
+    },
+  },
   'mixcloud': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?mixcloud\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
@@ -1687,7 +1707,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?theatricalia\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?whosampled\\.com', 'i'),
-      new RegExp('^(https?://)?(www\\.)?maniadb\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?imvdb\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?residentadvisor\\.net/(?!review)', 'i'),
       new RegExp('^(https?://)?(www\\.)?vkdb\\.jp', 'i'),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2003,6 +2003,35 @@ const testData = [
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
   },
+  // maniadb
+  {
+                     input_url: 'http://www.maniadb.com/artist.asp?p=114569',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.maniadb.com/artist/114569',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'http://www.maniadb.com/album.asp?a=736792',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.maniadb.com/album/736792',
+       only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'http://www.maniadb.com/index.php/album/736792',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.maniadb.com/album/736792',
+       only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'http://www.maniadb.com/album/736792/?a=736792',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://www.maniadb.com/album/736792',
+       only_valid_entity_types: ['release_group'],
+  },
   // (The) Metal Archives
   {
                      input_url: 'http://www.metal-archives.com/bands/Karna/26483',


### PR DESCRIPTION
# Implement MBS-10308: Clean maniadb URLs

Convert old format `/artist.asp?p=ID` to `/artist/ID`

Normalize
- protocol to `http` (as `https` is not available)
- domain name to `www.maniadb.com` (which is redirected to)

Drop
- `/index.php` legacy path prefix (rarely used nowadays)
- subpath `/` (rarely used nowadays)
- unneeded query and fragment

Only validate linking
- clean maniadb /artist/ URL with MB artist
- clean maniadb /albums/ URL with MB release group