### PR TITLE
OAuth2 improvements (MBS-11058) + Content-Security-Policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   musicbrainz-tests:
     docker:
-      - image: metabrainz/musicbrainz-tests:v-2020-05.1-pg12
+      - image: metabrainz/musicbrainz-tests:v-2020-09
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 

--- a/admin/sql/CreateTables.sql
+++ b/admin/sql/CreateTables.sql
@@ -2384,17 +2384,25 @@ CREATE TABLE editor_collection_deleted_entity (
     comment TEXT DEFAULT '' NOT NULL
 );
 
+CREATE TYPE oauth_code_challenge_method AS ENUM ('plain', 'S256');
+
 CREATE TABLE editor_oauth_token
 (
-    id                  SERIAL,
-    editor              INTEGER NOT NULL, -- references editor.id
-    application         INTEGER NOT NULL, -- references application.id
-    authorization_code  TEXT,
-    refresh_token       TEXT,
-    access_token        TEXT,
-    expire_time         TIMESTAMP WITH TIME ZONE NOT NULL,
-    scope               INTEGER NOT NULL DEFAULT 0,
-    granted             TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    id                      SERIAL,
+    editor                  INTEGER NOT NULL, -- references editor.id
+    application             INTEGER NOT NULL, -- references application.id
+    authorization_code      TEXT,
+    refresh_token           TEXT,
+    access_token            TEXT,
+    expire_time             TIMESTAMP WITH TIME ZONE NOT NULL,
+    scope                   INTEGER NOT NULL DEFAULT 0,
+    granted                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    code_challenge          TEXT,
+    code_challenge_method   oauth_code_challenge_method,
+    CONSTRAINT valid_code_challenge CHECK (
+        (code_challenge IS NULL) = (code_challenge_method IS NULL) AND
+        (code_challenge IS NULL OR code_challenge ~ E'^[A-Za-z0-9.~_-]{43,128}$')
+    )
 );
 
 CREATE TABLE editor_watch_preferences

--- a/admin/sql/updates/20200914-oauth-pkce.sql
+++ b/admin/sql/updates/20200914-oauth-pkce.sql
@@ -1,0 +1,15 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+SET search_path = musicbrainz, public;
+
+CREATE TYPE oauth_code_challenge_method AS ENUM ('plain', 'S256');
+ALTER TABLE editor_oauth_token ADD COLUMN code_challenge TEXT;
+ALTER TABLE editor_oauth_token ADD COLUMN code_challenge_method oauth_code_challenge_method;
+ALTER TABLE editor_oauth_token ADD CONSTRAINT valid_code_challenge CHECK (
+  (code_challenge IS NULL) = (code_challenge_method IS NULL) AND
+  (code_challenge IS NULL OR code_challenge ~ E'^[A-Za-z0-9.~_-]{43,128}$')
+);
+
+COMMIT;

--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -104,6 +104,8 @@ sub HTML_VALIDATOR { 'http://localhost:8888?out=json' }
 
 sub MB_LANGUAGES { qw( de el-gr es-es et fi fr it ja nl sq en ) }
 
