### PR TITLE
MBS-10821: Remove orphaned recordings from collections for deletion

### DIFF
--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1303,6 +1303,7 @@ AS $$
       DELETE FROM recording_rating_raw WHERE recording = OLD.recording;
       DELETE FROM recording_tag WHERE recording = OLD.recording;
       DELETE FROM recording_tag_raw WHERE recording = OLD.recording;
+      DELETE FROM editor_collection_recording WHERE recording = OLD.recording;
 
       DELETE FROM recording WHERE id = OLD.recording;
     END IF;

--- a/admin/sql/updates/20200512-mbs-10821-orphaned-recording-collection.sql
+++ b/admin/sql/updates/20200512-mbs-10821-orphaned-recording-collection.sql
@@ -1,0 +1,65 @@
+\set ON_ERROR_STOP 1
+BEGIN;
+
+CREATE OR REPLACE FUNCTION delete_orphaned_recordings()
+RETURNS TRIGGER
+AS $$
+  BEGIN
+    PERFORM TRUE
+    FROM recording outer_r
+    WHERE id = OLD.recording
+      AND edits_pending = 0
+      AND NOT EXISTS (
+        SELECT TRUE
+        FROM edit JOIN edit_recording er ON edit.id = er.edit
+        WHERE er.recording = outer_r.id
+          AND type IN (71, 207, 218)
+          LIMIT 1
+      ) AND NOT EXISTS (
+        SELECT TRUE FROM track WHERE track.recording = outer_r.id LIMIT 1
+      ) AND NOT EXISTS (
+        SELECT TRUE FROM l_area_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_artist_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_event_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_instrument_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_label_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_place_recording WHERE entity1 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_recording_recording WHERE entity1 = outer_r.id OR entity0 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_recording_release WHERE entity0 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_recording_release_group WHERE entity0 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_recording_series WHERE entity0 = outer_r.id
+          UNION ALL
+        SELECT TRUE FROM l_recording_work WHERE entity0 = outer_r.id
+          UNION ALL
+         SELECT TRUE FROM l_recording_url WHERE entity0 = outer_r.id
+      );
+
+    IF FOUND THEN
+      -- Remove references from tables that don't change whether or not this recording
+      -- is orphaned.
+      DELETE FROM isrc WHERE recording = OLD.recording;
+      DELETE FROM recording_alias WHERE recording = OLD.recording;
+      DELETE FROM recording_annotation WHERE recording = OLD.recording;
+      DELETE FROM recording_gid_redirect WHERE new_id = OLD.recording;
+      DELETE FROM recording_rating_raw WHERE recording = OLD.recording;
+      DELETE FROM recording_tag WHERE recording = OLD.recording;
+      DELETE FROM recording_tag_raw WHERE recording = OLD.recording;
+      DELETE FROM editor_collection_recording WHERE recording = OLD.recording;
+
+      DELETE FROM recording WHERE id = OLD.recording;
+    END IF;
+
+    RETURN NULL;
+  END;
+$$ LANGUAGE 'plpgsql';
+
+COMMIT;

--- a/t/pgtap/delete_orphaned_recordings.sql
+++ b/t/pgtap/delete_orphaned_recordings.sql
@@ -58,6 +58,11 @@ SELECT bag_eq(
   'old recordings still exist'
 );
 
+-- To test for MBS-10821
+INSERT INTO editor_collection (id, gid, editor, name, public, description, type)
+    VALUES (1, 'f34c079d-374e-4436-9448-da92dedef3cd', 1, 'collection1', FALSE, '', 12);
+INSERT INTO editor_collection_recording (collection, recording) VALUES (1, 1);
+
 -- Simulate the commit
 SET CONSTRAINTS remove_orphaned_tracks IMMEDIATE;
 


### PR DESCRIPTION
### Fix MBS-10821

An edit medium edit is stuck because one of the recordings that would be orphaned and removed with the edit is in an editor collection.

While silently removing the recording from a collection might not seem ideal, this is already what we do with other entity removals. The alternative would be to fail edits that would cause that, but that would block removal of any recordings that should be removed but are still present on an editor's collection for whatever reason, since the collection owner would need to actively remove them from the collection to allow the medium edit to ever apply.
