### PR TITLE
MBS-10692: Change React imports to "import * as React"

### DIFF
--- a/root/account/Donation.js
+++ b/root/account/Donation.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {CONTACT_URL, DONATE_URL} from '../constants';
 import StatusPage from '../components/StatusPage';

--- a/root/account/EmailVerificationStatus.js
+++ b/root/account/EmailVerificationStatus.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import StatusPage from '../components/StatusPage';
 

--- a/root/account/LostPasswordSent.js
+++ b/root/account/LostPasswordSent.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {CONTACT_URL} from '../constants';
 import StatusPage from '../components/StatusPage';

--- a/root/account/LostUsernameSent.js
+++ b/root/account/LostUsernameSent.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {CONTACT_URL} from '../constants';
 import StatusPage from '../components/StatusPage';

--- a/root/account/PreferencesSaved.js
+++ b/root/account/PreferencesSaved.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import StatusPage from '../components/StatusPage';

--- a/root/account/ResetPasswordStatus.js
+++ b/root/account/ResetPasswordStatus.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import StatusPage from '../components/StatusPage';
 

--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {ACCESS_SCOPE_PERMISSIONS} from '../../constants';
 import {compare} from '../../static/scripts/common/i18n';

--- a/root/account/sso/DiscourseRegistered.js
+++ b/root/account/sso/DiscourseRegistered.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 

--- a/root/account/sso/DiscourseUnconfirmedEmailAddress.js
+++ b/root/account/sso/DiscourseUnconfirmedEmailAddress.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 

--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 import {compare} from '../../static/scripts/common/i18n';

--- a/root/admin/attributes/Index.js
+++ b/root/admin/attributes/Index.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 

--- a/root/admin/attributes/Language.js
+++ b/root/admin/attributes/Language.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 import {compare} from '../../static/scripts/common/i18n';

--- a/root/admin/attributes/Script.js
+++ b/root/admin/attributes/Script.js
@@ -9,7 +9,7 @@
  */
 
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../../layout';
 import {compare} from '../../static/scripts/common/i18n';

--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import ArtistList from '../components/list/ArtistList';

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import EventList from '../components/list/EventList';

--- a/root/area/AreaHeader.js
+++ b/root/area/AreaHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import AreaContainmentLink
   from '../static/scripts/common/components/AreaContainmentLink';

--- a/root/area/AreaIndex.js
+++ b/root/area/AreaIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import LabelList from '../components/list/LabelList';

--- a/root/area/AreaLayout.js
+++ b/root/area/AreaLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import AreaSidebar from '../layout/components/sidebar/AreaSidebar';
@@ -17,7 +16,7 @@ import localizeAreaName from '../static/scripts/common/i18n/localizeAreaName';
 import AreaHeader from './AreaHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: AreaT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import PlaceList from '../components/list/PlaceList';

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import ReleaseList from '../components/list/ReleaseList';

--- a/root/area/AreaUsers.js
+++ b/root/area/AreaUsers.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import PaginatedResults from '../components/PaginatedResults';
 import EditorLink from '../static/scripts/common/components/EditorLink';

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import EventList from '../components/list/EventList';

--- a/root/artist/ArtistHeader.js
+++ b/root/artist/ArtistHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/artist/ArtistLayout.js
+++ b/root/artist/ArtistLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import ArtistSidebar from '../layout/components/sidebar/ArtistSidebar';
@@ -16,7 +15,7 @@ import ArtistSidebar from '../layout/components/sidebar/ArtistSidebar';
 import ArtistHeader from './ArtistHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: ArtistT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 import sortBy from 'lodash/sortBy';
 
 import EnterEdit from '../components/EnterEdit';

--- a/root/artist/ArtistRelationships.js
+++ b/root/artist/ArtistRelationships.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Relationships from '../components/Relationships';
 import RelationshipsTable from '../components/RelationshipsTable';

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import WorkList from '../components/list/WorkList';

--- a/root/artist/CannotSplit.js
+++ b/root/artist/CannotSplit.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import ArtistLayout from './ArtistLayout';
 

--- a/root/artist/SpecialPurpose.js
+++ b/root/artist/SpecialPurpose.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import ArtistLayout from './ArtistLayout';
 

--- a/root/collection/CollectionHeader.js
+++ b/root/collection/CollectionHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityTabLink from '../components/EntityTabLink';
 import SubHeader from '../components/SubHeader';

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import AreaList from '../components/list/AreaList';

--- a/root/collection/CollectionLayout.js
+++ b/root/collection/CollectionLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import CollectionSidebar
@@ -17,7 +16,7 @@ import CollectionSidebar
 import CollectionHeader from './CollectionHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: CollectionT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/collection/CreateCollection.js
+++ b/root/collection/CreateCollection.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import * as manifest from '../static/manifest';

--- a/root/collection/DeleteCollection.js
+++ b/root/collection/DeleteCollection.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import FormSubmit from '../components/FormSubmit';

