### PR TITLE
MBS-10469: Add 10 minute delay to shown CAA on front page

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1398,6 +1398,7 @@ sub newest_releases_with_artwork {
       WHERE cover_art_type.type_id = ?
         AND cover_art.ordering = 1
         AND edit.type = ?
+        AND cover_art.date_uploaded < NOW() - INTERVAL \'10 minutes\'
       ORDER BY edit.id DESC
       LIMIT 10';
 


### PR DESCRIPTION
# Problem

Currently a lot of cover art on the front page is not shown since it hasn’t been processed by the IA yet, so visitors see "Image not available yet" messages instead.


# Solution

MBS-10469: The proper solution to fix this would be to not show images on the front page until they’re actually processed, but I am not currently aware of a way to do this easily and reliably (there are database columns for storing sizes of the thumbnails, but they don’t seem to be populated, otherwise they would possibly be a good fit).

This is mostly meant as a temporary workaround to lessen the problem. It won’t remove the problem entirely, since sometimes cover arts take more than 10 minutes to generate, but having a 3+ hour long wait also seems excessive.

# Note

I don’t have access to a live test server, so I’ve only played around with the query in my local database copy, not actually tried it out on a running copy of the server code. Also, this is mostly meant as a proof-of-concept. I am happy to have this PR thrown away for a better solution. This is just to hopefully inspire some thought on the matter. :)