### PR TITLE
MBS-11085 / MBS-11089: Fix canHaveDiscID check / Fix missing favicons

### DIFF
--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -60,7 +60,7 @@ const ExternalLink = ({
   }
 
   return (
-    <li className={nonEmpty(className) || faviconClass(url)}>
+    <li className={nonEmpty(className) ? className : faviconClass(url)}>
       {element}
     </li>
   );

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -653,7 +653,7 @@ class Medium {
     canHaveDiscID() {
         var formatID = parseInt(this.formatID(), 10);
 
-        return !formatID || MB.formatsWithDiscIDs[formatID] != null;
+        return !formatID || MB.formatsWithDiscIDs.includes(formatID);
     }
 }
 


### PR DESCRIPTION
### Fix MBS-11085 / MBS-11089

MBS-11085: 
This was changed with cede01b1342c553ceb91e790f61eedcff26db5a8 - I assume under the assumption that MB.formatsWithDiscIDs is an object. It is not, though, it's just an array of IDs, so this was checking whether the position in the array matching the format ID was null. 
Changed to use includes, as it did before (just the native version).

MBS-11089:
While making the file flow strict-local I forgot to change this into a ternary, so it was being passed a boolean when className exists.
