### PR TITLE
MBS-10633: Allow changing username capitalization

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -676,6 +676,13 @@ sub is_name_used {
     return 0;
 }
 
+sub are_names_equivalent {
+    my ($self, $name1, $name2) = @_;
+
+    return $self->sql->select_single_value(
+        'SELECT lower(?) = lower(?)', $name1, $name2);
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -206,13 +206,14 @@ sub validate_username {
 
     my $username = $self->value;
     my $previous_username = $self->init_value;
+    my $editor_model = $self->form->ctx->model('Editor');
 
     if (defined $username) {
-        unless (defined $previous_username && $previous_username eq $username) {
+        unless (defined $previous_username && $editor_model->are_names_equivalent($previous_username, $username)) {
             if ($username =~ qr{^deleted editor \#\d+$}i) {
                 $self->add_error(l('This username is reserved for internal use.'));
             }
-            if ($self->form->ctx->model('Editor')->is_name_used($username)) {
+            if ($editor_model->is_name_used($username)) {
                 $self->add_error(l('Please choose another username, this one is already taken.'));
             }
         }


### PR DESCRIPTION
MBS-10633

It should be possible to change someone's username to the same username, but with different capitalization. This changes the comparison that checks if the username has changed to allow those
capitalization--only changes, by comparing normalized usernames instead. The registration system doesn't allow two usernames to only differ in capitalization in any case, so this should be perfectly safe.