### PR TITLE
MBS-9340: Only allow mul and zxx as the only work language 

### DIFF
--- a/lib/MusicBrainz/Server/Form/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Work.pm
@@ -68,6 +68,35 @@ sub is_empty_attribute {
     return !$field->field('type_id')->value && !$field->field('value')->value;
 }
 
+sub validate_languages {
+    my $self = shift;
+
+    my @languages = $self->field('languages')->fields;
+
+    my $is_valid = 1;
+
+    # If we have only one language, then it can be whatever
+    # If we have two or more, we check it's not mul (248) nor zxx (486)
+    # because combining those with anything else doesn't make sense
+    if (scalar @languages > 1) {
+        for my $language_field (@languages) {
+            if ($language_field->value == 284) {
+                $language_field->push_errors(
+                    l('You cannot select “[Multiple languages]” and specific languages at the same time.')
+                );
+                $is_valid = 0;
+            } elsif ($language_field->value == 486) {
+                $language_field->push_errors(
+                    l('You cannot select “[No lyrics]” and a lyrics language at the same time.')
+                );
+                $is_valid = 0;
+            }
+        }
+    }
+
+    return $is_valid;
+}
+
 after 'validate' => sub {
     my ($self) = @_;
 

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -69,7 +69,8 @@ const store = createStore(function (state: WorkForm = form, action) {
 
     case 'EDIT_LANGUAGE':
       state = mutate<WorkForm, _>(state, newState => {
-        newState.field.languages.field[action.index].value = action.languageId;
+        newState.field.languages.field[action.index].value =
+          action.languageId;
       });
       break;
 
@@ -272,7 +273,10 @@ function renderWorkLanguages() {
       addId="add-language"
       addLabel={l('Add Language')}
       getSelectField={_.identity}
-      hideAddButton={_.intersection(form.field.languages.field.map(lang => String(lang.value)), ["486", "284"]).length > 0}
+      hideAddButton={_.intersection(
+        form.field.languages.field.map(lang => String(lang.value)),
+        ['486', '284'],
+      ).length > 0}
       label={l('Lyrics Languages')}
       onAdd={addLanguage}
       onEdit={editLanguage}


### PR DESCRIPTION
### Implement MBS-9340

There's no case where it makes sense to have [Multiple languages] or [No lyrics] and a second, different language as a work language at the same time.

There's already a limitation on the JS layer that makes it so no more languages can be added if one of the two is selected, but that doesn't affect any languages already selected before them.

I chose not to further enforce this on the JS level because the form verification does all that is needed while making sure the selected languages do not get lost/deselected, which would seem annoying if the user selected one of these two by mistake.
