### PR TITLE
MBS-8412: Standardize pagination limits

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -23,10 +23,6 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name => 'edit',
 };
 
-__PACKAGE__->config(
-    paging_limit => 25,
-);
-
 =head1 NAME
 
 MusicBrainz::Server::Controller::Moderation - handle user interaction

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -34,10 +34,6 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Editor'
 };
 
-__PACKAGE__->config(
-    paging_limit => 25,
-);
-
 use Try::Tiny;
 
 =head1 NAME

--- a/lib/MusicBrainz/Server/Controller/User/Edits.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Edits.pm
@@ -6,10 +6,6 @@ BEGIN { extends 'MusicBrainz::Server::Controller' };
 use MusicBrainz::Server::Data::Utils qw( load_everything_for_edits );
 use MusicBrainz::Server::Constants ':edit_status';
 
-__PACKAGE__->config(
-    paging_limit => 25,
-);
-
 sub _edits {
     my ($self, $c, $loader) = @_;
 


### PR DESCRIPTION
### Implement MBS-8412

We have different pagination limits for different edit pages, which leads to situations like artist/mbid/edits showing 100 edits but the edit search reached when clicking "Refine this search"
(which a user would no doubt expect to be equivalent, until they refine it) only showing the first 25 of them.

This standardises all of those 25-edit lists to 100, our default pagination limit.

If this seems like too much for some reason then we could change all edit listings to show 50, but I think 100 should be doable since it was already used in most places anyway.