### PR TITLE
MBS-10671: Block ratings for unverified users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -21,6 +21,10 @@ sub rate : Local RequireAuth DenyWhenReadonly
 {
     my ($self, $c, $type) = @_;
 
+    if (!$c->user->has_confirmed_email_address) {
+        $c->detach('/error_401');
+    }
+
     my $entity_type = $c->request->params->{entity_type};
     my $entity_id = $c->request->params->{entity_id};
     my $rating = $c->request->params->{rating};

--- a/root/components/RatingStars.js
+++ b/root/components/RatingStars.js
@@ -53,7 +53,7 @@ const RatingStars = ({$c, entity}: Props) => {
           ) : null
         )}
 
-        {$c.user_exists ? (
+        {$c.user && $c.user.has_confirmed_email_address ? (
           ratingInts.map(rating => {
             const isCurrentRating = rating === currentStarRating;
             const newRating = isCurrentRating ? 0 : rating;

--- a/t/lib/t/MusicBrainz/Server/Controller/Rating.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Rating.pm
@@ -1,0 +1,43 @@
+package t::MusicBrainz::Server::Controller::Rating;
+use Test::Routine;
+use Test::More;
+use utf8;
+
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Context', 't::Mechanize';
+
+test 'Can rate' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+    $mech->get('/rating/rate/?entity_type=label&entity_id=2&rating=100');
+    is ($mech->status, 200);
+};
+
+test 'Cannot rate without a confirmed email address' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $c->model('Editor')->insert({
+        name => 'iwannarate',
+        password => 'password'
+    });
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'iwannarate', password => 'password' } );
+
+    $mech->get('/rating/rate/?entity_type=label&entity_id=2&rating=100');
+    is ($mech->status, 401, 'Rating rejected without confirmed address');
+};
+
+1;


### PR DESCRIPTION
MBS-10671

People are creating email-less accounts to mass-rate their favourite boy band. While that's mostly harmless, it's still stupid, and I can't see any reason why we should allow unverified users to submit ratings.

I haven't even tried to block submissions via the WS, since that doesn't seem very relevant for the kind of stuff we're trying to stop right now, but I guess we should do that too? Putting this up for now to make sure the general idea seems sound.