### PR TITLE
MBS-10659: Always show entity credits in rel edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -91,6 +91,8 @@ has '+data' => (
         relationship_id => Int,
         type0 => Str,
         type1 => Str,
+        entity0_credit => Optional[Str],
+        entity1_credit => Optional[Str],
         link => find_type_constraint('LinkHash'),
         new => find_type_constraint('RelationshipHash'),
         old => find_type_constraint('RelationshipHash'),
@@ -176,8 +178,10 @@ sub _build_relationship {
             defined $entity1->{id} ? (id => $entity1->{id}) : (),
             name => $entity1->{name},
         );
-    my $entity0_credit = $change->{entity0_credit} // '';
-    my $entity1_credit = $change->{entity1_credit} // '';
+    # We want to show the entities as actually credited even if the credit
+    # didn't change with this edit, but old edits won't have that data. 
+    my $entity0_credit = $change->{entity0_credit} // $data->{entity0_credit} // '';
+    my $entity1_credit = $change->{entity1_credit} // $data->{entity1_credit} // '';
 
     return Relationship->new(
         id => $data->{relationship_id},
@@ -439,6 +443,8 @@ sub initialize
                 name => $relationship->entity1->name
             },
         },
+        entity0_credit => $relationship->entity0_credit,
+        entity1_credit => $relationship->entity1_credit,
         edit_version => 2,
         $self->_change_data($relationship, %opts)
     });

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
@@ -93,6 +93,8 @@ cmp_deeply($edits[0]->data, {
             'gid' => '25d6b63a-12dc-41c9-858a-2f42ae610a7d'
         }
     },
+    'entity0_credit' => '',
+    'entity1_credit' => '',
     'edit_version' => 2,
 });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
@@ -145,6 +145,8 @@ test 'editing a relationship' => sub {
                 ended       => 0,
                 attributes  => [$additional_attribute, $string_instruments_attribute],
             },
+            entity0_credit => '',
+            entity1_credit => '',
             edit_version => 2,
         });
 
@@ -202,6 +204,8 @@ test 'editing a relationship' => sub {
                 end_date    => { month => 9, day => 9, year => 2009 },
                 attributes  => [$additional_attribute, $crazy_guitar, $string_instruments_attribute]
             },
+            entity0_credit => '',
+            entity1_credit => '',
             edit_version => 2,
         });
 
@@ -252,6 +256,8 @@ test 'editing a relationship' => sub {
             old => {
                 begin_date  => { month => 1, day => 1, year => 1999 },
             },
+            entity0_credit => '',
+            entity1_credit => '',
             edit_version => 2,
         });
 
@@ -296,6 +302,8 @@ test 'editing a relationship' => sub {
             relationship_id => 3,
             new => { ended => 0 },
             old => { ended => 1 },
+            entity0_credit => '',
+            entity1_credit => '',
             edit_version => 2,
         });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/RelationshipEditor.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/RelationshipEditor.pm
@@ -198,6 +198,8 @@ test 'Can edit relationship' => sub {
         relationship_id => 1,
         type0 => 'artist',
         type1 => 'recording',
+        entity0_credit => '',
+        entity1_credit => '',
     });
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -812,6 +812,8 @@ test 'editing a relationship' => sub {
             ended       => 0,
             attributes  => [$guitar_attribute]
         },
+        entity0_credit => '',
+        entity1_credit => '',
         edit_version => 2,
     });
 };
@@ -875,6 +877,8 @@ test 'editing a relationship with an unchanged attribute' => sub {
             end_date    => { month => undef, day => undef, year => undef },
             ended       => 0,
         },
+        entity0_credit => '',
+        entity1_credit => '',
         edit_version => 2,
     });
 };
@@ -935,6 +939,8 @@ test 'removing an attribute from a relationship' => sub {
         old => {
             attributes  => [$guitar_attribute],
         },
+        entity0_credit => '',
+        entity1_credit => '',
         edit_version => 2,
     });
 };

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -473,6 +473,8 @@ test 'Entity credits can be added to an existing relationship' => sub {
         relationship_id => 1,
         type1 => 'artist',
         type0 => 'artist',
+        entity1_credit => '',
+        entity0_credit => ''
     });
 };
 


### PR DESCRIPTION
MBS-10659

If one or both entities on the relationship have a credit, we want to still display that credit in the edit relationship edit, even if the edit itself doesn't change the credit (because it is still relevant to know the relationship is under a specific credit). Currently, the edit will display the main artist name at all times except if the credits are changing.