### PR TITLE
MBS-7409: Make "cannot attach discid" more obvious

### DIFF
--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -38,7 +38,7 @@
           </label>
           <small>(<a class="toggle" style="cursor:pointer;">[% l('show tracklist') %]</a>)</small>
           [% IF this_medium_has_cdtoc %]
-            <div class="error">[% l('This CDTOC is already attached to this medium') %]</div>
+            <div class="error">[% l('This CDTOC is already attached to this medium.') %]</div>
           [% END %]
         </td>
         <td colspan="6"></td>

--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -23,11 +23,14 @@
       <tr[% ' class="even"' IF zebra % 2 == 0 %]>
         <td class="pos"></td>
         <td>
-          <label
-            [%~ IF !medium.may_have_discids %] title="[% l('This medium format cannot have a disc ID attached') %]"[% END ~%]
-            [%~ IF this_medium_has_cdtoc %] title="[% l('This CDTOC is already attached to this medium') %]"[% END ~%]
-          >
-            <input type="radio" name="medium" value="[% medium.id %]"[% IF !medium.may_have_discids OR this_medium_has_cdtoc %] disabled="disabled"[% END %]/>
+          <label>
+            [% IF this_medium_has_cdtoc %]
+              <div class="cannot-attach-discid icon img" title="[% l('This CDTOC is already attached to this medium.') %]"></div>            
+            [% ELSIF !medium.may_have_discids %]
+              <div class="cannot-attach-discid icon img" title="[% l('This medium format cannot have a disc ID attached.') %]"></div>
+            [% ELSE %]
+              <input type="radio" name="medium" value="[% medium.id %]"/>
+            [% END %]
             [% medium.format_name %] [% medium.position %]
             [%~ IF medium.name %]:
                [% medium.name | html %]

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -742,6 +742,11 @@ table.tbl {
         background-size: 16px 16px;
         cursor: help !important;
     }
+
+    .cannot-attach-discid.icon {
+        background: data-uri('../images/icons/delete.png');
+        cursor: help !important;
+    }
 }
 
 #toggle-credits { float: right; }


### PR DESCRIPTION
### Implement MBS-7409

Instead of a disabled radio icon (which e.g. recent versions of Firefox display the same as a non-disabled one!), this uses a forbidden sign. That should give a much more clear sign that you're not supposed to select those entries.

Discussion on the ticket is divided between showing these entries at all or not, and another suggestion is to move them to a separate section. But for now I feel this is the easiest way to make the difference more clear, at least.

Example: 
![Screenshot from 2020-08-13 20-12-56](https://user-images.githubusercontent.com/1069224/90168593-f9e38000-dda5-11ea-8a9b-29b0dcae787b.png)
