### PR TITLE
MBS-8725: Allow mediums to have an unknown tracklist

### DIFF
--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -81,6 +81,10 @@ sub load_for_mediums
         my @media = @{ $id_to_medium{$track->medium_id} };
         $_->add_track($track) for @media;
     }
+    
+    foreach my $medium (@media) {
+        $medium->has_loaded_tracks(1);
+    }
 }
 
 sub find_by_recording

--- a/lib/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -87,10 +87,12 @@ sub initialize {
     my ($self, %opts) = @_;
 
     my $tracklist = delete $opts{tracklist};
-    $tracklist = tracks_to_hash($tracklist);
-    check_track_hash($tracklist);
-    die 'Tracklist specifies track IDs'
-        if grep { defined $_ } map { $_->{id} } @$tracklist;
+    if (@$tracklist) {
+        $tracklist = tracks_to_hash($tracklist);
+        check_track_hash($tracklist);
+        die 'Tracklist specifies track IDs'
+            if grep { defined $_ } map { $_->{id} } @$tracklist;
+    }
     $opts{tracklist} = $tracklist;
 
     my $release = delete $opts{release};

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -173,7 +173,7 @@ sub initialize
             $self->_changes($entity, %opts)
         };
 
-        if ($tracklist) {
+        if ($tracklist && @$tracklist) {
             $self->c->model('Track')->load_for_mediums($entity);
             $self->c->model('ArtistCredit')->load($entity->all_tracks);
 
@@ -193,6 +193,12 @@ sub initialize
                 $data->{old}{tracklist} = $old;
                 $data->{new}{tracklist} = $new;
             }
+        } elsif ($tracklist) {
+            $self->c->model('Track')->load_for_mediums($entity);
+            $self->c->model('ArtistCredit')->load($entity->all_tracks);
+
+            $data->{old}{tracklist} = tracks_to_hash($entity->tracks);
+            $data->{new}{tracklist} = [];
         }
 
         MusicBrainz::Server::Edit::Exceptions::NoChanges->throw

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -143,6 +143,7 @@ sub initialize
     my $entity = delete $opts{to_edit};
 
     my $tracklist = delete $opts{tracklist};
+    my $delete_tracklist = delete $opts{delete_tracklist};    
     my $data;
 
     $self->check_tracks_against_format($tracklist, $opts{format_id});
@@ -193,7 +194,7 @@ sub initialize
                 $data->{old}{tracklist} = $old;
                 $data->{new}{tracklist} = $new;
             }
-        } elsif ($tracklist) {
+        } elsif ($tracklist && $delete_tracklist) {
             $self->c->model('Track')->load_for_mediums($entity);
             $self->c->model('ArtistCredit')->load($entity->all_tracks);
 

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -32,6 +32,12 @@ has 'tracks' => (
     }
 );
 
