### PR TITLE
Refactor 435310dd54: Check DBDefs instead of stash

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -379,8 +379,8 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
 
     my @ip_hashes;
     if ($c->user_exists && $c->user->is_account_admin && !(
-            $c->stash->{server_details}->{staging_server} &&
-            $c->stash->{server_details}->{is_sanitized}))
+            DBDefs->DB_STAGING_SERVER &&
+            DBDefs->DB_STAGING_SERVER_SANITIZED))
     {
         my $store = $c->model('MB')->context->store;
         @ip_hashes = $store->set_members('userips:' . $user->id);


### PR DESCRIPTION
# Problem

Checking stash keys is less reliable than DBDefs when available, see https://github.com/metabrainz/musicbrainz-server/pull/1552#issuecomment-639541115 for details.

# Solution
Check DBDefs directly.