### PR TITLE
MBS-10546: Export search indexes dump to FTP

### DIFF
--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -1,0 +1,211 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+
+################################################################################
+
+=head1 NAME
+
+BundleSearchIndexesDump - Bundle search indexes dump from SolrCloud backups
+
+=head1 SYNOPSIS
+
+BundleSearchIndexesDump [options]
+
+Options:
+
+    -w, --working-dir DIRECTORY         directory that contains solr backups
+                                        to be turned into search indexes dump
+    -d, --debug                         print more progress messages
+
+    -h, --help                          show this help
+
+Environment:
+
+    BACKUP_STAMP                        timestamp used for backup directory name
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+
+################################################################################
+
+my $working_dir;
+my $debug_flag;
+my $help_flag;
+
+GetOptions(
+    "working-dir|w=s"            => \$working_dir,
+    "debug|d"                   => \$debug_flag,
+    "help|h"                    => \$help_flag,
+);
+
+pod2usage() if $help_flag;
+pod2usage(
+    -exitval => 64, # EX_USAGE
+    -message => "$0: unrecognized arguments",
+) if @ARGV;
+
+################################################################################
+
+$SIG{'INT'} = sub { exit 3 };
+
+use File::Copy qw( copy move );
+use POSIX qw( strftime );
+use String::ShellQuote qw( shell_quote );
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use DBDefs;
+use MusicBrainz::Script::MBDump qw( gpg_sign );
+
+################################################################################
+
+sub _debug { print "[debug] ", (sprintf shift, @_), "\n" if $debug_flag; }
+sub _info { print "[info] ", (sprintf shift, @_), "\n"; }
+sub _warn { warn "[warning] ", (sprintf shift, @_), "\n"; }
+sub _error { warn "[error] ", (sprintf shift, @_), "\n"; }
+
+my $BACKUP_STAMP = $ENV{BACKUP_STAMP};
+my $COMPRESSION_LEVEL = DBDefs->SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL;
+
+my @backup_dirs;
+my @extraneous_files;
+
+opendir(my $wdh, $working_dir) or die $!;
+for my $filename (sort grep { ! /^\.\.?$/ } readdir $wdh)
+{
+    if ($filename =~ /^backup_${BACKUP_STAMP}_/)
+    {
+        push @backup_dirs, $filename;
+    }
+    else
+    {
+        push @extraneous_files, $filename;
+    }
+}
+closedir $wdh;
+
+die "$working_dir has extraneous files: @extraneous_files\n"
+    if scalar @extraneous_files;
+
+my @public_domain_collections = qw(
+    area
+    artist
+    event
+    instrument
+    label
+    place
+    recording
+    release
+    release-group
+    series
+    url
+    work
+);
+
+my @private_collections = qw(
+    editor
+);
+
+for my $backup_dir (@backup_dirs)
+{
+    my $collection = $backup_dir =~ s/^backup_\d{8}-\d{6}_//r;
+    my $dump_dir = $collection;
+    opendir(my $bdh, "$working_dir/$backup_dir") or die $!;
+    if (grep { /^$collection$/ } @private_collections)
+    {
+        system 'rm', '-fr', "$working_dir/$backup_dir";
+        next;
+    }
+    @extraneous_files = ();
+    for my $filename (sort grep { ! /^\.\.?$/ } readdir $bdh)
+    {
+        push @extraneous_files, $filename
+            if ! $filename =~ 'backup\.properties|snapshot\.shard1';
+    }
+    closedir $bdh;
+    die "$working_dir/$backup_dir has extraneous files: @extraneous_files\n"
+        if scalar @extraneous_files;
+
+    my $working_dump_dir = "$working_dir/$dump_dir";
+    move("$working_dir/$backup_dir", $working_dump_dir) or die $!;
+    move("$working_dump_dir/snapshot.shard1", "$working_dump_dir/index") or die $!;
+
+    my $license_file = (grep { /^$collection$/ } @public_domain_collections)
+        ? "$FindBin::Bin/COPYING-PublicDomain"
+        : "$FindBin::Bin/COPYING-CCShareAlike";
+    copy($license_file, "$working_dump_dir/COPYING") or die $!;
+
+    my $readme_text = <<EOF;
+The files in the directory 'index' are a snapshot of the search index
+'$collection' from musicbrainz.org, in a format suitable for
+use with an Apache Solr server.  To import them, you need a compatible
+version of the MusicBrainz simple Solr search server schema (mbsssss).
+EOF
+    _write_file($working_dump_dir, 'README', $readme_text);
+
+    my $tar_file = "$collection.tar.zst";
+    _info("Creating $tar_file");
+    system
+        'bash', '-c',
+            'set -o pipefail; ' .
+            'tar' .
+            ' -C ' . shell_quote($working_dir) .
+            ' --create' .
+            ' --group=solr:8983' .
+            ' --owner=solr:8983' .
+            ' --remove-files' .
+            ' --verbose' .
+            ' -- ' .
+            shell_quote($dump_dir) .
+            " | zstd -T0 -$COMPRESSION_LEVEL" .
+            ' > ' . shell_quote("$working_dir/$tar_file");
+    if ($? != 0)
+    {
+        _error('Tar returned ' . ($? >> 8));
+        exit 70; # EX_SOFTWARE
+    }
+
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$tar_file");
+}
+
+for my $hash_program ('md5sum', 'sha256sum') {
+    my $hash_output_file = uc($hash_program . 's');
+    chomp (my $hash_bin = `which g$hash_program` || `which $hash_program`);
+    my $hash_command = "cd $working_dir" .
+        " && $hash_bin --binary *.tar.zst > $hash_output_file";
+    system $hash_command;
+    if ($? != 0)
+    {
+        _error('Failed command with ' . ($? >> 8) . ": $hash_command");
+        exit 70; # EX_SOFTWARE
+    }
+
+    MusicBrainz::Script::MBDump::gpg_sign("$working_dir/$hash_output_file");
+}
+
+_info 'Successfully bundled SolrCloud backups as search indexes dump.';
+exit;
+
+################################################################################
+
+sub _write_file
+{
+    my ($parent_dir, $file, $contents) = @_;
+
+    open(my $fh, '>' . $parent_dir . "/$file") or die $!;
+    print $fh $contents or die $!;
+    close $fh or die $!;
+}

