### PR TITLE
MBS-10737: Allow The Session place URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2271,7 +2271,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?thesession\\.org', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?)(?:\/.*)?\/([0-9]+)(?:.*)?$/, 'https://thesession.org/$1/$2');
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?thesession\.org\/(tunes|events|recordings(?:\/artists)?|sessions)(?:\/.*)?\/([0-9]+)(?:.*)?$/, 'https://thesession.org/$1/$2');
     },
     validate: function (url, id) {
       const m = /^https:\/\/thesession\.org\/([a-z\/]+)\/[0-9]+$/.exec(url);
@@ -2282,6 +2282,8 @@ const CLEANUPS = {
             return prefix === 'recordings/artists';
           case LINK_TYPES.otherdatabases.event:
             return prefix === 'events';
+          case LINK_TYPES.otherdatabases.place:
+            return prefix === 'sessions';
           case LINK_TYPES.otherdatabases.release_group:
             return prefix === 'recordings';
           case LINK_TYPES.otherdatabases.work:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3163,6 +3163,13 @@ const testData = [
        only_valid_entity_types: ['event'],
   },
   {
+                     input_url: 'https://thesession.org/sessions/display/432',
+             input_entity_type: 'place',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://thesession.org/sessions/432',
+       only_valid_entity_types: ['place'],
+  },
+  {
                      input_url: 'http://www.thesession.org/recordings/display/1488',
              input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
# Problem

MBS-10737: `thesession.org/sessions/` URLs cannot be entered

# Solution

Whitelist `/sessions/` pages and map it to MB events.