### PR TITLE
Drop autoselect for Apple Music

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -627,42 +627,11 @@ const CLEANUPS = {
   },
   'applemusic': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i')],
-    type: LINK_TYPES.streamingpaid,
     clean: function (url) {
       url = url.replace(/^https?:\/\/(?:geo\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
       // US page is the default, add its country-code to clarify (MBS-10623)
       url = url.replace(/^(https:\/\/music\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
       return url;
-    },
-    validate: function (url, id) {
-      const m = /^https:\/\/music\.apple\.com\/[a-z]{2}\/([a-z-]{3,})\/[0-9]+$/.exec(url);
-      if (m) {
-        const prefix = m[1];
-        switch (id) {
-          case LINK_TYPES.streamingpaid.artist:
-            if (prefix === 'artist') {
-              return {result: true};
-            }
-            return {
-              error: exp.l(
-                `Only Apple Music “{artist_url_pattern}” pages can be added
-                 directly to artists. Please link albums, videos, etc.
-                 to the appropriate release or recording instead.`,
-                {
-                  artist_url_pattern: (
-                    <span className="url-quote">{'/artist'}</span>
-                  ),
-                },
-              ),
-              result: false,
-            };
-          case LINK_TYPES.streamingpaid.recording:
-            return {result: prefix === 'music-video'};
-          case LINK_TYPES.streamingpaid.release:
-            return {result: prefix === 'album'};
-        }
-      }
-      return {result: false};
     },
   },
   'archive': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -372,24 +372,15 @@ const testData = [
   // Apple Music
   {
                      input_url: 'http://music.apple.com/artist/hangry-angry-f/id444923726',
-             input_entity_type: 'artist',
-    expected_relationship_type: 'streamingpaid',
             expected_clean_url: 'https://music.apple.com/us/artist/444923726',
-       only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'https://music.apple.com/ee/music-video/black-and-yellow/539886832?uo=4&mt=5&app=music',
-             input_entity_type: 'recording',
-    expected_relationship_type: 'streamingpaid',
             expected_clean_url: 'https://music.apple.com/ee/music-video/539886832',
-       only_valid_entity_types: ['recording'],
   },
   {
                      input_url: 'https://music.apple.com/jp/album/uchiagehanabi-single/1263790414',
-             input_entity_type: 'release',
-    expected_relationship_type: 'streamingpaid',
             expected_clean_url: 'https://music.apple.com/jp/album/1263790414',
-       only_valid_entity_types: ['release'],
   },
   // (Internet) Archive
   {


### PR DESCRIPTION
Apple Music links can apparently be both purchase or streaming. As such, until MBS-9902 is implemented we should only clean the links up but not autoselect a relationship.

