### PR TITLE
MBS-5747 / MBS-5997 / MBS-7029 / MBS-11122 / MBS-11294: Add filtering to artists' works tab + filtering improvements

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Ajax.pm
+++ b/lib/MusicBrainz/Server/Controller/Ajax.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::FilterUtils qw(
     create_artist_release_groups_form
     create_artist_releases_form
     create_artist_recordings_form
+    create_artist_works_form
 );
 
 sub filter_artist_release_groups_form : Local {
@@ -33,6 +34,16 @@ sub filter_artist_recordings_form : Local {
 
     my $artist_id = $c->req->query_params->{artist_id};
     my $form = create_artist_recordings_form($c, $artist_id);
+
+    $c->res->body(encode_json($form->TO_JSON));
+    $c->res->content_type('application/json; charset=utf-8');
+}
+
+sub filter_artist_works_form : Local {
+    my ($self, $c) = @_;
+
+    my $artist_id = $c->req->query_params->{artist_id};
+    my $form = create_artist_works_form($c, $artist_id);
 
     $c->res->body(encode_json($form->TO_JSON));
     $c->res->content_type('application/json; charset=utf-8');

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -94,6 +94,11 @@ sub _where_filter
             }
             push @params, $filter->{type_id};
         }
+        if (exists $filter->{secondary_type_id}) {
+            push @query, 'st.secondary_type = ?';
+            push @params, $filter->{secondary_type_id};
+            push @joins, 'JOIN release_group_secondary_type_join st ON rg.id = st.release_group';
+        }
         if (exists $filter->{type} && $filter->{type}) {
             my @types = ref($filter->{type}) ? @{ $filter->{type} } : ( $filter->{type} );
             my %partitioned_types = partition_by {

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -113,8 +113,12 @@ sub find_by_artist
         }
 
         if (exists $filter{type_id}) {
-            push @where_query, 'work.type = ?';
-            push @where_args, $filter{type_id};
+            if ($filter{type_id} eq '-1') {
+                push @where_query, 'work.type IS NULL';
+            } else {
+                push @where_query, 'work.type = ?';
+                push @where_args, $filter{type_id};
+            }
         }
     } else {
         push @where_args, ($artist_id) x 2;

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -14,6 +14,7 @@ sub create_artist_release_groups_form {
 
     my %form_args = (
         entity_type => 'release_group',
+        secondary_types => [ $c->model('ReleaseGroupSecondaryType')->get_all ],
         types => [ $c->model('ReleaseGroupType')->get_all ],
     );
 

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -6,6 +6,7 @@ our @EXPORT_OK = qw(
     create_artist_release_groups_form
     create_artist_releases_form
     create_artist_recordings_form
+    create_artist_works_form
 );
 
 sub create_artist_release_groups_form {
@@ -42,7 +43,18 @@ sub create_artist_recordings_form {
     $form_args{artist_credits} =
         $c->model('Recording')->find_artist_credits_by_artist($artist_id);
 
-    return $c->form(filter_form => 'Filter::Generic', %form_args);
+    return $c->form(filter_form => 'Filter::Recording', %form_args);
+}
+
+sub create_artist_works_form {
+    my ($c, $artist_id) = @_;
+
+    my %form_args = (
+        entity_type => 'work',
+        types => [ $c->model('WorkType')->get_all ],
+    );
+
+    return $c->form(filter_form => 'Filter::Work', %form_args);
 }
 
 1;

--- a/lib/MusicBrainz/Server/Form/Filter/Generic.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Generic.pm
@@ -12,6 +12,7 @@ has 'entity_type' => (
 
 has_field 'name' => (
     type => '+MusicBrainz::Server::Form::Field::Text',
+    default => '',
 );
 
 has_field 'cancel' => ( type => 'Submit' );

--- a/lib/MusicBrainz/Server/Form/Filter/Generic.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Generic.pm
@@ -10,33 +10,15 @@ has 'entity_type' => (
     required => 1,
 );
 
-has 'artist_credits' => (
-    isa => 'ArrayRef[ArtistCredit]',
-    is => 'ro',
-    required => 1,
-);
-
 has_field 'name' => (
     type => '+MusicBrainz::Server::Form::Field::Text',
-);
-
-has_field 'artist_credit_id' => (
-    type => 'Select',
 );
 
 has_field 'cancel' => ( type => 'Submit' );
 has_field 'submit' => ( type => 'Submit' );
 
 sub filter_field_names {
-    return qw/ name artist_credit_id /;
-}
-
-sub options_artist_credit_id {
-    my ($self, $field) = @_;
-    return [
-        map +{ value => $_->id, label => $_->name },
-        @{ $self->artist_credits }
-    ];
+    return qw/ name /;
 }
 
 around TO_JSON => sub {
@@ -44,7 +26,6 @@ around TO_JSON => sub {
 
     my $json = $self->$orig;
     $json->{entity_type} = $self->entity_type;
-    $json->{options_artist_credit_id} = $self->options_artist_credit_id;
     return $json;
 };
 

--- a/lib/MusicBrainz/Server/Form/Filter/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Recording.pm
@@ -1,4 +1,4 @@
-package MusicBrainz::Server::Form::Filter::ReleaseGroup;
+package MusicBrainz::Server::Form::Filter::Recording;
 use HTML::FormHandler::Moose;
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
@@ -8,22 +8,12 @@ has 'artist_credits' => (
     required => 1,
 );
 
-has 'types' => (
-    isa => 'ArrayRef[ReleaseGroupType]',
-    is => 'ro',
-    required => 1,
-);
-
 has_field 'artist_credit_id' => (
     type => 'Select',
 );
 
-has_field 'type_id' => (
-    type => 'Select',
-);
-
 sub filter_field_names {
-    return qw/ name artist_credit_id type_id /;
+    return qw/ name artist_credit_id /;
 }
 
 sub options_artist_credit_id {
@@ -34,20 +24,11 @@ sub options_artist_credit_id {
     ];
 }
 
-sub options_type_id {
-    my ($self, $field) = @_;
-    return [
-        map +{ value => $_->id, label => $_->name },
-        @{ $self->types }
-    ];
-}
-
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
     $json->{options_artist_credit_id} = $self->options_artist_credit_id;
-    $json->{options_type_id} = $self->options_type_id;
     return $json;
 };
 

--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -7,10 +7,20 @@ use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
+has 'artist_credits' => (
+    isa => 'ArrayRef[ArtistCredit]',
+    is => 'ro',
+    required => 1,
+);
+
 has 'countries' => (
     isa => 'ArrayRef[Area]',
     is => 'ro',
     required => 1,
+);
+
+has_field 'artist_credit_id' => (
+    type => 'Select',
 );
 
 has_field 'country_id' => (
@@ -23,6 +33,14 @@ has_field 'date' => (
 
 sub filter_field_names {
     return qw/ name artist_credit_id country_id date /;
+}
+
+sub options_artist_credit_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->artist_credits }
+    ];
 }
 
 sub options_country_id {
@@ -44,6 +62,7 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
+    $json->{options_artist_credit_id} = $self->options_artist_credit_id;
     $json->{options_country_id} = $self->options_country_id;
     return $json;
 };

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Form::Filter::ReleaseGroup;
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( lp );
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
 has 'artist_credits' => (
@@ -47,6 +48,7 @@ sub options_artist_credit_id {
 sub options_secondary_type_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'release group type') },
         map +{ value => $_->id, label => $_->l_name },
         @{ $self->secondary_types }
     ];
@@ -55,6 +57,7 @@ sub options_secondary_type_id {
 sub options_type_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'release group type') },
         map +{ value => $_->id, label => $_->l_name },
         @{ $self->types }
     ];

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
@@ -37,7 +37,7 @@ sub options_artist_credit_id {
 sub options_type_id {
     my ($self, $field) = @_;
     return [
-        map +{ value => $_->id, label => $_->name },
+        map +{ value => $_->id, label => $_->l_name },
         @{ $self->types }
     ];
 }

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
@@ -8,6 +8,12 @@ has 'artist_credits' => (
     required => 1,
 );
 
+has 'secondary_types' => (
+    isa => 'ArrayRef[ReleaseGroupSecondaryType]',
+    is => 'ro',
+    required => 1,
+);
+
 has 'types' => (
     isa => 'ArrayRef[ReleaseGroupType]',
     is => 'ro',
@@ -22,8 +28,12 @@ has_field 'type_id' => (
     type => 'Select',
 );
 
+has_field 'secondary_type_id' => (
+    type => 'Select',
+);
+
 sub filter_field_names {
-    return qw/ name artist_credit_id type_id /;
+    return qw/ name artist_credit_id secondary_type_id type_id /;
 }
 
 sub options_artist_credit_id {
@@ -31,6 +41,14 @@ sub options_artist_credit_id {
     return [
         map +{ value => $_->id, label => $_->name },
         @{ $self->artist_credits }
+    ];
+}
+
+sub options_secondary_type_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->l_name },
+        @{ $self->secondary_types }
     ];
 }
 
