### PR TITLE
MBS-10916: showing AcousticBrainz info in the Recording sidebar

### DIFF
--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -14,6 +14,8 @@ import ArtistCreditLink
 import CodeLink from '../../../static/scripts/common/components/CodeLink';
 import formatTrackLength
   from '../../../static/scripts/common/utility/formatTrackLength';
+import SidebarAcousticBrainz
+  from '../../../static/scripts/common/components/sidebar/AcousticBrainz';
 import ExternalLinks from '../ExternalLinks';
 
 import AnnotationLinks from './AnnotationLinks';
@@ -60,6 +62,8 @@ const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
           </SidebarProperty>
         ))}
       </SidebarProperties>
+
+      <SidebarAcousticBrainz recording={recording} />
 
       <SidebarRating entity={recording} />
 

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -40,6 +40,7 @@ require('./common/components/ReleaseEvents');
 require('./common/components/WorkArtists');
 require("./common/MB/Control/SelectAll");
 require("./common/components/TagEditor");
+require("./common/components/sidebar/AcousticBrainz");
 
 import(/* webpackChunkName: "common-artwork-viewer" */ "./common/artworkViewer");
 import(/* webpackChunkName: "common-dialogs" */ "./common/dialogs");

--- a/root/static/scripts/common/components/sidebar/AcousticBrainz.js
+++ b/root/static/scripts/common/components/sidebar/AcousticBrainz.js
@@ -1,0 +1,82 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import hydrate from '../../../../../utility/hydrate';
+import {SidebarProperty, SidebarProperties} from
+  '../../../../../layout/components/sidebar/SidebarProperties';
+
+const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
+  const [count, setCount] = React.useState(0);
+  const [data, setData] = React.useState(null);
+
+  function fetchAcousticBrainzCount() {
+    const countUrl = `//acousticbrainz.org/api/v1/${recording.gid}/count`;
+    fetch(countUrl).then(
+      resp => resp.json(),
+    ).then(
+      data => {
+        setCount(data.count);
+        if (data.count) {
+          fetchAcousticBrainzData();
+        }
+      },
+    );
+  }
+
+  function fetchAcousticBrainzData() {
+    const dataUrl = `//acousticbrainz.org/api/v1/${recording.gid}/low-level`;
+    fetch(dataUrl).then(
+      resp => resp.json(),
+    ).then(
+      data => {
+        setData(data);
+      },
+    );
+  }
+
+  React.useEffect(fetchAcousticBrainzCount, [recording.gid]);
+  return count ? (
+    <>
+      <h2>
+        {l('Acoustic information')}
+      </h2>
+
+      <a className="external" href={`//acousticbrainz.org/${recording.gid}`}>
+        {texp.ln(
+          '{count} submission on AcousticBrainz',
+          '{count} submissions on AcousticBrainz',
+          count,
+          {count},
+        )}
+      </a>
+
+      {data === null ? null : (
+        <SidebarProperties>
+
+          {data.tonal.key_strength > 0.5 ? (
+            <SidebarProperty className="acousticbrainz_key" label={l('Key:')}>
+              {`${data.tonal.key_key} ${data.tonal.key_scale}`}
+            </SidebarProperty>
+          ) : null}
+
+          <SidebarProperty className="acousticbrainz_bpm" label={l('BPM:')}>
+            {Math.round(data.rhythm.bpm)}
+          </SidebarProperty>
+        </SidebarProperties>
+      )}
+    </>
+  ) : null;
+};
+
+export default (hydrate<{recording: RecordingT}>(
+  'div.acousticbrainz',
+  SidebarAcousticBrainz,
+): React.AbstractComponent<{recording: RecordingT}, void>);

--- a/root/static/scripts/common/components/sidebar/AcousticBrainz.js
+++ b/root/static/scripts/common/components/sidebar/AcousticBrainz.js
@@ -64,7 +64,7 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
   return count ? (
     <>
       <h2>
-        {l('Acoustic information')}
+        {l('Acoustic analysis')}
       </h2>
 
       <a className="external" href={`//acousticbrainz.org/${recording.gid}`}>

--- a/root/static/scripts/common/components/sidebar/AcousticBrainz.js
+++ b/root/static/scripts/common/components/sidebar/AcousticBrainz.js
@@ -56,6 +56,10 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
     return key.includes('#') ? KEY_LABELS[key] : key;
   }
 
