### PR TITLE
MBS-10768: Fix crash in donation check for names with slashes

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -401,7 +401,7 @@ sub donation_check
     my $days = 0.0;
     if ($nag) {
         my $response = $self->c->lwp->get(
-            'https://metabrainz.org/donations/nag-check/' . uri_escape_utf8($obj->name)
+            'https://metabrainz.org/donations/nag-check?editor=' . uri_escape_utf8($obj->name)
         );
 
         if ($response->is_success && $response->content =~ /\s*([-01]+),([-0-9.]+)\s*/) {


### PR DESCRIPTION
### Fix MBS-10768

Changes to use the newer format for the nag check URL, which does support usernames with slashes (MEB-115). This avoids an ISE on the Donation Check page for these users.
This is fairly minor, since we only have 140 or so of these usernames, but still, we do have them :)
