### PR TITLE
Fix unspecified RG type

### DIFF
--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -160,7 +160,7 @@ const ReleaseGroupList = ({
       return (
         <React.Fragment key={type}>
           <h3>
-            {type === 'null'
+            {type === ''
               ? l('Unspecified type')
               : releaseGroupType(releaseGroupsOfType[0])
             }


### PR DESCRIPTION
With the lodash changes for groupBy, the type here is no longer null but empty string, so currently no type string is shown at all.