### PR TITLE
MBS-11065: Only block smart links if they have a path

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -604,7 +604,7 @@ const URL_SHORTENERS = [
   'unitedmasters.com',
   'untd.io',
   'yep.it',
-].map(host => new RegExp('^https?://([^/]+\\.)?' + host + '/', 'i'));
+].map(host => new RegExp('^https?://([^/]+\\.)?' + host + '/.+', 'i'));
 
 function isShortened(url) {
   return URL_SHORTENERS.some(function (shortenerRegex) {


### PR DESCRIPTION
### Fix MBS-11065

In rare cases, the actual host of smart links might be a legitimate relationship as the homepage for a distributor (e.g. distrokid.com, unitedmasters.com). We will still want to block the specific smart links but not the host without any additional path.

It's true that, say, https://distrokid.com was already allowed, but simply copy-pasting their URL does give https://distrokid.com/ (which is blocked). We might as well make it a bit less annoying.