### PR TITLE
MBS-10724: Make list sorting options consistent

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -237,8 +237,14 @@ sub _order_by {
         "begin_date" => sub {
             return "begin_date_year, begin_date_month, begin_date_day, musicbrainz_collate(name)"
         },
+        "begin_area" => sub {
+            return "begin_area, musicbrainz_collate(name)"
+        },
         "end_date" => sub {
             return "end_date_year, end_date_month, end_date_day, musicbrainz_collate(name)"
+        },
+        "end_area" => sub {
+            return "end_area, musicbrainz_collate(name)"
         },
         "type" => sub {
             return "type, musicbrainz_collate(name)"

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -228,6 +228,9 @@ sub _order_by {
         "name" => sub {
             return "musicbrainz_collate(name)"
         },
+        "area" => sub {
+            return "area, musicbrainz_collate(name)"
+        },
         "gender" => sub {
             return "gender, musicbrainz_collate(name)"
         },

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -234,6 +234,12 @@ sub _order_by {
         "gender" => sub {
             return "gender, musicbrainz_collate(name)"
         },
+        "begin_date" => sub {
+            return "begin_date_year, begin_date_month, begin_date_day, musicbrainz_collate(name)"
+        },
+        "end_date" => sub {
+            return "end_date_year, end_date_month, end_date_day, musicbrainz_collate(name)"
+        },
         "type" => sub {
             return "type, musicbrainz_collate(name)"
         }

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -194,6 +194,9 @@ sub _order_by {
         "name" => sub {
             return "musicbrainz_collate(name)"
         },
+        "area" => sub {
+            return "area, musicbrainz_collate(name)"
+        },
         "address" => sub {
             return "musicbrainz_collate(address), musicbrainz_collate(name)"
         },

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -200,6 +200,12 @@ sub _order_by {
         "address" => sub {
             return "musicbrainz_collate(address), musicbrainz_collate(name)"
         },
+        "begin_date" => sub {
+            return "begin_date_year, begin_date_month, begin_date_day, musicbrainz_collate(name)"
+        },
+        "end_date" => sub {
+            return "end_date_year, end_date_month, end_date_day, musicbrainz_collate(name)"
+        },
         "type" => sub {
             return "type, musicbrainz_collate(name)"
         }

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -319,9 +319,18 @@ sub find_by_recording
 
 sub _order_by {
     my ($self, $order) = @_;
+
+    my $extra_join = "";
+    my $also_select = "";
+
     my $order_by = order_by($order, "name", {
         "name" => sub {
             return "musicbrainz_collate(name)"
+        },
+        "artist" => sub {
+            $extra_join = "JOIN artist_credit ac ON ac.id = rg.artist_credit";
+            $also_select = "ac.name AS ac_name";
+            return "musicbrainz_collate(ac_name), musicbrainz_collate(release_group.name)";
         },
         "primary_type" => sub {
             return "primary_type_id, musicbrainz_collate(name)"
@@ -331,7 +340,7 @@ sub _order_by {
         }
     });
 
-    return $order_by
+    return ($order_by, $extra_join, $also_select)
 }
 
 sub _insert_hook_after_each {

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -73,6 +73,7 @@ const listPicker = (props: Props, canRemoveFromCollection: boolean) => {
       return (
         <ArtistList
           artists={props.entities}
+          showBeginEnd
           showRatings
           {...sharedProps}
         />

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -90,6 +90,8 @@ const ArtistList = ({
         entity => entity.begin_area,
         'begin_area',
         l('Begin Area'),
+        order,
+        sortable,
       ) : null;
       const endDateColumn = showBeginEnd
         ? defineEndDateColumn(order, sortable)
@@ -98,6 +100,8 @@ const ArtistList = ({
         entity => entity.end_area,
         'end_area',
         l('End Area'),
+        order,
+        sortable,
       ) : null;
       const instrumentUsageColumn = showInstrumentCreditsAndRelTypes
         ? defineInstrumentUsageColumn(instrumentCreditsAndRelTypes)

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -84,7 +84,7 @@ const ArtistList = ({
         sortable,
       );
       const beginDateColumn = showBeginEnd
-        ? defineBeginDateColumn()
+        ? defineBeginDateColumn(order, sortable)
         : null;
       const beginAreaColumn = showBeginEnd ? defineEntityColumn(
         entity => entity.begin_area,
@@ -92,7 +92,7 @@ const ArtistList = ({
         l('Begin Area'),
       ) : null;
       const endDateColumn = showBeginEnd
-        ? defineEndDateColumn()
+        ? defineEndDateColumn(order, sortable)
         : null;
       const endAreaColumn = showBeginEnd ? defineEntityColumn(
         entity => entity.end_area,


### PR DESCRIPTION
We're super inconsistent on what columns we can sort by or not. This makes it so that if an entity can be sorted by a column, others can too.