### PR TITLE
MBS-10742: Show right number of hidden events

### DIFF
--- a/root/static/scripts/common/components/ReleaseEvents.js
+++ b/root/static/scripts/common/components/ReleaseEvents.js
@@ -17,7 +17,9 @@ import isDateEmpty from '../utility/isDateEmpty';
 
 import EntityLink from './EntityLink';
 
-const COLLAPSE_THRESHOLD = 4;
+const TO_SHOW_BEFORE = 2;
+const TO_SHOW_AFTER = 1;
+const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + TO_SHOW_AFTER + 2;
 
 const releaseEventKey = event => (
   String(event.country ? event.country.id : '') + '\0' +
@@ -103,7 +105,7 @@ const ReleaseEvents = ({
   };
 
   const tooManyEvents = events
-    ? events.length > COLLAPSE_THRESHOLD
+    ? events.length >= TO_TRIGGER_COLLAPSE
     : false;
 
   return (
@@ -112,7 +114,7 @@ const ReleaseEvents = ({
         {(tooManyEvents && !expanded) ? (
           <>
             <ul {...containerProps}>
-              {events.slice(0, COLLAPSE_THRESHOLD - 2).map(
+              {events.slice(0, TO_SHOW_BEFORE).map(
                 event => buildReleaseEventRow(event, abbreviated),
               )}
               <li className="show-all" key="show-all">
@@ -123,11 +125,13 @@ const ReleaseEvents = ({
                   title={l('Show all release events')}
                 >
                   {bracketedText(texp.l('show {n} more', {
-                    n: events.length - COLLAPSE_THRESHOLD,
+                    n: events.length - (TO_SHOW_BEFORE + TO_SHOW_AFTER),
                   }))}
                 </a>
               </li>
-              {buildReleaseEventRow(events[events.length - 1], abbreviated)}
+              {events.slice(-TO_SHOW_AFTER).map(
+                event => buildReleaseEventRow(event, abbreviated),
+              )}
             </ul>
           </>
         ) : (

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -14,7 +14,8 @@ import {bracketedText} from '../utility/bracketed';
 
 import ArtistCreditLink from './ArtistCreditLink';
 
-const COLLAPSE_THRESHOLD = 4;
+const TO_SHOW_BEFORE = 4;
+const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + 2;
 
 const buildWorkArtistRow = (artistCredit: ArtistCreditT) => {
   return (
@@ -47,7 +48,7 @@ const WorkArtists = ({artists}: WorkArtistsProps) => {
   };
 
   const tooManyArtists = artists
-    ? artists.length > COLLAPSE_THRESHOLD
+    ? artists.length >= TO_TRIGGER_COLLAPSE
     : false;
 
   return (
@@ -56,7 +57,7 @@ const WorkArtists = ({artists}: WorkArtistsProps) => {
         {(tooManyArtists && !expanded) ? (
           <>
             <ul {...containerProps}>
-              {artists.slice(0, COLLAPSE_THRESHOLD).map(
+              {artists.slice(0, TO_SHOW_BEFORE).map(
                 artist => buildWorkArtistRow(artist),
               )}
               <li className="show-all" key="show-all">
@@ -67,7 +68,7 @@ const WorkArtists = ({artists}: WorkArtistsProps) => {
                   title={l('Show all artists')}
                 >
                   {bracketedText(texp.l('show {n} more', {
-                    n: artists.length - COLLAPSE_THRESHOLD,
+                    n: artists.length - TO_SHOW_BEFORE,
                   }))}
                 </a>
               </li>


### PR DESCRIPTION
### Fix MBS-10742

The number being printed in "show {n} more" was events.length - COLLAPSE_THRESHOLD, but in fact the code prints two events before the collapse and one after - 3, not the 4 for COLLAPSE_THRESHOLD.

This moves the numbers to (easier to understand) constants, and then ensures we show the right number of events.