### PR TITLE
MBS-10613: Only show git info on staging servers

### DIFF
--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -44,7 +44,7 @@ const Footer = ({$c}) => {
           </>
         ) : null}
 
-        {DBDefs.GIT_BRANCH ? (
+        {DBDefs.DB_STAGING_SERVER && DBDefs.GIT_BRANCH ? (
           <>
             <br />
             {exp.l('Running: {git_details}', {


### PR DESCRIPTION
### Fix MBS-10613

For some reason we were showing git branch info on production. This information was meant for staging servers, so this adds a check to ensure we only display it in those.