### PR TITLE
MBS-10863: Fix Edit barcodes edit display for no barcode -> barcode

### DIFF
--- a/root/edit/details/edit_barcodes.tt
+++ b/root/edit/details/edit_barcodes.tt
@@ -15,7 +15,7 @@
     [% IF !submission.exists('old_barcode') %]
       <tr>
           <th>[% l('Barcode:') %]</th>
-          <td colspan="2">[% submission.barcode | html %]</td>
+          <td colspan="2">[% submission.new_barcode.format | html %]</td>
       </tr>
     [% ELSE %]
        [% display_diff(l('Barcode:'), submission.old_barcode.format, submission.new_barcode.format) %]


### PR DESCRIPTION
### Fix MBS-10863

While in the edit data the field that is used here is "barcode", the display data maps it to "new_barcode", so no barcode was shown when the edit just added a new barcode to releases that had none.

By the way, any reason we shouldn't just use a diff anyway and just pass an empty string if no old barcode exists?