### PR TITLE
MBS-10608: Restore parameter options for edit note search

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -247,9 +247,9 @@
   </span>
 [% END %]
 
-[% MACRO predicate_edit_notes(field, field_contents) BLOCK %]
+[% MACRO predicate_edit_notes BLOCK %]
   [%~ IF c.user_exists ~%]
-    [% predicate_link(field, undef, 'editor') %]
+    [% predicate_user('edit_note_author') %]
   [%~ ELSE ~%]
     [% WRAPPER wfield predicate="set" %]
       [%~ needs_login() ~%]
@@ -430,7 +430,7 @@
     [% predicate_set('status', status, [], 8) %]
     [% predicate_set('release_quality', quality) %]
     [% predicate_vote_count('vote_count') %]
-    [% predicate_edit_notes('edit_note_author') %]
+    [% predicate_edit_notes %]
 
     [% FOR linked_type=[ 'artist', 'label', 'series' ];
          predicate_subscription(linked_type);


### PR DESCRIPTION
MBS-10608

Fixes regression introduced by my code at https://github.com/metabrainz/musicbrainz-server/commit/e690b6bb1df9b0563ff2202be33b456dbb8494ea#diff-b398f96e41b6461cfb244c7b7679e17bR433