### PR TITLE
Reduce noise in webservice server logs

### DIFF
--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -325,7 +325,7 @@ sub limit_releases_by_tracks {
 
     for my $release (@{$releases}) {
         $c->model('Medium')->load_for_releases($release);
-        $track_count += sum map { $_->track_count } $release->all_mediums;
+        $track_count += (sum map { $_->track_count } $release->all_mediums) // 0;
         last if $track_count > DBDefs->WS_TRACK_LIMIT && $release_count > 0;
         $release_count++;
     }

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -542,7 +542,7 @@ sub _serialize_work
         for my $attr (@attributes) {
             my $attr_node = $attr_list_node->addNewChild(undef, 'attribute');
             $attr_node->appendText($attr->value);
-            $attr_node->_setAttribute('value-id', $attr->value_gid);
+            $attr_node->_setAttribute('value-id', $attr->value_gid) if defined $attr->value_gid;
             $attr_node->_setAttribute('type', $attr->type->name);
             $attr_node->_setAttribute('type-id', $attr->type->gid);
         }

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -771,7 +771,7 @@ sub _serialize_cdstub
     $cdstub_node->_setAttribute('id', $cdstub->discid);
 
     $cdstub_node->appendTextChild('title', $cdstub->title);
-    $cdstub_node->appendTextChild('artist', $cdstub->artist);
+    $cdstub_node->appendTextChild('artist', $cdstub->artist) if $cdstub->artist;
     $cdstub_node->appendTextChild('barcode', $cdstub->barcode) if $cdstub->barcode;
     $cdstub_node->appendTextChild('disambiguation', $cdstub->comment) if $cdstub->comment;
 


### PR DESCRIPTION
Fix 3 noisy warnings that represent over 98% of webservice servers logs for the three last days at least.