### PR TITLE
MBS-10138: Fix guess case for titles finishing in "f"

### DIFF
--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -792,6 +792,7 @@ MB.GuessCase.Handler.Base = function (gc) {
         if (gc.i.matchCurrentWord(gc.re.FEAT)) {
             // Special cases (f.) and (f/), have to check if next word is a "." or a "/"
             if ((gc.i.matchCurrentWord(gc.re.FEAT_F)) &&
+                gc.i.getNextWord() &&
                 !gc.i.getNextWord().match(/^[\/.]$/)) {
                     return false;
             }

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -327,7 +327,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(22);
+  t.plan(23);
 
   const tests = [
     {
@@ -460,6 +460,12 @@ test('BugFixes', function (t) {
       input: 'I Love My iPad, My IPod and My Iphone!',
       expected: 'I Love My iPad, My iPod and My iPhone!',
       bug: 'MBS-7421',
+      mode: 'English',
+    },
+    {
+      input: 'Stuff with f',
+      expected: 'Stuff With F',
+      bug: 'MBS-10138',
       mode: 'English',
     },
 


### PR DESCRIPTION
### Fix MBS-10138

Guess case tries to find whether a title includes "f/" or "f." (for featuring artists) by finding a solitary F, and then checking if the next "word" is "/" or ".". This usually works, but since it does it by trying to match the next word, we need to check whether said word actually exists at all before attempting to match. Otherwise, an F at the end of a title will lead to an attempted match on null (since there's no next word) and Guess Case crashing.