### PR TITLE
Fix a warning from /release-group/ overview page in server logs

### DIFF
--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -48,7 +48,7 @@ type Props = {
 function buildReleaseStatusTable($c, releaseStatusGroup) {
   const status = releaseStatusGroup[0].status;
   return (
-    <>
+    <React.Fragment key={status ? status.name : 'no-status'}>
       <tr className="subh">
         {$c.user_exists ? <th /> : null}
         <th colSpan={$c.session && $c.session.tport ? 8 : 7}>
@@ -89,7 +89,7 @@ function buildReleaseStatusTable($c, releaseStatusGroup) {
             : null}
         </tr>
       ))}
-    </>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
Add missing key prop to Fragment siblings, see https://reactjs.org/docs/lists-and-keys.html#keys.