### PR TITLE
Update search plugin settings

### DIFF
--- a/root/static/search_plugins/firefox/musicbrainzartist-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist-old.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Artist (direct)"
  description="Direct search for an artist on MusicBrainz.org" 
- action="http://musicbrainz.org/search/oldsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search/oldsearch.html"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzartist-old.src" 
- updateIcon="http://musicbrainz.org/images/aicon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzartist-old.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/artist.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzartist-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist-old.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzartist-old.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzartist-old.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/artist.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzartist-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist-old.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="artist">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzartist-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist-old.src
@@ -4,8 +4,8 @@
 # Created:  December 2, 2004
 # by: Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="artist">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzartist.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Artist (indexed)"
  description="Indexed search for an artist on MusicBrainz.org" 
- action="http://musicbrainz.org/search/textsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzartist.src" 
- updateIcon="http://musicbrainz.org/images/aicon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzartist.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/artist.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzartist.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="artist">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzartist.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzartist.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzartist.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/artist.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzartist.src
+++ b/root/static/search_plugins/firefox/musicbrainzartist.src
@@ -4,8 +4,8 @@
 # Based upon a plugin, created by:
 # Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="artist">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzlabel-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel-old.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="label">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzlabel-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel-old.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzlabel-old.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzlabel-old.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/label.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzlabel-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel-old.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Label (direct)"
  description="Direct search for a label on MusicBrainz.org" 
- action="http://musicbrainz.org/search/oldsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search/oldsearch.html"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzlabel-old.src" 
- updateIcon="http://musicbrainz.org/images/bicon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzlabel-old.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/label.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzlabel-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel-old.src
@@ -4,8 +4,8 @@
 # Based upon a plugin, created by:
 # Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Date: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="label">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzlabel.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="label">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzlabel.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzlabel.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzlabel.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/label.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzlabel.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel.src
@@ -4,8 +4,8 @@
 # Based upon a plugin, created by:
 # Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Date: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="label">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzlabel.src
+++ b/root/static/search_plugins/firefox/musicbrainzlabel.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Label (indexed)"
  description="Indexed search for a label on MusicBrainz.org" 
- action="http://musicbrainz.org/search/textsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzlabel.src" 
- updateIcon="http://musicbrainz.org/images/bicon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzlabel.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/label.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzrelease-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease-old.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="release">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzrelease-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease-old.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzrelease-old.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzrelease-old.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/release.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzrelease-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease-old.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Release (direct)"
  description="Direct search for a release on MusicBrainz.org" 
- action="http://musicbrainz.org/search/oldsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search/oldsearch.html"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzrelease-old.src" 
- updateIcon="http://musicbrainz.org/images/licon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzrelease-old.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/release.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzrelease-old.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease-old.src
@@ -4,8 +4,8 @@
 # Created:  December 2, 2004
 # by: Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="release">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzrelease.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="release"> 
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzrelease.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Release (indexed)"
  description="Indexed search for a release on MusicBrainz.org" 
- action="http://musicbrainz.org/search/textsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainzrelease.src" 
- updateIcon="http://musicbrainz.org/images/licon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainzrelease.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/release.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainzrelease.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease.src
@@ -4,8 +4,8 @@
 # Based upon a plugin, created by:
 # Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="release"> 
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainzrelease.src
+++ b/root/static/search_plugins/firefox/musicbrainzrelease.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainzrelease.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainzrelease.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/release.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainztrack-old.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack-old.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainztrack-old.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainztrack-old.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/recording.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainztrack-old.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack-old.src
@@ -4,8 +4,8 @@
 # Created:  December 2, 2004
 # by: Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="track">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainztrack-old.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack-old.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="track">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainztrack-old.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack-old.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Track (direct)"
  description="Direct search for a track on MusicBrainz.org" 
- action="http://musicbrainz.org/search/oldsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search/oldsearch.html"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainztrack-old.src" 
- updateIcon="http://musicbrainz.org/images/ticon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainztrack-old.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/recording.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainztrack.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack.src
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="https://musicbrainz.org/search/plugins/firefox/musicbrainztrack.src" 
+ update="https://musicbrainz.org/static/search_plugins/firefox/musicbrainztrack.src" 
  updateIcon="https://musicbrainz.org/static/images/entity/recording.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/firefox/musicbrainztrack.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack.src
@@ -4,8 +4,8 @@
 # Based upon a plugin, created by:
 # Kim Plowright (www.mildlydiverting.com or kim dot plowright at gmail dot com)
 #
-# Last updated: May 8, 2007
-# by: Jan van Thiel (MusicBrainz user: zout)
+# Last updated: August 6, 2020
+# by: jesus2099
 
 <search
  version="7.1"
@@ -18,7 +18,6 @@
 <input name="query" user="">
 <input name="type" value="track">
 <input name="limit" value="25">
-<input name="handlearguments" value="1">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainztrack.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack.src
@@ -17,7 +17,6 @@
 
 <input name="query" user="">
 <input name="type" value="track">
