### PR TITLE
MBS-11062: Link basic how-tos from the front page

### DIFF
--- a/root/main/index.js
+++ b/root/main/index.js
@@ -178,6 +178,12 @@ const Homepage = ({
               <li>
                 <a href="/doc/Frequently_Asked_Questions">{l('FAQs')}</a>
               </li>
+              <li>
+                <a href="/doc/How_to_Add_an_Artist">{l('How to add artists')}</a>
+              </li>
+              <li>
+                <a href="/doc/How_to_Add_a_Release">{l('How to add releases')}</a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
### Implement MBS-11062

The Quick Start section in the front page seems like a good place to direct people to the most basic editing how-tos: artists and releases. A general link to the how-to page is in the documentation menu, but having these two somewhere that might be more directly accessible to newcomers can't hurt.

While we have a lot more how tos, these two are the ones that seem the most useful for new users, and from the bottom of those two they can always find the links to the more advanced ones.

![Screenshot from 2020-09-03 14-18-09](https://user-images.githubusercontent.com/1069224/92108586-50b20780-edf0-11ea-863c-fcb955dd3473.png)
