### PR TITLE
MBS-10718: Always use link orders for grouping

### DIFF
--- a/root/components/StaticRelationshipsDisplay.js
+++ b/root/components/StaticRelationshipsDisplay.js
@@ -50,11 +50,18 @@ const StaticRelationshipsDisplay = ({
 
         phraseRows.push(
           <React.Fragment key={targetGroup.key}>
-            {groupSize > 1 && targetGroup.linkOrder ? (
-              exp.l('{num}. {relationship}', {
-                num: targetGroup.linkOrder,
-                relationship: relationshipLink,
-              })
+            {targetGroup.linkOrder ? (
+              targetGroup.isOrderable ? (
+                exp.l('{num}. {relationship}', {
+                  num: targetGroup.linkOrder,
+                  relationship: relationshipLink,
+                })
+              ) : (
+                exp.l('{relationship} (order: {num})', {
+                  num: targetGroup.linkOrder,
+                  relationship: relationshipLink,
+                })
+              )
             ) : relationshipLink}
             <br />
           </React.Fragment>,

--- a/root/utility/groupRelationships.js
+++ b/root/utility/groupRelationships.js
@@ -45,6 +45,7 @@ export type RelationshipTargetGroupT = {
   earliestDatePeriod: DatePeriodRoleT,
   editsPending: boolean,
   hasAttributes: boolean,
+  isOrderable: boolean,
   key: string,
   linkOrder: number | null,
   target: CoreEntityT,
@@ -374,7 +375,7 @@ export default function groupRelationships(
       ? relationship.entity0_credit
       : relationship.entity1_credit;
     const isOrderable = targetIsOrderable(relationship);
-    const linkOrder = isOrderable ? relationship.linkOrder : null;
+    const linkOrder = relationship.linkOrder;
     const datePeriod = {
       begin_date: relationship.begin_date,
       end_date: relationship.end_date,
@@ -410,6 +411,7 @@ export default function groupRelationships(
         earliestDatePeriod: datePeriod,
         editsPending: relationship.editsPending,
         hasAttributes,
+        isOrderable,
         key: String(target.id) + UNIT_SEP + targetCredit + UNIT_SEP +
           (linkOrder ?? ''),
         linkOrder,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10718

Previously, we only avoided grouping relationships with different link orders if we were viewing it from the "orderable" side. This modifies the code to use the link orders no matter which side we're viewing them from.

However, displaying the link orders as "1. Foo", "2. Bar", etc. doesn't make any sense from the non-orderable side, because the target entities there aren't what's being ordered (the source entity is). So I've changed it to display as "Foo (order 1)", "Bar (order 2)" from that side instead. (Let me know if you have a better idea here.)

A before screenshot can be found in the linked ticket. After:
<img width="423" alt="Screen Shot 2020-03-25 at 3 39 44 AM" src="https://user-images.githubusercontent.com/1056556/77517954-f7aa7480-6e4a-11ea-9041-4a9a0e2c72a0.png">
