### PR TITLE
Fix noisy warnings about medium: uninitialized value in numeric eq/ne

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -576,7 +576,7 @@ sub allow_auto_edit
             return 0 if $old_name ne $new_name;
             return 0 if $old->{length} && $old->{length} != $new->{length};
             return 0 if hash_artist_credit($old->{artist_credit}) ne hash_artist_credit($new->{artist_credit});
-            return 0 if $old->{recording_id} != $new->{recording_id};
+            return 0 if ($old->{recording_id} // 0) != ($new->{recording_id} // 0);
         }
     }
 

--- a/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
@@ -34,7 +34,7 @@ sub is_perfect_match {
     my @medium_tracks = @{ $self->medium->cdtoc_tracks };
 
     return (@cdtoc_info == @medium_tracks) && all {
-      $_->[0]{length_time} == $_->[1]->length
+      defined $_->[1]->length && $_->[0]{length_time} == $_->[1]->length
     } (pairs (zip @cdtoc_info, @medium_tracks));
 }
 


### PR DESCRIPTION
Fix two not serious but very noisy warnings (in website server logs) that are often triggered when attaching a CDTOC or editing a tracklist. See commits’ message for details.

These replace the just wrong commits https://github.com/metabrainz/musicbrainz-server/pull/1377/commits/88a904cfbb39eb0f3dee344abf66893f313e9a10 and https://github.com/metabrainz/musicbrainz-server/pull/1377/commits/54139c65fd862fb23dd93427946a0c6f3c93d635 picked from #1377