### PR TITLE
Enforce ESLint rules followed so far

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           sudo -E -H -u musicbrainz make -C po all_quiet deploy
           NODE_ENV=test WEBPACK_MODE=development sudo -E -H -u musicbrainz carton exec -- ./script/compile_resources.sh server web-tests
           sudo -E -H -u musicbrainz ./node_modules/.bin/flow --quiet
+          sudo -E -H -u musicbrainz ./node_modules/.bin/eslint --max-warnings 0 .
           rm /etc/service/chrome/down && sv start chrome
           sudo -E -H -u musicbrainz carton exec -- perl \
               -I lib \

--- a/.eslintrc.unfixed.yaml
+++ b/.eslintrc.unfixed.yaml
@@ -1,0 +1,105 @@
+rules:
+  no-await-in-loop: error
+  no-extra-semi: warn
+  no-unused-vars: error
+  consistent-return: error
+  eqeqeq: [warn, smart]
+  no-else-return: warn
+  no-multi-spaces: [error, {ignoreEOLComments: true}]
+  wrap-iife: warn
+  array-element-newline: [warn, consistent]
+  camelcase: [warn, {properties: never,
+                     allow: [
+                       "l_attributes",
+                       "ln_attributes",
+                       "lp_attributes",
+                       "l_countries",
+                       "ln_countries",
+                       "lp_countries",
+                       "l_instrument_descriptions",
+                       "ln_instrument_descriptions",
+                       "lp_instrument_descriptions",
+                       "l_instruments",
+                       "ln_instruments",
+                       "lp_instruments",
+                       "l_languages",
+                       "ln_languages",
+                       "lp_languages",
+                       "l_relationships",
+                       "ln_relationships",
+                       "lp_relationships",
+                       "l_scripts",
+                       "ln_scripts",
+                       "lp_scripts",
+                       "l_statistics",
+                       "ln_statistics",
+                       "lp_statistics",
+                       "N_l",
+                       "N_ln",
+                       "N_lp",
+                     ]}]
+  comma-dangle: [warn, {arrays: always-multiline,
+                        objects: always-multiline,
+                        imports: always-multiline,
+                        exports: always-multiline,
+                        functions: always-multiline}]
+  comma-spacing: [warn, {before: false, after: true}]
+  computed-property-spacing: [warn, never, {"enforceForClassMembers": true}]
+  consistent-this: [warn, self]
+  function-paren-newline: [warn, consistent]
+  jsx-quotes: [warn, prefer-double]
+  key-spacing: [warn, {mode: minimum}]
+  max-len: [warn, {code: 78,
+                   ignoreUrls: true,
+                   ignoreStrings: false,
+                   ignoreTemplateLiterals: false,
+                   ignoreRegExpLiterals: true}]
+  multiline-comment-style: [warn, starred-block]
+  newline-per-chained-call: [warn, {ignoreChainWithDepth: 3}]
+  no-lonely-if: warn
+  no-multiple-empty-lines: [warn, {max: 2, maxBOF: 0, maxEOF: 0}]
+  no-trailing-spaces: warn
+  object-curly-newline: [warn, {multiline: true, consistent: true}]
+  object-curly-spacing: [warn, never]
+  operator-assignment: [warn, always]
+  operator-linebreak: [warn, after, {overrides: {?: before, :: before}}]
+  padded-blocks: [warn, never]
+  quote-props: [warn, consistent-as-needed, {numbers: true}]
+  quotes: [warn, single, {avoidEscape: true,
+                          allowTemplateLiterals: true}]
+  semi: [warn, always, {omitLastInOneLineBlock: true}]
+  semi-style: [warn, last]
+  sort-keys: [warn, asc, {caseSensitive: false, natural: true}]
+  space-before-function-paren: [warn, {anonymous: always,
+                                       named: never,
+                                       asyncArrow: always}]
+  space-infix-ops: [warn, {int32Hint: true}]
+  no-var: warn
+  prefer-const: warn
+  import/first: warn
+  import/newline-after-import: [warn, {count: 1}]
+  import/no-commonjs: error
+  import/order: [warn, {newlines-between: always}]
+  react/no-access-state-in-setstate: error
+  react/no-multi-comp: [warn, {ignoreStateless: true}]
+  react/no-render-return-value: warn
+  react/prefer-stateless-function: warn
+  react/self-closing-comp: error
+  react/sort-comp: [warn, {order: [type-annotations,
+                                   static-methods,
+                                   lifecycle,
+                                   everything-else,
+                                   render]}]
+  react/jsx-boolean-value: [warn, never]
+  react/jsx-closing-bracket-location: [error, tag-aligned]
+  react/jsx-first-prop-new-line: [error, multiline-multiprop]
+  react/jsx-key: warn
+  react/jsx-no-bind: [warn, {ignoreDOMComponents: true}]
+  react/jsx-no-literals: warn
+  react/jsx-sort-props: warn
+  flowtype/boolean-style: [warn, boolean]
+  flowtype/delimiter-dangle: [warn, always-multiline]
+  flowtype/no-types-missing-file-annotation: error
+  flowtype/no-weak-types: warn
+  flowtype/sort-keys: [warn, asc]
+  react-hooks/exhaustive-deps: warn

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -72,7 +72,6 @@ rules:
   # Possible Errors
   for-direction: error
   no-async-promise-executor: error
