### PR TITLE
MBS-11104: Always show credits in RelationshipsTable

### DIFF
--- a/root/area/AreaRecordings.js
+++ b/root/area/AreaRecordings.js
@@ -29,7 +29,6 @@ const AreaRecordings = ({
         'This area has no relationships to any recordings.',
       )}
       heading={l('Relationships')}
-      showCredits
     />
   </AreaLayout>
 );

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -62,7 +62,6 @@ const AreaReleases = ({
         'This area has no relationships to any releases.',
       )}
       heading={l('Relationships')}
-      showCredits
     />
   </AreaLayout>
 );

--- a/root/area/AreaWorks.js
+++ b/root/area/AreaWorks.js
@@ -26,7 +26,6 @@ const AreaWorks = ({$c, area}: Props): React.Element<typeof AreaLayout> => (
         'This area has no relationships to any works.',
       )}
       heading={l('Relationships')}
-      showCredits
     />
   </AreaLayout>
 );

--- a/root/artist/ArtistRelationships.js
+++ b/root/artist/ArtistRelationships.js
@@ -46,7 +46,6 @@ const ArtistRelationships = ({
     <RelationshipsTable
       entity={artist}
       heading={l('Appearances')}
-      showCredits
     />
   </ArtistLayout>
 );

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -27,14 +27,12 @@ type Props = {
   +entity: CoreEntityT,
   +fallbackMessage?: string,
   +heading: string,
-  +showCredits?: boolean,
 };
 
 const RelationshipsTable = ({
   entity,
   fallbackMessage,
   heading,
-  showCredits = false,
 }: Props): React.MixedElement | null => {
   const appearances = generateRelationshipAppearancesList(entity);
   const relationshipTypes = Object.keys(appearances);
@@ -56,7 +54,7 @@ const RelationshipsTable = ({
         ? relationship.entity1_credit
         : relationship.entity0_credit;
 
-      if (!hasCreditColumn && showCredits && sourceCredit) {
+      if (!hasCreditColumn && sourceCredit) {
         hasCreditColumn = 1;
       }
       if (!hasAttributeColumn && relationship.attributes?.length) {


### PR DESCRIPTION
### Implement MBS-11104

I can't see any reason why we would not want to show relationship credits on all relationship tables. These aren't any less relevant on say label or place relationship tables as they are in artist or area ones.
