### PR TITLE
MBS-10365 (V): Convert entity lists to react-table

### DIFF
--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -16,6 +16,8 @@ declare module 'react-table' {
   declare export type ColumnInstance = {
     +className?: string,
     +getHeaderProps: (props?: {...}) => {...},
+    // Not actually part of react-table but our own expansion of it
+    +headerProps?: {[attribute: string]: string},
     +render: (type: 'Header' | string, props?: {...}) => React$Node,
   };
 

--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -37,6 +37,7 @@ declare module 'react-table' {
   declare export type Row<+D> = {
     +cells: $ReadOnlyArray<Cell<mixed>>,
     +getRowProps: (props?: {...}) => {...},
+    +index: number,
     +original: D,
   };
 

--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -1,15 +1,17 @@
+// @flow strict
+
 declare module 'react-table' {
   declare export type CellRenderProps<D, +V> = {
+    +cell: Cell<V>,
     +column: ColumnInstance,
     +row: Row<D>,
-    +cell: Cell<V>,
   };
 
   declare export type ColumnOptions<D, V> = {
     +accessor?: $Keys<D> | ((D) => V),
-    +id?: string,
-    +Header?: Renderer<HeaderProps<D>>,
     +Cell?: React$AbstractComponent<CellRenderProps<D, V>, mixed>,
+    +Header?: Renderer<HeaderProps<D>>,
+    +id?: string,
     ...,
   };
 

--- a/root/components/RemoveFromMergeTableCell.js
+++ b/root/components/RemoveFromMergeTableCell.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import ENTITIES from '../../entities';
 
+// Converted to react-table at root/utility/tableColumns.js
 const RemoveFromMergeTableCell = ({
   entity,
   toMerge,

--- a/root/components/RemoveFromMergeTableHeader.js
+++ b/root/components/RemoveFromMergeTableHeader.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+// Converted to react-table at root/utility/tableColumns.js
 const RemoveFromMergeTableHeader = (
   {toMerge}: {toMerge: $ReadOnlyArray<CoreEntityT>},
 ) => (

--- a/root/components/Table.js
+++ b/root/components/Table.js
@@ -13,7 +13,11 @@ import {useTable} from 'react-table';
 import loopParity from '../utility/loopParity';
 
 const renderTableHeaderCell = (column) => (
-  <th {...column.getHeaderProps({className: column.className})}>
+  <th
+    {...column.getHeaderProps(
+      {...column.headerProps, className: column.className},
+    )}
+  >
     {column.render('Header')}
   </th>
 );

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -176,9 +176,9 @@ export function defineCountColumn<D>(
   className?: string,
 ): ColumnOptions<D, number> {
   return {
-    Cell: ({row: {original}}) => (
+    Cell: ({cell: {value}}) => (
       <CatalystContext.Consumer>
-        {($c: CatalystContextT) => formatCount($c, getCount(original))}
+        {($c: CatalystContextT) => formatCount($c, value)}
       </CatalystContext.Consumer>
     ),
     Header: (sortable
@@ -190,6 +190,7 @@ export function defineCountColumn<D>(
         />
       )
       : title),
+    accessor: row => getCount(row),
     className: className || 'count c',
     id: columnName,
   };


### PR DESCRIPTION
On top of https://github.com/metabrainz/musicbrainz-server/pull/1413

MBS-10365

* [ ] Artist
* [x] Event
* [x] Recording
* [x] Release
* [x] Release group

Artist (the only one left) is a bit more annoying since the component is currently being shared between search results and normal lists. We might want to split that one for now, until we can figure out how to easily do search results with react-table.