-<input name="limit" value="25">
 
 <interpret 
  resultListStart="<table border="0" cellspacing="0" cellpadding="4" id="SearchResults">"

--- a/root/static/search_plugins/firefox/musicbrainztrack.src
+++ b/root/static/search_plugins/firefox/musicbrainztrack.src
@@ -11,8 +11,8 @@
  version="7.1"
  name="MusicBrainz: Track (indexed)"
  description="Indexed search for a track on MusicBrainz.org" 
- action="http://musicbrainz.org/search/textsearch.html"
- searchForm="http://musicbrainz.org/search.html"
+ action="https://musicbrainz.org/search"
+ searchForm="https://musicbrainz.org/search"
  method="GET" >
 
 <input name="query" user="">
@@ -27,7 +27,7 @@
 </search>
 
 <browser
- update="http://musicbrainz.org/search/plugins/firefox/musicbrainztrack.src" 
- updateIcon="http://musicbrainz.org/images/ticon.png"
+ update="https://musicbrainz.org/search/plugins/firefox/musicbrainztrack.src" 
+ updateIcon="https://musicbrainz.org/static/images/entity/recording.png"
  updateCheckDays="14"
 >

--- a/root/static/search_plugins/opensearch/musicbrainz_artist.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_artist.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Artist</ShortName>
   <Description>Indexed search for an artist on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=artist&amp;limit=25&amp;handlearguments=1&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=artist&amp;limit=25&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/artist.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_artist.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_artist.xml
@@ -4,12 +4,12 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Artist</ShortName>
   <Description>Indexed search for an artist on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=artist&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://musicbrainz.org/search?type=artist&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
-  <Image width="16" height="16">http://musicbrainz.org/static/images/entity/artist.png</Image>
+  <Image width="16" height="16">https://musicbrainz.org/static/images/entity/artist.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <moz:SearchForm>http://musicbrainz.org/search.html</moz:SearchForm>
-  <moz:UpdateUrl>http://musicbrainz.org/search/plugins/opensearch/musicbrainzartist.xml</moz:UpdateUrl>
-  <moz:IconUpdateUrl>http://musicbrainz.org/static/images/entity/artist.png</moz:IconUpdateUrl>
+  <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
+  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzartist.xml</moz:UpdateUrl>
+  <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/artist.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_artist.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_artist.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Artist</ShortName>
   <Description>Indexed search for an artist on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=artist&amp;limit=25&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=artist&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/artist.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_artist.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_artist.xml
@@ -9,7 +9,7 @@
   <Image width="16" height="16">https://musicbrainz.org/static/images/entity/artist.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
-  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzartist.xml</moz:UpdateUrl>
+  <moz:UpdateUrl>https://musicbrainz.org/static/search_plugins/opensearch/musicbrainz_artist.xml</moz:UpdateUrl>
   <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/artist.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_label.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_label.xml
@@ -9,7 +9,7 @@
   <Image width="16" height="16">https://musicbrainz.org/static/images/entity/label.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
-  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzlabel.xml</moz:UpdateUrl>
+  <moz:UpdateUrl>https://musicbrainz.org/static/search_plugins/opensearch/musicbrainz_label.xml</moz:UpdateUrl>
   <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/label.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_label.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_label.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Label</ShortName>
   <Description>Indexed search for a label on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=label&amp;limit=25&amp;handlearguments=1&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=label&amp;limit=25&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/label.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_label.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_label.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Label</ShortName>
   <Description>Indexed search for a label on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=label&amp;limit=25&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=label&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/label.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_label.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_label.xml
@@ -4,12 +4,12 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Label</ShortName>
   <Description>Indexed search for a label on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=label&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://musicbrainz.org/search?type=label&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
-  <Image width="16" height="16">http://musicbrainz.org/static/images/entity/label.png</Image>
+  <Image width="16" height="16">https://musicbrainz.org/static/images/entity/label.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <moz:SearchForm>http://musicbrainz.org/search.html</moz:SearchForm>
-  <moz:UpdateUrl>http://musicbrainz.org/search/plugins/opensearch/musicbrainzlabel.xml</moz:UpdateUrl>
-  <moz:IconUpdateUrl>http://musicbrainz.org/static/images/entity/label.png</moz:IconUpdateUrl>
+  <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
+  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzlabel.xml</moz:UpdateUrl>
+  <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/label.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_release.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_release.xml
@@ -4,12 +4,12 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Release</ShortName>
   <Description>Indexed search for a release on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=release&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://musicbrainz.org/search?type=release&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
-  <Image width="16" height="16">http://musicbrainz.org/static/images/entity/release.png</Image>
+  <Image width="16" height="16">https://musicbrainz.org/static/images/entity/release.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <moz:SearchForm>http://musicbrainz.org/search.html</moz:SearchForm>
-  <moz:UpdateUrl>http://musicbrainz.org/search/plugins/opensearch/musicbrainzrelease.xml</moz:UpdateUrl>
-  <moz:IconUpdateUrl>http://musicbrainz.org/static/images/entity/release.png</moz:IconUpdateUrl>
+  <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
+  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzrelease.xml</moz:UpdateUrl>
+  <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/release.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_release.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_release.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Release</ShortName>
   <Description>Indexed search for a release on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=release&amp;limit=25&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=release&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/release.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_release.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_release.xml
