### PR TITLE
MBS-10661: Highlight recording-work pending edits in release

### DIFF
--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -55,13 +55,17 @@ const renderWorkRelationship = (relationship: RelationshipT) => {
     false, /* forGrouping */
   );
 
+  const title = relationship.editsPending
+    ? <span className="mp">{phrase}</span>
+    : phrase;
+
   const targetCredit = backward
     ? relationship.entity0_credit
     : relationship.entity1_credit;
 
   return (
     <React.Fragment key={relationship.id}>
-      <dt>{addColon(phrase)}</dt>
+      <dt>{addColon(title)}</dt>
       <dd>
         <EntityLink content={targetCredit} entity={work} />
         {' '}


### PR DESCRIPTION
MBS-10661

Recording-work rels are the only ones not currently highlighted if they have pending edits on release pages. This adds the same "mp" class as the other relationships get.