### PR TITLE
MBS-10689: Update MapBox API calls

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -381,7 +381,7 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
 # Mapbox access token must be set to display area/place maps.
-# sub MAPBOX_MAP_ID { 'mapbox.streets' }
+# sub MAPBOX_MAP_ID { 'mapbox/streets-v11' }
 # sub MAPBOX_ACCESS_TOKEN { '' }
 
 # Disallow OAuth2 requests over plain HTTP

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -359,7 +359,7 @@ sub COVER_ART_ARCHIVE_UPLOAD_PREFIXER { shift; sprintf("//%s.s3.us.archive.org/"
 sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 
 # Mapbox access token must be set to display area/place maps.
-sub MAPBOX_MAP_ID { 'mapbox.streets' }
+sub MAPBOX_MAP_ID { 'mapbox/streets-v11' }
 sub MAPBOX_ACCESS_TOKEN { '' }
 
 # Disallow OAuth2 requests over plain HTTP

--- a/root/static/scripts/common/leaflet.js
+++ b/root/static/scripts/common/leaflet.js
@@ -48,10 +48,12 @@ L.Icon.Default.prototype._getIconUrl = function (name) {
 export function createMap(latitude, longitude, zoom) {
   const map = L.map('largemap').setView([latitude, longitude], zoom);
 
-  L.tileLayer('https://{s}.tiles.mapbox.com/v4/' + DBDefs.MAPBOX_MAP_ID + '/{z}/{x}/{y}.png?access_token=' + DBDefs.MAPBOX_ACCESS_TOKEN, {
+  L.tileLayer('https://api.mapbox.com/styles/v1/' + DBDefs.MAPBOX_MAP_ID + '/tiles/{z}/{x}/{y}?access_token=' + DBDefs.MAPBOX_ACCESS_TOKEN, {
     attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> ' +
                  '<a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
     maxZoom: 18,
+    tileSize: 512,
+    zoomOffset: -1,
   }).addTo(map);
 
   return map;

--- a/root/static/scripts/common/leaflet.js
+++ b/root/static/scripts/common/leaflet.js
@@ -11,30 +11,30 @@ import L from 'leaflet/dist/leaflet-src';
 import * as DBDefs from './DBDefs-client';
 
 const iconsUrls = {
-  'arena-marker-icon-2x.png':
-    require('../../images/leaflet/arena-marker-icon-2x.png'),
   'arena-marker-icon.png':
     require('../../images/leaflet/arena-marker-icon.png'),
+  'arena-marker-icon-2x.png':
+    require('../../images/leaflet/arena-marker-icon-2x.png'),
   'cluster-marker-icon.png':
     require('../../images/leaflet/cluster-marker-icon.png'),
-  'marker-icon-2x.png': require('../../images/leaflet/marker-icon-2x.png'),
   'marker-icon.png': require('../../images/leaflet/marker-icon.png'),
-  'religious-marker-icon-2x.png':
-    require('../../images/leaflet/religious-marker-icon-2x.png'),
+  'marker-icon-2x.png': require('../../images/leaflet/marker-icon-2x.png'),
   'religious-marker-icon.png':
     require('../../images/leaflet/religious-marker-icon.png'),
-  'stadium-marker-icon-2x.png':
-    require('../../images/leaflet/stadium-marker-icon-2x.png'),
+  'religious-marker-icon-2x.png':
+    require('../../images/leaflet/religious-marker-icon-2x.png'),
   'stadium-marker-icon.png':
     require('../../images/leaflet/stadium-marker-icon.png'),
-  'studio-marker-icon-2x.png':
-    require('../../images/leaflet/studio-marker-icon-2x.png'),
+  'stadium-marker-icon-2x.png':
+    require('../../images/leaflet/stadium-marker-icon-2x.png'),
   'studio-marker-icon.png':
     require('../../images/leaflet/studio-marker-icon.png'),
-  'venue-marker-icon-2x.png':
-    require('../../images/leaflet/venue-marker-icon-2x.png'),
+  'studio-marker-icon-2x.png':
+    require('../../images/leaflet/studio-marker-icon-2x.png'),
   'venue-marker-icon.png':
     require('../../images/leaflet/venue-marker-icon.png'),
+  'venue-marker-icon-2x.png':
+    require('../../images/leaflet/venue-marker-icon-2x.png'),
 };
 
 L.Icon.Default.prototype._getIconUrl = function (name) {


### PR DESCRIPTION
The old Studio Classic style for MapBox we use is being discontinued in June 2020. This follows the instructions on their guide (https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/) in order to move to the latest version of the maps.
