### PR TITLE
Fix blog post link in generated git tag message

### DIFF
--- a/script/tag.sh
+++ b/script/tag.sh
@@ -35,7 +35,7 @@ tag="v-$year-$month-$day"
 read -e -i "$tag" -p 'Tag? ' -r tag
 
 blog_url="https://blog.metabrainz.org/$year/$month/$day/"
-blog_url+="server-update-$year-$month-$day/"
+blog_url+="musicbrainz-server-update-$year-$month-$day/"
 read -e -i "$blog_url" -p 'Blog post URL? ' -r blog_url
 
 set -x


### PR DESCRIPTION
It fixes a regression from <https://github.com/metabrainz/musicbrainz-server/pull/1337>.

----

I also fixed blog post links that were broken for all of 2020 [tags](https://github.com/metabrainz/musicbrainz-server/tags).