### PR TITLE
MBS-10862: Report "CatNoLooksLikeLabelCode"

### DIFF
--- a/lib/MusicBrainz/Server/Report/CatNoLooksLikeLabelCode.pm
+++ b/lib/MusicBrainz/Server/Report/CatNoLooksLikeLabelCode.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Report::CatNoLooksLikeLabelCode;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub component_name { 'CatNoLooksLikeLabelCode' }
+
+sub query {
+    "
+        SELECT
+            r.id AS release_id, rl.catalog_number,
+            row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+        FROM
+            release_label rl
+            JOIN release r
+            ON r.id = rl.release
+            JOIN artist_credit ac ON r.artist_credit = ac.id
+        WHERE rl.catalog_number ~ '^LC[\\s-]*\\d{4,5}\$'
+    "
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::PagedReport;
     ArtistsWithNoSubscribers
     BadAmazonURLs
     CatNoLooksLikeASIN
+    CatNoLooksLikeLabelCode
     CollaborationRelationships
     CoverArtRelationships
     DeprecatedRelationshipArtists
@@ -101,6 +102,7 @@ use MusicBrainz::Server::Report::ArtistsWithMultipleOccurrencesInArtistCredits;
 use MusicBrainz::Server::Report::ArtistsWithNoSubscribers;
 use MusicBrainz::Server::Report::BadAmazonURLs;
 use MusicBrainz::Server::Report::CatNoLooksLikeASIN;
+use MusicBrainz::Server::Report::CatNoLooksLikeLabelCode;
 use MusicBrainz::Server::Report::CollaborationRelationships;
 use MusicBrainz::Server::Report::CoverArtRelationships;
 use MusicBrainz::Server::Report::DeprecatedRelationshipArtists;

--- a/root/report/CatNoLooksLikeLabelCode.js
+++ b/root/report/CatNoLooksLikeLabelCode.js
@@ -1,0 +1,100 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+import PaginatedResults from '../components/PaginatedResults';
+import loopParity from '../utility/loopParity';
+import EntityLink from '../static/scripts/common/components/EntityLink';
+import ArtistCreditLink
+  from '../static/scripts/common/components/ArtistCreditLink';
+
+import FilterLink from './FilterLink';
+import type {ReportDataT, ReportReleaseCatNoT} from './types';
+
+const CatNoLooksLikeLabelCode = ({
+  $c,
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseCatNoT>): React.Element<typeof Layout> => (
+  <Layout
+    $c={$c}
+    fullWidth
+    title={l('Releases with catalog numbers that look like Label Codes')}
+  >
+    <h1>{l('Releases with catalog numbers that look like Label Codes')}</h1>
+
+    <ul>
+      <li>
+        {exp.l(
+          `This report shows releases which have catalog numbers that look
+           like {doc_link|Label Codes}. This is often wrong, since the two
+           are often confused: label codes apply to the label, not to a
+           specific release. If you confirm this is a label code (check
+           the label page to see if they match, for example), remove it or,
+           even better, try to find the actual catalog number.`,
+          {doc_link: '/doc/Label/Label_Code'},
+        )}
+      </li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+
+      {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
+    </ul>
+
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Catalog Number')}</th>
+            <th>{l('Release')}</th>
+            <th>{l('Artist')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <tr className={loopParity(index)} key={item.release_id}>
+              {item.release ? (
+                <>
+                  <td>{item.catalog_number}</td>
+                  <td>
+                    <EntityLink entity={item.release} />
+                  </td>
+                  <td>
+                    <ArtistCreditLink
+                      artistCredit={item.release.artistCredit}
+                    />
+                  </td>
+                </>
+              ) : (
+                <td colSpan="3">
+                  {l('This release no longer exists.')}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </PaginatedResults>
+
+  </Layout>
+);
+
+export default CatNoLooksLikeLabelCode;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -312,6 +312,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           </a>
         </li>
         <li>
+          <a href="/report/CatNoLooksLikeLabelCode">
+            {l('Releases with catalog numbers that look like Label Codes')}
+          </a>
+        </li>
+        <li>
           <a href="/report/UnlinkedPseudoReleases">
             {l(`Translated/Transliterated Pseudo-Releases not linked to
                 an original version`)}

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -133,6 +133,7 @@ module.exports = {
   'report/AsinsWithMultipleReleases': require('../report/AsinsWithMultipleReleases'),
   'report/BadAmazonUrls': require('../report/BadAmazonUrls'),
   'report/CatNoLooksLikeAsin': require('../report/CatNoLooksLikeAsin'),
+  'report/CatNoLooksLikeLabelCode': require('../report/CatNoLooksLikeLabelCode'),
   'report/CollaborationRelationships': require('../report/CollaborationRelationships'),
   'report/CoverArtRelationships': require('../report/CoverArtRelationships'),
   'report/DeprecatedRelationshipArtists': require('../report/DeprecatedRelationshipArtists'),


### PR DESCRIPTION
### Implement MBS-10862

This finds catalog numbers that look like label codes, which seems to be a surprisingly common error.