### PR TITLE
MBS-9769: add entities added stats on editor profile

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -30,6 +30,7 @@ our %EXPORT_TAGS = (
     quality            => _get(qr/^QUALITY_/),
     alias              => _get(qr/^EDIT_.*_ALIAS$/),
     annotation         => _get(qr/^EDIT_.*_ADD_ANNOTATION$/),
+    create_entity      => _get(qr/^EDIT_.*_CREATE$/),
     historic           => _get(qr/^EDIT_HISTORIC_/),
     editor             => _get(qr/^EDITOR_/),
     vote               => _get(qr/^VOTE_/),

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -391,6 +391,7 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
 
     my $edit_stats = $c->model('Editor')->various_edit_counts($user->id);
     $edit_stats->{last_day_count} = $c->model('Editor')->last_24h_edit_count($user->id);
+    my $added_entities = $c->model('Editor')->added_entities_counts($user->id);
 
     my @ip_hashes;
     if ($c->user_exists && $c->user->is_account_admin && !(
@@ -408,6 +409,7 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
         subscriberCount => $c->stash->{subscriber_count},
         user            => $user,
         votes           => $c->stash->{votes},
+        addedEntities   => $added_entities,
     );
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -619,6 +619,11 @@ sub various_edit_counts {
 
 sub added_entities_counts {
     my ($self, $editor_id) = @_;
+
+    my $cache_key = "editor:$editor_id:added_entities_counts";
+    my $cached_result = $self->c->cache->get($cache_key);
+    return $cached_result if defined $cached_result;
+
     my %result = map { $_ => 0 }
         qw( artist release cover_art event label place series work other );
 
@@ -648,6 +653,9 @@ sub added_entities_counts {
         my ($type, $count) = @$row;
         $result{$type} = $count;
     }
+
+    $self->c->cache->set($cache_key, \%result, 60 * 60 * 24);
+
     return \%result;
 }
 

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -25,6 +25,8 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Constants qw( :edit_status :privileges );
 use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
+use MusicBrainz::Server::Constants qw( :create_entity );
+use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_ADD_COVER_ART );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Subscription' => {
@@ -611,6 +613,40 @@ sub various_edit_counts {
     for my $row (@$rows) {
         my ($category, $count) = @$row;
         $result{$category . '_count'} = $count;
+    }
+    return \%result;
+}
+
+sub added_entities_counts {
+    my ($self, $editor_id) = @_;
+    my %result = map { $_ => 0 }
+        qw( artist release cover_art event label place series work other );
+
+    my $query =
+        q{SELECT
+              CASE
+                WHEN type = ? THEN 'artist'
+                WHEN type = ? THEN 'release'
+                WHEN type = ? THEN 'cover_art'
+                WHEN type = ? THEN 'event'
+                WHEN type = ? THEN 'label'
+                WHEN type = ? THEN 'place'
+                WHEN type = ? THEN 'series'
+                WHEN type = ? THEN 'work'
+                ELSE 'other'
+              END AS type,
+              COUNT(*) AS count
+            FROM edit
+           WHERE editor = ?
+           GROUP BY type};
+    my @params = ($EDIT_ARTIST_CREATE, $EDIT_RELEASE_CREATE,
+        $EDIT_RELEASE_ADD_COVER_ART, $EDIT_EVENT_CREATE, $EDIT_LABEL_CREATE,
+        $EDIT_PLACE_CREATE, $EDIT_SERIES_CREATE, $EDIT_WORK_CREATE);
+    my $rows = $self->sql->select_list_of_lists($query, @params, $editor_id);
+
+    for my $row (@$rows) {
+        my ($type, $count) = @$row;
+        $result{$type} = $count;
     }
     return \%result;
 }

--- a/root/static/scripts/common/constants/editTypes.js
+++ b/root/static/scripts/common/constants/editTypes.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+export const EDIT_ARTIST_CREATE: 1 = 1;
+export const EDIT_LABEL_CREATE: 10 = 10;
 export const EDIT_RELEASEGROUP_CREATE: 20 = 20;
 export const EDIT_RELEASEGROUP_EDIT: 21 = 21;
 export const EDIT_RELEASE_CREATE: 31 = 31;
@@ -20,9 +22,13 @@ export const EDIT_MEDIUM_CREATE: 51 = 51;
 export const EDIT_MEDIUM_EDIT: 52 = 52;
 export const EDIT_MEDIUM_DELETE: 53 = 53;
 export const EDIT_MEDIUM_ADD_DISCID: 55 = 55;
+export const EDIT_PLACE_CREATE: 61 = 61;
 export const EDIT_RECORDING_EDIT: 72 = 72;
 export const EDIT_RELATIONSHIP_CREATE: 90 = 90;
 export const EDIT_RELATIONSHIP_EDIT: 91 = 91;
 export const EDIT_RELATIONSHIP_DELETE: 92 = 92;
+export const EDIT_SERIES_CREATE: 140 = 140;
 export const EDIT_SERIES_EDIT: 141 = 141;
+export const EDIT_EVENT_CREATE: 150 = 150;
 export const EDIT_RELEASE_REORDER_MEDIUMS: 313 = 313;
+export const EDIT_RELEASE_ADD_COVER_ART: 314 = 314;


### PR DESCRIPTION
# Problem
MBS-9769
Display the number of entities created (artists, releases, etc.) on the editor main page

# Solution
See screenshot on MBS-9769: new colum on the editor main page with the count of added entities for the main entity types (artists, releases, works, events...)

# Checklist for author
Tested on local instance with sample data, looks ready to me

# Action
I'm actually not sure how what the performance will be for editors with e.g. > 1 million edits. Can we try this on a test server?