### PR TITLE
MBS-10770: add report about relationships with future dates

### DIFF
--- a/lib/MusicBrainz/Server/Report/RecordingsWithFutureDates.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingsWithFutureDates.pm
@@ -1,0 +1,67 @@
+package MusicBrainz::Server::Report::RecordingsWithFutureDates;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
+
+sub query {
+    "
+        WITH
+        link AS (
+            SELECT
+                l.id,
+                l.begin_date_year AS begin,
+                l.end_date_year AS end,
+                lt.gid AS link_gid,
+                lt.name AS link_name,
+                lt.entity_type0,
+                lt.entity_type1
+            FROM
+                link AS l
+                JOIN link_type AS lt ON lt.id = l.link_type
+            WHERE
+                l.begin_date_year > date_part('year', now())
+                OR l.end_date_year > date_part('year', now()) + 5
+        )
+        SELECT
+            link.begin,
+            link.end,
+            link.link_gid,
+            link.link_name,
+            CASE
+                WHEN entity_type0 = 'recording' THEN l_.entity0
+                WHEN entity_type1 = 'recording' THEN l_.entity1
+                ELSE NULL
+            END AS recording_id,
+            row_number() OVER (ORDER BY link.begin, link.end)
+        FROM
+            link
+            JOIN (
+                SELECT link, entity0, entity1 FROM l_area_recording
+                UNION ALL
+                SELECT link, entity0, entity1 FROM l_artist_recording
+                UNION ALL
+                SELECT link, entity0, entity1 FROM l_label_recording
+                UNION ALL
+                SELECT link, entity0, entity1 FROM l_place_recording
+                UNION ALL
+                SELECT link, entity0, entity1 FROM l_recording_recording
+                UNION ALL
+                SELECT link, entity0, entity1 FROM l_recording_work
+            ) AS l_ ON l_.link = link.id
+    ";
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 Jerome Roy
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -67,6 +67,7 @@ use MusicBrainz::Server::PagedReport;
     RecordingsWithEarliestReleaseRelationships
     RecordingsWithVaryingTrackLengths
     RecordingTrackDifferentName
+    RecordingsWithFutureDates
     ReleasedTooEarly
     ReleaseGroupsWithoutVACredit
     ReleaseGroupsWithoutVALink
@@ -149,6 +150,7 @@ use MusicBrainz::Server::Report::RecordingsWithEarliestReleaseRelationships;
 use MusicBrainz::Server::Report::RecordingsWithVaryingTrackLengths;
 #use MusicBrainz::Server::Report::RecordingsSameNameDifferentArtistsSameName;
 use MusicBrainz::Server::Report::RecordingTrackDifferentName;
+use MusicBrainz::Server::Report::RecordingsWithFutureDates;
 use MusicBrainz::Server::Report::ReleasedTooEarly;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVACredit;
 use MusicBrainz::Server::Report::ReleaseGroupsWithoutVALink;

--- a/root/report/DeprecatedRelationshipRecordings.js
+++ b/root/report/DeprecatedRelationshipRecordings.js
@@ -46,7 +46,7 @@ React.Element<typeof Layout> => (
       {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
     </ul>
 
-    <RecordingRelationshipList items={items} pager={pager} />
+    <RecordingRelationshipList items={items} pager={pager} showArtist />
 
   </Layout>
 );

--- a/root/report/RecordingsWithFutureDates.js
+++ b/root/report/RecordingsWithFutureDates.js
@@ -1,0 +1,53 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+
+import RecordingRelationshipList from './components/RecordingRelationshipList';
+import type {ReportDataT, ReportRecordingRelationshipT} from './types';
+
+const RecordingsWithFutureDates = ({
+  $c,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingRelationshipT>): React.Element<typeof Layout> => (
+  <Layout
+    $c={$c}
+    fullWidth
+    title={l('Recordings with relationships having dates in the future')}
+  >
+    <h1>{l('Recordings with relationships having dates in the future')}</h1>
+
+    <ul>
+      <li>
+        {exp.l(
+          `This report shows recordings with relationships using dates in the
+           future. Those are probably typos (e.g. 2109 instead of 2019).`
+        )}
+      </li>
+      <li>
+        {texp.l('Total relationships found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+    </ul>
+
+    <RecordingRelationshipList items={items} pager={pager} showDates />
+
+  </Layout>
+);
+
+export default RecordingsWithFutureDates;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -473,6 +473,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
             {l('Recordings with a different name than their only track')}
           </a>
         </li>
+        <li>
+          <a href="/report/RecordingsWithFutureDates">
+            {l('Recordings with dates in the future')}
+          </a>
+        </li>
       </ul>
 
       <h2>{l('Places')}</h2>

--- a/root/report/components/RecordingRelationshipList.js
+++ b/root/report/components/RecordingRelationshipList.js
@@ -19,16 +19,24 @@ import ArtistCreditLink
 type Props = {
   +items: $ReadOnlyArray<ReportRecordingRelationshipT>,
   +pager: PagerT,
+  +showDates?: boolean,
 };
 
 const RecordingRelationshipList = ({
   items,
   pager,
+  showDates,
 }: Props): React.Element<typeof PaginatedResults> => (
   <PaginatedResults pager={pager}>
     <table className="tbl">
       <thead>
         <tr>
+          {showDates ? (
+            <>
+              <th>{l('Begin date')}</th>
+              <th>{l('End date')}</th>
+            </>
+          ) : null}
           <th>{l('Relationship Type')}</th>
           <th>{l('Artist')}</th>
           <th>{l('Recording')}</th>
@@ -37,6 +45,16 @@ const RecordingRelationshipList = ({
       <tbody>
         {items.map((item, index) => (
           <tr className={loopParity(index)} key={item.recording_id}>
+            {showDates ? (
+              <>
+                <td>
+                  {item.begin}
+                </td>
+                <td>
+                  {item.end}
+                </td>
+              </>
+            ) : null}
             <td>
               <a href={'/relationship/' + encodeURIComponent(item.link_gid)}>
                 {l_relationships(item.link_name)}

--- a/root/report/components/RecordingRelationshipList.js
+++ b/root/report/components/RecordingRelationshipList.js
@@ -20,12 +20,14 @@ type Props = {
   +items: $ReadOnlyArray<ReportRecordingRelationshipT>,
   +pager: PagerT,
   +showDates?: boolean,
+  +showArtist?: boolean,
 };
 
 const RecordingRelationshipList = ({
   items,
   pager,
   showDates,
+  showArtist,
 }: Props): React.Element<typeof PaginatedResults> => (
   <PaginatedResults pager={pager}>
     <table className="tbl">
@@ -38,7 +40,9 @@ const RecordingRelationshipList = ({
             </>
           ) : null}
           <th>{l('Relationship Type')}</th>
-          <th>{l('Artist')}</th>
+          {showArtist ? (
+            <th>{l('Artist')}</th>
+          ) : null}
           <th>{l('Recording')}</th>
         </tr>
       </thead>
@@ -62,11 +66,13 @@ const RecordingRelationshipList = ({
             </td>
             {item.recording ? (
               <>
-                <td>
-                  <ArtistCreditLink
-                    artistCredit={item.recording.artistCredit}
-                  />
-                </td>
+                {showArtist ? (
+                  <td>
+                    <ArtistCreditLink
+                      artistCredit={item.recording.artistCredit}
+                    />
+                  </td>
+                ) : null}
                 <td>
                   <EntityLink entity={item.recording} />
                 </td>

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -150,6 +150,8 @@ export type ReportRecordingAnnotationT = {
 };
 
 export type ReportRecordingRelationshipT = {
+  +begin?: number,
+  +end?: number,
   +link_gid: string,
   +link_name: string,
   +recording: ?RecordingT,

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -181,6 +181,7 @@ module.exports = {
   'report/RecordingTrackDifferentName': require('../report/RecordingTrackDifferentName'),
   'report/RecordingsSameNameDifferentArtistsSameName': require('../report/RecordingsSameNameDifferentArtistsSameName'),
   'report/RecordingsWithEarliestReleaseRelationships': require('../report/RecordingsWithEarliestReleaseRelationships'),
+  'report/RecordingsWithFutureDates': require('../report/RecordingsWithFutureDates'),
   'report/RecordingsWithVaryingTrackLengths': require('../report/RecordingsWithVaryingTrackLengths'),
   'report/RecordingsWithoutVaCredit': require('../report/RecordingsWithoutVaCredit'),
   'report/RecordingsWithoutVaLink': require('../report/RecordingsWithoutVaLink'),


### PR DESCRIPTION
# Problem
MBS-10770 new report about recordings with relationships having dates in the future

# Solution
New report (.pm + .js) to display dates / relation type / link to recording

The SQL query looks for begin dates > current year OR end date > (current year + 5y)


# Action
I tried to keep the SQL query straightforward. On the JS side I added the support of date columns on RecordingRelationshipList instead of creating a new one (even if for this report the Artist column is not needed).
Works on my local instance with the sample data so I don't expect more work to be needed (except i18n) before merging.