### PR TITLE
MBS-11117: Create report for too long discIDs

### DIFF
--- a/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
@@ -1,0 +1,42 @@
+package MusicBrainz::Server::Report::CDTOCDubiousLength;
+use Moose;
+
+with 'MusicBrainz::Server::Report::CDTOCReport';
+
+sub table { 'cd_toc_dubious_length' }
+sub component_name { 'CDTocDubiousLength' }
+
+sub query {
+    q{
+        SELECT
+            cdtoc.id AS cdtoc_id,
+            medium_format.name AS format,
+            cdtoc.leadout_offset / 75 AS length, -- seconds
+            row_number() OVER (
+                ORDER BY medium_format.name, cdtoc.leadout_offset DESC)
+        FROM
+            cdtoc
+            JOIN medium_cdtoc ON medium_cdtoc.cdtoc = cdtoc.id
+            JOIN medium ON medium_cdtoc.medium = medium.id
+            JOIN medium_format ON medium.format = medium_format.id
+        WHERE
+            leadout_offset > 75 * 60 * 100 -- cutoff 100 minutes
+        ORDER BY
+            medium_format.name,
+            cdtoc.leadout_offset DESC
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 Jerome Roy
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Report/CDTOCReport.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCReport.pm
@@ -1,0 +1,34 @@
+package MusicBrainz::Server::Report::CDTOCReport;
+use Moose::Role;
+
+with 'MusicBrainz::Server::Report::QueryReport';
+
+around inflate_rows => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $items = $self->$orig(@_);
+
+    my $cdtocs = $self->c->model('CDTOC')->get_by_ids(
+        map { $_->{cdtoc_id} } @$items
+    );
+
+    return [
+        map +{
+            %$_,
+            cdtoc => $cdtocs->{ $_->{cdtoc_id} },
+        }, @$items
+    ];
+};
+
+1;
+
+=head1 COPYRIGHT
+
+Copyright (C) 2020 Jerome Roy
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -22,6 +22,7 @@ use MusicBrainz::Server::PagedReport;
     BadAmazonURLs
     CatNoLooksLikeASIN
     CatNoLooksLikeLabelCode
+    CDTOCDubiousLength
     CollaborationRelationships
     CoverArtRelationships
     DeprecatedRelationshipArtists
@@ -105,6 +106,7 @@ use MusicBrainz::Server::Report::ArtistsWithNoSubscribers;
 use MusicBrainz::Server::Report::BadAmazonURLs;
 use MusicBrainz::Server::Report::CatNoLooksLikeASIN;
 use MusicBrainz::Server::Report::CatNoLooksLikeLabelCode;
+use MusicBrainz::Server::Report::CDTOCDubiousLength;
 use MusicBrainz::Server::Report::CollaborationRelationships;
 use MusicBrainz::Server::Report::CoverArtRelationships;
 use MusicBrainz::Server::Report::DeprecatedRelationshipArtists;

--- a/root/report/CDTocDubiousLength.js
+++ b/root/report/CDTocDubiousLength.js
@@ -1,0 +1,49 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 Jerome Roy
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+
+import CDTocList from './components/CDTocList';
+import type {ReportDataT, ReportCDTocT} from './types';
+
+const CDTocDubiousLength = ({
+  $c,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportCDTocT>): React.Element<typeof Layout> => (
+  <Layout $c={$c} fullWidth title={l('Disc IDs with dubious duration')}>
+    <h1>{l('Disc IDs with dubious duration')}</h1>
+
+    <ul>
+      <li>
+        {l(`This report shows disc IDs indicating a total duration much longer
+        than what a standard CD allows (at least 100 minutes). This usually
+        means a disc ID was created for the wrong format (SACD) or with a
+        buggy tool. These disc IDs can safely be removed.`)}
+      </li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+    </ul>
+
+    <CDTocList items={items} pager={pager} />
+
+  </Layout>
+);
+
+export default CDTocDubiousLength;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -565,6 +565,16 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           </a>
         </li>
       </ul>
+
+      <h2>{l('Disc IDs')}</h2>
+
+      <ul>
+        <li>
+          <a href="/report/CDTOCDubiousLength">
+            {l('Disc IDs with dubious duration')}
+          </a>
+        </li>
+      </ul>
     </div>
   </Layout>
 );

--- a/root/report/components/CDTocList.js
+++ b/root/report/components/CDTocList.js
@@ -1,0 +1,74 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 Jerome Roy
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import PaginatedResults from '../../components/PaginatedResults';
+import loopParity from '../../utility/loopParity';
+import type {ReportCDTocT} from '../types';
+import CDTocLink
+  from '../../static/scripts/common/components/CDTocLink';
+import formatTrackLength
+  from '../../static/scripts/common/utility/formatTrackLength';
+
+type Props = {
+  +items: $ReadOnlyArray<ReportCDTocT>,
+  +pager: PagerT,
+};
+
+const CDTocList = ({
+  items,
+  pager,
+}: Props): React.Element<typeof PaginatedResults> => {
+  const colSpan = 3;
+
+  return (
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Disc ID')}</th>
+            <th>{l('Format')}</th>
+            <th>{l('Length')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => {
+            return (
+              <tr className={loopParity(index)} key={item.cdtoc_id}>
+                {item.cdtoc ? (
+                  <>
+                    <td>
+                      <CDTocLink
+                        cdToc={item.cdtoc}
+                        content={item.cdtoc.discid}
+                      />
+                    </td>
+                    <td>
+                      {item.format}
+                    </td>
+                    <td>
+                      {formatTrackLength(1000 * item.length)}
+                    </td>
+                  </>
+                ) : (
+                  <td colSpan={colSpan}>
+                    {l('This Disc ID no longer exists.')}
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </PaginatedResults>
+  );
+};
+
+export default CDTocList;

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -39,6 +39,14 @@ export type ReportArtistUrlT = {
   +url: UrlT,
 };
 
+export type ReportCDTocT = {
+  +cdtoc: ?CDTocT,
+  +cdtoc_id: number,
+  +format: string,
+  +length: number,
+  +row_number: number,
+};
+
 export type ReportCollaborationT = {
   +artist0: ?ArtistT,
   +artist1: ?ArtistT,

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -139,6 +139,7 @@ module.exports = {
   'report/BadAmazonUrls': require('../report/BadAmazonUrls'),
   'report/CatNoLooksLikeAsin': require('../report/CatNoLooksLikeAsin'),
   'report/CatNoLooksLikeLabelCode': require('../report/CatNoLooksLikeLabelCode'),
+  'report/CDTocDubiousLength': require('../report/CDTocDubiousLength'),
   'report/CollaborationRelationships': require('../report/CollaborationRelationships'),
   'report/CoverArtRelationships': require('../report/CoverArtRelationships'),
   'report/DeprecatedRelationshipArtists': require('../report/DeprecatedRelationshipArtists'),

--- a/root/types.js
+++ b/root/types.js
@@ -733,12 +733,9 @@ declare type MediumFormatT = {
 };
 
 declare type MediumT = $ReadOnly<{
-  /*
-   * TODO: still missing +cdtocs: $ReadOnlyArray<MediumCdTocT>
-   * (MediumCdTocT is not defined yet)
-   */
   ...EntityRoleT<'track'>,
   ...LastUpdateRoleT,
+  +cdtocs: $ReadOnlyArray<MediumCDTocT>,
   +editsPending: boolean,
   +format: MediumFormatT | null,
   +format_id: number,


### PR DESCRIPTION
# Problem

MBS-11117: new report about discid durations above 100 minutes, that should be fixed or removed.
cf https://community.metabrainz.org/t/sacd-types-and-discid/494807/8

# Solution

cf screenshot on MBS-11117

# Action

There are a few things that need a serious review and will probably need rework:

* the report could be applied on releases but it makes more sense to have it on discids directly. Since there was no report on cdtocs yet, I had to create a lib/MusicBrainz/Server/Report/CdTocReport.pm ~~that just passes the parameters of the report SQL query. Not sure it would make more sense to pass the 'id' there, since we don't have gid on the cdtoc table.~~ (Edit: I had to use "id" in the end in order to use CDTocLink)

~~* CDTOCs are not defined with React yet. I didn't want to modify EntityLink so I just defined the href=/cdtoc/... link in root/report/components/CdTocList.js, but that should probably be changed for other conversions to React.~~

* I pass durations from SQL in seconds and convert to milliseconds in JS to use formatTrackLength. Exporting durations in millisecond in SQL would be over the 2**31 integer limit in postgres

* I don't speak Perl so I just copy-pasted lib/MusicBrainz/Server/Report/CdTocReport.pm, I'm not sure what's inside is correct