### PR TITLE
MBS-10840: Fix key names in English guess case

### DIFF
--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -290,8 +290,30 @@ export const English = assign({}, DefaultMode, {
     },
   )),
 
+  /*
+   * This changes key names in titles to follow
+   * the English classical music guidelines.
+   * See https://musicbrainz.org/doc/Style/Classical/Language/English#Keys
+   */
+  fixEnglishKeyNames(is) {
+    return is.replace(
+      /\bin ([a-g])(?:[\s-]([Ff]lat|[Ss]harp))?\s(dorian|lydian|major|minor|mixolydian)(?:\b|$)/ig,
+      function (match, p1, p2, p3) {
+        return 'in ' + p1.toUpperCase() +
+          (p2 ? '-' + p2.toLowerCase() : '') +
+          ' ' + p3.toLowerCase();
+      },
+    );
+  },
+
   isSentenceCaps() {
     return false;
+  },
+
+  runPostProcess(is) {
+    is = DefaultMode.runPostProcess(is);
+    is = this.fixEnglishKeyNames(is);
+    return is;
   },
 });
 

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -177,7 +177,7 @@ test('Recording', function (t) {
 });
 
 test('Work', function (t) {
-  t.plan(19);
+  t.plan(22);
 
   const tests = [
     {
@@ -312,6 +312,30 @@ test('Work', function (t) {
       bug: 'MBS-5338',
       mode: 'English',
       roman: true,
+      keepuppercase: false,
+    },
+    {
+      input: 'My brother is a minor',
+      expected: 'My Brother Is a Minor',
+      bug: 'MBS-10840',
+      mode: 'English',
+      roman: false,
+      keepuppercase: false,
+    },
+    {
+      input: 'Sonata in a minor',
+      expected: 'Sonata in A minor',
+      bug: 'MBS-10840',
+      mode: 'English',
+      roman: false,
+      keepuppercase: false,
+    },
+    {
+      input: 'Sonata in g flat major',
+      expected: 'Sonata in G-flat major',
+      bug: 'MBS-10840',
+      mode: 'English',
+      roman: false,
       keepuppercase: false,
     },
   ];


### PR DESCRIPTION
### Implement MBS-10840

Guess Case currently does a pretty bad job with classical key names: they should be "in B-flat major" or whatnot as per the guidelines, but the guess case code just capitalizes them as any other words.
This is normally annoying, and sometimes kinda ridiculous ("Sonata in a Minor" is a quite  different from "Sonata in A minor"!).
The code only runs for key names preceded by "in", to avoid false positives ("Signed to a Major" or whatnot). I'm sure there are still some cases where this will give a false positive, but I'm pretty sure they will be much less common than the classical releases it currently mangles.
