### PR TITLE
MBS-11072: Improve GenerateSQLScripts.pl usability

### DIFF
--- a/admin/GenerateSQLScripts.pl
+++ b/admin/GenerateSQLScripts.pl
@@ -4,6 +4,57 @@ use utf8;
 use warnings;
 use strict;
 
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+
+################################################################################
+
+=head1 NAME
+
+GenerateSQLScripts.pl - Generate SQL DROP scripts for each script in DIRECTORY
+
+=head1 SYNOPSIS
+
+GenerateSQLScripts.pl [options] [--] [DIRECTORY]
+
+Generate a corresponding SQL DROP script for each SQL CREATE script in DIRECTORY
+(admin/sql/ by default).
+
+Options:
+
+    -h, --help                          show this help
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+Copyright (C) 2012 Aurélien Mino
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+
+################################################################################
+
+my $help_flag;
+
+GetOptions(
+    "help|h"                    => \$help_flag,
+);
+
+pod2usage() if $help_flag;
+
+my $extra_arguments_count = $#ARGV + 1;
+
+pod2usage(
+    -exitval => 64, # EX_USAGE
+    -message => "$0: too many arguments",
+) if $extra_arguments_count > 1;
+
+################################################################################
+
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
@@ -339,24 +390,3 @@ sub process_triggers
 
 process_triggers("CreateTriggers.sql", "DropTriggers.sql");
 process_triggers("CreateReplicationTriggers.sql", "DropReplicationTriggers.sql");
-
-=head1 COPYRIGHT
-
-Copyright (C) 2009 Lukas Lalinsky
-Copyright (C) 2012 Aurélien Mino
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-=cut

--- a/admin/GenerateSQLScripts.pl
+++ b/admin/GenerateSQLScripts.pl
@@ -81,6 +81,7 @@ sub find_search_path
     my $search_path = '';
     my $infile = "CreateTables.sql";
     unless (grep { $_ eq $infile } @create_scripts) {
+        print "Use empty search_path by default\n";
         return $search_path;
     }
     unless (-e "$dir/$infile") {
@@ -174,6 +175,8 @@ sub process_tables
     }
     close $drop_fh;
     close $trunc_fh;
+    print "Generated DropTables.sql\n";
+    print "Generated TruncateTables.sql\n";
 
     if (-e "$dir/CreateViews.sql") {
         open FILE, "<$dir/CreateViews.sql";
@@ -195,6 +198,7 @@ sub process_tables
             print OUT "DROP VIEW $view;\n";
         }
         close OUT;
+        print "Generated DropViews.sql\n";
     } else {
         unless (grep { $_ eq 'CreateViews.sql' } @create_scripts) {
             print "Could not find CreateViews.sql, skipping\n"
@@ -211,6 +215,7 @@ sub process_tables
             print OUT "SELECT setval('${table}_${col}_seq', COALESCE((SELECT MAX(${col}) FROM $table), 0) + 1, FALSE);\n";
         }
         close OUT;
+        print "Generated DropViews.sql\n";
     }
 
     if (keys %foreign_keys) {
@@ -240,6 +245,7 @@ sub process_tables
             }
         }
         close OUT;
+        print "Generated CreateFKConstraints.sql\n";
 
         open OUT, ">$dir/DropFKConstraints.sql";
         print OUT "-- Automatically generated, do not edit.\n";
@@ -254,6 +260,7 @@ sub process_tables
             }
         }
         close OUT;
+        print "Generated DropFKConstraints.sql\n";
     } else {
         print "No foreign keys, skipping\n";
     }
@@ -272,6 +279,7 @@ sub process_tables
             print OUT "PRIMARY KEY ($cols);\n";
         }
         close OUT;
+        print "Generated CreatePrimaryKeys.sql\n";
 
         open OUT, ">$dir/DropPrimaryKeys.sql";
         print OUT "-- Automatically generated, do not edit.\n";
@@ -282,6 +290,7 @@ sub process_tables
             print OUT "ALTER TABLE $table DROP CONSTRAINT IF EXISTS ${table}_pkey;\n";
         }
         close OUT;
+        print "Generated DropPrimaryKeys.sql\n";
     } else {
         print "No primary keys, skipping\n";
     }
@@ -302,6 +311,7 @@ sub process_tables
         }
         print OUT "COMMIT;\n";
         close OUT;
+        print "Generated CreateReplicationTriggers.sql\n";
     }
 }
 
@@ -335,6 +345,7 @@ sub process_indexes
         print OUT "DROP INDEX $index;\n";
     }
     close OUT;
+    print "Generated $outfile\n";
 }
 
 if (grep { $_ eq 'CreateIndexes.sql' } @create_scripts) {
@@ -382,6 +393,7 @@ sub process_functions
         print OUT "DROP AGGREGATE $name ($type);\n";
     }
     close OUT;
+    print "Generated $outfile\n";
 }
 
 if (grep { $_ eq 'CreateFunctions.sql' } @create_scripts) {
@@ -414,6 +426,7 @@ sub process_triggers
         print OUT "DROP TRIGGER $trigger->[0] ON $trigger->[1];\n";
     }
     close OUT;
+    print "Generated $outfile\n";
 }
 
 if (grep { $_ eq 'CreateTriggers.sql' } @create_scripts) {


### PR DESCRIPTION
# Problem

[MBVM-60](https://tickets.metabrainz.org/browse/MBVM-60): Output of `setup-amqp-triggers` is misleading and incomplete

# Solution

MBS-11072:
- Self-document `GenerateSQLScripts` with `-h` option
- Add an option to specify a limited set of files to be parsed
- Improve output to log about successfully parsed files

# Checklist for author

* [X] Locally tested with `setup-amqp-triggers`

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Merge the related PR to `musicbrainz-docker` when upgrading to the next release of MusicBrainz Server.