### PR TITLE
Bump react-table version to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "querystring": "0.2.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-table": "7.0.0-beta.26",
+    "react-table": "7.1.0",
     "redux": "3.6.0",
     "shell-quote": "1.7.2",
     "shelljs": "0.8.3",

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -14,8 +14,8 @@ import {withCatalystContext} from '../../context';
 import {
   defineCheckboxColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineTypeColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -50,15 +50,12 @@ const AreaList = ({
         sortable: sortable,
         typeContext: 'area_type',
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: areas})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
         nameColumn,
         typeColumn,
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && areas.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [$c.user, areas, checkboxes, mergeForm, order, sortable],

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -20,8 +20,8 @@ import {
   defineBeginDateColumn,
   defineEndDateColumn,
   defineInstrumentUsageColumn,
-  defineRemoveFromMergeColumn,
   ratingsColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -110,9 +110,6 @@ const ArtistList = ({
           instrumentCreditsAndRelTypes: instrumentCreditsAndRelTypes,
         })
         : null;
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: artists})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -127,7 +124,7 @@ const ArtistList = ({
         ...(endAreaColumn ? [endAreaColumn] : []),
         ...(showRatings ? [ratingsColumn] : []),
         ...(instrumentUsageColumn ? [instrumentUsageColumn] : []),
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && artists.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -20,12 +20,12 @@ import {
   defineCheckboxColumn,
   defineDatePeriodColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineSeriesNumberColumn,
   defineTypeColumn,
   defineTextColumn,
   locationColumn,
   ratingsColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -106,9 +106,6 @@ const EventList = ({
         order: order,
         sortable: sortable,
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: events})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -121,7 +118,7 @@ const EventList = ({
         dateColumn,
         timeColumn,
         ...(showRatings ? [ratingsColumn] : []),
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && events.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -14,9 +14,9 @@ import {withCatalystContext} from '../../context';
 import {
   defineCheckboxColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineTypeColumn,
   instrumentDescriptionColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -51,16 +51,15 @@ const InstrumentList = ({
         sortable: sortable,
         typeContext: 'instrument_type',
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: instruments})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
         nameColumn,
         typeColumn,
         instrumentDescriptionColumn,
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && instruments.length > 2
+          ? [removeFromMergeColumn]
+          : []),
       ];
     },
     [$c.user, checkboxes, instruments, mergeForm, order, sortable],

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -20,8 +20,8 @@ import {
   defineEntityColumn,
   defineBeginDateColumn,
   defineEndDateColumn,
-  defineRemoveFromMergeColumn,
   ratingsColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -82,9 +82,6 @@ const LabelList = ({
         order: order,
         sortable: sortable,
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: labels})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -95,7 +92,7 @@ const LabelList = ({
         beginDateColumn,
         endDateColumn,
         ...(showRatings ? [ratingsColumn] : []),
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && labels.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -19,7 +19,7 @@ import {
   defineEntityColumn,
   defineBeginDateColumn,
   defineEndDateColumn,
-  defineRemoveFromMergeColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -69,9 +69,6 @@ const PlaceList = ({
       });
       const beginDateColumn = defineBeginDateColumn({});
       const endDateColumn = defineEndDateColumn({});
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: places})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -81,7 +78,7 @@ const PlaceList = ({
         areaColumn,
         beginDateColumn,
         endDateColumn,
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && places.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [$c.user, checkboxes, mergeForm, order, places, sortable],

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -18,11 +18,11 @@ import {
   defineCheckboxColumn,
   defineInstrumentUsageColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineSeriesNumberColumn,
   defineTextColumn,
   isrcsColumn,
   ratingsColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type Props = {
@@ -90,9 +90,6 @@ const RecordingList = ({
           instrumentCreditsAndRelTypes: instrumentCreditsAndRelTypes,
         })
         : null;
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: recordings})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -103,7 +100,9 @@ const RecordingList = ({
         ...(showRatings ? [ratingsColumn] : []),
         lengthColumn,
         ...(instrumentUsageColumn ? [instrumentUsageColumn] : []),
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && recordings.length > 2
+          ? [removeFromMergeColumn]
+          : []),
       ];
     },
     [

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -19,10 +19,10 @@ import {
   defineCheckboxColumn,
   defineNameColumn,
   defineSeriesNumberColumn,
-  defineRemoveFromMergeColumn,
   defineTextColumn,
   defineCountColumn,
   ratingsColumn,
+  removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
 type ReleaseGroupListTableProps = {
@@ -108,9 +108,6 @@ export const ReleaseGroupListTable = withCatalystContext<
         getCount: entity => entity.release_count,
         title: l('Releases'),
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: releaseGroups})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -121,7 +118,9 @@ export const ReleaseGroupListTable = withCatalystContext<
         ...(showType ? [typeColumn] : []),
         ...(showRatings ? [ratingsColumn] : []),
         releaseNumberColumn,
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && releaseGroups.length > 2
+          ? [removeFromMergeColumn]
+          : []),
       ];
     },
     [

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -14,8 +14,8 @@ import {withCatalystContext} from '../../context';
 import {
   defineCheckboxColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineTypeColumn,
+  removeFromMergeColumn,
   seriesOrderingTypeColumn,
 } from '../../utility/tableColumns';
 
@@ -51,16 +51,13 @@ const SeriesList = ({
         sortable: sortable,
         typeContext: 'series_type',
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: series})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
         nameColumn,
         typeColumn,
         seriesOrderingTypeColumn,
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && series.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [$c.user, checkboxes, mergeForm, order, series, sortable],

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -15,12 +15,12 @@ import {
   defineArtistRolesColumn,
   defineCheckboxColumn,
   defineNameColumn,
-  defineRemoveFromMergeColumn,
   defineSeriesNumberColumn,
   defineTypeColumn,
   attributesColumn,
   iswcsColumn,
   ratingsColumn,
+  removeFromMergeColumn,
   workArtistsColumn,
   workLanguagesColumn,
 } from '../../utility/tableColumns';
@@ -69,9 +69,6 @@ const WorkList = ({
         sortable: sortable,
         typeContext: 'work_type',
       });
-      const removeFromMergeColumn = mergeForm
-        ? defineRemoveFromMergeColumn({toMerge: works})
-        : null;
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),
@@ -84,7 +81,7 @@ const WorkList = ({
         workLanguagesColumn,
         attributesColumn,
         ...(showRatings ? [ratingsColumn] : []),
-        ...(removeFromMergeColumn ? [removeFromMergeColumn] : []),
+        ...(mergeForm && works.length > 2 ? [removeFromMergeColumn] : []),
       ];
     },
     [

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -171,7 +171,7 @@ export function defineCheckboxColumn(
           value={original.id}
         />
       ),
-    Header: props.mergeForm ? null : <input type="checkbox" />,
+    Header: props.mergeForm ? '' : <input type="checkbox" />,
     headerProps: {className: 'checkbox-cell'},
     id: 'checkbox',
   };
@@ -418,7 +418,7 @@ export function defineRemoveFromMergeColumn(
         </a>
       ) : null;
     },
-    Header: props.toMerge.length > 2 ? '' : null,
+    Header: '',
     headerProps: {
       'aria-label': l('Remove from merge'),
       'style': {width: '1em'},

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -400,33 +400,6 @@ export function defineReleaseLabelsColumn(
   };
 }
 
-export function defineRemoveFromMergeColumn(
-  props: {
-    +toMerge: $ReadOnlyArray<CoreEntityT>,
-  },
-): ColumnOptions<ArtistT | RecordingT | ReleaseT, number> {
-  return {
-    Cell: ({row: {original}}) => {
-      const url = ENTITIES[original.entityType].url;
-      return props.toMerge.length > 2 ? (
-        <a href={`/${url}/merge?remove=${original.id}&submit=remove`}>
-          <button
-            className="remove-item icon"
-            title={l('Remove from merge')}
-            type="button"
-          />
-        </a>
-      ) : null;
-    },
-    Header: '',
-    headerProps: {
-      'aria-label': l('Remove from merge'),
-      'style': {width: '1em'},
-    },
-    id: 'remove-from-merge',
-  };
-}
-
 export function defineSeriesNumberColumn(
   props: {
     +seriesItemNumbers: {+[entityId: number]: string},
@@ -561,6 +534,28 @@ export const ratingsColumn:
     accessor: 'rating',
     cellProps: {className: 'c'},
     headerProps: {className: 'rating c'},
+  };
+
+export const removeFromMergeColumn:
+  ColumnOptions<ArtistT | RecordingT | ReleaseT, number> = {
+    Cell: ({row: {original}}) => {
+      const url = ENTITIES[original.entityType].url;
+      return (
+        <a href={`/${url}/merge?remove=${original.id}&submit=remove`}>
+          <button
+            className="remove-item icon"
+            title={l('Remove from merge')}
+            type="button"
+          />
+        </a>
+      );
+    },
+    Header: '',
+    headerProps: {
+      'aria-label': l('Remove from merge'),
+      'style': {width: '1em'},
+    },
+    id: 'remove-from-merge',
   };
 
 export const seriesOrderingTypeColumn:

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,6 +830,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@scarf/scarf@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.5.tgz#accee0bce88a9047672f7c8faf3cada59c996b81"
+  integrity sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ==
+
 "@sentry/apm@5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.10.2.tgz#41a401b3964b68514439f8a595b12c6fd05ab21a"
@@ -5295,10 +5300,12 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-table@7.0.0-beta.26:
-  version "7.0.0-beta.26"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.0.0-beta.26.tgz#20ab9a7bd21f01930e764198410a642a3ae28e79"
-  integrity sha512-Pw/1T9kiAjV1cIf6K6bQV6yNQc3O7XUGin1RcSR1xFKw0RNGC5vl1VDPZrNep1BXDsbR6o8O63X45HFNVg6HzA==
+react-table@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.1.0.tgz#c975cd67e917c54190b6c9df29f085285b0c3f4e"
+  integrity sha512-AZpgW0Xpo6Z7jxXZIBovzCGoYVkuBwATsJh7X4+JXwq9JtDaorOmxWC9gKx5Hui4d+n+I99enyyJS+LRtKydxA==
+  dependencies:
+    "@scarf/scarf" "^1.0.4"
 
 react@16.13.1:
   version "16.13.1"


### PR DESCRIPTION
The low usage we have of the API is affected by neither deprecation nor breaking change.

References:
* https://github.com/tannerlinsley/react-table/blob/master/CHANGELOG.md
* https://github.com/tannerlinsley/react-table/releases