### PR TITLE
MBS-10803: Fix allowing Metal Archives artist URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1633,7 +1633,7 @@ const CLEANUPS = {
         const prefix = m[1];
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
-            return prefix === 'bands' || prefix === 'band';
+            return /^(?:artists?|bands?)$/.test(prefix);
           case LINK_TYPES.otherdatabases.label:
             return prefix === 'labels';
           case LINK_TYPES.otherdatabases.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2117,6 +2117,20 @@ const testData = [
   },
   // (The) Metal Archives
   {
+                     input_url: 'http://metal-archives.com/artists/Phillip_Gallagher/591782',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/artists/Phillip_Gallagher/591782',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://metal-archives.com/artist/view/id/591782',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.metal-archives.com/artist/view/id/591782',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://www.metal-archives.com/bands/Karna/26483',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
# Problem

MBS-10803: Cannot link to `https://www.metal-archives.com/artists/<artist>/<number>`

Actually a bug in implementation https://github.com/metabrainz/musicbrainz-server/pull/1432.

# Solution

Allow both `/artists/<artist>/<number>` and `/artist/view/id/<number>`.