### PR TITLE
MBS-10695: Show language names on work lists

### DIFF
--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -88,10 +88,11 @@ export const WorkListRow = withCatalystContext<WorkListRowProps>(({
     <td>
       <ul>
         {work.languages.map(language => (
-          <li key={language.language.id}>
-            <abbr title={l_languages(language.language.name)}>
-              {language.language.iso_code_3}
-            </abbr>
+          <li
+            data-iso-639-3={language.language.iso_code_3}
+            key={language.language.id}
+          >
+            {l_languages(language.language.name)}
           </li>
         ))}
       </ul>

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -487,10 +487,11 @@ export const workLanguagesColumn:
     Cell: ({cell: {value}}) => (
       <ul>
         {value.map(language => (
-          <li key={language.language.id}>
-            <abbr title={l_languages(language.language.name)}>
-              {language.language.iso_code_3}
-            </abbr>
+          <li
+            data-iso-639-3={language.language.iso_code_3}
+            key={language.language.id}
+          >
+            {l_languages(language.language.name)}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
We currently show the code plus the main language on hover, but the code is unclear to most users and we do have enough space here to show the whole name.

This moves the code to a data-iso-639-3 attribute, in case people want to be able to access it still.