### PR TITLE
MBS-10723: Separate className for cell and header

### DIFF
--- a/flow-typed/npm/react-table_v7.x.x.js
+++ b/flow-typed/npm/react-table_v7.x.x.js
@@ -16,7 +16,8 @@ declare module 'react-table' {
   };
 
   declare export type ColumnInstance = {
-    +className?: string,
+    +cellProps?: {[attribute: string]: string},
+    +getCellProps: (props?: {...}) => {...},
     +getHeaderProps: (props?: {...}) => {...},
     // Not actually part of react-table but our own expansion of it
     +headerProps?: {[attribute: string]: string},

--- a/root/components/Table.js
+++ b/root/components/Table.js
@@ -14,9 +14,7 @@ import loopParity from '../utility/loopParity';
 
 const renderTableHeaderCell = (column) => (
   <th
-    {...column.getHeaderProps(
-      {...column.headerProps, className: column.className},
-    )}
+    {...column.getHeaderProps(column.headerProps)}
   >
     {column.render('Header')}
   </th>
@@ -29,7 +27,7 @@ const renderTableHeaderRow = (headerGroup) => (
 );
 
 const renderTableCell = (cell) => (
-  <td {...cell.getCellProps({className: cell.column.className})}>
+  <td {...cell.getCellProps(cell.column.cellProps)}>
     {cell.render('Cell')}
   </td>
 );

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -84,7 +84,7 @@ const RecordingList = ({
         l('Length'),
         order,
         sortable,
-        lengthClass,
+        {className: lengthClass ?? ''},
       );
       const instrumentUsageColumn = showInstrumentCreditsAndRelTypes
         ? defineInstrumentUsageColumn(instrumentCreditsAndRelTypes)

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -76,7 +76,8 @@ export const ReleaseGroupListTable = withCatalystContext(({
         l('Year'),
         order,
         sortable,
-        'year c',
+        {className: 'c'},
+        {className: 'year c'},
       );
       const nameColumn =
         defineNameColumn<ReleaseGroupT>(

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -112,7 +112,7 @@ const ReleaseList = ({
         l('Barcode'),
         order,
         sortable,
-        'barcode-cell',
+        {className: 'barcode-cell'},
       );
       const instrumentUsageColumn = showInstrumentCreditsAndRelTypes
         ? defineInstrumentUsageColumn(instrumentCreditsAndRelTypes)

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -66,7 +66,8 @@ export function defineActionsColumn(
     ),
     Header: l('Actions'),
     accessor: 'id',
-    className: 'actions',
+    cellProps: {className: 'actions'},
+    headerProps: {className: 'actions'},
     id: 'actions',
   };
 }
@@ -99,7 +100,7 @@ export function defineArtistCreditColumn<D>(
       )
       : title),
     accessor: row => getArtistCredit(row)?.names[0].name ?? '',
-    className: 'artist',
+    headerProps: {className: 'artist'},
     id: columnName,
   };
 }
@@ -162,7 +163,7 @@ export function defineCheckboxColumn(
         />
       ),
     Header: mergeForm ? null : <input type="checkbox" />,
-    className: 'checkbox-cell',
+    headerProps: {className: 'checkbox-cell'},
     id: 'checkbox',
   };
 }
@@ -173,7 +174,6 @@ export function defineCountColumn<D>(
   title: string,
   order?: string = '',
   sortable?: boolean = false,
-  className?: string,
 ): ColumnOptions<D, number> {
   return {
     Cell: ({cell: {value}}) => (
@@ -191,7 +191,8 @@ export function defineCountColumn<D>(
       )
       : title),
     accessor: row => getCount(row),
-    className: className || 'count c',
+    cellProps: {className: 'c'},
+    headerProps: {className: 'count c'},
     id: columnName,
   };
 }
@@ -416,7 +417,8 @@ export function defineSeriesNumberColumn(
     Cell: ({cell: {value}}) => seriesItemNumbers[value],
     Header: l('#'),
     accessor: 'id',
-    className: 'number-column',
+    cellProps: {className: 'number-column'},
+    headerProps: {className: 'number-column'},
     id: 'series-number',
   };
 }
@@ -427,7 +429,8 @@ export function defineTextColumn<D>(
   title: string,
   order?: string = '',
   sortable?: boolean = false,
-  className?: string,
+  cellProps?: {className: string, ...},
+  headerProps?: {className: string, ...},
 ): ColumnOptions<D, StrOrNum> {
   return {
     Cell: ({row: {original}}) => getText(original),
@@ -441,7 +444,8 @@ export function defineTextColumn<D>(
       )
       : title),
     accessor: row => getText(row) ?? '',
-    className: className || null,
+    cellProps: cellProps,
+    headerProps: headerProps,
     id: columnName,
   };
 }
@@ -519,6 +523,7 @@ export const iswcsColumn:
     ),
     Header: N_l('ISWC'),
     accessor: 'iswcs',
+    cellProps: {className: 'iswc'},
   };
 
 export const locationColumn:
@@ -533,7 +538,8 @@ export const ratingsColumn:
     Cell: ({row: {original}}) => <RatingStars entity={original} />,
     Header: N_l('Rating'),
     accessor: 'rating',
-    className: 'rating c',
+    cellProps: {className: 'c'},
+    headerProps: {className: 'rating c'},
   };
 
 export const seriesOrderingTypeColumn:


### PR DESCRIPTION
# Fix MBS-10723

On top of https://github.com/metabrainz/musicbrainz-server/pull/1435

The lenghtClass for recording merges should only apply to cells, but currently className applies to both cells and headers. This uses the existing headerProps and creates an equivalent cellProps for cell attributes.