### PR TITLE
MBS-10107: Add overview page for rel attributes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
@@ -26,14 +26,14 @@ sub _load_tree
 
 sub base : Chained('/') PathPart('relationship-attribute') CaptureArgs(0) { }
 
-sub index : Path('/relationship-attributes') Args(0)
+sub list : Path('/relationship-attributes') Args(0)
 {
     my ($self, $c) = @_;
 
     $self->_load_tree($c);
 
     $c->stash(
-        component_path  => 'relationship/linkattributetype/RelationshipAttributeTypesIndex',
+        component_path  => 'relationship/linkattributetype/RelationshipAttributeTypesList',
         component_props => {root => $c->stash->{root}->TO_JSON},
         current_view    => 'Node',
     );
@@ -62,7 +62,7 @@ sub create : Path('/relationship-attributes/create') Args(0) RequireAuth(relatio
             );
         });
 
-        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/index'));
+        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/list'));
         $c->detach;
     }
 }
@@ -93,7 +93,7 @@ sub edit : Chained('load') RequireAuth(relationship_editor)
             );
         });
 
-        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/index'));
+        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/list'));
         $c->detach;
     }
 }
@@ -130,7 +130,7 @@ sub delete : Chained('load') RequireAuth(relationship_editor) SecureForm
             );
         });
 
-        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/index'));
+        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/list'));
         $c->detach;
     }
 }

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
@@ -6,7 +6,7 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_RELATIONSHIP_ATTRIBUTE
     $INSTRUMENT_ROOT_ID
 );
-
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Validation qw( is_guid );
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
@@ -25,6 +25,28 @@ sub _load_tree
 }
 
 sub base : Chained('/') PathPart('relationship-attribute') CaptureArgs(0) { }
