### PR TITLE
MBS-10885: Fix error when URL has been removed

### DIFF
--- a/root/report/BadAmazonUrls.js
+++ b/root/report/BadAmazonUrls.js
@@ -73,10 +73,14 @@ const BadAmazonUrls = ({
                     />
                   </td>
                   <td>
-                    <EntityLink
-                      content={item.url.href_url}
-                      entity={item.url}
-                    />
+                    {item.url ? (
+                      <EntityLink
+                        content={item.url.href_url}
+                        entity={item.url}
+                      />
+                    ) : (
+                      l('This URL no longer exists.')
+                    )}
                   </td>
                 </>
               ) : (


### PR DESCRIPTION
# Problem
MBS-10885: <https://musicbrainz.org/report/BadAmazonURLs> is crashing after a reported URL has been removed.

# Solution
Inform the URL no longer exists instead.