### PR TITLE
MBS-10611: Remove double brackets from (ended) relationships

### DIFF
--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -31,7 +31,9 @@ export function displayDatedExtraAttributes(
   pair: DatedExtraAttributes,
 ) {
   const renderedDatePeriods = commaOnlyListText(
-    pair.datePeriods.map(relationshipDateText),
+    pair.datePeriods.map(datePeriod => (
+      relationshipDateText(datePeriod, false /* bracketEnded */)
+    )),
   );
   const renderedExtraAttributes = commaOnlyList(
     pair.attributes.map(displayLinkAttribute),

--- a/root/utility/relationshipDateText.js
+++ b/root/utility/relationshipDateText.js
@@ -14,6 +14,7 @@ import areDatesEqual from './areDatesEqual';
 
 export default function relationshipDateText(
   r: $ReadOnly<{...DatePeriodRoleT, ...}>,
+  bracketEnded?: boolean = true,
 ) {
   if (r.begin_date) {
     if (r.end_date) {
@@ -34,7 +35,11 @@ export default function relationshipDateText(
   } else if (r.end_date) {
     return texp.l('until {date}', {date: formatDate(r.end_date)});
   } else if (r.ended) {
-    return bracketedText(l('ended'));
+    let text = l('ended');
+    if (bracketEnded) {
+      text = bracketedText(text);
+    }
+    return text;
   }
   return '';
 }


### PR DESCRIPTION
The brackets are used when displaying the relationship date text alongside long link phrases, as we do on relationship edit pages, but they don't make sense for the static relationships display, where brackets are always present.