### PR TITLE
MBS-10856: Trim whitespace on relationship credits

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -349,6 +349,9 @@ sub process_relationship {
     $data->{entity0} = $data->{entities}->[0];
     $data->{entity1} = $data->{entities}->[1];
 
+    trim_string($data, 'entity0_credit');
+    trim_string($data, 'entity1_credit');
+
     my $begin_date = clean_partial_date(delete $data->{begin_date});
     my $end_date = clean_partial_date(delete $data->{end_date});
     my $ended = delete $data->{ended};


### PR DESCRIPTION
### Fix MBS-10856

We have a control_for_whitespace_entity0_credit constraint, so trying to add a relationship credit ending in whitespace was causing an error. This actually trims the credits before submitting, as we do with other strings.