### PR TITLE
MBS-10994: Convert user/message.tt to React

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -243,10 +243,13 @@ sub _check_for_confirmed_email {
 
     unless ($c->user->has_confirmed_email_address) {
         $c->stash(
-            title    => l('Send Email'),
-            message  => l('You cannot contact other users because you have not {url|verified your email address}.',
-                          {url => $c->uri_for_action('/account/resend_verification')}),
-            template => 'user/message.tt',
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Send Email'),
+                message  => l('You cannot contact other users because you have not {url|verified your email address}.',
+                            {url => $c->uri_for_action('/account/resend_verification')}),
+            },
+            current_view    => 'Node',
         );
         $c->detach;
     }
@@ -265,10 +268,13 @@ sub contact : Chained('load') RequireAuth HiddenOnSlaves CSRFToken
     my $editor = $c->stash->{user};
     unless ($editor->email) {
         $c->stash(
-            title    => l('Send Email'),
-            message  => l('The editor {name} has no email address attached to their account.',
-                         { name => $editor->name }),
-            template => 'user/message.tt',
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Send Email'),
+                message  => l('The editor {name} has no email address attached to their account.',
+                            { name => $editor->name }),
+            },
+            current_view    => 'Node',
         );
         $c->detach;
     }
@@ -276,7 +282,18 @@ sub contact : Chained('load') RequireAuth HiddenOnSlaves CSRFToken
     _check_for_confirmed_email($c);
 
     if (exists $c->req->params->{sent}) {
-        $c->stash( template => 'user/email_sent.tt' );
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Email Sent'),
+                message  => l("Your email has been successfully sent! Click {link|here} to continue to {user}'s profile.",
+                            {
+                                link => $c->uri_for_action('/user/profile', [ $editor->name ]),
+                                user => $editor->name
+                            }),
+            },
+            current_view    => 'Node',
+        );
         $c->detach;
     }
 

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -253,6 +253,7 @@ module.exports = {
   'user/PrivilegedUsers': require('../user/PrivilegedUsers'),
   'user/ReportUser': require('../user/ReportUser'),
   'user/UserCollections': require('../user/UserCollections'),
+  'user/UserMessage': require('../user/UserMessage'),
   'user/UserProfile': require('../user/UserProfile'),
   'vote/VotingIndex': require('../vote/VotingIndex'),
   'work/WorkIndex': require('../work/WorkIndex'),

--- a/root/user/UserMessage.js
+++ b/root/user/UserMessage.js
@@ -1,0 +1,29 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import StatusPage from '../components/StatusPage';
+import expand2react from '../static/scripts/common/i18n/expand2react';
+
+type Props = {
+  +message: string,
+  +title: string,
+};
+
+const UserMessage = ({
+  message,
+  title,
+}: Props): React.Element<typeof StatusPage> => (
+  <StatusPage title={title}>
+    <p>{expand2react(message)}</p>
+  </StatusPage>
+);
+
+export default UserMessage;

--- a/root/user/email_sent.tt
+++ b/root/user/email_sent.tt
@@ -1,9 +1,0 @@
-[%- WRAPPER 'layout.tt' title=l('Email Sent') full_width=1 -%]
-
-    <h1>[% l('Email Sent') %]</h1>
-
-    <p>[% l("Your email has been successfully sent! Click {link|here} to continue to {user}'s profile.",
-            { link => c.uri_for_action('/user/profile', [ user.name ]),
-              user => user.name }) %]</p>
-
-[%- END -%]

--- a/root/user/message.tt
+++ b/root/user/message.tt
@@ -1,7 +1,0 @@
-[% WRAPPER "layout.tt" full_width=1 %]
-
-    <h1>[% title %]</h1>
-
-    <p>[% message %]</p>
-
-[% END %]


### PR DESCRIPTION
### Implement MBS-10994

This reuses the existing StatusPage component, which works perfectly for the use case (but should maybe be renamed by now).

email_sent.tt was effectively the same page but with the messages defined on the TT instead of the Perl side. I moved them to the Perl side so it can also use UserMessage.
