### PR TITLE
MBS-11064: Mark ended links as such in the URL editor

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -33,6 +33,7 @@ import * as URLCleanup from './URLCleanup';
 import validation from './validation';
 
 type LinkStateT = {
+  ended: boolean,
   relationship: number | string | null,
   type: number | null,
   url: string,
@@ -269,6 +270,7 @@ export class ExternalLinksEditor
 
             return (
               <ExternalLink
+                ended={link.ended}
                 errorMessage={error || ''}
                 handleUrlBlur={
                   this.handleUrlBlur.bind(this, index)
@@ -326,6 +328,7 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
 }
 
 type LinkProps = {
+  ended: boolean,
   errorMessage: React.Node,
   handleUrlBlur: (number, SyntheticEvent<HTMLInputElement>) => void,
   handleUrlChange: (number, SyntheticEvent<HTMLInputElement>) => void,
@@ -422,6 +425,12 @@ export class ExternalLink extends React.Component<LinkProps> {
             type="url"
             value={props.url}
           />
+          {props.ended &&
+            <div className="notification" data-visible="1">
+              {l(`This link has been marked as no longer valid (‘ended’)
+                  and is kept for archival purposes only.
+                  There's generally no need to remove these links.`)}
+            </div>}
           {props.errorMessage &&
             <div className="error field-error" data-visible="1">
               {props.errorMessage}
@@ -454,6 +463,7 @@ export class ExternalLink extends React.Component<LinkProps> {
 }
 
 const defaultLinkState: LinkStateT = {
+  ended: false,
   relationship: null,
   type: null,
   url: '',
@@ -508,6 +518,7 @@ export function parseRelationships(
 
     if (target.entityType === 'url') {
       accum.push({
+        ended: data.ended,
         relationship: data.id,
         type: data.linkTypeID,
         url: target.name,

--- a/root/static/styles/colors.less
+++ b/root/static/styles/colors.less
@@ -40,6 +40,7 @@
 @light-border-background: @very-light-border;        // the background for the light-border tables
 
 @warning-background: #FFFFD0;                        // "warning" background
+@warning-text: #17A2B8;                              // "warning" text message color
 
 @positive-bg: #B1EBB0;                               // background color for positive and success states
 @positive-light-bg: #E4FBE4;                         // lighter version

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -166,6 +166,7 @@ ul.errors {
 }
 
 ul.errors li, .error { color: @negative-text; }
+.notification { color: @warning-text; }
 span.success { color: @positive-text; }
 
 input.error,


### PR DESCRIPTION
### Implement MBS-11064

This adds a message explaining that ended links are marked as ended, and as such not considered current, and should probably not be removed.

The color used is the information color from bootstrap, since I wasn't sure what would be a good pick.

![Screenshot from 2020-09-03 16-21-36](https://user-images.githubusercontent.com/1069224/92122770-8e209000-ee04-11ea-9dc2-96403f70bc1e.png)


@yvanzo mentioned as an alternative not showing the ended links at all in the editor. I personally feel that's a bit too hardcore, but it might be safer!