### PR TITLE
MBS-10693: Restore FieldErrors for target on artist merges

### DIFF
--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -12,6 +12,7 @@ import sortBy from 'lodash/sortBy';
 
 import EnterEdit from '../components/EnterEdit';
 import EnterEditNote from '../components/EnterEditNote';
+import FieldErrors from '../components/FieldErrors';
 import FormRowCheckbox from '../components/FormRowCheckbox';
 import ArtistList from '../components/list/ArtistList';
 import {withCatalystContext} from '../context';
@@ -37,6 +38,7 @@ const ArtistMerge = ({$c, form, toMerge}: Props) => (
           artists={sortBy(toMerge, 'name')}
           mergeForm={form}
         />
+        <FieldErrors field={form.field.target} />
 
         <FormRowCheckbox
           field={form.field.rename}


### PR DESCRIPTION
This got accidentally removed with 379959b