### PR TITLE
MBS-10903: Update Operabase cleanup / validation

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2023,12 +2023,12 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?operabase\\.com', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\/a\/([^\/?#]+)\/([0-9]+).*$/, 'https://operabase.com/a/$1/$2');
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\/(?:a\/[^\/?#]+|artists)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/artists/$1');
     },
     validate: function (url, id) {
       return {
         result: id === LINK_TYPES.otherdatabases.artist &&
-          /^https:\/\/operabase\.com\/a\/[^\/?#]+\/[0-9]+$/.test(url),
+          /^https:\/\/operabase\.com\/artists\/[0-9]+$/.test(url),
       };
     },
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2500,7 +2500,14 @@ const testData = [
                      input_url: 'www.operabase.com/a/Risto_Joost/21715/future',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://operabase.com/a/Risto_Joost/21715',
+            expected_clean_url: 'https://operabase.com/artists/21715',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://www.operabase.com/artists/megan-esther-grey-101303/en',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://operabase.com/artists/101303',
        only_valid_entity_types: ['artist'],
   },
   {


### PR DESCRIPTION
### Implement MBS-10903

While old Operabase cleaned links still redirect correctly, they have changed their URL format. The new format is simpler and no longer requires the artist name.