+has has_loaded_tracks => (
+    is => 'rw',
+    isa => 'Bool',
+    default => 0,
+);
+
 has 'release_id' => (
     is => 'rw',
     isa => 'Int'

--- a/root/components/medium.tt
+++ b/root/components/medium.tt
@@ -33,34 +33,40 @@
 [%~ END ~%]
 
 [%~ MACRO medium_body(medium) BLOCK ~%]
-  [% show_artists = medium.has_multiple_artists %]
-  <tbody>
-    <tr class="subh">
-      <th class="pos t">[%~ l('#') ~%]</th>
-      <th>[% l('Title') %]</th>
-      [% IF show_artists %]
-        <th>[% l('Artist') %]</th>
-      [% END %]
-      <th class="rating c">[% l('Rating') %]</th>
-      <th class="treleases">[% l('Length') %]</th>
-    </tr>
-
-    [% FOR track IN medium.audio_tracks %]
-      [% medium_track_row(track, show_artists) %]
-    [% END %]
-
-    [% IF medium.data_tracks.size %]
+  [% IF !medium.tracks.size %]
+    <tbody>
+      <td>[% l('The tracklist for this medium is unknown.') %]</td>
+    </tbody>
+  [% ELSE %]
+    [% show_artists = medium.has_multiple_artists %]
+    <tbody>
       <tr class="subh">
-        <td colspan="6">
-          [% data_track_icon %]
-          [% l('Data Tracks') %]
-        </td>
+        <th class="pos t">[%~ l('#') ~%]</th>
+        <th>[% l('Title') %]</th>
+        [% IF show_artists %]
+          <th>[% l('Artist') %]</th>
+        [% END %]
+        <th class="rating c">[% l('Rating') %]</th>
+        <th class="treleases">[% l('Length') %]</th>
       </tr>
-      [% FOR track IN medium.data_tracks %]
+
+      [% FOR track IN medium.audio_tracks %]
         [% medium_track_row(track, show_artists) %]
       [% END %]
-    [% END %]
-  </tbody>
+
+      [% IF medium.data_tracks.size %]
+        <tr class="subh">
+          <td colspan="6">
+            [% data_track_icon %]
+            [% l('Data Tracks') %]
+          </td>
+        </tr>
+        [% FOR track IN medium.data_tracks %]
+          [% medium_track_row(track, show_artists) %]
+        [% END %]
+      [% END %]
+    </tbody>
+  [% END %]
 [%~ END ~%]
 
 [%~ MACRO medium_credits(medium) BLOCK ~%]

--- a/root/edit/details/AddMedium.js
+++ b/root/edit/details/AddMedium.js
@@ -158,32 +158,36 @@ const AddMedium = ({allowNew, edit}: Props): React.MixedElement => {
         <td>
           <table className="tbl">
             <tbody>
-              <MediumTracklist
-                allowNew={allowNew}
-                showArtists
-                tracks={display.tracks}
-              />
+              {display.tracks?.length ? (
+                <MediumTracklist
+                  allowNew={allowNew}
+                  showArtists
+                  tracks={display.tracks}
+                />
+              ) : l('The tracklist for this medium is unknown.')}
             </tbody>
           </table>
         </td>
       </tr>
 
-      <tr>
-        <th>{l('Artist Credits:')}</th>
-        <td>
-          <table className="tbl">
-            <thead>
-              <tr>
-                <th className="pos">{l('#')}</th>
-                <th>{l('Artist')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <CondensedTrackACs tracks={display.tracks} />
-            </tbody>
-          </table>
-        </td>
-      </tr>
+      {display.tracks?.length ? (
+        <tr>
+          <th>{l('Artist Credits:')}</th>
+          <td>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th className="pos">{l('#')}</th>
+                  <th>{l('Artist')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <CondensedTrackACs tracks={display.tracks} />
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      ) : null}
     </table>
   );
 };

--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -16,7 +16,14 @@
       <legend data-bind="text: formattedName()"></legend>
 
       <table id="track-recording-assignation" data-bind="if: loaded">
-        <thead>
+        <tbody data-bind="if: tracks().length === 0">
+          <tr>
+            <td></td>
+            <td class="name" style="padding: 1em">[% l('The tracklist for this medium is unknown.') %]</td>
+          <tr>
+        </tbody>
+
+        <thead data-bind="if: tracks().length > 0">
           <tr>
             <th></th>
             <th colspan="2" style="text-align: left">[% l('track') %]</th>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -264,7 +264,7 @@
     <p>
       <label>
         <input type="checkbox" data-bind="checked: hasUnknownTracklist" />
-        [% l('The tracklist for this release is currently unknown.') %]
+        [% l('I have no information about this release’s media and tracklist.') %]
       </label>
     </p>
   <!-- /ko -->
@@ -369,8 +369,17 @@
     <!-- /ko -->
 
     <div data-bind="visible: loaded() && !collapsed()">
+      <!-- ko if: tracks().length === 0 -->
+      <p style="margin: 1em">
+        <label>
+          <input id="tracks-unknown" type="checkbox" data-bind="checked: tracksUnknownToUser" />
+          [% l('I don’t know the tracklist for this medium.') %]
+        </label>
+      </p>
+      <!-- /ko -->
+
       <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: needsTracks">
-        [%~ l('A tracklist is required.') ~%]
+        [%~ l('Tracks are required. If you don’t know them, but do know some info (such as the format or number of media), tick the “I don’t know the tracklist for this medium” checkbox above and enter the available info. If you have no information about this release’s media, remove all media.') ~%]
       </p>
 
       <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: needsTrackInfo">

--- a/root/release/edit_relationships.tt
+++ b/root/release/edit_relationships.tt
@@ -61,12 +61,25 @@
           <tr class="subh">
             <td></td>
             <td colspan="2">
-              <input type="checkbox" class="medium-recordings">
+              <!-- ko ifnot: tracks.length === 0 -->
+                <input type="checkbox" class="medium-recordings">
+              <!-- /ko -->
               <span data-bind="html: positionName"></span>
             </td>
-            <td><input type="checkbox" class="medium-works"></td>
+            <td>
+              <!-- ko ifnot: tracks.length === 0 -->
+                <input type="checkbox" class="medium-works">
+              <!-- /ko -->
+            </td>
           </tr>
-          <!-- ko template: {name: 'template.track', foreach: tracks} --><!-- /ko -->
+          <!-- ko if: tracks.length === 0 -->
+            <tr>
+              <td colspan="4">[% l('The tracklist for this medium is unknown.') %]</td>
+            </tr>
+          <!-- /ko -->
+          <!-- ko if: tracks.length > 0 -->
+            <!-- ko template: {name: 'template.track', foreach: tracks} --><!-- /ko -->
+          <!-- /ko -->
         </tbody>
       </table>
       <!-- /ko -->

--- a/root/release/index.tt
+++ b/root/release/index.tt
@@ -6,7 +6,7 @@
 
     [% IF release.mediums.size == 0 %]
       <p>
-        [% l('The tracklist for this release is currently unknown.') %]
+        [% l('We have no information about this release’s media and tracklist.') %]
       </p>
     [% ELSE %]
       <button type="button" id="toggle-credits" class="btn-link"></button>
@@ -22,14 +22,14 @@
                    href="[% c.uri_for_action('/release/show', [medium.release.gid]) _
                             '/disc/' _ medium.position _ '#disc' _ medium.position %]">
                   <span class="expand-triangle">
-                    [% medium.tracks.size ? '&#x25BC;' : '&#x25B6;' %]
+                    [% medium.has_loaded_tracks ? '&#x25BC;' : '&#x25B6;' %]
                   </span>
                   [% medium_description(medium) %]
                 </a>
               </th>
             </tr>
           </thead>
-          [% medium_body(medium) IF medium.tracks.size %]
+          [% medium_body(medium) IF medium.has_loaded_tracks %]
         </table>
         [% IF medium.combined_track_relationships.size; has_any_credits = 1; END %]
       [% END %]

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -206,6 +206,9 @@ releaseEditor.edits = {
 
         if (!deepEqual(newWithoutPosition, oldWithoutPosition)) {
           newWithoutPosition.to_edit = medium.id;
+          newWithoutPosition.delete_tracklist = medium.tracksUnknownToUser()
+            ? 1
+            : 0;
           edits.push(MB.edit.mediumEdit(newWithoutPosition, oldWithoutPosition));
         }
       } else {

--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -208,7 +208,7 @@ releaseEditor.edits = {
           newWithoutPosition.to_edit = medium.id;
           edits.push(MB.edit.mediumEdit(newWithoutPosition, oldWithoutPosition));
         }
-      } else if (medium.hasTracks()) {
+      } else {
         /*
          * With regards to the medium position, make sure that:
          *

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -185,16 +185,18 @@ test('mediumEdit and releaseReorderMediums edits are generated for non-loaded me
 
   t.deepEqual(releaseEditor.edits.medium(release), [
     {
+      'delete_tracklist': 0,
       'edit_type': 52,
       'format_id': 2,
-      'hash': '7e795b9d8b514ec0549c667c8da7a844d9d00835',
+      'hash': '4d8fba45c5ebf8ee7282b5ca1db761eb458cd844',
       'name': 'bar!',
       'to_edit': 456,
     },
     {
+      'delete_tracklist': 0,
       'edit_type': 52,
       'format_id': 1,
-      'hash': 'bee90ecf182e5b8f1a80b4393f2ded17c2d0109c',
+      'hash': '910c6b6397c2301324b52662b45927b443e58195',
       'name': 'foo!',
       'to_edit': 123,
     },

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
@@ -355,6 +355,60 @@ test 'release lookup with artists + aliases' => sub {
         };
 };
 
+test 'release lookup with recordings, no tracks' => sub {
+
+    MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
+
+    ws2_test_json 'release lookup with recordings, no tracks',
+    '/release/b3b7e934-445b-4c68-a097-730c6a6d47e7?inc=recordings' =>
+        {
+            id => "b3b7e934-445b-4c68-a097-730c6a6d47e7",
+            title => "Testy",
+            status => "Pseudo-Release",
+            "status-id" => "41121bb9-3413-3818-8a9a-9742318349aa",
+            quality => "normal",
+            "text-representation" => {
+                language => "jpn",
+                script => "Latn",
+            },
+            "cover-art-archive" => {
+                artwork => JSON::false,
+                count => 0,
+                front => JSON::false,
+                back => JSON::false,
+                darkened => JSON::false,
+            },
+            date => "2001-07-04",
+            country => "JP",
+            "release-events" => [{
+                date => "2001-07-04",
+                "area" => {
+                    disambiguation => '',
+                    "id" => "2db42837-c832-3c27-b4a3-08198f75693c",
+                    "name" => "Japan",
+                    "sort-name" => "Japan",
+                    "iso-3166-1-codes" => ["JP"],
+                    "type" => JSON::null,
+                    "type-id" => JSON::null,
+                },
+            }],
+            barcode => "4942463511227",
+            asin => "B00005LA6G",
+            disambiguation => "",
+            packaging => JSON::null,
+            "packaging-id" => JSON::null,
+            media => [
+                {
+                    format => 'CD',
+                    "format-id" => "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+                    title => '',
+                    position => 1,
+                    "track-count" => 0,
+                },
+            ],
+        };
+};
+
 test 'release lookup with labels and recordings' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -536,6 +536,50 @@ ws_test 'release lookup with discids and recordings',
     </release>
 </metadata>';
 
+ws_test 'release lookup, no tracks',
+    '/release/b3b7e934-445b-4c68-a097-730c6a6d47e7?inc=recordings' =>
+    '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <release id="b3b7e934-445b-4c68-a097-730c6a6d47e7">
+        <title>Testy</title>
+        <status id="41121bb9-3413-3818-8a9a-9742318349aa">Pseudo-Release</status>
+        <quality>normal</quality>
+        <text-representation>
+            <language>jpn</language>
+            <script>Latn</script>
+        </text-representation>
+        <date>2001-07-04</date>
+        <country>JP</country>
+        <release-event-list count="1">
+            <release-event>
+                <date>2001-07-04</date>
+                <area id="2db42837-c832-3c27-b4a3-08198f75693c">
+                    <name>Japan</name>
+                    <sort-name>Japan</sort-name>
+                    <iso-3166-1-code-list>
+                        <iso-3166-1-code>JP</iso-3166-1-code>
+                    </iso-3166-1-code-list>
+                </area>
+            </release-event>
+        </release-event-list>
+        <barcode>4942463511227</barcode>
+        <asin>B00005LA6G</asin>
+        <cover-art-archive>
+            <artwork>false</artwork>
+            <count>0</count>
+            <front>false</front>
+            <back>false</back>
+        </cover-art-archive>
+        <medium-list count="1">
+          <medium>
+            <position>1</position>
+            <format id="9712d52a-4509-3d4b-a1a2-67c88c643e31">CD</format>
+            <track-list count="0" />
+          </medium>
+        </medium-list>
+      </release>
+</metadata>';
+
 ws_test 'release lookup, barcode is NULL',
     '/release/fbe4eb72-0f24-3875-942e-f581589713d4' =>
     '<?xml version="1.0" encoding="UTF-8"?>

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -60,6 +60,7 @@ INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, 
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, 1998, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '22dd2db3-88ea-4428-a7a8-5cd3acf23175', 135345, NULL, 'm-flo', 'm-flo', 2, NULL, NULL);
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, NULL, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '5b85945c-c9ca-4346-a58e-7992f6c6a5b6', 180273, '2010-05-23 13:32:49.951844+00', 'SKC & Bratwa', 'SKC & Bratwa', 2, NULL, NULL);
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, NULL, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '802673f0-9b88-4e8a-bb5c-dd01d68b086f', 265420, NULL, '7人祭', '7nin Matsuri', 2, NULL, NULL);
+INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, NULL, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '802673f0-9b88-4e8a-bb5c-dd01d68b086a', 265421, NULL, 'Testy', 'Testy', 2, NULL, NULL);
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, NULL, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '97fa3f6e-557c-4227-bc0e-95a7f9f3285d', 283833, NULL, 'BAGDAD CAFE THE trench town', 'BAGDAD CAFE THE trench town', NULL, NULL, NULL);
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, 2004, 'USA electro pop', NULL, 0, NULL, NULL, NULL, '0', NULL, '6fe9f838-112e-44f1-af83-97464f08285b', 398438, '2009-09-03 07:02:56.975521+00', 'Wedlock', 'Wedlock', 2, NULL, NULL);
 INSERT INTO artist (begin_date_day, begin_date_month, begin_date_year, comment, area, edits_pending, end_date_day, end_date_month, end_date_year, ended, gender, gid, id, last_updated, name, sort_name, type, begin_area, end_area) VALUES (NULL, NULL, NULL, '', NULL, 0, NULL, NULL, NULL, '0', NULL, '05d83760-08b5-42bb-a8d7-00d80b3bf47c', 398598, NULL, 'Paul Allgood', 'Allgood, Paul', 1, NULL, NULL);
@@ -110,6 +111,7 @@ INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (1
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (135345, 1, '2011-01-18 16:24:02.551922+00', 'm-flo', 764);
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (180273, 1, '2011-01-18 16:24:02.551922+00', 'SKC & Bratwa', 13);
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (265420, 1, '2011-01-18 16:24:02.551922+00', '7人祭', 32);
+INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (265421, 1, '2011-01-18 16:24:02.551922+00', 'Testy', 32);
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (283833, 1, '2011-01-18 16:24:02.551922+00', 'BAGDAD CAFE THE trench town', 53);
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (398438, 1, '2011-01-18 16:24:02.551922+00', 'Wedlock', 175);
 INSERT INTO artist_credit (id, artist_count, created, name, ref_count) VALUES (398598, 1, '2011-01-18 16:24:02.551922+00', 'Paul Allgood', 68);
@@ -123,6 +125,7 @@ INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, positi
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (135345, 135345, '', 'm-flo', 0);
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (180273, 180273, '', 'SKC & Bratwa', 0);
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (265420, 265420, '', '7人祭', 0);
+INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (265421, 265421, '', 'Testy', 0);
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (283833, 283833, '', 'BAGDAD CAFE THE trench town', 0);
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (398438, 398438, '', 'Wedlock', 0);
 INSERT INTO artist_credit_name (artist, artist_credit, join_phrase, name, position) VALUES (398598, 398598, '', 'Paul Allgood', 0);
@@ -150,6 +153,7 @@ INSERT INTO instrument_alias (id, instrument, name, sort_name) VALUES
 -- RGs
 
 INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES (265420, '', 0, 'b84625af-6229-305f-9f1b-59c0185df016', 377462, '2009-05-24 20:47:00.490177+00', 'サマーれげぇ!レインボー', 2);
+INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES (265421, '', 0, 'b84625af-6229-305f-9f1b-59c0185df017', 377463, '2009-05-24 20:47:00.490177+00', 'Testy', 2);
 INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES (11545, '', 0, '202cad78-a2e1-3fa7-b8bc-77c1f737e3da', 155364, '2009-05-24 20:47:00.490177+00', 'For Beginner Piano', 1);
 INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES (427385, '', 0, '22b54315-6e51-350b-bb34-e6e16f7688bd', 597897, '2009-05-24 20:47:00.490177+00', 'My Demons', 1);
 INSERT INTO release_group (artist_credit, comment, edits_pending, gid, id, last_updated, name, type) VALUES (427385, '', 0, '56683a0b-45b8-3664-a231-5b68efe2e7e2', 761939, '2009-05-24 20:47:00.490177+00', 'Repercussions', 1);
@@ -455,6 +459,7 @@ INSERT INTO isrc (created, edits_pending, id, isrc, recording, source) VALUES ('
 
 INSERT INTO release (artist_credit, barcode, comment, edits_pending, gid, id, language, last_updated, name, packaging, quality, release_group, script, status) VALUES (265420, '4942463511227', '', 0, '0385f276-5f4f-4c81-a7a4-6bd7b8d85a7e', 49161, 198, NULL, 'サマーれげぇ!レインボー', NULL, -1, 377462, 85, 1);
 INSERT INTO release (artist_credit, barcode, comment, edits_pending, gid, id, language, last_updated, name, packaging, quality, release_group, script, status) VALUES (265420, '4942463511227', '', 0, 'b3b7e934-445b-4c68-a097-730c6a6d47e6', 123054, 198, NULL, 'Summer Reggae! Rainbow', NULL, -1, 377462, 28, 4);
+INSERT INTO release (artist_credit, barcode, comment, edits_pending, gid, id, language, last_updated, name, packaging, quality, release_group, script, status) VALUES (265421, '4942463511227', '', 0, 'b3b7e934-445b-4c68-a097-730c6a6d47e7', 123055, 198, NULL, 'Testy', NULL, -1, 377463, 28, 4);
 INSERT INTO release (status, release_group, edits_pending, packaging, id, quality, last_updated, script, language, name, artist_credit, barcode, comment, gid) VALUES (1, 155364, 0, NULL, 24752, -1, '2010-02-22 02:01:29.413661+00', 28, 120, 'For Beginner Piano', 11545, '5021603064126', '', '4f5a6b97-a09b-4893-80d1-eae1f3bfa221');
 INSERT INTO release (status, release_group, edits_pending, packaging, id, quality, last_updated, script, language, name, artist_credit, barcode, comment, gid) VALUES (1, 155364, 0, NULL, 243064, -1, '2010-02-22 02:01:29.413661+00', 28, 120, 'For Beginner Piano', 11545, NULL, '', 'fbe4eb72-0f24-3875-942e-f581589713d4');
 INSERT INTO release (status, release_group, edits_pending, packaging, id, quality, last_updated, script, language, name, artist_credit, barcode, comment, gid) VALUES (1, 155364, 0, NULL, 654729, -1, '2010-02-22 02:01:29.413661+00', 28, 120, 'For Beginner Piano', 11545, '', '', 'dd66bfdd-6097-32e3-91b6-67f47ba25d4c');
@@ -479,6 +484,7 @@ INSERT INTO release (status, release_group, edits_pending, packaging, id, qualit
 
 UPDATE release_meta SET amazon_asin = 'B00005LA6G', date_added = '2005-07-09 06:10:18.57297+00', info_url = 'http://www.amazon.co.jp/gp/product/B00005LA6G', cover_art_presence = 'absent', amazon_store = NULL WHERE id = 49161;
 UPDATE release_meta SET amazon_asin = 'B00005LA6G', date_added = '2006-03-18 07:45:41.990026+00', info_url = 'http://www.amazon.co.jp/gp/product/B00005LA6G', cover_art_presence = 'absent', amazon_store = NULL WHERE id = 123054;
+UPDATE release_meta SET amazon_asin = 'B00005LA6G', date_added = '2006-03-18 07:45:41.990026+00', info_url = 'http://www.amazon.co.jp/gp/product/B00005LA6G', cover_art_presence = 'absent', amazon_store = NULL WHERE id = 123055;
 UPDATE release_meta SET amazon_asin = 'B00001IVAI', date_added = '2003-10-28 13:47:22.987027+00', info_url = 'http://www.amazon.com/gp/product/B00001IVAI', cover_art_presence = 'absent', amazon_store = NULL WHERE id = 24752;
 UPDATE release_meta SET amazon_asin = 'B00001IVAI', date_added = '2003-10-28 13:47:22.987027+00', info_url = 'http://www.amazon.com/gp/product/B00001IVAI', cover_art_presence = 'absent', amazon_store = NULL WHERE id = 243064;
 UPDATE release_meta SET amazon_asin = NULL, date_added = '2003-10-28 13:47:22.987027+00', info_url = NULL, cover_art_presence = 'absent', amazon_store = NULL WHERE id = 654729;
@@ -510,6 +516,7 @@ INSERT INTO release_country (release, country, date_year, date_month, date_day) 
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (59312, 107, 2004, 1, 15);
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (59662, 107, 2004, 3, 17);
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (123054, 107, 2001, 7, 4);
+INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (123055, 107, 2001, 7, 4);
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (243064, 222, 1999, 9, 23);
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (246898, 221, 2007, 1, 29);
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (278075, 221, 1999, 6, 21);
@@ -527,6 +534,7 @@ INSERT INTO release_country (release, country, date_year, date_month, date_day) 
 
 INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 1, 49161, '2011-01-18 15:21:33.71184+00', '', 1, 49161, 3);
 INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 1, 123054, '2011-01-18 15:21:33.71184+00', '', 1, 123054, 3);
+INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 1, 123055, '2011-01-18 15:21:33.71184+00', '', 1, 123055, 0);
 INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 1, 24752, '2011-01-18 15:21:33.71184+00', '', 1, 24752, 10);
 INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 1, 243064, '2011-01-18 15:21:33.71184+00', '', 1, 243064, 10);
 INSERT INTO medium (edits_pending, format, id, last_updated, name, position, release, track_count) VALUES (0, 7, 654729, '2011-01-18 15:21:33.71184+00', '', 1, 654729, 10);


### PR DESCRIPTION
### Implement MBS-8725

This had to be reverted because I fucked up and didn't realize that the code as it was would remove the tracklist if the edit didn't actually change the tracklist at all. Now it checks that there is tracklist info in the edit opts before removing anything. 

On top of https://github.com/metabrainz/musicbrainz-server/pull/1632 to ensure that it doesn't happen again.