### PR TITLE
MBS-2768: Add acoustID info in the recording merge table

### DIFF
--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -19,10 +19,12 @@ import {
   defineNameColumn,
   defineSeriesNumberColumn,
   defineTextColumn,
+  acoustidColumn,
   isrcsColumn,
   ratingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
+import hydrate from '../../utility/hydrate';
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
@@ -33,6 +35,7 @@ type Props = {
   +mergeForm?: MergeFormT,
   +order?: string,
   +recordings: $ReadOnlyArray<RecordingT>,
+  +showAcoustid?: boolean,
   +showExpandedArtistCredits?: boolean,
   +showInstrumentCreditsAndRelTypes?: boolean,
   +showRatings?: boolean,
@@ -48,6 +51,7 @@ const RecordingList = ({
   order,
   recordings,
   seriesItemNumbers,
+  showAcoustid = false,
   showExpandedArtistCredits = false,
   showInstrumentCreditsAndRelTypes = false,
   showRatings = false,
@@ -97,6 +101,7 @@ const RecordingList = ({
         artistCreditColumn,
         isrcsColumn,
         ...(showRatings ? [ratingsColumn] : []),
+        ...(showAcoustid ? [acoustidColumn] : []),
         lengthColumn,
         ...(instrumentUsageColumn ? [instrumentUsageColumn] : []),
         ...(mergeForm && recordings.length > 2
@@ -113,6 +118,7 @@ const RecordingList = ({
       order,
       recordings,
       seriesItemNumbers,
+      showAcoustid,
       showExpandedArtistCredits,
       showInstrumentCreditsAndRelTypes,
       showRatings,
@@ -128,4 +134,7 @@ const RecordingList = ({
   );
 };
 
-export default RecordingList;
+export default (hydrate<Props>(
+  'div.recording-list',
+  RecordingList,
+): React.AbstractComponent<Props, void>);

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -55,6 +55,7 @@ const RecordingMerge = ({
           mergeForm={form}
           recordings={sortByEntityName(toMerge)}
           showExpandedArtistCredits
+          showAcoustid
         />
         <FieldErrors field={form.field.target} />
 

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -30,6 +30,8 @@ require('./common/sentry');
 window.ko = require('knockout');
 window.$ = window.jQuery = require('jquery');
 
+require('../../components/list/RecordingList');
+
 require('../lib/jquery.ui/ui/jquery-ui.custom');
 
 require('./common/components/Annotation');

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -503,6 +503,57 @@ export const isrcsColumn:
     accessor: 'isrcs',
   };
 
+const AcoustidCell = ({
+  value,
+}: {value: string}): React.Element<typeof React.Fragment> => {
+  const url = '//api.acoustid.org/v2/track/list_by_mbid' +
+    `?format=json&disabled=1&mbid=${value}`;
+  const [tracks, setTracks] = React.useState([]);
+  const [isLoaded, setIsLoaded] = React.useState(false);
+  React.useEffect(() => {
+    fetch(url).then(
+      resp => resp.json(),
+    ).then(data => {
+      setTracks(data.tracks);
+      setIsLoaded(true);
+    });
+  }, [url]);
+
+  return (
+    <React.Fragment>
+      {
+        isLoaded ? (
+          tracks.length ? (
+            <ul>
+              {tracks.map((track) => (
+                <li key={track.id}>
+                  <code>
+                    <a
+                      className={'external' +
+                        (track.disabled ? ' disabled-acoustid' : '')}
+                      href={`//acoustid.org/track/${track.id}`}
+                    >
+                      {track.id.slice(0, 6) + '…'}
+                    </a>
+                  </code>
+                </li>
+              ))}
+            </ul>
+          ) : null
+        ) : <p className="loading-message">{l('Loading...')}</p>
+      }
+    </React.Fragment>
+  );
+};
+
+export const acoustidColumn:
+  ColumnOptions<{+gid?: string, ...}, string> = {
+    Cell: ({cell: {value}}) => (<AcoustidCell value={value} />),
+    Header: N_l('AcoustIDs'),
+    accessor: 'gid',
+    id: 'acoustid',
+  };
+
 export const iswcsColumn:
   ColumnOptions<{
     +iswcs: $ReadOnlyArray<IswcT>,


### PR DESCRIPTION
# Problem
MBS-2768

# Solution
Use React hook to fetch the acoustIDs on the fly from the merge page.

# Checklist for author
Works on my local instance (see screenshot on MBS-2768)

# Action
As for MBS-10916 the main question is to check on a test server that the performance is good