### PR TITLE
MBS-10707: Actually remove discID if add edit is rejected

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
@@ -117,5 +117,15 @@ override 'insert' => sub {
     $self->entity_id($medium_cdtoc);
 };
 
+override 'reject' => sub {
+    my ($self) = @_;
+    my $cdtoc_id = $self->c->model('CDTOC')->find_or_insert($self->data->{cdtoc});
+    my $medium_cdtoc = $self->c->model('MediumCDTOC')->get_by_medium_cdtoc(
+        $self->data->{medium_id},
+        $cdtoc_id
+    );
+    $self->c->model('MediumCDTOC')->delete($medium_cdtoc->id);
+};
+
 no Moose;
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Seems like if an open AddDiscID edit was voted down or cancelled, we had no way to actually remove the discID that was inserted when the edit was opened. This changes it so that rejecting the edit will actually remove the added discID.