### PR TITLE
Fix new localizable messages

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1453,8 +1453,8 @@ const CLEANUPS = {
         return {
           error: l(
             `Explore links are not officially connected to a location.
-             If you want to link a to a location, try and find
-             the place's Instagram profile instead, if there's one.`,
+             If you want to link a place to a location, try and find
+             the place’s Instagram profile instead, if there is one.`,
           ),
           result: false,
         };

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1066,9 +1066,12 @@ const CLEANUPS = {
           }
           return {result: prefix === undefined};
         }
+        if (prefix === 'video/') {
+          return {result: true};
+        }
         return {
           error: linkToVideoMsg(),
-          result: prefix === 'video/',
+          result: false,
         };
       }
       return {result: false};
@@ -2560,9 +2563,12 @@ const CLEANUPS = {
           }
           return {result: prefix === undefined};
         }
+        if (prefix === 'videos/') {
+          return {result: true};
+        }
         return {
           error: linkToVideoMsg(),
-          result: prefix === 'videos/',
+          result: true,
         };
       }
       return {result: false};
@@ -2853,21 +2859,30 @@ const CLEANUPS = {
         case LINK_TYPES.youtube.label:
         case LINK_TYPES.youtube.place:
         case LINK_TYPES.youtube.series:
+          if (/^https:\/\/www\.youtube\.com\/(?!watch\?v=[a-zA-Z0-9_-])/.test(url)) {
+            return {result: true};
+          }
           return {
             error: linkToChannelMsg(),
-            result: /^https:\/\/www\.youtube\.com\/(?!watch\?v=[a-zA-Z0-9_-])/.test(url),
+            result: false,
           };
         case LINK_TYPES.streamingfree.recording:
+          if (/^https:\/\/www\.youtube\.com\/watch\?v=[a-zA-Z0-9_-]+$/.test(url)) {
+            return {result: true};
+          }
           return {
             error: linkToVideoMsg(),
-            result: /^https:\/\/www\.youtube\.com\/watch\?v=[a-zA-Z0-9_-]+$/.test(url),
+            result: false,
           };
         case LINK_TYPES.streamingfree.release:
+          if (/^https:\/\/www\.youtube\.com\/(watch\?v=[a-zA-Z0-9_-]+|playlist\?list=[a-zA-Z0-9_-]+)$/.test(url)) {
+            return {result: true};
+          }
           return {
             error: l(
               'Only video and playlist links are allowed on releases.',
             ),
-            result: /^https:\/\/www\.youtube\.com\/(watch\?v=[a-zA-Z0-9_-]+|playlist\?list=[a-zA-Z0-9_-]+)$/.test(url),
+            result: false,
           };
       }
       return {result: false};

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2785,12 +2785,12 @@ const CLEANUPS = {
       if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/.*#/.test(url)) {
         return {
           error: exp.l(
-            `Links to specific sections of Wikipedia articles are not 
+            `Links to specific sections of Wikipedia articles are not
              allowed. Please remove “{fragment}” if still appropriate.
              See the {url|guidelines}.`,
             {
               fragment: (
-                <span className="url-quote" key="fragment">
+                <span className="url-quote">
                   {url.replace(
                     /^(?:https?:\/\/)?(?:[^.\/]+\.)?wikipedia\.org\/[^#]*#(.*)$/,
                     '#$1',

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2591,7 +2591,7 @@ const CLEANUPS = {
     type: LINK_TYPES.image,
     validate: function () {
       return {
-        error: l('This site does not allow direct links to their images'),
+        error: l('This site does not allow direct links to their images.'),
         result: false,
       };
     },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -423,10 +423,16 @@ const CLEANUPS = {
           case LINK_TYPES.allmusic.release:
             if (prefix === 'album/mw') {
               return {
-                error: l(
-                  `Allmusic album links should be added to release groups.
+                error: exp.l(
+                  `Allmusic “{album_url_pattern}” links should be added to
+                   release groups.
                    To find the appropriate release link for this release,
                    please check the Releases tab for the Allmusic album.`,
+                  {
+                    album_url_pattern: (
+                      <span className="url-quote">{'/album'}</span>
+                    ),
+                  },
                 ),
                 result: false,
               };
@@ -1138,9 +1144,15 @@ const CLEANUPS = {
           case LINK_TYPES.discogs.release:
             if (prefix === 'master') {
               return {
-                error: l(
-                  `Discogs master links group several releases,
+                error: exp.l(
+                  `Discogs “{master_url_pattern}” links group several
+                   releases,
                    so this should be added to the release group instead.`,
+                  {
+                    master_url_pattern: (
+                      <span className="url-quote">{'/master'}</span>
+                    ),
+                  },
                 ),
                 result: false,
               };
@@ -1451,10 +1463,16 @@ const CLEANUPS = {
       }
       if (/^https:\/\/www\.instagram\.com\/explore\//.test(url)) {
         return {
-          error: l(
-            `Explore links are not officially connected to a location.
+          error: exp.l(
+            `Instagram “{explore_url_pattern}” links are not officially
+             connected to a location.
              If you want to link a place to a location, try and find
              the place’s Instagram profile instead, if there is one.`,
+            {
+              explore_url_pattern: (
+                <span className="url-quote">{'/explore'}</span>
+              ),
+            },
           ),
           result: false,
         };
@@ -1503,10 +1521,15 @@ const CLEANUPS = {
               return {result: true};
             }
             return {
-              error: l(
-                `Only iTunes artist pages can be added directly 
-                 to artists. Please link albums, videos, etc. 
+              error: exp.l(
+                `Only iTunes “{artist_url_pattern}” pages can be added
+                 directly to artists. Please link albums, videos, etc.
                  to the appropriate release or recording instead.`,
+                {
+                  artist_url_pattern: (
+                    <span className="url-quote">{'/artist'}</span>
+                  ),
+                },
               ),
               result: false,
             };

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -427,8 +427,13 @@ const CLEANUPS = {
                   `Allmusic “{album_url_pattern}” links should be added to
                    release groups.
                    To find the appropriate release link for this release,
-                   please check the Releases tab for the Allmusic album.`,
+                   please check the Releases tab from {album_url|your link}.`,
                   {
+                    album_url: {
+                      href: url,
+                      rel: 'noopener noreferrer',
+                      target: '_blank',
+                    },
                     album_url_pattern: (
                       <span className="url-quote">{'/album'}</span>
                     ),

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -331,7 +331,7 @@ const UserProfileInformation = withCatalystContext(({
         ) : null}
 
         {$c.user?.is_account_admin && ipHashes.length ? (
-          <UserProfileProperty name={l('IP lookup:')}>
+          <UserProfileProperty name={bracketedText(l('IP lookup'))}>
             <ul className="inline">
               {commaOnlyList(ipHashes.map(ipHash => (
                 <a


### PR DESCRIPTION
# Problem

Many new error messages have been added with #1515 and #1529. A word is likely missing according to https://community.metabrainz.org/t/incomplete-string-is-not-translatable/478813 and I found some other phrasing issues while translating.

# Solution

See commit messages for details.

# Checklist for authors

* [x] Check newly added messages for further issues
* [x] <del>Add context strings</del> (MBS-10864)

# Action

1. Get latest translations before re-uploading `server` resource to Transifex