### PR TITLE
MBS-10835: Don't send verification mail if address in use

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -652,13 +652,23 @@ sub _send_confirmation_email
         chk    => $self->_checksum($email, $editor->id, $time),
     });
 
+    my $email_in_use = $c->model('Editor')->is_email_used_elsewhere($email, $editor->id);
+
     try {
-        $c->model('Email')->send_email_verification(
-            email             => $email,
-            verification_link => $verification_link,
-            ip                => $c->req->address,
-            editor            => $editor
-        );
+        if ($email_in_use) {
+            $c->model('Email')->send_email_in_use(
+                email             => $email,
+                ip                => $c->req->address,
+                editor            => $editor
+            );            
+        } else {
+            $c->model('Email')->send_email_verification(
+                email             => $email,
+                verification_link => $verification_link,
+                ip                => $c->req->address,
+                editor            => $editor
+            );
+        }
     }
     catch {
         $c->flash->{message} = l(

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -689,6 +689,14 @@ sub allocate_remember_me_token {
     }
 }
 
+sub is_email_used_elsewhere {
+    my ($self, $email, $user_id) = @_;
+
+    return 1 if $self->sql->select_single_value(
+        'SELECT 1 FROM editor WHERE lower(email) = lower(?) AND id != ?', $email, $user_id);
+    return 0;
+}
+
 sub is_name_used {
     my ($self, $name) = @_;
 

--- a/lib/MusicBrainz/Server/Email.pm
+++ b/lib/MusicBrainz/Server/Email.pm
@@ -180,6 +180,60 @@ EOS
     return $self->_create_email(\@headers, $body);
 }
 
+sub _create_email_in_use_email
+{
+    my ($self, %opts) = @_;
+
+    my @headers = (
+        'To'         => $opts{email},
+        'From'       => $EMAIL_NOREPLY_ADDRESS,
+        'Reply-To'   => $EMAIL_SUPPORT_ADDRESS,
+        'Message-Id' => _message_id('email-in-use-%d', time()),
+        'Subject'    => 'Email address already in use',
+    );
+
+    my $lost_username_link = $url_prefix . '/lost-username';
+    my $lost_password_link = $url_prefix . '/lost-password';
+    my $bot_code_of_conduct_link = $url_prefix . '/doc/Code_of_Conduct/Bots';
+    my $ip = $opts{ip};
+    my $user_name = $opts{editor}->name;
+
+    my $body = <<EOS;
+Hello $user_name,
+
+You have requested to verify this email address for the MusicBrainz account $user_name,
+but we already have at least one account using this address in our database.
+If you have forgotten your old username, you can recover it from the following link:
+
+$lost_username_link
+
+You can then request a password reset, if needed, from the link below:
+
+$lost_password_link
+
+If clicking the links above doesn't work, please copy and paste the URL in a
+new browser window instead.
+
+If you have a specific reason why you need a second account (for example,
+you want to run a bot and have notes also reach you at this address)
+please drop us a line (see $CONTACT_URL for details). We will look into
+your specific case. For bots, also let us know about what you are intending
+to do with it (see $bot_code_of_conduct_link).
+
+If you didn't initiate this request and feel that you've received this email in
+error, don't worry, you don't need to take any further action and can safely
+disregard this email.
+
+This email was triggered by a request from the IP address [$ip].
+
+Thanks for using MusicBrainz!
+
+-- The MusicBrainz Team
+EOS
+
+    return $self->_create_email(\@headers, $body);
+}
+
 sub _create_lost_username_email
 {
     my ($self, %opts) = @_;
@@ -420,6 +474,14 @@ sub send_email_verification
     my ($self, %opts) = @_;
 
     my $email = $self->_create_email_verification_email(%opts);
+    return $self->_send_email($email);
+}
+
+sub send_email_in_use
+{
+    my ($self, %opts) = @_;
+
+    my $email = $self->_create_email_in_use_email(%opts);
     return $self->_send_email($email);
 }
 


### PR DESCRIPTION
### Implement MBS-10835

To avoid email reuse, this only sends a verification email if the address isn't being used by any other editor.

For cases where the user has a good reason to reuse the address (such as bots) they can let us know and we can manually override the whole thing by skipping verification.

I don't have email sending setup locally. If this seems generally fine, I can throw it on test and try from there, but before that let's make sure I didn't do anything too dumb.