### PR TITLE
MBS-4118: Add full-icu to Node for locale strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "detect-node": "2.0.3",
     "file-loader": "3.0.1",
     "filesize": "2.0.4",
+    "full-icu": "1.3.1",
     "generic-diff": "1.0.1",
     "he": "1.1.1",
     "imports-loader": "0.8.0",

--- a/script/start_renderer.pl
+++ b/script/start_renderer.pl
@@ -43,5 +43,6 @@ if ($child) {
     push @argv, ('--socket', $socket) if $socket;
     push @argv, ('--workers', $workers) if $workers;
     chdir qq($FindBin::Bin/../);
-    exec 'node', 'root/server.js', @argv;
+    # If updating to a min. req. of Node 13+, check if icu-data-dir is still needed
+    exec 'node', '--icu-data-dir=node_modules/full-icu', 'root/server.js', @argv;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,6 +3370,11 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
+full-icu@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.1.tgz#e67fdf58523f1d1e0d9143b1542fe2024c1c8997"
+  integrity sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==
+
 function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
### Fix MBS-4118

Without this, Number.toLocaleString and Date.toLocaleString always use the English locale in Node 12, at the very least.

See https://nodejs.org/docs/latest-v12.x/api/intl.html

For testing, see that (e.g.) the statistics page does have the right thousand separators (comma for English, space for Estonian, thin space for French and dots for Spanish) rather than always having comma-separators.