### PR TITLE
MBS-11036: Don't show Add release button when moving CD TOC

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -300,6 +300,7 @@ sub _attach_list {
 
             $c->stash(
                 template => 'cdtoc/attach_filter_release.tt',
+                cdtoc_action => 'add',
                 results => [sort_by { $_->entity->release_group ? $_->entity->release_group->gid : '' } @$releases]
             );
             $c->detach;
@@ -415,6 +416,7 @@ sub move : Local Edit
             $c->model('Track')->load_for_mediums(@mediums);
             $c->stash(
                 template => 'cdtoc/attach_filter_release.tt',
+                cdtoc_action => 'move',
                 results => $releases
             );
             $c->detach;

--- a/root/cdtoc/attach_filter_release.tt
+++ b/root/cdtoc/attach_filter_release.tt
@@ -70,13 +70,15 @@
     [%- END -%]
   </form>
 
-  <h2>[% l('Add a new release') %]</h2>
-  <p>[% l("If you don't see the release you are looking for, you can still add a new one,
-    using this CD TOC:") %]</p>
+  [%- IF cdtoc_action == 'add' -%]
+    <h2>[% l('Add a new release') %]</h2>
+    <p>[% l("If you don't see the release you are looking for, you can still add a new one,
+      using this CD TOC:") %]</p>
 
-  <form action="[% c.uri_for('/release/add') %]" method="post">
-    <input type="hidden" name="name" value="[% query_release.field('query').value %]" />
-    <input type="hidden" name="mediums.0.toc" value="[% toc %]" />
-    [% form_submit(l('Add a new release')) %]
-  </form>
+    <form action="[% c.uri_for('/release/add') %]" method="post">
+      <input type="hidden" name="name" value="[% query_release.field('query').value %]" />
+      <input type="hidden" name="mediums.0.toc" value="[% toc %]" />
+      [% form_submit(l('Add a new release')) %]
+    </form>
+  [%- END -%]
 [% END %]


### PR DESCRIPTION
### Implement MBS-11036

This button is currently broken, but after some talk we decided that it shouldn't be fixed, but dropped. There's no way to know
that moving (as opposed to additionally adding) a CD TOC to a new release is correct, except for very specific cases.

It makes more sense to only allow moving the CD TOC to another existing release. If it has been added by mistake, it can either be removed from the wrong one (and the new release can just be added based on the CD TOC) or it can be moved after adding the release.
