### PR TITLE
MBS-9931: Fail gracefully when trying to remove example rel

### DIFF
--- a/lib/MusicBrainz/Server/Entity/EditNote.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNote.pm
@@ -45,7 +45,7 @@ has 'post_time' => (
 );
 
 sub _localize_text {
-    my ($text) = @_;
+    my ($text, $depth) = @_;
 
     state $json = JSON::XS->new->utf8(0);
 
@@ -55,11 +55,11 @@ sub _localize_text {
         my $source_args = $source->{args} // {};
         my %args = map {
             my $value = $source_args->{$_};
-            $_ => (ref($value) ? $value : _localize_text($value // ''))
+            $_ => (ref($value) ? $value : _localize_text($value // '', $depth + 1))
         } keys %{$source_args};
 
         $text = l($source->{message} // '', \%args);
-    } else {
+    } elsif ($depth == 0) {
         # Otherwise, assume this message uses edit note syntax.
         $text = format_editnote($text);
     }
@@ -73,7 +73,7 @@ sub localize {
     my $text = $self->text;
 
     if ($self->editor_id == $EDITOR_MODBOT) {
-        return _localize_text($text);
+        return _localize_text($text, 0);
     }
 
     return $text;

--- a/t/sql/edit_relationship_delete.sql
+++ b/t/sql/edit_relationship_delete.sql
@@ -13,11 +13,15 @@ INSERT INTO url (id, gid, url) VALUES
     (1, '67ff507e-1239-40a7-9023-53621d701797', 'http://en.wikipedia.org/wiki/Artist1'),
     (2, 'a803cfdd-b08f-4f51-893c-0784bb74a497', 'http://www.amazon.com/gp/product/Release1');
 
-INSERT INTO link (id, link_type, attribute_count) VALUES (1, 103, 0), (2, 179, 0), (3, 77, 0);
+INSERT INTO link (id, link_type, attribute_count)
+    VALUES (1, 103, 0), (2, 179, 0), (3, 77, 0), (4, 179, 0);
 
 INSERT INTO l_artist_artist (id, link, entity0, entity1) VALUES (1, 1, 3, 4);
 
-INSERT INTO l_artist_url (id, link, entity0, entity1) VALUES (1, 2, 3, 1);
+INSERT INTO l_artist_url (id, link, entity0, entity1) VALUES (1, 2, 3, 1), (2, 4, 3, 2);
+
+INSERT INTO documentation.l_artist_url_example (id, published, name)
+    VALUES (2, TRUE, 'E1');
 
 INSERT INTO release_group (id, gid, name, artist_credit, type, comment, edits_pending)
     VALUES (1, '1466a797-4481-4699-be0f-468e1f009669', 'Release Group 1', 1, 1, '', 0);


### PR DESCRIPTION
### Implement MBS-9931

If someone tries to remove an example relationship, the edit gets stuck. We don't want people to actually remove these themselves, so this fails the edit and asks them to contact us.

Eventually, we might want to block entering these removals completely, but that's much harder and given the situation is pretty rare, this seems like a good first step.