--- a/admin/RequestSolrCloudBackups
+++ b/admin/RequestSolrCloudBackups
@@ -1,0 +1,306 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+
+################################################################################
+
+=head1 NAME
+
+RequestSolrCloudBackups - Request MB SolrCloud leader to backup every collection
+
+=head1 SYNOPSIS
+
+RequestSolrCloudBackups [options]
+
+Options:
+
+    -c, --collection COLLECTION         backup given collection only
+    -d, --debug                         print more progress messages
+
+    -h, --help                          show this help
+
+Environment:
+
+    BACKUP_STAMP                        timestamp used for backup directory name
+                                        (default: date +%Y%m%d-%H%M%S GMT)
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2019 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+
+################################################################################
+
+my $sample_collection;
+my $debug_flag;
+my $help_flag;
+
+GetOptions(
+    "collection|c=s"            => \$sample_collection,
+    "debug|d"                   => \$debug_flag,
+    "help|h"                    => \$help_flag,
+);
+
+pod2usage() if $help_flag;
+pod2usage(
+    -exitval => 64, # EX_USAGE
+    -message => "$0: unrecognized arguments",
+) if @ARGV;
+
+################################################################################
+
+$SIG{'INT'} = sub { exit 3 };
+
+use JSON::XS qw( decode_json encode_json );
+use POSIX qw( strftime );
+use Readonly;
+use URI;
+use URI::QueryParam;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use DBDefs;
+use MusicBrainz::Server::Context;
+
+################################################################################
+
+sub _debug { print "[debug] ", (sprintf shift, @_), "\n" if $debug_flag; }
+sub _info { print "[info] ", (sprintf shift, @_), "\n"; }
+sub _warn { warn "[warning] ", (sprintf shift, @_), "\n"; }
+sub _error { warn "[error] ", (sprintf shift, @_), "\n"; }
+
+foreach my $def (qw(
+    SOLRCLOUD_COLLECTIONS_API
+    SOLRCLOUD_BACKUP_LOCATION
+))
+{
+    if (!DBDefs->$def)
+    {
+        _error("$def is not set in DBDefs.");
+        exit 78; # EX_CONFIG
+    }
+}
+
+Readonly my $COLLECTIONS_API => DBDefs->SOLRCLOUD_COLLECTIONS_API;
+Readonly my $BACKUP_LOCATION => DBDefs->SOLRCLOUD_BACKUP_LOCATION;
+
+Readonly my $BACKUP_STAMP => $ENV{BACKUP_STAMP} // strftime "%Y%m%d-%H%M%S", gmtime;
+
+my $c = MusicBrainz::Server::Context->create_script_context;
+
+# pending   => Backup request has not been sent yet
+Readonly my $BACKUP_REQUEST_PENDING => 'pending';
+# running   => Solr Cloud is processing backup request
+Readonly my $BACKUP_REQUEST_RUNNING => 'running';
+# completed => Solr Cloud completely processed backup request
+Readonly my $BACKUP_REQUEST_COMPLETED => 'completed';
+
+Readonly my $collections => $sample_collection
+    ? [$sample_collection]
+    : [grep { $_ ne 'editor' } @{ list_solr_collections() }];
+my %backup_requests;
+prepare_backup_requests();
+_info 'Requesting SolrCloud to backup all collections...';
+do_backup_collections();
+wait_backup_complete();
+_info 'Successfully completed backup for all collections on SolrCloud.';
+exit;
+
+################################################################################
+
+sub list_solr_collections
+{
+    my $solr_response = _query_collections_api('LIST');
+    return $solr_response->{collections};
+}
+
+sub prepare_backup_requests
+{
+    my $next_request_id = 1500;
+    my $has_error;
+    foreach my $collection (sort @$collections)
+    {
+        my $request_id = $next_request_id++;
+        $backup_requests{$request_id} = {
+            name => 'backup_' . $BACKUP_STAMP . '_' . $collection,
+            collection => $collection,
+            status => $BACKUP_REQUEST_PENDING,
+        };
+        my $solr_response = _query_collections_api('REQUESTSTATUS', {
+                requestid => $request_id,
+            }
+        );
+        my $solr_request_status = $solr_response->{status}->{state};
+        if ($solr_request_status ne 'notfound')
+        {
+            _error(
+                "A request to SolrCloud with id '%d' is '%s' already: '%s'",
+                $request_id,
+                $solr_request_status,
+                encode_json($solr_response),
+            );
+            $has_error = 1;
+        }
+    }
+    exit 70 if $has_error; # EX_SOFTWARE
+}
+
+sub do_backup_collections
+{
+    foreach my $request_id (sort keys %backup_requests)
+    {
+        my $backup_name = $backup_requests{$request_id}{name};
+        my $collection = $backup_requests{$request_id}{collection};
+
+        _debug (
+            "Sending backup request '%d' of collection '%s' as '%s'.",
+            $request_id,
+            $collection,
+            $backup_name,
+        );
+        my $solr_response = _query_collections_api('BACKUP', {
+                name => $backup_name,
+                collection => $collection,
+                location => $BACKUP_LOCATION,
+                async => $request_id,
+            }
+        );
+        if (defined $solr_response->{error})
+        {
+            _error(
+                "Failed to backup request '%s' of collection '%s' as '%s': " .
+                "Error '%s'",
+                $request_id,
+                $collection,
+                $backup_name,
+                $solr_response->{error},
+            );
+            _flush_running_requests_status();
+            exit 70; # EX_SOFTWARE
+        }
+        $backup_requests{$request_id}{status} = $BACKUP_REQUEST_RUNNING;
+    }
+}
+
+sub wait_backup_complete
+{
+    while (
+        grep { $backup_requests{$_}{status} eq $BACKUP_REQUEST_RUNNING }
+        keys %backup_requests
+    )
+    {
+        my $pause = '60';
+        _debug "Sleeping $pause";
+        sleep $pause;
+        foreach my $request_id (
+            sort
+            grep { $backup_requests{$_}{status} eq $BACKUP_REQUEST_RUNNING }
+            keys %backup_requests
+        )
+        {
+            my $solr_response = _query_collections_api('REQUESTSTATUS', {
+                    requestid => $request_id,
+                }
+            );
+            _debug (
+                "Received: %s",
+                encode_json($solr_response),
+            );
+            if (exists $solr_response->{error}) {
+                _error(
+                    "Failed on backup request '%s' of collection '%s' as '%s': " .
+                    "Error '%s'",
+                    $request_id,
+                    $backup_requests{$request_id}{collection},
+                    $backup_requests{$request_id}{name},
+                    $solr_response->{error},
+                );
+                _flush_running_requests_status();
+                exit 70; # EX_SOFTWARE
+            }
+            elsif ($solr_response->{status}->{state} eq 'completed')
+            {
+                $backup_requests{$request_id}{status} = $BACKUP_REQUEST_COMPLETED;
+                _query_collections_api('DELETESTATUS', {
+                        requestid => $request_id,
+                    }
+                );
+            }
+            elsif ($solr_response->{status}->{state} ne 'running')
+            {
+                _error(
+                    "Failed on backup request '%s' of collection '%s' as '%s': " .
+                    "Unhandled state '%s'",
+                    $request_id,
+                    $backup_requests{$request_id}{collection},
+                    $backup_requests{$request_id}{name},
+                    $solr_response->{status}->{state},
+                );
+                _flush_running_requests_status();
+                exit 70; # EX_SOFTWARE
+            }
+        }
+    }
+}
+
+sub _flush_running_requests_status
+{
+    foreach my $request_id (
+        sort
+        grep { $backup_requests{$_}{status} eq $BACKUP_REQUEST_RUNNING }
+        keys %backup_requests
+    )
+    {
+        _query_collections_api('DELETESTATUS', {
+                requestid => $request_id,
+            }
+        );
+    }
+}
+
+sub _query_collections_api
+{
+    my ($action, $parameters) = @_;
+
+    my $uri = new URI->new($COLLECTIONS_API);
+    $uri->query_param('action' => $action);
+    foreach my $key (keys %{$parameters})
+    {
+        $uri->query_param_append($key, $parameters->{$key});
+    }
+    _debug "Querying '" . ($uri =~ s/%/%%/gr) . "'";
+
+    my $http_response = $c->lwp->get($uri);
+    if (!$http_response->is_success)
+    {
+        _error(
+            "Failed HTTP request '%s': Error '%s'",
+            $uri =~ s/%/%%/gr,
+            $http_response->status_line,
+        );
+        exit 70; # EX_SOFTWARE
+    }
+
+    my $http_content = $http_response->decoded_content;
+    my $solr_response = decode_json($http_content);
+    if (($solr_response->{responseHeader}->{status} // '') ne '0')
+    {
+        _error(
+            "Failed Solr request at '%s': Response '%s'",
+            $uri =~ s/%/%%/gr,
+            $http_content,
+        );
+        exit 70; # EX_SOFTWARE
+    }
+    return $solr_response;
+}

--- a/admin/RunSearchIndexesDump
+++ b/admin/RunSearchIndexesDump
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -o errexit
+
+exec 220>/tmp/.RunSearchIndexesDump.lock || exit 1
+# Will be automatically released when the script exits.
+flock -n 220 || { echo "Failed to obtain lock. Another instance is running?" >&2; exit 1; }
+
+# This is to help with disk space monitoring - run "df" before and after
+echo "Disk space when RunSearchIndexesDump starts:" ; df -m
+trap 'echo "Disk space when RunSearchIndexesDump ends:" ; df -m' 0
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+cd "$MB_SERVER_ROOT"
+
+source admin/config.sh
+
+. ./admin/functions.sh
+make_temp_dir
+
+DUMP_DIR="$SEARCH_INDEXES_DUMP_DIR"
+DUMP_STAMP=`TZ=UTC date +'%Y%m%d-%H%M%S'`
+
+# Create necessary directories and set permissions.
+mkdir -m "$SEARCH_INDEXES_DUMP_DIR_MODE" -p "$DUMP_DIR/$DUMP_STAMP"
+chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" \
+    "$DUMP_DIR" \
+    "$DUMP_DIR"/"$DUMP_STAMP"
+
+echo `date`" : Requesting SolrCloud backups"
+BACKUP_STAMP="$DUMP_STAMP" \
+    ./admin/RequestSolrCloudBackups \
+    || exit $?
+
+echo `date`" : Retrieving SolrCloud backups"
+MBS_ADMIN_CONFIG=config.search-indexes-dump.sh \
+    ./bin/rsync-solrcloud-backups "$TEMP_DIR" \
+    || exit $?
+
+echo `date`" : Making a search indexes dump"
+BACKUP_STAMP="$DUMP_STAMP" \
+    ./admin/BundleSearchIndexesDump \
+    --working-dir "$TEMP_DIR" \
+    || exit $?
+
+# Copy the dump to the FTP directory.
+chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" "$TEMP_DIR"/*
+chmod "$SEARCH_INDEXES_DUMP_FILE_MODE" "$TEMP_DIR"/*
+mv "$TEMP_DIR"/* "$DUMP_DIR"/"$DUMP_STAMP"/
+
+# Finally create a "latest-is" file, indicating the export we just did.
+rm -rf "$DUMP_DIR"/latest-is-*
+> "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+chmod "$SEARCH_INDEXES_DUMP_FILE_MODE" "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" "$DUMP_DIR"/latest-is-"$DUMP_STAMP"
+
+# Finally finally, create a LATEST file whose *contents* are this export's tag
+rm -rf "$DUMP_DIR"/LATEST
+echo "$DUMP_STAMP" > "$DUMP_DIR"/LATEST
+chmod "$SEARCH_INDEXES_DUMP_FILE_MODE" "$DUMP_DIR"/LATEST
+chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" "$DUMP_DIR"/LATEST
+
+./bin/delete-old-fullexports -k -r "$DUMP_DIR"
+
+MBS_ADMIN_CONFIG=config.search-indexes-dump.sh ./bin/rsync-fullexport-files

--- a/admin/config.default.sh
+++ b/admin/config.default.sh
@@ -15,6 +15,13 @@ JSON_DUMP_GROUP=musicbrainz
 JSON_DUMP_DIR_MODE=755
 JSON_DUMP_FILE_MODE=644
 
+# Same, but for search index dumps.
+SEARCH_INDEXES_DUMP_DIR=/home/musicbrainz/search-index-dumps
+SEARCH_INDEXES_DUMP_USER=musicbrainz
+SEARCH_INDEXES_DUMP_GROUP=musicbrainz
+SEARCH_INDEXES_DUMP_DIR_MODE=755
+SEARCH_INDEXES_DUMP_FILE_MODE=644
+
 # Where to back things up to, who should own the backup files, and what mode
 # those files should have.
 # The backups include a full database export, and all replication data.

--- a/admin/config.search-indexes-dump.sh
+++ b/admin/config.search-indexes-dump.sh
@@ -1,0 +1,4 @@
+RSYNC_FULLEXPORT_DIR="$SEARCH_INDEXES_DUMP_DIR"
+RSYNC_FULLEXPORT_KEY='~/.ssh/rsync-data-search-index-dumps'
+RSYNC_LATEST_KEY='~/.ssh/rsync-data-search-index-dumps-latest'
+RSYNC_SOLRCLOUD_BACKUPS_KEY='~/.ssh/rsync-solrcloud-collections-backup'

--- a/admin/cron/daily-json-dump.sh
+++ b/admin/cron/daily-json-dump.sh
@@ -3,8 +3,8 @@
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
 cd "$MB_SERVER_ROOT"
 
-# Only do this on the nominated days (0=Sun 6=Sat)
-if date +%w | grep -q [36]
+# Only do this on the nominated days 3=Wed and 6=Sat (for reference 0=Sun)
+if date +%w | grep -qw '[36]'
 then
     ./admin/RunJSONDump
 fi

--- a/admin/cron/daily-search-indexes-dump.sh
+++ b/admin/cron/daily-search-indexes-dump.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e -o pipefail -u
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
+cd "$MB_SERVER_ROOT"
+
+# Only do this on the nominated days (0=Sun 6=Sat)
+if date +%w | grep -q [36]
+then
+    ./admin/RunSearchIndexesDump
+fi

--- a/admin/cron/daily-search-indexes-dump.sh
+++ b/admin/cron/daily-search-indexes-dump.sh
@@ -5,8 +5,8 @@ set -e -o pipefail -u
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)
 cd "$MB_SERVER_ROOT"
 
-# Only do this on the nominated days (0=Sun 6=Sat)
-if date +%w | grep -q [36]
+# Only do this on the nominated days 3=Wed and 6=Sat (for reference 0=Sun)
+if date +%w | grep -qw '[36]'
 then
     ./admin/RunSearchIndexesDump
 fi

--- a/admin/cron/daily.sh
+++ b/admin/cron/daily.sh
@@ -52,8 +52,8 @@ echo `date`" : Removing unused works"
 ./admin/cleanup/RemoveEmpty work
 
 # Dump all the data
-# Only do this on the nominated days (0=Sun 6=Sat)
-if date +%w | grep -q [36]
+# Only do this on the nominated days 3=Wed and 6=Sat (for reference 0=Sun)
+if date +%w | grep -qw '[36]'
 then
     FULL=1
 fi
@@ -62,7 +62,7 @@ fi
 # Do any necessary packet bundling
 echo `date`" : Bundling replication packets, daily"
 ./admin/replication/BundleReplicationPackets $FTP_DATA_DIR/replication --period daily --require-previous
-if date +%w | grep -q [6]
+if date +%w | grep -qw '[6]'
 then
     echo `date`" : + weekly"
     ./admin/replication/BundleReplicationPackets $FTP_DATA_DIR/replication --period weekly --require-previous
@@ -77,7 +77,7 @@ nice ./admin/RunReports.pl
 
 # Process subscriptions
 echo `date`" : Processing subscriptions"
-if date +%w | grep -q [6]
+if date +%w | grep -qw '[6]'
 then
     WEEKLY="--weekly"
 fi

--- a/bin/rsync-solrcloud-backups
+++ b/bin/rsync-solrcloud-backups
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+unset SSH_AUTH_SOCK
+
+set -u
+
+DESTINATION="$1"
+
+MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+cd "$MB_SERVER_ROOT"
+
+source admin/config.sh
+source admin/functions.sh
+
+RSYNC_SOLRCLOUD_BACKUPS_BANDWIDTH="$(perl -Ilib -e 'use DBDefs; print DBDefs->SOLRCLOUD_RSYNC_BANDWIDTH;')"
+RSYNC_SOLRCLOUD_BACKUPS_CIPHER_SPEC="$(perl -Ilib -e 'use DBDefs; print DBDefs->SOLRCLOUD_SSH_CIPHER_SPEC;')"
+SOLRCLOUD_COLLECTIONS_API="$(perl -Ilib -e 'use DBDefs; print DBDefs->SOLRCLOUD_COLLECTIONS_API;')"
+RSYNC_SOLRCLOUD_BACKUPS_HOST="$(
+    curl -sS "$SOLRCLOUD_COLLECTIONS_API?action=OVERSEERSTATUS" \
+        | jq -r '.leader' \
+        | sed 's/:.*//'
+)"
+
+if [ -n "$RSYNC_SOLRCLOUD_BACKUPS_HOST" ]; then
+    RSYNC_SOLRCLOUD_BACKUPS_PORT=${RSYNC_SOLRCLOUD_BACKUPS_PORT:-22}
+
+    retry rsync \
+        --archive \
+        --bwlimit="$RSYNC_SOLRCLOUD_BACKUPS_BANDWIDTH" \
+        --delete \
+        --exclude="zk_backup" \
+        --rsh "ssh -i $RSYNC_SOLRCLOUD_BACKUPS_KEY -c $RSYNC_SOLRCLOUD_BACKUPS_CIPHER_SPEC -o Compression=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_SOLRCLOUD_BACKUPS_PORT" \
+        --verbose \
+        solr@"$RSYNC_SOLRCLOUD_BACKUPS_HOST":. \
+        "$DESTINATION/"
+
+    make_temp_dir
+
+    retry rsync \
+        --archive \
+        --delete \
+        --rsh "ssh -i $RSYNC_SOLRCLOUD_BACKUPS_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_SOLRCLOUD_BACKUPS_PORT" \
+        --verbose \
+        "$TEMP_DIR/" \
+        solr@"$RSYNC_SOLRCLOUD_BACKUPS_HOST":.
+fi

--- a/docker/musicbrainz-search-indexes-dump/consul-template-search-indexes-dump.conf
+++ b/docker/musicbrainz-search-indexes-dump/consul-template-search-indexes-dump.conf
@@ -1,0 +1,4 @@
+template {
+    source = "/home/musicbrainz/musicbrainz-server/lib/DBDefs.pm.ctmpl"
+    destination = "/home/musicbrainz/musicbrainz-server/lib/DBDefs.pm"
+}

--- a/docker/musicbrainz-search-indexes-dump/consul-template.service
+++ b/docker/musicbrainz-search-indexes-dump/consul-template.service
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec run-consul-template -config /etc/consul-template-search-indexes-dump.conf

--- a/docker/musicbrainz-search-indexes-dump/crontab
+++ b/docker/musicbrainz-search-indexes-dump/crontab
@@ -1,0 +1,4 @@
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PERL_CARTON_PATH=/home/musicbrainz/carton-local
+SHELL=/bin/bash
+10 4 * * * mkdir -p $HOME/log/daily-search-indexes-dump && cd $HOME/musicbrainz-server && carton exec -- admin/cron/daily-search-indexes-dump.sh > $HOME/log/daily-search-indexes-dump/$(date --utc +\%FT\%TZ).log 2>&1

--- a/docker/templates/DBDefs.pm.ctmpl
+++ b/docker/templates/DBDefs.pm.ctmpl
@@ -213,11 +213,16 @@ sub GIT_SHA { {{executeTemplate "QUOTED_STRING" (env "GIT_SHA")}} }
 {{executeTemplate "STRING_DEF" "RENDERER_SOCKET"}}
 {{executeTemplate "STRING_DEF" "REPLICATION_ACCESS_TOKEN"}}
 {{executeTemplate "STRING_DEF" "SEARCH_ENGINE"}}
+{{executeTemplate "STRING_DEF" "SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL"}}
 {{executeTemplate "STRING_DEF" "SEARCH_SERVER"}}
 {{executeTemplate "STRING_DEF" "SENTRY_DSN"}}
 {{executeTemplate "STRING_DEF" "SENTRY_DSN_PUBLIC"}}
 {{executeTemplate "STRING_DEF" "SESSION_COOKIE"}}
 {{executeTemplate "STRING_DEF" "SMTP_SECRET_CHECKSUM"}}
+{{executeTemplate "STRING_DEF" "SOLRCLOUD_BACKUP_LOCATION"}}
+{{executeTemplate "STRING_DEF" "SOLRCLOUD_COLLECTIONS_API"}}
+{{executeTemplate "STRING_DEF" "SOLRCLOUD_RSYNC_BANDWIDTH"}}
+{{executeTemplate "STRING_DEF" "SOLRCLOUD_SSH_CIPHER_SPEC"}}
 {{executeTemplate "STRING_DEF" "STATIC_RESOURCES_LOCATION"}}
 {{executeTemplate "STRING_DEF" "WEB_SERVER"}}
 {{executeTemplate "STRING_DEF" "WEB_SERVER_SSL"}}

--- a/docker/templates/Dockerfile.search-indexes-dump.m4
+++ b/docker/templates/Dockerfile.search-indexes-dump.m4
@@ -1,0 +1,26 @@
+m4_include(`server_base.m4')m4_dnl
+
+RUN apt_install(`jq zstd')
+
+RUN chown_mb(`/home/musicbrainz/log') && \
+    chown_mb(`/home/musicbrainz/search-index-dumps')
+
+copy_common_mbs_files
+
+COPY \
+    docker/musicbrainz-search-indexes-dump/consul-template-search-indexes-dump.conf \
+    /etc/
+
+COPY \
+    docker/musicbrainz-search-indexes-dump/consul-template.service \
+    /etc/service/consul-template/run
+RUN chmod 755 /etc/service/consul-template/run
+
+COPY docker/musicbrainz-search-indexes-dump/crontab /var/spool/cron/crontabs/musicbrainz
+
+RUN chown musicbrainz:musicbrainz /var/spool/cron/crontabs/musicbrainz && \
+    chmod 600 /var/spool/cron/crontabs/musicbrainz
+
+copy_mb(`docker/templates/DBDefs.pm.ctmpl lib/')
+
+git_info

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -439,6 +439,13 @@ sub DISCOURSE_SSO_SECRET { '' }
 sub USE_SET_DATABASE_HEADER { shift->USE_SELENIUM_HEADER }
 sub USE_SELENIUM_HEADER { 0 }
 
+# Used to create search indexes dump from SolrCloud.
+sub SOLRCLOUD_COLLECTIONS_API { undef }
+sub SOLRCLOUD_BACKUP_LOCATION { undef }
+sub SOLRCLOUD_RSYNC_BANDWIDTH { undef }
+sub SOLRCLOUD_SSH_CIPHER_SPEC { undef }
+sub SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL { undef }
+
 sub WIKIMEDIA_COMMONS_IMAGES_ENABLED { 1 }
 
 # On release browse endpoints in the webservice, we limit the number of

--- a/lib/MusicBrainz/Script/MBDump.pm
+++ b/lib/MusicBrainz/Script/MBDump.pm
@@ -118,7 +118,7 @@ sub copy_readme() {
 }
 
 sub gpg_sign {
-    my ($self, $file_to_be_signed) = @_;
+    my ($file_to_be_signed) = @_;
 
     my $sign_with = DBDefs->GPG_SIGN_KEY;
     return unless $sign_with;
@@ -175,7 +175,7 @@ sub make_tar {
     $? == 0 or die "Tar returned $?";
     log(sprintf "Tar completed in %d seconds\n", tv_interval($t0));
 
-    $self->gpg_sign("$output_dir/$tar_file");
+    gpg_sign("$output_dir/$tar_file");
 }
 
 sub copy_file {
@@ -218,7 +218,7 @@ sub write_checksum_files {
 
         $? == 0 or die "$hash_program returned $?";
 
-        $self->gpg_sign("$output_dir/$hash_output_file");
+        gpg_sign("$output_dir/$hash_output_file");
     }
 }
 


### PR DESCRIPTION
# Add MBS-10546: Dump MB Solr data along with MB DB full export

Bootstrapping a mirror with indexed search requires huge resources.
Solution here is to provide search indexes dump on FTP to start with.

Since search indexes dump must have all entities from latest mbdumps, and is allowed to have more recent entities (that will be replicated), it starts at 4:10 which is expected to be after the end of full export.

SolrCloud collections backup is pretty fast (few minutes).

However compressing 50GB takes some time, thus the dedicated service.

It adds the following five entries to DBDefs:
* SOLRCLOUD_COLLECTIONS_API that is SolrCloud Collections API endpoint.
* SOLRCLOUD_BACKUP_LOCATION that is the absolute path on SolrCloud leader filesystem to save backups to and retrieve these from.
* SOLRCLOUD_RSYNC_BANDWIDTH that is passed to `rsync --bwlimit` to prevent the search service to timeout during backup's download.
* SOLRCLOUD_SSH_CIPHER_SPEC that is passed to `ssh -c` to lower CPU load of retrieving backups. Differences can be significant according to https://blog.famzah.net/2010/06/11/openssh-ciphers-performance-benchmark/
* SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL that is passed to `zstd -` to set compression level with the best trade-off between speed and size.