### PR TITLE
MBS-10186: Check for missing CD TOC on SetTrackLengths

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
@@ -5,6 +5,7 @@ use namespace::autoclean;
 use MooseX::Types::Moose qw( ArrayRef Int Str );
 use MooseX::Types::Structured qw( Dict );
 use MusicBrainz::Server::Constants qw( $EDIT_SET_TRACK_LENGTHS );
+use MusicBrainz::Server::Data::Utils qw( localized_note );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Translation qw( N_l );
 
@@ -130,6 +131,16 @@ sub accept {
         MusicBrainz::Server::Edit::Exceptions::FailedDependency->throw(
             'The medium to set track times for no longer exists. It may '.
             'have been merged or removed since this edit was entered.'
+        );
+    }
+
+    my $cdtoc_id = $self->data->{cdtoc}{id};
+    if (!$self->c->model('CDTOC')->get_by_id($cdtoc_id)) {
+        MusicBrainz::Server::Edit::Exceptions::FailedDependency->throw(
+            localized_note(
+                N_l('The CD TOC the track times were being set from ' .
+                    'has been removed since this edit was entered.')
+            )
         );
     }
 


### PR DESCRIPTION
### Fix MBS-10186

If a CD TOC is removed before an edit setting track times from it applies, the edit currently fails to close. This fails it with an appropriate failed dependency message.
