### PR TITLE
MBS-7835: Old Create work edits should display [No lyrics] for zxx

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -67,6 +67,9 @@ sub build_display_data
 
     if (defined $data->{language_id}) {
         $display->{language} = $loaded->{Language}->{$data->{language_id}};
+        if ($display->{language}->iso_code_3 eq "zxx") {
+            $display->{language}->name(l("[No lyrics]"));
+        }
     }
 
     if (defined $data->{languages}) {


### PR DESCRIPTION
MBS-10063 (https://github.com/metabrainz/musicbrainz-server/pull/966) fixed this for most edits, but old Create work edits (from the one-language-per-work time) weren't touched. This fixes that. Old Edit work edits are not affected.