### PR TITLE
MBS-11077: Update sort parameter for load_display_reviews

### DIFF
--- a/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
+++ b/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
@@ -23,7 +23,7 @@ sub load_display_reviews {
         release_group => $release_group->gid,
         offset => 0,
         limit => 1,
-        sort => 'created'
+        sort => 'published_on'
     );
 
     $url->query_form(%params);


### PR DESCRIPTION
### Fix MBS-11077

For some reason, CB's c3d344dabecbbcb007b266861e7ddd64b83107c2 commit replaced "created" with "published_on" (without any doc update nor any backwards compatibility), breaking our review display code.