### PR TITLE
MBS-7473: Allow specifying a release MBID when attaching a CD TOC

### DIFF
--- a/root/cdtoc/attach_filter_release.tt
+++ b/root/cdtoc/attach_filter_release.tt
@@ -6,7 +6,7 @@
     [% USE r = FormRenderer(query_release) %]
     <input type="hidden" name="toc" value="[% toc %]" />
     [% WRAPPER form_row %]
-      [% r.label('query', l('Release title or MBID:')) %]
+      [% r.label('query', add_colon(l('Release title or MBID'))) %]
       [% r.text('query') %]
       [% form_submit(l('Search'), 'inline') %]
     [% END %]

--- a/root/cdtoc/attach_filter_release.tt
+++ b/root/cdtoc/attach_filter_release.tt
@@ -6,7 +6,7 @@
     [% USE r = FormRenderer(query_release) %]
     <input type="hidden" name="toc" value="[% toc %]" />
     [% WRAPPER form_row %]
-      [% r.label('query', l('Release title:')) %]
+      [% r.label('query', l('Release title or MBID:')) %]
       [% r.text('query') %]
       [% form_submit(l('Search'), 'inline') %]
     [% END %]
@@ -57,7 +57,14 @@
       <div class="row">
         <div class="label required">[% l('Results:') %]</div>
         <div class="no-label">
-          <p>[%- l('No results found. Try refining your search query.') -%]</p>
+          <p>
+            [%- IF was_mbid_search;
+                  l('We couldn’t find a release matching that MBID.');
+                ELSE;
+                  l('No results found. Try refining your search query.');
+                END
+            -%]
+          </p>
         </div>
       </div>
     [%- END -%]

--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -16,10 +16,16 @@
       <td>[% tagger_icon(release) %]</td>
     [%- END -%]
   </tr>
-  [% FOR medium=release.mediums %]
-    [% NEXT UNLESS
-        medium.cdtoc_track_count == cdtoc.track_count;
-       this_medium_has_cdtoc = medium_has_cdtoc.defined AND (medium.id == medium_has_cdtoc) %]
+  [%-
+    attachable_mediums = [];
+    FOR medium=release.mediums;
+      IF medium.cdtoc_track_count == cdtoc.track_count;
+        attachable_mediums.push(medium);
+      END;
+    END;
+  -%]
+  [% FOR medium=attachable_mediums %]
+      [%- this_medium_has_cdtoc = medium_has_cdtoc.defined AND (medium.id == medium_has_cdtoc) -%]
       <tr[% ' class="even"' IF zebra % 2 == 0 %]>
         <td class="pos"></td>
         <td>
@@ -49,6 +55,13 @@
         </td>
       </tr>
     </tr>
+  [% END %]
+  [% IF was_mbid_search && !attachable_mediums.size %]
+    <tr[% ' class="even"' IF zebra % 2 == 0 %]>
+      <td class="error" colspan="7">
+        [% l('None of the mediums on this release can have the given CD TOC attached, because they have the wrong number of tracks.') %]
+      </td>
+    <tr>
   [% END %]
 [% END %]
 

--- a/root/cdtoc/lookup.tt
+++ b/root/cdtoc/lookup.tt
@@ -68,7 +68,7 @@
   <form action="[% c.req.uri_for_action('/cdtoc/attach') %]" method="get">
     [% USE r = FormRenderer(query_release) %]
     <input type="hidden" name="toc" value="[% toc %]" />
-    [% form_row_text(r, 'query', l('Release:')) %]
+    [% form_row_text(r, 'query', l('Release title or MBID:')) %]
     <div class="row no-label">
       [% form_submit(l('Search')) %]
     </div>

--- a/root/cdtoc/lookup.tt
+++ b/root/cdtoc/lookup.tt
@@ -68,7 +68,7 @@
   <form action="[% c.req.uri_for_action('/cdtoc/attach') %]" method="get">
     [% USE r = FormRenderer(query_release) %]
     <input type="hidden" name="toc" value="[% toc %]" />
-    [% form_row_text(r, 'query', l('Release title or MBID:')) %]
+    [% form_row_text(r, 'query', add_colon(l('Release title or MBID'))) %]
     <div class="row no-label">
       [% form_submit(l('Search')) %]
     </div>


### PR DESCRIPTION
If the specified MBID can't have the CD TOC attached, I figured it'd be confusing to show an empty results page, so it shows the requested release with a custom error message.