### PR TITLE
MBS-10666: Collapse long artist lists in work merge page

### DIFF
--- a/root/server/components.js
+++ b/root/server/components.js
@@ -292,6 +292,7 @@ module.exports = {
   'series/SeriesHeader': require('../series/SeriesHeader'),
   'static/scripts/common/components/Annotation': require('../static/scripts/common/components/Annotation'),
   'static/scripts/common/components/ArtistCreditLink': require('../static/scripts/common/components/ArtistCreditLink'),
+  'static/scripts/common/components/ArtistRoles': require('../static/scripts/common/components/ArtistRoles'),
   'static/scripts/common/components/CritiqueBrainzReview': require('../static/scripts/common/components/CritiqueBrainzReview'),
   'static/scripts/common/components/ReleaseEvents': require('../static/scripts/common/components/ReleaseEvents'),
   'static/scripts/common/components/SearchIcon': require('../static/scripts/common/components/SearchIcon'),

--- a/root/work/merge.tt
+++ b/root/work/merge.tt
@@ -31,18 +31,12 @@
                     </td>
                     <td>
                       <ul>
-                        [% FOR rel_artist=entity.writers %]
-                        <li>
-                          [% l('{artist} ({roles})', { artist => link_artist(rel_artist.entity),
-                          roles  => rel_artist.roles.join(', ') }) %]</li>
-                        [% END %]
+                        [%~ React.embed(c, 'static/scripts/common/components/ArtistRoles', {relations => entity.writers}) ~%]
                       </ul>
                     </td>
                     <td>
                       <ul>
-                        [% FOR rel_artist=entity.artists %]
-                        <li>[% artist_credit(rel_artist) %]</li>
-                        [% END %]
+                        [%~ React.embed(c, 'static/scripts/common/components/WorkArtists', {artists => entity.artists}) ~%]
                       </ul>
                     </td>
                     <td class="iswc">


### PR DESCRIPTION
MBS-10666

This reuses the React component for work artists rather than having its own implementation, allowing us to use the built-in collapsing options.

I also changed the work writers column to reuse our React component for that - the only difference it makes is showing disambiguations, which seems like unambiguously an improvement.