### PR TITLE
MBS-10908: Stop recording-of rel edits showing for all recordings of a work

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -60,6 +60,8 @@ has '+data' => (
     ]
 );
 
+sub link_type { shift->data->{link_type} }
+
 sub initialize
 {
     my ($self, %opts) = @_;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -74,6 +74,8 @@ has 'relationship' => (
 sub model0 { type_to_model(shift->data->{relationship}{link}{type}{entity0_type}) }
 sub model1 { type_to_model(shift->data->{relationship}{link}{type}{entity1_type}) }
 
+sub link_type { shift->data->{relationship}{link}{type} }
+
 sub foreign_keys
 {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -105,6 +105,8 @@ has 'relationship' => (
     is => 'rw'
 );
 
+sub link_type { shift->data->{link}{link_type} }
+
 sub foreign_keys
 {
     my ($self) = @_;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
@@ -71,6 +71,8 @@ has '+data' => (
     ]
 );
 
+sub link_type { shift->data->{link_type} }
+
 sub foreign_keys {
     my ($self) = @_;
 


### PR DESCRIPTION
### Fix MBS-10908

While it's generally useful to show relationship changes for a work on recordings and releases connected to the work (MBS-6532), for example if writers are being added or changed, there's one very common use case (recording-work "recording of" rels) where the edits are just noise on other recording entries. The fact that other, unrelated recording is or isn't a recording of this work should never affect the other recordings of the work in any way.

This makes it so the edit is only added to the edit histories of recordings and releases connected to the work if the relationship type is *not* "recording of". The recording and release(s) that are directly connected to the edit will still be linked through the recording side of the edit data.

Also, the previous implementation of MBS-6532 had an error in which all changes made to any work also appeared on all artists who ever recorded that work. This was unintentional, and this removes it (if it gets explicitly asked for for non-"recording of" rels it can be readded in a more intentional, not side-effecty way).
