### PR TITLE
MBS-10829: Fix SOLR syntax for recording with no length

### DIFF
--- a/root/static/scripts/release-editor/recordingAssociation.js
+++ b/root/static/scripts/release-editor/recordingAssociation.js
@@ -85,7 +85,7 @@ function recordingQuery(track, name) {
 
   var titleAndArtists = utils.constructLuceneFieldConjunction(params);
   var justTitle = utils.constructLuceneField(params.recording, 'recording');
-  var query = '(' + titleAndArtists + ')^2 OR (' + justTitle + ')';
+  var query;
 
   var duration = parseInt(track.length(), 10);
 
@@ -93,8 +93,16 @@ function recordingQuery(track, name) {
     var a = duration - MAX_LENGTH_DIFFERENCE;
     var b = duration + MAX_LENGTH_DIFFERENCE;
 
-    duration = utils.constructLuceneField([`[${a} TO ${b}] OR \\-`], 'dur');
-    query = '(' + query + ') AND ' + duration;
+    const durationCondition =
+      utils.constructLuceneField([`[${a} TO ${b}]`], 'dur');
+    const durationOrNoneCondition =
+      '(' + durationCondition + ' OR (NOT dur:[* TO *]))';
+    query =
+      '(' + titleAndArtists + ' AND ' + durationOrNoneCondition + ')^2' +
+      ' OR ' +
+      '(' + justTitle + ' AND ' + durationCondition + ')';
+  } else {
+    query = '(' + titleAndArtists + ')^2 OR (' + justTitle + ')';
   }
 
   return query;


### PR DESCRIPTION
### Fix MBS-10829

This wasn't actually finding recordings without length at all, except when the track also had no length (which made the query different).

This makes it so that recordings without length can also be found. Because we're unlikely to want recordings without length and *also* with a different artist as the track, and that can cause a lot of false positives, this restricts the no-length results to ones with matching artists.

While this certainly improves the inline search, I feel that this causes more (less precise) suggested recordings to appear. If you find while testing that that's the case, please do feel free to suggest improvements to the query.

I tested with "A Soul to Bear" by Fall of Efrafa, FWIW, but ideally you'd test it with other recordings that have no times to make sure it works always :) 