### PR TITLE
MBS-10901: Fix ISE when historic EditRelationship data is broken

### DIFF
--- a/root/static/scripts/common/components/Warning.js
+++ b/root/static/scripts/common/components/Warning.js
@@ -28,6 +28,7 @@ const Warning = ({
     <WarningIcon />
     <p>
       <strong>{addColon(l('Warning'))}</strong>
+      {' '}
       {message}
     </p>
   </div>


### PR DESCRIPTION
### Fix MBS-10901

We seem to have some cases where historic EditRelationship edits do not have "new" for some of the "old" relationships in the old-new pairs. This makes no sense, so it's probably just data corruption caused during the NGS migration - we can't do much about it, so this just displays those old rels unchanged (diff with themselves) which is the least neurotic of the possibilities.