-  no-await-in-loop: error
   no-cond-assign: warn
   no-constant-condition: [error, {checkLoops: false}]
   no-control-regex: off
@@ -82,7 +81,6 @@ rules:
   no-duplicate-case: error
   no-empty-character-class: error
   no-empty: [error, {allowEmptyCatch: true}]
-  no-extra-semi: warn
   no-irregular-whitespace: warn
   no-misleading-character-class: error
   no-obj-calls: error
@@ -94,7 +92,6 @@ rules:
   no-unreachable: error
   no-unsafe-finally: error
   no-unsafe-negation: error
-  no-unused-vars: error
   no-with: error
   require-atomic-updates: error
   use-isnan: error
@@ -103,20 +100,15 @@ rules:
   # Best Practices
   block-scoped-var: warn
   class-methods-use-this: off
-  consistent-return: error
   curly: [error, all]
   dot-location: [warn, property]
   dot-notation: [warn, {allowKeywords: true}]
-  eqeqeq: [warn, smart]
   no-alert: off
-  no-else-return: warn
   no-eq-null: off
   no-floating-decimal: warn
   no-global-assign: error
-  no-multi-spaces: [error, {ignoreEOLComments: true}]
   no-useless-catch: warn
   radix: warn
-  wrap-iife: warn
 
   # Strict Mode
   strict: off
@@ -128,102 +120,35 @@ rules:
   # Stylistic Issues
   array-bracket-newline: [warn, consistent]
   array-bracket-spacing: [warn, never]
-  array-element-newline: [warn, consistent]
   block-spacing: [warn, always]
   brace-style: [warn, 1tbs]
-  camelcase: [warn, {properties: never,
-                     allow: [
-                       "l_attributes",
-                       "ln_attributes",
-                       "lp_attributes",
-                       "l_countries",
-                       "ln_countries",
-                       "lp_countries",
-                       "l_instrument_descriptions",
-                       "ln_instrument_descriptions",
-                       "lp_instrument_descriptions",
-                       "l_instruments",
-                       "ln_instruments",
-                       "lp_instruments",
-                       "l_languages",
-                       "ln_languages",
-                       "lp_languages",
-                       "l_relationships",
-                       "ln_relationships",
-                       "lp_relationships",
-                       "l_scripts",
-                       "ln_scripts",
-                       "lp_scripts",
-                       "l_statistics",
-                       "ln_statistics",
-                       "lp_statistics",
-                       "N_l",
-                       "N_ln",
-                       "N_lp",
-                     ]}]
-  comma-dangle: [warn, {arrays: always-multiline,
-                        objects: always-multiline,
-                        imports: always-multiline,
-                        exports: always-multiline,
-                        functions: always-multiline}]
-  comma-spacing: [warn, {before: false, after: true}]
   comma-style: [warn, last]
-  computed-property-spacing: [warn, never, {"enforceForClassMembers": true}]
-  consistent-this: [warn, self]
   eol-last: [warn, always]
   func-call-spacing: [warn, never]
-  function-paren-newline: [warn, consistent]
   implicit-arrow-linebreak: [warn, beside]
   indent: [warn, 2, {CallExpression: {arguments: first}, SwitchCase: 1, ignoredNodes: ["JSXElement", "ArrowFunctionExpression"]}]
-  jsx-quotes: [warn, prefer-double]
-  key-spacing: [warn, {mode: minimum}]
   keyword-spacing: [warn, {before: true, after: true}]
   linebreak-style: [warn, unix]
   lines-between-class-members: [warn, always]
