### PR TITLE
MBS-9728: Allow new emojis in titles

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -317,9 +317,6 @@ sub collapse_whitespace {
     # Replace all spaces with U+0020
     =~ s/\s/ /gr
 
-    # Remove non-printable characters.
-    =~ s/[^[:print:]]//gr
-
     # Compress whitespace
     =~ s/\s{2,}/ /gr
 }
@@ -328,8 +325,12 @@ sub sanitize {
     my $t = shift;
 
     $t = NFC($t);
+    # Before removing invalid characters, convert space control characters
+    # into U+0020 (or else they'll be removed).
+    $t = collapse_whitespace($t);
     $t = remove_invalid_characters($t);
     $t = remove_direction_marks($t);
+    # Collapse spaces again, since characters may have been removed.
     $t = collapse_whitespace($t);
 
     return $t;
@@ -380,13 +381,27 @@ sub remove_direction_marks {
     }
 }
 
+# https://www.unicode.org/faq/private_use.html#nonchar4
+my $noncharacter_pattern = '\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}';
+{
+    for my $i (1 .. 16) {
+        my $hex_i = sprintf('%X', $i);
+        $noncharacter_pattern .= "\\x{${hex_i}FFFE}\\x{${hex_i}FFFF}";
+    }
+}
+
 sub remove_invalid_characters {
     shift
     # trim XML-invalid characters
     =~ s/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]//gor
-    # trim other undesirable characters
-    =~ s/[\x{200B}\x{00AD}]//gor
-    #     zwsp    shy
+    # trim other undesirable characters:
+    # - zwsp
+    # - shy
+    # - Other, control
+    # - Other, surrogate
+    # - Other, private use
+    # - Noncharacters
+    =~ s/[\x{200B}\x{00AD}\p{Cc}\p{Co}${noncharacter_pattern}]//gr
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -397,11 +397,12 @@ sub remove_invalid_characters {
     # trim other undesirable characters:
     # - zwsp
     # - shy
+    # - bom
     # - Other, control
     # - Other, surrogate
     # - Other, private use
     # - Noncharacters
-    =~ s/[\x{200B}\x{00AD}\p{Cc}\p{Co}${noncharacter_pattern}]//gr
+    =~ s/[\x{200B}\x{00AD}\x{FEFF}\p{Cc}\p{Co}${noncharacter_pattern}]//gr
 }
 
 sub type_to_model

--- a/t/lib/t/MusicBrainz/Server/Data/Utils.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Utils.pm
@@ -187,6 +187,12 @@ test 'Test trim and sanitize' => sub {
     $run->("A\x{FDD0}  B",
            "A B",
            'collapses spaces after a non-printable character');
+
+    $run->("\x{FEFF} A \x{FEFF} B \x{FEFF}",
+           "A B",
+           'strips BOM, removes leading/trailing whitespace',
+           " A B ",
+           'strips BOM, keeps leading/trailing whitespace');
 };
 
 1;


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-9728

The `:print:` char class doesn't include code points reserved for future use, since characters that don't exist aren't printable. But clearly, new emojis are added quite often and they'll always outpace the particular version of Unicode supported by our Perl interpreter.

Instead of stripping non-`:print:` characters, I've tried to construct the desired class of characters to remove explicitly. I didn't strip `\p{Cf}` (format characters) since it does appear we allow LRM/RLM under some circumstances in `remove_direction_marks`, though we may still want to remove zero-width joiners and language tag chars.

Obviously this may allow the entry of some unassigned code points if someone manages to enter them, but I'm not sure we need to worry about preventing that at all costs.