### PR TITLE
MBS-10907: Set white background color to HTML body

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -5,6 +5,7 @@ html {
 body {
     padding: 0;
     margin: 0;
+    background-color: #FFF;
     color: @text-black;
     font-family: @sans-serif;
     min-width: @min-width;
@@ -335,7 +336,6 @@ img.gravatar {
 #current-editing {
     margin-top: 1em;
     padding: 16px;
-    background: #FFF;
     overflow: visible;
     position: relative;
     display: table;


### PR DESCRIPTION
# Problem

MBS-10907

Previously, background color was set for the main content only.  Header and footer were lesser readable when the browser’s background color was not white as well.

# Solution

This patch defines the background for HTML body instead of main content.