### PR TITLE
MBS-10855: Show [removed] recording in historic EditTrack

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/ChangeTrackArtist.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/ChangeTrackArtist.pm
@@ -8,6 +8,7 @@ use MusicBrainz::Server::Translation qw( N_l );
 use MusicBrainz::Server::Edit::Historic::Base;
 
 use aliased 'MusicBrainz::Server::Entity::Artist';
+use aliased 'MusicBrainz::Server::Entity::Recording';
 
 sub edit_name     { N_l('Edit track (historic)') }
 sub edit_kind     { 'edit' }
@@ -36,7 +37,10 @@ sub build_display_data
 {
     my ($self, $loaded) = @_;
     return {
-        recording => $loaded->{Recording}->{ $self->data->{recording_id} },
+        recording => $loaded->{Recording}->{ $self->data->{recording_id} } ||
+                Recording->new(
+                    id => $self->data->{recording_id},
+                ),
         artist => {
             old => $loaded->{Artist}->{ $self->data->{old_artist_id} } ||
                 Artist->new(


### PR DESCRIPTION
### Fix MBS-10855

We were showing nothing at all for the recording in historic Edit Track (ChangeTrackArtist) edits if the recording ID didn't resolve to an existing recording. That's kinda confusing, so this ensures we at least show Recording: [removed] there to clarify the situation.

