### PR TITLE
MBS-10845: User lookup tools for account admins

### DIFF
--- a/lib/MusicBrainz/Redis.pm
+++ b/lib/MusicBrainz/Redis.pm
@@ -61,6 +61,24 @@ sub get_multi {
     return \%result;
 }
 
+sub set_add {
+    my ($self, $key, @values) = @_;
+
+    $self->_connection->sadd(
+        $self->_prepare_key($key),
+        map { $self->_encode_value($_) } @values,
+    );
+    return;
+}
+
+sub set_members {
+    my ($self, $key) = @_;
+
+    return map {
+        $self->_decode_value($_)
+    } $self->_connection->smembers($self->_prepare_key($key));
+}
+
 sub set {
     my ($self, $key, $value, $exptime) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -381,8 +381,15 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     my $edit_stats = $c->model('Editor')->various_edit_counts($user->id);
     $edit_stats->{last_day_count} = $c->model('Editor')->last_24h_edit_count($user->id);
 
+    my @ip_hashes;
+    if ($c->user_exists && $c->user->is_account_admin) {
+        my $store = $c->model('MB')->context->store;
+        @ip_hashes = $store->set_members('userips:' . $user->id);
+    }
+
     my %props = (
         editStats       => $edit_stats,
+        ipHashes        => \@ip_hashes,
         subscribed      => $c->stash->{subscribed},
         subscriberCount => $c->stash->{subscriber_count},
         user            => $user,

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -167,6 +167,27 @@ sub find_by_email
     return $self->_get_by_keys('email', $email);
 }
 
+sub find_by_ip {
+    my ($self, $ip) = @_;
+
+    my $query = 'SELECT ' . $self->_columns .
+        ' FROM ' . $self->_table . ' WHERE id = any(?)' .
+        ' ORDER BY member_since LIMIT 100';
+
+    my @ids = $self->store->set_members("ipusers:$ip");
+    $self->query_to_list($query, [\@ids]);
+}
+
+sub search_by_email {
+    my ($self, $email) = @_;
+
+    my $query = 'SELECT ' . $self->_columns .
+        ' FROM ' . $self->_table . ' WHERE email ~ ?' .
+        ' ORDER BY member_since LIMIT 100';
+
+    $self->query_to_list($query, [$email]);
+}
+
 sub find_by_area {
     my ($self, $area_id, $limit, $offset) = @_;
     my (

--- a/lib/MusicBrainz/Server/Form/Admin/EmailSearch.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/EmailSearch.pm
@@ -1,0 +1,22 @@
+package MusicBrainz::Server::Form::Admin::EmailSearch;
+
+use HTML::FormHandler::Moose;
+
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => (default => 'emailsearch');
+
+has_field 'email' => (type => 'Text');
+has_field 'submit' => (type => 'Submit');
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -1,0 +1,70 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import FormRowText from '../components/FormRowText';
+import FormSubmit from '../components/FormSubmit';
+import {withCatalystContext} from '../context';
+import Layout from '../layout';
+
+import UserList from './components/UserList';
+
+type Props = {
+  +$c: CatalystContextT,
+  +form: FormT<{
+    +email: ReadOnlyFieldT<string>,
+  }>,
+  +results?: $ReadOnlyArray<EditorT>,
+};
+
+const EmailSearch = ({
+  $c,
+  form,
+  results,
+}: Props) => (
+  <Layout fullWidth title={l('Search users by email')}>
+    <div id="content">
+      <h1>{l('Search users by email')}</h1>
+
+      <form action="/admin/email-search" method="post">
+        <p>
+          {exp.l(
+            'Enter a {link|POSIX regular expression}.',
+            {
+              link: 'https://www.postgresql.org/docs/12/' +
+                'functions-matching.html#FUNCTIONS-POSIX-REGEXP',
+            },
+          )}
+        </p>
+
+        <FormRowText
+          field={form.field.email}
+          label={addColonText(l('Email'))}
+          size={50}
+          uncontrolled
+        />
+
+        <div className="row no-label">
+          <FormSubmit
+            label={l('Search')}
+            name="emailsearch.submit"
+            value="1"
+          />
+        </div>
+
+        {results?.length ? (
+          <UserList $c={$c} users={results} />
+        ) : null}
+      </form>
+    </div>
+  </Layout>
+);
+
+export default withCatalystContext<Props>(EmailSearch);

--- a/root/admin/IpLookup.js
+++ b/root/admin/IpLookup.js
@@ -1,0 +1,45 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {withCatalystContext} from '../context';
+import Layout from '../layout';
+
+import UserList from './components/UserList';
+
+type Props = {
+  +$c: CatalystContextT,
+  +ipHash: string,
+  +users: $ReadOnlyArray<EditorT>,
+};
+
+const IpLookup = ({
+  $c,
+  ipHash,
+  users,
+}: Props) => (
+  <Layout fullWidth title={l('IP lookup')}>
+    <div id="content">
+      <h1>{l('IP lookup')}</h1>
+      <p>
+        {l('IP hash:') + ' ' + ipHash}
+      </p>
+      {users.length ? (
+        <UserList $c={$c} users={users} />
+      ) : (
+        <p>
+          {l('No results')}
+        </p>
+      )}
+    </div>
+  </Layout>
+);
+
+export default withCatalystContext<Props>(IpLookup);

--- a/root/admin/components/UserList.js
+++ b/root/admin/components/UserList.js
@@ -1,0 +1,63 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import EditorLink from '../../static/scripts/common/components/EditorLink';
+import bracketed from '../../static/scripts/common/utility/bracketed';
+import formatUserDate from '../../utility/formatUserDate';
+import loopParity from '../../utility/loopParity';
+
+type Props = {
+  +$c: CatalystContextT,
+  +users: $ReadOnlyArray<EditorT>,
+};
+
+const UserList = ({$c, users}: Props) => (
+  <table className="tbl">
+    <thead>
+      <tr>
+        <th>{l('Editor')}</th>
+        <th>{l('Member since')}</th>
+        <th>{l('Email')}</th>
+        <th>{l('Verified on')}</th>
+        <th>{l('Last login')}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {users.map((user, index) => (
+        <tr className={loopParity(index)} key={user.name}>
+          <td>
+            <EditorLink editor={user} />
+            {' '}
+            {bracketed(
+              <a href={'/admin/user/delete/' + encodeURIComponent(user.name)}>
+                {l('delete')}
+              </a>,
+            )}
+          </td>
+          <td>{formatUserDate($c, user.registration_date)}</td>
+          <td>{user.email}</td>
+          <td>
+            {user.email_confirmation_date ? (
+              formatUserDate($c, user.email_confirmation_date)
+            ) : null}
+          </td>
+          <td>
+            {user.last_login_date ? (
+              formatUserDate($c, user.last_login_date)
+            ) : null}
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default UserList;

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -131,9 +131,14 @@ const AdminMenu = ({user}: UserProp) => (
       ) : null}
 
       {user.is_account_admin ? (
-        <li>
-          <a href="/admin/attributes">{l('Edit Attributes')}</a>
-        </li>
+        <>
+          <li>
+            <a href="/admin/attributes">{l('Edit Attributes')}</a>
+          </li>
+          <li>
+            <a href="/admin/email-search">{l('Email Search')}</a>
+          </li>
+        </>
       ) : null}
     </ul>
   </li>

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -32,6 +32,8 @@ module.exports = {
   'account/sso/DiscourseRegistered': require('../account/sso/DiscourseRegistered'),
   'account/sso/DiscourseUnconfirmedEmailAddress': require('../account/sso/DiscourseUnconfirmedEmailAddress'),
   'admin/EditBanner': require('../admin/EditBanner'),
+  'admin/EmailSearch': require('../admin/EmailSearch'),
+  'admin/IpLookup': require('../admin/IpLookup'),
   'admin/attributes/Attribute': require('../admin/attributes/Attribute'),
   'admin/attributes/Index': require('../admin/attributes/Index'),
   'admin/attributes/Language': require('../admin/attributes/Language'),

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -18,6 +18,8 @@ import commaList from '../static/scripts/common/i18n/commaList';
 import expand2react from '../static/scripts/common/i18n/expand2react';
 import bracketed, {bracketedText}
   from '../static/scripts/common/utility/bracketed';
+import escapeRegExp from '../static/scripts/common/utility/escapeRegExp';
+import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList';
 import nonEmpty from '../static/scripts/common/utility/nonEmpty';
 import {formatCount, formatPercentage} from '../statistics/utilities';
 import formatUserDate from '../utility/formatUserDate';
@@ -96,6 +98,7 @@ const UserProfileProperty = ({
 
 type UserProfileInformationProps = {
   +$c: CatalystContextT,
+  +ipHashes: $ReadOnlyArray<string>,
   +subscribed: boolean,
   +subscriberCount: number,
   +user: EditorT,
@@ -104,6 +107,7 @@ type UserProfileInformationProps = {
 
 const UserProfileInformation = withCatalystContext(({
   $c,
+  ipHashes,
   subscribed,
   subscriberCount,
   user,
@@ -130,6 +134,12 @@ const UserProfileInformation = withCatalystContext(({
   const encodedName = encodeURIComponent(user.name);
 
   const {area, biography, gender, languages} = user;
+
+  /*
+   * Whether the user making the request is an account admin (not
+   * the user whose profile is being viewed).
+   */
+  const isAccountAdmin = !!($c.user?.is_account_admin);
 
   return (
     <>
@@ -161,11 +171,29 @@ const UserProfileInformation = withCatalystContext(({
                 )
               ) : (
                 $c.user ? (
-                  bracketed(
-                    <a href={`/user/${encodedName}/contact`}>
-                      {l('send email')}
-                    </a>,
-                  )
+                  <>
+                    {bracketed(
+                      <a href={`/user/${encodedName}/contact`}>
+                        {l('send email')}
+                      </a>,
+                    )}
+                    {isAccountAdmin ? (
+                      <>
+                        {' '}
+                        {bracketed(
+                          <a
+                            href={
+                              '/admin/email-search/?emailsearch.email=' +
+                              encodeURIComponent(escapeRegExp(user.email)) +
+                              '&emailsearch.submit=1'
+                            }
+                          >
+                            {l('find all users of this email')}
+                          </a>,
+                        )}
+                      </>
+                    ) : null}
+                  </>
                 ) : null
               )}
             </>
@@ -212,7 +240,7 @@ const UserProfileInformation = withCatalystContext(({
           {memberSince}
         </UserProfileProperty>
 
-        {$c.user && (viewingOwnProfile || $c.user.is_account_admin) ? (
+        {(viewingOwnProfile || isAccountAdmin) ? (
           <UserProfileProperty name={l('Last login:')}>
             {user.last_login_date
               ? formatUserDate($c, user.last_login_date)
@@ -298,6 +326,21 @@ const UserProfileInformation = withCatalystContext(({
                   {bracketedText(FLUENCY_NAMES[language.fluency]())}
                 </li>
               ))}
+            </ul>
+          </UserProfileProperty>
+        ) : null}
+
+        {$c.user?.is_account_admin && ipHashes.length ? (
+          <UserProfileProperty name={l('IP lookup:')}>
+            <ul className="inline">
+              {commaOnlyList(ipHashes.map(ipHash => (
+                <a
+                  href={'/admin/ip-lookup/' + encodeURIComponent(ipHash)}
+                  key={ipHash}
+                >
+                  {ipHash.substring(0, 7)}
+                </a>
+              )))}
             </ul>
           </UserProfileProperty>
         ) : null}
@@ -525,6 +568,7 @@ const UserProfileStatistics = withCatalystContext(({
 type UserProfileProps = {
   +$c: CatalystContextT,
   +editStats: EditStatsT,
+  +ipHashes: $ReadOnlyArray<string>,
   +subscribed: boolean,
   +subscriberCount: number,
   +user: EditorT,
@@ -534,6 +578,7 @@ type UserProfileProps = {
 const UserProfile = ({
   $c,
   editStats,
+  ipHashes,
   subscribed,
   subscriberCount,
   user,
@@ -545,6 +590,7 @@ const UserProfile = ({
   return (
     <UserAccountLayout entity={user} page="index">
       <UserProfileInformation
+        ipHashes={ipHashes}
         subscribed={subscribed}
         subscriberCount={subscriberCount}
         user={user}

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -84,6 +84,8 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Admin::delete_user",
   "Controller::Admin::edit_banner",
   "Controller::Admin::edit_user",
+  "Controller::Admin::email_search",
+  "Controller::Admin::ip_lookup",
   "Controller::Ajax::filter_artist_recordings_form",
   "Controller::Ajax::filter_artist_release_groups_form",
   "Controller::Ajax::filter_artist_releases_form",


### PR DESCRIPTION
/admin/email-search:

Allows account admins to search users by email using a POSIX regular expression. Since I didn't bother paging the results, it's limited to returning 100 users (in case someone were to accidentally enter a pattern matching half the database) ordered by signup date.

/admin/ip-lookup/$hash:

Allows account admins to see a list of users accessing MusicBrainz from a specific IP hash (an MD5 of their IP address). This is linked from users' profile pages, which now display a list of hashed IPs "belonging" to a user to account admins. (The point of the hash isn't to be cryptographically secure, since admins can find this data in the server logs anyway; it's just to obscure the possible geographic location of the user, since it doesn't seem relevant in most cases.)

Redis keys mapping a user ID to a list of IP hashes and vice versa (an IP hash to a list of user IDs) have an expiration of 6 months, but this expiration is refreshed whenever a relevant user or IP accesses the site.