### PR TITLE
MBS-9502: Add search for pre-existing barcode value in release editor

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -310,6 +310,7 @@
     </p>
     <!-- ko with: target() && target().barcode -->
     <p data-bind="visible: message, text: message"></p>
+    <p data-bind="visible: existing, html: existing"></p>
     <p class="field-error" data-bind="visible: error() || confirmed()">
       <label>
         <strong>

--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -308,6 +308,9 @@
       [% l('Please enter the barcode of the release you are entering, see <a href="{url}" target="_blank">Barcode</a> for more information.',
            { url => doc_link('Barcode') }) %]
     </p>
+    <p>
+      [% l('If you do not know whether the release has a barcode or not, just leave this blank.') %]
+    </p>
     <!-- ko with: target() && target().barcode -->
     <p data-bind="visible: message, text: message"></p>
     <p data-bind="visible: existing, html: existing"></p>
@@ -320,9 +323,6 @@
       </label>
     </p>
     <!-- /ko -->
-    <p>
-      [% l('If you do not know whether the release has a barcode or not, just leave this blank.') %]
-    </p>
   </div>
 
   <div class="bubble" data-bind="bubble: $root.annotationBubble">

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -759,6 +759,7 @@ class Barcode {
         this.original = data;
         this.barcode = ko.observable(data);
         this.message = ko.observable("");
+        this.existing = ko.observable("");
         this.confirmed = ko.observable(false);
         this.error = validation.errorField(ko.observable(""));
 


### PR DESCRIPTION
# Problem
MBS-9502
Display warning when creating a new release if the barcode is already linked to an existing release

# Solution
Add request to ws/2/release with the barcode as the same time as the UPC/EAN validation is performed
Display a sentence suggesting to check to search page results and confirm the new release is different.

# Checklist for author
Looks ready to me.
Works on my local instance with the sample database

# Action
Please confirm the call to /ws/2/ is the right way to do this.