### PR TITLE
MBS-10990: Limit edit displays to 50 edits per page 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -23,6 +23,10 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name => 'edit',
 };
 
+__PACKAGE__->config(
+    paging_limit => 50,
+);
+
 =head1 NAME
 
 MusicBrainz::Server::Controller::Moderation - handle user interaction

--- a/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditListing.pm
@@ -61,7 +61,7 @@ sub _list {
 
     my $type   = model_to_type( $self->{model} );
     my $entity = $c->stash->{ $self->{entity_name} };
-    my $edits  = $self->_load_paged($c, $find->($type, $entity));
+    my $edits  = $self->_load_paged($c, $find->($type, $entity), limit => 50);
 
     $c->stash(
         edits => $edits, # stash early in case an ISE occurs

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -34,8 +34,6 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'Editor'
 };
 
-use Try::Tiny;
-
 =head1 NAME
 
 MusicBrainz::Server::Controller::User - Catalyst Controller to handle

--- a/lib/MusicBrainz/Server/Controller/User/Edits.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Edits.pm
@@ -6,6 +6,10 @@ BEGIN { extends 'MusicBrainz::Server::Controller' };
 use MusicBrainz::Server::Data::Utils qw( load_everything_for_edits );
 use MusicBrainz::Server::Constants ':edit_status';
 
+__PACKAGE__->config(
+    paging_limit => 50,
+);
+
 sub _edits {
     my ($self, $c, $loader) = @_;
 


### PR DESCRIPTION
### Implement MBS-10990

MBS-8412 standardised all lists to 100 items, including edit lists (which used to be 25 items, except for the EditListing role, which didn't set a limit so it used the standard 100 item limit).

Some users were overwhelmed by 100 edits everywhere, so this sets all edit lists to 50 items per list, including in EditListing.
