### PR TITLE
Install bzip2 in the test-database docker image

### DIFF
--- a/docker/templates/Dockerfile.test-database.m4
+++ b/docker/templates/Dockerfile.test-database.m4
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # install_extensions.sh removes certain build dependencies that we need, so we
 # can't install everything here.
 # Note: curl is also a dependency of carton.
-RUN apt_install(`ca-certificates curl sudo')
+RUN apt_install(`bzip2 ca-certificates curl sudo')
 
 RUN cd /tmp && \
     curl -O https://raw.githubusercontent.com/metabrainz/docker-postgres/0daa45e/postgres-master/install_extensions.sh && \


### PR DESCRIPTION
This is needed for importing dumps. It was present in the postgres 9.5 base image but isn't present in the postgres 12 image.