### PR TITLE
Function to generate Flow types from edit data

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -156,6 +156,33 @@ done with the following command:
 
     $ prove -l t/js.t
 
+### Flow
+
+Our JavaScript uses [Flow](https://flow.org/) for static type checking.
+If you're adding a new JS file, it should have a `@flow strict-local`
+header at the top to enable type checking.
+
+To ensure all types are correct after making a change, run Flow:
+
+    $ ./node_modules/.bin/flow
+
+Global type declarations available to all files are found in
+[root/types.js](root/types.js) and [root/vars.js](root/vars.js).
+The latter is for functions and variables that are auto-imported by
+Webpack's [ProvidePlugin](webpack/providePluginConfig.js).
+
+We have a couple of scripts you may find useful that generate Flow object
+types based on JSON data:
+
+ * `./script/generate_edit_data_flow_type.js --edit-type $EDIT_TYPE_ID`
+   will generate an object type to represent the edit data of `$EDIT_TYPE_ID`.
+   However, this requires having a `PROD_STANDBY` database configured in
+   DBDefs.pm, as it uses production data to ensure a correct type.
+
+ * `cat $JSON | ./script/generate_json_flow_type.js` will generate an object
+   type for a stream of JSON objects (which each must be on a single line).
+   Passing a single object is fine, too.
+
 ### Selenium
 
 We have a set of browser-automated UI tests running with Selenium WebDriver.

--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1445,4 +1445,39 @@ CREATE OR REPLACE FUNCTION mb_simple_tsvector(input text) RETURNS tsvector AS $$
   SELECT to_tsvector('musicbrainz.mb_simple', musicbrainz.mb_lower(input));
 $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 
+-----------------------------------------------------------------------
+-- Edit data helpers
+-----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION edit_data_type_info(data JSONB) RETURNS TEXT AS $$
+BEGIN
+    CASE jsonb_typeof(data)
+    WHEN 'object' THEN
+        RETURN '{' ||
+            (SELECT string_agg(
+                to_json(key) || ':' ||
+                edit_data_type_info(jsonb_extract_path(data, key)),
+                ',' ORDER BY key)
+               FROM jsonb_object_keys(data) AS key) ||
+            '}';
+    WHEN 'array' THEN
+        RETURN '[' ||
+            (SELECT string_agg(
+                DISTINCT edit_data_type_info(item),
+                ',' ORDER BY edit_data_type_info(item))
+               FROM jsonb_array_elements(data) AS item) ||
+            ']';
+    WHEN 'string' THEN
+        RETURN '1';
+    WHEN 'number' THEN
+        RETURN '2';
+    WHEN 'boolean' THEN
+        RETURN '4';
+    WHEN 'null' THEN
+        RETURN '8';
+    END CASE;
+    RETURN '';
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE STRICT;
+
 -- vi: set ts=4 sw=4 et :

--- a/flow-typed/npm/pg-cursor_v2.x.x.js
+++ b/flow-typed/npm/pg-cursor_v2.x.x.js
@@ -1,0 +1,37 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable flowtype/sort-keys */
+
+declare module 'pg-cursor' {
+  import type {PgResultSet, Submittable} from 'pg';
+
+  declare type CursorQueryConfig = {
+    +rowMode?: 'array',
+  };
+
+  declare class Cursor<+R> implements Submittable {
+    constructor(
+      text: string,
+      values: $ReadOnlyArray<mixed>,
+      config?: CursorQueryConfig,
+    ): void,
+    read(
+      rowCount: number,
+      callback: (Error, Array<R>, PgResultSet<R>) => void,
+    ): void,
+    close((Error) => void): void,
+    // shim for pg.Result class
+    _result: {
+      parseRow: ($ReadOnlyArray<string>) => R | null,
+    },
+  }
+
+  declare module.exports: typeof Cursor;
+}

--- a/flow-typed/npm/pg_v8.x.x.js
+++ b/flow-typed/npm/pg_v8.x.x.js
@@ -1,0 +1,80 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable flowtype/sort-keys */
+
+declare module 'pg' {
+  declare export type ClientConfig = {
+    +user?: string,
+    +database?: string,
+    +password?: string,
+    +port?: number,
+    +host?: string,
+  };
+
+  declare export type QueryConfig<+V = mixed> = {
+    +name?: string,
+    +text: string,
+    +values?: $ReadOnlyArray<mixed>,
+  };
+
+  declare export type PgResultSet<Row> = {
+    +rowCount: number,
+    +rows: Array<Row>,
+  };
+
+  declare interface Submittable {
+    submit: (Connection) => void,
+  }
+
+  declare class Client {
+    constructor(config?: string | ClientConfig): void,
+    connect(): Promise<empty>,
+    end(): Promise<empty>,
+    escapeIdentifier(string): string,
+    escapeLiteral(string): string,
+    query<R, +V = mixed>(
+      config: string | QueryConfig<V>,
+      values?: $ReadOnlyArray<V>,
+    ): Promise<PgResultSet<R>>,
+    query<R, +V = mixed>(
+      config: string | QueryConfig<V>,
+      values: ?$ReadOnlyArray<V>,
+      callback: (?Error, ?PgResultSet<R>) => void,
+    ): void,
+    query<R, +V = mixed>(
+      config: string | QueryConfig<V>,
+      callback: (?Error, ?PgResultSet<R>) => void,
+    ): void,
+    query<Q: Submittable, +V = mixed>(
+      config: Q,
+      values?: $ReadOnlyArray<V>,
+    ): Q,
+  }
+
+  declare class Connection {}
+
+  declare class Query<R, +V = mixed> implements Submittable {
+    constructor(
+      config: string | QueryConfig<V>,
+      values?: $ReadOnlyArray<V>,
+      callback?: (?Error, ?PgResultSet<R>) => void,
+    ): void,
+    submit: (Connection) => void,
+    // shim for pg.Result class
+    _result: {
+      parseRow: ($ReadOnlyArray<string>) => R | null,
+    },
+  }
+
+  declare module.exports: {
+    Client: typeof Client,
+    Query: typeof Query,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "less-plugin-clean-css": "1.5.1",
     "leven": "2.0.0",
     "mutate-cow": "4.0.3",
+    "pg": "8.3.3",
+    "pg-cursor": "2.3.3",
     "po2json": "0.4.1",
     "querystring": "0.2.0",
     "react": "16.13.1",

--- a/root/edit/details/RemoveRelationship.js
+++ b/root/edit/details/RemoveRelationship.js
@@ -14,6 +14,65 @@ import Relationship
 
 type RemoveRelationshipEditT = {
   ...EditT,
+  +data: {
+    +edit_version?: number,
+    +relationship: {
+      +entity0: {
+        +gid?: string,
+        +id: number,
+        +name: string,
+      },
+      +entity0_credit?: string,
+      +entity1: {
+        +gid?: string,
+        +id: number,
+        +name: string,
+      },
+      +entity1_credit?: string,
+      +extra_phrase_attributes?: string,
+      +id: number,
+      +link: {
+        +attributes?: $ReadOnlyArray<{
+          +credited_as?: string,
+          +gid?: string,
+          +id?: string | number,
+          +name?: string,
+          +root_gid?: string,
+          +root_id?: string | number,
+          +root_name?: string,
+          +text_value?: string,
+          +type?: {
+            +gid: string,
+            +id: string | number,
+            +name: string,
+            +root: {
+              +gid: string,
+              +id: string | number,
+              +name: string,
+            },
+          },
+        }>,
+        +begin_date: {
+          +day: number | null,
+          +month: number | null,
+          +year: string | number | null,
+        },
+        +end_date: {
+          +day: number | null,
+          +month: number | null,
+          +year: string | number | null,
+        },
+        +ended?: string,
+        +type: {
+          +entity0_type: string,
+          +entity1_type: string,
+          +id?: string | number,
+          +long_link_phrase?: string,
+        },
+      },
+      +phrase?: string,
+    },
+  },
   +display_data: {
     +relationship: RelationshipT,
   },

--- a/root/static/scripts/common/DBDefs.js.flow
+++ b/root/static/scripts/common/DBDefs.js.flow
@@ -3,6 +3,15 @@ declare module.exports: {
   +BETA_REDIRECT_HOSTNAME: string,
   +CANONICAL_SERVER: string,
   +CRITIQUEBRAINZ_SERVER: string,
+  +DATABASES: {
+    +[name: string]: {
+      +database: string,
+      +host: string,
+      +password: string,
+      +port: number,
+      +user: string,
+    },
+  },
   +DB_READ_ONLY: boolean,
   +DB_STAGING_SERVER: boolean,
   +DB_STAGING_SERVER_DESCRIPTION: string,

--- a/root/utility/generateFlowType.js
+++ b/root/utility/generateFlowType.js
@@ -1,0 +1,176 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable multiline-comment-style */
+/* eslint-disable import/no-commonjs */
+
+const crypto = require('crypto');
+
+const TYPE_STRING = 1;
+const TYPE_NUMBER = 2;
+const TYPE_BOOLEAN = 4;
+const TYPE_NULL = 8;
+
+class TypeInfo {
+/*::
+  +isEditDataTypeInfo: boolean;
+  array: TypeInfo | null;
+  count: number;
+  object: {
+    __proto__: null,
+    [property: string]: TypeInfo,
+  } | null;
+  primitive: number;
+*/
+
+  constructor(parent, isEditDataTypeInfo) {
+    this.array = null;
+    this.count = 0;
+    this.object = null;
+    this.isEditDataTypeInfo =
+      (isEditDataTypeInfo == null
+        ? parent.isEditDataTypeInfo
+        : isEditDataTypeInfo);
+    this.primitive = 0;
+  }
+
+  printTypeInfo(indentation) {
+    const types = [];
+    if ((this.primitive & TYPE_STRING) === TYPE_STRING) {
+      types.push('string');
+    }
+    if ((this.primitive & TYPE_NUMBER) === TYPE_NUMBER) {
+      types.push('number');
+    }
+    if ((this.primitive & TYPE_BOOLEAN) === TYPE_BOOLEAN) {
+      types.push('boolean');
+    }
+    if ((this.primitive & TYPE_NULL) === TYPE_NULL) {
+      types.push('null');
+    }
+    if (this.array) {
+      types.push(
+        '$ReadOnlyArray<' +
+        this.array.printTypeInfo(indentation) +
+        '>',
+      );
+    }
+    const objectKeyInfo = this.object;
+    if (objectKeyInfo) {
+      let typeRepr = '{\n';
+      const keys = Object.keys(objectKeyInfo).sort();
+      const nextIndentation = indentation + '  ';
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const keyTypeInfo = objectKeyInfo[key];
+        typeRepr += nextIndentation + '+' +
+          key + (keyTypeInfo.count < this.count ? '?' : '') + ': ' +
+          keyTypeInfo.printTypeInfo(nextIndentation) +
+          ',\n';
+      }
+      typeRepr += indentation + '}';
+      types.push(typeRepr);
+    }
+    return types.join(' | ');
+  }
+
+  processTypes(data) {
+    this.count++;
+    if (this.isEditDataTypeInfo && data == null) {
+      throw new Error('data should not be null');
+    }
+    switch (typeof data) {
+      case 'boolean':
+        if (this.isEditDataTypeInfo) {
+          throw new Error('Unexpected boolean value');
+        } else {
+          this.primitive |= TYPE_BOOLEAN;
+          return;
+        }
+      case 'number':
+        if (this.isEditDataTypeInfo) {
+          switch (data) {
+            case TYPE_BOOLEAN:
+            case TYPE_NULL:
+            case TYPE_NUMBER:
+            case TYPE_STRING:
+              this.primitive |= data;
+              return;
+            default:
+              throw new Error('Unknown data type: ' + data);
+          }
+        } else {
+          this.primitive |= TYPE_NUMBER;
+          return;
+        }
+      case 'string':
+        if (this.isEditDataTypeInfo) {
+          throw new Error('Unexpected string value');
+        } else {
+          this.primitive |= TYPE_STRING;
+          return;
+        }
+      case 'object': {
+        if (data == null) {
+          this.primitive |= TYPE_NULL;
+          return;
+        }
+        if (Array.isArray(data)) {
+          let arrayTypeInfo = this.array;
+          if (arrayTypeInfo == null) {
+            arrayTypeInfo = this.array = new TypeInfo(this);
+          }
+          for (let i = 0; i < data.length; i++) {
+            arrayTypeInfo.processTypes(data[i]);
+          }
+        } else {
+          let objectKeyInfo = this.object;
+          if (objectKeyInfo == null) {
+            objectKeyInfo = this.object = Object.create(null);
+          }
+          for (const key in data) {
+            let keyTypeInfo = objectKeyInfo[key];
+            if (keyTypeInfo == null) {
+              keyTypeInfo = objectKeyInfo[key] = new TypeInfo(this);
+            }
+            keyTypeInfo.processTypes(data[key]);
+          }
+        }
+        return;
+      }
+    }
+    throw new Error('Unknown value: ' + JSON.stringify(data));
+  }
+}
+
+exports.generateFlowType = async function (
+  objectStrings/*: AsyncIterable<string> */,
+  options/*:: ?: {
+    +isEditDataTypeInfo: boolean,
+  } */,
+)/*: Promise<string> */ {
+  const seenTypes = new Set();
+  const isEditDataTypeInfo = options && options.isEditDataTypeInfo;
+  const rootTypeInfo = new TypeInfo(
+    null,
+    isEditDataTypeInfo == null ? false : isEditDataTypeInfo,
+  );
+
+  for await (const objectString of objectStrings) {
+    const hash = crypto.createHash('md5')
+      .update(objectString)
+      .digest('hex');
+    if (!seenTypes.has(hash)) {
+      seenTypes.add(hash);
+      rootTypeInfo.processTypes(JSON.parse(objectString));
+    }
+  }
+
+  return rootTypeInfo.printTypeInfo('');
+};

--- a/script/generate_edit_data_flow_type.js
+++ b/script/generate_edit_data_flow_type.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable import/no-commonjs */
+
+const pg = require('pg');
+const Cursor = require('pg-cursor');
+const yargs = require('yargs')
+  .option('edit-type', {
+    describe: 'Specifies the edit type number to generate a Flow type for.',
+    type: 'number',
+  })
+  .required('edit-type');
+
+const DBDefs = require('../root/static/scripts/common/DBDefs');
+const {generateFlowType} = require('../root/utility/generateFlowType');
+
+(async function () {
+  const pgClient = new pg.Client(DBDefs.DATABASES.PROD_STANDBY);
+  await pgClient.connect();
+
+  class SingleColumnCursor extends Cursor/*:: <string> */ {
+    constructor(config, values, callback) {
+      super(config, values, callback);
+      this._result.parseRow = function (rowData) {
+        return rowData[0];
+      };
+    }
+  }
+
+  await pgClient.query('BEGIN');
+  await pgClient.query('SET LOCAL statement_timeout = 0');
+
+  const cursor = pgClient.query(
+    new SingleColumnCursor(
+      'SELECT DISTINCT edit_data_type_info(ed.data) ' +
+        'FROM edit_data ed ' +
+        'JOIN edit e ON e.id = ed.edit ' +
+       'WHERE e.type = $1',
+      [yargs.argv['edit-type']],
+    ),
+  );
+
+  const createIterator = () => {
+    let buffer/*: Array<string> | null */ = [];
+    let index = 0;
+    return {
+      /*:: @@asyncIterator: function () { return this; }, */
+      async next() {
+        if (buffer == null) {
+          return {done: true};
+        }
+        if (index < buffer.length) {
+          return {
+            done: false,
+            value: buffer[index++],
+          };
+        }
+        return new Promise((resolve, reject) => {
+          cursor.read(500, (err, rows) => {
+            if (err) {
+              reject(err);
+            } else if (rows.length) {
+              buffer = rows;
+              index = 0;
+              resolve({
+                done: false,
+                value: buffer[index++],
+              });
+            } else {
+              buffer = null;
+              resolve({done: true});
+            }
+          });
+        });
+      },
+    };
+  };
+
+  const objectStrings = {
+    // $FlowIssue[prop-missing]
+    [Symbol.asyncIterator]: createIterator,
+    /*:: @@asyncIterator: createIterator, */
+  };
+
+  console.log(await generateFlowType(objectStrings, {
+    isEditDataTypeInfo: true,
+  }));
+
+  await pgClient.query('ROLLBACK');
+  pgClient.end();
+}());

--- a/script/generate_json_flow_type.js
+++ b/script/generate_json_flow_type.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable import/no-commonjs */
+
+const readline = require('readline');
+
+const {generateFlowType} = require('../root/utility/generateFlowType');
+
+(async function () {
+  console.log(
+    await generateFlowType(
+      readline.createInterface({
+        input: process.stdin,
+        terminal: false,
+      }),
+      {isEditDataTypeInfo: false},
+    ),
+  );
+}());

--- a/yarn.lock
+++ b/yarn.lock
@@ -1919,6 +1919,11 @@ buffer-shims@~1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
   integrity sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=
 
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -5166,6 +5171,11 @@ package-hash@^3.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -5320,6 +5330,63 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+pg-connection-string@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.3.0.tgz#c13fcb84c298d0bfa9ba12b40dd6c23d946f55d6"
+  integrity sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==
+
+pg-cursor@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.3.3.tgz#f2ae9508f47bf6a667b9d3883466cbafcab47bf0"
+  integrity sha512-0hwZEd+gjDGgN42BFYOp2fVLyKUbk8jjDyO/PLU34W19shoh/qnCDAUzfa4+IhUGjAgN0r/xIT3pANT946zaFg==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.2.1.tgz#5f4afc0f58063659aeefa952d36af49fa28b30e0"
+  integrity sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
+
+pg-protocol@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.2.5.tgz#28a1492cde11646ff2d2d06bdee42a3ba05f126c"
+  integrity sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@8.3.3:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.3.3.tgz#0338631ca3c39b4fb425b699d494cab17f5bb7eb"
+  integrity sha512-wmUyoQM/Xzmo62wgOdQAn5tl7u+IA1ZYK7qbuppi+3E+Gj4hlUxVHjInulieWrd0SfHi/ADriTb5ILJ/lsJrSg==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.3.0"
+    pg-pool "^3.2.1"
+    pg-protocol "^1.2.5"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  integrity sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
+  dependencies:
+    split "^1.0.0"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -5397,6 +5464,28 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -6097,6 +6186,11 @@ selenium-webdriver@4.0.0-alpha.5:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
+  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
+
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -6362,6 +6456,13 @@ split@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
   integrity sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=
+  dependencies:
+    through "2"
+
+split@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
 


### PR DESCRIPTION
A SQL function, `edit_data_type_info()`, is added that generates "type info" for a single column of edit data.

A script, script/generate_edit_data_flow_type.js, is added which takes an edit type, `selects edit_data_type_info()` for every row of edit data for that type, and outputs a single merged Flow type representing the edit data overall for that type.

For example:

```sh
./script/generate_edit_data_flow_type.js --edit-type 92
```

Generates a Flow type for `EDIT_RELATIONSHIP_DELETE`.

The `PROD_STANDBY` database must be configured in DBDefs.pm to use this utility.

The underlying code used to build the Flow type may also be useful to generate Flow types for other JSON data, e.g. entities.json, so I've added script/generate_json_flow_type.js for this more general purpose too. Here's an example invoking that script:

```sh
cat entities.json | jq -c | script/generate_json_flow_type.js
```

(This expects the JSON object on a single line, so `jq -c` is used to compact the data first.)

I've committed the type generated for root/edit/details/RemoveRelationship.js as an example.

I think this will help with two things:
1. The SQL function by itself is useful to see all the different data formats an edit type has, which can make it easier to identify places we can clean up the data later.
2. The combined Flow type generated by edit_data_flow_type.js is useful for accessing the edit data safely (type-checked by Flow) in a React template. This isn't so important now, but in the future we'll likely want to move `build_display_data` etc. into JS.