### PR TITLE
MBS-11078 / MBS-11081: Fix pregap bugs in Add medium

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -844,7 +844,7 @@ END -%]
   END %] ([% direction %])
 [%~ END ~%]
 
-[%~ MACRO pregap_track_icon BLOCK ~%]
+[%~ MACRO pregap_track_icon BLOCK ~%]  [% # Converted to React at root/static/scripts/common/components/PregapTrackIcon.js %]
   <div class="pregap-track icon img" title="[% l('This track is hidden in the pregap.') %]"></div>
 [%~ END ~%]
 

--- a/root/edit/details/AddMedium.js
+++ b/root/edit/details/AddMedium.js
@@ -73,7 +73,7 @@ const CondensedTrackACs = ({
   }
 
   let thisCredit;
-  let thisPosition = 0;
+  let thisPosition = tracks[0].position - 1;
   let rowCounter = 0;
   let startNumber = tracks[0].number;
   let endNumber;

--- a/root/medium/MediumTracklist.js
+++ b/root/medium/MediumTracklist.js
@@ -16,6 +16,8 @@ import EntityLink, {DeletedLink}
   from '../static/scripts/common/components/EntityLink';
 import DataTrackIcon
   from '../static/scripts/common/components/DataTrackIcon';
+import PregapTrackIcon
+  from '../static/scripts/common/components/PregapTrackIcon';
 import formatTrackLength
   from '../static/scripts/common/utility/formatTrackLength';
 import loopParity from '../utility/loopParity';
@@ -62,6 +64,12 @@ const MediumTracklist = ({
         id={track.gid}
       >
         <td className="pos t">
+          {track.position === 0 ? (
+            <>
+              <PregapTrackIcon />
+              {' '}
+            </>
+          ) : null}
           <span style={{display: 'none'}}>
             {track.position}
           </span>

--- a/root/medium/tracklist.tt
+++ b/root/medium/tracklist.tt
@@ -41,6 +41,9 @@ dl.ars dt {
 [%# model tracks as blank nodes %]
 <tr class="[% loop.parity %][% ' mp' IF track.edits_pending %]" id="[% track.gid %]">
     <td class="pos t">
+      [% IF track.position == 0 %]
+        [% pregap_track_icon %]
+      [% END %]
       <span style="display: none">[% track.position %]</span>
       [%- track.number -%]
     </td>

--- a/root/static/scripts/common/components/PregapTrackIcon.js
+++ b/root/static/scripts/common/components/PregapTrackIcon.js
@@ -1,0 +1,19 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+const PregapTrackIcon = (): React.Element<'div'> => (
+  <div
+    className="pregap-track icon img"
+    title={l('This track is hidden in the pregap.')}
+  />
+);
+
+export default PregapTrackIcon;


### PR DESCRIPTION
### Fix MBS-11078 / MBS-11081

One of these (MBS-11078) is a newly introduced regression. The other (MBS-11081) has been there from the beginning, but hey, might as well fix it too so once the edit works again, it's also complete.

MBS-11081 also brings the icon to a couple other places related to discIDs, where it certainly won't hurt.