### PR TITLE
MBS-10923: Fix inconsistent ordering in find_by_collection

### DIFF
--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -191,7 +191,10 @@ sub _order_by {
         },
     });
 
-    return ($order_by, $extra_join, $also_select)
+    my $inner_order_by = $order_by
+        =~ s/ac_name/ac.name/r;
+
+    return ($order_by, $extra_join, $also_select, $inner_order_by);
 }
 
 sub can_delete {

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -647,10 +647,10 @@ sub _order_by {
 
     my $order_by = order_by($order, "date", {
         "date" => sub {
-            return "date_year, date_month, date_day, name COLLATE musicbrainz"
+            return "date_year, date_month, date_day, release.name COLLATE musicbrainz"
         },
         "name" => sub {
-            return "name COLLATE musicbrainz, date_year, date_month, date_day"
+            return "release.name COLLATE musicbrainz, date_year, date_month, date_day"
         },
         "country" => sub {
             $extra_join = "LEFT JOIN area ON release_event.country = area.id";
@@ -660,7 +660,7 @@ sub _order_by {
         "artist" => sub {
             $extra_join = "JOIN artist_credit ac ON ac.id = release.artist_credit";
             $also_select = "ac.name AS ac_name";
-            return "ac_name COLLATE musicbrainz, name COLLATE musicbrainz";
+            return "ac_name COLLATE musicbrainz, release.name COLLATE musicbrainz";
         },
         "label" => sub {
             $extra_join = "LEFT OUTER JOIN
@@ -669,7 +669,7 @@ sub _order_by {
                     GROUP BY release) rl
                 ON rl.release = release.id";
             $also_select = "rl.labels AS labels";
-            return "labels, name COLLATE musicbrainz";
+            return "labels, release.name COLLATE musicbrainz";
         },
         "catno" => sub {
             $extra_join = "LEFT OUTER JOIN
@@ -677,25 +677,25 @@ sub _order_by {
                   WHERE catalog_number IS NOT NULL GROUP BY release) rl
                 ON rl.release = release.id";
             $also_select = "catnos";
-            return "catnos, name COLLATE musicbrainz";
+            return "catnos, release.name COLLATE musicbrainz";
         },
         "format" => sub {
             $extra_join = "LEFT JOIN medium ON medium.release = release.id
                            LEFT JOIN medium_format ON medium.format = medium_format.id";
             $also_select = "medium_format.name AS medium_format_name";
-            return "medium_format_name, name COLLATE musicbrainz";
+            return "medium_format_name COLLATE musicbrainz, release.name COLLATE musicbrainz";
         },
         "tracks" => sub {
             $extra_join = "LEFT JOIN
                 (SELECT medium.release, sum(track_count) AS total_track_count
                     FROM medium
-                    GROUP BY medium.release) medium
-                ON medium.release = release.id";
+                    GROUP BY medium.release) tc
+                ON tc.release = release.id";
             $also_select = "total_track_count";
-            return "total_track_count, name COLLATE musicbrainz";
+            return "total_track_count, release.name COLLATE musicbrainz";
         },
         "barcode" => sub {
-            return "length(barcode), barcode, name COLLATE musicbrainz"
+            return "length(barcode), barcode, release.name COLLATE musicbrainz"
         },
     });
 
@@ -707,7 +707,15 @@ sub _order_by {
 
     $extra_join = "LEFT JOIN release_event ON release_event.release = release.id " . $extra_join;
 
-    return ($order_by, $extra_join, $also_select);
+    my $inner_order_by = $order_by
+        =~ s/country_name/area.name/r
+        =~ s/ac_name/ac.name/r
+        =~ s/labels/rl.labels/r
+        =~ s/catnos/rl.catnos/r
+        =~ s/medium_format_name/medium_format.name/r
+        =~ s/total_track_count/tc.total_track_count/r;
+
+    return ($order_by, $extra_join, $also_select, $inner_order_by);
 }
 
 sub _insert_hook_after_each {

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -340,7 +340,10 @@ sub _order_by {
         }
     });
 
-    return ($order_by, $extra_join, $also_select)
+    my $inner_order_by = $order_by
+        =~ s/ac_name/ac.name/r;
+
+    return ($order_by, $extra_join, $also_select, $inner_order_by);
 }
 
 sub _insert_hook_after_each {

--- a/lib/MusicBrainz/Server/Data/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Collection.pm
@@ -6,8 +6,9 @@ requires '_order_by', '_table', '_type', '_columns', '_new_from_row', 'c';
 sub find_by_collection {
     my ($self, $collection_id, $limit, $offset, $order) = @_;
 
-    my ($order_by, $extra_join, $also_select) = $self->_order_by($order);
+    my ($order_by, $extra_join, $also_select, $inner_order_by) = $self->_order_by($order);
     $extra_join //= '';
+    $inner_order_by //= $order_by;
 
     my $table = $self->_table;
     my $type = $self->_type;
@@ -22,9 +23,9 @@ sub find_by_collection {
         JOIN editor_collection_$type ec ON " . $self->_id_column . " = ec.$type
         $extra_join
         WHERE ec.collection = ?
-        ORDER BY id
+        ORDER BY id, $inner_order_by
       ) $type
-      ORDER BY $order_by";
+      ORDER BY $order_by, id";
 
     $self->query_to_list_limited($query, [$collection_id], $limit, $offset);
 }


### PR DESCRIPTION
`DISTINCT ON (release.id)` is used here because the joins create "duplicate" rows for every release. With DISTINCT ON, only the first row from each set is kept, so the ORDER BY in the inner query is important. If `$order_by` is say `date_year, date_month, date_day, name COLLATE musicbrainz`, then after sorting by id we also want it to consistently pick the row with the earliest year, then month, etc. (There will be a different row for each release event.)

In the outer query, we also want to make sure that releases that happen to have the same release date and name (or whatever the configured sort order is) are next ordered by id, otherwise the sort is undefined.

One gotcha here is that `$order_by` references column aliases that can be used in the outer query, but not the inner one. We have to return a separate `$inner_order_by` with explicit column references where needed. This is icky but I couldn't come up with anything better. One solution might be to replace all the joins with semi-joins, which would also remove the need for DISTINCT ON, but I haven't evaluated the performance of that.

It's not really feasible to write a test for this that fails consistently, since the order is going to depend on the order PG retrieves things, and that's unlikely to change in a very small test DB.