### PR TITLE
MBS-11069: Fix diff highlighting of white spaces

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -895,6 +895,10 @@ tr.diff-removal {
     background: @negative-bg;
 }
 
+.diff-only-a, .diff-only-b {
+    white-space: pre-wrap;
+}
+
 /* Statistics pages */
 table.timeline-controls, table.database-statistics {
     border-collapse: collapse;


### PR DESCRIPTION
# Problem

MBS-11069

Browsers omit the rendering of trailing white spaces by default when they wrap content to fit the width of the containing element. In case the white spaces are part of the highlighted differences, they should be rendered before line wraps as well.

# Solution

Change the behavior of white spaces for diffs via CSS, see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

# Action

Someone should verify this change on a test server as I haven't installed the server on my machine (Hopefully I've added this to the correct stylesheet). I only verified that this works by dynamically changing the CSS of the [example that was given for the ticket](
https://musicbrainz.org/edit/62573212) using the Firefox development tools.