### PR TITLE
MBS-11039: Don't use entity id as key for seriesItemNumbers

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -61,11 +61,11 @@ sub show : PathPart('') Chained('load') {
     });
 
     my @entities;
-    my $item_numbers = {};
+    my @item_numbers;
 
     for (@$items) {
         push @entities, $_->{entity};
-        $item_numbers->{$_->{entity}->id} = $_->{ordering_key};
+        push @item_numbers, $_->{ordering_key};
     }
 
     if ($series->type->item_entity_type eq 'event') {
@@ -103,7 +103,7 @@ sub show : PathPart('') Chained('load') {
         numberOfRevisions => $c->stash->{number_of_revisions},
         pager             => serialize_pager($c->stash->{pager}),
         series            => $series,
-        seriesItemNumbers => $item_numbers,
+        seriesItemNumbers => \@item_numbers,
         wikipediaExtract  => $c->stash->{wikipedia_extract},
     );
 

--- a/root/types.js
+++ b/root/types.js
@@ -1025,7 +1025,7 @@ declare type SeriesT = $ReadOnly<{
 }>;
 
 declare type SeriesItemNumbersRoleT = {
-  +seriesItemNumbers?: {+[entityId: number]: string},
+  +seriesItemNumbers?: $ReadOnlyArray<string>,
 };
 
 declare type SeriesOrderingTypeT = OptionTreeT<'series_ordering_type'>;

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -404,11 +404,11 @@ export function defineReleaseLabelsColumn(
 
 export function defineSeriesNumberColumn(
   props: {
-    +seriesItemNumbers: {+[entityId: number]: string},
+    +seriesItemNumbers: $ReadOnlyArray<string>,
   },
 ): ColumnOptions<CoreEntityT, number> {
   return {
-    Cell: ({cell: {value}}) => props.seriesItemNumbers[value],
+    Cell: ({row: {index}}) => props.seriesItemNumbers[index],
     Header: l('#'),
     accessor: 'id',
     cellProps: {className: 'number-column'},


### PR DESCRIPTION
### Fix MBS-11039

An entity can appear more than once in a series with different series numbers. While it is uncommon, it is supported and has real-life use cases. With the current code, the number is overwritten and only the latest number is displayed for all rows of the series table.

This changes seriesItemNumbers to be an array that is later accessed based on the index of the react-table row (so, the entities array map).

As far as I can tell, this should work in any event where the arrays are just taken directly from Perl and sent up to React (even if we were to introduce server-side filtering or ordering later). If I'm missing a reason why this is a bad idea, do let me know! It's the most minor change I could figure out to fix this. I expect this would cause issues if we eventually decided to drop pagination etc and do filtering and ordering directly from react-table, but I trust we'd find a better alternative while researching for that change :) 