### PR TITLE
MBS-10683 / MBS-10684 / MBS-10685: Place map fixes

### DIFF
--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -47,7 +47,7 @@
     [%- area_bubble() -%]
 
     <div class="bubble" id="coordinates-bubble">
-        <p>[% l('Enter coordinates manually or drag the marker to get coordinates from the map.') %]</p>
+        <p>[% l('Enter coordinates manually or click the map to get coordinates from the marker. If you’re too far out, clicking will zoom instead.') %]</p>
         <div id="largemap"></div>
         [% script_manifest('place/map.js', { 'data-args' => map_data_args }) %]
     </div>

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -47,8 +47,7 @@ map.on('click', function (e) {
         updateCoordinates(e.latlng);
     } else {
         // If the map is zoomed too far out, marker placement would be wildly inaccurate, so just zoom in.
-        map.setView(e.latlng);
-        map.zoomIn(2);
+        map.setView(e.latlng, map.getZoom() + 2);
     }
 });
 

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -84,10 +84,9 @@ $('input[name=edit-place\\.coordinates]').on('input', function () {
             $('input[name=edit-place\\.coordinates]').addClass('success');
             coordinatesError(false);
 
-            marker.setLatLng(L.latLng(data.coordinates.latitude, data.coordinates.longitude));
-
-            map.panTo(L.latLng(data.coordinates.latitude, data.coordinates.longitude));
-            map.setZoom(16);
+            const coords = L.latLng(data.coordinates.latitude, data.coordinates.longitude);
+            marker.setLatLng(coords);
+            map.setView(coords, 16);
         }).fail(function (jqxhr, textStatus) {
             if (textStatus === 'abort') {
                 return;


### PR DESCRIPTION
MBS-10683 / MBS-10684 / MBS-10685

An issue occurs sometimes with Leaflet that moves the marker to the entered coordinates, but then zooms the map on (0, 0). It seems to be a race condition of some kind between panTo and setZoom.

This moves from panTo + setZoom to setView (which allows passing a zoom parameter, obviating the need for a second call to setZoom). panTo actually uses setView internally anyway.

This seems to lead to consistent correct results locally, so hopefully it'll also do the trick in the main servers.