### PR TITLE
MBS-7465: Update the tag cloud

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -39,7 +39,8 @@ sub cloud : Path('/tags')
 {
     my ($self, $c, $name) = @_;
 
-    my ($cloud, $hits) = $c->model('Tag')->get_cloud(200);
+    my $cloud = $c->model('Tag')->get_cloud(200);
+    my $hits = scalar @$cloud;
 
     $c->stash(
         current_view => 'Node',


### PR DESCRIPTION
This uses a query suggested by Ian McEwen in the comments to [MBS-7465](https://tickets.metabrainz.org/browse/MBS-7465), with some modifications. I've modified his "UNION ALL" suggestion to also limit each individual entity subquery to the top 200 tags for each entity; this reduces the execution time by an additional 1s while still giving reasonably accurate results. (We don't show the exact counts in any case, just use them to size the tag names.)

We also now store the results of the query in Redis for 24 hours, so the tag cloud is effectively updated once per day.