### PR TITLE
MBS-10893: Document selecting artist for CD lookup

### DIFF
--- a/root/cdtoc/attach_filter_artist.tt
+++ b/root/cdtoc/attach_filter_artist.tt
@@ -18,6 +18,9 @@
         <div class="row">
           <div class="label required">[% l('Results:') %]</div>
           <div class="no-label">
+            <p>[%- l('Click the radio button to select the appropriate artist, or click the artist’s name to get more info.') -%]</p>
+          </div>
+          <div class="no-label">
             [% WRAPPER 'components/with-pager.tt' %]
              <ul class="radio-list">
               [%- FOREACH artist=artists -%]


### PR DESCRIPTION
# Problem

MBS-10893: Picard users reaching CD lookup are not necessarily fluent with the MB website UI, so the might click the linked name instead of using the radio button to select the appropriate artist.

# Solution

Add the following help text ahead of results:

> Click the radio button to select the appropriate artist, or click the artist’s name to get more info.