### PR TITLE
MBS-10930: Fix loading relationship entities for removed reltypes

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -230,6 +230,8 @@ sub build_display_data
             grep { !exists $loaded->{LinkAttributeType}{$_->{type}{id}} }
                 @{ $self->data->{attributes} // [] }
         )),
+        source_type => $type0,
+        target_type => $type1,
         entity0 => defined $entity0->id ? undef : $entity0,
         entity1 => defined $entity1->id ? undef : $entity1,
     }

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -285,7 +285,9 @@ around TO_JSON => sub {
         id              => $self->id ? $self->id + 0 : undef,
         linkOrder       => $self->link_order ? $self->link_order + 0 : 0,
         linkTypeID      => $link->type_id ? $link->type_id + 0 : undef,
+        source_type     => $self->source_type,
         target          => $self->target->TO_JSON,
+        target_type     => $self->target_type,
         verbosePhrase   => $self->verbose_phrase,
     };
 

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -70,15 +70,23 @@ const RelationshipContent = ({
   const linkType = linkedEntities.link_type[relationship.linkTypeID];
   let entity0 = relationship.entity0;
   let entity1 = relationship.entity1;
+  const type0 = linkType.type0 ||
+    (direction === 'backward'
+      ? relationship.target_type
+      : relationship.source_type);
+  const type1 = linkType.type1 ||
+    (direction === 'backward'
+      ? relationship.source_type
+      : relationship.target_type);
   if (!entity0 || !entity1) {
     if (direction === 'backward') {
       entity0 = relationship.target;
-      entity1 = linkedEntities[linkType.type1][relationship.entity1_id] ||
-        {entityType: linkType.type1, id: relationship.entity1_id};
+      entity1 = linkedEntities[type1][relationship.entity1_id] ||
+        {entityType: type1, id: relationship.entity1_id};
     } else {
       entity1 = relationship.target;
-      entity0 = linkedEntities[linkType.type0][relationship.entity0_id] ||
-        {entityType: linkType.type0, id: relationship.entity0_id};
+      entity0 = linkedEntities[type0][relationship.entity0_id] ||
+        {entityType: type0, id: relationship.entity0_id};
     }
   }
   const longPhrase = interpolate(

--- a/root/types.js
+++ b/root/types.js
@@ -855,7 +855,9 @@ declare type RelationshipT = {
   +id: number,
   +linkOrder: number,
   +linkTypeID: number,
+  +source_type: string,
   +target: CoreEntityT,
+  +target_type: string,
 };
 
 declare type ReleaseGroupSecondaryTypeT =

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Release.pm
@@ -79,6 +79,8 @@ test all => sub {
         entity1_credit => '',
         entity0_id => 9496,
         entity1_id => 4525123,
+        source_type => 'recording',
+        target_type => 'artist'
     }, "BoA performed vocals");
 
     is_deeply(


### PR DESCRIPTION
### Fix MBS-10930

Removed reltypes (such as "microblog") no longer have info on which entity types they expected as type0 and type1. Luckily, we have source_type and target_type on relationships which serve the same purpose and can be used as a replacement.

