### PR TITLE
MBS-10931: Avoid crashing on missing ID

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
@@ -216,8 +216,8 @@ sub _display_relationships {
             my $entity1_type = $_->{entity1_type};
             my $model0 = type_to_model( $_->{entity0_type} );
             my $model1 = type_to_model( $_->{entity1_type} );
-            my $entity0_id = $_->{entity0_id};
-            my $entity1_id = $_->{entity1_id};
+            my $entity0_id = $_->{entity0_id} // 0;
+            my $entity1_id = $_->{entity1_id} // 0;
             my $entity0 = $loaded->{ $model0 }{ $entity0_id } ||
                 $self->c->model($model0)->_entity_class->new(
                     id => $entity0_id,


### PR DESCRIPTION
### Fix MBS-10931

Some historic relationship edits seem to be missing the ID for some of the related entities, but we expect an ID. Rather than making the ID optional, it seems sensible to do // 0 like we already do elsewhere for similar situations.
