### PR TITLE
Fix innocuous warnings caused by Edit release edit

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -174,7 +174,7 @@ sub build_display_data
             my $country_id = $event->{country_id};
             return MusicBrainz::Server::Entity::ReleaseEvent->new(
                 country_id => $country_id,
-                country => $loaded->{Area}{$country_id},
+                defined $country_id ? (country => $loaded->{Area}{$country_id}) : (),
                 date => MusicBrainz::Server::Entity::PartialDate->new_from_row($event->{date}),
             )
         };


### PR DESCRIPTION
# Problem

Edits adding release event without country such as edit 72951011 were causing the following warnings to occur in website server logs:

    Use of uninitialized value $country_id in hash element at
        lib/MusicBrainz/Server/Edit/Release/Edit.pm line 178.

    Use of uninitialized value within @_ in anonymous hash ({}) at
        lib/perl5/x86_64-linux-gnu-thread-multi/Moose/Object.pm line 42.

These warnings are neither causing nor revealing any issue but occurred 600 times just on yesterday.