### PR TITLE
Remove $c.user_exists from JS

### DIFF
--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -41,7 +41,7 @@ const AreaArtists = ({
             showRatings
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -43,7 +43,7 @@ const AreaEvents = ({
             showType
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -40,7 +40,7 @@ const AreaLabels = ({
             showRatings
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -57,7 +57,7 @@ const AreaPlaces = ({
               places={places}
             />
           </PaginatedResults>
-          {$c.user_exists ? (
+          {$c.user ? (
             <div className="row">
               <span className="buttons">
                 <button type="submit">

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -40,7 +40,7 @@ const AreaReleases = ({
             releases={releases}
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -44,7 +44,7 @@ const ArtistEvents = ({
             showType
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -288,7 +288,7 @@ const ArtistIndex = ({
               showRatings
             />
           </PaginatedResults>
-          {$c.user_exists ? (
+          {$c.user ? (
             <div className="row">
               <FormSubmit label={l('Merge release groups')} />
             </div>

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -59,7 +59,7 @@ const ArtistRecordings = ({
             showRatings
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <FormSubmit label={l('Add selected recordings for merging')} />
           </div>

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -55,7 +55,7 @@ const ArtistReleases = ({
         <PaginatedResults pager={pager}>
           <ReleaseList checkboxes="add-to-merge" releases={releases} />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <FormSubmit label={l('Add selected releases for merging')} />
           </div>

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -40,7 +40,7 @@ const ArtistWorks = ({
             works={works}
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -175,7 +175,7 @@ const CollectionIndex = (props: Props) => {
         {collection.description_html ? (
           <>
             <h2>{l('Description')}</h2>
-            {$c.user_exists ||
+            {$c.user ||
               (collection.editor && !collection.editor.is_limited) ? (
                 expand2react(collection.description_html)
               ) : (

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -43,7 +43,7 @@ const ArtistCreditList = ({$c, artistCredits, entity}: Props) => {
             <th>
               {l('Name')}
             </th>
-            {$c.user_exists ? (
+            {$c.user ? (
               <th className="actions">
                 {l('Actions')}
               </th>
@@ -56,7 +56,7 @@ const ArtistCreditList = ({$c, artistCredits, entity}: Props) => {
               <td>
                 <ArtistCreditLink artistCredit={credit} />
               </td>
-              {$c.user_exists ? (
+              {$c.user ? (
                 <td className="actions">
                   <a href={`/artist/${entity.gid}/credit/${credit.id}/edit`}>
                     {credit.editsPending

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -86,7 +86,7 @@ function buildTabs(
     ));
   }
 
-  if (showAdmin || DBDefs.DB_STAGING_TESTING_FEATURES && $c.user_exists) {
+  if (showAdmin || DBDefs.DB_STAGING_TESTING_FEATURES && $c.user) {
     tabs.push(buildTab(
       page,
       l('Edit User'),

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -37,7 +37,7 @@ const AreaList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn =
@@ -54,7 +54,7 @@ const AreaList = ({
         ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
       ];
     },
-    [$c.user_exists, areas, checkboxes, mergeForm, order, sortable],
+    [$c.user, areas, checkboxes, mergeForm, order, sortable],
   );
 
   return <Table columns={columns} data={areas} />;

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -53,7 +53,7 @@ const ArtistList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn = defineNameColumn<ArtistT>(
@@ -125,7 +125,7 @@ const ArtistList = ({
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       artists,
       checkboxes,
       instrumentCreditsAndRelTypes,

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -61,7 +61,7 @@ const EventList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const seriesNumberColumn = seriesItemNumbers
@@ -119,7 +119,7 @@ const EventList = ({
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       artist,
       artistRoles,
       checkboxes,

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -38,7 +38,7 @@ const InstrumentList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn =
@@ -56,7 +56,7 @@ const InstrumentList = ({
         ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
       ];
     },
-    [$c.user_exists, checkboxes, instruments, mergeForm, order, sortable],
+    [$c.user, checkboxes, instruments, mergeForm, order, sortable],
   );
 
   return <Table columns={columns} data={instruments} />;

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -45,7 +45,7 @@ const LabelList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn =
@@ -84,7 +84,7 @@ const LabelList = ({
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       checkboxes,
       labels,
       mergeForm,

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -41,7 +41,7 @@ const PlaceList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn =
@@ -81,7 +81,7 @@ const PlaceList = ({
         ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
       ];
     },
-    [$c.user_exists, checkboxes, mergeForm, order, places, sortable],
+    [$c.user, checkboxes, mergeForm, order, places, sortable],
   );
 
   return <Table columns={columns} data={places} />;

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -56,7 +56,7 @@ const RecordingList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const seriesNumberColumn = seriesItemNumbers
@@ -106,7 +106,7 @@ const RecordingList = ({
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       checkboxes,
       instrumentCreditsAndRelTypes,
       lengthClass,

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -70,7 +70,7 @@ export const ReleaseGroupListTable = withCatalystContext<
 
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const seriesNumberColumn = seriesItemNumbers
@@ -126,7 +126,7 @@ export const ReleaseGroupListTable = withCatalystContext<
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       checkboxes,
       mergeForm,
       order,

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -55,7 +55,7 @@ const ReleaseList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && checkboxes
+      const checkboxColumn = $c.user && checkboxes
         ? defineCheckboxColumn(checkboxes)
         : null;
       const seriesNumberColumn = seriesItemNumbers
@@ -136,7 +136,7 @@ const ReleaseList = ({
     },
     [
       $c.session,
-      $c.user_exists,
+      $c.user,
       checkboxes,
       filterLabel,
       instrumentCreditsAndRelTypes,

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -38,7 +38,7 @@ const SeriesList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const nameColumn = defineNameColumn<SeriesT>(
@@ -59,7 +59,7 @@ const SeriesList = ({
         ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
       ];
     },
-    [$c.user_exists, checkboxes, mergeForm, order, series, sortable],
+    [$c.user, checkboxes, mergeForm, order, series, sortable],
   );
 
   return <Table columns={columns} data={series} />;

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -48,7 +48,7 @@ const WorkList = ({
 }: Props) => {
   const columns = React.useMemo(
     () => {
-      const checkboxColumn = $c.user_exists && (checkboxes || mergeForm)
+      const checkboxColumn = $c.user && (checkboxes || mergeForm)
         ? defineCheckboxColumn(checkboxes, mergeForm)
         : null;
       const seriesNumberColumn = seriesItemNumbers
@@ -84,7 +84,7 @@ const WorkList = ({
       ];
     },
     [
-      $c.user_exists,
+      $c.user,
       checkboxes,
       mergeForm,
       order,

--- a/root/context.js
+++ b/root/context.js
@@ -31,7 +31,6 @@ const defaultContext = {
     current_language: 'en',
     current_language_html: 'en',
   },
-  user_exists: false,
 };
 
 const defaultSanitizedContext = {
@@ -45,7 +44,6 @@ const defaultSanitizedContext = {
     current_language: 'en',
   },
   user: null,
-  user_exists: false,
 };
 
 const CatalystContext =

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -85,7 +85,7 @@ const EditSidebar = ({$c, edit}: Props) => (
     </SidebarProperties>
 
     <p>
-      {$c.user_exists ? (
+      {$c.user ? (
         <a href={`/edit/${edit.id}/data`}>
           <bdi>{l('Raw edit data for this edit')}</bdi>
         </a>

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -48,7 +48,7 @@ const EditSummary = ({$c, edit, index}: Props) => {
 
       <Vote edit={edit} index={index} summary />
 
-      {$c.user_exists && !DBDefs.DB_READ_ONLY && (mayAddNote || mayApprove || mayCancel) ? (
+      {$c.user && !DBDefs.DB_READ_ONLY && (mayAddNote || mayApprove || mayCancel) ? (
         <div className="cancel-edit buttons">
           {mayAddNote ? (
             <a className="positive edit-note-toggle">{l('Add Note')}</a>

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -44,7 +44,7 @@ const InstrumentArtists = ({
             showRatings
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -48,7 +48,7 @@ const InstrumentRecordings = ({
             showRatings
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -43,7 +43,7 @@ const InstrumentReleases = ({
             showInstrumentCreditsAndRelTypes
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -26,7 +26,7 @@ type PropsT = {
 };
 
 const Index = ({$c, isrcs, recordings}: PropsT) => {
-  const userExists = $c.user_exists;
+  const userExists = !!$c.user;
   const isrc = isrcs[0];
   return (
     <Layout fullWidth title={texp.l('ISRC “{isrc}”', {isrc: isrc.isrc})}>

--- a/root/iswc/Index.js
+++ b/root/iswc/Index.js
@@ -21,7 +21,7 @@ type Props = {
 };
 
 const Index = ({$c, iswcs, works}: Props) => {
-  const userExists = $c.user_exists;
+  const userExists = !!$c.user;
   const iswc = iswcs[0];
   return (
     <Layout fullWidth title={texp.l('ISWC “{iswc}”', {iswc: iswc.iswc})}>

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -65,7 +65,7 @@ const LabelIndex = ({
             releases={releases}
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <FormRow>
             <FormSubmit label={l('Add selected releases for merging')} />
           </FormRow>

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -310,7 +310,7 @@ const BottomMenu = ({$c}: {+$c: CatalystContextT}) => {
         <AboutMenu />
         <ProductsMenu />
         <SearchMenu />
-        {$c.user_exists ? <EditingMenu /> : null}
+        {$c.user ? <EditingMenu /> : null}
         <DocumentationMenu />
         {serverLanguages && serverLanguages.length > 1 ? (
           <LanguageMenu

--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -21,7 +21,7 @@ type Props = {
 
 const CollectionLinks = ({$c, entity}: Props) => {
   const numberOfCollections = $c.stash.number_of_collections || 0;
-  if (!$c.user_exists) {
+  if (!$c.user) {
     return null;
   }
   return (

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -60,7 +60,7 @@ const CollectionSidebar = ({$c, collection}: Props) => {
         </li>
       </ul>
 
-      {$c.user_exists ? (
+      {$c.user ? (
         <>
           <h2 className="subscriptions">{l('Subscriptions')}</h2>
           <ul className="links">

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -23,7 +23,7 @@ const EditLinks = ({$c, children, entity}: Props) => (
   <>
     <h2 className="editing">{l('Editing')}</h2>
     <ul className="links">
-      {$c.user_exists ? children : (
+      {$c.user ? children : (
         <>
           <li>
             <RequestLogin $c={$c} text={l('Log in to edit')} />

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -55,7 +55,7 @@ const SidebarTags = ({
 }: SidebarTagsProps) => (
   $c.action.name === 'tags' ? null : (
     <>
-      {($c.user_exists && aggregatedTags && userTags) ? (
+      {($c.user && aggregatedTags && userTags) ? (
         <SidebarTagEditor
           $c={$c}
           aggregatedTags={aggregatedTags}

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -42,7 +42,7 @@ const PlaceEvents = ({
             showType
           />
         </PaginatedResults>
-        {$c.user_exists ? (
+        {$c.user ? (
           <div className="row">
             <span className="buttons">
               <button type="submit">

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -50,7 +50,7 @@ function buildReleaseStatusTable($c, releaseStatusGroup) {
   return (
     <React.Fragment key={status ? status.name : 'no-status'}>
       <tr className="subh">
-        {$c.user_exists ? <th /> : null}
+        {$c.user ? <th /> : null}
         <th colSpan={$c.session && $c.session.tport ? 8 : 7}>
           {status?.name
             ? lp_attributes(status.name, 'release_status')
@@ -59,7 +59,7 @@ function buildReleaseStatusTable($c, releaseStatusGroup) {
       </tr>
       {releaseStatusGroup.map((release, index) => (
         <tr className={loopParity(index)} key={release.id}>
-          {$c.user_exists
+          {$c.user
             ? (
               <td>
                 <input
@@ -129,7 +129,7 @@ const ReleaseGroupIndex = ({
             <table className="tbl">
               <thead>
                 <tr>
-                  {$c.user_exists ? (
+                  {$c.user ? (
                     <th className="checkbox-cell">
                       <input type="checkbox" />
                     </th>
@@ -150,7 +150,7 @@ const ReleaseGroupIndex = ({
               </tbody>
             </table>
           </PaginatedResults>
-          {$c.user_exists ? (
+          {$c.user ? (
             <FormRow>
               <FormSubmit label={l('Add selected releases for merging')} />
             </FormRow>

--- a/root/report/DuplicateArtists.js
+++ b/root/report/DuplicateArtists.js
@@ -128,7 +128,7 @@ const DuplicateArtists = ({
               })}
             </tbody>
           </table>
-          {$c.user_exists ? (
+          {$c.user ? (
             <FormRow>
               <FormSubmit label={l('Add selected artists for merging')} />
             </FormRow>

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -85,7 +85,7 @@ const Annotation = ({
       <SanitizedCatalystContext.Consumer>
         {$c => (
           <div className="annotation-details">
-            {$c.user_exists ? (
+            {$c.user ? (
               latestAnnotation && (annotation.id === latestAnnotation.id) ? (
                 <>
                   {exp.l('Annotation last modified by {user} on {date}.', {

--- a/root/static/scripts/common/components/ArtistListEntry.js
+++ b/root/static/scripts/common/components/ArtistListEntry.js
@@ -65,7 +65,7 @@ const ArtistListRow = withCatalystContext(({
   showSortName,
 }: ArtistListRowProps) => (
   <>
-    {$c.user_exists && (checkboxes || mergeForm) ? (
+    {$c.user && (checkboxes || mergeForm) ? (
       <td>
         {mergeForm
           ? renderMergeCheckboxElement(artist, mergeForm, index)

--- a/root/static/scripts/common/components/InstrumentListEntry.js
+++ b/root/static/scripts/common/components/InstrumentListEntry.js
@@ -34,7 +34,7 @@ const InstrumentListRow = withCatalystContext(({
   instrument,
 }: InstrumentListRowProps) => (
   <>
-    {$c.user_exists && checkboxes ? (
+    {$c.user && checkboxes ? (
       <td>
         <input
           name={checkboxes}

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -140,7 +140,7 @@ class VoteButtons extends React.Component<VoteButtonsProps> {
 
     return (
       <span className={'tag-vote-buttons' + className}>
-        {this.props.$c.user_exists ? (
+        {this.props.$c.user ? (
           <>
             <UpvoteButton {...this.props} />
             <DownvoteButton {...this.props} />
@@ -512,7 +512,7 @@ export const MainTagEditor = hydrate<TagEditorProps>(
 
           {(positiveTagsOnly && !tags.every(isAlwaysVisible)) ? (
             <>
-              {this.props.$c.user_exists ? (
+              {this.props.$c.user ? (
                 <p>
                   {l(
                     `Tags with a score of zero or below,
@@ -537,7 +537,7 @@ export const MainTagEditor = hydrate<TagEditorProps>(
               <p>
                 {l('All tags are being shown.')}
               </p>
-              {this.props.$c.user_exists ? (
+              {this.props.$c.user ? (
                 <p>
                   <a href="#" onClick={this.hideNegativeTags.bind(this)}>
                     {l(
@@ -556,7 +556,7 @@ export const MainTagEditor = hydrate<TagEditorProps>(
             </>
           ) : null}
 
-          {this.props.$c.user_exists ? (
+          {this.props.$c.user ? (
             <>
               <h2>{l('Add Tags')}</h2>
               <p>

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -50,7 +50,7 @@ export const WorkListRow = withCatalystContext<WorkListRowProps>(({
   work,
 }: WorkListRowProps) => (
   <>
-    {$c.user_exists && checkboxes ? (
+    {$c.user && checkboxes ? (
       <td>
         <input
           name={checkboxes}

--- a/root/types.js
+++ b/root/types.js
@@ -191,7 +191,6 @@ declare type CatalystContextT = {
   +sessionid: string | null,
   +stash: CatalystStashT,
   +user?: CatalystUserT,
-  +user_exists: boolean,
 };
 
 declare type CatalystRequestContextT = {
@@ -940,7 +939,6 @@ declare type SanitizedCatalystContextT = {
     +invalid_csrf_token?: boolean,
   },
   +user: SanitizedEditorT | null,
-  +user_exists: boolean,
 };
 
 declare type SanitizedEditorPreferencesT = {

--- a/root/user/UserCollections.js
+++ b/root/user/UserCollections.js
@@ -127,12 +127,12 @@ const CollectionsEntityTypeSection = ({
         typeColumn,
         sizeColumn,
         collaboratorsColumn,
-        ...($c.user_exists ? [subscriptionColumn] : []),
+        ...($c.user ? [subscriptionColumn] : []),
         ...(viewingOwnProfile || isCollaborative ? [privacyColumn] : []),
         ...(viewingOwnProfile && !isCollaborative ? [actionsColumn] : []),
       ];
     },
-    [$c.user, $c.user_exists, isCollaborative, type, user.id],
+    [$c.user, $c.user, isCollaborative, type, user.id],
   );
 
   return (

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -109,7 +109,7 @@ const UserProfileInformation = withCatalystContext(({
   user,
   viewingOwnProfile,
 }: UserProfileInformationProps) => {
-  const showBioAndURL = !user.is_limited || $c.user_exists;
+  const showBioAndURL = !!(!user.is_limited || $c.user);
   let memberSince;
   if (user.name === 'rob') {
     memberSince = l('The Dawn of the Project');
@@ -160,7 +160,7 @@ const UserProfileInformation = withCatalystContext(({
                   </a>,
                 )
               ) : (
-                $c.user_exists ? (
+                $c.user ? (
                   bracketed(
                     <a href={`/user/${encodedName}/contact`}>
                       {l('send email')}
@@ -250,7 +250,7 @@ const UserProfileInformation = withCatalystContext(({
           ) : (
             l('0')
           )}
-          {$c.user_exists && !viewingOwnProfile ? (
+          {$c.user && !viewingOwnProfile ? (
             <>
               {' '}
               {bracketed(
@@ -557,7 +557,7 @@ const UserProfile = ({
         votes={votes}
       />
 
-      {$c.user_exists && !viewingOwnProfile ? (
+      {$c.user && !viewingOwnProfile ? (
         <h2 style={{clear: 'both'}}>
           <a href={`/user/${encodedName}/report`}>
             {l('Report this user for bad behavior')}

--- a/root/utility/sanitizedContext.js
+++ b/root/utility/sanitizedContext.js
@@ -35,7 +35,6 @@ function sanitizedContext(
       invalid_csrf_token: stash.invalid_csrf_token,
     },
     user: user ? sanitizedEditor(user) : null,
-    user_exists: $c.user_exists,
   };
 }
 


### PR DESCRIPTION
`user_exists` exists on the Perl side to check if a user is logged in without possibly fetching that user from the database. It serves no purpose in our JavaScript; if the user is logged in, `$c.user` will be defined.