### PR TITLE
Skip looking for latest vote when not logged in

### DIFF
--- a/root/edit/edit_header.tt
+++ b/root/edit/edit_header.tt
@@ -30,7 +30,7 @@
                         [%~ END ~%]
                     </td>
                     <td class="vote-count">
-                        [%~ IF edit.latest_vote_for_editor(c.user.id) || c.user.id == edit.editor_id || !edit.is_open ~%]
+                        [%~ IF c.user.id && edit.latest_vote_for_editor(c.user.id) || c.user.id == edit.editor_id || !edit.is_open ~%]
                             <div>
                                 [%~ IF !c.user_exists ~%]
                                     <strong>[%- add_colon(l('Vote tally')) _ ' ' -%]</strong>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Each search for edits was filling logs with one hundred of:

    [warning] GET …/search/edits?… caused a warning:
    Argument "" isn't numeric in numeric eq (==)
    at lib/MusicBrainz/Server/Edit.pm line 144.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch prevents calling this subroutine for not logged in users.