### PR TITLE
MBS-11014: Add context to DuplicateViolation on rels editor

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -17,7 +17,7 @@ use MusicBrainz::Server::Data::Utils qw(
     type_to_model
 );
 use MusicBrainz::Server::Edit::Utils qw( gid_or_id );
-use MusicBrainz::Server::Translation qw( N_l );
+use MusicBrainz::Server::Translation qw( l N_l );
 
 use aliased 'MusicBrainz::Server::Entity::Link';
 use aliased 'MusicBrainz::Server::Entity::LinkType';
@@ -413,7 +413,13 @@ sub initialize
 
     if ($existent_id && $relationship->id != $existent_id) {
         MusicBrainz::Server::Edit::Exceptions::DuplicateViolation->throw(
-            'This relationship already exists.'
+            l('The “{relationship_type}” relationship between “{entity0}” and “{entity1}” already exists.',
+              {
+                entity0 => $new_entity0->name,
+                entity1 => $new_entity1->name,
+                relationship_type => MusicBrainz::Server::Translation::Relationships::l($new_link_type->name),
+              }
+            )
         );
     }
 


### PR DESCRIPTION
### Implement MBS-11014

While this will be fixed more properly in the React conversion (where the message will be shown by the affected relationship, so we can revert to the original string), in the meantime this string gives a bit more useful information than just "This relationship already exists" at the bottom of the relationship editor.

The original string, which should be re-added on the React conversion, is still in use in several other places so the translation will not be lost.