### PR TITLE
Improve Flow error suppressions

### DIFF
--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -139,8 +139,15 @@ class EditProfileForm extends React.Component<Props, State> {
     e: SyntheticEvent<HTMLSelectElement>,
     languageIndex: number,
   ) {
-    // $FlowFixMe ~ string incompatible with FluencyT's string literals
-    const selectedFluency: FluencyT = e.currentTarget.value;
+    const selectedValue = e.currentTarget.value;
+    let selectedFluency: FluencyT | null = null;
+    switch (selectedValue) {
+      case 'basic':
+      case 'intermediate':
+      case 'advanced':
+      case 'native':
+        selectedFluency = selectedValue;
+    }
     this.setState(prevState => mutate<State, _>(prevState, newState => {
       const compound = newState.form.field.languages.field[languageIndex];
       compound.field.fluency.value = selectedFluency;

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -160,7 +160,10 @@ function handleItemMouseDown(event) {
   event.preventDefault();
 }
 
-function setScrollPosition(menuId: string, siblingAccessor: string) {
+function setScrollPosition(
+  menuId: string,
+  siblingAccessor: 'nextElementSibling' | 'previousElementSibling',
+) {
   const menu = document.getElementById(menuId);
   if (!menu) {
     return;
@@ -169,7 +172,7 @@ function setScrollPosition(menuId: string, siblingAccessor: string) {
   if (!selectedItem) {
     return;
   }
-  // $FlowFixMe
+  // $FlowIssue[prop-missing]
   const item = selectedItem[siblingAccessor];
   if (!item) {
     return;

--- a/root/static/scripts/common/components/CodeLink.js
+++ b/root/static/scripts/common/components/CodeLink.js
@@ -19,7 +19,7 @@ const CodeLink = ({code}: Props): React.MixedElement=> {
   let link = (
     <a href={entityHref(code)}>
       <bdi>
-        {/* $FlowFixMe */}
+        {/* $FlowIssue[prop-missing] */}
         <code>{code[code.entityType]}</code>
       </bdi>
     </a>

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -207,9 +207,15 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
   debouncePendingVotes: () => void;
 
+  flushPendingVotes: (asap?: boolean) => void;
+
   genreMap: {+[genreName: string]: GenreT, ...};
 
   genreNames: $ReadOnlyArray<string>;
+
+  handleSubmit: (SyntheticEvent<HTMLFormElement>) => void;
+
+  onBeforeUnload: () => void;
 
   pendingVotes: Map<string, PendingVoteT>;
 
@@ -223,13 +229,9 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       tags: createInitialTagState(props.aggregatedTags, props.userTags),
     };
 
-    // $FlowFixMe - These binds will go away with the move to functional components.
     this.flushPendingVotes = this.flushPendingVotes.bind(this);
-    // $FlowFixMe
     this.onBeforeUnload = this.onBeforeUnload.bind(this);
-    // $FlowFixMe
     this.handleSubmit = this.handleSubmit.bind(this);
-    // $FlowFixMe
     this.setTagsInput = this.setTagsInput.bind(this);
 
     this.genreMap = props.genreMap ?? {};

--- a/root/static/scripts/common/hooks/useOutsideClickEffect.js
+++ b/root/static/scripts/common/hooks/useOutsideClickEffect.js
@@ -13,6 +13,10 @@ const TARGET_REFS = new Map();
 
 if (typeof document !== 'undefined') {
   document.addEventListener('mouseup', function (event: MouseEvent) {
+    const eventTarget = event.target;
+    if (!(eventTarget instanceof Node)) {
+      return;
+    }
     /*
      * N.B. It's possible for action() to cause a component to re-render that
      * then calls `useOutsideClickEffect` again, mutating `TARGET_REFS`. Thus
@@ -23,9 +27,8 @@ if (typeof document !== 'undefined') {
         continue;
       }
       const target = ref.current;
-      // $FlowFixMe
-      if (target && !target.contains(event.target)) {
-        action(event.target);
+      if (target && !target.contains(eventTarget)) {
+        action(eventTarget);
       }
     }
   });

--- a/root/static/scripts/common/linkedEntities.js
+++ b/root/static/scripts/common/linkedEntities.js
@@ -105,7 +105,7 @@ const linkedEntities/*: LinkedEntities */ = Object.create(Object.seal({
 
   setLinkedEntities(update/*: ?LinkedEntities */) {
     for (const key of Object.keys(linkedEntities)) {
-      // $FlowFixMe
+      // $FlowIgnore[incompatible-type]
       delete linkedEntities[key];
       /*
        * The above line is deleting the own property only, not the one on the

--- a/root/static/scripts/common/utility/parseIntegerOrNull.js
+++ b/root/static/scripts/common/utility/parseIntegerOrNull.js
@@ -9,7 +9,7 @@
 
 import parseInteger from './parseInteger';
 
-export default function parseIntegerOrNull(str: string): $FlowFixMe | null {
+export default function parseIntegerOrNull(str: string): number | null {
   const integer = parseInteger(str);
   return isNaN(integer) ? null : integer;
 }


### PR DESCRIPTION
We can make error suppressions more granular by specifying which exact error code we're ignoring. (Sort of like specifying which exceptions to catch.)

https://flow.org/en/docs/errors/

In some cases I removed the suppression altogether by addressing the underlying issue, if it seemed reasonable enough to.