### PR TITLE
Escape ', ", `, and GIT_MSG in GIT_MSG

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,7 +4,7 @@ PUSH_TARGETS := $(filter-out push-cpanfile-snapshot,$(shell echo "$(TARGETS)" | 
 
 export DOCKER_CMD ?= docker
 export GIT_BRANCH := $(shell ../script/git_info branch)
-export GIT_MSG := $(shell ../script/git_info msg)
+export GIT_MSG := .quote_never_ever_use_in_a_commit_message.$(subst ',\',$(subst ",\",$(shell ../script/git_info msg))).end_quote_never_ever_use_in_a_commit_message.
 export GIT_SHA := $(shell ../script/git_info sha)
 
 .PHONY : $(BUILD_TARGETS) $(PUSH_TARGETS) config build-all push-all all

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -145,11 +145,10 @@ copy_mb(``script/functions.sh script/git_info script/'')')
 m4_define(
     `git_info',
     `m4_dnl
-m4_pushdef(`git_info', ``git_info'')
 ENV `GIT_BRANCH' GIT_BRANCH
-ENV `GIT_MSG' GIT_MSG
-ENV `GIT_SHA' GIT_SHA
-m4_popdef(`git_info')')
+ENV `GIT_MSG' m4_changequote(`.quote_never_ever_use_in_a_commit_message.', `.end_quote_never_ever_use_in_a_commit_message.')GIT_MSG
+m4_changequote`'m4_dnl
+ENV `GIT_SHA' GIT_SHA')
 
 m4_define(
     `install_new_xz_utils',


### PR DESCRIPTION
There were three issues here:

 1. Docker requires ' and " to be escaped in the ENV command.
 2. m4 could break spectacularly if you used its quote delimiters in the commit message. There's no way to escape these, so we have to temporarily change the quotes to something that'll never appear.
 3. The GIT_MSG wasn't quoted in m4, so underwent macro expansion.

If the commit title I've used here doesn't (1) immediately crash the Docker build or (2) cause it to hang forever due to recursive macro expansion in `GIT_MSG`, this should be a success. :)