### PR TITLE
MBS-10956: Load ratings everywhere we also load user ratings

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -120,6 +120,7 @@ sub artists : Chained('load')
         $c->model('Gender')->load(@$artists);
         $c->model('Area')->load(@$artists);
         $c->model('Area')->load_containment(map { $_->{area}, $_->{begin_area}, $_->{end_area} } @$artists);
+        $c->model('Artist')->load_meta(@$artists);
     if ($c->user_exists) {
         $c->model('Artist')->rating->load_user_ratings($c->user->id, @$artists);
     }
@@ -184,6 +185,7 @@ sub labels : Chained('load')
     $c->model('LabelType')->load(@$labels);
     $c->model('Area')->load(@$labels);
     $c->model('Area')->load_containment(map { $_->{area} } @$labels);
+    $c->model('Label')->load_meta(@$labels);
     if ($c->user_exists) {
         $c->model('Label')->rating->load_user_ratings($c->user->id, @$labels);
     }

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -330,6 +330,7 @@ sub works : Chained('load')
         $c->model('Work')->find_by_artist($c->stash->{artist}->id, shift, shift);
     });
     $c->model('Work')->load_related_info(@$works);
+    $c->model('Work')->load_meta(@$works);
     $c->model('Work')->rating->load_user_ratings($c->user->id, @$works) if $c->user_exists;
 
     my %props = (

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -143,6 +143,7 @@ sub show : Chained('load') PathPart('') {
         $c->model('ReleaseGroupSecondaryType')->load_for_release_groups(@$entities);
     } elsif ($entity_type eq 'event') {
         $c->model('EventType')->load(@$entities);
+        $c->model('Event')->load_meta(@$entities);
         $model->load_performers(@$entities);
         $model->load_locations(@$entities);
         if ($c->user_exists) {
@@ -155,6 +156,7 @@ sub show : Chained('load') PathPart('') {
     } elsif ($entity_type eq 'recording') {
         $c->model('ArtistCredit')->load(@$entities);
         $c->model('ISRC')->load_for_recordings(@$entities);
+        $c->model('Recording')->load_meta(@$entities);
         if ($c->user_exists) {
             $c->model('Recording')->rating->load_user_ratings($c->user->id, @$entities);
         }

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -71,6 +71,7 @@ sub show : PathPart('') Chained('load') {
     if ($series->type->item_entity_type eq 'event') {
         $c->model('Event')->load_related_info(@entities);
         $c->model('Event')->load_areas(@entities);
+        $c->model('Event')->load_meta(@entities);
         $c->model('Event')->rating->load_user_ratings($c->user->id, @entities) if $c->user_exists;
     }
 
@@ -95,6 +96,7 @@ sub show : PathPart('') Chained('load') {
 
     if ($series->type->item_entity_type eq 'work') {
         $c->model('Work')->load_related_info(@entities);
+        $c->model('Work')->load_meta(@entities);
         $c->model('Work')->rating->load_user_ratings($c->user->id, @entities) if $c->user_exists;
     }
 


### PR DESCRIPTION
### Fix MBS-10956

This is a generalization of MBS-10937. For some reason, a fair amount of places where we load user ratings are missing a load_meta call, so the average community rating is never loaded there (and the rating stars will thus remain grayed out). This adds the load_meta calls everywhere we already load user ratings for display.

