### PR TITLE
MBS-11114: Allow track times to be unset

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -159,7 +159,12 @@ class Track {
 
     var newLength = utils.unformatTrackLength(length);
 
-    if (!newLength) {
+    /*
+     * The result of `unformatTrackLength` is NaN when the length entered
+     * by the user can't be parsed. If they've *cleared* the length, it's
+     * null.
+     */
+    if (Number.isNaN(newLength)) {
       this.formattedLength('');
       return;
     }

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -492,6 +492,7 @@ const seleniumTests = [
   {name: 'release-editor/Seeding.html', login: true, sql: 'vision_creation_newsun.sql'},
   {name: 'release-editor/MBS-10359.html', login: true},
   {name: 'release-editor/MBS-11015.html', login: true},
+  {name: 'release-editor/MBS-11114.html', login: true},
 ];
 
 const testPath = name => path.resolve(__dirname, 'selenium', name);

--- a/t/selenium/release-editor/MBS-11114.html
+++ b/t/selenium/release-editor/MBS-11114.html
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost:5000" />
+<title>MBS-11114</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">MBS-11114</td></tr>
+</thead>
+<tbody>
+<!-- This test case demonstrates that you can remove/clear a track length after it's set. -->
+<tr>
+    <td>open</td>
+    <td>/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit</td>
+    <td></td>
+</tr>
+<tr>
+    <td>click</td>
+    <td>xpath=//a[@href='#tracklist']</td>
+    <td></td>
+</tr>
+<tr>
+    <td>pause</td>
+    <td>1000</td>
+    <td></td>
+</tr>
+<tr>
+    <td>type</td>
+    <td>xpath=(//tr[contains(@class, 'track')])[1]//input[contains(@class, 'track-length')]</td>
+    <td></td>
+</tr>
+<tr>
+    <td>click</td>
+    <td>xpath=//a[@href='#edit-note']</td>
+    <td></td>
+</tr>
+<tr>
+  <td>type</td>
+  <td>id=edit-note-text</td>
+  <td>clearing the track time because BLARGH</td>
+</tr>
+<tr>
+  <td>clickAndWait</td>
+  <td>id=enter-edit</td>
+  <td></td>
+</tr>
+<tr>
+    <td>assertEditData</td>
+    <td>1</td>
+    <td>
+      {
+        "status": 1,
+        "type": 52,
+        "data": {
+          "new": {
+            "tracklist": [
+              {
+                "id": 18674665,
+                "name": "2 + 2 = 5 (The Lukewarm.)",
+                "length": null,
+                "number": "1",
+                "position": 1,
+                "recording_id": "20937085",
+                "artist_credit": {
+                  "names": [
+                    {
+                      "name": "Nine Inch Nails",
+                      "artist": {
+                        "id": "347",
+                        "name": "Nine Inch Nails"
+                      },
+                      "join_phrase": ""
+                    }
+                  ]
+                },
+                "is_data_track": "0"
+              }
+            ]
+          },
+          "old": {
+            "tracklist": [
+              {
+                "id": 18674665,
+                "name": "2 + 2 = 5 (The Lukewarm.)",
+                "length": 199386,
+                "number": "1",
+                "position": 1,
+                "recording_id": "20937085",
+                "artist_credit": {
+                  "names": [
+                    {
+                      "name": "Nine Inch Nails",
+                      "artist": {
+                        "id": "347",
+                        "name": "Nine Inch Nails"
+                      },
+                      "join_phrase": ""
+                    }
+                  ]
+                },
+                "is_data_track": "0"
+              }
+            ]
+          },
+          "release": {
+            "id": 1693299,
+            "name": "★"
+          },
+          "entity_id": 1690850
+        }
+      }
+    </td>
+</tr>
+<tr>
+    <td>open</td>
+    <td>/test/accept-edit/1</td>
+    <td></td>
+</tr>
+<tr>
+    <td>open</td>
+    <td>/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33</td>
+    <td></td>
+</tr>
+<!-- Check that the release length is unset. -->
+<tr>
+    <td>assertEval</td>
+    <td>Array.from(document.querySelector('h2.release-information + dl.properties').children).map(function (node) { return node.textContent }).join('\n')</td>
+    <td>Barcode:
+888751738621
+Format:
+CD</td>
+</tr>
+<!-- MBS-11114: Check that the track length is unset. -->
+<tr>
+    <td>assertEval</td>
+    <td>/\?:\?\?/.test(document.querySelector('table.medium &gt; tbody &gt; tr:not(.subh) &gt; td.treleases').textContent)</td>
+    <td>true</td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
0d45452121257d336c915f1b78f1114a21afe518 broke this by incorrectly removing the "useless" isNaN check, which it turns out was not "useless." The result of `unformatTrackLength` is null when the length is empty, so the bug is that we'd bail out too early with the new check and fail to set `this.length(newLength)`. The result is only NaN when the input can't be parsed. A test is now added.