### PR TITLE
MBS-10715 / MBS-10716: Block Amazon and Apple redirect links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -573,15 +573,18 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'amazon': {
-    match: [new RegExp(
-      '^(https?://)?' +
-      '(((?!music)[^/])+\.)?' +
-      '(amazon\\.(' + (
-        'ae|at|com\\.au|com\\.br|ca|cn|com|de|es|fr|in' +
-        '|it|jp|co\\.jp|com\\.mx|nl|se|sg|com\\.tr|co\\.uk'
-      ) + ')|amzn\\.com)',
-      'i',
-    )],
+    match: [
+      new RegExp(
+        '^(https?://)?' +
+        '(((?!music)[^/])+\.)?' +
+        '(amazon\\.(' + (
+          'ae|at|com\\.au|com\\.br|ca|cn|com|de|es|fr|in' +
+          '|it|jp|co\\.jp|com\\.mx|nl|se|sg|com\\.tr|co\\.uk'
+        ) + ')|amzn\\.com)',
+        'i',
+      ),
+      new RegExp('^(https?://)?([^/]+\\.)?amzn\\.to', 'i'),
+    ],
     restrict: [LINK_TYPES.amazon],
     clean: function (url) {
       /*
@@ -613,6 +616,24 @@ const CLEANUPS: CleanupEntries = {
       return '';
     },
     validate: function (url) {
+      if (/amzn\.to\//i.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
+
       // If you change this, please update the BadAmazonURLs report.
       return {
         result: /^https:\/\/www\.amazon\.(ae|at|com\.au|com\.br|ca|cn|com|de|es|fr|in|it|jp|co\.jp|com\.mx|nl|se|sg|com\.tr|co\.uk)\//.test(url),

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -777,7 +777,10 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'applemusic': {
-    match: [new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i')],
+    match: [
+      new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i'),
+      new RegExp('^(https?://)?([^/]+\\.)?apple\\.co/', 'i'),
+    ],
     restrict: [
       LINK_TYPES.downloadpurchase,
       LINK_TYPES.streamingpaid,
@@ -790,6 +793,24 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
+      if (/^(?:https?:\/\/)?(?:[^/]+\.)?apple\.co\//i.test(url)) {
+        return {
+          error: exp.l(
+            `This is a redirect link. Please follow {redirect_url|your link}
+             and add the link it redirects to instead.`,
+            {
+              redirect_url: {
+                href: url,
+                rel: 'noopener noreferrer',
+                target: '_blank',
+              },
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
+
       const m = /^https:\/\/music\.apple\.com\/[a-z]{2}\/([a-z-]{3,})\/[0-9]+$/.exec(url);
       if (m) {
         const prefix = m[1];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -391,6 +391,14 @@ const testData = [
             expected_clean_url: 'https://books.apple.com/us/audiobook/id1462355665',
        only_valid_entity_types: ['release'],
   },
+  // apple.co
+  {
+                     input_url: 'http://apple.co/2mXDtEs',
+             input_entity_type: 'release',
+       input_relationship_type: 'downloadpurchase',
+    expected_relationship_type: undefined,
+       only_valid_entity_types: [],
+  },
   // Apple Music
   {
                      input_url: 'http://music.apple.com/artist/hangry-angry-f/id444923726',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -313,6 +313,14 @@ const testData = [
        input_relationship_type: 'amazon',
        only_valid_entity_types: [],
   },
+  // amzn.to
+  {
+                     input_url: 'http://amzn.to/2n4b5k4',
+             input_entity_type: 'release',
+       input_relationship_type: 'amazon',
+    expected_relationship_type: undefined,
+       only_valid_entity_types: [],
+  },
   // Ameba
   {
                      input_url: 'https://ameblo.jp/murataayumi',


### PR DESCRIPTION
### Implement MBS-10715 / MBS-10716 

Sadly these can't be massaged into the real link like some other ones can, so we need to just block them and ask the user to follow the redirect.

On top of https://github.com/metabrainz/musicbrainz-server/pull/2347 for the Apple links.