### PR TITLE
MBS-10926: add 'copy date' button on relationship editor dialog

### DIFF
--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -125,6 +125,9 @@
       <input type="text" data-bind="value: date.year, valueUpdate: 'afterkeydown'" maxlength="4" placeholder="[% l('YYYY') %]" size="4" />-<!--
       --><input type="text" data-bind="value: date.month, valueUpdate: 'afterkeydown'" maxlength="2" placeholder="[% l('MM') %]" size="2" />-<!--
       --><input type="text" data-bind="value: date.day, valueUpdate: 'afterkeydown'" maxlength="2" placeholder="[% l('DD') %]" size="2" />
+      <!-- ko if: isBeginDate -->
+        <button class="icon copy-date" type="button" title="[% l('Copy to end date') | html %]" data-bind="click: $parent.copyDate"></button>
+      <!-- /ko -->
       <div class="error" data-bind="text: $parent.dateError(date)"></div>
       <div class="error" data-bind="text: isBeginDate ? $parent.tooShortBeginYearError() : $parent.tooShortEndYearError()"></div>
     </td>

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -354,6 +354,13 @@ const RE = MB.relationshipEditor = MB.relationshipEditor || {};
             relationship.entities(relationship.entities().slice(0).reverse());
         }
 
+        copyDate(data, event) {
+            const dialog = ko.contextFor(event.target).$parent;
+            dialog.relationship().end_date.year(data.date.year());
+            dialog.relationship().end_date.month(data.date.month());
+            dialog.relationship().end_date.day(data.date.day());
+        }
+
         backward() {
             return this.source === this.relationship().entities()[1];
         }

--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -29,3 +29,7 @@ div.rel-editor-dialog .warning {
     font-weight: bold;
 }
 #content.rel-editor .error-field {border-bottom: 2px red dotted;}
+
+button.copy-date {
+    background-image: data-uri('../images/icons/down.png');
+}


### PR DESCRIPTION
# Problem

MBS-10926: Add "paste date" button in relationship editor dialogs

# Solution
Minimal solution to keep the UI simple:
 * only the copy begin → end behavior
 * only on the relationship editor

The userscript still exists for more complex behavior.
I guess this part will be converted to React later, so it might be easy to apply somewhere else.

# Checklist for author
Looks ready to me