### PR TITLE
MBS-9420: Load collection info for sidebar in sub split

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -703,6 +703,7 @@ sub stop_watching : Chained('load') RequireAuth {
 sub split : Chained('load') Edit {
     my ($self, $c) = @_;
     my $artist = $c->stash->{artist};
+    $self->_stash_collections($c);
 
     if (!can_split($artist)) {
         my %props = (


### PR DESCRIPTION
### Fix MBS-9420

Just adding 'split' to the usual after sub list doesn't work, so I just added it to the actual sub split.
