### PR TITLE
MBS-10641: Fix link to open edits for subcriptions

### DIFF
--- a/lib/MusicBrainz/Server/Email/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Email/Subscriptions.pm
@@ -104,7 +104,7 @@ To view or edit your subscription list, please use the following link:
 [% self.server %]/user/[% escape(self.editor.name) %]/subscriptions
 
 To see all open edits for your subscribed entities, see this link:
-[% self.server %]/edit/subscribed
+[% self.server %]/edit/subscribed?open=1
 };
 }
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-10641: Email says “see all **open** edits for your subscribed entities” but actually links to all edits for subscribed entities, not just the open ones.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Append supported query parameter `open=1` to the link.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Read the [Contributing Guidelines](https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md)
* [x] Delete irrelevant parts of this template