### PR TITLE
MBS-10712: Fix loading old release name if ID is missing

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/MergeRelease.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/MergeRelease.pm
@@ -68,8 +68,9 @@ sub build_display_data
         releases => {
             old => [
                 map {
+                    my $old_release = $_;
                     if (my @ids = @{ $_->{release_ids} }) {
-                        map { $loaded->{Release}->{ $_ } // Release->new(name => $_->{name}) } @ids;
+                        map { $loaded->{Release}->{ $_ } // Release->new(name => $old_release->{name}) } @ids;
                     }
                     else {
                         Release->new(name => $_->{name} )


### PR DESCRIPTION
# Fix MBS-10712

This was doing `name => $_->{name}`, but by that time `$_` is the release ID (a number) rather than the old release itself. Fixed by storing the old release before the second map and just getting the name from there.