@@ -47,6 +65,7 @@ around TO_JSON => sub {
 
     my $json = $self->$orig;
     $json->{options_artist_credit_id} = $self->options_artist_credit_id;
+    $json->{options_secondary_type_id} = $self->options_secondary_type_id;
     $json->{options_type_id} = $self->options_type_id;
     return $json;
 };

--- a/lib/MusicBrainz/Server/Form/Filter/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Work.pm
@@ -31,7 +31,7 @@ sub options_role_type {
 sub options_type_id {
     my ($self, $field) = @_;
     return [
-        map +{ value => $_->id, label => $_->name },
+        map +{ value => $_->id, label => $_->l_name },
         @{ $self->types }
     ];
 }

--- a/lib/MusicBrainz/Server/Form/Filter/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Work.pm
@@ -1,6 +1,6 @@
 package MusicBrainz::Server::Form::Filter::Work;
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l lp );
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
 has 'types' => (
@@ -31,6 +31,7 @@ sub options_role_type {
 sub options_type_id {
     my ($self, $field) = @_;
     return [
+        { value => '-1', label => lp('[none]', 'work type') },
         map +{ value => $_->id, label => $_->l_name },
         @{ $self->types }
     ];

--- a/lib/MusicBrainz/Server/Form/Filter/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Work.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Form::Filter::Work;
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( l );
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
 has 'types' => (
@@ -8,12 +9,23 @@ has 'types' => (
     required => 1,
 );
 
+has_field 'role_type' => (
+    type => 'Select',
+);
+
 has_field 'type_id' => (
     type => 'Select',
 );
 
 sub filter_field_names {
-    return qw/ name type_id /;
+    return qw/ name role_type type_id /;
+}
+
+sub options_role_type {
+    return [
+        { value => 1, label => l('As performer') },
+        { value => 2, label => l('As writer') },
+    ];
 }
 
 sub options_type_id {
@@ -28,6 +40,7 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
+    $json->{options_role_type} = $self->options_role_type;
     $json->{options_type_id} = $self->options_type_id;
     return $json;
 };

--- a/lib/MusicBrainz/Server/Form/Filter/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Work.pm
@@ -1,0 +1,45 @@
+package MusicBrainz::Server::Form::Filter::Work;
+use HTML::FormHandler::Moose;
+extends 'MusicBrainz::Server::Form::Filter::Generic';
+
+has 'types' => (
+    isa => 'ArrayRef[WorkType]',
+    is => 'ro',
+    required => 1,
+);
+
+has_field 'type_id' => (
+    type => 'Select',
+);
+
+sub filter_field_names {
+    return qw/ name type_id /;
+}
+
+sub options_type_id {
+    my ($self, $field) = @_;
+    return [
+        map +{ value => $_->id, label => $_->name },
+        @{ $self->types }
+    ];
+}
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{options_type_id} = $self->options_type_id;
+    return $json;
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -11,25 +11,39 @@ import * as React from 'react';
 
 import WorkList from '../components/list/WorkList';
 import PaginatedResults from '../components/PaginatedResults';
+import Filter from '../static/scripts/common/components/Filter';
+import {type FilterFormT}
+  from '../static/scripts/common/components/FilterForm';
 import {returnToCurrentPage} from '../utility/returnUri';
 
 import ArtistLayout from './ArtistLayout';
 
 type Props = {
   +$c: CatalystContextT,
+  +ajaxFilterFormUrl: string,
   +artist: ArtistT,
+  +filterForm: ?FilterFormT,
+  +hasFilter: boolean,
   +pager: PagerT,
   +works: ?$ReadOnlyArray<WorkT>,
 };
 
 const ArtistWorks = ({
   $c,
+  ajaxFilterFormUrl,
   artist,
+  filterForm,
+  hasFilter,
   pager,
   works,
 }: Props): React.Element<typeof ArtistLayout> => (
   <ArtistLayout entity={artist} page="works" title={l('Works')}>
     <h2>{l('Works')}</h2>
+
+    <Filter
+      ajaxFormUrl={ajaxFilterFormUrl}
+      initialFilterForm={filterForm}
+    />
 
     {works?.length ? (
       <form
@@ -55,7 +69,9 @@ const ArtistWorks = ({
       </form>
     ) : (
       <p>
-        {l('This artist is not currently associated with any works.')}
+        {hasFilter
+          ? l('No works found that match this search.')
+          : l('This artist is not currently associated with any works.')}
       </p>
     )}
   </ArtistLayout>

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -19,11 +19,13 @@ export type FilterFormT = $ReadOnly<{
     +country_id?: ReadOnlyFieldT<number>,
     +date?: ReadOnlyFieldT<string>,
     +name: ReadOnlyFieldT<string>,
+    +role_type?: ReadOnlyFieldT<number>,
     +type_id?: ReadOnlyFieldT<number>,
   }>,
   entity_type: 'recording' | 'release' | 'release_group',
   options_artist_credit_id: SelectOptionsT,
   options_country_id: SelectOptionsT,
+  options_role_type?: SelectOptionsT,
   options_type_id?: SelectOptionsT,
 }>;
 
@@ -53,6 +55,8 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
   const countryIdOptions = form.options_country_id;
   const countryIdField = form.field.country_id;
   const dateField = form.field.date;
+  const roleTypeField = form.field.role_type;
+  const roleTypeOptions = form.options_role_type;
 
   return (
     <div id="filter">
@@ -105,6 +109,25 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
                 />
               </td>
             </tr>
+
+            {roleTypeField && roleTypeOptions ? (
+              <tr>
+                <td>
+                  {addColonText(l('Role'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={roleTypeField}
+                    options={{
+                      grouped: false,
+                      options: roleTypeOptions,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+            ) : null}
 
             {countryIdField && countryIdOptions ? (
               <tr>

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -39,6 +39,8 @@ function getSubmitText(type: string) {
       return l('Filter releases');
     case 'release_group':
       return l('Filter release groups');
+    case 'work':
+      return l('Filter works');
   }
   return '';
 }

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -20,12 +20,14 @@ export type FilterFormT = $ReadOnly<{
     +date?: ReadOnlyFieldT<string>,
     +name: ReadOnlyFieldT<string>,
     +role_type?: ReadOnlyFieldT<number>,
+    +secondary_type_id?: ReadOnlyFieldT<number>,
     +type_id?: ReadOnlyFieldT<number>,
   }>,
   entity_type: 'recording' | 'release' | 'release_group',
   options_artist_credit_id: SelectOptionsT,
   options_country_id: SelectOptionsT,
   options_role_type?: SelectOptionsT,
+  options_secondary_type_id?: SelectOptionsT,
   options_type_id?: SelectOptionsT,
 }>;
 
@@ -50,6 +52,8 @@ function getSubmitText(type: string) {
 const FilterForm = ({form}: Props): React.Element<'div'> => {
   const typeIdField = form.field.type_id;
   const typeIdOptions = form.options_type_id;
+  const secondaryTypeIdField = form.field.secondary_type_id;
+  const secondaryTypeIdOptions = form.options_secondary_type_id;
   const artistCreditIdField = form.field.artist_credit_id;
   const artistCreditIdOptions = form.options_artist_credit_id;
   const countryIdOptions = form.options_country_id;
@@ -72,6 +76,25 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
                   <SelectField
                     field={typeIdField}
                     options={{grouped: false, options: typeIdOptions}}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+            ) : null}
+
+            {secondaryTypeIdField && secondaryTypeIdOptions ? (
+              <tr>
+                <td>
+                  {addColonText(l('Secondary type'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={secondaryTypeIdField}
+                    options={{
+                      grouped: false,
+                      options: secondaryTypeIdOptions,
+                    }}
                     style={{maxWidth: '40em'}}
                     uncontrolled
                   />

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -1,0 +1,303 @@
+package t::MusicBrainz::Server::Controller::Artist::Filtering;
+use utf8;
+use Test::Routine;
+use MusicBrainz::Server::Test qw( test_xpath_html );
+
+with 't::Mechanize', 't::Context';
+
+=head2 Test description
+
+This test checks whether filtering works for different entity lists
+in artist pages (RGs, recordings, works).
+
+=cut
+
+test 'Test overview (release group) filtering' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+filtering');
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435',
+        'Fetched artist overview page',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '6',
+        'There are six entries in the unfiltered release group tables',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.name=Symphony',
+        'Fetched artist overview page with name filter "Symphony"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '2',
+        'There are two entries in the release group tables after filtering by name',
+    );
+    $tx->is(
+        '//table[@class="tbl release-group-list"]/tbody/tr[1]/td[2]',
+        'Concerto for Orchestra / Symphony no. 3',
+        'The first entry is named "Concerto for Orchestra / Symphony no. 3"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.artist_credit_id=3401',
+        'Fetched artist overview page with artist credit filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '1',
+        'There is one entry in the release group tables after filtering by credit',
+    );
+    $tx->is(
+        '//table[@class="tbl release-group-list"]/tbody/tr[1]/td[2]',
+        'Piano Concerto / Symphony no. 2',
+        'The entry is named "Piano Concerto / Symphony no. 2"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.type_id=2',
+        'Fetched artist overview page with type filter "Single"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '1',
+        'There is one entry in the release group tables after filtering by "Single" type',
+    );
+    $tx->is(
+        '//table[@class="tbl release-group-list"]/tbody/tr[1]/td[2]',
+        'Jeux vénetiens',
+        'The entry is named "Jeux vénetiens"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.type_id=-1',
+        'Fetched artist overview page with type filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '1',
+        'There is one entry in the release group tables after filtering by no type',
+    );
+    $tx->is(
+        '//table[@class="tbl release-group-list"]/tbody/tr[1]/td[2]',
+        'String Quartet',
+        'The entry is named "String Quartet"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.secondary_type_id=6',
+        'Fetched artist overview page with secondary type filter "Live"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '2',
+        'There are two entries in the release group tables after filtering by "Live" secondary type',
+    );
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"])',
+        '2',
+        'There are two tables present, for albums and singles',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.type_id=1&filter.secondary_type_id=6',
+        'Fetched artist overview page with type filter "Album" and secondary type filter "Live"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '1',
+        'There is one entry in the release group tables after filtering by both "Album" and "Live"',
+    );
+    $tx->is(
+        '//table[@class="tbl release-group-list"]/tbody/tr[1]/td[2]',
+        'Lutosławski',
+        'The entry is named "Lutosławski"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.type_id=1&filter.secondary_type_id=-1',
+        'Fetched artist overview page with type filter "Album" and secondary type filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl release-group-list"]/tbody/tr)',
+        '3',
+        'There are three entries in the release group tables after filtering by album with no secondary type',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?filter.type_id=2&filter.name=Symphony',
+        'Fetched artist overview page with name filter "Symphony" and type filter "Single"',
+    );
+
+    $mech->content_contains(
+        'No release groups found that match this search.',
+        'The "no results" message is shown',
+    );
+};
+
+test 'Test recording page filtering' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+filtering');
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings',
+        'Fetched artist recordings page',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the unfiltered recording table',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.name=Symphony',
+        'Fetched artist recordings page with name filter "Symphony"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the recording table after filtering by name',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Symphony no. 3',
+        'The entry is named "Symphony no. 3"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.artist_credit_id=3402',
+        'Fetched artist recordings page with artist credit filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the recording table after filtering by credit',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[2]',
+        'Sinfonia Varsovia, Witold Lutosławski',
+        'The first has the expected artist credit"',
+    );
+};
+
+test 'Test work page filtering' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+filtering');
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works',
+        'Fetched artist works page',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '5',
+        'There are five entries in the unfiltered work table',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.role_type=1',
+        'Fetched artist works page with "as performer" filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the "as performer" work table (even though one work was performed twice)',
+    );
+    $mech->content_lacks('Mini Overture', 'Not performed work is not shown');
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.role_type=2',
+        'Fetched artist works page with "as writer" filter',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the "as writer" work table',
+    );
+    $mech->content_lacks(
+        'Brandenburgisches Konzert',
+        'Not written work is not shown',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.type_id=16',
+        'Fetched artist works page with type filter "Symphony"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the work table after filtering by "Symphony" type',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.type_id=-1',
+        'Fetched artist works page with type filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the work table after filtering by no type',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Interlude',
+        'The entry is named "Interlude"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.name=Interlude',
+        'Fetched artist works page with name filter "Interlude"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the work table after filtering by name "Interlude"',
+    );
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -88,6 +88,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Ajax::filter_artist_recordings_form',
   'Controller::Ajax::filter_artist_release_groups_form',
   'Controller::Ajax::filter_artist_releases_form',
+  'Controller::Ajax::filter_artist_works_form',
   'Controller::Area::alias',
   'Controller::Area::aliases',
   'Controller::Area::annotation_diff',

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -658,6 +658,7 @@ const seleniumTests = [
     sql: 'duplicate_checker.sql',
   },
   {name: 'CD_Lookup.json5', login: true},
+  {name: 'FilterForm.json5', sql: 'filtering.sql'},
 ];
 
 const testPath = name => path.resolve(__dirname, 'selenium', name);

--- a/t/selenium/FilterForm.json5
+++ b/t/selenium/FilterForm.json5
@@ -1,0 +1,41 @@
+{
+  title: 'Test filter form',
+  commands: [
+    {
+      command: 'open',
+      target: '/artist/af4c43d3-c0e0-421e-ac64-000329af0435',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "!!document.getElementById('filter')",
+      value: 'false',
+    },
+    {
+      command: 'click',
+      target: 'link=Filter',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "!!document.getElementById('filter')",
+      value: 'true',
+    },
+    {
+      command: 'type',
+      target: 'name=filter.name',
+      value: 'Symphon',
+    },
+    {
+      command: 'click',
+      target: "css=#filter button.submit",
+      value: '',
+    },
+
+    {
+      command: 'assertLocationMatches',
+      target: '/artist/af4c43d3-c0e0-421e-ac64-000329af0435?(?:.*)filter.name=Symphon',
+      value: '',
+    },
+  ],
+}

--- a/t/selenium/Redirect_Merged_Entities.json5
+++ b/t/selenium/Redirect_Merged_Entities.json5
@@ -34,6 +34,16 @@
     },
     {
       command: 'open',
+      target: '/artist/f21a407e-3af9-4539-ab3d-c92a5230dff6/recordings?filter.cancel=1',
+      value: '',
+    },
+    {
+      command: 'assertLocationMatches',
+      target: '\\/artist\\/1155431a-d35e-4863-9ae0-e3c24eb61aa9\\/recordings\\?filter.cancel=1',
+      value: '',
+    },
+    {
+      command: 'open',
       target: '/artist/f21a407e-3af9-4539-ab3d-c92a5230dff6/alias/37382/edit',
       value: '',
     },

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -1,0 +1,68 @@
+SET client_min_messages TO 'warning';
+
+-- Artists
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (3400, 'af4c43d3-c0e0-421e-ac64-000329af0435', 'Witold Lutosławski', 'Lutosławski, Witold'),
+           (3401, 'dea28aa9-1086-4ffa-8739-0ccc759de1ce', 'Berliner Philharmoniker', 'Berliner Philharmoniker'),
+           (3402, '802cd1ab-d87f-4418-915f-ff716defb87d', 'Sinfonia Varsovia', 'Sinfonia Varsovia'),
+           (3403, '24f1766e-9635-4d58-a4d4-9413f9f98a4c', 'Johann Sebastian Bach', 'Bach, Johann Sebastian');
+
+INSERT INTO artist_credit (id, name, artist_count)
+    VALUES (3400, 'Witold Lutosławski', 1),
+           (3401, 'Berliner Philharmoniker, Witold Lutosławski', 2),
+           (3402, 'Sinfonia Varsovia, Witold Lutosławski', 2);
+
+INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phrase)
+    VALUES (3400, 0, 3400, 'Witold Lutosławski', ''),
+           (3401, 0, 3401, 'Berliner Philharmoniker', ', '),
+           (3401, 1, 3400, 'Witold Lutosławski', ''),
+           (3402, 0, 3402, 'Sinfonia Varsovia', ', '),
+           (3402, 1, 3400, 'Witold Lutosławski', '');
+-- RGs
+
+INSERT INTO release_group (id, gid, name, artist_credit, type)
+    VALUES (3400, 'bee95816-da7d-3902-9038-3e8f9b3ebe9f', 'Concerto for Orchestra / Symphony no. 3', 3400, 1),
+           (3401, '6dfcff0b-9434-48b9-bf14-ed674dd626f5', 'Piano Concerto / Symphony no. 2', 3401, 1),
+           (3402, '98b72608-a824-40c5-b5df-81cf981faf7e', 'Symphonies / Concertos / Choral and Vocal Works', 3400, 1),
+           (3403, '33d71de2-d3c6-4906-908e-df59d70b283d', 'Lutosławski', 3400, 1),
+           (3404, 'fc9b775a-6c06-3828-b6a4-220b65cfef60', 'String Quartet', 3400, NULL),
+           (3405, '5a52075e-f5eb-3de5-8236-aa21cc05cb1e', 'Jeux vénetiens', 3400, 2);
+
+INSERT INTO release_group_secondary_type_join (release_group, secondary_type)
+    VALUES (3403, 6), (3405, 6);
+
+-- Recordings
+
+INSERT INTO recording (id, gid, name, artist_credit)
+    VALUES (3400, 'ce82bfa1-733a-494a-aaa0-fc5de79bd54f', 'Interludium', 3402),
+           (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401),
+           (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401),
+           (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402);
+
+-- Works
+
+INSERT INTO work (id, gid, name, type)
+    VALUES (3400, 'a0cd8685-0626-49e2-8722-aa8c726287db', 'Interlude', NULL),
+           (3401, '4d89910c-14ae-4d23-b7d4-9cbe111981b6', 'Symphony no. 3', 16),
+           (3402, '4ef6d273-4534-4b37-97f1-3e01d76b2fe5', 'Symphony no. 4', 16),
+           (3403, 'fcedfaf3-63ad-4ea2-949a-b16cdc2cd019', 'Mini Overture', 12),
+           (3404, 'dbb7157a-5dc3-41c4-aacc-4e3d4705e132', 'Brandenburgisches Konzert Nr. 5 D-Dur, BWV 1050', 4);
+
+-- Relationships
+
+INSERT INTO link (id, link_type, attribute_count)
+    VALUES (3400, 278, 0), (3401, 278, 0), (3402, 278, 0), (3403, 278, 0), -- performance
+           (3404, 151, 0), (3405, 151, 0), (3406, 151, 0), (3407, 151, 0), -- conductor
+           (3408, 150, 0), (3409, 150, 0), (3410, 150, 0), (3411, 150, 0), -- orchestra
+           (3412, 168, 0), (3413, 168, 0), (3414, 168, 0), (3415, 168, 0), (3416, 168, 0); -- composer
+
+INSERT INTO l_artist_recording (id, link, entity0, entity1)
+    VALUES (3400, 3404, 3400, 3400), (3401, 3405, 3400, 3401), (3402, 3406, 3400, 3402), (3403, 3407, 3400, 3403), -- conductor
+           (3404, 3408, 3402, 3400), (3405, 3409, 3401, 3401), (3406, 3410, 3401, 3402), (3407, 3411, 3402, 3403); --orchestra
+
+INSERT INTO l_artist_work (id, link, entity0, entity1)
+    VALUES (3400, 3412, 3400, 3400), (3401, 3413, 3400, 3401), (3402, 3414, 3400, 3402), (3403, 3415, 3400, 3403), (3404, 3416, 3403, 3404);
+
+INSERT INTO l_recording_work (id, link, entity0, entity1)
+    VALUES (3400, 3400, 3400, 3400), (3401, 3401, 3401, 3401), (3402, 3402, 3402, 3404), (3403, 3403, 3403, 3404);


### PR DESCRIPTION
### Implement MBS-5747 / MBS-5997 / MBS-7029 / MBS-11294
### Fix MBS-11122

First commit adds basic filters on work name and work type.
Second adds an option to filter performers vs writers.
Third fixes a small preexisting translation bug that I accidentally copied to works too.
Fourth adds basic secondary type filtering to RG filters.
Fifth stops a warning.
Sixth allows filtering by type = none.