### PR TITLE
Fix noisy warnings about event’s search: uninitialized value $text in substitution (s///)

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -56,7 +56,6 @@ __PACKAGE__->config(
             'format_length' => \&MusicBrainz::Server::Filters::format_length,
             'format_wikitext' => \&MusicBrainz::Server::Filters::format_wikitext,
             'format_editnote' => \&MusicBrainz::Server::Filters::format_editnote,
-            'format_setlist' => \&MusicBrainz::Server::Filters::format_setlist,
             'locale' => \&MusicBrainz::Server::Filters::locale,
             'gravatar' => \&MusicBrainz::Server::Filters::gravatar,
             'coverart_https' => \&MusicBrainz::Server::Filters::coverart_https

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -16,7 +16,7 @@ with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'EventType' };
 
 use MooseX::Types::Structured qw( Dict );
 use MooseX::Types::Moose qw( ArrayRef Object Str );
-use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json non_empty );
 use MusicBrainz::Server::Entity::Util::JSON qw( add_linked_entity );
 use MusicBrainz::Server::Filters qw( format_setlist );
 use MusicBrainz::Server::Types qw( Time );
@@ -109,6 +109,8 @@ around TO_JSON => sub {
     my @related_series = $self->related_series;
     add_linked_entity('series', $_->id, $_) for @related_series;
 
+    my $setlist = $self->setlist;
+
     return {
         %{ $self->$orig },
         areas => [map +{
@@ -124,7 +126,7 @@ around TO_JSON => sub {
             entity => $_->{entity},
         }, $self->all_places],
         related_series => [map { $_->id } @related_series],
-        setlist => format_setlist($self->setlist),
+        (non_empty($setlist) ? (setlist => format_setlist($setlist)) : ()),
         time => $self->formatted_time,
     };
 };

--- a/root/event/EventIndex.js
+++ b/root/event/EventIndex.js
@@ -31,32 +31,36 @@ const EventIndex = ({
   event,
   numberOfRevisions,
   wikipediaExtract,
-}: Props) => (
-  <EventLayout entity={event} page="index">
-    {eligibleForCleanup ? (
-      <CleanupBanner entityType="event" />
-    ) : null}
-    <Annotation
-      annotation={event.latest_annotation}
-      collapse
-      entity={event}
-      numberOfRevisions={numberOfRevisions}
-    />
-    <WikipediaExtract
-      cachedWikipediaExtract={wikipediaExtract || null}
-      entity={event}
-    />
-    <Relationships source={event} />
-    {event.setlist ? (
-      <>
-        <h2 className="setlist">{l('Setlist')}</h2>
-        <p className="setlist">
-          {expand2react(event.setlist)}
-        </p>
-      </>
-    ) : null}
-    {manifest.js('event/index.js', {async: 'async'})}
-  </EventLayout>
-);
+}: Props) => {
+  const setlist = event.setlist;
+
+  return (
+    <EventLayout entity={event} page="index">
+      {eligibleForCleanup ? (
+        <CleanupBanner entityType="event" />
+      ) : null}
+      <Annotation
+        annotation={event.latest_annotation}
+        collapse
+        entity={event}
+        numberOfRevisions={numberOfRevisions}
+      />
+      <WikipediaExtract
+        cachedWikipediaExtract={wikipediaExtract || null}
+        entity={event}
+      />
+      <Relationships source={event} />
+      {setlist ? (
+        <>
+          <h2 className="setlist">{l('Setlist')}</h2>
+          <p className="setlist">
+            {expand2react(setlist)}
+          </p>
+        </>
+      ) : null}
+      {manifest.js('event/index.js', {async: 'async'})}
+    </EventLayout>
+  );
+};
 
 export default EventIndex;

--- a/root/types.js
+++ b/root/types.js
@@ -489,7 +489,7 @@ declare type EventT = $ReadOnly<{
   }>,
   +places: $ReadOnlyArray<{+entity: PlaceT}>,
   +related_series: $ReadOnlyArray<number>,
-  +setlist: string,
+  +setlist?: string,
   +time: string,
 }>;
 


### PR DESCRIPTION
* Fix noisy warnings on `/search` and `/ws/js/event` endpoints, see commit message for details.
* Stop exporting `format_setlist` filter to templates, as events are now rendered using React.

It replaces commit https://github.com/metabrainz/musicbrainz-server/pull/1377/commits/4e5b3917c2550159898280cab6bff2a54bbe3864 submitted in #1377