### PR TITLE
MBS-11086: Add icon for tabs with errors in release editor

### DIFF
--- a/root/release/edit/editnote.tt
+++ b/root/release/edit/editnote.tt
@@ -1,7 +1,7 @@
 <div id="form">
   <!-- ko if: validation.errorsExist -->
     <div class="warning">
-      <p>[% l('Some errors were detected in the data you’ve entered. Click on the tabs shaded red and correct any visible errors.') %]</p>
+      <p>[% l('Some errors were detected in the data you’ve entered. Click on the highlighted tabs and correct any visible errors.') %]</p>
     </div>
   <!-- /ko -->
 

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -35,7 +35,14 @@ fieldset {
 }
 
 .warning { border-radius: 6px; }
-.error-tab { background: @negative-light-bg; }
+.error-tab {
+    background-color: @negative-light-bg;
+    background-image: data-uri('../images/icons/warning.png');
+    background-repeat: no-repeat;
+    background-position: left 0.5em top 0.5em;
+    background-size: 16px 16px;
+}
+.error-tab a { padding-left: 2em; }
 .page-error { .error; padding: 1em 0.5em; }
 
 /* __________________________________


### PR DESCRIPTION
### Implement MBS-11086

Some high contrast modes make the red background in the tabs white, making it impossible to know which tabs actually have errors. This adds a warning icon to the appropriate tabs to make it more clear. It probably also helps with color-blindness to some degree, so 2x1.

Standard:
![Screenshot from 2020-09-10 10-11-05](https://user-images.githubusercontent.com/1069224/92693299-1d223080-f34e-11ea-8858-4a82bafd816b.png)

High contrast:
![Screenshot from 2020-09-10 10-11-34](https://user-images.githubusercontent.com/1069224/92693304-1eebf400-f34e-11ea-914e-17ce3fc95000.png)
