### PR TITLE
MBS-10927: Check whether entity existed before setting allowNew

### DIFF
--- a/root/edit/details/AddRelationship.js
+++ b/root/edit/details/AddRelationship.js
@@ -36,7 +36,13 @@ const AddRelationship = ({edit}: Props): React.MixedElement => {
     <table className="details add-relationship">
       <tr>
         <th>{l('Relationship:')}</th>
-        <td><Relationship allowNew relationship={relationship} /></td>
+        <td>
+          <Relationship
+            allowNewEntity0={!edit.display_data.entity0?.id}
+            allowNewEntity1={!edit.display_data.entity1?.id}
+            relationship={relationship}
+          />
+        </td>
       </tr>
       {edit.display_data.relationship.linkOrder ? (
         <tr>

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -20,7 +20,8 @@ import relationshipDateText
 import DescriptiveLink from './DescriptiveLink';
 
 type Props = {
-  +allowNew?: boolean,
+  +allowNewEntity0?: boolean,
+  +allowNewEntity1?: boolean,
   +relationship: RelationshipT,
 };
 
@@ -61,7 +62,8 @@ const HistoricRelationshipContent = ({
 };
 
 const RelationshipContent = ({
-  allowNew,
+  allowNewEntity0,
+  allowNewEntity1,
   relationship,
 }: Props) => {
   const direction = relationship.direction;
@@ -84,12 +86,12 @@ const RelationshipContent = ({
     'long_link_phrase',
     false /* forGrouping */,
     <DescriptiveLink
-      allowNew={allowNew}
+      allowNew={allowNewEntity0}
       content={relationship.entity0_credit}
       entity={entity0}
     />,
     <DescriptiveLink
-      allowNew={allowNew}
+      allowNew={allowNewEntity1}
       content={relationship.entity1_credit}
       entity={entity1}
     />,
@@ -125,14 +127,25 @@ export const HistoricRelationship = ({
 );
 
 const Relationship = ({
-  allowNew,
+  allowNewEntity0,
+  allowNewEntity1,
   relationship,
 }: Props): React.MixedElement => (
   relationship.editsPending ? (
     <span className="mp mp-rel">
-      <RelationshipContent allowNew={allowNew} relationship={relationship} />
+      <RelationshipContent
+        allowNewEntity0={allowNewEntity0}
+        allowNewEntity1={allowNewEntity1}
+        relationship={relationship}
+      />
     </span>
-  ) : <RelationshipContent allowNew={allowNew} relationship={relationship} />
+  ) : (
+    <RelationshipContent
+      allowNewEntity0={allowNewEntity0}
+      allowNewEntity1={allowNewEntity1}
+      relationship={relationship}
+    />
+  )
 );
 
 export default Relationship;


### PR DESCRIPTION
### Fix MBS-10927

Add Relationship edits were always assuming allowNew should be set, but in reality this should only be set where the entity didn't ever exist (usually in previews) rather than every time the entity was missing.

While in most cases I could think of either both entities should have allowNew or neither should, I made a separate allowNew for entity0 and entity1, just in case.
