### PR TITLE
MBS-10939, MBS-10940: Speed up Data::Release::find_by_artist for VA, allow filtering by date/country

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -12,7 +12,12 @@ use JSON::XS;
 use List::AllUtils qw( all );
 use List::MoreUtils qw( part );
 use List::UtilsBy qw( nsort_by partition_by );
-use MusicBrainz::Server::Constants qw( :quality $EDIT_RELEASE_CREATE $STATUS_APPLIED );
+use MusicBrainz::Server::Constants qw(
+    :quality
+    $EDIT_RELEASE_CREATE
+    $STATUS_APPLIED
+    $VARTIST_ID
+);
 use MusicBrainz::Server::Entity::Barcode;
 use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Release;
@@ -179,23 +184,37 @@ sub find_by_artist
     push @$conditions, "acn.artist = ?";
     push @$params, $artist_id;
 
-    my $query = "
-      SELECT *
-      FROM (
-        SELECT DISTINCT ON (release.id)
-          " . $self->_columns . ",
-          date_year, date_month, date_day, area.name AS country_name
-        FROM " . $self->_table . "
-        JOIN artist_credit_name acn ON acn.artist_credit = release.artist_credit
-        " . join(' ', @$extra_joins) . "
-        LEFT JOIN release_event ON release_event.release = release.id
-        LEFT JOIN area ON area.id = release_event.country
-        WHERE " . join(" AND ", @$conditions) . "
-        ORDER BY release.id, date_year, date_month, date_day,
-          country_name, barcode, release.name COLLATE musicbrainz
-      ) release
-      ORDER BY date_year, date_month, date_day,
-        country_name, barcode, name COLLATE musicbrainz";
+    my $query;
+    if ($artist_id == $VARTIST_ID) {
+        # MBS-10939: For VA, only order by ID. Sorting by date, country
+        # name, etc. doesn't currently scale at this level and causes
+        # load issues on our DB server.
+        $query = "
+            SELECT DISTINCT ON (release.id) " .
+            $self->_columns . " FROM " . $self->_table . "
+            JOIN artist_credit_name acn ON acn.artist_credit = release.artist_credit
+            " . join(' ', @$extra_joins) . "
+            WHERE " . join(" AND ", @$conditions) . "
+            ORDER BY release.id";
+    } else {
+        $query = "
+            SELECT *
+            FROM (
+              SELECT DISTINCT ON (release.id)
+                " . $self->_columns . ",
+                date_year, date_month, date_day, area.name AS country_name
+              FROM " . $self->_table . "
+              JOIN artist_credit_name acn ON acn.artist_credit = release.artist_credit
+              " . join(' ', @$extra_joins) . "
+              LEFT JOIN release_event ON release_event.release = release.id
+              LEFT JOIN area ON area.id = release_event.country
+              WHERE " . join(" AND ", @$conditions) . "
+              ORDER BY release.id, date_year, date_month, date_day,
+                country_name, barcode, release.name COLLATE musicbrainz
+            ) release
+            ORDER BY date_year, date_month, date_day,
+              country_name, barcode, name COLLATE musicbrainz";
+    }
     $self->query_to_list_limited($query, $params, $limit, $offset, undef, cache_hits => 1);
 }
 

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -196,7 +196,7 @@ sub find_by_artist
       ) release
       ORDER BY date_year, date_month, date_day,
         country_name, barcode, name COLLATE musicbrainz";
-    $self->query_to_list_limited($query, $params, $limit, $offset);
+    $self->query_to_list_limited($query, $params, $limit, $offset, undef, cache_hits => 1);
 }
 
 sub find_by_instrument {
@@ -276,7 +276,7 @@ sub find_by_label
       ORDER BY date_year, date_month, date_day, catalog_number,
         name COLLATE musicbrainz, country_name,
         barcode";
-    $self->query_to_list_limited($query, $params, $limit, $offset);
+    $self->query_to_list_limited($query, $params, $limit, $offset, undef, cache_hits => 1);
 }
 
 sub find_by_disc_id

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -139,6 +139,33 @@ sub _where_filter
                 push @joins, 'JOIN release_group_secondary_type_join st ON release.release_group = st.release_group';
             }
         }
+        my $country_id_filter = $filter->{country_id};
+        my $date_filter = $filter->{date};
+        if (defined $country_id_filter || defined $date_filter) {
+            my $country_date_query = 'release.id IN (SELECT release FROM release_event WHERE ';
+            my @country_date_conditions;
+            if (defined $country_id_filter) {
+                push @country_date_conditions, 'country = ?';
+                push @params, $country_id_filter;
+            }
+            if (defined $date_filter) {
+                my $date = MusicBrainz::Server::Entity::PartialDate->new($date_filter);
+                if (defined $date->year) {
+                    push @country_date_conditions, 'date_year = ?';
+                    push @params, $date->year;
+                }
+                if (defined $date->month) {
+                    push @country_date_conditions, 'date_month = ?';
+                    push @params, $date->month;
+                }
+                if (defined $date->day) {
+                    push @country_date_conditions, 'date_day = ?';
+                    push @params, $date->day;
+                }
+            }
+            $country_date_query .= (join ' AND ', @country_date_conditions) . ')';
+            push @query, $country_date_query;
+        }
     }
 
     return (\@query, \@joins, \@params);

