### PR TITLE
MBS-8650: Lower how long an IPI must be to 5

### DIFF
--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -170,7 +170,7 @@ sub is_valid_ipi
 sub format_ipi
 {
     my $ipi = shift;
-    return $ipi unless $ipi =~ /^[0-9\s.]{9,}$/;
+    return $ipi unless $ipi =~ /^[0-9\s.]{5,}$/;
     $ipi =~ s/[\s.]//g;
     return sprintf("%011.0f", $ipi)
 }

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -144,9 +144,10 @@ test 'Test is_valid_ipi' => sub {
 };
 
 test 'Test format_ipi' => sub {
-    is(format_ipi('014107338'), '00014107338');
+    is(format_ipi('07338'), '00000007338', '5 (or more) character IPI is zero-padded');
     is(format_ipi('274.373.649'), '00274373649');
     is(format_ipi('274 373 649'), '00274373649');
+    is(format_ipi('7338'), '7338', 'Too short IPI is returned as-is');
     is(format_ipi('MusicBrainz::Server::Entity::ArtistIPI=HASH(0x11c9a410)'),
        'MusicBrainz::Server::Entity::ArtistIPI=HASH(0x11c9a410)',
        'Regression test #MBS-5066');


### PR DESCRIPTION
### Implement MBS-8650

5 digits was the shortest our users found in SACEM (see ticket). Given that it seems unlikely a user would randomly type 5 digits by mistake in the IPI field, going down to this seems safe to me.
