### PR TITLE
Bump react-table version to 7.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "querystring": "0.2.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-table": "7.1.0",
+    "react-table": "7.2.1",
     "redux": "3.6.0",
     "shell-quote": "1.7.2",
     "shelljs": "0.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,10 +5512,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-table@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.1.0.tgz#c975cd67e917c54190b6c9df29f085285b0c3f4e"
-  integrity sha512-AZpgW0Xpo6Z7jxXZIBovzCGoYVkuBwATsJh7X4+JXwq9JtDaorOmxWC9gKx5Hui4d+n+I99enyyJS+LRtKydxA==
+react-table@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.2.1.tgz#d85f5a59b6441ccd9e0acddc93c288c54a7de7ee"
+  integrity sha512-cICU3w5yFWTDluz9yFePziEQXGt3PK5R1Va3InP7qMGnZOKm8kv0GiDMli+VOqE1uM1dBYPb9BEad15up1ac6g==
   dependencies:
     "@scarf/scarf" "^1.0.4"
 


### PR DESCRIPTION
> The low usage we have of the API is affected by neither deprecation nor breaking change.
> 
> Reference:
> * https://github.com/tannerlinsley/react-table/releases