### PR TITLE
MBS-10941: Rename XML Web Service into "MusicBrainz API" 

### DIFF
--- a/admin/DumpJSON
+++ b/admin/DumpJSON
@@ -28,7 +28,7 @@ Interally, when making the requests to fetch the JSON, all inc parameters are
 included except:
 
  * Those that perform subqueries and return 25 linked entities:
-   https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries
+   https://wiki.musicbrainz.org/MusicBrainz_API#Subqueries
 
  * 'work-level-rels' on recording and release lookups.
 

--- a/admin/nginx/mbserver-rewrites.conf
+++ b/admin/nginx/mbserver-rewrites.conf
@@ -70,8 +70,8 @@ rewrite ^/about/licenses\.html$                  $mb_server/doc/About/Data_Licen
 rewrite ^/about/stats\.html$                     $mb_server/doc/Server_Statistics            permanent;
 rewrite ^/cd_submission\.html$                   $mb_server/doc/How_to_Add_Disc_IDs          permanent;
 rewrite ^/db_structure\.html$                    $mb_server/doc/MusicBrainz_Database/Schema  permanent;
-rewrite ^/development/mmd$                       $mb_server/doc/Development/XML_Web_Service  permanent;
-rewrite ^/development/mmd/(.*)$                  $mb_server/doc/Development/XML_Web_Service  permanent;
+rewrite ^/development/mmd$                       $mb_server/doc/MusicBrainz_API              permanent;
+rewrite ^/development/mmd/(.*)$                  $mb_server/doc/MusicBrainz_API              permanent;
 rewrite ^/disc\.html$                            $mb_server/doc/Disc_ID_Calculation          permanent;
 rewrite ^/documentation\.html$                   $mb_server/doc/MusicBrainz_Documentation    permanent;
 rewrite ^/download\.html$                        $mb_server/doc/Products                     permanent;
@@ -83,7 +83,7 @@ rewrite ^/list\.html$                            $mb_server/doc/Communication/Ma
 rewrite ^/mod_faq\.html$                         $mb_server/doc/Editing_FAQ                  permanent;
 rewrite ^/mod_intro\.html$                       $mb_server/doc/How_Editing_Works            permanent;
 rewrite ^/news/licenses\.html$                   $mb_server/doc/About/Data_License           permanent;
-rewrite ^/ns/mmd-2\.0$                           $mb_server/doc/Development/XML_Web_Service  permanent;
+rewrite ^/ns/mmd-2\.0$                           $mb_server/doc/MusicBrainz_API              permanent;
 rewrite ^/press\.html$                           $mb_server/doc/About/Press                  permanent;
 rewrite ^/products/libdiscid$                    $mb_server/doc/libdiscid                    permanent;
 rewrite ^/products/libmusicbrainz$               $mb_server/doc/libmusicbrainz               permanent;
@@ -258,7 +258,7 @@ rewrite ^/show/edit/conditions\.html$              $mb_server/doc/Edit_Types    
 rewrite ^/show/stats$                              $mb_server/statistics               permanent;
 
 # Rewrite for web service documentation
-rewrite ^/ws/2/?$ $mb_server/doc/XML_Web_Service/Version_2 permanent;
+rewrite ^/ws/2/?$ $mb_server/doc/MusicBrainz_API permanent;
 
 ##########
 

--- a/lib/MusicBrainz/Server/Release.pm
+++ b/lib/MusicBrainz/Server/Release.pm
@@ -27,10 +27,6 @@ use warnings;
 
 use MusicBrainz::Server::Translation qw( l ln );
 
-use constant NONALBUMTRACKS_NAME => "[non-album tracks]";
-
-use constant RELEASE_ATTR_NONALBUMTRACKS => 0;
-
 use constant RELEASE_ATTR_ALBUM          => 1;
 use constant RELEASE_ATTR_SINGLE         => 2;
 use constant RELEASE_ATTR_EP             => 3;

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -81,8 +81,6 @@ sub load_type_and_status
         lc('sa-' . $_->name)=> $_->id,
         lc('va-' . $_->name)=> $_->id,
     } @statuses;
-
-    $types{'nat'} = $types{'non-album tracks'};
 }
 
 sub validate_type

--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -122,13 +122,13 @@ const Index = ({
     <p>
       {exp.l(
         `Do you want to develop an application that uses the
-         {ws|MusicBrainz web service}? {register|Register an application}
-         to generate OAuth tokens. See our {oauth2|OAuth documentation}
-         for more details.`,
+         {mb_api_doc_url|MusicBrainz API}? 
+         {register_url|Register an application} to generate OAuth tokens.
+         See our {oauth2_doc_url|OAuth documentation} for more details.`,
         {
-          oauth2: '/doc/Development/OAuth2',
-          register: '/account/applications/register',
-          ws: '/doc/Development/XML_Web_Service/Version_2',
+          mb_api_doc_url: '/doc/MusicBrainz_API',
+          oauth2_doc_url: '/doc/Development/OAuth2',
+          register_url: '/account/applications/register',
         },
       )}
     </p>

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -108,7 +108,7 @@ const Details = ({
           <th>
             {addColon(exp.l(
               '{xml_ws_docs|XML}',
-              {xml_ws_docs: '/doc/Development/XML_Web_Service/Version_2'},
+              {xml_ws_docs: '/doc/MusicBrainz_API'},
             ))}
           </th>
           <td>
@@ -124,7 +124,7 @@ const Details = ({
           <th>
             {addColon(exp.l(
               '{json_ws_docs|JSON}',
-              {json_ws_docs: '/doc/Development/JSON_Web_Service'},
+              {json_ws_docs: '/doc/MusicBrainz_API'},
             ))}
           </th>
           <td>

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -170,7 +170,7 @@ const ProductsMenu = () => (
         <a href="/doc/Developer_Resources">{l('Developer Resources')}</a>
       </li>
       <li>
-        <a href="/doc/XML_Web_Service">{l('XML Web Service')}</a>
+        <a href="/doc/MusicBrainz_API">{l('MusicBrainz API')}</a>
       </li>
       <li>
         <a href="/doc/Live_Data_Feed">{l('Live Data Feed')}</a>


### PR DESCRIPTION
### Implement MBS-10941

We are officially unmarking the JSON API as beta, making it more visible, and moving from "web service" to "API" as a name for both XML and JSON. The documentation has already been updated, so this makes the needed changes to MBS. We won't actually rename WebService on the code, this is just an outward-facing change.
