### PR TITLE
MBS-11107: Support nameVariation for other entity types

### DIFF
--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -191,9 +191,8 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     href = entity.href_url;
   }
 
-  // TODO: support name variations for all entity types?
-  if (!subPath &&
-      (entity.entityType === 'artist' || entity.entityType === 'recording')) {
+  // URLs are kind of weird and we probably don't care to set this for them
+  if (!subPath && entity.entityType !== 'url') {
     if (nameVariation === undefined && typeof content === 'string') {
       nameVariation = content !== entity.name;
     }


### PR DESCRIPTION
### MBS-11107

We can use relationship credits with most entity types. As such, it makes sense to supply the same hover info + span class name for them as we currently do for artists and recordings.

I special-cased URLs since I expect we don't really want to have hover features for them if we print a pretty-name and not the URL.