### PR TITLE
MBS-11017: Normalize IMSLP to HTTPS and add validation

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1494,6 +1494,49 @@ const CLEANUPS = {
   'imslp': {
     match: [new RegExp('^(https?://)?(www\\.)?imslp\\.org/', 'i')],
     type: {...LINK_TYPES.score, ...LINK_TYPES.imslp},
+    clean: function (url) {
+      // Standardise to https
+      return url.replace(/^https?:\/\/(?:www\.)?(.*)$/, 'https://$1');
+    },
+    validate: function (url, id) {
+      switch (id) {
+        case LINK_TYPES.imslp.artist:
+          if (/^https:\/\/imslp\.org\/wiki\/Category:/.test(url)) {
+            return {result: true};
+          }
+          return {
+            error: exp.l(
+              `Only IMSLP “{category_url_pattern}” links are allowed
+               for artists. Please link work pages to the specific
+               work in question.`,
+              {
+                category_url_pattern: (
+                  <span className="url-quote">{'Category:'}</span>
+                ),
+              },
+            ),
+            result: false,
+          };
+        case LINK_TYPES.score.work:
+          if (/^https:\/\/imslp\.org\/wiki\/(?!Category:)/.test(url)) {
+            return {result: true};
+          }
+          return {
+            error: exp.l(
+              `IMSLP “{category_url_pattern}” links are only allowed
+               for artists. Please link the specific work page to this
+               work instead, if available.`,
+              {
+                category_url_pattern: (
+                  <span className="url-quote">{'Category:'}</span>
+                ),
+              },
+            ),
+            result: false,
+          };
+      }
+      return {result: false};
+    },
   },
   'indiegogo': {
     match: [new RegExp('^(https?://)?(www\\.)?indiegogo\\.com/(individuals|projects)/', 'i')],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1684,12 +1684,14 @@ const testData = [
                      input_url: 'http://imslp.org/wiki/Category:Buxtehude%2C_Dietrich',
              input_entity_type: 'artist',
     expected_relationship_type: 'imslp',
+            expected_clean_url: 'https://imslp.org/wiki/Category:Buxtehude%2C_Dietrich',
        only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'http://imslp.org/wiki/Die_Zauberfl%C3%B6te,_K.620_(Mozart,_Wolfgang_Amadeus)',
              input_entity_type: 'work',
     expected_relationship_type: 'score',
+            expected_clean_url: 'https://imslp.org/wiki/Die_Zauberfl%C3%B6te,_K.620_(Mozart,_Wolfgang_Amadeus)',
        only_valid_entity_types: ['work'],
   },
   // Indiegogo


### PR DESCRIPTION
### Implement MBS-11017

IMSLP defaults to HTTPS, so we should clean up links to follow that.
This also adds basic validation: score links shouldn't include "Category", and artist ones should, since Category:Whatever links are their entries for a person and are never (AFAICT) used for a specific work or score.