+  function roundedBPM(data) {
+    return Math.round(data.tonal.key_strength * 100) / 100;
+  }
+
   React.useEffect(fetchAcousticBrainzCount, [recording.gid]);
   return count ? (
     <>
@@ -64,12 +68,7 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
       </h2>
 
       <a className="external" href={`//acousticbrainz.org/${recording.gid}`}>
-        {texp.ln(
-          '{count} submission on AcousticBrainz',
-          '{count} submissions on AcousticBrainz',
-          count,
-          {count},
-        )}
+        {l('AcousticBrainz entry')}
       </a>
 
       {data === null ? null : (
@@ -77,12 +76,24 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
 
           {data.tonal.key_strength > 0.5 ? (
             <SidebarProperty className="acousticbrainz_key" label={l('Key:')}>
-              {`${keyLabel(data.tonal.key_key)} ${data.tonal.key_scale}`}
+              <abbr
+                title={
+                  l(`Automatic suggestion from entry #1/${count}`) +
+                  ' ' +
+                  l(` (key strength ${roundedBPM(data)})`)
+                }
+              >
+                {`${keyLabel(data.tonal.key_key)} ${data.tonal.key_scale}`}
+              </abbr>
             </SidebarProperty>
           ) : null}
 
           <SidebarProperty className="acousticbrainz_bpm" label={l('BPM:')}>
-            {Math.round(data.rhythm.bpm)}
+            <abbr
+              title={l(`Automatic suggestion from entry #1/${count}`)}
+            >
+              {Math.round(data.rhythm.bpm)}
+            </abbr>
           </SidebarProperty>
         </SidebarProperties>
       )}

--- a/root/static/scripts/common/components/sidebar/AcousticBrainz.js
+++ b/root/static/scripts/common/components/sidebar/AcousticBrainz.js
@@ -32,12 +32,14 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
   }
 
   function fetchAcousticBrainzData() {
-    const dataUrl = `//acousticbrainz.org/api/v1/${recording.gid}/low-level`;
+    const dataUrl = '//acousticbrainz.org/api/v1/low-level?' +
+      `recording_ids=${recording.gid}&` +
+      'features=tonal.key_key;tonal.key_scale;tonal.key_strength;rhythm.bpm';
     fetch(dataUrl).then(
       resp => resp.json(),
     ).then(
       data => {
-        setData(data);
+        setData(data[recording.gid][0]);
       },
     );
   }

--- a/root/static/scripts/common/components/sidebar/AcousticBrainz.js
+++ b/root/static/scripts/common/components/sidebar/AcousticBrainz.js
@@ -13,6 +13,14 @@ import hydrate from '../../../../../utility/hydrate';
 import {SidebarProperty, SidebarProperties} from
   '../../../../../layout/components/sidebar/SidebarProperties';
 
+const KEY_LABELS = {
+  'A#': 'A♯/B♭',
+  'C#': 'C♯/D♭',
+  'D#': 'D♯/E♭',
+  'F#': 'F♯/G♭',
+  'G#': 'G♯/A♭',
+};
+
 const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
   const [count, setCount] = React.useState(0);
   const [data, setData] = React.useState(null);
@@ -44,6 +52,10 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
     );
   }
 
+  function keyLabel(key) {
+    return key.includes('#') ? KEY_LABELS[key] : key;
+  }
+
   React.useEffect(fetchAcousticBrainzCount, [recording.gid]);
   return count ? (
     <>
@@ -65,7 +77,7 @@ const SidebarAcousticBrainz = ({recording}: {recording: RecordingT}) => {
 
           {data.tonal.key_strength > 0.5 ? (
             <SidebarProperty className="acousticbrainz_key" label={l('Key:')}>
-              {`${data.tonal.key_key} ${data.tonal.key_scale}`}
+              {`${keyLabel(data.tonal.key_key)} ${data.tonal.key_scale}`}
             </SidebarProperty>
           ) : null}
 


### PR DESCRIPTION
# Problem
MBS-10916
Display AcousticBrainz info in Recording pages sidebar

# Solution
Use React hook to fetch submission count from AB API. If not zero, fetch low-level data (tonal and rhythm).
See screenshot in MBS-10916

# Checklist for author
Tested on local database with sample data, works as expected

# Action
Check that the number of requests/data transfer amount to the AcousticBrainz API is reasonable. Another solution I tested quickly would be to display the result in the figerprints tab instead: less API requests vs lower visibility of the information