### PR TITLE
Fix some left-behind "import React" imports

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -7,9 +7,9 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {Element} from "React";import partition from 'lodash/partition';
+import partition from 'lodash/partition';
 import unionBy from 'lodash/unionBy';
-import React, {useEffect, useMemo, useReducer, useRef} from 'react';
+import * as React from 'react';
 
 import ENTITIES from '../../../../../entities';
 import useOutsideClickEffect from '../hooks/useOutsideClickEffect';
@@ -228,10 +228,10 @@ function setScrollPosition(menuId: string, siblingAccessor: string) {
   }
 }
 
-export default function Autocomplete2(props: Props): Element<"div"> {
+export default function Autocomplete2(props: Props): React.Element<"div"> {
   const {entityType, id} = props;
 
-  const [state, dispatch] = useReducer<State, Actions>(
+  const [state, dispatch] = React.useReducer<State, Actions>(
     reducer,
     INITIAL_STATE,
   );
@@ -251,7 +251,7 @@ export default function Autocomplete2(props: Props): Element<"div"> {
    * handler, `instance.state` should be used instead, as it'll refer to the
    * state of the last render.
    */
-  const instanceRef = useRef<Instance | null>(null);
+  const instanceRef = React.useRef<Instance | null>(null);
   const instance: Instance = instanceRef.current || (instanceRef.current = {
     container: {current: null},
 
@@ -464,7 +464,7 @@ export default function Autocomplete2(props: Props): Element<"div"> {
   const menuId = `${id}-menu`;
   const statusId = `${id}-status`;
 
-  const menuItems = useMemo(() => instance.renderItems(
+  const menuItems = React.useMemo(() => instance.renderItems(
     state.items,
     state.highlightedIndex,
     state.selectedItem,
@@ -476,7 +476,7 @@ export default function Autocomplete2(props: Props): Element<"div"> {
     instance.stopRequests,
   );
 
-  useEffect(() => {
+  React.useEffect(() => {
     /*
      * This gives event handlers access to the props and state of the most
      * recent render. `useEffect` runs after a completed render; this does

--- a/root/static/scripts/common/components/FingerprintTable.js
+++ b/root/static/scripts/common/components/FingerprintTable.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {AbstractComponent} from "React";import React, {useEffect, useState} from 'react';
+import * as React from 'react';
 
 import loopParity from '../../../../utility/loopParity';
 import hydrate from '../../../../utility/hydrate';
@@ -23,11 +23,11 @@ function orderTracks(a, b) {
 }
 
 const FingerprintTable = ({recording}: {recording: RecordingT}) => {
-  const [tracks, setTracks] = useState([]);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const [tracks, setTracks] = React.useState([]);
+  const [isLoaded, setIsLoaded] = React.useState(false);
 
   // We ensure fetch only runs client-side since it's not in node
-  useEffect(() => {
+  React.useEffect(() => {
     fetch(
       '//api.acoustid.org/v2/track/list_by_mbid' +
       `?format=json&disabled=1&jsoncallback=?&mbid=${recording.gid}`,
@@ -91,4 +91,4 @@ const FingerprintTable = ({recording}: {recording: RecordingT}) => {
 export default (hydrate<{recording: RecordingT}>(
   'div.acoustid-fingerprints',
   FingerprintTable,
-): AbstractComponent<{recording: RecordingT}, void>);
+): React.AbstractComponent<{recording: RecordingT}, void>);

--- a/root/static/scripts/common/components/ReleaseEvents.js
+++ b/root/static/scripts/common/components/ReleaseEvents.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {AbstractComponent} from "React";import React, {useCallback, useState} from 'react';
+import * as React from 'react';
 
 import CountryAbbr from '../../../../components/CountryAbbr';
 import hydrate from '../../../../utility/hydrate';
@@ -86,14 +86,14 @@ const ReleaseEvents = ({
   abbreviated = true,
   events,
 }: ReleaseEventsProps) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
+  const [expanded, setExpanded] = React.useState<boolean>(false);
 
-  const expand = useCallback(event => {
+  const expand = React.useCallback(event => {
     event.preventDefault();
     setExpanded(true);
   });
 
-  const collapse = useCallback(event => {
+  const collapse = React.useCallback(event => {
     event.preventDefault();
     setExpanded(false);
   });
@@ -159,4 +159,4 @@ const ReleaseEvents = ({
 export default (hydrate<ReleaseEventsProps>(
   'div.release-events-container',
   ReleaseEvents,
-): AbstractComponent<ReleaseEventsProps, void>);
+): React.AbstractComponent<ReleaseEventsProps, void>);

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import type {AbstractComponent} from "React";import React, {useCallback, useState} from 'react';
+import * as React from 'react';
 
 import hydrate from '../../../../utility/hydrate';
 import {bracketedText} from '../utility/bracketed';
@@ -30,14 +30,14 @@ type WorkArtistsProps = {
 };
 
 const WorkArtists = ({artists}: WorkArtistsProps) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
+  const [expanded, setExpanded] = React.useState<boolean>(false);
 
-  const expand = useCallback(event => {
+  const expand = React.useCallback(event => {
     event.preventDefault();
     setExpanded(true);
   });
 
-  const collapse = useCallback(event => {
+  const collapse = React.useCallback(event => {
     event.preventDefault();
     setExpanded(false);
   });
@@ -99,4 +99,4 @@ const WorkArtists = ({artists}: WorkArtistsProps) => {
 export default (hydrate<WorkArtistsProps>(
   'div.work-artists-container',
   WorkArtists,
-): AbstractComponent<WorkArtistsProps, void>);
+): React.AbstractComponent<WorkArtistsProps, void>);


### PR DESCRIPTION
We seem to have missed these when we did the conversion to the "import * as React" format.