-  max-len: [warn, {code: 78,
-                   ignoreUrls: true,
-                   ignoreStrings: false,
-                   ignoreTemplateLiterals: false,
-                   ignoreRegExpLiterals: true}]
   max-statements-per-line: [warn, {max: 1}]
-  multiline-comment-style: [warn, starred-block]
   multiline-ternary: off
   new-cap: off
   new-parens: warn
-  newline-per-chained-call: [warn, {ignoreChainWithDepth: 3}]
-  no-lonely-if: warn
   no-mixed-spaces-and-tabs: warn
   no-multi-assign: off
-  no-multiple-empty-lines: [warn, {max: 2, maxBOF: 0, maxEOF: 0}]
   no-negated-condition: warn
   no-nested-ternary: off
   no-plusplus: off
   no-tabs: warn
   no-ternary: off
-  no-trailing-spaces: warn
   no-underscore-dangle: off
   no-unneeded-ternary: warn
   no-whitespace-before-property: warn
-  object-curly-newline: [warn, {multiline: true, consistent: true}]
-  object-curly-spacing: [warn, never]
   object-property-newline: [warn, {allowAllPropertiesOnSameLine: true}]
   one-var: [warn, never]
-  operator-assignment: [warn, always]
-  operator-linebreak: [warn, after, {overrides: {?: before, :: before}}]
-  padded-blocks: [warn, never]
-  quote-props: [warn, consistent-as-needed, {numbers: true}]
-  quotes: [warn, single, {avoidEscape: true,
-                          allowTemplateLiterals: true}]
-  semi: [warn, always, {omitLastInOneLineBlock: true}]
   semi-spacing: [warn, {before: false, after: true}]
-  semi-style: [warn, last]
-  sort-keys: [warn, asc, {caseSensitive: false, natural: true}]
   space-before-blocks: [warn, always]
-  space-before-function-paren: [warn, {anonymous: always,
-                                       named: never,
-                                       asyncArrow: always}]
   space-in-parens: [warn, never]
-  space-infix-ops: [warn, {int32Hint: true}]
   space-unary-ops: [warn, {words: true, nonwords: false}]
   spaced-comment: [warn, always, {block: {balanced: true}, markers: [":", "::"]}]
   switch-colon-spacing: [warn, {after: true, before: false}]
@@ -241,8 +166,6 @@ rules:
   no-this-before-super: error
   no-useless-constructor: warn
   no-useless-rename: warn
-  no-var: warn
-  prefer-const: warn
   prefer-numeric-literals: warn
   require-yield: error
   rest-spread-spacing: [warn, never]
@@ -257,13 +180,9 @@ rules:
 
   import/export: error
   import/extensions: [warn, never]
-  import/first: warn
-  import/newline-after-import: [warn, {count: 1}]
-  import/no-commonjs: error
   import/no-duplicates: warn
   import/no-dynamic-require: error
   import/no-unresolved: error
-  import/order: [warn, {newlines-between: always}]
 
   #######################
   # eslint-plugin-react #
@@ -279,7 +198,6 @@ rules:
   react/forbid-elements: off
   react/forbid-prop-types: off
   react/forbid-foreign-prop-types: off
-  react/no-access-state-in-setstate: error
   react/no-array-index-key: off
   react/no-children-prop: error
   react/no-danger: off
@@ -292,9 +210,7 @@ rules:
   react/no-direct-mutation-state: error
   react/no-find-dom-node: warn
   react/no-is-mounted: warn
-  react/no-multi-comp: [warn, {ignoreStateless: true}]
   react/no-redundant-should-component-update: error
-  react/no-render-return-value: warn
   react/no-set-state: off
   react/no-typos: error
   react/no-string-refs: warn
@@ -305,46 +221,32 @@ rules:
   react/no-unused-state: error
   react/no-will-update-set-state: error
   react/prefer-es6-class: off
-  react/prefer-stateless-function: warn
   react/prop-types: off
   react/react-in-jsx-scope: error
   react/require-default-props: off
   react/require-optimization: off
   react/require-render-return: error
-  react/self-closing-comp: error
-  react/sort-comp: [warn, {order: [type-annotations,
-                                   static-methods,
-                                   lifecycle,
-                                   everything-else,
-                                   render]}]
   react/sort-prop-types: off
   react/style-prop-object: error
   react/void-dom-elements-no-children: error
 
   # JSX-specific rules
-  react/jsx-boolean-value: [warn, never]
-  react/jsx-closing-bracket-location: [error, tag-aligned]
   react/jsx-closing-tag-location: error
   react/jsx-curly-spacing: [error, {when: never, children: true}]
   react/jsx-equals-spacing: [error, never]
   react/jsx-filename-extension: [error, {extensions: [.js]}]