+sub OAUTH2_ENABLE_PKCE { 1 }
+
 sub PLUGIN_CACHE_OPTIONS {
     my $self = shift;
     return {

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -364,6 +364,10 @@ sub COVER_ART_ARCHIVE_DOWNLOAD_PREFIX { "//coverartarchive.org" };
 sub MAPBOX_MAP_ID { 'mapbox/streets-v11' }
 sub MAPBOX_ACCESS_TOKEN { '' }
 
+# Enable PKCE for OAuth 2.0 clients.
+# Currently requires a schema change: admin/sql/updates/20200914-oauth-pkce.sql
+sub OAUTH2_ENABLE_PKCE { 0 }
+
 # Disallow OAuth2 requests over plain HTTP
 sub OAUTH2_ENFORCE_TLS { my $self = shift; !$self->DB_STAGING_SERVER }
 

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -580,6 +580,7 @@ sub TO_JSON {
         current_language_html
         entity
         genre_map
+        globals_script_nonce
         jsonld_data
         last_replication_date
         more_tags

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -171,7 +171,7 @@ sub _send_password_reset_email
     };
 }
 
-sub lost_password : Path('/lost-password') ForbiddenOnSlaves CSRFToken
+sub lost_password : Path('/lost-password') ForbiddenOnSlaves SecureForm
 {
     my ($self, $c) = @_;
 
@@ -220,7 +220,7 @@ sub lost_password : Path('/lost-password') ForbiddenOnSlaves CSRFToken
     $c->detach;
 }
 
-sub reset_password : Path('/reset-password') ForbiddenOnSlaves DenyWhenReadonly CSRFToken
+sub reset_password : Path('/reset-password') ForbiddenOnSlaves DenyWhenReadonly SecureForm
 {
     my ($self, $c) = @_;
 
@@ -302,7 +302,7 @@ sub reset_password : Path('/reset-password') ForbiddenOnSlaves DenyWhenReadonly 
     $c->stash->{form} = $form;
 }
 
-sub lost_username : Path('/lost-username') ForbiddenOnSlaves CSRFToken
+sub lost_username : Path('/lost-username') ForbiddenOnSlaves SecureForm
 {
     my ($self, $c) = @_;
 
@@ -350,7 +350,7 @@ request is received), update the profile data in the database.
 
 =cut
 
-sub edit : Local RequireAuth DenyWhenReadonly CSRFToken {
+sub edit : Local RequireAuth DenyWhenReadonly SecureForm {
     my ($self, $c) = @_;
 
     my $editor = $c->model('Editor')->get_by_id($c->user->id);
@@ -442,7 +442,7 @@ when use to update the database data when we receive a valid POST request.
 
 =cut
 
-sub change_password : Path('/account/change-password') RequireSSL DenyWhenReadonly CSRFToken
+sub change_password : Path('/account/change-password') RequireSSL DenyWhenReadonly SecureForm
 {
     my ($self, $c) = @_;
 
@@ -480,7 +480,7 @@ Change the users preferences
 
 =cut
 
-sub preferences : Path('/account/preferences') RequireAuth DenyWhenReadonly CSRFToken
+sub preferences : Path('/account/preferences') RequireAuth DenyWhenReadonly SecureForm
 {
     my ($self, $c) = @_;
 
@@ -532,7 +532,7 @@ new user.
 
 =cut
 
-sub register : Path('/register') ForbiddenOnSlaves RequireSSL DenyWhenReadonly CSRFToken
+sub register : Path('/register') ForbiddenOnSlaves RequireSSL DenyWhenReadonly SecureForm
 {
     my ($self, $c) = @_;
 
@@ -726,7 +726,7 @@ sub applications : Path('/account/applications') RequireAuth RequireSSL
     );
 }
 
-sub revoke_application_access : Path('/account/applications/revoke-access') Args(2) RequireAuth DenyWhenReadonly CSRFToken
+sub revoke_application_access : Path('/account/applications/revoke-access') Args(2) RequireAuth DenyWhenReadonly SecureForm
 {
     my ($self, $c, $application_id, $scope) = @_;
 
@@ -754,7 +754,7 @@ sub revoke_application_access : Path('/account/applications/revoke-access') Args
     }
 }
 
-sub register_application : Path('/account/applications/register') RequireAuth RequireSSL DenyWhenReadonly CSRFToken
+sub register_application : Path('/account/applications/register') RequireAuth RequireSSL DenyWhenReadonly SecureForm
 {
     my ($self, $c) = @_;
 
@@ -781,7 +781,7 @@ sub register_application : Path('/account/applications/register') RequireAuth Re
     }
 }
 
-sub edit_application : Path('/account/applications/edit') Args(1) RequireAuth RequireSSL DenyWhenReadonly CSRFToken
+sub edit_application : Path('/account/applications/edit') Args(1) RequireAuth RequireSSL DenyWhenReadonly SecureForm
 {
     my ($self, $c, $id) = @_;
 
@@ -814,7 +814,7 @@ sub edit_application : Path('/account/applications/edit') Args(1) RequireAuth Re
     }
 }
 
-sub remove_application : Path('/account/applications/remove') Args(1) RequireAuth RequireSSL DenyWhenReadonly CSRFToken
+sub remove_application : Path('/account/applications/remove') Args(1) RequireAuth RequireSSL DenyWhenReadonly SecureForm
 {
     my ($self, $c, $id) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -6,7 +6,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller' };
 
 use MusicBrainz::Server::Translation qw(l ln );
 
-sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves CSRFToken
+sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves SecureForm
 {
     my ($self, $c, $user_name) = @_;
 
@@ -97,7 +97,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves CSRF
     );
 }
 
-sub delete_user : Path('/admin/user/delete') Args(1) RequireAuth HiddenOnSlaves CSRFToken {
+sub delete_user : Path('/admin/user/delete') Args(1) RequireAuth HiddenOnSlaves SecureForm {
     my ($self, $c, $name) = @_;
 
     my $editor = $c->model('Editor')->get_by_name($name);
@@ -136,7 +136,7 @@ sub delete_user : Path('/admin/user/delete') Args(1) RequireAuth HiddenOnSlaves 
     }
 }
 
-sub edit_banner : Path('/admin/banner/edit') Args(0) RequireAuth(banner_editor) CSRFToken {
+sub edit_banner : Path('/admin/banner/edit') Args(0) RequireAuth(banner_editor) SecureForm {
     my ($self, $c) = @_;
 
     my $current_message = $c->stash->{server_details}->{alert};

--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -64,7 +64,7 @@ sub attribute_index : Chained('attribute_base') PathPart('') RequireAuth(account
     );
 }
 
-sub create : Chained('attribute_base') RequireAuth(account_admin) CSRFToken {
+sub create : Chained('attribute_base') RequireAuth(account_admin) SecureForm {
     my ($self, $c) = @_;
     my $model = $c->stash->{model};
 
@@ -85,7 +85,7 @@ sub create : Chained('attribute_base') RequireAuth(account_admin) CSRFToken {
     }
 }
 
-sub edit : Chained('attribute_base') Args(1) RequireAuth(account_admin) CSRFToken {
+sub edit : Chained('attribute_base') Args(1) RequireAuth(account_admin) SecureForm {
     my ($self, $c, $id) = @_;
     my $model = $c->stash->{model};
     my $attr = $c->model($model)->get_by_id($id);
@@ -107,7 +107,7 @@ sub edit : Chained('attribute_base') Args(1) RequireAuth(account_admin) CSRFToke
     }
 }
 
-sub delete : Chained('attribute_base') Args(1) RequireAuth(account_admin) CSRFToken {
+sub delete : Chained('attribute_base') Args(1) RequireAuth(account_admin) SecureForm {
     my ($self, $c, $id) = @_;
     my $model = $c->stash->{model};
     my $attr = $c->model($model)->get_by_id($id);

--- a/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
@@ -54,7 +54,7 @@ sub index : Path Args(0)
     );
 }
 
-sub create : Local Args(0) RequireAuth(wiki_transcluder) Edit CSRFToken
+sub create : Local Args(0) RequireAuth(wiki_transcluder) Edit SecureForm
 {
     my ($self, $c) = @_;
 
@@ -86,7 +86,7 @@ sub create : Local Args(0) RequireAuth(wiki_transcluder) Edit CSRFToken
     );
 }
 
-sub edit : Local Args(0) RequireAuth(wiki_transcluder) Edit CSRFToken
+sub edit : Local Args(0) RequireAuth(wiki_transcluder) Edit SecureForm
 {
     my ($self, $c) = @_;
 
@@ -127,7 +127,7 @@ sub edit : Local Args(0) RequireAuth(wiki_transcluder) Edit CSRFToken
     );
 }
 
-sub delete : Local Args(0) RequireAuth(wiki_transcluder) Edit CSRFToken
+sub delete : Local Args(0) RequireAuth(wiki_transcluder) Edit SecureForm
 {
     my ($self, $c) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
+++ b/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
@@ -25,7 +25,7 @@ sub index : Path('')
     );
 }
 
