### PR TITLE
MBS-10640: Fix donation check

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -7,6 +7,7 @@ use Digest::SHA qw(sha1_base64);
 use JSON;
 use List::MoreUtils qw( uniq );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Form::Utils qw(
     build_grouped_options
     language_options
@@ -689,12 +690,15 @@ sub donation : Local RequireAuth HiddenOnSlaves
     my $result = $c->model('Editor')->donation_check($c->user);
     $c->detach('/error_500') unless $result;
 
+    # If nag is 0, don't nag - if 1 or -1 then nag
+    my $nag = $result->{nag} != 0;
+
     $c->stash(
         current_view => 'Node',
         component_path => 'account/Donation',
         component_props => {
             days => sprintf("%.0f", $result->{days}),
-            nag => $result->{nag} > 0,
+            nag => boolean_to_json($nag),
         }
     );
 }

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -405,6 +405,7 @@ sub donation_check
         );
 
         if ($response->is_success && $response->content =~ /\s*([-01]+),([-0-9.]+)\s*/) {
+            # Possible values for nag will be -1, 0, 1 (only 0 means do not nag)
             $nag = $1;
             $days = $2;
         } else {


### PR DESCRIPTION
### Fix MBS-10640

This was only saying you needed to donate if the MeB site returned a nag status of 1: "known editor, donation time has passed". It was not saying it when it returned -1 ("we don't know of this editor, has never donated before").

This change makes it so that only 0 ("no-nag period applies currently") is shown as "you don't need
to donate".