### PR TITLE
MBS-10853: Include link to subbed users' open edits in sub email

### DIFF
--- a/lib/MusicBrainz/Server/Email/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Email/Subscriptions.pm
@@ -105,6 +105,9 @@ To view or edit your subscription list, please use the following link:
 
 To see all open edits for your subscribed entities, see this link:
 [% self.server %]/edit/subscribed?open=1
+
+To see all open edits by your subscribed editors, see this link:
+[% self.server %]/edit/subscribed_editors?open=1
 };
 }
 


### PR DESCRIPTION
### Implement MBS-10853

We already have the link for the entities, so there's no reason not to also give the equivalent link for subscribed editors.