@@ -9,7 +9,7 @@
   <Image width="16" height="16">https://musicbrainz.org/static/images/entity/release.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
-  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainzrelease.xml</moz:UpdateUrl>
+  <moz:UpdateUrl>https://musicbrainz.org/static/search_plugins/opensearch/musicbrainz_release.xml</moz:UpdateUrl>
   <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/release.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_release.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_release.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Release</ShortName>
   <Description>Indexed search for a release on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=release&amp;limit=25&amp;handlearguments=1&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=release&amp;limit=25&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/release.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_track.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_track.xml
@@ -9,7 +9,7 @@
   <Image width="16" height="16">https://musicbrainz.org/static/images/entity/recording.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
-  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainztrack.xml</moz:UpdateUrl>
+  <moz:UpdateUrl>https://musicbrainz.org/static/search_plugins/opensearch/musicbrainz_track.xml</moz:UpdateUrl>
   <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/recording.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_track.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_track.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Track</ShortName>
   <Description>Indexed search for a track on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=track&amp;limit=25&amp;handlearguments=1&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=track&amp;limit=25&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/recording.png</Image>
   <InputEncoding>UTF-8</InputEncoding>

--- a/root/static/search_plugins/opensearch/musicbrainz_track.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_track.xml
@@ -4,12 +4,12 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Track</ShortName>
   <Description>Indexed search for a track on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=track&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="https://musicbrainz.org/search?type=track&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
-  <Image width="16" height="16">http://musicbrainz.org/static/images/entity/recording.png</Image>
+  <Image width="16" height="16">https://musicbrainz.org/static/images/entity/recording.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <moz:SearchForm>http://musicbrainz.org/search.html</moz:SearchForm>
-  <moz:UpdateUrl>http://musicbrainz.org/search/plugins/opensearch/musicbrainztrack.xml</moz:UpdateUrl>
-  <moz:IconUpdateUrl>http://musicbrainz.org/static/images/entity/recording.png</moz:IconUpdateUrl>
+  <moz:SearchForm>https://musicbrainz.org/search</moz:SearchForm>
+  <moz:UpdateUrl>https://musicbrainz.org/search/plugins/opensearch/musicbrainztrack.xml</moz:UpdateUrl>
+  <moz:IconUpdateUrl>https://musicbrainz.org/static/images/entity/recording.png</moz:IconUpdateUrl>
   <moz:UpdateInterval>14</moz:UpdateInterval>
 </OpenSearchDescription>

--- a/root/static/search_plugins/opensearch/musicbrainz_track.xml
+++ b/root/static/search_plugins/opensearch/musicbrainz_track.xml
@@ -4,7 +4,7 @@
   <!-- Created on Tue, 11 Sep 2007 22:47:34 GMT -->
   <ShortName>MusicBrainz: Track</ShortName>
   <Description>Indexed search for a track on MusicBrainz.org</Description>
-  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=track&amp;limit=25&amp;query={searchTerms}"/>
+  <Url type="text/html" method="get" template="http://musicbrainz.org/search/textsearch.html?type=track&amp;query={searchTerms}"/>
   <Developer>https://metabrainz.org/contact</Developer>
   <Image width="16" height="16">http://musicbrainz.org/static/images/entity/recording.png</Image>
   <InputEncoding>UTF-8</InputEncoding>


### PR DESCRIPTION
Problem
-------

Mozilla/Netscape search and OpenSearch files are outdated:

- Some icon URLs are broken
- **Their update URLs are broken**
- They are pointing to HTTP URLs (now we exclusively use HTTPS)
- They are using pre-NGS pages like search.html, textsearch.html and oldsearch.html

For the most part, it just relies on some redirects and works out well.
But I think it's cleaner to use canonical URLs.


Solution
--------

I replaced broken URLs by working URLs.
I also set canonical URLs instead of HTTP and pre-NGS URLs that were indirectly working after redirecting the user.

I am not sure that Firefox or another browser actually uses those non-standard OpenSearch `<Mox:UpdateUrl>` tags at all.
See https://developer.mozilla.org/fr/docs/Web/OpenSearch#Supporting_automatic_updates_for_OpenSearch_plugins
But having correct URLs cannot harm.


Action
------

1. I left all the detailed commits to ease the review but I'd like to eventually **squash** (?) them all in one commit.
  Apparently can be done by you who would [Squash and merge](https://github.blog/2016-04-01-squash-your-commits/) this PR, see [more details](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits).
2. It looks like my Firefox **does** use the **OpenSearch** (search_plugins/opensearch/) `.xml` files (they are provided in all MusicBrainz.org html page headers) and **not** the **Mozilla/Netscape** (search_plugins/firefox/) `.src` files.
  See https://developer.mozilla.org/fr/search?q=firefox%20search%20plugin and https://developer.mozilla.org/fr/search?q=mozilla%20netscape%20search
  Maybe we should remove the **search_plugins/firefox/** folder entirely (in another PR).