--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -3,7 +3,11 @@ package MusicBrainz::Server::Data::Role::QueryToList;
 use strict;
 use warnings;
 
+use Digest::MD5 qw( md5 );
 use Moose::Role;
+use Readonly;
+
+Readonly my $HITS_CACHE_TIMEOUT => 60 * 30; # 30 minutes
 
 sub query_to_list {
     my ($self, $query, $args, $builder) = @_;
@@ -18,44 +22,71 @@ sub query_to_list {
 sub query_to_list_limited {
     my ($self, $query, $args, $limit, $offset, $builder, %opts) = @_;
 
-    $builder //= $self->can('_new_from_row');
-
     my @args = @$args;
-    my $count = @args;
+    my $arg_count = @args;
+
+    my $hits;
+    my $hits_cache_key;
+    if ($opts{cache_hits}) {
+        # Running count(*) over the entire query for every page is
+        # expensive, so we cache the number of hits for 30 minutes if
+        # the option is specified. The count doesn't have to be exact,
+        # just close enough that we can estimate the number of pages.
+        # In all likelihood, the number of pages isn't going to change
+        # that often for certain lists unless a large number of
+        # entities are added or removed. Other lists, like for voting
+        # on edits, are likely to change more frequently.
+        $hits_cache_key =
+            'query_to_list_limited:' .
+            md5(join "\0",
+                $query,
+                map { ref($_) eq 'ARRAY' ? (@$_) : $_ } @args);
+        $hits = $self->c->cache->get($hits_cache_key);
+    }
+
+    $builder //= $self->can('_new_from_row');
 
     if (defined $offset) {
         if ($opts{dollar_placeholders}) {
-            $query .= ' OFFSET $' . (++$count);
+            $query .= ' OFFSET $' . (++$arg_count);
         } else {
             $query .= ' OFFSET ?';
         }
         push @args, $offset;
     }
 
-    my $wrapping_query = qq{
-        WITH x AS ($query)
-        SELECT x.*, c.count AS total_row_count
-        FROM x, (SELECT count(*) from x) c
-    };
+    if (!defined $hits) {
+        $query = qq{
+            WITH x AS ($query)
+            SELECT x.*, c.count AS total_row_count
+            FROM x, (SELECT count(*) from x) c
+        };
+    }
 
     if (defined $limit) {
         if ($opts{dollar_placeholders}) {
-            $wrapping_query .= ' LIMIT $' . (++$count);
+            $query .= ' LIMIT $' . (++$arg_count);
         } else {
-            $wrapping_query .= ' LIMIT ?';
+            $query .= ' LIMIT ?';
         }
         push @args, $limit;
     }
 
-    my $hits = 0;
+    my $total_row_count;
     my @rows = map {
-        $hits = delete $_->{total_row_count};
-        $builder->($self, $_);
-    } @{$self->c->sql->select_list_of_hashes($wrapping_query, @args)};
+        my $row = $_;
+        $total_row_count = delete $row->{total_row_count};
+        $builder->($self, $row);
+    } @{$self->c->sql->select_list_of_hashes($query, @args)};
 
-    $hits += ($offset // 0);
+    if (!defined $hits) {
+        $hits = ($total_row_count // 0) + ($offset // 0);
+        if ($opts{cache_hits}) {
+            $self->c->cache->set($hits_cache_key, $hits, $HITS_CACHE_TIMEOUT);
+        }
+    }
 
-    (\@rows, $hits);
+    (\@rows, ($hits // 0));
 }
 
 no Moose::Role;

--- a/lib/MusicBrainz/Server/Entity/PartialDate.pm
+++ b/lib/MusicBrainz/Server/Entity/PartialDate.pm
@@ -39,6 +39,8 @@ around BUILDARGS => sub {
         return $class->$orig( $info );
     }
 
+    $info = {} if !ref($info); # if parsing failed
+
     my %info = map { $_ => $info->{$_} }
         grep { defined($info->{$_}) } keys %$info;
 

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -30,8 +30,9 @@ sub create_artist_releases_form {
 
     $form_args{artist_credits} =
         $c->model('Release')->find_artist_credits_by_artist($artist_id);
+    $form_args{countries} = [$c->model('CountryArea')->get_all];
 
-    return $c->form(filter_form => 'Filter::Generic', %form_args);
+    return $c->form(filter_form => 'Filter::Release', %form_args);
 }
 
 sub create_artist_recordings_form {

--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -1,0 +1,51 @@
+package MusicBrainz::Server::Form::Filter::Release;
+
+use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Data::Utils qw( non_empty );
+use MusicBrainz::Server::Translation qw( l );
+use aliased 'MusicBrainz::Server::Entity::PartialDate';
+
+extends 'MusicBrainz::Server::Form::Filter::Generic';
+
+has 'countries' => (
+    isa => 'ArrayRef[Area]',
+    is => 'ro',
+    required => 1,
+);
+
+has_field 'country_id' => (
+    type => 'Select',
+);
+
+has_field 'date' => (
+    type => 'Text',
+);
+
+sub filter_field_names {
+    return qw/ name artist_credit_id country_id date /;
+}
+
+sub options_country_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->countries }
+    ];
+}
+
+sub validate_date {
+    my ($self, $field) = @_;
+    return unless non_empty($field->value);
+    $field->push_errors(l('Must be a valid date or partial date. Examples: 2006-05-25, 1990-01, ????-01, ...'))
+        if PartialDate->new($field->value)->is_empty;
+}
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{options_country_id} = $self->options_country_id;
+    return $json;
+};
+
+1;

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -9,17 +9,21 @@
 
 import * as React from 'react';
 
+import FieldErrors from '../../../../components/FieldErrors';
 import SelectField from '../../../../components/SelectField';
 import {addColonText} from '../i18n/addColon';
 
 export type FilterFormT = $ReadOnly<{
   ...FormT<{
     +artist_credit_id: ReadOnlyFieldT<number>,
+    +country_id?: ReadOnlyFieldT<number>,
+    +date?: ReadOnlyFieldT<string>,
     +name: ReadOnlyFieldT<string>,
     +type_id?: ReadOnlyFieldT<number>,
   }>,
   entity_type: 'recording' | 'release' | 'release_group',
   options_artist_credit_id: SelectOptionsT,
+  options_country_id: SelectOptionsT,
   options_type_id?: SelectOptionsT,
 }>;
 
@@ -44,6 +48,9 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
   const typeIdOptions = form.options_type_id;
   const artistCreditIdField = form.field.artist_credit_id;
   const artistCreditIdOptions = form.options_artist_credit_id;
+  const countryIdOptions = form.options_country_id;
+  const countryIdField = form.field.country_id;
+  const dateField = form.field.date;
 
   return (
     <div id="filter">
@@ -52,7 +59,7 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
           <tbody>
             {typeIdField && typeIdOptions ? (
               <tr>
-                <td style={{whiteSpace: 'nowrap'}}>
+                <td>
                   {addColonText(l('Type'))}
                 </td>
                 <td>
@@ -68,7 +75,7 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
 
             {artistCreditIdField && artistCreditIdOptions ? (
               <tr>
-                <td style={{whiteSpace: 'nowrap'}}>
+                <td>
                   {l('Artist credit:')}
                 </td>
                 <td>
@@ -96,6 +103,43 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
                 />
               </td>
             </tr>
+
+            {countryIdField && countryIdOptions ? (
+              <tr>
+                <td>
+                  {addColonText(l('Country'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={countryIdField}
+                    options={{
+                      grouped: false,
+                      options: countryIdOptions,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+            ) : null}
+
+            {dateField ? (
+              <tr>
+                <td>
+                  {addColonText(l('Date'))}
+                </td>
+                <td>
+                  <input
+                    defaultValue={dateField.value ?? ''}
+                    name={dateField.html_name}
+                    size="47"
+                    type="text"
+                  />
+                  <FieldErrors field={dateField} />
+                </td>
+              </tr>
+            ) : null}
+
             <tr>
               <td />
               <td>

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -485,6 +485,11 @@ ul.conditions button.remove img {
     background: @very-light-bg;
     .border-radius(3px);
     padding: 0.5em;
+    ul.errors { margin-left: 0; }
+    td:first-child {
+        vertical-align: top;
+        white-space: nowrap;
+    }
 }
 
 input.icon, div.icon.img, button.icon {

--- a/t/lib/t/MusicBrainz/Server/Data/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Release.pm
@@ -556,7 +556,7 @@ $sql->commit;
 
 };
 
-test 'find_by_artist orders by release date and country' => sub {
+test 'find_by_artist orders by release date and country for non-VA, id only for VA (MBS-10939)' => sub {
     my $test = shift;
     my $c = $test->c;
 
@@ -578,7 +578,17 @@ EOSQL
     my ($releases, undef) = $c->model('Release')->find_by_artist(1, 10, 0);
     is_deeply(
         [map { $_->id } @$releases],
-        [8, 7, 1, 9, 110, 100, 2, 6]
+        [1, 2, 6, 7, 8, 9, 100, 110]
+    );
+
+    $c->sql->do(<<EOSQL);
+UPDATE release SET artist_credit = 3 WHERE artist_credit = 1;
+EOSQL
+
+    ($releases, undef) = $c->model('Release')->find_by_artist(3, 10, 0);
+    is_deeply(
+        [map { $_->id } @$releases],
+        [8, 7, 1, 9, 110, 100, 2, 6, 10]
     );
 };
 


### PR DESCRIPTION
In addition to those two tickets, I added a commit to cache the number of hits from `find_by_artist` and `find_by_label` for 30 minutes so that we don't have to run `count(*)` over the entire set of results on every page load.