### PR TITLE
MBS-10771: Block tagging for unverified users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Tag.pm
@@ -62,7 +62,7 @@ sub _vote_on_tags {
     my ($self, $c, $method) = @_;
 
     $c->res->headers->header('X-Robots-Tag' => 'noindex');
-    if (!$c->user_exists) {
+    if (!$c->user_exists || !$c->user->has_confirmed_email_address) {
         $c->res->status(401);
         $c->res->body('{}');
         $c->detach;

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -54,46 +54,47 @@ const SidebarTags = ({
 }: SidebarTagsProps): React.Element<typeof React.Fragment> | null => (
   $c.action.name === 'tags' ? null : (
     <>
-      {($c.user && aggregatedTags && userTags) ? (
-        <SidebarTagEditor
-          $c={$c}
-          aggregatedTags={aggregatedTags}
-          entity={entity}
-          more={more}
-          userTags={userTags}
-        />
-      ) : (
-        <div id="sidebar-tags">
-          <h2>{l('Genres')}</h2>
-          <div className="genre-list">
+      {($c.user?.has_confirmed_email_address &&
+        aggregatedTags && userTags) ? (
+          <SidebarTagEditor
+            $c={$c}
+            aggregatedTags={aggregatedTags}
+            entity={entity}
+            more={more}
+            userTags={userTags}
+          />
+        ) : (
+          <div id="sidebar-tags">
+            <h2>{l('Genres')}</h2>
+            <div className="genre-list">
+              <p>
+                <TagList
+                  entity={entity}
+                  isGenreList
+                  tags={aggregatedTags}
+                />
+              </p>
+            </div>
+
+            <h2>{l('Other tags')}</h2>
+            <div id="sidebar-tag-list">
+              <p>
+                <TagList
+                  entity={entity}
+                  tags={aggregatedTags}
+                />
+              </p>
+            </div>
+
             <p>
-              <TagList
+              <EntityLink
+                content={l('See all tags')}
                 entity={entity}
-                isGenreList
-                tags={aggregatedTags}
+                subPath="tags"
               />
             </p>
           </div>
-
-          <h2>{l('Other tags')}</h2>
-          <div id="sidebar-tag-list">
-            <p>
-              <TagList
-                entity={entity}
-                tags={aggregatedTags}
-              />
-            </p>
-          </div>
-
-          <p>
-            <EntityLink
-              content={l('See all tags')}
-              entity={entity}
-              subPath="tags"
-            />
-          </p>
-        </div>
-      )}
+        )}
     </>
   )
 );

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -140,7 +140,7 @@ class VoteButtons extends React.Component<VoteButtonsProps> {
 
     return (
       <span className={'tag-vote-buttons' + className}>
-        {this.props.$c.user ? (
+        {this.props.$c.user?.has_confirmed_email_address ? (
           <>
             <UpvoteButton {...this.props} />
             <DownvoteButton {...this.props} />
@@ -512,7 +512,7 @@ export const MainTagEditor: React.AbstractComponent<TagEditorProps, void> = hydr
 
           {(positiveTagsOnly && !tags.every(isAlwaysVisible)) ? (
             <>
-              {this.props.$c.user ? (
+              {this.props.$c.user?.has_confirmed_email_address ? (
                 <p>
                   {l(
                     `Tags with a score of zero or below,
@@ -521,7 +521,7 @@ export const MainTagEditor: React.AbstractComponent<TagEditorProps, void> = hydr
                 </p>
               ) : (
                 <p>
-                  {l('Tags with a score of zero or below are hidden.') + ' '}
+                  {l('Tags with a score of zero or below are hidden.')}
                 </p>
               )}
               <p>
@@ -537,7 +537,7 @@ export const MainTagEditor: React.AbstractComponent<TagEditorProps, void> = hydr
               <p>
                 {l('All tags are being shown.')}
               </p>
-              {this.props.$c.user ? (
+              {this.props.$c.user?.has_confirmed_email_address ? (
                 <p>
                   <a href="#" onClick={this.hideNegativeTags.bind(this)}>
                     {l(
@@ -556,7 +556,7 @@ export const MainTagEditor: React.AbstractComponent<TagEditorProps, void> = hydr
             </>
           ) : null}
 
-          {this.props.$c.user ? (
+          {this.props.$c.user?.has_confirmed_email_address ? (
             <>
               <h2>{l('Add Tags')}</h2>
               <p>

--- a/root/types.js
+++ b/root/types.js
@@ -961,6 +961,7 @@ declare type SanitizedEditorPreferencesT = {
 declare type SanitizedEditorT = {
   ...EntityRoleT<'editor'>,
   +gravatar: string,
+  +has_confirmed_email_address: boolean,
   +name: string,
   +preferences: SanitizedEditorPreferencesT,
 };

--- a/root/utility/sanitizedEditor.js
+++ b/root/utility/sanitizedEditor.js
@@ -16,6 +16,7 @@ function sanitizedEditor(
   return {
     entityType: 'editor',
     gravatar: editor.gravatar,
+    has_confirmed_email_address: editor.has_confirmed_email_address,
     id: editor.id,
     name: editor.name,
     preferences: {


### PR DESCRIPTION
### Implement MBS-10771

People are creating email-less accounts to mass-tag their favourite boy band. While that's mostly harmless, it's still stupid, and I can't see any reason why we should allow unverified users to submit tags.

Ratings were already blocked recently by MBS-10671 / https://github.com/metabrainz/musicbrainz-server/pull/1404.

Most "changes" are just extra indentation required from splitting lines because `has_confirmed_email_address` is a pretty long name.