### PR TITLE
MBS-10704: Only show Rels header if something to display

### DIFF
--- a/root/components/Relationships.js
+++ b/root/components/Relationships.js
@@ -93,7 +93,7 @@ const Relationships = ({
 
   return (
     <>
-      {source.relationships?.length ? (
+      {relationships.length ? (
         <>
           {noRelationshipsHeading ? null : (
             <h2 className="relationships">{l('Relationships')}</h2>


### PR DESCRIPTION
MBS-10704

We're checking source.relationships here, but that includes relationships not on displayTargets (for example, for works, it includes recording relationships). Changed this to only look at the actual relationships to be displayed.