### PR TITLE
MBS-10895: conflicting discids report

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesConflictingDiscIDs.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesConflictingDiscIDs.pm
@@ -1,0 +1,77 @@
+package MusicBrainz::Server::Report::ReleasesConflictingDiscIDs;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub component_name { 'ReleasesConflictingDiscIds' }
+
+sub query {
+    q{
+        WITH
+        mc AS (
+            SELECT
+                UNNEST(ARRAY_AGG(cdtoc)) AS cdtoc,
+                medium
+            FROM
+                medium_cdtoc
+            GROUP BY
+                medium
+            HAVING
+                COUNT(medium) > 1
+        ),
+        toc AS (
+            SELECT
+                c.discid,
+                c.leadout_offset,
+                m.position,
+                r.id,
+                r.name,
+                r.artist_credit
+            FROM
+                cdtoc AS c
+                INNER JOIN mc ON c.id = mc.cdtoc
+                INNER JOIN medium AS m ON m.id = mc.medium
+                INNER JOIN release AS r ON r.id = m.release
+        ),
+        results AS (
+            SELECT
+                MAX(leadout_offset) - MIN(leadout_offset) AS maxdiff,
+                id,
+                position,
+                name,
+                artist_credit
+            FROM
+                toc
+            GROUP BY
+                id,
+                position,
+                name,
+                artist_credit
+            HAVING
+                COUNT(discid) > 1
+        )
+        SELECT
+            id AS release_id,
+            position,
+            row_number() OVER (ORDER BY artist_credit, name)
+        FROM
+            results
+        WHERE
+            (maxdiff / 75) > (3*60)  -- cutoff 3min
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 Jerome Roy
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -81,6 +81,7 @@ use MusicBrainz::Server::PagedReport;
     ReleasesWithoutVALink
     ReleasesWithUnlikelyLanguageScript
     ReleasesMissingDiscIDs
+    ReleasesConflictingDiscIDs
     SeparateDiscs
     SetInDifferentRG
     SingleMediumReleasesWithMediumTitles
@@ -163,6 +164,7 @@ use MusicBrainz::Server::Report::ReleasesWithoutVACredit;
 use MusicBrainz::Server::Report::ReleasesWithoutVALink;
 use MusicBrainz::Server::Report::ReleasesWithUnlikelyLanguageScript;
 use MusicBrainz::Server::Report::ReleasesMissingDiscIDs;
+use MusicBrainz::Server::Report::ReleasesConflictingDiscIDs;
 use MusicBrainz::Server::Report::SeparateDiscs;
 use MusicBrainz::Server::Report::SetInDifferentRG;
 use MusicBrainz::Server::Report::SingleMediumReleasesWithMediumTitles;

--- a/root/report/ReleasesConflictingDiscIds.js
+++ b/root/report/ReleasesConflictingDiscIds.js
@@ -1,0 +1,54 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+
+import ReleaseList from './components/ReleaseList';
+import FilterLink from './FilterLink';
+import type {ReportDataT, ReportReleaseT} from './types';
+
+const ReleasesConflictingDiscIds = ({
+  $c,
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof Layout> => (
+  <Layout $c={$c} fullWidth title={l('Releases with conflicting disc IDs')}>
+    <h1>{l('Releases with conflicting disc IDs')}</h1>
+
+    <ul>
+      <li>
+        {l(`This report shows releases that have conflicting disc IDs on the
+            same medium with significant differences in duration. This usually
+            means a disc ID was applied to the wrong medium or the wrong
+            release.`)}
+      </li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+
+      {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
+    </ul>
+
+    <ReleaseList items={items} pager={pager} subPath='discids' />
+
+  </Layout>
+);
+
+export default ReleasesConflictingDiscIds;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -401,6 +401,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           </a>
         </li>
         <li>
+          <a href="/report/ReleasesConflictingDiscIDs">
+            {l('Releases with conflicting disc IDs')}
+          </a>
+        </li>
+        <li>
           <a href="/report/ReleaseLabelSameArtist">
             {l('Releases where artist name and label name are the same')}
           </a>

--- a/root/report/components/ReleaseList.js
+++ b/root/report/components/ReleaseList.js
@@ -20,12 +20,14 @@ type Props = {
   +items: $ReadOnlyArray<ReportReleaseT>,
   +pager: PagerT,
   +showLanguageAndScript?: boolean,
+  +subPath?: string,
 };
 
 const ReleaseList = ({
   items,
   pager,
   showLanguageAndScript,
+  subPath,
 }: Props): React.Element<typeof PaginatedResults> => {
   const colSpan = showLanguageAndScript ? 3 : 2;
 
@@ -48,7 +50,7 @@ const ReleaseList = ({
                 {item.release ? (
                   <>
                     <td>
-                      <EntityLink entity={item.release} />
+                      <EntityLink entity={item.release} subPath={subPath} />
                     </td>
                     <td>
                       <ArtistCreditLink

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -191,6 +191,7 @@ module.exports = {
   'report/ReleasedTooEarly': require('../report/ReleasedTooEarly'),
   'report/ReleasesInCaaWithCoverArtRelationships': require('../report/ReleasesInCaaWithCoverArtRelationships'),
   'report/ReleasesMissingDiscIds': require('../report/ReleasesMissingDiscIds'),
+  'report/ReleasesConflictingDiscIds': require('../report/ReleasesConflictingDiscIds'),
   'report/ReleasesToConvert': require('../report/ReleasesToConvert'),
   'report/ReleasesWithCaaNoTypes': require('../report/ReleasesWithCaaNoTypes'),
   'report/ReleasesWithDownloadRelationships': require('../report/ReleasesWithDownloadRelationships'),


### PR DESCRIPTION
# Problem
MBS-10895

# Solution
New report (.pm and .js)
Add subPath to report/<ReleaseList> react class in order to have links directly to release/uuid/discids page

# Checklist for author
Ready for review.
Works on my local instance with sample data

# Action
Possibly change what the cutoff should be, I started with a 5 minutes minimal difference between discids on the same medium