### PR TITLE
MBS-10669: Clean and validate Metal Archives URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1618,6 +1618,33 @@ const CLEANUPS = {
       return false;
     },
   },
+  'metalarchives': {
+    match: [new RegExp('^(https?://)?(www\\.)?metal-archives\\.com/', 'i')],
+    type: _.defaults({}, LINK_TYPES.review, LINK_TYPES.otherdatabases),
+    clean: function (url) {
+      return url.replace(
+        /^(?:https?:\/\/)?(?:www\.)?metal-archives\.com\/([a-z]+(?:\/[^\/?#]+)+).*$/,
+        'https://www.metal-archives.com/$1',
+      );
+    },
+    validate: function (url, id) {
+      const m = /^https:\/\/www\.metal-archives\.com\/([a-z]+)\/[^?#]+[^\/?#]$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return prefix === 'bands' || prefix === 'band';
+          case LINK_TYPES.otherdatabases.label:
+            return prefix === 'labels';
+          case LINK_TYPES.otherdatabases.release:
+            return prefix === 'albums';
+          case LINK_TYPES.review.release_group:
+            return prefix === 'reviews';
+        }
+      }
+      return false;
+    },
+  },
   'mixcloud': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?mixcloud\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
@@ -1802,7 +1829,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?isrc\\.ncl\\.edu\\.tw/', 'i'),
       new RegExp('^(https?://)?(www\\.)?rolldabeats\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?psydb\\.net/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?metal-archives\\.com/(bands?|albums|artists|labels)', 'i'),
       new RegExp('^(https?://)?(www\\.)?spirit-of-metal\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?lortel\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?theatricalia\\.com/', 'i'),
@@ -1972,7 +1998,6 @@ const CLEANUPS = {
   'review': {
     match: [
       new RegExp('^(https?://)?(www\\.)?bbc\\.co\\.uk/music/reviews/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?metal-archives\\.com/reviews/', 'i'),
       new RegExp('^(https?://)?(www\\.)?residentadvisor\\.net/review', 'i'),
     ],
     type: LINK_TYPES.review,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2120,16 +2120,36 @@ const testData = [
                      input_url: 'http://www.metal-archives.com/bands/Karna/26483',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/bands/Karna/26483',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.metal-archives.com/band/view/id/26483',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/band/view/id/26483',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.metal-archives.com/labels/%D0%98%D0%B7%D0%BB%D1%83%D1%87%D0%B5%D0%BD%D0%B8%D1%8F/51751#label_tabs_albums',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/labels/%D0%98%D0%B7%D0%BB%D1%83%D1%87%D0%B5%D0%BD%D0%B8%D1%8F/51751',
+       only_valid_entity_types: ['label'],
   },
   {
                      input_url: 'http://www.metal-archives.com/albums/Corubo/Ypykuera/193860',
-             input_entity_type: 'release_group',
+             input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/albums/Corubo/Ypykuera/193860',
+       only_valid_entity_types: ['release'],
   },
   {
                      input_url: 'http://www.metal-archives.com/reviews/Myrkwid/Part_I/36375/',
              input_entity_type: 'release_group',
     expected_relationship_type: 'review',
+            expected_clean_url: 'https://www.metal-archives.com/reviews/Myrkwid/Part_I/36375',
+       only_valid_entity_types: ['release_group'],
   },
   // Mixcloud
   {


### PR DESCRIPTION
# Implement MBS-10669

The motivation behind this change is to map MA /albums/ to MB /release/.

Auto-select is extended to invalid Metal Archives URLs (/user/, ...).

Normalize
- protocol to `https` (as `http` is redirected to)
- domain name to `www.metal-archives.com` (which is redirected to)

Drop
- trailing `/` (rarely used nowadays)
- unneeded query `?` and fragment `#`

Only validate linking
- clean MA /bands/ and /band/ URL with MB artist
- clean MA /labels/ URL with MB label
- clean MA /albums/ URL with MB release (and no longer release group)
- clean MA /reviews/ URL with MB release group (as reviews)

Notes:
- MA /band/ URL is allowed, as it is already present in MB DB, and there is no redirect from /bands/ to /band/ on MA website, that is it is already in use and there is no easy conversion path. Dealing with such duplicates is an issue not specific to MA URL.
- MA /label/ is blocked as it is not present in MB DB.