### PR TITLE
MBS-10992: Disable ended URL links

### DIFF
--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -64,13 +64,21 @@ const RelationshipTargetLinks = ({
 }: Props): React.MixedElement => {
   const target = relationship.target;
   const targetCredit = relationship.targetCredit;
+  const disableLink = relationship.earliestDatePeriod.ended &&
+                      target.entityType === 'url';
   let link;
   if (hiddenArtistCredit &&
       target.artistCredit &&
       artistCreditsAreEqual(hiddenArtistCredit, target.artistCredit)) {
     link = <EntityLink content={targetCredit} entity={target} />;
   } else {
-    link = <DescriptiveLink content={targetCredit} entity={target} />;
+    link = (
+      <DescriptiveLink
+        content={targetCredit}
+        disableLink={disableLink}
+        entity={target}
+      />
+    );
   }
   const datesAndAttributes = semicolonOnlyList(
     relationship.datedExtraAttributesList.map(displayDatedExtraAttributes),

--- a/root/components/StaticRelationshipsDisplay.js
+++ b/root/components/StaticRelationshipsDisplay.js
@@ -10,7 +10,6 @@
 import * as React from 'react';
 
 import RelationshipTargetLinks from '../components/RelationshipTargetLinks';
-import commaList from '../static/scripts/common/i18n/commaList';
 import type {
   RelationshipTargetTypeGroupT,
 } from '../utility/groupRelationships';

--- a/root/static/scripts/common/components/AreaWithContainmentLink.js
+++ b/root/static/scripts/common/components/AreaWithContainmentLink.js
@@ -21,6 +21,7 @@ type Props = {
   +allowNew?: boolean,
   +area: AreaT,
   +content?: Expand2ReactOutput,
+  +disableLink?: boolean,
   +showDisambiguation?: boolean,
   +target?: '_blank',
 };

--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -17,6 +17,7 @@ import EntityLink from './EntityLink';
 type DescriptiveLinkProps = {
   +allowNew?: boolean,
   +content?: Expand2ReactOutput,
+  +disableLink?: boolean,
   +entity: CollectionT | CoreEntityT,
   +showDeletedArtists?: boolean,
   +target?: '_blank',
@@ -25,11 +26,18 @@ type DescriptiveLinkProps = {
 const DescriptiveLink = ({
   allowNew,
   content,
+  disableLink = false,
   entity,
   showDeletedArtists = true,
   target,
 }: DescriptiveLinkProps): Expand2ReactOutput | React.Node => {
-  const props = {content, showDisambiguation: true, target, allowNew};
+  const props = {
+    allowNew,
+    content,
+    disableLink,
+    showDisambiguation: true,
+    target,
+  };
 
   if (entity.entityType === 'area' && entity.gid) {
     return <AreaWithContainmentLink area={entity} {...props} />;

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -109,6 +109,7 @@ const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
 type EntityLinkProps = {
   +allowNew?: boolean,
   +content?: ?Expand2ReactOutput,
+  +disableLink?: boolean,
   +entity: CoreEntityT | CollectionT,
   +hover?: string,
   +nameVariation?: boolean,
@@ -129,6 +130,7 @@ type EntityLinkProps = {
 const EntityLink = ({
   allowNew = false,
   content,
+  disableLink = false,
   entity,
   hover,
   nameVariation,
@@ -202,7 +204,9 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   if (hover) {
     anchorProps.title = hover;
   }
-  content = <a key="link" {...anchorProps}>{isolateText(content)}</a>;
+  content = disableLink
+    ? <span className="deleted">{isolateText(content)}</span>
+    : <a key="link" {...anchorProps}>{isolateText(content)}</a>;
 
   if (nameVariation) {
     content = (

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -96,11 +96,13 @@ const RelationshipContent = ({
     <DescriptiveLink
       allowNew={allowNewEntity0}
       content={relationship.entity0_credit}
+      disableLink={relationship.ended && entity0.entityType === 'url'}
       entity={entity0}
     />,
     <DescriptiveLink
       allowNew={allowNewEntity1}
       content={relationship.entity1_credit}
+      disableLink={relationship.ended && entity1.entityType === 'url'}
       entity={entity1}
     />,
   );

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -90,6 +90,7 @@ const RelationshipDiff = ({
   const oldSourceLink = (
     <DescriptiveLink
       content={oldRelationship.entity0_credit}
+      disableLink={oldRelationship.ended && oldSource.entityType === 'url'}
       entity={oldSource}
     />
   );
@@ -97,6 +98,7 @@ const RelationshipDiff = ({
   const newSourceLink = (
     <DescriptiveLink
       content={newRelationship.entity0_credit}
+      disableLink={newRelationship.ended && newSource.entityType === 'url'}
       entity={newSource}
     />
   );
@@ -104,6 +106,7 @@ const RelationshipDiff = ({
   const oldTargetLink = (
     <DescriptiveLink
       content={oldRelationship.entity1_credit}
+      disableLink={oldRelationship.ended && oldTarget.entityType === 'url'}
       entity={oldTarget}
     />
   );
@@ -111,6 +114,7 @@ const RelationshipDiff = ({
   const newTargetLink = (
     <DescriptiveLink
       content={newRelationship.entity1_credit}
+      disableLink={newRelationship.ended && newTarget.entityType === 'url'}
       entity={newTarget}
     />
   );


### PR DESCRIPTION
### Implement MBS-10992

If a URL relationship has an "ended" flag (e.g. an artist's homepage is gone), this displays it as just text (a "disabled link").

Especially significant in cases where the URL has been taken over by a cyber-squatter/scammer or some other disreputable site that we do not want to provide links (and possible page-rank) to.