### PR TITLE
Add missing N_l import

### DIFF
--- a/lib/MusicBrainz/Script/RemoveEmpty.pm
+++ b/lib/MusicBrainz/Script/RemoveEmpty.pm
@@ -21,6 +21,7 @@ use MusicBrainz::Server::Constants qw(
 use MusicBrainz::Server::Log qw( log_debug log_warning log_notice );
 use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
+use MusicBrainz::Server::Translation qw( N_l );
 
 with 'MooseX::Runnable';
 with 'MooseX::Getopt';


### PR DESCRIPTION
Fixes my mistake where I forgot an import in recently changed code. Seems the cron containers didn't get updated this release for some reason, meaning the bug isn't out yet.