### PR TITLE
MBS-10747: Fix misleading open edit message

### DIFF
--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -54,9 +54,7 @@ export function getEditStatusName(edit: EditT) {
 export function getEditStatusDescription(edit: EditT) {
   switch (edit.status) {
     case EDIT_STATUS_OPEN:
-      return l(
-        'This edit is open and awaiting votes before it can be applied.',
-      );
+      return l('This edit is open for voting.');
     case EDIT_STATUS_APPLIED:
       return l('This edit has been successfully applied.');
     case EDIT_STATUS_FAILEDVOTE:


### PR DESCRIPTION
### Fix MBS-10747

"This edit is open and awaiting votes before it can be applied." suggests the edit can't be applied without votes, which is not true. Just "This edit is open for voting" actually describes the situation well enough without making any additional claims.