### PR TITLE
MBS-11121: Normalize Apple Music beta links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -628,7 +628,7 @@ const CLEANUPS = {
   'applemusic': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i')],
     clean: function (url) {
-      url = url.replace(/^https?:\/\/(?:geo\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
+      url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
       // US page is the default, add its country-code to clarify (MBS-10623)
       url = url.replace(/^(https:\/\/music\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
       return url;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -374,6 +374,10 @@ const testData = [
             expected_clean_url: 'https://music.apple.com/us/artist/444923726',
   },
   {
+                     input_url: 'https://beta.music.apple.com/ca/artist/imposs/205021452',
+            expected_clean_url: 'https://music.apple.com/ca/artist/205021452',
+  },
+  {
                      input_url: 'https://music.apple.com/ee/music-video/black-and-yellow/539886832?uo=4&mt=5&app=music',
             expected_clean_url: 'https://music.apple.com/ee/music-video/539886832',
   },


### PR DESCRIPTION
### Implement MBS-11121

They point to the same content, so just removing `beta.` from them works.