### PR TITLE
Ignore local::lib files for docker/js tools too

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.cpanm/
 .dockerignore
 .DS_Store
 blib/
@@ -6,6 +7,7 @@ Dockerfile
 lib/DBDefs.pm
 lib/DBDefs.pm.bak
 node_modules/
+perl_modules/
 postgresql-musicbrainz-collate/
 postgresql-musicbrainz-unaccent/
 root/static/build/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
+.cpanm/**/*.js
+perl_modules/**/*.js
 root/static/build/**/*.js
 root/static/lib/**/*.js
 root/static/scripts/tests/typeInfo.js

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,8 +1,10 @@
 [ignore]
+<PROJECT_ROOT>/.cpanm/.*
 <PROJECT_ROOT>/.nyc_output/.*
 <PROJECT_ROOT>/coverage/.*
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/root/static/build/.*
+<PROJECT_ROOT>/perl_modules/.*
 <PROJECT_ROOT>/t/.*
 /Volumes/.*
 


### PR DESCRIPTION
This patch completes pull request https://github.com/metabrainz/musicbrainz-server/pull/1319 that added `local::lib` files to the ignore list of Git only.