### PR TITLE
MBS-10721: Improve track info in ArtistCreditBubble

### DIFF
--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -21,6 +21,7 @@ type Props = {
   +allowNew?: boolean,
   +area: AreaT,
   +content?: Expand2ReactOutput,
+  +deletedCaption?: string,
   +disableLink?: boolean,
   +showDisambiguation?: boolean,
   +target?: '_blank',

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -17,6 +17,7 @@ import EntityLink from './EntityLink';
 type DescriptiveLinkProps = {
   +allowNew?: boolean,
   +content?: Expand2ReactOutput,
+  +deletedCaption?: string,
   +disableLink?: boolean,
   +entity: CollectionT | CoreEntityT,
   +showDeletedArtists?: boolean,
@@ -26,6 +27,7 @@ type DescriptiveLinkProps = {
 const DescriptiveLink = ({
   allowNew,
   content,
+  deletedCaption,
   disableLink = false,
   entity,
   showDeletedArtists = true,
@@ -34,6 +36,7 @@ const DescriptiveLink = ({
   const props = {
     allowNew,
     content,
+    deletedCaption,
     disableLink,
     showDisambiguation: true,
     target,

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -20,16 +20,18 @@ import nonEmpty from '../utility/nonEmpty';
 
 type DeletedLinkProps = {
   +allowNew: boolean,
+  +deletedCaption?: string,
   +name: ?Expand2ReactOutput,
 };
 
 export const DeletedLink = ({
   allowNew,
+  deletedCaption,
   name,
 }: DeletedLinkProps): React.Element<'span'> => {
-  const caption = allowNew
+  const caption = deletedCaption || (allowNew
     ? l('This entity will be created by this edit.')
-    : l('This entity has been removed, and cannot be displayed correctly.');
+    : l('This entity has been removed, and cannot be displayed correctly.'));
 
   return (
     <span
@@ -109,6 +111,7 @@ const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
 type EntityLinkProps = {
   +allowNew?: boolean,
   +content?: ?Expand2ReactOutput,
+  +deletedCaption?: string,
   +disableLink?: boolean,
   +entity: CoreEntityT | CollectionT,
   +hover?: string,
@@ -130,6 +133,7 @@ type EntityLinkProps = {
 const EntityLink = ({
   allowNew = false,
   content,
+  deletedCaption,
   disableLink = false,
   entity,
   hover,
@@ -167,7 +171,13 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
       return <NoInfoURL allowNew={allowNew} url={entity.href_url} />;
     }
     if (showDeleted) {
-      return <DeletedLink allowNew={allowNew} name={content} />;
+      return (
+        <DeletedLink
+          allowNew={allowNew}
+          deletedCaption={deletedCaption}
+          name={content}
+        />
+      );
     }
     return null;
   }

--- a/root/static/scripts/edit/components/ArtistCreditBubble.js
+++ b/root/static/scripts/edit/components/ArtistCreditBubble.js
@@ -71,6 +71,13 @@ const ArtistCreditBubble = ({
               {entity.entityType === 'track'
                 ? (
                   <DescriptiveLink
+                    allowNew
+                    content={entity.name() === ''
+                      ? l('[missing track name]')
+                      : null}
+                    deletedCaption={entity.name() === ''
+                      ? l('You haven’t entered a track name yet.')
+                      : l('This track hasn’t been created yet.')}
                     entity={assign(
                       Object.create(entity), {artistCredit: artistCredit},
                     )}


### PR DESCRIPTION
### Fix MBS-10721

This solves several issues with the track names in ArtistCreditBubble:
1) Editing a new track's AC before adding a name showed [removed] as the title. Now it will show [missing track name], with a tooltip explaining that the user still needs to enter a track name.
2) Editing an existing track's AC after blanking its name showed no title at all, making clicking through to the track impossible. Now it will show [missing track name], but still link to the track.
3) Editing a new track's AC when a name had already been added still set the "deleted" class on the track name and displayed the "has been removed" tooltip. Now it doesn't show it as removed and uses the caption "This track hasn’t been created yet."