### PR TITLE
MBS-11061: Disallow MusicBrainz URLs in relationships

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -237,6 +237,9 @@ export class ExternalLinksEditor
               error = l('Required field.');
             } else if (!isValidURL(link.url)) {
               error = l('Enter a valid url e.g. "http://google.com/"');
+            } else if (isMusicBrainz(link.url)) {
+              error = l(`Links to MusicBrainz URLs are not allowed.
+                         Did you mean to paste something else?`);
             } else if (isShortened(link.url)) {
               error = l(`Please don’t enter bundled/shortened URLs,
                          enter the destination URL(s) instead.`);
@@ -610,6 +613,10 @@ function isShortened(url) {
   return URL_SHORTENERS.some(function (shortenerRegex) {
     return url.match(shortenerRegex) !== null;
   });
+}
+
+function isMusicBrainz(url) {
+  return /^https?:\/\/([^/]+\.)?musicbrainz\.org/.test(url);
 }
 
 type InitialOptionsT = {


### PR DESCRIPTION
### Implement MBS-11061

I checked and there were only three more-or-less legitimate cases of this (among a larger amount of stuff clearly pasted in error such as links to the same entity the URL was added to). One of those was a link to our wiki summit page as an "official website" link for the Summit 2014, where some music got recorded (and arguably that is not an official website anyway) and the other two were artists using their own MusicBrainz user profile for a bio and then linking to their user page as their biography page (which is something I think we should disencourage anyway and feels very spammy, while being no better than just adding the same text to an annotation).