### PR TITLE
Sanitize IP hashes on staging servers

### DIFF
--- a/lib/DBDefs.pm.sample
+++ b/lib/DBDefs.pm.sample
@@ -209,8 +209,10 @@ sub WEB_SERVER                { "www.musicbrainz.example.com" }
 # If left empty the default value will be shown.
 # sub DB_STAGING_SERVER_DESCRIPTION { '' }
 
-# Only change this if running a non-sanitized database on a dev server,
-# e.g. http://test.musicbrainz.org.
+# Only change this if running a non-sanitized database on a staging server,
+# e.g. http://beta.musicbrainz.org.
+# * It shows a banner informing that 'all passwords have been reset to "mb"'.
+# * It disables the IP lookup admin tool.
 # sub DB_STAGING_SERVER_SANITIZED { 1 }
 
 # Testing features enable "Accept edit" and "Reject edit" links on edits,

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -154,8 +154,10 @@ sub DB_STAGING_SERVER { 1 }
 # If left empty the default value will be shown.
 sub DB_STAGING_SERVER_DESCRIPTION { '' }
 
-# Only change this if running a non-sanitized database on a dev server,
-# e.g. http://test.musicbrainz.org.
+# Only change this if running a non-sanitized database on a staging server,
+# e.g. http://beta.musicbrainz.org.
+# * It shows a banner informing that 'all passwords have been reset to "mb"'.
+# * It disables the IP lookup admin tool.
 sub DB_STAGING_SERVER_SANITIZED { 1 }
 
 # Testing features enable "Accept edit" and "Reject edit" links on edits,

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -226,14 +226,18 @@ sub begin : Private
         my $store = $c->model('MB')->context->store;
 
         if ($c->user_exists) {
-            my $ip_md5 = md5_hex($c->req->address);
-            my $user_id = $c->user->id;
+            if (!DBDefs->DB_STAGING_SERVER ||
+                !DBDefs->DB_STAGING_SERVER_SANITIZED)
+            {
+                my $ip_md5 = md5_hex($c->req->address);
+                my $user_id = $c->user->id;
 
-            $store->set_add("ipusers:$ip_md5", $user_id);
-            $store->expire("ipusers:$ip_md5", $IP_STORE_EXPIRES);
+                $store->set_add("ipusers:$ip_md5", $user_id);
+                $store->expire("ipusers:$ip_md5", $IP_STORE_EXPIRES);
 
-            $store->set_add("userips:$user_id", $ip_md5);
-            $store->expire("userips:$user_id", $IP_STORE_EXPIRES);
+                $store->set_add("userips:$user_id", $ip_md5);
+                $store->expire("userips:$user_id", $IP_STORE_EXPIRES);
+            }
 
             if ($c->action->name ne 'notes_received') {
                 my $user_name = $c->user->name;

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -378,7 +378,10 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     $edit_stats->{last_day_count} = $c->model('Editor')->last_24h_edit_count($user->id);
 
     my @ip_hashes;
-    if ($c->user_exists && $c->user->is_account_admin) {
+    if ($c->user_exists && $c->user->is_account_admin && !(
+            $c->stash->{server_details}->{staging_server} &&
+            $c->stash->{server_details}->{is_sanitized}))
+    {
         my $store = $c->model('MB')->context->store;
         @ip_hashes = $store->set_members('userips:' . $user->id);
     }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
IP hashes were stored and displayed to everyone on `test.musicbrainz.org` since everyone has account admin permissions.

# Solution
Do not store IP hashes on staging servers running a sanitized database.
This is the same condition that is already used to inform that all passwords have been reset.

# Action

1. Set `DB_STAGING_SERVER_SANITIZED` to `1` for `test.musicbrainz.org`