-sub nominate : Path('nominate') Args(1) RequireAuth(auto_editor) CSRFToken
+sub nominate : Path('nominate') Args(1) RequireAuth(auto_editor) SecureForm
 {
     my ($self, $c, $editor) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -577,7 +577,7 @@ sub userinfo : Local
 
     if ($c->request->method eq 'OPTIONS') {
         $c->res->headers->header('Access-Control-Allow-Headers' => 'authorization');
-        $self->_send_options_response($c, 'GET');
+        $self->_send_options_response($c, 'GET, POST');
     }
 
     $c->authenticate({}, 'musicbrainz.org');

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -33,6 +33,9 @@ sub authorize : Local Args(0) RequireAuth SecureForm
 {
     my ($self, $c) = @_;
 
+    # https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-4.2.4
+    $c->res->header('Referrer-Policy' => 'strict-origin-when-cross-origin');
+
     $self->_enforce_tls_html($c);
 
     my %params;

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -29,14 +29,9 @@ sub index : Private
     $c->detach;
 }
 
-sub authorize : Local Args(0) RequireAuth CSRFToken
+sub authorize : Local Args(0) RequireAuth SecureForm
 {
     my ($self, $c) = @_;
-
-    # https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-4.14
-    # Authorization servers MUST prevent clickjacking attacks.
-    $c->response->header('X-Frame-Options' => 'DENY');
-    $c->response->header('Content-Security-Policy' => q(default-src 'self' staticbrainz.org));
 
     $self->_enforce_tls_html($c);
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -33,6 +33,10 @@ sub authorize : Local Args(0) RequireAuth CSRFToken
 {
     my ($self, $c) = @_;
 
+    # https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-4.14
+    # Authorization servers MUST prevent clickjacking attacks.
+    $c->response->header('X-Frame-Options' => 'DENY');
+
     $self->_enforce_tls_html($c);
 
     my %params;

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -36,6 +36,7 @@ sub authorize : Local Args(0) RequireAuth CSRFToken
     # https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-4.14
     # Authorization servers MUST prevent clickjacking attacks.
     $c->response->header('X-Frame-Options' => 'DENY');
+    $c->response->header('Content-Security-Policy' => q(default-src 'self' staticbrainz.org));
 
     $self->_enforce_tls_html($c);
 

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -200,8 +200,6 @@ sub begin : Private
 {
     my ($self, $c) = @_;
 
-    return if exists $c->action->attributes->{Minimal};
-
     ensure_ssl($c) if $c->action->attributes->{RequireSSL};
 
     $c->stats->enable(1) if DBDefs->DEVELOPMENT_SERVER;
@@ -389,8 +387,6 @@ sub end : ActionClass('RenderView')
     my $attrs = $c->action->attributes;
 
     $c->generate_csrf_token if exists $attrs->{CSRFToken};
-
-    return if exists $attrs->{Minimal};
 
     $c->stash->{server_details} = {
         %{ $c->stash->{server_details} // {} },

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -133,7 +133,7 @@ sub do_login : Private
     $c->detach;
 }
 
-sub login : Path('/login') ForbiddenOnSlaves RequireSSL CSRFToken
+sub login : Path('/login') ForbiddenOnSlaves RequireSSL SecureForm
 {
     my ($self, $c) = @_;
 
@@ -259,7 +259,7 @@ Allows users to contact other users via email
 
 =cut
 
-sub contact : Chained('load') RequireAuth HiddenOnSlaves CSRFToken
+sub contact : Chained('load') RequireAuth HiddenOnSlaves SecureForm
 {
     my ($self, $c) = @_;
 
@@ -569,7 +569,7 @@ sub privileged : Path('/privileged')
     );
 }
 
-sub report : Chained('load') RequireAuth HiddenOnSlaves CSRFToken {
+sub report : Chained('load') RequireAuth HiddenOnSlaves SecureForm {
     my ($self, $c) = @_;
 
     my $reporter = $c->user;

--- a/lib/MusicBrainz/Server/Controller/Watch.pm
+++ b/lib/MusicBrainz/Server/Controller/Watch.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Watch;
 use Moose;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
-sub list : Local RequireAuth CSRFToken {
+sub list : Local RequireAuth SecureForm {
     my ($self, $c) = @_;
 
     if ($c->form_posted && $c->validate_csrf_token) {

--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -178,6 +178,38 @@ sub revoke_access
                     $editor_id, $application_id, $scope);
 }
 
+sub revoke_token {
+    my ($self, $application_id, $token) = @_;
+
+    die 'undef token' unless defined $token;
+
+    # If the token is a refresh token, or if it's an access token with no
+    # associated refresh token ("online" apps), delete the entire
+    # authorization grant.
+    return if $self->sql->select_single_value(
+        'DELETE FROM editor_oauth_token ' .
+        'WHERE application = $1 ' .
+        'AND (' .
+            '(refresh_token IS NOT NULL AND refresh_token = $2) OR ' .
+            '(refresh_token IS NULL AND access_token = $2)' .
+        ') RETURNING id',
+        $application_id, $token,
+    );
+
+    # Otherwise, only NULL the access token. RFC 7009 specifies that we MAY
+    # revoke the respective refresh token as well, but our implementation
+    # allows it to continue to be used unless the client explicitly revokes
+    # the refresh token.
+    $self->sql->do(
+        'UPDATE editor_oauth_token ' .
+        'SET access_token = NULL ' .
+        'WHERE application = ? ' .
+        'AND access_token = ?',
+        $application_id, $token,
+    );
+    return;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -235,9 +235,13 @@ sub generate_gid
     lc(Data::UUID::MT->new( version => 4 )->create_string());
 }
 
-sub generate_token
-{
-    encode_base64url(pack('LLLL', irand(), irand(), irand(), irand()));
+Readonly my $TOKEN_SIZE => 6; # times 32 bits
+sub generate_token {
+    encode_base64url(
+        pack(
+            'L' x $TOKEN_SIZE,
+            map { irand() } (1 .. $TOKEN_SIZE),
+        ));
 }
 
 sub get_area_containment_query {

--- a/lib/MusicBrainz/Server/Entity/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Entity/EditorOAuthToken.pm
@@ -36,6 +36,16 @@ has 'authorization_code' => (
     is => 'rw',
 );
 
+has 'code_challenge' => (
+    isa => 'Maybe[Str]',
+    is => 'rw',
+);
+
+has 'code_challenge_method' => (
+    isa => 'Maybe[Str]',
+    is => 'rw',
+);
+
 has 'refresh_token' => (
     isa => 'Maybe[Str]',
     is => 'rw',

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -101,7 +101,6 @@
 
         <div id="page"[% IF full_width %] class="fullwidth"[% END %][% IF homepage %] class="homepage"[% END %]>
             [%- content -%]
-            <div style="clear: both"></div>
         </div>
 
         [%- INCLUDE 'layout/merge-helper.tt'

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -112,11 +112,9 @@ const Head = ({$c, ...props}: HeadProps): React.Element<'head'> => (
     />
 
     <noscript>
-      <style
-        dangerouslySetInnerHTML={{
-          __html: '.header > .right > .bottom > .menu' +
-                  ' > li:focus > ul { left: auto; }',
-        }}
+      <link
+        href={require('../../static/styles/noscript.less')}
+        rel="stylesheet"
         type="text/css"
       />
     </noscript>

--- a/root/layout/components/globalsScript.js
+++ b/root/layout/components/globalsScript.js
@@ -9,9 +9,10 @@
 
 import * as React from 'react';
 
-import {SanitizedCatalystContext} from '../../context';
+import {CatalystContext} from '../../context';
 import DBDefs from '../../static/scripts/common/DBDefs-client-values';
 import escapeClosingTags from '../../utility/escapeClosingTags';
+import sanitizedContext from '../../utility/sanitizedContext';
 
 /*
  * In production, lib/DBDefs.pm is rendered by consul-template, and so
@@ -43,13 +44,13 @@ const CLIENT_DBDEFS_CODE =
   ')})';
 
 export default ((
-  <SanitizedCatalystContext.Consumer>
+  <CatalystContext.Consumer>
     {$c => {
       const CLIENT_CATALYST_CONTEXT_CODE =
         'Object.defineProperty(window,' +
         JSON.stringify(GLOBAL_CATALYST_CONTEXT_NAMESPACE) +
         ',{value:Object.freeze(' +
-        escapeClosingTags(JSON.stringify($c)) +
+        escapeClosingTags(JSON.stringify(sanitizedContext($c))) +
         ')})';
       return (
         <script
@@ -57,8 +58,9 @@ export default ((
             __html: CLIENT_DBDEFS_CODE + ';' +
               CLIENT_CATALYST_CONTEXT_CODE,
           }}
+          nonce={$c.stash.globals_script_nonce}
         />
       );
     }}
-  </SanitizedCatalystContext.Consumer>
+  </CatalystContext.Consumer>
 ): React.MixedElement);

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -230,7 +230,6 @@ const Layout = ({
         id="page"
       >
         {children}
-        <div style={{clear: 'both'}} />
       </div>
 
       {($c.session?.merger && !$c.stash.hide_merge_helper /*:: === true */) &&

--- a/root/oauth2/OAuth2FormPost.js
+++ b/root/oauth2/OAuth2FormPost.js
@@ -1,0 +1,63 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+type Props = {
+  +applicationName: string,
+  +fields: {+[fieldName: string]: string, ...},
+  +redirectUri: string,
+};
+
+const OAuth2FormPost = ({
+  applicationName,
+  fields,
+  redirectUri,
+}: Props): React.Element<'html'> => {
+  const title = texp.l('Redirecting to {application}', {
+    application: applicationName,
+  });
+  return (
+    <html>
+      <head>
+        <title>{title}</title>
+      </head>
+      <body>
+        <form action={redirectUri} method="post">
+          <h1>{title}</h1>
+          <p>
+            {l(`If this page doesn’t redirect automatically,
+                press “Submit” below.`)}
+          </p>
+          {Object.entries(fields).map(([fieldName, value]) => (
+            <input
+              key={fieldName}
+              name={fieldName}
+              type="hidden"
+              value={value}
+            />
+          ))}
+          <input type="submit" value={l('Submit')} />
+        </form>
+        <script
+          /*
+           * If for some reason you need to change the script below, you
+           * should also update its Content-Security-Policy sha256 in
+           * Controller::OAuth2::_send_redirect_response.
+           */
+          dangerouslySetInnerHTML={{
+            __html: 'document.forms[0].submit()',
+          }}
+        />
+      </body>
+    </html>
+  );
+};
+
+export default OAuth2FormPost;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -103,6 +103,7 @@ module.exports = {
   'mbid/NotFound': require('../mbid/NotFound'),
   'oauth2/OAuth2Authorize': require('../oauth2/OAuth2Authorize'),
   'oauth2/OAuth2Error': require('../oauth2/OAuth2Error'),
+  'oauth2/OAuth2FormPost': require('../oauth2/OAuth2FormPost'),
   'oauth2/OAuth2Oob': require('../oauth2/OAuth2Oob'),
   'place/PlaceEvents': require('../place/PlaceEvents'),
   'place/PlaceIndex': require('../place/PlaceIndex'),

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -182,6 +182,11 @@ form .input-note {
     font-size: @small-text;
 }
 
+.sanitized-password-note {
+    color: #F22;
+    font-weight: bold;
+}
+
 ul.radio-list {
     list-style-type: none;
     list-style-image: none;

--- a/root/static/styles/noscript.less
+++ b/root/static/styles/noscript.less
@@ -1,0 +1,1 @@
+.header > .right > .bottom > .menu > li:focus > ul { left: auto; }

--- a/root/types.js
+++ b/root/types.js
@@ -218,6 +218,7 @@ declare type CatalystStashT = {
   +current_language_html: string,
   +entity?: CoreEntityT,
   +genre_map?: {+[genreName: string]: GenreT, ...},
+  +globals_script_nonce?: string,
   +hide_merge_helper?: boolean,
   +invalid_csrf_token?: boolean,
   +jsonld_data?: {...},

--- a/root/user/login.tt
+++ b/root/user/login.tt
@@ -25,7 +25,7 @@
         [% form_row_password(r, 'password', l('Password:')) %]
         [% IF server_details.staging_server && server_details.is_sanitized %]
             <div class="row no-label">
-                <span class="input-note" style="color: #f22; font-weight: bold;">[% l('This is a development server; all passwords have been reset to "mb".') %]</span>
+                <span class="input-note sanitized-password-note">[% l('This is a development server; all passwords have been reset to "mb".') %]</span>
             </div>
         [% END %]
 

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -96,6 +96,11 @@ test 'Authorize web workflow online' => sub {
     my $client_id = 'id-web';
     my $redirect_uri = 'http://www.example.com/callback';
 
+    my $headers_ok = sub {
+        csp_headers_ok($test);
+        is($test->mech->response->header('Referrer-Policy'), 'strict-origin-when-cross-origin');
+    };
+
     # This requires login first
     $test->mech->get_ok('/oauth2/authorize?client_id=id-web&response_type=code&scope=profile&state=xxx&redirect_uri=http://www.example.com/callback');
     html_ok($test->mech->content);
@@ -107,7 +112,7 @@ test 'Authorize web workflow online' => sub {
     $test->mech->content_like(qr{Test Web is requesting permission});
     $test->mech->content_like(qr{View your public account information});
     $test->mech->content_unlike(qr{Perform the above operations when I'm not using the application});
-    csp_headers_ok($test);
+    $headers_ok->();
 
     # Deny the request
     $test->mech->max_redirect(0);
@@ -117,12 +122,12 @@ test 'Authorize web workflow online' => sub {
     # Incorrect scope
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=code&scope=does-not-exist&state=xxx&redirect_uri=$redirect_uri");
     oauth_redirect_error($test->mech, 'www.example.com', '/callback', 'xxx', 'invalid_scope');
-    csp_headers_ok($test);
+    $headers_ok->();
 
     # Incorrect response type
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=yyy&scope=profile&state=xxx&redirect_uri=$redirect_uri");
     oauth_redirect_error($test->mech, 'www.example.com', '/callback', 'xxx', 'unsupported_response_type');
-    csp_headers_ok($test);
+    $headers_ok->();
 
     # https://tools.ietf.org/html/rfc6749#section-3.1
     # Request and response parameters MUST NOT be included more than once.
@@ -142,21 +147,21 @@ test 'Authorize web workflow online' => sub {
         is($test->mech->status, 400);
         $test->mech->content_like(qr{invalid_request});
         $test->mech->content_like(qr{Parameter is included more than once in the request: $dupe_param});
-        csp_headers_ok($test);
+        $headers_ok->();
     }
 
     # Authorize the request
     $test->mech->get_ok("/oauth2/authorize?client_id=$client_id&response_type=code&scope=profile&state=xxx&redirect_uri=$redirect_uri");
     $test->mech->submit_form( form_name => 'confirm', button => 'confirm.submit' );
     my $code = oauth_redirect_ok($test->mech, 'www.example.com', '/callback', 'xxx');
-    csp_headers_ok($test);
+    $headers_ok->();
     oauth_authorization_code_ok($test, $code, 2, 11, 0);
 
     # Try to authorize one more time, this time we should be redirected automatically and only get the access_token
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=code&scope=profile&state=yyy&redirect_uri=$redirect_uri");
     my $code2 = oauth_redirect_ok($test->mech, 'www.example.com', '/callback', 'yyy');
     isnt($code, $code2);
-    csp_headers_ok($test);
+    $headers_ok->();
     oauth_authorization_code_ok($test, $code2, 2, 11, 0);
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -17,12 +17,12 @@ sub oauth_redirect_ok
 {
     my ($mech, $host, $path, $state) = @_;
 
-    is(302, $mech->status);
+    is($mech->status, 302);
     my $uri = URI->new($mech->response->header('Location'));
-    is('http', $uri->scheme);
-    is($host, $uri->host);
-    is($path, $uri->path);
-    is($state, $uri->query_param('state'));
+    is($uri->scheme, 'http');
+    is($uri->host, $host);
+    is($uri->path, $path);
+    is($uri->query_param('state'), $state);
     my $code = $uri->query_param('code');
     ok($code);
 
@@ -33,14 +33,14 @@ sub oauth_redirect_error
 {
     my ($mech, $host, $path, $state, $error) = @_;
 
-    is(302, $mech->status);
+    is($mech->status, 302);
     my $uri = URI->new($mech->response->header('Location'));
-    is('http', $uri->scheme);
-    is($host, $uri->host);
-    is($path, $uri->path);
-    is($state, $uri->query_param('state'));
-    is($error, $uri->query_param('error'));
-    is(undef, $uri->query_param('code'));
+    is($uri->scheme, 'http');
+    is($uri->host, $host);
+    is($uri->path, $path);
+    is($uri->query_param('state'), $state);
+    is($uri->query_param('error'), $error);
+    is($uri->query_param('code'), undef);
 }
 
 sub oauth_authorization_code_ok
@@ -49,16 +49,16 @@ sub oauth_authorization_code_ok
 
     my $token = $test->c->model('EditorOAuthToken')->get_by_authorization_code($code);
     ok($token);
-    is($application_id, $token->application_id);
-    is($editor_id, $token->editor_id);
-    is($code, $token->authorization_code);
+    is($token->application_id, $application_id);
+    is($token->editor_id, $editor_id);
+    is($token->authorization_code, $code);
     if ($offline) {
-        isnt(undef, $token->refresh_token);
+        isnt($token->refresh_token, undef);
     }
     else {
-        is(undef, $token->refresh_token);
+        is($token->refresh_token, undef);
     }
-    is(undef, $token->access_token);
+    is($token->access_token, undef);
 
     my $application = $test->c->model('Application')->get_by_id($application_id);
     $test->mech->post_ok('/oauth2/token', {
@@ -300,8 +300,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_grant', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_grant');
 
     # Expired authorization code
     $code = "kEbi7Dwg4hGRFvz9W8VIuQ";
@@ -313,8 +313,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_grant', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_grant');
 
     $code = "liUxgzsg4hGvDxX9W8VIuQ";
 
@@ -326,8 +326,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(401, $test->mech->status);
-    is('invalid_client', $response->{error});
+    is($test->mech->status, 401);
+    is($response->{error}, 'invalid_client');
 
     # Incorrect client_id
     $test->mech->post('/oauth2/token', {
@@ -338,8 +338,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(401, $test->mech->status);
-    is('invalid_client', $response->{error});
+    is($test->mech->status, 401);
+    is($response->{error}, 'invalid_client');
 
     # Missing client_secret
     $test->mech->post('/oauth2/token', {
@@ -349,8 +349,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(401, $test->mech->status);
-    is('invalid_client', $response->{error});
+    is($test->mech->status, 401);
+    is($response->{error}, 'invalid_client');
 
     # Incorrect client_secret
     $test->mech->post('/oauth2/token', {
@@ -361,8 +361,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(401, $test->mech->status);
-    is('invalid_client', $response->{error});
+    is($test->mech->status, 401);
+    is($response->{error}, 'invalid_client');
 
     # Missing grant_type
     $test->mech->post('/oauth2/token', {
@@ -372,8 +372,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_request', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_request');
 
     # Incorrect grant_type
     $test->mech->post('/oauth2/token', {
@@ -384,8 +384,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('unsupported_grant_type', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'unsupported_grant_type');
 
     # Missing redirect_uri
     $test->mech->post('/oauth2/token', {
@@ -395,8 +395,8 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_request', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_request');
 
     # Incorect redirect_uri
     $test->mech->post('/oauth2/token', {
@@ -407,8 +407,8 @@ test 'Exchange authorization code' => sub {
         code => $code
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_request', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_request');
 
     # Missing code
     $test->mech->post('/oauth2/token', {
@@ -418,8 +418,8 @@ test 'Exchange authorization code' => sub {
         redirect_uri => 'urn:ietf:wg:oauth:2.0:oob',
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_request', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_request');
 
     # Correct code, but incorrect application
     $test->mech->post('/oauth2/token', {
@@ -430,14 +430,14 @@ test 'Exchange authorization code' => sub {
         code => $code
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_grant', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_grant');
 
     # Correct parameters, but GET request
     $test->mech->get("/oauth2/token?client_id=id-desktop&client_secret=id-desktop-secret&grant_type=authorization_code&redirect_uri=urn:ietf:wg:oauth:2.0:oob&code=$code");
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_request', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_request');
 
     # No problems, receives access token
     $test->mech->post_ok('/oauth2/token', {
@@ -448,9 +448,9 @@ test 'Exchange authorization code' => sub {
         code => $code,
     });
     $response = from_json($test->mech->content);
-    is(undef, $response->{error});
-    is(undef, $response->{error_description});
-    is('bearer', $response->{token_type});
+    is($response->{error}, undef);
+    is($response->{error_description}, undef);
+    is($response->{token_type}, 'bearer');
     ok($response->{access_token});
     ok($response->{refresh_token});
     ok($response->{expires_in});
@@ -472,8 +472,8 @@ test 'Exchange refresh code' => sub {
         refresh_token => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_grant', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_grant');
 
     # Correct token, but incorrect application
     $code = "yi3qjrMf4hG9VVUxXMVIuQ";
@@ -484,8 +484,8 @@ test 'Exchange refresh code' => sub {
         refresh_token => $code,
     });
     $response = from_json($test->mech->content);
-    is(400, $test->mech->status);
-    is('invalid_grant', $response->{error});
+    is($test->mech->status, 400);
+    is($response->{error}, 'invalid_grant');
 
     # No problems, receives access token
     $test->mech->post_ok('/oauth2/token', {
@@ -495,7 +495,7 @@ test 'Exchange refresh code' => sub {
         refresh_token => $code,
     });
     $response = from_json($test->mech->content);
-    is('bearer', $response->{token_type});
+    is($response->{token_type}, 'bearer');
     ok($response->{access_token});
     ok($response->{refresh_token});
     ok($response->{expires_in});

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -91,6 +91,7 @@ test 'Authorize web workflow online' => sub {
     $test->mech->content_like(qr{Test Web is requesting permission});
     $test->mech->content_like(qr{View your public account information});
     $test->mech->content_unlike(qr{Perform the above operations when I'm not using the application});
+    is($test->mech->response->header('X-Frame-Options'), 'DENY');
 
     # Deny the request
     $test->mech->max_redirect(0);
@@ -100,10 +101,12 @@ test 'Authorize web workflow online' => sub {
     # Incorrect scope
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=code&scope=does-not-exist&state=xxx&redirect_uri=$redirect_uri");
     oauth_redirect_error($test->mech, 'www.example.com', '/callback', 'xxx', 'invalid_scope');
+    is($test->mech->response->header('X-Frame-Options'), 'DENY');
 
     # Incorrect response type
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=yyy&scope=profile&state=xxx&redirect_uri=$redirect_uri");
     oauth_redirect_error($test->mech, 'www.example.com', '/callback', 'xxx', 'unsupported_response_type');
+    is($test->mech->response->header('X-Frame-Options'), 'DENY');
 
     # https://tools.ietf.org/html/rfc6749#section-3.1
     # Request and response parameters MUST NOT be included more than once.
@@ -123,18 +126,21 @@ test 'Authorize web workflow online' => sub {
         is($test->mech->status, 400);
         $test->mech->content_like(qr{invalid_request});
         $test->mech->content_like(qr{Parameter is included more than once in the request: $dupe_param});
+        is($test->mech->response->header('X-Frame-Options'), 'DENY');
     }
 
     # Authorize the request
     $test->mech->get_ok("/oauth2/authorize?client_id=$client_id&response_type=code&scope=profile&state=xxx&redirect_uri=$redirect_uri");
     $test->mech->submit_form( form_name => 'confirm', button => 'confirm.submit' );
     my $code = oauth_redirect_ok($test->mech, 'www.example.com', '/callback', 'xxx');
+    is($test->mech->response->header('X-Frame-Options'), 'DENY');
     oauth_authorization_code_ok($test, $code, 2, 11, 0);
 
     # Try to authorize one more time, this time we should be redirected automatically and only get the access_token
     $test->mech->get("/oauth2/authorize?client_id=$client_id&response_type=code&scope=profile&state=yyy&redirect_uri=$redirect_uri");
     my $code2 = oauth_redirect_ok($test->mech, 'www.example.com', '/callback', 'yyy');
     isnt($code, $code2);
+    is($test->mech->response->header('X-Frame-Options'), 'DENY');
     oauth_authorization_code_ok($test, $code2, 2, 11, 0);
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -225,6 +225,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::Medium::fragments",
   "Controller::OAuth2::authorize",
   "Controller::OAuth2::oob",
+  "Controller::OAuth2::revoke",
   "Controller::OAuth2::token",
   "Controller::OAuth2::tokeninfo",
   "Controller::OAuth2::userinfo",

--- a/t/sql/oauth.sql
+++ b/t/sql/oauth.sql
@@ -19,7 +19,8 @@ INSERT INTO editor_oauth_token (editor, application, refresh_token, access_token
     VALUES (11, 1, 'yi3qjrMf4hG9VVUxXMVIuQ', '7Fjfp0ZBr1KtDRbnfVdmIw', now() + interval '1 hour', 1),
            (11, 1, 'uTuPnUfMRQPx8HBnHf22eg', 'Nlaa7v15QHm9g8rUOmT3dQ', now() + interval '1 hour', 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128),
            (11, 1, 'xi2Aq4235zX32XUx1231u1', '3fxf40Z5r6K78D9b031xaw', now() - interval '1 hour', 1),
-           (14, 1, 'r29KLDbKINaCcrEEpv89XA', 'h_UngEx7VcA6I-XybPS13Q', now() + interval '1 hour', 1);
+           (14, 1, 'r29KLDbKINaCcrEEpv89XA', 'h_UngEx7VcA6I-XybPS13Q', now() + interval '1 hour', 1),
+           (14, 2, NULL, '8YCRGDkkIooBHeriCgk1d6oUpWJ-XCDd', now() + interval '1 hour', 1);
 
 INSERT INTO editor_collection (gid, editor, name, public, type)
     VALUES ('181685d4-a23a-4140-a343-b7d15de26ff7', 11, 'editor1''s super secret collection', FALSE, 1);


### PR DESCRIPTION
If you're on the MusicBrainz team and have access to the OAuch Security Report, this should resolve all issues except TC4, TC11, TC12, and TC14 (some of those are breaking changes). This also sets a Content-Security-Policy on other pages that deal with account/admin data.

None of the changes here should be breaking except for the "Disallow same parameter twice" one, and that should be very low impact. The `Content-Security-Policy` headers might in theory interfere with userscripts and custom CSS in Firefox (I think Chrome is fine), *but* it's not set on any pages where userscripts typically run (edit and entity pages). We could see what impact it has after putting it on beta in any case.

I'm not sure that the report's analysis of our token entropy size was correct since we do use four random 32-bit integers from `Math::Random::Secure::irand` which is 128 bits. I did increase that to 192 bits anyway. So all OAuth-related tokens plus remember_me tokens will now be slightly longer.