### PR TITLE
Sleep when deploying

### DIFF
--- a/script/update_containers.sh
+++ b/script/update_containers.sh
@@ -83,6 +83,8 @@ else
   pause=30
 fi
 
+last_host=${HOSTS/* }
+
 for host in $HOSTS
 do
   echo "$host: Updating containers..."
@@ -90,7 +92,10 @@ do
     sudo -H -S -- \
       /root/docker-server-configs/scripts/update_services.sh \
         $DEPLOY_ENV $SERVICES
-  sleep $pause
+  if [[ $host != "$last_host" ]]
+  then
+    sleep $pause
+  fi
 done
 
 # vi: set et sts=2 sw=2 ts=2 :

--- a/script/update_containers.sh
+++ b/script/update_containers.sh
@@ -76,6 +76,13 @@ else
   HOSTS="$*"
 fi
 
+if [[ $DEPLOY_ENV == beta ]]
+then
+  pause=90
+else
+  pause=30
+fi
+
 for host in $HOSTS
 do
   echo "$host: Updating containers..."
@@ -83,7 +90,7 @@ do
     sudo -H -S -- \
       /root/docker-server-configs/scripts/update_services.sh \
         $DEPLOY_ENV $SERVICES
-  sleep 30
+  sleep $pause
 done
 
 # vi: set et sts=2 sw=2 ts=2 :


### PR DESCRIPTION
Because deploying a new beta version is more work, we need more restful sleeps! Joking aside, this is because there are only 2 servers in beta, and starting a container currently takes more than 30 seconds. This is due to `compile_resources.sh` being run by the container rather than at build time.