### PR TITLE
MBS-10892: Show private collaborated-on collections on sidebars

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -78,6 +78,7 @@ role
             ($collaborative_collections) = $c->model('Collection')->find_by({
                 collaborator_id => $c->user->id,
                 entity_type => $entity_type,
+                show_private => $c->user->id,
             });
             foreach my $collection (@$collaborative_collections) {
                 $containment{$collection->id} = 1 if $entity_collections_map{$collection->id};


### PR DESCRIPTION
### Fix MBS-10892

This needs to be changed so that users can actually add and remove entities from collections they're collaborators on from the entity's sidebar.

The Collection::find_by code is awful and should be refactored, but this does what needs to for now.
