### PR TITLE
MBS-10764: Convert historic Remove Label Alias edit to React 

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/RemoveLabelAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/RemoveLabelAlias.pm
@@ -12,7 +12,7 @@ sub edit_name { N_l('Remove label alias') }
 sub edit_kind { 'remove' }
 sub historic_type { 62 }
 sub edit_type { $EDIT_HISTORIC_REMOVE_LABEL_ALIAS }
-sub edit_template { 'historic/remove_label_alias' }
+sub edit_template_react { 'historic/RemoveLabelAlias' }
 
 sub _build_related_entities {
     my $self = shift;

--- a/root/edit/details/historic/RemoveLabelAlias.js
+++ b/root/edit/details/historic/RemoveLabelAlias.js
@@ -1,0 +1,28 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+type RemoveLabelAliasEditT = {
+  ...EditT,
+  +display_data: {
+    +alias: string,
+  },
+};
+
+const RemoveLabelAlias = ({edit}: {+edit: RemoveLabelAliasEditT}) => (
+  <table className="details remove-label-alias">
+    <tr>
+      <th>{l('Alias:')}</th>
+      <td>{edit.display_data.alias}</td>
+    </tr>
+  </table>
+);
+
+export default RemoveLabelAlias;

--- a/root/edit/details/historic/remove_label_alias.tt
+++ b/root/edit/details/historic/remove_label_alias.tt
@@ -1,6 +1,0 @@
-<table class="details">
-  <tr>
-    <th>[% l('Alias:') %]</th>
-    <td>[% edit.display_data.alias | html %]</td>
-  </tr>
-</table>

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -291,6 +291,7 @@ module.exports = {
   'edit/details/MergeSeries': require('../edit/details/MergeSeries'),
   'edit/details/MergeWorks': require('../edit/details/MergeWorks'),
   'edit/details/historic/MergeReleases': require('../edit/details/historic/MergeReleases'),
+  'edit/details/historic/RemoveLabelAlias': require('../edit/details/historic/RemoveLabelAlias'),
   'edit/details/historic/RemovePuid': require('../edit/details/historic/RemovePuid'),
   'edit/details/historic/RemoveRelease': require('../edit/details/historic/RemoveRelease'),
   'edit/details/historic/RemoveReleases': require('../edit/details/historic/RemoveReleases'),


### PR DESCRIPTION
### Implement MBS-10764

The only change from the TT is to add the "remove-label-alias" class, for consistency.

Amazingly enough, it seems no info about the label itself is stored with these old edits, so all we do is literally print the alias being removed as a string.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1462