### PR TITLE
Fix noisy warning about autocomplete: uninitialized value in numeric gt (>)

### DIFF
--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -238,7 +238,7 @@ sub _with_primary_alias {
                 } @{ $result->{aliases} };
 
             $out->{primaryAlias} = undef;
-            if ($primary_alias && $alias_preference{$munge_lang->($primary_alias->locale)} > 0) {
+            if ($primary_alias && ($alias_preference{$munge_lang->($primary_alias->locale)} // 0) > 0) {
                 $out->{primaryAlias} = $primary_alias->name;
             }
             push @output, $out;


### PR DESCRIPTION
Fix a not serious but noisy warning (in website server logs) that is triggered by ws/js entity autocomplete.

Note: Since `alias_preference` is an ordered list of user preferred languages, it is expected to not necessarily intersects the set of available languages with primary alias for a result/entity.

It is picked from https://github.com/metabrainz/musicbrainz-server/pull/1377