+
+sub show : PathPart('') Chained('load')
+{
+    my ($self, $c) = @_;
+
+    my $attribute = $c->model('LinkAttributeType')->get_tree(
+        undef, # don't filter
+        $c->stash->{link_attr_type}->{id}
+    );
+    my @relationships = $c->model('LinkType')->find_by_attribute($attribute->{id});
+
+    my %props = (
+        attribute => $attribute->TO_JSON,
+        relationships => to_json_array(\@relationships),
+    );
+
+    $c->stash(
+        component_path  => 'relationship/linkattributetype/RelationshipAttributeTypeIndex',
+        component_props => \%props,
+        current_view => 'Node',
+    );
+}
 
 sub list : Path('/relationship-attributes') Args(0)
 {
@@ -54,7 +76,7 @@ sub create : Path('/relationship-attributes/create') Args(0) RequireAuth(relatio
         if $parent_link_attr_type;
 
     if ($c->form_posted_and_valid($form)) {
-        $c->model('MB')->with_transaction(sub {
+        my $attribute_edit = $c->model('MB')->with_transaction(sub {
             $self->_insert_edit(
                 $c, $form,
                 edit_type => $EDIT_RELATIONSHIP_ADD_ATTRIBUTE,
@@ -62,7 +84,7 @@ sub create : Path('/relationship-attributes/create') Args(0) RequireAuth(relatio
             );
         });
 
-        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/list'));
+        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/show', [ $attribute_edit->entity_gid ]));
         $c->detach;
     }
 }
@@ -93,7 +115,7 @@ sub edit : Chained('load') RequireAuth(relationship_editor)
             );
         });
 
-        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/list'));
+        $c->response->redirect($c->uri_for_action('relationship/linkattributetype/show', [ $link_attr_type->gid ]));
         $c->detach;
     }
 }

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -31,7 +31,9 @@ sub _columns
 {
     return 'id, parent, child_order, gid, name, description, root, ' .
            '(SELECT r.name FROM link_attribute_type r WHERE r.id = link_attribute_type.root) root_name, ' .
+           '(SELECT r.name FROM link_attribute_type r WHERE r.id = link_attribute_type.parent) parent_name, ' .
            '(SELECT r.gid FROM link_attribute_type r WHERE r.id = link_attribute_type.root) root_gid, ' .
+           '(SELECT r.gid FROM link_attribute_type r WHERE r.id = link_attribute_type.parent) parent_gid, ' .
            'COALESCE(
                 (SELECT TRUE FROM link_text_attribute_type
                  WHERE attribute_type = link_attribute_type.id),
@@ -62,6 +64,18 @@ sub _column_mapping
         description => 'description',
         free_text   => 'free_text',
         creditable  => 'creditable',
+        parent => sub {
+            my ($row) = @_;
+            if ($row->{parent}) {
+                MusicBrainz::Server::Entity::LinkAttributeType->new({
+                    id => $row->{parent},
+                    gid => $row->{parent_gid},
+                    name => $row->{parent_name},
+                    root_id => $row->{root},
+                    root_gid => $row->{root_gid},
+                });
+            }
+        },
         root => sub {
             my ($row) = @_;
             MusicBrainz::Server::Entity::LinkAttributeType->new({

--- a/lib/MusicBrainz/Server/Data/LinkType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkType.pm
@@ -94,6 +94,18 @@ around get_by_gid => sub
     return $obj;
 };
 
+sub find_by_attribute
+{
+    my ($self, $attribute_id) = @_;
+    my $query = "SELECT " . $self->_columns . "
+                 FROM " . $self->_table . "
+                     JOIN link_type_attribute_type ltat ON ltat.link_type = link_type.id
+                 WHERE ltat.attribute_type = ?
+                 ORDER BY link_type.name COLLATE musicbrainz";
+
+    $self->query_to_list($query, [$attribute_id]);
+}
+
 sub load
 {
     my ($self, @objs) = @_;

--- a/lib/MusicBrainz/Server/Data/Role/OptionsTree.pm
+++ b/lib/MusicBrainz/Server/Data/Role/OptionsTree.pm
@@ -6,7 +6,7 @@ with 'MusicBrainz::Server::Data::Role::Context';
 with 'MusicBrainz::Server::Data::Role::SelectAll';
 
 sub get_tree {
-    my ($self, $filter) = @_;
+    my ($self, $filter, $root_id) = @_;
 
     my @objects;
 
@@ -26,6 +26,8 @@ sub get_tree {
         my $parent = $obj->parent_id ? $id_to_obj{$obj->parent_id} : $root;
         $parent->add_child($obj);
     }
+
+    return $id_to_obj{$root_id} if defined $root_id;
 
     return $root;
 }

--- a/lib/MusicBrainz/Server/Entity/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Entity/LinkAttributeType.pm
@@ -33,6 +33,16 @@ has 'root' => (
     isa => 'LinkAttributeType',
 );
 
+has 'parent_gid' => (
+    is => 'rw',
+    isa => 'Maybe[Str]',
+);
+
+has 'parent_name' => (
+    is => 'rw',
+    isa => 'Maybe[Str]',
+);
+
 sub l_name {
     my $self = shift;
     my $rootid = defined $self->root ? $self->root->id : $self->root_id;
@@ -76,6 +86,11 @@ around TO_JSON => sub {
         $self->link_entity('link_attribute_type', $root->id, $root);
     }
 
+    my $parent = $self->parent;
+    if ($parent) {
+        $self->link_entity('link_attribute_type', $parent->id, $parent);
+    }
+
     my $children = to_json_array($self->children);
 
     return {
@@ -83,6 +98,7 @@ around TO_JSON => sub {
         gid => $self->gid,
         root_id => $self->root_id + 0,
         root_gid => $self->root_gid,
+        parent_id => $self->parent_id + 0,
         free_text => boolean_to_json($self->free_text),
         creditable => boolean_to_json($self->creditable),
         $self->instrument_comment ? (instrument_comment => $self->instrument_comment) : (),

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -1,0 +1,201 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../../layout';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
+import linkedEntities from '../../static/scripts/common/linkedEntities';
+import bracketed, {bracketedText}
+  from '../../static/scripts/common/utility/bracketed';
+import formatEntityTypeName
+  from '../../static/scripts/common/utility/formatEntityTypeName';
+import {isRelationshipEditor}
+  from '../../static/scripts/common/utility/privileges';
+import {upperFirst} from '../../static/scripts/common/utility/strings';
+import compareChildren from '../utility/compareChildren';
+
+type Props = {
+  +$c: CatalystContextT,
+  +attribute: LinkAttrTypeT,
+  +relationships: Array<LinkTypeT>,
+};
+
+const AttributeTree = ({
+  attribute,
+}: {attribute: LinkAttrTypeT}): React.Element<'li'> => {
+  const childrenAttrs = attribute.children || [];
+  return (
+    <li style={{marginTop: '0.25em'}}>
+      <strong>
+        <a href={'/relationship-attribute/' + attribute.gid}>
+          {upperFirst(l_relationships(attribute.name))}
+        </a>
+      </strong>
+      {' '}
+      {attribute.description ? (
+        <>
+          {bracketed(expand2react(l_relationships(attribute.description)))}
+          {' '}
+        </>
+      ) : null}
+      {bracketedText(attribute.child_order.toString())}
+
+      {childrenAttrs.length ? (
+        <ul>
+          {childrenAttrs
+            .slice(0)
+            .sort(compareChildren)
+            .map(attribute => (
+              <AttributeTree
+                attribute={attribute}
+                key={attribute.gid}
+              />
+            ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+};
+
+const RelationshipAttributeTypeIndex = ({
+  $c,
+  attribute,
+  relationships,
+}: Props): React.Element<typeof Layout> => {
+  const childrenAttrs = attribute.children || [];
+  const attrName = upperFirst(l_relationships(attribute.name));
+  const title = l('Relationship Attribute') + ' / ' + attrName;
+  const parent = attribute.parent_id == null
+    ? null
+    : linkedEntities.link_attribute_type[attribute.parent_id];
+
+  return (
+    <Layout $c={$c} fullWidth noIcons title={title}>
+      <div id="content">
+        <h1 className="hierarchy-links">
+          <a href="/relationship-attributes">
+            {l('Relationship Attributes')}
+          </a>
+          {' / '}
+          {attrName}
+        </h1>
+
+        {isRelationshipEditor($c.user) ? (
+          <span className="buttons" style={{float: 'right'}}>
+            <a href={'/relationship-attribute/' + attribute.gid + '/edit'}>
+              {l('Edit')}
+            </a>
+            {childrenAttrs.length ? null : (
+              <a
+                href={'/relationship-attribute/' + attribute.gid + '/delete'}
+              >
+                {l('Remove')}
+              </a>
+            )}
+          </span>
+        ) : null}
+
+        {attribute.description ? (
+          <>
+            <h2>{l('Description')}</h2>
+            <p>{expand2react(l_relationships(attribute.description))}</p>
+          </>
+        ) : null}
+
+        <p>
+          {isRelationshipEditor($c.user) ? (
+            <>
+              <strong>{l('ID:')}</strong>
+              {' '}
+              {attribute.id}
+              <br />
+              <strong>{l('Child order:')}</strong>
+              {' '}
+              {attribute.child_order}
+              <br />
+            </>
+          ) : null}
+          <strong>{l('UUID:')}</strong>
+          {' '}
+          {attribute.gid}
+          <br />
+          {parent ? (
+            <>
+              <strong>{addColonText(l('Parent attribute'))}</strong>
+              {' '}
+              <a href={'/relationship-attribute/' + parent.gid}>
+                {upperFirst(l_relationships(parent.name))}
+              </a>
+            </>
+          ) : null}
+        </p>
+
+        {childrenAttrs.length ? (
+          <>
+            <h2>{l('Possible values')}</h2>
+            <ul>
+              {childrenAttrs
+                .slice(0)
+                .sort(compareChildren)
+                .map(attribute => (
+                  <AttributeTree
+                    attribute={attribute}
+                    key={attribute.gid}
+                  />
+                ))}
+            </ul>
+          </>
+        ) : null}
+
+        <h2>{l('Relationship usage')}</h2>
+        {relationships.length ? (
+          <>
+            <p>
+              {l(`This attribute is being used
+                  by the following relationship types:`)}
+            </p>
+
+            {relationships.map(relationship => (
+              <React.Fragment key={relationship.gid}>
+                <h3>
+                  <a
+                    href={'/relationship/' + relationship.gid}
+                  >
+                    {upperFirst(l_relationships(relationship.name))}
+                  </a>
+                  {' '}
+                  {bracketedText(texp.l(
+                    '{type0} - {type1}',
+                    {
+                      type0: formatEntityTypeName(relationship.type0),
+                      type1: formatEntityTypeName(relationship.type1),
+                    },
+                  ))}
+                </h3>
+                {relationship.description ? (
+                  <p>
+                    {expand2react(l_relationships(relationship.description))}
+                  </p>
+                ) : null}
+              </React.Fragment>
+            ))}
+          </>
+        ) : (
+          <p>
+            {l(`This attribute isn’t directly being used
+                by any relationship types.`)}
+          </p>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default RelationshipAttributeTypeIndex;

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -154,7 +154,7 @@ const AttributesList = ({$c, root}: AttributesListProps) => {
   );
 };
 
-const RelationshipAttributeTypesIndex = ({
+const RelationshipAttributeTypesList = ({
   $c,
   root,
 }: AttributesListProps): React.Element<typeof Layout> => (
@@ -173,4 +173,4 @@ const RelationshipAttributeTypesIndex = ({
   </Layout>
 );
 
-export default RelationshipAttributeTypesIndex;
+export default RelationshipAttributeTypesList;

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -70,13 +70,24 @@ const AttributeDetails = ({
             </a>
           </>
         )}
+        {' | '}
+        <a href={'/relationship-attribute/' + attribute.gid}>
+          {l('Documentation')}
+        </a>
         {' ]'}
 
       </>
     ) : (
-      attribute.description && attribute.description !== attribute.name
-        ? descriptionSection
-        : null
+      <>
+        {attribute.description && attribute.description !== attribute.name
+          ? descriptionSection
+          : null}
+        {' [ '}
+        <a href={'/relationship-attribute/' + attribute.gid}>
+          {l('Documentation')}
+        </a>
+        {' ]'}
+      </>
     )
   );
 };

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -132,6 +132,7 @@ module.exports = {
   'recording/RecordingIndex': require('../recording/RecordingIndex'),
   'recording/RecordingMerge': require('../recording/RecordingMerge'),
   'relationship/linkattributetype/RelationshipAttributeTypeInUse': require('../relationship/linkattributetype/RelationshipAttributeTypeInUse'),
+  'relationship/linkattributetype/RelationshipAttributeTypeIndex': require('../relationship/linkattributetype/RelationshipAttributeTypeIndex'),
   'relationship/linkattributetype/RelationshipAttributeTypesList': require('../relationship/linkattributetype/RelationshipAttributeTypesList'),
   'relationship/linktype/RelationshipTypeInUse': require('../relationship/linktype/RelationshipTypeInUse'),
   'relationship/linktype/RelationshipTypeIndex': require('../relationship/linktype/RelationshipTypeIndex'),

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -132,7 +132,7 @@ module.exports = {
   'recording/RecordingIndex': require('../recording/RecordingIndex'),
   'recording/RecordingMerge': require('../recording/RecordingMerge'),
   'relationship/linkattributetype/RelationshipAttributeTypeInUse': require('../relationship/linkattributetype/RelationshipAttributeTypeInUse'),
-  'relationship/linkattributetype/RelationshipAttributeTypesIndex': require('../relationship/linkattributetype/RelationshipAttributeTypesIndex'),
+  'relationship/linkattributetype/RelationshipAttributeTypesList': require('../relationship/linkattributetype/RelationshipAttributeTypesList'),
   'relationship/linktype/RelationshipTypeInUse': require('../relationship/linktype/RelationshipTypeInUse'),
   'relationship/linktype/RelationshipTypeIndex': require('../relationship/linktype/RelationshipTypeIndex'),
   'relationship/linktype/RelationshipTypePairTree': require('../relationship/linktype/RelationshipTypePairTree'),

--- a/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Create.pm
@@ -40,7 +40,7 @@ test 'Can create new relationship attribute' => sub {
         ok($mech->success);
 
         my @redir = $response->redirects;
-        like($redir[0]->content, qr{http://localhost/relationship-attributes}, "Redirect contains link to main relationship-attributes page.");
+        like($redir[0]->content, qr{http://localhost/relationship-attribute/}, "Redirect contains link to attribute page.");
     } $test->c;
 
     is(@edits, 1);

--- a/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Edit.pm
@@ -39,7 +39,7 @@ test 'Editing a relationship attribute /relationship-attribute/edit for a valid 
         ok($mech->success);
 
         my @redir = $response->redirects;
-        like($redir[0]->content, qr{http://localhost/relationship-attributes}, "Redirect contains link to main relationship page.");
+        like($redir[0]->content, qr{http://localhost/relationship-attribute/0a5341f8-3b1d-4f99-a0c6-26b7f4e42c7f}, "Redirect contains link to attribute type page.");
     } $test->c;
 
     is(@edits, 1);

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -287,6 +287,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Relationship::LinkAttributeType::base",
   "Controller::Relationship::LinkAttributeType::create",
   "Controller::Relationship::LinkAttributeType::list",
+  "Controller::Relationship::LinkAttributeType::show",
   "Controller::Relationship::LinkType::base",
   "Controller::Relationship::LinkType::create",
   "Controller::Relationship::LinkType::list",

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -286,7 +286,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Recording::tags",
   "Controller::Relationship::LinkAttributeType::base",
   "Controller::Relationship::LinkAttributeType::create",
-  "Controller::Relationship::LinkAttributeType::index",
+  "Controller::Relationship::LinkAttributeType::list",
   "Controller::Relationship::LinkType::base",
   "Controller::Relationship::LinkType::create",
   "Controller::Relationship::LinkType::list",


### PR DESCRIPTION
### Implement MBS-10107

There's no good reason why we don't have these, and it would be good if relationship-attribute/$gid wasn't an error.

If we have them, it makes sense to go to them and not the main list after creating or adding an attribute, so I made that change too, and linked to them from the attributes list.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1451

![Screenshot from 2020-04-06 01-16-04](https://user-images.githubusercontent.com/1069224/78511300-3671f000-77a4-11ea-9892-2f4efa7d0481.png)
