### PR TITLE
MBS-10607: Add context to (unknown) strings

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -11,7 +11,7 @@ use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Edit::Types qw( Nullable PartialDateHash );
 use MusicBrainz::Server::Edit::Utils qw( gid_or_id merge_value );
 use MusicBrainz::Server::Entity::Area;
-use MusicBrainz::Server::Translation qw( N_l l );
+use MusicBrainz::Server::Translation qw( N_l l lp );
 use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_name );
 use Scalar::Util qw( looks_like_number );
 
@@ -94,7 +94,7 @@ sub process_medium_formats
 
     return combined_medium_format_name(map {
         if ($_ eq '(unknown)') {
-            l('(unknown)');
+            lp('(unknown)', 'medium format');
         }
         else {
             MediumFormat->new(name => $_)->l_name;

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -5,7 +5,7 @@ use List::AllUtils qw( any );
 use List::MoreUtils qw( uniq );
 use MusicBrainz::Server::Entity::Barcode;
 use MusicBrainz::Server::Entity::Types;
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l lp );
 
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_name );
@@ -181,7 +181,7 @@ sub combined_format_name
     my ($self) = @_;
     my @mediums = @{$self->mediums};
     return "" if !@mediums;
-    return combined_medium_format_name(map { $_->l_format_name() || l('(unknown)') } @mediums );
+    return combined_medium_format_name(map { $_->l_format_name() || lp('(unknown)', 'medium format') } @mediums );
 }
 
 has [qw( cover_art_url info_url amazon_asin amazon_store )] => (

--- a/root/edit/details/add_isrcs.tt
+++ b/root/edit/details/add_isrcs.tt
@@ -2,7 +2,7 @@
   [% IF edit.data.client_version.defined %]
   <tr>
     <th>[% l('Client:') %]</th>
-    <td>[% (edit.data.client_version || l('(unknown)')) | html %]</td>
+    <td>[% (edit.data.client_version || lp('(unknown)', 'isrc client')) | html %]</td>
   </tr>
   [% END %]
 

--- a/root/edit/details/historic/convert_release_to_multiple_artists.tt
+++ b/root/edit/details/historic/convert_release_to_multiple_artists.tt
@@ -9,7 +9,7 @@
         [% END %]
       </ul>
       [% ELSE;
-           l('(unknown)');
+          lp('(unknown)', 'release');
          END %]
     </td>
   </tr>

--- a/root/edit/details/historic/mac_to_sac.tt
+++ b/root/edit/details/historic/mac_to_sac.tt
@@ -6,11 +6,11 @@
       <ul>
         [% FOR release=edit.display_data.releases %]
         <li>[% release.defined ? link_entity(release) :
-                                 l('(unknown)') %]</li>
+                                 lp('(unknown)', 'release') %]</li>
         [% END %]
       </ul>
       [% ELSE %]
-        [% l('(unknown)') %]
+        [% lp('(unknown)', 'release') %]
       [% END %]
     </td>
   </tr>

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -77,7 +77,7 @@ const Details = ({
           <td>
             {entity.last_updated
               ? formatUserDate($c, entity.last_updated)
-              : l('(unknown)')}
+              : lp('(unknown)', 'last updated')}
           </td>
         </tr>
         <tr>

--- a/root/recording/RecordingIndex.js
+++ b/root/recording/RecordingIndex.js
@@ -68,7 +68,7 @@ const RecordingAppearancesTable = ({
               <th colSpan="10">
                 {status
                   ? lp_attributes(status.name, 'release_status')
-                  : l('(unknown)')
+                  : lp('(unknown)', 'release status')
                 }
               </th>
             </tr>

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -54,7 +54,7 @@ function buildReleaseStatusTable($c, releaseStatusGroup) {
         <th colSpan={$c.session && $c.session.tport ? 8 : 7}>
           {status?.name
             ? lp_attributes(status.name, 'release_status')
-            : l('(unknown)')}
+            : lp('(unknown)', 'release status')}
         </th>
       </tr>
       {releaseStatusGroup.map((release, index) => (

--- a/root/static/scripts/release-editor/duplicates.js
+++ b/root/static/scripts/release-editor/duplicates.js
@@ -181,7 +181,7 @@ function combinedMediumFormatName(mediums) {
             return (count > 1 ? count + "\u00D7" : "") +
                 (format
                     ? lp_attributes(format, 'medium_format')
-                    : l('(unknown)'));
+                    : lp('(unknown)', 'medium format'));
         })
         .join(" + ");
 }


### PR DESCRIPTION
MBS-10607

We have plenty of "(unknown)" strings, and the thing that is unknown can be one of many. Depending on the thing, though, the translation should vary (for example, a release format is "desconocido" in Spanish but a release itself is "desconocida" - gender variation). This adds context to the different strings to make it possible to translate them separately.