### PR TITLE
MBS-10932: Allow linking Instagram videos to MusicBrainz recordings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,15 @@ jobs:
           NODE_ENV=test WEBPACK_MODE=development sudo -E -H -u musicbrainz carton exec -- ./script/compile_resources.sh server web-tests
           sudo -E -H -u musicbrainz ./node_modules/.bin/flow --quiet
           rm /etc/service/chrome/down && sv start chrome
-          export JUNIT_OUTPUT_FILE=junit_output/js.xml
-          sudo -E -H -u musicbrainz carton exec -- prove \
+          sudo -E -H -u musicbrainz carton exec -- perl \
               -I lib \
               t/js.t \
+              | tee >(./node_modules/.bin/tap-junit > ./junit_output/js.xml) \
+              | ./node_modules/.bin/tap-difflet
+          sudo -E -H -u musicbrainz carton exec -- node \
               t/web.js \
-              --harness=TAP::Harness::JUnit \
-              -v
+              | tee >(./node_modules/.bin/tap-junit > ./junit_output/js_web.xml) \
+              | ./node_modules/.bin/tap-difflet
           sv kill chrome
           ./docker/musicbrainz-tests/add_mbtest_alias.sh
           sudo -u postgres createdb -O musicbrainz -T musicbrainz_test -U postgres musicbrainz_test_json_dump

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1458,8 +1458,8 @@ const CLEANUPS = {
       // Ignore explore URLs since we'll block them anyway
       if (!(/^https:\/\/www\.instagram\.com\/(explore|p)\//.test(url))) {
         // Point /stories/ sections to the main user profile instead
-        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/stories\/([^\/?#]+)\/?(?:[\/?#].*)?$/, 'https://www.instagram.com/$1/');
-        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/([^\/?#]+)\/?(?:[\/?#].*)?$/, 'https://www.instagram.com/$1/');
+        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/stories\/([^\/?#]+).*$/, 'https://www.instagram.com/$1/');
+        url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/([^\/?#]+).*$/, 'https://www.instagram.com/$1/');
       }
       return url;
     },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1448,9 +1448,14 @@ const CLEANUPS = {
   },
   'instagram': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?instagram\\.com/', 'i')],
-    type: LINK_TYPES.socialnetwork,
+    type: _.defaults(
+      {},
+      LINK_TYPES.socialnetwork,
+      LINK_TYPES.streamingfree,
+    ),
     clean: function (url) {
-      // Ignore explore/photo URLs since we'll block them anyway
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/(?:p|tv)\/([^\/?#]+).*$/, 'https://www.instagram.com/p/$1/');
+      // Ignore explore URLs since we'll block them anyway
       if (!(/^https:\/\/www\.instagram\.com\/(explore|p)\//.test(url))) {
         // Point /stories/ sections to the main user profile instead
         url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?instagram\.com\/stories\/([^\/?#]+)\/?(?:[\/?#].*)?$/, 'https://www.instagram.com/$1/');
@@ -1458,9 +1463,11 @@ const CLEANUPS = {
       }
       return url;
     },
-    validate: function (url) {
+    validate: function (url, id) {
       // Block explore/photo URLs, which aren't really a social network link
-      if (/^https:\/\/www\.instagram\.com\/p\//.test(url)) {
+      if (/^https:\/\/www\.instagram\.com\/p\//.test(url) &&
+        !_.includes(LINK_TYPES.streamingfree, id)
+      ) {
         return {
           error: l(
             `Please do not link directly to images,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1687,6 +1687,13 @@ const testData = [
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'https://www.instagram.com/stories/nathanwpylestrangeplanet/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.instagram.com/nathanwpylestrangeplanet/',
+       only_valid_entity_types: [],
+  },
+  {
                      input_url: 'https://www.instagram.com/p/B3Mew-Cl2Z9/',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1694,6 +1694,20 @@ const testData = [
        only_valid_entity_types: [],
   },
   {
+                     input_url: 'https://www.instagram.com/tv/B3Mew-Cl2Z9/?igshid=ekrqbty1ix6c',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.instagram.com/p/B3Mew-Cl2Z9/',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
+                     input_url: 'https://www.instagram.com/p/B_7IG9gonk0/',
+             input_entity_type: 'release',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.instagram.com/p/B_7IG9gonk0/',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
                      input_url: 'https://www.instagram.com/explore/locations/277133756/pacha-club-ibiza/',
              input_entity_type: 'place',
     expected_relationship_type: 'socialnetwork',


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

1. In CircleCI, failed tests for JavaScript (including URLCleanup) did not show actual results (to compare to expected results).
   See [job #10360’s summary](https://app.circleci.com/pipelines/github/metabrainz/musicbrainz-server/3507/workflows/1dd22714-0b21-436c-ac93-9ccbbfb5b363/jobs/10360) and [job #10360’s steps](https://app.circleci.com/pipelines/github/metabrainz/musicbrainz-server/3507/workflows/1dd22714-0b21-436c-ac93-9ccbbfb5b363/jobs/10360/steps) for example.
2. MBS-10932:  Until then, Instagram photos were disallowed to be linked to an entity, but videos had not been even considered.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

1. Fix CircleCI config in commit https://github.com/metabrainz/musicbrainz-server/pull/1590/commits/4ab7fce77bda0832f3d364bef44dcf4f858ea154
   See [job #10370’s summary](https://app.circleci.com/pipelines/github/metabrainz/musicbrainz-server/3515/workflows/23d346bd-f090-4330-b4f7-215a177b0799/jobs/10370) and [job #10370’s steps](https://app.circleci.com/pipelines/github/metabrainz/musicbrainz-server/3515/workflows/23d346bd-f090-4330-b4f7-215a177b0799/jobs/10370/steps) for example.
2. The rest of this patch allows linking a recording to a video on Instagram.
   Since `/p/` and `/tv/` are interchangeable in Instagram URLs, and since the default format used to link to a video is `/p/` on an Instagram profile, this patch also normalizes `/tv/` URLs to `/p/` instead.