### PR TITLE
Fix ubernoisy warning about artwork image suffix on homepage

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1411,6 +1411,7 @@ sub newest_releases_with_artwork {
         Artwork->new(
             id => $caa_id,
             release => $release,
+            suffix => 'spoof',
         );
     });
 }


### PR DESCRIPTION
Suffix used to not be loaded on homepage, spamming website logs with this warning:

    Use of uninitialized value in concatenation (.) or string at lib/MusicBrainz/Server/Entity/Artwork.pm line 88

This patch mutes this warning for the homepage only by setting an arbitrary value as suffix.

It’s the 3rd commit picked from https://github.com/metabrainz/musicbrainz-server/pull/1377

----

It doesn’t solve similar warnings triggered on cover art edits’ display which are less frequent.