### PR TITLE
MBS-10564: Display non-ASCII YouTube channel names too

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/YouTube.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/YouTube.pm
@@ -11,7 +11,7 @@ sub sidebar_name {
     if ($self->url =~ m{^(?:https?:)?//(?:www.)?youtube.com/watch\?v=([a-z0-9_-]+)/?$}i) {
         return 'Play on YouTube';
     }
-    elsif ($self->url =~ m{^(?:https?:)?//(?:www.)?youtube.com/(?:(?:c|user)/)?([a-z0-9_-]+)/?$}i) {
+    elsif ($self->decoded =~ m{^(?:https?:)?//(?:www.)?youtube.com/(?:(?:c|user)/)?([^/#?]+)/?$}i) {
         return $1;
     }
     else {


### PR DESCRIPTION
### Fix MBS-10564

The sidebar limited the YouTube channel names to ASCII, but that is not how this actually works (the example channel URL from the ticket is "三浦コウkomiura"). This uses the decoded version of the URL for printing, and prints (almost) anything that could be a channel name.
