### PR TITLE
MBS-9894: Fix timeline month off by 1

### DIFF
--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -382,7 +382,7 @@ class TimelineLine {
             const serial = [];
             for (const key in data) {
                 const {year, month, day} = parseDate(key);
-                serial.push([Date.UTC(year, month, day), data[key]]);
+                serial.push([Date.UTC(year, month - 1, day), data[key]]);
             }
             serial.sort((a, b) => a[0] - b[0]);
 


### PR DESCRIPTION
Months start at 0 in Javascript Date