### PR TITLE
MBS-10688: Show a human readable error when attaching a dupe CDTOC

### DIFF
--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -18,18 +18,25 @@
   </tr>
   [% FOR medium=release.mediums %]
     [% NEXT UNLESS
-        medium.cdtoc_track_count == cdtoc.track_count %]
+        medium.cdtoc_track_count == cdtoc.track_count;
+       this_medium_has_cdtoc = medium_has_cdtoc.defined AND (medium.id == medium_has_cdtoc) %]
       <tr[% ' class="even"' IF zebra % 2 == 0 %]>
         <td class="pos"></td>
         <td>
-          <label[% IF !medium.may_have_discids %] title="[%l('This medium format cannot have a disc ID attached') %]"[% END %]>
-            <input type="radio" name="medium" value="[% medium.id %]"[% IF !medium.may_have_discids %] disabled="disabled"[% END %]/>
+          <label
+            [%~ IF !medium.may_have_discids %] title="[% l('This medium format cannot have a disc ID attached') %]"[% END ~%]
+            [%~ IF this_medium_has_cdtoc %] title="[% l('This CDTOC is already attached to this medium') %]"[% END ~%]
+          >
+            <input type="radio" name="medium" value="[% medium.id %]"[% IF !medium.may_have_discids OR this_medium_has_cdtoc %] disabled="disabled"[% END %]/>
             [% medium.format_name %] [% medium.position %]
             [%~ IF medium.name %]:
                [% medium.name | html %]
             [% END %]
           </label>
           <small>(<a class="toggle" style="cursor:pointer;">[% l('show tracklist') %]</a>)</small>
+          [% IF this_medium_has_cdtoc %]
+            <div class="error">[% l('This CDTOC is already attached to this medium') %]</div>
+          [% END %]
         </td>
         <td colspan="6"></td>
       </tr>


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-10688

If the selected medium already has the CDTOC being attached, go back to the filter/listing page and show a readable error message informing the user rather than a cryptic "Bad Request" page.
<img width="401" alt="Screen Shot 2020-03-25 at 4 46 14 PM" src="https://user-images.githubusercontent.com/1056556/77588604-34f91b80-6eb8-11ea-8425-27f3b6e1f1f1.png">
