### PR TITLE
MBS-11040: Use expand2react for annotation display

### DIFF
--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
 
@@ -59,9 +60,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
           <td>
             {display.html
               ? (
-                <span
-                  dangerouslySetInnerHTML={{__html: display.html}}
-                />
+                expand2react(display.html)
               ) : (
                 <p>
                   <span

--- a/root/edit/details/historic/AddReleaseAnnotation.js
+++ b/root/edit/details/historic/AddReleaseAnnotation.js
@@ -9,6 +9,8 @@
 
 import * as React from 'react';
 
+import expand2react
+  from '../../../static/scripts/common/i18n/expand2react';
 import HistoricReleaseList from '../../components/HistoricReleaseList';
 
 type AddReleaseAnnotationEditT = {
@@ -38,9 +40,7 @@ const AddReleaseAnnotation = ({edit}: Props): React.Element<'table'> => {
         <td>
           {display.html
             ? (
-              <span
-                dangerouslySetInnerHTML={{__html: display.html}}
-              />
+              expand2react(display.html)
             ) : (
               <p>
                 <span className="comment">

--- a/root/report/components/ArtistAnnotationList.js
+++ b/root/report/components/ArtistAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportArtistAnnotationT} from '../types';
 
@@ -52,7 +53,7 @@ const ArtistAnnotationList = ({
                 {l('This artist no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/LabelAnnotationList.js
+++ b/root/report/components/LabelAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportLabelAnnotationT} from '../types';
 
@@ -44,7 +45,7 @@ const LabelAnnotationList = ({
                 {l('This label no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/PlaceAnnotationList.js
+++ b/root/report/components/PlaceAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportPlaceAnnotationT} from '../types';
 
@@ -44,7 +45,7 @@ const PlaceAnnotationList = ({
                 {l('This place no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/RecordingAnnotationList.js
+++ b/root/report/components/RecordingAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportRecordingAnnotationT} from '../types';
 import ArtistCreditLink
@@ -54,7 +55,7 @@ const RecordingAnnotationList = ({
                 {l('This recording no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/ReleaseAnnotationList.js
+++ b/root/report/components/ReleaseAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportReleaseAnnotationT} from '../types';
 import ArtistCreditLink
@@ -54,7 +55,7 @@ const ReleaseAnnotationList = ({
                 {l('This release no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/ReleaseGroupAnnotationList.js
+++ b/root/report/components/ReleaseGroupAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportReleaseGroupAnnotationT} from '../types';
 import ArtistCreditLink
@@ -60,7 +61,7 @@ const ReleaseGroupAnnotationList = ({
                 {l('This release group no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/SeriesAnnotationList.js
+++ b/root/report/components/SeriesAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportSeriesAnnotationT} from '../types';
 
@@ -44,7 +45,7 @@ const SeriesAnnotationList = ({
                 {l('This series no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/report/components/WorkAnnotationList.js
+++ b/root/report/components/WorkAnnotationList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import loopParity from '../../utility/loopParity';
 import type {ReportWorkAnnotationT} from '../types';
 
@@ -44,7 +45,7 @@ const WorkAnnotationList = ({
                 {l('This work no longer exists.')}
               </td>
             )}
-            <td dangerouslySetInnerHTML={{__html: item.text}} />
+            <td>{expand2react(item.text)}</td>
             <td>{item.created}</td>
           </tr>
         ))}

--- a/root/search/components/AnnotationResults.js
+++ b/root/search/components/AnnotationResults.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
 import loopParity from '../../utility/loopParity';
@@ -36,7 +37,7 @@ function buildResult(result, index) {
       <td>
         {annotation.parent ? <EntityLink entity={annotation.parent} /> : null}
       </td>
-      <td dangerouslySetInnerHTML={{__html: annotation.html}} />
+      <td>{expand2react(annotation.html)}</td>
     </tr>
   );
 }

--- a/root/static/scripts/common/components/Annotation.js
+++ b/root/static/scripts/common/components/Annotation.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 import mutate from 'mutate-cow';
 
+import expand2react from '../i18n/expand2react';
 import {SanitizedCatalystContext} from '../../../../context';
 import formatUserDate from '../../../../utility/formatUserDate';
 import hydrate from '../../../../utility/hydrate';
@@ -61,18 +62,16 @@ const Annotation = ({
     <>
       <h2 className="annotation">{l('Annotation')}</h2>
 
-      {collapse
-        ? (
-          <Collapsible
-            className="annotation"
-            html={annotation.html}
-          />
-        ) : (
-          <div
-            className="annotation-body"
-            dangerouslySetInnerHTML={{__html: annotation.html}}
-          />
-        )}
+      {collapse ? (
+        <Collapsible
+          className="annotation"
+          html={annotation.html}
+        />
+      ) : (
+        <div className="annotation-body">
+          {expand2react(annotation.html)}
+        </div>
+      )}
 
       {showChangeLog ? (
         <p>

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -46,7 +46,7 @@ const condSubstThenTextContent = /^[^<>{}|]+/;
 const percentSign = /(%)/;
 const linkSubstStart = /^\{([0-9A-z_]+)\|/;
 const htmlTagStart = /^<(?=[a-z])/;
-const htmlTagName = /^(a|abbr|br|code|em|li|p|span|strong|ul)(?=[\s\/>])/;
+const htmlTagName = /^(a|abbr|br|code|em|h1|h2|h3|h4|h5|h6|hr|li|ol|p|span|strong|ul)(?=[\s\/>])/;
 const htmlTagEnd = /^>/;
 const htmlSelfClosingTagEnd = /^\s*\/>/;
 const htmlAttrStart = /^\s+(?=[a-z])/;


### PR DESCRIPTION
### Implement MBS-11040

The html tags legitimately generated by annotations are added to htmlTagName (should already have been added really, since the same are in use for collection descriptions).

expand2react does struggle with malformed returns from Text::WikiFormat more than dangerouslySetInnerHTML, which ignores plenty of the issues, but that should be fixed at the source, I expect.

We can choose to merge this as-is, or we can choose to try and finally deal with the Text::WikiFormat mess. If we opt for the latter, we can:
* Improve the Text::WikiFormat module 
* Try and find a JS library that does the work for us
* Write our own code to do this (which is probably not super hard, famous last words and all that)