### PR TITLE
MBS-9651: Ignore superseded votes for editor stats

### DIFF
--- a/lib/MusicBrainz/Server/Data/Vote.pm
+++ b/lib/MusicBrainz/Server/Data/Vote.pm
@@ -133,7 +133,7 @@ sub editor_statistics
 
     my $base_query = "SELECT vote, count(vote) AS count " .
         "FROM vote " .
-        "WHERE editor = ? ";
+        "WHERE NOT superseded AND editor = ? ";
 
     my $q_all_votes    = $base_query . "GROUP BY vote";
     my $q_recent_votes = $base_query .


### PR DESCRIPTION
MBS-9651

When searching for votes or compiling general voting statistics we ignore votes that have been superseded (i.e. we only count the last vote by an editor for each particular edit). This changes the editor profile vote count to also ignore superseded votes.