### PR TITLE
MBS-10515: Fix sort of release recordings in merge

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1088,8 +1088,9 @@ sub determine_recording_merges {
         track       => $_->{new_track_number},
         destination => $_->{new_recording},
         sources     => $_->{old_recordings},
-    }, nsort_by {
-        $_->{new_medium_position}, $_->{new_track_position}
+    }, sort {
+        $a->{new_medium_position} <=> $b->{new_medium_position} ||
+        $a->{new_track_position} <=> $b->{new_track_position}
     } values %recording_merges]);
 }
 


### PR DESCRIPTION
MBS-10515

This was attempting to nsort_by by two columns, but that doesn't seem to work, and it was sorting only by track position. Changed it to use a usual sort with a manually defined sort function, to ensure it sorts by medium first then track.