### PR TITLE
MBS-11049: Temporarily disable external links to Decoda

### DIFF
--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -50,7 +50,8 @@ my %URL_SPECIALIZATIONS = (
     'DAHR'                => qr{^https?://adp\.library\.ucsb\.edu/}i,
     'Dailymotion'         => qr{^https?://(?:www\.)?dailymotion\.com/}i,
     'DanceDB'             => qr{^https?://(?:www\.)?tedcrane\.com/DanceDB/}i,
-    'Decoda'              => qr{^https?://(?:www\.)?decoda\.com/}i,
+    # Temporarily grey Decoda out as it has been reported to be compromised
+    # 'Decoda'              => qr{^https?://(?:www\.)?decoda\.com/}i,
     'Deezer'              => qr{^https?://(?:www\.)?deezer\.com/}i,
     'DHHU'                => qr{^https?://(?:www\.)?dhhu\.dk/}i,
     'Directlyrics'        => qr{^https?://(?:www\.)?directlyrics\.com/}i,

--- a/root/components/RelationshipTargetLinks.js
+++ b/root/components/RelationshipTargetLinks.js
@@ -25,6 +25,7 @@ import type {
   DatedExtraAttributes,
   RelationshipTargetGroupT,
 } from '../utility/groupRelationships';
+import isDisabledLink from '../utility/isDisabledLink';
 import relationshipDateText from '../utility/relationshipDateText';
 
 export function displayDatedExtraAttributes(
@@ -64,8 +65,7 @@ const RelationshipTargetLinks = ({
 }: Props): React.MixedElement => {
   const target = relationship.target;
   const targetCredit = relationship.targetCredit;
-  const disableLink = relationship.earliestDatePeriod.ended &&
-                      target.entityType === 'url';
+  const disableLink = isDisabledLink(relationship.earliestDatePeriod, target);
   let link;
   if (hiddenArtistCredit &&
       target.artistCredit &&

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -17,6 +17,7 @@ import entityHref from '../utility/entityHref';
 import formatDatePeriod from '../utility/formatDatePeriod';
 import isolateText from '../utility/isolateText';
 import nonEmpty from '../utility/nonEmpty';
+import isGreyedOut from '../../../../url/utility/isGreyedOut';
 
 type DeletedLinkProps = {
   +allowNew: boolean,
@@ -215,8 +216,17 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     anchorProps.title = hover;
   }
   content = disableLink
-    ? <span className="deleted">{isolateText(content)}</span>
-    : <a key="link" {...anchorProps}>{isolateText(content)}</a>;
+    ? (
+      <span
+        className="deleted"
+        title={entity.entityType === 'url' && isGreyedOut(href)
+          ? l(`This link has been temporarily disabled because
+               it has been reported as potentially harmful.`)
+          : null}
+      >
+        {isolateText(content)}
+      </span>
+    ) : <a key="link" {...anchorProps}>{isolateText(content)}</a>;
 
   if (nameVariation) {
     content = (

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -14,6 +14,7 @@ import bracketed from '../utility/bracketed';
 import {displayLinkAttributes}
   from '../utility/displayLinkAttribute';
 import {interpolate, getExtraAttributes} from '../../edit/utility/linkPhrase';
+import isDisabledLink from '../../../../utility/isDisabledLink';
 import relationshipDateText
   from '../../../../utility/relationshipDateText';
 
@@ -96,13 +97,13 @@ const RelationshipContent = ({
     <DescriptiveLink
       allowNew={allowNewEntity0}
       content={relationship.entity0_credit}
-      disableLink={relationship.ended && entity0.entityType === 'url'}
+      disableLink={isDisabledLink(relationship, entity0)}
       entity={entity0}
     />,
     <DescriptiveLink
       allowNew={allowNewEntity1}
       content={relationship.entity1_credit}
-      disableLink={relationship.ended && entity1.entityType === 'url'}
+      disableLink={isDisabledLink(relationship, entity1)}
       entity={entity1}
     />,
   );

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -21,6 +21,7 @@ import linkedEntities from '../../../common/linkedEntities';
 import bracketed from '../../../common/utility/bracketed';
 import displayLinkAttribute, {displayLinkAttributes}
   from '../../../common/utility/displayLinkAttribute';
+import isDisabledLink from '../../../../../utility/isDisabledLink';
 import {
   getPhraseAndExtraAttributes,
   type CachedLinkData,
@@ -90,7 +91,7 @@ const RelationshipDiff = ({
   const oldSourceLink = (
     <DescriptiveLink
       content={oldRelationship.entity0_credit}
-      disableLink={oldRelationship.ended && oldSource.entityType === 'url'}
+      disableLink={isDisabledLink(oldRelationship, oldSource)}
       entity={oldSource}
     />
   );
@@ -98,7 +99,7 @@ const RelationshipDiff = ({
   const newSourceLink = (
     <DescriptiveLink
       content={newRelationship.entity0_credit}
-      disableLink={newRelationship.ended && newSource.entityType === 'url'}
+      disableLink={isDisabledLink(newRelationship, newSource)}
       entity={newSource}
     />
   );
@@ -106,7 +107,7 @@ const RelationshipDiff = ({
   const oldTargetLink = (
     <DescriptiveLink
       content={oldRelationship.entity1_credit}
-      disableLink={oldRelationship.ended && oldTarget.entityType === 'url'}
+      disableLink={isDisabledLink(oldRelationship, oldTarget)}
       entity={oldTarget}
     />
   );
@@ -114,7 +115,7 @@ const RelationshipDiff = ({
   const newTargetLink = (
     <DescriptiveLink
       content={newRelationship.entity1_credit}
-      disableLink={newRelationship.ended && newTarget.entityType === 'url'}
+      disableLink={isDisabledLink(newRelationship, newTarget)}
       entity={newTarget}
     />
   );

--- a/root/url/UrlIndex.js
+++ b/root/url/UrlIndex.js
@@ -27,8 +27,15 @@ const UrlIndex = ({$c, url}: Props): React.Element<typeof UrlLayout> => (
         <th>{addColonText(l('URL'))}</th>
         <td>
           {isGreyedOut(url.href_url)
-            ? <span className="deleted">{url.href_url}</span>
-            : <a href={url.href_url}>{url.pretty_name}</a>
+            ? (
+              <span
+                className="deleted"
+                title={l(`This link has been temporarily disabled because
+                          it has been reported as potentially harmful.`)}
+              >
+                {url.href_url}
+              </span>
+            ) : <a href={url.href_url}>{url.pretty_name}</a>
           }
         </td>
       </tr>

--- a/root/url/UrlIndex.js
+++ b/root/url/UrlIndex.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import Relationships from '../components/Relationships';
 
 import UrlLayout from './UrlLayout';
+import isGreyedOut from './utility/isGreyedOut';
 
 type Props = {
   +$c: CatalystContextT,
@@ -24,7 +25,12 @@ const UrlIndex = ({$c, url}: Props): React.Element<typeof UrlLayout> => (
     <table className="details">
       <tr>
         <th>{addColonText(l('URL'))}</th>
-        <td><a href={url.href_url}>{url.pretty_name}</a></td>
+        <td>
+          {isGreyedOut(url.href_url)
+            ? <span className="deleted">{url.href_url}</span>
+            : <a href={url.href_url}>{url.pretty_name}</a>
+          }
+        </td>
       </tr>
     </table>
     <Relationships source={url} />

--- a/root/url/utility/isGreyedOut.js
+++ b/root/url/utility/isGreyedOut.js
@@ -1,0 +1,16 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+const greyRegExp = new RegExp('^https?://(?:www\.)?decoda\.com/');
+
+export default function isGreyedOut(
+  url: string,
+): boolean {
+  return greyRegExp.test(url);
+}

--- a/root/utility/isDisabledLink.js
+++ b/root/utility/isDisabledLink.js
@@ -7,11 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import isGreyedOut from '../url/utility/isGreyedOut';
+
 export default function isDisabledLink(
   relationshipOrLinkDatePeriod: {+ended: boolean, ...},
   entity: CoreEntityT,
 ): boolean {
   return entity.entityType === 'url' && (
-    relationshipOrLinkDatePeriod.ended
+    relationshipOrLinkDatePeriod.ended || isGreyedOut(entity.href_url)
   );
 }

--- a/root/utility/isDisabledLink.js
+++ b/root/utility/isDisabledLink.js
@@ -1,0 +1,17 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function isDisabledLink(
+  relationshipOrLinkDatePeriod: {+ended: boolean, ...},
+  entity: CoreEntityT,
+): boolean {
+  return entity.entityType === 'url' && (
+    relationshipOrLinkDatePeriod.ended
+  );
+}


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-11049: Decoda has been reported to sometimes redirect to a scam page.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

To do no harm, this patch temporarily disables external links to Decoda.
It should be reverted whenever their situation gets resolved.