### PR TITLE
MBS-10839: Add merge button to recording list in artist overview

### DIFF
--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -297,13 +297,20 @@ const ArtistIndex = ({
       ) : null}
 
       {hasRecordings ? (
-        <PaginatedResults pager={pager}>
-          <RecordingList
-            checkboxes="add-to-merge"
-            recordings={recordings}
-            showRatings
-          />
-        </PaginatedResults>
+        <form action="/recording/merge_queue" method="post">
+          <PaginatedResults pager={pager}>
+            <RecordingList
+              checkboxes="add-to-merge"
+              recordings={recordings}
+              showRatings
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <FormSubmit label={l('Add selected recordings for merging')} />
+            </div>
+          ) : null}
+        </form>
       ) : null}
 
       <p>{message}</p>


### PR DESCRIPTION
### Fix MBS-10839

For some reason, we didn't have a merge option if an artist only has standalone recordings and those are shown on the artist overview.