### PR TITLE
MBS-10891: Replace Magic MP3 Tagger link with AudioRanger

### DIFF
--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -150,7 +150,7 @@ const ProductsMenu = () => (
         <a href="//picard.musicbrainz.org">{l('MusicBrainz Picard')}</a>
       </li>
       <li>
-        <a href="/doc/Magic_MP3_Tagger">{l('Magic MP3 Tagger')}</a>
+        <a href="/doc/AudioRanger">{l('AudioRanger')}</a>
       </li>
       <li>
         <a href="/doc/Yate_Music_Tagger">{l('Yate Music Tagger')}</a>

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -153,7 +153,7 @@ const Homepage = ({
                 </a>
               </li>
               <li>
-                <a href="/doc/Magic_MP3_Tagger">{l('Magic MP3 Tagger')}</a>
+                <a href="/doc/AudioRanger">{l('AudioRanger')}</a>
               </li>
               <li>
                 <a href="/doc/Yate_Music_Tagger">{l('Yate Music Tagger')}</a>


### PR DESCRIPTION
### Implement MBS-10891

Magic MP3 Tagger has been replaced by the creator's new tool, AudioRanger. This updates the links so we don't point to deprecated software.
