### PR TITLE
Polyfill improvements (also unbreaks IE11)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,9 +30,8 @@ module.exports = function (api) {
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-react-constant-elements',
     ['@babel/plugin-transform-runtime', {
-      corejs: 3,
+      corejs: false,
       helpers: true,
-      proposals: true,
       regenerator: true,
       useESModules: false,
     }],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const ignore = require('./webpack/babel-ignored');
+
 const BROWSER_TARGETS = {
   chrome: '49',
   edge: '14',
@@ -44,16 +46,10 @@ module.exports = function (api) {
     plugins.push('babel-plugin-istanbul');
   }
 
-  const ignore = [
-    'node_modules',
-    'root/static/scripts/tests/typeInfo.js',
-    /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
-  ];
-
   return {
-    presets,
-    plugins,
     ignore,
+    plugins,
+    presets,
     sourceType: 'unambiguous',
   };
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "7.10.2",
     "@babel/preset-flow": "7.10.1",
     "@babel/register": "7.10.1",
-    "@babel/runtime-corejs3": "7.10.2",
+    "@babel/runtime": "7.11.2",
     "@sentry/browser": "5.10.2",
     "@sentry/node": "5.10.2",
     "babel-loader": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "webpack-cli": "3.2.3",
     "webpack-manifest-plugin": "2.0.4",
     "webpack-node-externals": "1.7.2",
+    "whatwg-fetch": "3.4.0",
     "yargs": "3.10.0"
   },
   "devDependencies": {

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -36,8 +36,6 @@ require('./common/components/Annotation');
 require('./common/components/CommonsImage');
 require('./common/components/FingerprintTable');
 require('./common/components/WikipediaExtract');
-require('./common/i18n');
-require('./common/entity');
 require('./common/MB/Control/Autocomplete');
 require('./common/components/ReleaseEvents');
 require('./common/components/WorkArtists');

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -1,3 +1,7 @@
+/* global polyfills not provided by core-js */
+require('whatwg-fetch');
+/* end global polyfills */
+
 require('./public-path');
 
 /*

--- a/webpack/babel-ignored.js
+++ b/webpack/babel-ignored.js
@@ -1,5 +1,10 @@
 module.exports = [
-  /node_modules/,
+  /*
+   * The modules in the negative-lookahead assertion (?!...) are exceptions
+   * to the node_modules exclusion. These most likely use language features
+   * that aren't supported in IE11.
+   */
+  /node_modules\/(?!jed|mutate-cow)/,
   /root\/static\/scripts\/tests\/typeInfo\.js/,
   /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
 ];

--- a/webpack/babel-ignored.js
+++ b/webpack/babel-ignored.js
@@ -1,0 +1,5 @@
+module.exports = [
+  /node_modules/,
+  /root\/static\/scripts\/tests\/typeInfo\.js/,
+  /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
+];

--- a/webpack/babel-ignored.js
+++ b/webpack/babel-ignored.js
@@ -4,7 +4,7 @@ module.exports = [
    * to the node_modules exclusion. These most likely use language features
    * that aren't supported in IE11.
    */
-  /node_modules\/(?!jed|mutate-cow)/,
+  /node_modules\/(?!@babel\/runtime|jed|mutate-cow|react)/,
   /root\/static\/scripts\/tests\/typeInfo\.js/,
   /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
 ];

--- a/webpack/moduleConfig.js
+++ b/webpack/moduleConfig.js
@@ -8,6 +8,7 @@
 
 const CleanCSSPlugin = require('less-plugin-clean-css');
 
+const ignore = require('./babel-ignored');
 const {PRODUCTION_MODE} = require('./constants');
 
 const lessOptions = {};
@@ -23,7 +24,7 @@ module.exports = {
 
   rules: [
     {
-      exclude: /node_modules/,
+      exclude: ignore,
       test: /\.js$/,
       use: {
         loader: 'babel-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,20 +945,19 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@7.10.2":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
-  integrity sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz#67aded13fffbbc2cb93247388cf84d77a4be9a71"
   integrity sha512-6toWAfaALQjt3KMZQc6fABqZwUDDuWzz+cAfPhqyEnzxvdWOAkjwPNxgF8xlmo7OWLsSjaKjsskpKHRLaMArOA==
   dependencies:
     core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.8.4":

--- a/yarn.lock
+++ b/yarn.lock
@@ -7130,6 +7130,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
+  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
+
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
While testing the lodash removal PR in IE11, I found that it was already broken in that browser even before the PR. So I started working on fixing that, since it's one of our supported browsers. Then I discovered some more disturbing stuff unrelated to IE11 (see commit "Disable core-js on plugin-transform-runtime"). That commit shaves about 502 kB off of common-chunks, or 37 kB after minification.