### PR TITLE
Fix noisy warning about editor’s gravatar: uninitialized value in lc

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -281,7 +281,7 @@ sub new_privileged {
 sub gravatar {
     my $self = shift;
 
-    if ($self->preferences->show_gravatar) {
+    if ($self->preferences->show_gravatar && $self->email) {
         my $hex = md5_hex(lc $self->email);
         return "//gravatar.com/avatar/$hex?d=mm";
     }


### PR DESCRIPTION
Fix a not serious but noisy warning (in website server logs) that is triggered when trying to display gravatar of an editor without email.

Note: Since users are allowed to delete their email (automatically marking them as beginners), it is normal that their email might be missing while their preferences are still here.

Nevertheless, most of these are either inactive or spam (or both).

It is the 2nd commit picked from #1377.