### PR TITLE
MBS-11115: Show extra info when attaching/moving discIDs

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -187,7 +187,9 @@ sub attach : Local DenyWhenReadonly
         ) unless $medium->may_have_discids;
 
         $c->model('Release')->load($medium);
-        $c->model('ArtistCredit')->load($medium->release);
+        $c->model('Track')->load_for_mediums($medium);
+        $c->model('Recording')->load($medium->all_tracks);
+        $c->model('ArtistCredit')->load($medium->all_tracks, $medium->release);
 
         $c->stash( medium => $medium );
 
@@ -371,11 +373,13 @@ sub move : Local Edit
 
         $c->model('Medium')->load($medium_cdtoc);
 
+        $c->model('Track')->load_for_mediums($medium);
+        $c->model('Recording')->load($medium->all_tracks);
         $c->model('Release')->load($medium, $medium_cdtoc->medium);
         $c->model('Release')->load_release_events($medium->release);
         $c->model('ReleaseLabel')->load($medium->release);
         $c->model('Label')->load($medium->release->all_labels);
-        $c->model('ArtistCredit')->load($medium->release, $medium_cdtoc->medium->release);
+        $c->model('ArtistCredit')->load($medium->all_tracks, $medium->release, $medium_cdtoc->medium->release);
 
         $c->stash(
             medium => $medium

--- a/root/cdtoc/attach_confirm.tt
+++ b/root/cdtoc/attach_confirm.tt
@@ -4,6 +4,24 @@
         {release} by {artist}?', { discid => cdtoc.discid, format => medium.format_name,
                                    pos => medium.position, release => link_entity(medium.release),
                                    artist => artist_credit(medium.release.artist_credit) }) -%]</p>
+  <h2>[% l('Medium') %]</h2>
+  <table class="tbl">
+    <thead>
+      <tr>
+        <th>[% l('#') %]</th>
+        <th>[% l('Title') %]</th>
+        <th>[% l('Artist') %]</th>
+        <th>[% l('Length') %]</th>
+      </tr>
+    </thead>
+    <tbody>
+    [%- INCLUDE 'medium/tracklist.tt' tracks=medium.tracks show_artists=1 hide_rating=1 -%]
+    </tbody>
+  </table>
+
+  <h2>[% l('Track duration comparison') %]</h2>
+  [%- track_duration_changes([1 .. medium.cdtoc_tracks.size], medium.cdtoc_tracks, cdtoc.track_details, 'length', 'length_time', add_colon(l('Medium track lengths')), add_colon(l('CD TOC track lengths'))) -%]
+
   <form action="[% c.req.uri %]" method="post">
       [% INCLUDE "forms/edit-note.tt" %]
       [% enter_edit() %]

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -736,8 +736,18 @@ END ~%]
     }) -%]
 [%- END -%]
 
-[%~ MACRO track_duration_changes(loop_over, old_base, new_base, old_prop, new_prop) BLOCK -%]
+[%~ MACRO track_duration_changes(loop_over, old_base, new_base, old_prop, new_prop, old_label, new_label) BLOCK -%]
   [% USE Diff %]
+  [%- IF old_label && new_label -%]
+    <table class="wrap-block details">
+        <tr>
+            <th>[%- old_label -%]</th>
+        </tr>
+        <tr>
+            <th>[%- new_label -%]</th>
+        </tr>
+    </table>
+  [%- END -%]  
   [%- FOR i = loop_over %]
      [%- IF old_prop;
        old_length = old_base.${ loop.index }.${ old_prop } | format_length;

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -86,10 +86,6 @@ table.vote-tally {
     }
 }
 
-.wrap-block {
-    display: inline-block;
-}
-
 .warn-lengths {
     color: @negative-text;
     font-weight: bold;

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -883,6 +883,15 @@ table.details {
     }
 }
 
+table.wrap-block {
+    display: inline-block;
+
+    th {
+        width: auto;
+    }
+}
+
+
 div.diff .diff-only-b,
 span.diff-only-b,
 tr.diff-addition {


### PR DESCRIPTION
### Implement MBS-11115

To be able to make sure that you're attaching the disc ID to the right disc before entering the edit, this displays info about the medium and compares the medium lengths to the ones on the disc ID.

![Screenshot from 2020-09-21 13-01-11](https://user-images.githubusercontent.com/1069224/93755167-80904600-fc0b-11ea-9009-b620daf08cb0.png)
