### PR TITLE
MBS-10841: Add "Guess case" per medium

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -441,6 +441,7 @@
           <button type="button" class="open-track-parser" data-click="openTrackParser">[% l('Track Parser') %]</button>
           <button type="button" class="reset-track-numbers" data-click="resetTrackNumbers">[%- l('Reset track numbers') -%]</button>
           <button type="button" data-click="swapTitlesWithArtists">[%- l('Swap track titles with artist credits') -%]</button>
+          <button type="button" data-click="guessMediumCase">[%- l('Guess case') -%]</button>
           <button type="button" data-click="guessMediumFeatArtists">[%- l('Guess feat. artists from track titles') -%]</button>
         </div>
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -311,6 +311,11 @@ const actions = {
         guessFeat(track);
     },
 
+    guessMediumCase: function (medium) {
+        releaseEditor.guessCaseMediumName(medium);
+        releaseEditor.guessCaseTrackNames(medium);
+    },
+
     guessMediumFeatArtists: function (medium) {
         _.each(medium.tracks(), guessFeat);
     },


### PR DESCRIPTION
### Implement MBS-10841

Sometimes, for example, one medium will have English titles and another titles in a language that requires sentence guess case, or most discs in a boxset are correct (and might become worse with automatic guesses) but one or two need guess case.
This add an extra Guess case button under each medium (there's already plenty of buttons there so it fits well) that affects only the tracks for that medium plus the medium title.
