### PR TITLE
MBS-10890: Do not load language for works multiple times

### DIFF
--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -51,7 +51,7 @@ sub load
 sub load_for_works {
     my ($self, @objs) = @_;
 
-    @objs = grep { defined $_ } @objs;
+    @objs = grep { defined $_ && !scalar($_->all_languages) } @objs;
 
     $self->c->model('Work')->language->load_for(@objs);
 


### PR DESCRIPTION
### Fix MBS-10890

This avoids languages being loaded for works each time load_for_works runs, which was making edit listings show "Russian, Russian, Russian" if the work was loaded three times in the list of edits. Now they won't be loaded again if the work already has languages loaded.

Thanks @mwiencek for the suggestion.