### PR TITLE
MBS-10850: Update BadAmazonURLs report to avoid false positives

### DIFF
--- a/lib/MusicBrainz/Server/Report/BadAmazonURLs.pm
+++ b/lib/MusicBrainz/Server/Report/BadAmazonURLs.pm
@@ -20,7 +20,8 @@ sub query
             JOIN release r ON lru.entity0 = r.id
         WHERE
             url ~ 'amazon\.' AND
-            url !~ '^https?://www\.amazon\.(com|ca|cn|de|es|fr|it|co\.(jp|uk)|in|com\.(br|mx))/gp/product/[0-9A-Z]{10}$'
+            url !~ '^https?://www\.amazon\.(com|ca|co\.uk|fr|ae|at|de|it|sg|co\.jp|jp|cn|es|in|nl|com\.br|com\.mx|com\.au|com\.tr)/gp/product/[0-9A-Z]{10}$' AND
+            url !~ '^https?://music\.amazon\.(com|ca|co\.uk|fr|ae|at|de|it|sg|co\.jp|jp|cn|es|in|nl|com\.br|com\.mx|com\.au|com\.tr)' 
     };
 }
 

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -477,6 +477,7 @@ const CLEANUPS = {
       return null;
     },
     validate: function (url) {
+      // If you change this, please update the BadAmazonURLs report.
       return {result: /^https:\/\/www\.amazon\.(com|ca|co\.uk|fr|ae|at|de|it|sg|co\.jp|jp|cn|es|in|nl|com\.br|com\.mx|com\.au|com\.tr)\//.test(url)};
     },
   },
@@ -507,6 +508,7 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
+      // If you change this, please update the BadAmazonURLs report.
       const m = /^https:\/\/music\.amazon\.(?:com|ca|co\.uk|fr|ae|at|de|it|sg|co\.jp|jp|cn|es|in|nl|com\.br|com\.mx|com\.au|com\.tr)\/(albums|artists)/.exec(url);
       if (m) {
         const prefix = m[1];


### PR DESCRIPTION
### Fix MBS-10850

Two big issues here: first, we currently support quite a few more subdomains than this accepted even for proper Amazon store products, and second, this was catching every Amazon Music link as a false positive.

Added comments to URLCleanup to help us avoid this in the future.