-  react/jsx-first-prop-new-line: [error, multiline-multiprop]
   react/jsx-handler-names: warn
   react/jsx-indent: [error, 2]
   react/jsx-indent-props: [error, 2]
-  react/jsx-key: warn
   react/jsx-max-props-per-line: [error, {maximum: 1, when: multiline}]
-  react/jsx-no-bind: [warn, {ignoreDOMComponents: true}]
   react/jsx-no-comment-textnodes: warn
   react/jsx-no-duplicate-props: [error, {ignoreCase: true}]
-  react/jsx-no-literals: warn
   react/jsx-no-target-blank: error
   react/jsx-no-undef: [error, {allowGlobals: true}]
   react/jsx-one-expression-per-line: [warn, {allow: single-child}]
   react/jsx-curly-brace-presence: [error, {props: never, children: ignore}]
   react/jsx-pascal-case: error
   react/jsx-sort-default-props: warn
-  react/jsx-sort-props: warn
   react/jsx-tag-spacing: [error, {beforeClosing: never}]
   react/jsx-uses-react: warn
   react/jsx-uses-vars: warn
@@ -360,16 +262,12 @@ rules:
   # eslint-plugin-flowtype #
   ##########################
 
-  flowtype/boolean-style: [warn, boolean]
   flowtype/define-flow-type: warn
-  flowtype/delimiter-dangle: [warn, always-multiline]
   flowtype/generic-spacing: [warn, never]
   flowtype/no-dupe-keys: error
   flowtype/no-flow-fix-me-comments: off
   flowtype/no-mutable-array: off
   flowtype/no-primitive-constructor-types: error
-  flowtype/no-types-missing-file-annotation: error
-  flowtype/no-weak-types: warn
   flowtype/object-type-delimiter: [warn, comma]
   flowtype/require-exact-type: off
   flowtype/require-indexer-name: [warn, always]
@@ -377,7 +275,6 @@ rules:
   flowtype/require-return-type: off
   flowtype/require-valid-file-annotation: off
   flowtype/semi: [warn, always]
-  flowtype/sort-keys: [warn, asc]
   flowtype/space-after-type-colon: [warn, always, {allowLineBreak: true}]
   flowtype/space-before-generic-bracket: [warn, never]
   flowtype/space-before-type-colon: [warn, never]
@@ -389,4 +286,3 @@ rules:
   #############################
 
   react-hooks/rules-of-hooks: error
-  react-hooks/exhaustive-deps: warn

--- a/script/check_unfixed_eslint_rules
+++ b/script/check_unfixed_eslint_rules
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SCRIPT_NAME=$(basename "$0")
+
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [options] file.js [file.js] [dir]
+
+Check suggested ESLint rules not passing yet on given file(s).
+EOH
+)
+
+if [[ $# -ne 0 && $1 =~ -*h(elp)? ]]
+then
+  echo "$HELP"
+  exit 0 # EX_OK
+elif [[ $# -eq 0 ]]
+then
+  echo >&2 "$SCRIPT_NAME: missing file or directory"
+  echo >&2 "Try '$SCRIPT_NAME help' for usage."
+  exit 64 # EX_USAGE
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../" || exit 66 # EX_NOINPUT
+
+./node_modules/eslint/bin/eslint.js \
+  --config .eslintrc.unfixed.yaml \
+  --max-warnings 0 \
+  "$@"
+
+# vi: set et sts=2 sw=2 ts=2 :

--- a/script/xgettext.js
+++ b/script/xgettext.js
@@ -139,8 +139,8 @@ const catchErrors = cb => {
     try {
       cb(match);
     } catch (err) {
-      console.error
-        (`Bad string in ${JSON.stringify(currentFile)}:`,
+      console.error(
+        `Bad string in ${JSON.stringify(currentFile)}:`,
         match,
       );
       throw err;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

A lot of efforts have been made to make the code follow some ESLint rules already, but nothing prevents new code to break them again. But `estlint` cannot be run with all rules currently defined in `.eslintrc` and not followed by code prior to these rules.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Create a script that checks only the rules followed so far. This script is for continuous integration and to be run manually for convenience when creating new code. It follows PR #1681 which enforced `indent` rule but for `script/xgettext.js`.

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Add other rules that have already been applied, if any.
2. Gradually add more rules when fixing code to follow them.
