### PR TITLE
MBS-10999: Make adding first IPI/ISNI an auto-edit

### DIFF
--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1088,7 +1088,7 @@ sub determine_recording_merges {
 
             return (0, {
                 message => $RELEASE_MERGE_ERRORS{ambiguous_recording_merge},
-                args => {
+                vars => {
                     source_recording => _link_recording($source),
                     target_recordings => comma_list(map { _link_recording($_) } @{$target}),
                 },
@@ -1116,7 +1116,7 @@ sub determine_recording_merges {
             if ($new_id == $old_id) {
                 return (0, {
                     message => $RELEASE_MERGE_ERRORS{recording_merge_cycle},
-                    args => {
+                    vars => {
                         recording1 => _link_recording($old_recording),
                         recording2 => _link_recording($new_recording),
                     },

--- a/lib/MusicBrainz/Server/Data/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Data/Role/IPI.pm
@@ -21,6 +21,31 @@ role
         value_type          => 'ipi',
     };
 
+    method find_reused_ipis => sub {
+        my ($self, @ipis) = @_;
+        my $query = "SELECT 'artist' AS entity_type, artist_ipi.ipi, COUNT(*) AS count
+                    FROM artist
+                        JOIN artist_ipi ON artist.id = artist_ipi.artist
+                    WHERE artist_ipi.ipi = any(?)
+                    GROUP BY artist_ipi.ipi
+                    UNION ALL
+                    SELECT 'label' AS entity_type, label_ipi.ipi, COUNT(*) AS count
+                    FROM label
+                        JOIN label_ipi ON label.id = label_ipi.label
+                    WHERE label_ipi.ipi = any(?)
+                    GROUP BY label_ipi.ipi";
+        my $results = $self->sql->select_list_of_hashes($query, \@ipis, \@ipis);
+        my %reused_ipis;
+        for my $result (@$results) {
+            my $ipi = $result->{ipi};
+            my $entity_count = $result->{count};
+            my $entity_type = $result->{entity_type};
+            $reused_ipis{$ipi}{$entity_type} = $entity_count;
+        }
+
+        return \%reused_ipis;
+    };
+
 };
 
 no Moose::Role;

--- a/lib/MusicBrainz/Server/Data/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ISNI.pm
@@ -21,6 +21,31 @@ role
         value_type          => 'isni',
     };
 
+    method find_reused_isnis => sub {
+        my ($self, @isnis) = @_;
+        my $query = "SELECT 'artist' AS entity_type, artist_isni.isni, COUNT(*) AS count
+                    FROM artist
+                        JOIN artist_isni ON artist.id = artist_isni.artist
+                    WHERE artist_isni.isni = any(?)
+                    GROUP BY artist_isni.isni
+                    UNION ALL
+                    SELECT 'label' AS entity_type, label_isni.isni, COUNT(*) AS count
+                    FROM label
+                        JOIN label_isni ON label.id = label_isni.label
+                    WHERE label_isni.isni = any(?)
+                    GROUP BY label_isni.isni";
+        my $results = $self->sql->select_list_of_hashes($query, \@isnis, \@isnis);
+        my %reused_isnis;
+        for my $result (@$results) {
+            my $isni = $result->{isni};
+            my $entity_count = $result->{count};
+            my $entity_type = $result->{entity_type};
+            $reused_isnis{$isni}{$entity_type} = $entity_count;
+        }
+
+        return \%reused_isnis;
+    };
+
 };
 
 no Moose::Role;

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -685,12 +685,13 @@ sub datetime_to_iso8601 {
 }
 
 sub localized_note {
-    my ($message, $args) = @_;
+    my ($message, %opts) = @_;
 
     state $json = JSON::XS->new;
     'localize:' . $json->encode({
         message => $message,
-        defined $args ? (args => $args) : (),
+        version => 1,
+        %opts,
     });
 }
 

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -193,9 +193,33 @@ around allow_auto_edit => sub {
     return 0 if exists $self->data->{old}{end_area_id} &&
         defined($self->data->{old}{end_area_id}) && $self->data->{old}{end_area_id} != 0;
 
-    return 0 if $self->data->{new}{ipi_codes};
+    if (defined $self->data->{new}{ipi_codes}) {
+        # If there's already IPIs for the artist, not an autoedit
+        if (@{ $self->data->{old}{ipi_codes} // [] }) {
+            return 0;
+        }
 
-    return 0 if $self->data->{new}{isni_codes};
+        # If there's already an entity with any of the IPIs, not an autoedit
+        my $reused_ipis = $self->reused_ipis;
+
+        if (%$reused_ipis) {
+            return 0;
+        }
+    }
+        
+    if (defined $self->data->{new}{isni_codes}) {
+        # If there's already ISNIs for the artist, not an autoedit
+        if (@{ $self->data->{old}{isni_codes} // [] }) {
+            return 0;
+        }
+
+        # If there's already an entity with any of the ISNIs, not an autoedit
+        my $reused_isnis = $self->reused_isnis;
+
+        if (%$reused_isnis) {
+            return 0;
+        }
+    }
 
     return $self->$orig(@args);
 };

--- a/lib/MusicBrainz/Server/Edit/Label/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Edit.pm
@@ -171,9 +171,33 @@ around allow_auto_edit => sub {
     # Don't allow an autoedit if the area changed
     return 0 if defined $self->data->{old}{area_id};
 
-    return 0 if $self->data->{new}{ipi_codes};
+    if (defined $self->data->{new}{ipi_codes}) {
+        # If there's already IPIs for the label, not an autoedit
+        if (@{ $self->data->{old}{ipi_codes} // [] }) {
+            return 0;
+        }
 
-    return 0 if $self->data->{new}{isni_codes};
+        # If there's already an entity with any of the IPIs, not an autoedit
+        my $reused_ipis = $self->reused_ipis;
+
+        if (%$reused_ipis) {
+            return 0;
+        }
+    }
+        
+    if (defined $self->data->{new}{isni_codes}) {
+        # If there's already ISNIs for the label, not an autoedit
+        if (@{ $self->data->{old}{isni_codes} // [] }) {
+            return 0;
+        }
+
+        # If there's already an entity with any of the ISNIs, not an autoedit
+        my $reused_isnis = $self->reused_isnis;
+
+        if (%$reused_isnis) {
+            return 0;
+        }
+    }
 
     return $self->$orig(@args);
 };

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -282,8 +282,7 @@ sub accept {
                 'as an example of its relationship type in the documentation. ' .
                 'If you still think this should be removed, please ' .
                 '{contact_url|contact us}.'),
-            {contact_url => $CONTACT_URL},
-        
+            vars => {contact_url => $CONTACT_URL},
         );
         MusicBrainz::Server::Edit::Exceptions::GeneralError->throw($error);
     }

--- a/lib/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -322,10 +322,12 @@ sub do_merge
     unless ($can_merge) {
         my $error = localized_note(
             N_l('These releases could not be merged: {reason}'),
-            {reason => localized_note(
-                $cannot_merge_reason->{message},
-                $cannot_merge_reason->{args},
-            )},
+            vars => {
+                reason => localized_note(
+                    $cannot_merge_reason->{message},
+                    vars => $cannot_merge_reason->{vars},
+                ),
+            },
         );
         MusicBrainz::Server::Edit::Exceptions::GeneralError->throw($error);
     }

--- a/lib/MusicBrainz/Server/Edit/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/IPI.pm
@@ -1,6 +1,17 @@
 package MusicBrainz::Server::Edit::Role::IPI;
 use 5.10.0;
 use Moose::Role;
+use utf8;
+
+use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
+use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
+use MusicBrainz::Server::Translation qw( N_l );
+use Set::Scalar;
+
+has 'reused_ipis' => (
+    isa => 'HashRef',
+    is  => 'rw'
+);
 
 with 'MusicBrainz::Server::Edit::Role::ValueSet' => {
     prop_name => 'ipi_codes',
@@ -10,6 +21,68 @@ with 'MusicBrainz::Server::Edit::Role::ValueSet' => {
             ->ipi->find_by_entity_id($self->entity_id);
     },
     extract_value => sub { shift->ipi }
+};
+
+after initialize => sub {
+    my ($self, %opts) = @_;
+
+    my $old_ipis = $self->data->{old}{ipi_codes} // [];
+    my $new_ipis = $self->data->{new}{ipi_codes} // [];
+    my $added_ipis_set = Set::Scalar->new(@$new_ipis) - Set::Scalar->new(@$old_ipis);
+    my @added_ipis = $added_ipis_set->members;
+    $self->reused_ipis($self->c->model($self->_edit_model)->find_reused_ipis(@added_ipis));
+};
+
+after post_insert => sub {
+    my $self = shift;
+
+    for my $ipi (keys %{ $self->reused_ipis }) {
+        my $artist_dupe_count = $self->reused_ipis->{$ipi}->{artist};
+        my $label_dupe_count = $self->reused_ipis->{$ipi}->{label};
+        my $edit_note;
+
+        if ($artist_dupe_count) {
+            $edit_note = localized_note(
+                'The IPI {ipi} is already in use on {artist_count} artist. Please check {artist_search|all uses of this IPI}.',
+                function => 'ln',
+                args => ['The IPI {ipi} is already in use on {artist_count} artists. Please check {artist_search|all uses of this IPI}.', $artist_dupe_count],
+                vars => {
+                    artist_count => $artist_dupe_count,
+                    artist_search => "/search?query=ipi%3A$ipi&advanced=1&type=artist",
+                    ipi => $ipi,
+                }
+            );
+
+            $self->c->model('EditNote')->add_note(
+                $self->{id},
+                {
+                    editor_id => $EDITOR_MODBOT,
+                    text => $edit_note
+                }
+            );            
+        }
+
+        if ($label_dupe_count) {
+            $edit_note = localized_note(
+                'The IPI {ipi} is already in use on {label_count} label. Please check {label_search|all uses of this IPI}.',
+                function => 'ln',
+                args => ['The IPI {ipi} is already in use on {label_count} labels. Please check {label_search|all uses of this IPI}.', $label_dupe_count],
+                vars => {
+                    ipi => $ipi,
+                    label_search => "/search?query=ipi%3A$ipi&advanced=1&type=label",
+                    label_count => $label_dupe_count,
+                }
+            );
+
+            $self->c->model('EditNote')->add_note(
+                $self->{id},
+                {
+                    editor_id => $EDITOR_MODBOT,
+                    text => $edit_note
+                }
+            );
+        }
+    }
 };
 
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
@@ -1,6 +1,17 @@
 package MusicBrainz::Server::Edit::Role::ISNI;
 use 5.10.0;
 use Moose::Role;
+use utf8;
+
+use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
+use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
+use MusicBrainz::Server::Translation qw( N_l );
+use Set::Scalar;
+
+has 'reused_isnis' => (
+    isa => 'HashRef',
+    is  => 'rw'
+);
 
 with 'MusicBrainz::Server::Edit::Role::ValueSet' => {
     prop_name => 'isni_codes',
@@ -10,6 +21,68 @@ with 'MusicBrainz::Server::Edit::Role::ValueSet' => {
             ->isni->find_by_entity_id($self->entity_id);
     },
     extract_value => sub { shift->isni }
+};
+
+after initialize => sub {
+    my ($self, %opts) = @_;
+
+    my $old_isnis = $self->data->{old}{isni_codes} // [];
+    my $new_isnis = $self->data->{new}{isni_codes} // [];
+    my $added_isnis_set = Set::Scalar->new(@$new_isnis) - Set::Scalar->new(@$old_isnis);
+    my @added_isnis = $added_isnis_set->members;
+    $self->reused_isnis($self->c->model($self->_edit_model)->find_reused_isnis(@added_isnis));
+};
+
+after post_insert => sub {
+    my $self = shift;
+
+    for my $isni (keys %{ $self->reused_isnis }) {
+        my $artist_dupe_count = $self->reused_isnis->{$isni}->{artist};
+        my $label_dupe_count = $self->reused_isnis->{$isni}->{label};
+        my $edit_note;
+
+        if ($artist_dupe_count) {
+            $edit_note = localized_note(
+                'The ISNI {isni} is already in use on {artist_count} artist. Please check {artist_search|all uses of this ISNI}.',
+                function => 'ln',
+                args => ['The ISNI {isni} is already in use on {artist_count} artists. Please check {artist_search|all uses of this ISNI}.', $artist_dupe_count],
+                vars => {
+                    artist_count => $artist_dupe_count,
+                    artist_search => "/search?query=isni%3A$isni&advanced=1&type=artist",
+                    isni => $isni,
+                }
+            );
+
+            $self->c->model('EditNote')->add_note(
+                $self->{id},
+                {
+                    editor_id => $EDITOR_MODBOT,
+                    text => $edit_note
+                }
+            );            
+        }
+
+        if ($label_dupe_count) {
+            $edit_note = localized_note(
+                'The ISNI {isni} is already in use on {label_count} label. Please check {label_search|all uses of this ISNI}.',
+                function => 'ln',
+                args => ['The ISNI {isni} is already in use on {label_count} labels. Please check {label_search|all uses of this ISNI}.', $label_dupe_count],
+                vars => {
+                    isni => $isni,
+                    label_search => "/search?query=isni%3A$isni&advanced=1&type=label",
+                    label_count => $label_dupe_count,
+                }
+            );
+
+            $self->c->model('EditNote')->add_note(
+                $self->{id},
+                {
+                    editor_id => $EDITOR_MODBOT,
+                    text => $edit_note
+                }
+            );
+        }
+    }
 };
 
 no Moose;


### PR DESCRIPTION
### Implement MBS-10999

We generally allow auto-edits for everyone if data is being added where it didn't earlier exist. For some reason though we didn't make that check for IPIs and ISNIs. It makes sense to make the edit go into voting for cases where an IPI or ISNI already exists, but otherwise we should act in the same way as we do for other data.

We check whether an ISNI / IPI is already in use elsewhere, and block autoediting in that case. Whether the edit was otherwise autoeditable or not, ModBot will leave a note specifying that the IPI or ISNI is already in use in x artists / labels, and linking to a search to find out which (actually building the list for display on the edit turned out to be almost impossible with localized_note, so this is the best compromise I could find)