### PR TITLE
MBS-10699: Remove "medley" from guess case

### DIFF
--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -90,7 +90,6 @@ const lowerCaseBracketWordsList = [
   'intro',
   'karaoke',
   'maxi',
-  'medley',
   'mono',
   'orchestral',
   'outro',


### PR DESCRIPTION
# Implements MBS-10699

Most often, "Medley" is the last word of the title. Guess case used to put that word in parenthesis as extra title information. Even though it sometimes is correct, it is more often wrong, e.g. "Detroit Medley".