### PR TITLE
MBS-11041: Make ModBot leave a note on autoremoval edits

### DIFF
--- a/lib/MusicBrainz/Script/RemoveEmpty.pm
+++ b/lib/MusicBrainz/Script/RemoveEmpty.pm
@@ -19,7 +19,7 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_SERIES_DELETE
 );
 use MusicBrainz::Server::Log qw( log_debug log_warning log_notice );
-use MusicBrainz::Server::Data::Utils qw( type_to_model );
+use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
 with 'MooseX::Runnable';
@@ -122,6 +122,24 @@ sub run {
                     editor => $modbot,
                     privileges => $BOT_FLAG | $AUTO_EDITOR_FLAG
                 );
+
+                $self->c->model('EditNote')->add_note(
+                    $edit->id,
+                    {
+                        editor_id => $EDITOR_MODBOT,
+                        text => localized_note(
+                            N_l('This entity was automatically removed because it was empty:
+                                 it had no relationships associated with it, nor (if
+                                 relevant for the type of entity in question) any recordings,
+                                 releases nor release groups.
+                                 If you consider this was a valid, non-duplicate entry
+                                 that does belong in MusicBrainz, feel free to add it again,
+                                 but please ensure enough data is added to it this time
+                                 to avoid another automatic removal.')
+                        )
+                    }
+                );
+
                 ++$removed
             }, $self->c->sql);
         }


### PR DESCRIPTION
### Implement MBS-11041

These edits often confuse users, who don't understand why their added entity has been removed without a word by some weird editor. This adds an explanatory edit note which should hopefully avoid those situations and help them understand they can readd the entity if needed.

![Screenshot from 2020-08-18 15-25-18](https://user-images.githubusercontent.com/1069224/90512580-0b8ea400-e167-11ea-83dd-a7c7abab1483.png)

@mwiencek: please let me know if localized_note would not work here for some reason :)