### PR TITLE
MBS-10833: Avoid crashing if entity0_id is missing

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
@@ -208,6 +208,9 @@ sub _expand_relationships {
     } @$mappings;
 }
 
+# To access entities missing an ID via linkedEntities later on
+my $fake_entity_id = 1000000000;
+
 sub _display_relationships {
     my ($self, $data, $loaded) = @_;
     return [
@@ -216,7 +219,7 @@ sub _display_relationships {
             my $entity1_type = $_->{entity1_type};
             my $model0 = type_to_model( $_->{entity0_type} );
             my $model1 = type_to_model( $_->{entity1_type} );
-            my $entity0_id = $_->{entity0_id};
+            my $entity0_id = $_->{entity0_id} // $fake_entity_id++;
             my $entity1_id = $_->{entity1_id};
             my $entity0 = $loaded->{ $model0 }{ $entity0_id } ||
                 $self->c->model($model0)->_entity_class->new(

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -239,8 +239,10 @@ sub _interpolate {
             return $alt1;
         }
     };
-    $phrase =~ s/{(.*?)(?::(.*?))?}/$replace_attrs->(lc $1, $2)/eg;
-    trim_in_place($phrase);
+    if (defined $phrase) {
+        $phrase =~ s/{(.*?)(?::(.*?))?}/$replace_attrs->(lc $1, $2)/eg;
+        trim_in_place($phrase);
+    }
 
     my @extra_attrs = map { @$_ } values %extra_attrs;
     return [ $phrase, comma_only_list(@extra_attrs) ];
@@ -280,9 +282,9 @@ around TO_JSON => sub {
         entity1_credit  => $self->entity1_credit,
         entity0_id      => $self->entity0_id,
         entity1_id      => $self->entity1_id,
-        id              => $self->id + 0,
-        linkOrder       => $self->link_order + 0,
-        linkTypeID      => $link->type_id + 0,
+        id              => $self->id ? $self->id + 0 : undef,
+        linkOrder       => $self->link_order ? $self->link_order + 0 : 0,
+        linkTypeID      => $link->type_id ? $link->type_id + 0 : undef,
         target          => $self->target->TO_JSON,
         verbosePhrase   => $self->verbose_phrase,
     };


### PR DESCRIPTION
### Fix MBS-10833

Some old edits (at least edit 12587968) are missing this.

