### PR TITLE
MBS-10882: Remove accidental duplicate push

### DIFF
--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -75,7 +75,6 @@ sub _where_filter
 
     if (defined $filter) {
         if (exists $filter->{name}) {
-            push @query,
             push @query, "(mb_simple_tsvector(rg.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR rg.name = ?)";
             push @params, $filter->{name}, $filter->{name};
         }


### PR DESCRIPTION
### Fix MBS-10882

This was causing a SQL error and thus an ISE when filtering by name.

