### PR TITLE
MBS-10842: Remove report link from deleted editors

### DIFF
--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CONTACT_URL} from '../constants';
 import UserAccountLayout from '../components/UserAccountLayout';
 import FormCsrfToken from '../components/FormCsrfToken';
 import FormRow from '../components/FormRow';
@@ -81,76 +82,94 @@ const ReportUser = ({
   >
     <h2>{l('Report User')}</h2>
 
-    <p>
-      {exp.l(`Please review our {uri|Code of Conduct} before sending a
-              report.`,
-             {uri: {href: '/doc/Code_of_Conduct', target: '_blank'}})}
-    </p>
+    {user.deleted ? (
+      <p>
+        {exp.l(
+          `This user account has already been deleted,
+           so there’s probably no need to report it.
+           If you feel there’s a problem that still needs action,
+           please {link|contact us}.`,
+          {link: CONTACT_URL},
+        )}
+      </p>
+    ) : (
+      <>
+        <p>
+          {exp.l(
+            `Please review our {uri|Code of Conduct} before
+             sending a report.`,
+            {uri: {href: '/doc/Code_of_Conduct', target: '_blank'}},
+          )}
+        </p>
 
-    <p>
-      {exp.l(`Your report will be sent to our {uri|account administrators},
-              who will decide what action to take.`,
-             {uri: {href: '/privileged', target: '_blank'}})}
-    </p>
+        <p>
+          {exp.l(
+            `Your report will be sent to our {uri|account administrators},
+             who will decide what action to take.`,
+            {uri: {href: '/privileged', target: '_blank'}},
+          )}
+        </p>
 
-    <p>
-      <strong>{addColonText(l('Note'))}</strong>
-      {' '}
-      {exp.l(
-        `Be sure to provide direct links to examples of the behaviour you’re 
-         reporting (for example, use
-         “<code>https://musicbrainz.org/edit/23</code>”
-         instead of “edit #23”, and use
-         “<code>https://musicbrainz.org/edit/42</code> and
-         <code>https://musicbrainz.org/edit/43</code>”
-         instead of
-         “<code>https://musicbrainz.org/user/SomeUser/edits</code>”).
-         Providing links makes it much easier for the recipients of the
-         report to look into the issues; a report without links is
-         unlikely to be acted on fast, since it will require a lot of
-         additional research.`,
-      )}
-    </p>
+        <p>
+          <strong>{addColonText(l('Note'))}</strong>
+          {' '}
+          {exp.l(
+            `Be sure to provide direct links to examples of the behaviour
+             you’re reporting (for example, use
+             “<code>https://musicbrainz.org/edit/23</code>”
+             instead of “edit #23”, and use
+             “<code>https://musicbrainz.org/edit/42</code> and
+             <code>https://musicbrainz.org/edit/43</code>”
+             instead of
+             “<code>https://musicbrainz.org/user/SomeUser/edits</code>”).
+             Providing links makes it much easier for the recipients of the
+             report to look into the issues; a report without links is
+             unlikely to be acted on fast, since it will require a lot of
+             additional research.`,
+          )}
+        </p>
 
-    <form action={$c.req.uri} className="report-form" method="post">
-      <FormCsrfToken />
+        <form action={$c.req.uri} className="report-form" method="post">
+          <FormCsrfToken />
 
-      <FormRowSelect
-        field={form.field.reason}
-        label={addColonText(l('Reason'))}
-        options={reportReasonOptions}
-        uncontrolled
-      />
+          <FormRowSelect
+            field={form.field.reason}
+            label={addColonText(l('Reason'))}
+            options={reportReasonOptions}
+            uncontrolled
+          />
 
-      <FormRowTextArea
-        cols={50}
-        field={form.field.message}
-        label={addColonText(l('Message'))}
-        required
-        rows={10}
-      />
+          <FormRowTextArea
+            cols={50}
+            field={form.field.message}
+            label={addColonText(l('Message'))}
+            required
+            rows={10}
+          />
 
-      <FormRowCheckbox
-        field={form.field.reveal_address}
-        help={
-          <p>
-            {exp.l(
-              `If you don’t want our admins to contact you further regarding 
-               this report, you can uncheck the checkbox above.
-               <br />
-               We recommend leaving it checked, so that you can be contacted if 
-               the report is resolved or the admins need more information.`,
-            )}
-          </p>
-        }
-        label={l('Reveal my email address')}
-      />
+          <FormRowCheckbox
+            field={form.field.reveal_address}
+            help={
+              <p>
+                {exp.l(
+                  `If you don’t want our admins to contact you further
+                   regarding this report, you can uncheck the checkbox above.
+                   <br />
+                   We recommend leaving it checked, so that you can be
+                   contacted if the report is resolved or the admins
+                   need more information.`,
+                )}
+              </p>
+            }
+            label={l('Reveal my email address')}
+          />
 
-      <FormRow hasNoLabel>
-        <FormSubmit label={l('Send')} />
-      </FormRow>
-    </form>
-
+          <FormRow hasNoLabel>
+            <FormSubmit label={l('Send')} />
+          </FormRow>
+        </form>
+      </>
+    )}
   </UserAccountLayout>
 );
 

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -557,7 +557,7 @@ const UserProfile = ({
         votes={votes}
       />
 
-      {$c.user && !viewingOwnProfile ? (
+      {$c.user && !viewingOwnProfile && !user.deleted ? (
         <h2 style={{clear: 'both'}}>
           <a href={`/user/${encodedName}/report`}>
             {l('Report this user for bad behavior')}


### PR DESCRIPTION
### Implement MBS-10842

There seems to be no reason to allow reporting deleted editors, since they already deleted their account. I talked to Freso and he agreed. If there's a particular problem they still want us to look at they can contact us at support.

This changes the /report page to say that - I could have blocked it if the user has been deleted, but it feels that if somebody makes the effort of trying to get to /report without the link, we might as well explain the issue.