### PR TITLE
Document newly required version 10.15 of Node.js

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ Prerequisites
     in lib/DBDefs.pm.  The defaults should be fine if you don't use
     your redis install for anything else.
 
-6.  Node.js and Yarn
+6.  Node.js (at least version 10.15) and Yarn
 
     Node.js is required to build (and optionally minify) our JavaScript and CSS.
     If you plan on accessing musicbrainz-server inside a web browser, you should

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Full installation instructions are available in [INSTALL.md](INSTALL.md).
 General Prerequisites:
 
 * Ubuntu/Debian
+* Node (at least version 10.15)
 * Perl (at least version 5.18.2)
 * PostgreSQL (at least version 9.5)
 


### PR DESCRIPTION
Since the commit 83ecd3bf42d (in the pull request #1370), the `script/compile_resources.sh` returned:

    error selenium-webdriver@4.0.0-alpha.5:
    The engine "node" is incompatible with this module.
    Expected version ">= 10.15.0".

This requirement seems reasonable enough since Node.js v10 is the oldest still active (soon in maintenance only) LTS: <https://nodejs.org/about/releases>.

----

Notes:
* our [`docker`](https://github.com/metabrainz/musicbrainz-server/tree/v-2020-02-18/docker) containers already has been using Node.js 10.17 for months;
* `musicbrainz-docker` is going to use Node.js 10.19 with merging the pull request <https://github.com/metabrainz/musicbrainz-docker/pull/123> that includes the commit <https://github.com/metabrainz/musicbrainz-docker/pull/123/commits/bbff5cbd9319a71148c17aaa9d3e580992de32af>.