### PR TITLE
MBS-10804: Remove redundant header with editor name

### DIFF
--- a/root/edit/notes.tt
+++ b/root/edit/notes.tt
@@ -18,7 +18,6 @@
       [% IF edit.editor_may_add_note(c.user)  %]
           <div class="add-edit-note edit-note"
               [% 'style="display: none"' IF hide -%]>
-              <h3 class="owner">[% link_entity(c.user) %]</h3>
               <p class="edit-note-help">
                   [% l('Edit notes support {doc_formatting|a limited set of wiki formatting options}.
                         Please do always keep the {doc_coc|Code of Conduct} in mind when writing edit notes!',


### PR DESCRIPTION
# Problem
Because this header is styled the same way as the edit note headers
(the ones with an actual edit note), having this header makes it look
like there is a comment missing.

**Before:**
![image](https://user-images.githubusercontent.com/54449/80937585-c3a86480-8da3-11ea-9aa3-96259271e472.png)

**After:**
![image](https://user-images.githubusercontent.com/54449/80937611-d91d8e80-8da3-11ea-9345-cc70c5aef4b0.png)


# Solution
Redundant header has been removed. 