--- a/root/collection/EditCollection.js
+++ b/root/collection/EditCollection.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import * as manifest from '../static/manifest';
 import CollectionEditForm

--- a/root/components/Aliases/AliasTable.js
+++ b/root/components/Aliases/AliasTable.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-
+import * as React from 'react';
 
 import AliasTableBody from './AliasTableBody';
 

--- a/root/components/Aliases/AliasTableBody.js
+++ b/root/components/Aliases/AliasTableBody.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import AliasTableRow from './AliasTableRow';
 

--- a/root/components/Aliases/AliasTableRow.js
+++ b/root/components/Aliases/AliasTableRow.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import isolateText from '../../static/scripts/common/utility/isolateText';
 import formatDate from '../../static/scripts/common/utility/formatDate';

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import ArtistCreditLink

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import EntityLink from '../../static/scripts/common/components/EntityLink';

--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {commaOnlyListText} from '../static/scripts/common/i18n/commaOnlyList';
 import {bracketedText} from '../static/scripts/common/utility/bracketed';

--- a/root/components/CleanupBanner.js
+++ b/root/components/CleanupBanner.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const cleanupBannerStrings = {
   artist: N_l(

--- a/root/components/EnterEdit.js
+++ b/root/components/EnterEdit.js
@@ -7,12 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 
 type Props<F> = {
-  +children: ReactNode,
+  +children: React.Node,
   +form: FormT<{...F, +make_votable: ReadOnlyFieldT<boolean>}>,
 };
 

--- a/root/components/EnterEditNote.js
+++ b/root/components/EnterEditNote.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';

--- a/root/components/EntityTabLink.js
+++ b/root/components/EntityTabLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../static/scripts/common/components/EntityLink';
 

--- a/root/components/FieldErrors.js
+++ b/root/components/FieldErrors.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import expand2react from '../static/scripts/common/i18n/expand2react';
 import subfieldErrors, {type FieldShape} from '../utility/subfieldErrors';

--- a/root/components/FormLabel.js
+++ b/root/components/FormLabel.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 type Props = {
   +forField?: {+html_name: string, ...},

--- a/root/components/FormRow.js
+++ b/root/components/FormRow.js
@@ -7,11 +7,10 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +hasNoLabel?: boolean,
 };
 

--- a/root/components/FormRowEmailLong.js
+++ b/root/components/FormRowEmailLong.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowTextLong from './FormRowTextLong';

--- a/root/components/FormRowPartialDate.js
+++ b/root/components/FormRowPartialDate.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';

--- a/root/components/FormRowRadio.js
+++ b/root/components/FormRowRadio.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {unwrapNl} from '../static/scripts/common/i18n';
 

--- a/root/components/FormRowSelectList.js
+++ b/root/components/FormRowSelectList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';

--- a/root/components/FormRowText.js
+++ b/root/components/FormRowText.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';

--- a/root/components/FormRowTextArea.js
+++ b/root/components/FormRowTextArea.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';

--- a/root/components/FormRowTextLong.js
+++ b/root/components/FormRowTextLong.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowText from './FormRowText';

--- a/root/components/FormRowURLLong.js
+++ b/root/components/FormRowURLLong.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import type {Props as FormRowTextProps} from './FormRowText';
 import FormRowTextLong from './FormRowTextLong';

--- a/root/components/FormSubmit.js
+++ b/root/components/FormSubmit.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 type Props = {
   +className?: string,

--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../static/scripts/common/components/EntityLink';
 import commaList from '../static/scripts/common/i18n/commaList';

--- a/root/components/HiddenField.js
+++ b/root/components/HiddenField.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 type Props = {
   +field: ReadOnlyFieldT<number | string>,

--- a/root/components/LinkSearchableLanguage.js
+++ b/root/components/LinkSearchableLanguage.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import LinkSearchableProperty from './LinkSearchableProperty';
 

--- a/root/components/LinkSearchableProperty.js
+++ b/root/components/LinkSearchableProperty.js
@@ -9,7 +9,7 @@
 
 import {URL} from 'url';
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import escapeLuceneValue

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -7,12 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
+
 import Paginator from './Paginator';
-import type {Node as ReactNode} from 'react';
+
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +pager: PagerT,
   +query?: string,
   +search?: boolean,

--- a/root/components/Paginator.js
+++ b/root/components/Paginator.js
@@ -8,7 +8,7 @@
  */
 
 import {range} from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import uriWith from '../utility/uriWith';

--- a/root/components/RatingStars.js
+++ b/root/components/RatingStars.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import ratingTooltip from '../utility/ratingTooltip';

--- a/root/components/RemoveFromMergeTableCell.js
+++ b/root/components/RemoveFromMergeTableCell.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import ENTITIES from '../../entities';
 

--- a/root/components/RemoveFromMergeTableHeader.js
+++ b/root/components/RemoveFromMergeTableHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const RemoveFromMergeTableHeader = (
   {toMerge}: {toMerge: $ReadOnlyArray<CoreEntityT>},

--- a/root/components/SelectField.js
+++ b/root/components/SelectField.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {unwrapNl} from '../static/scripts/common/i18n';
 import getSelectValue from '../utility/getSelectValue';

--- a/root/components/SortableTableHeader.js
+++ b/root/components/SortableTableHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import uriWith from '../utility/uriWith';

--- a/root/components/StatusPage.js
+++ b/root/components/StatusPage.js
@@ -7,13 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 
 type Props = {
-  children: ReactNode,
+  children: React.Node,
   title: string,
 };
 

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import ArtistListEntry

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import loopParity from '../../utility/loopParity';

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 import {groupBy} from 'lodash';
 
 import {withCatalystContext} from '../../context';

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Table from '../Table';
 import {withCatalystContext} from '../../context';

--- a/root/doc/DocError.js
+++ b/root/doc/DocError.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import Layout from '../layout';

--- a/root/doc/DocPage.js
+++ b/root/doc/DocPage.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import * as DBDefs from '../static/scripts/common/DBDefs';

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';

--- a/root/edit/details/AddArea.js
+++ b/root/edit/details/AddArea.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
 import formatDate from '../../static/scripts/common/utility/formatDate';

--- a/root/edit/details/AddArtist.js
+++ b/root/edit/details/AddArtist.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   artistBeginAreaLabel,

--- a/root/edit/details/AddEvent.js
+++ b/root/edit/details/AddEvent.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty';

--- a/root/edit/details/AddPlace.js
+++ b/root/edit/details/AddPlace.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import DescriptiveLink from
   '../../static/scripts/common/components/DescriptiveLink';

--- a/root/edit/details/AddRemoveAlias.js
+++ b/root/edit/details/AddRemoveAlias.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import bracketed from '../../static/scripts/common/utility/bracketed';
 import formatEntityTypeName

--- a/root/edit/details/AddSeries.js
+++ b/root/edit/details/AddSeries.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 

--- a/root/edit/details/AddWork.js
+++ b/root/edit/details/AddWork.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import {commaOnlyListText} from

--- a/root/edit/details/EditAlias.js
+++ b/root/edit/details/EditAlias.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';

--- a/root/edit/details/EditPlace.js
+++ b/root/edit/details/EditPlace.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import DescriptiveLink from
   '../../static/scripts/common/components/DescriptiveLink';

--- a/root/edit/details/EditSeries.js
+++ b/root/edit/details/EditSeries.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import Diff from '../../static/scripts/edit/components/edit/Diff';

--- a/root/edit/details/MergeAreas.js
+++ b/root/edit/details/MergeAreas.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import AreaList from '../../components/list/AreaList';
 

--- a/root/edit/details/MergeArtists.js
+++ b/root/edit/details/MergeArtists.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import ArtistList from '../../components/list/ArtistList';
 import yesNo from '../../static/scripts/common/utility/yesNo';

--- a/root/edit/details/MergeEvents.js
+++ b/root/edit/details/MergeEvents.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EventList from '../../components/list/EventList';
 

--- a/root/edit/details/MergeInstruments.js
+++ b/root/edit/details/MergeInstruments.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import InstrumentList from '../../components/list/InstrumentList';
 

--- a/root/edit/details/MergeLabels.js
+++ b/root/edit/details/MergeLabels.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import LabelList from '../../components/list/LabelList';
 

--- a/root/edit/details/MergePlaces.js
+++ b/root/edit/details/MergePlaces.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import PlaceList from '../../components/list/PlaceList';
 

--- a/root/edit/details/MergeRecordings.js
+++ b/root/edit/details/MergeRecordings.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import RecordingList from '../../components/list/RecordingList';
 

--- a/root/edit/details/MergeReleaseGroups.js
+++ b/root/edit/details/MergeReleaseGroups.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {ReleaseGroupListTable} from '../../components/list/ReleaseGroupList';
 

--- a/root/edit/details/MergeSeries.js
+++ b/root/edit/details/MergeSeries.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import SeriesList from '../../components/list/SeriesList';
 

--- a/root/edit/details/MergeWorks.js
+++ b/root/edit/details/MergeWorks.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import WorkList from '../../components/list/WorkList';
 

--- a/root/edit/details/historic/MergeReleases.js
+++ b/root/edit/details/historic/MergeReleases.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import DescriptiveLink
   from '../../../static/scripts/common/components/DescriptiveLink';

--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EditorLink from '../static/scripts/common/components/EditorLink';
 import bracketed from '../static/scripts/common/utility/bracketed';

--- a/root/elections/ElectionTable/ElectionTableRows.js
+++ b/root/elections/ElectionTable/ElectionTableRows.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import EditorLink from '../../static/scripts/common/components/EditorLink';
@@ -64,7 +63,7 @@ const ElectionTableRow = withCatalystContext(({
 
 const ElectionTableRows = (
   {elections}: {+elections: $ReadOnlyArray<AutoEditorElectionT>},
-): ReactNode => elections.map((election, index) => (
+): React.Node => elections.map((election, index) => (
   <ElectionTableRow
     election={election}
     index={index}

--- a/root/elections/ElectionTable/index.js
+++ b/root/elections/ElectionTable/index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Rows from './ElectionTableRows';
 

--- a/root/elections/ElectionVotes.js
+++ b/root/elections/ElectionVotes.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EditorLink from '../static/scripts/common/components/EditorLink';
 import formatUserDate from '../utility/formatUserDate';

--- a/root/elections/ElectionVoting.js
+++ b/root/elections/ElectionVoting.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {canCancel, canSecond, canVote, isInvolved}
   from '../utility/voting';

--- a/root/elections/Index.js
+++ b/root/elections/Index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 

--- a/root/elections/Nominate.js
+++ b/root/elections/Nominate.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import ConfirmLayout from '../components/ConfirmLayout';
 import EditorLink from '../static/scripts/common/components/EditorLink';

--- a/root/elections/Show.js
+++ b/root/elections/Show.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import Layout from '../layout';

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import chooseLayoutComponent from '../utility/chooseLayoutComponent';
 import AliasesComponent from '../components/Aliases';

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {ENTITIES} from '../static/scripts/common/constants';
 import DBDefs from '../static/scripts/common/DBDefs';

--- a/root/entity/NotFound.js
+++ b/root/entity/NotFound.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import expand2react from '../static/scripts/common/i18n/expand2react';
 import NotFoundComponent from '../components/NotFound';

--- a/root/entity/Subscribers.js
+++ b/root/entity/Subscribers.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EditorLink from '../static/scripts/common/components/EditorLink';
 import chooseLayoutComponent from '../utility/chooseLayoutComponent';

--- a/root/entity/Tags.js
+++ b/root/entity/Tags.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import chooseLayoutComponent from '../utility/chooseLayoutComponent';
 import {withCatalystContext} from '../context';

--- a/root/event/EventHeader.js
+++ b/root/event/EventHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/event/EventIndex.js
+++ b/root/event/EventIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract

--- a/root/event/EventLayout.js
+++ b/root/event/EventLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import EventSidebar from '../layout/components/sidebar/EventSidebar';
@@ -16,7 +15,7 @@ import EventSidebar from '../layout/components/sidebar/EventSidebar';
 import EventHeader from './EventHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: EventT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/genre/CreateGenre.js
+++ b/root/genre/CreateGenre.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 

--- a/root/genre/DeleteGenre.js
+++ b/root/genre/DeleteGenre.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import FormSubmit from '../components/FormSubmit';

--- a/root/genre/EditGenre.js
+++ b/root/genre/EditGenre.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import GenreEditForm from './GenreEditForm';
 import GenreLayout from './GenreLayout';

--- a/root/genre/GenreEditForm.js
+++ b/root/genre/GenreEditForm.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import FormRowTextLong from '../components/FormRowTextLong';

--- a/root/genre/GenreHeader.js
+++ b/root/genre/GenreHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 import EntityLink from '../static/scripts/common/components/EntityLink';

--- a/root/genre/GenreIndex.js
+++ b/root/genre/GenreIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import TagLink from '../static/scripts/common/components/TagLink';
 

--- a/root/genre/GenreLayout.js
+++ b/root/genre/GenreLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import GenreSidebar from '../layout/components/sidebar/GenreSidebar';
@@ -16,7 +15,7 @@ import GenreSidebar from '../layout/components/sidebar/GenreSidebar';
 import GenreHeader from './GenreHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: GenreT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import ArtistList from '../components/list/ArtistList';

--- a/root/instrument/InstrumentHeader.js
+++ b/root/instrument/InstrumentHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/instrument/InstrumentIndex.js
+++ b/root/instrument/InstrumentIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract

--- a/root/instrument/InstrumentLayout.js
+++ b/root/instrument/InstrumentLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import InstrumentSidebar
@@ -20,7 +19,7 @@ import localizeInstrumentName
 import InstrumentHeader from './InstrumentHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: InstrumentT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import RecordingList from '../components/list/RecordingList';

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import ReleaseList from '../components/list/ReleaseList';

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import EntityLink from '../static/scripts/common/components/EntityLink';

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import Layout from '../layout';

--- a/root/label/LabelHeader.js
+++ b/root/label/LabelHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import CleanupBanner from '../components/CleanupBanner';

--- a/root/label/LabelLayout.js
+++ b/root/label/LabelLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import LabelSidebar from '../layout/components/sidebar/LabelSidebar';
@@ -16,7 +15,7 @@ import LabelSidebar from '../layout/components/sidebar/LabelSidebar';
 import LabelHeader from './LabelHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: LabelT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/label/LabelRelationships.js
+++ b/root/label/LabelRelationships.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Relationships from '../components/Relationships';
 import RelationshipsTable from '../components/RelationshipsTable';

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -8,7 +8,7 @@
  */
 
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import {VARTIST_GID} from '../../static/scripts/common/constants';

--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -8,7 +8,7 @@
 
 import URL from 'url';
 
-import React from 'react';
+import * as React from 'react';
 import _ from 'lodash';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import * as manifest from '../../static/manifest';

--- a/root/layout/components/Header.js
+++ b/root/layout/components/Header.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import HeaderLogo from './HeaderLogo';
 import TopMenu from './TopMenu';

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import DescriptiveLink

--- a/root/layout/components/MetaDescription.js
+++ b/root/layout/components/MetaDescription.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {artistBeginLabel, artistEndLabel} from '../../artist/utils';
 import formatBarcode from '../../static/scripts/common/utility/formatBarcode';

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import SearchIcon from '../../static/scripts/common/components/SearchIcon';
 import * as DBDefs from '../../static/scripts/common/DBDefs';

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import RequestLogin from '../../components/RequestLogin';
 import {withCatalystContext} from '../../context';

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 import CommonsImage

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   artistBeginAreaLabel,

--- a/root/layout/components/sidebar/CollectionList.js
+++ b/root/layout/components/sidebar/CollectionList.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 import entityHref from '../../../static/scripts/common/utility/entityHref';
@@ -57,7 +56,7 @@ type CollectionListProps = {
   +ownCollectionsHeader: string,
   +ownCollectionsNoneText: string,
   +sectionClass: string,
-  +usersLink: ReactNode,
+  +usersLink: React.Node,
   +usersLinkHeader: string,
 };
 

--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 

--- a/root/layout/components/sidebar/LastUpdated.js
+++ b/root/layout/components/sidebar/LastUpdated.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 import formatUserDate from '../../../utility/formatUserDate';

--- a/root/layout/components/sidebar/MergeLink.js
+++ b/root/layout/components/sidebar/MergeLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 
 type Props = {

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 import ArtistCreditLink

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../context';
 import ArtistCreditLink

--- a/root/layout/components/sidebar/RemoveLink.js
+++ b/root/layout/components/sidebar/RemoveLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import entityHref from '../../../static/scripts/common/utility/entityHref';
 

--- a/root/layout/components/sidebar/SidebarRating.js
+++ b/root/layout/components/sidebar/SidebarRating.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import RatingStars from '../../../components/RatingStars';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';

--- a/root/layout/components/sidebar/UrlSidebar.js
+++ b/root/layout/components/sidebar/UrlSidebar.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EditLinks from './EditLinks';
 import LastUpdated from './LastUpdated';

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import {formatUserDateObject} from '../utility/formatUserDate';

--- a/root/main/404.js
+++ b/root/main/404.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import Layout from '../layout';

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -8,7 +8,7 @@
  */
 
 import he from 'he';
-import React from 'react';
+import * as React from 'react';
 
 import {ArtworkImage} from '../components/Artwork';
 import Layout from '../layout';

--- a/root/mbid/NotFound.js
+++ b/root/mbid/NotFound.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import NotFound from '../components/NotFound';
 

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import EventList from '../components/list/EventList';

--- a/root/place/PlaceHeader.js
+++ b/root/place/PlaceHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/place/PlaceIndex.js
+++ b/root/place/PlaceIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract

--- a/root/place/PlaceLayout.js
+++ b/root/place/PlaceLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import PlaceSidebar from '../layout/components/sidebar/PlaceSidebar';
@@ -16,7 +15,7 @@ import PlaceSidebar from '../layout/components/sidebar/PlaceSidebar';
 import PlaceHeader from './PlaceHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: PlaceT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/place/PlaceMap.js
+++ b/root/place/PlaceMap.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import * as manifest from '../static/manifest';
 import * as DBDefs from '../static/scripts/common/DBDefs-client';

--- a/root/place/PlacePerformances.js
+++ b/root/place/PlacePerformances.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import RelationshipsTable from '../components/RelationshipsTable';
 

--- a/root/recording/RecordingFingerprints.js
+++ b/root/recording/RecordingFingerprints.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FingerprintTable
   from '../static/scripts/common/components/FingerprintTable';

--- a/root/recording/RecordingHeader.js
+++ b/root/recording/RecordingHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 import ArtistCreditLink

--- a/root/recording/RecordingIndex.js
+++ b/root/recording/RecordingIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import PaginatedResults from '../components/PaginatedResults';
 import Relationships from '../components/Relationships';

--- a/root/recording/RecordingLayout.js
+++ b/root/recording/RecordingLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import RecordingSidebar from '../layout/components/sidebar/RecordingSidebar';
@@ -19,7 +18,7 @@ import {
 import RecordingHeader from './RecordingHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: RecordingT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EnterEdit from '../components/EnterEdit';
 import EnterEditNote from '../components/EnterEditNote';

--- a/root/release/ReleaseHeader.js
+++ b/root/release/ReleaseHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 import ArtistCreditLink

--- a/root/release/ReleaseLayout.js
+++ b/root/release/ReleaseLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import ReleaseSidebar from '../layout/components/sidebar/ReleaseSidebar';
@@ -18,7 +17,7 @@ import {reduceArtistCredit}
 import ReleaseHeader from './ReleaseHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: ReleaseT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/release_group/ReleaseGroupHeader.js
+++ b/root/release_group/ReleaseGroupHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 import ArtistCreditLink

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../context';
 import Annotation from '../static/scripts/common/components/Annotation';

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import ReleaseGroupSidebar
@@ -19,7 +18,7 @@ import {reduceArtistCredit}
 import ReleaseGroupHeader from './ReleaseGroupHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: ReleaseGroupT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import DescriptiveLink

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import ArtistListEntry

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import ArtistRoles from '../../static/scripts/common/components/ArtistRoles';

--- a/root/search/components/PaginatedSearchResults.js
+++ b/root/search/components/PaginatedSearchResults.js
@@ -7,15 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
-
+import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 
 type Props<T> = {
-  +buildResult: (SearchResultT<T>, number) => ReactNode,
-  +columns: ReactNode,
+  +buildResult: (SearchResultT<T>, number) => React.Node,
+  +columns: React.Node,
   +pager: PagerT,
   +query: string,
   +results: $ReadOnlyArray<SearchResultT<T>>,

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {CatalystContext, withCatalystContext} from '../../context';
 import EntityLink from '../../static/scripts/common/components/EntityLink';

--- a/root/search/components/ResultsLayout.js
+++ b/root/search/components/ResultsLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import Layout from '../../layout';
@@ -18,7 +17,7 @@ import SearchForm from './SearchForm';
 
 type Props = {
   +$c: CatalystContextT,
-  +children: ReactNode,
+  +children: React.Node,
   +form: SearchFormT,
   +lastUpdated?: string,
 };

--- a/root/search/components/SearchForm.js
+++ b/root/search/components/SearchForm.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import * as DBDefs from '../../static/scripts/common/DBDefs';
 import FormRowRadio from '../../components/FormRowRadio';

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../context';
 import EntityLink from '../../static/scripts/common/components/EntityLink';

--- a/root/series/SeriesHeader.js
+++ b/root/series/SeriesHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/series/SeriesIndex.js
+++ b/root/series/SeriesIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import EventList from '../components/list/EventList';

--- a/root/series/SeriesLayout.js
+++ b/root/series/SeriesLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import SeriesSidebar from '../layout/components/sidebar/SeriesSidebar';
@@ -16,7 +15,7 @@ import SeriesSidebar from '../layout/components/sidebar/SeriesSidebar';
 import SeriesHeader from './SeriesHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: SeriesT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -11,7 +11,7 @@ import 'leaflet.markercluster/dist/leaflet.markercluster-src';
 
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 
 import EntityLink from '../common/components/EntityLink';
 import {createMap, L} from '../common/leaflet';

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -10,7 +10,7 @@
 import 'leaflet.markercluster/dist/leaflet.markercluster-src';
 
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import EntityLink from '../common/components/EntityLink';

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 import mutate from 'mutate-cow';
 
 import {withCatalystContext} from '../../../../context';

--- a/root/static/scripts/common/components/AreaContainmentLink.js
+++ b/root/static/scripts/common/components/AreaContainmentLink.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import commaOnlyList from '../../common/i18n/commaOnlyList';
 

--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import commaOnlyList from '../../common/i18n/commaOnlyList';
 

--- a/root/static/scripts/common/components/AttributeList.js
+++ b/root/static/scripts/common/components/AttributeList.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {bracketedText} from '../utility/bracketed';
 

--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -8,7 +8,7 @@
 
 import _ from 'lodash';
 import ko from 'knockout';
-import React from 'react';
+import * as React from 'react';
 
 import SearchIcon from './SearchIcon';
 

--- a/root/static/scripts/common/components/CodeLink.js
+++ b/root/static/scripts/common/components/CodeLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import entityHref from '../utility/entityHref';
 

--- a/root/static/scripts/common/components/Collapsible.js
+++ b/root/static/scripts/common/components/Collapsible.js
@@ -7,9 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {ElementRef} from 'react';
-
+import * as React from 'react';
 
 type Props = {
   +className: string,
@@ -42,7 +40,7 @@ class Collapsible extends React.Component<Props, State> {
     }
   }
 
-  containerRef: {current: null | ElementRef<'div'>};
+  containerRef: {current: null | React.ElementRef<'div'>};
 
   handleToggle: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 

--- a/root/static/scripts/common/components/CommonsImage.js
+++ b/root/static/scripts/common/components/CommonsImage.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import hydrate, {minimalEntity} from '../../../../utility/hydrate';
 import entityHref from '../utility/entityHref';

--- a/root/static/scripts/common/components/CritiqueBrainzReview.js
+++ b/root/static/scripts/common/components/CritiqueBrainzReview.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../../context';
 import formatUserDate from '../../../../utility/formatUserDate';

--- a/root/static/scripts/common/components/EditorLink.js
+++ b/root/static/scripts/common/components/EditorLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import entityHref from '../utility/entityHref';
 import isolateText from '../utility/isolateText';

--- a/root/static/scripts/common/components/ExpandedArtistCredit.js
+++ b/root/static/scripts/common/components/ExpandedArtistCredit.js
@@ -6,7 +6,7 @@
  * http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import commaOnlyList from '../i18n/commaOnlyList';
 

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -8,7 +8,7 @@
  */
 
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import hydrate, {minimalEntity} from '../../../../utility/hydrate';
 import loopParity from '../../../../utility/loopParity';

--- a/root/static/scripts/common/components/TagLink.js
+++ b/root/static/scripts/common/components/TagLink.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const TagLink = ({tag}: {tag: string}) => (
   <a href={`/tag/${encodeURIComponent(tag)}`}>{tag}</a>

--- a/root/static/scripts/common/components/TaggerIcon.js
+++ b/root/static/scripts/common/components/TaggerIcon.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {withCatalystContext} from '../../../../context';
 

--- a/root/static/scripts/common/components/WikipediaExtract.js
+++ b/root/static/scripts/common/components/WikipediaExtract.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import hydrate, {minimalEntity} from '../../../../utility/hydrate';
 import entityHref from '../utility/entityHref';

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -9,7 +9,7 @@
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 
 import ArtistCreditLink from './components/ArtistCreditLink';
 import EditorLink from './components/EditorLink';

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -8,7 +8,7 @@
 
 import ko from 'knockout';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import ArtistCreditLink from './components/ArtistCreditLink';

--- a/root/static/scripts/common/utility/isolateText.js
+++ b/root/static/scripts/common/utility/isolateText.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 function isolateText(content: ?React$Node) {
   if (content != null && content !== '') {

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -9,7 +9,7 @@
 import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 
 import MB from '../common/MB';

--- a/root/static/scripts/edit/check-duplicates.js
+++ b/root/static/scripts/edit/check-duplicates.js
@@ -10,7 +10,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 import MB from '../common/MB';
 import clean from '../common/utility/clean';

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -8,7 +8,7 @@
 
 import $ from 'jquery';
 import {assign} from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import ArtistCreditLink from '../../common/components/ArtistCreditLink';
 import DescriptiveLink from '../../common/components/DescriptiveLink';

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -9,7 +9,7 @@
 import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import mutate from 'mutate-cow';
 

--- a/root/static/scripts/edit/components/ArtistCreditEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditEditor.js
@@ -10,7 +10,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import mutate from 'mutate-cow';
 
 import Autocomplete from '../../common/components/Autocomplete';

--- a/root/static/scripts/edit/components/ArtistCreditNameEditor.js
+++ b/root/static/scripts/edit/components/ArtistCreditNameEditor.js
@@ -7,7 +7,7 @@
  */
 
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 import Autocomplete from '../../common/components/Autocomplete';
 import clean from '../../common/utility/clean';

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Tooltip from './Tooltip';
 

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityLink from '../../common/components/EntityLink';
 

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -6,7 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 class RemoveButton extends React.Component {
   render() {

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -7,7 +7,7 @@
  */
 
 import ko from 'knockout';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 
 import MB from '../../common/MB';

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -8,7 +8,7 @@
 
 import ko from 'knockout';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 import MB from '../../common/MB';
 import FieldErrors from '../../../../components/FieldErrors';

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -11,7 +11,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 import {
   FAVICON_CLASSES,

--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -8,7 +8,7 @@
  */
 
 import {assign, capitalize} from 'lodash';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 
 import getBooleanCookie from '../common/utility/getBooleanCookie';
 

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -9,7 +9,7 @@
 import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 
 import '../../../lib/jquery-ui';
 

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -10,7 +10,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 import {reduceArtistCredit} from '../common/immutable-entities';
 import ArtistCreditEditor from '../edit/components/ArtistCreditEditor';

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -9,7 +9,7 @@
 import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 
 import {reduceArtistCredit} from '../common/immutable-entities';

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -9,7 +9,7 @@
 import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import {reduceArtistCredit} from '../common/immutable-entities';

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -10,7 +10,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 import _ from 'lodash';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 
 import {reduceArtistCredit} from '../common/immutable-entities';
 import bracketed from '../common/utility/bracketed';

--- a/root/static/scripts/tests/i18n/expand2.js
+++ b/root/static/scripts/tests/i18n/expand2.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import React from 'react';
+import * as React from 'react';
 
 import {VarArgs} from '../../common/i18n/expand2';
 import expand2html from '../../common/i18n/expand2html';

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import ko from 'knockout';
 import mutate from 'mutate-cow';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import {createStore} from 'redux';
 
 import FormRowSelectList from '../../components/FormRowSelectList';

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -11,7 +11,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import ko from 'knockout';
 import mutate from 'mutate-cow';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {createStore} from 'redux';
 

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import manifest from '../static/manifest';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';

--- a/root/statistics/CoverArt.js
+++ b/root/statistics/CoverArt.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 import {range} from 'lodash';
 
 import {l_statistics as l}

--- a/root/statistics/Editors.js
+++ b/root/statistics/Editors.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 import EditorLink from '../static/scripts/common/components/EditorLink';

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {l as lMbServer} from '../static/scripts/common/i18n';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';

--- a/root/statistics/Formats.js
+++ b/root/statistics/Formats.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 import {withCatalystContext} from '../context';

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 import {range} from 'lodash';
 
 import {l_statistics as l, lp_statistics as lp}

--- a/root/statistics/LanguagesScripts.js
+++ b/root/statistics/LanguagesScripts.js
@@ -8,7 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import manifest from '../static/manifest';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';

--- a/root/statistics/NoStatistics.js
+++ b/root/statistics/NoStatistics.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {compare} from '../static/scripts/common/i18n';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -8,8 +8,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import Tabs from '../components/Tabs';
@@ -18,10 +17,10 @@ import {l_statistics as l, N_l_statistics as N_l}
   from '../static/scripts/common/i18n/statistics';
 
 type StatisticsLayoutPropsT = {
-  +children: ReactNode,
+  +children: React.Node,
   +fullWidth: boolean,
   +page: string,
-  +sidebar?: ?ReactNode,
+  +sidebar?: ?React.Node,
   +title: string,
 };
 

--- a/root/tag/NotFound.js
+++ b/root/tag/NotFound.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import NotFound from '../components/NotFound';
 

--- a/root/taglookup/Form.js
+++ b/root/taglookup/Form.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import FormRow from '../components/FormRow';
 import FormRowText from '../components/FormRowText';

--- a/root/taglookup/Index.js
+++ b/root/taglookup/Index.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 

--- a/root/taglookup/NotFound.js
+++ b/root/taglookup/NotFound.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import NotFound from '../components/NotFound';
 

--- a/root/taglookup/types.js
+++ b/root/taglookup/types.js
@@ -7,8 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {Node as ReactNode} from 'react';
-
 export type TagLookupFormT = FormT<{
   +artist: ReadOnlyFieldT<string>,
   +duration: ReadOnlyFieldT<string>,
@@ -25,7 +23,7 @@ export type TagLookupPropsT = {
 
 export type TagLookupResultsPropsT<T> = {
   +$c: CatalystContextT,
-  +children: ReactNode,
+  +children: React$Node,
   +form: TagLookupFormT,
   +nag: boolean,
   +pager: PagerT,

--- a/root/url/UrlHeader.js
+++ b/root/url/UrlHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 import EntityLink from '../static/scripts/common/components/EntityLink';

--- a/root/url/UrlIndex.js
+++ b/root/url/UrlIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Relationships from '../components/Relationships';
 

--- a/root/url/UrlLayout.js
+++ b/root/url/UrlLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import UrlSidebar from '../layout/components/sidebar/UrlSidebar';
@@ -16,7 +15,7 @@ import UrlSidebar from '../layout/components/sidebar/UrlSidebar';
 import UrlHeader from './UrlHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: UrlT,
   +fullWidth?: boolean,
   +page: string,

--- a/root/user/PrivilegedUsers.js
+++ b/root/user/PrivilegedUsers.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -9,7 +9,7 @@
 
 import mutate from 'mutate-cow';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 export default function hydrate<Config>(
   containerSelector: string,

--- a/root/work/WorkHeader.js
+++ b/root/work/WorkHeader.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
 

--- a/root/work/WorkIndex.js
+++ b/root/work/WorkIndex.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract

--- a/root/work/WorkLayout.js
+++ b/root/work/WorkLayout.js
@@ -7,8 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
+import * as React from 'react';
 
 import Layout from '../layout';
 import WorkSidebar from '../layout/components/sidebar/WorkSidebar';
@@ -16,7 +15,7 @@ import WorkSidebar from '../layout/components/sidebar/WorkSidebar';
 import WorkHeader from './WorkHeader';
 
 type Props = {
-  +children: ReactNode,
+  +children: React.Node,
   +entity: WorkT,
   +fullWidth?: boolean,
   +page: string,


### PR DESCRIPTION
This is the correct way to do it according to React devs: facebook/react@0934879

It has the benefit of allowing us not to import the types separately, FWIW.