### PR TITLE
Prevent two statement timeouts in reports

### DIFF
--- a/lib/MusicBrainz/Server/Report/QueryReport.pm
+++ b/lib/MusicBrainz/Server/Report/QueryReport.pm
@@ -11,6 +11,12 @@ sub run {
     my $qualified_table = $self->qualified_table;
     my $query = $self->query;
 
+    if ($self->can('statement_timeout')) {
+        $self->sql->do(
+            'SET LOCAL statement_timeout = ?',
+            $self->statement_timeout,
+        );
+    }
     $self->sql->do("DROP TABLE IF EXISTS $qualified_table");
     $self->sql->do(
         "SELECT s.*

--- a/lib/MusicBrainz/Server/Report/RecordingTrackDifferentName.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingTrackDifferentName.pm
@@ -4,6 +4,8 @@ use Moose;
 with 'MusicBrainz::Server::Report::RecordingReport',
      'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
 
+sub statement_timeout { '120s' }
+
 sub query {
     "
         SELECT

--- a/lib/MusicBrainz/Server/Report/RecordingsSameNameDifferentArtistsSameName.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingsSameNameDifferentArtistsSameName.pm
@@ -4,6 +4,10 @@ use Moose;
 with 'MusicBrainz::Server::Report::RecordingReport',
      'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
 
+# MBS-10843: This report has been disabled since the upgrade to PG 12,
+# because its query can no longer execute in under 5 minutes in
+# production.
+
 sub query {
     "
     SELECT

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -65,7 +65,6 @@ use MusicBrainz::Server::PagedReport;
     RecordingsWithoutVALink
     RecordingsWithEarliestReleaseRelationships
     RecordingsWithVaryingTrackLengths
-    RecordingsSameNameDifferentArtistsSameName
     RecordingTrackDifferentName
     ReleasedTooEarly
     ReleaseGroupsWithoutVACredit
@@ -146,7 +145,7 @@ use MusicBrainz::Server::Report::RecordingsWithoutVACredit;
 use MusicBrainz::Server::Report::RecordingsWithoutVALink;
 use MusicBrainz::Server::Report::RecordingsWithEarliestReleaseRelationships;
 use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
-use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;
+#use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;
 use MusicBrainz::Server::Report::RecordingTrackDifferentName;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -449,7 +449,12 @@ const ReportsIndex = ({$c}: {$c: CatalystContextT}) => (
                 to VA`)}
           </a>
         </li>
-        <li>
+        {/*
+          * MBS-10843: This report has been disabled since the upgrade
+          * to PG 12, because its query can no longer execute in under
+          * 5 minutes in production.
+          */}
+        <li style={{display: 'none'}}>
           <a href="/report/RecordingsSameNameDifferentArtistsSameName">
             {l(`Recordings with the same name by different artists
                 with the same name`)}


### PR DESCRIPTION
This should unbreak daily.sh for now and allow subscription emails to get out without us having to manually kill RunReports.pl.