### PR TITLE
MBS-10883: Revert Maybe->Optional for Remove PUID

### DIFF
--- a/lib/MusicBrainz/Server/Edit/PUID/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/PUID/Delete.pm
@@ -22,8 +22,8 @@ has '+data' => (
     isa => Dict[
         # Edit migration might not be able to find out what these
         # were
-        recording_puid_id => Optional[Int],
-        puid_id           => Optional[Int],
+        recording_puid_id => Maybe[Int],
+        puid_id           => Maybe[Int],
         recording         => Dict[
             id => Int,
             name => Str


### PR DESCRIPTION
### Fix MBS-10883

I was overzealous with this change last time - while client_version should be Optional, recording_puid_id can be there and be undef, and it should be Maybe. I'm expecting puid_id to be the same.
