### PR TITLE
MBS-10623: Auto-add US iTunes store country-code

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1341,10 +1341,12 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/(?:geo\.)?itunes\.apple\.com\/([a-z]{2}\/)?(artist|album|audiobook|author|music-video|podcast|preorder)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://itunes.apple.com/$1$2/id$3');
       // Author seems to be a different interface for artist with the same ID
       url = url.replace(/^(https:\/\/itunes\.apple\.com(?:\/[a-z]{2})?)\/author\//, '$1/artist/');
+      // US store is the default, add its country-code to clarify (MBS-10623)
+      url = url.replace(/^(https:\/\/itunes\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/itunes\.apple\.com\/(?:[a-z]{2}\/)?([a-z-]{3,})\/id[0-9]+$/.exec(url);
+      const m = /^https:\/\/itunes\.apple\.com\/[a-z]{2}\/([a-z-]{3,})\/id[0-9]+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1716,7 +1716,7 @@ const testData = [
                      input_url: 'http://itunes.apple.com/artist/hangry-angry-f/id444923726',
              input_entity_type: 'artist',
     expected_relationship_type: 'downloadpurchase',
-            expected_clean_url: 'https://itunes.apple.com/artist/id444923726',
+            expected_clean_url: 'https://itunes.apple.com/us/artist/id444923726',
        only_valid_entity_types: ['artist'],
   },
   {
@@ -1730,7 +1730,7 @@ const testData = [
                      input_url: 'http://itunes.apple.com/music-video/gangnam-style/id564322420?v0=WWW-NAUS-ITSTOP100-MUSICVIDEOS&ign-mpt=uo%3D2',
              input_entity_type: 'recording',
     expected_relationship_type: 'downloadpurchase',
-            expected_clean_url: 'https://itunes.apple.com/music-video/id564322420',
+            expected_clean_url: 'https://itunes.apple.com/us/music-video/id564322420',
        only_valid_entity_types: ['recording'],
   },
   {
@@ -1750,7 +1750,7 @@ const testData = [
                      input_url: 'https://itunes.apple.com/album/beatbox-+-iphone-+-guitar/id589456329?ign-mpt=uo%3D4',
              input_entity_type: 'release',
     expected_relationship_type: 'downloadpurchase',
-            expected_clean_url: 'https://itunes.apple.com/album/id589456329',
+            expected_clean_url: 'https://itunes.apple.com/us/album/id589456329',
   },
   {
                      input_url: 'https://itunes.apple.com/us/album/skyfall-single/id566322358',


### PR DESCRIPTION
# Implement MBS-10623

iTunes stores are country-specific. When unspecified, the default store is the US one.

Adding country-code `/us` when missing makes it more clear it isn’t global.