### PR TITLE
Beta (MBS-11069): Avoid code formatting within white space sensitive area

### DIFF
--- a/root/edit/details/edit_medium.tt
+++ b/root/edit/details/edit_medium.tt
@@ -199,11 +199,11 @@
                  </td>
                  <td><span class="diff-only-a">[% IF old_track.recording; descriptive_link(old_track.recording); END %]</span></td>
                  <td>
-                   [% # If no recording_id exists, it's creating a recording
+                   [%~ # If no recording_id exists, it's creating a recording
                      SET allow_new = 1 IF !new_track.recording_id
-                   %]
+                   ~%]
                    <span class="diff-only-b">[% descriptive_link(new_track.recording) %]</span>
-                   [% SET allow_new = 0 IF !new_track.recording_id %]
+                   [%~ SET allow_new = 0 IF !new_track.recording_id ~%]
                  </td>
                </tr>
           [% END %]

--- a/root/edit/details/edit_medium.tt
+++ b/root/edit/details/edit_medium.tt
@@ -199,13 +199,11 @@
                  </td>
                  <td><span class="diff-only-a">[% IF old_track.recording; descriptive_link(old_track.recording); END %]</span></td>
                  <td>
-                   <span class="diff-only-b">
-                     [% # If no recording_id exists, it's creating a recording
-                       SET allow_new = 1 IF !new_track.recording_id
-                     %]
-                     [% descriptive_link(new_track.recording) %]
-                     [% SET allow_new = 0 IF !new_track.recording_id %]
-                   </span>
+                   [% # If no recording_id exists, it's creating a recording
+                     SET allow_new = 1 IF !new_track.recording_id
+                   %]
+                   <span class="diff-only-b">[% descriptive_link(new_track.recording) %]</span>
+                   [% SET allow_new = 0 IF !new_track.recording_id %]
                  </td>
                </tr>
           [% END %]

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -895,6 +895,10 @@ tr.diff-removal {
     background: @negative-bg;
 }
 
+.diff-only-a, .diff-only-b {
+    white-space: pre-wrap;
+}
+
 /* Statistics pages */
 table.timeline-controls, table.database-statistics {
     border-collapse: collapse;


### PR DESCRIPTION
# Problem

Too many leading and trailing white spaces are rendered for the positive part of the diff for changed recordings, see the [comment on the ticket](https://tickets.metabrainz.org/browse/MBS-11069?focusedCommentId=55354&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-55354).
This is a regression of #1691 which changed the style of highlighted differences to always render white spaces inside their `<span>` elements.

# Solution

Move the code of the template that is not generating output out of the `<span>` element to avoid code formatting within the white space sensitive area.

# Action

This change needs to be verified again on a test server as I haven't installed the server on my machine.