### PR TITLE
MBS-10756: Remove link_order from rels sort

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -173,7 +173,7 @@ sub _load
                       JOIN link l ON link = l.id
                       JOIN link_type lt ON lt.id = l.link_type";
 
-        my $order = 'lt.name, link_order,
+        my $order = 'lt.name,
                      l.begin_date_year, l.begin_date_month, l.begin_date_day,
                      l.end_date_year,   l.end_date_month,   l.end_date_day,
                      l.ended';


### PR DESCRIPTION
### Fix MBS-10756

Commit 2e2e5c670816e2892374e977874f21b2d8cb2419 added a sort by link_order here, but this causes issues (in RelationshipsTable we'd expect rels to sort by date but the ones with a higher link_order are getting pushed to the bottom) and doesn't actually do any good (the places where we care about link order, we already sort the rels properly on the JS side).