### PR TITLE
MBS-11127: Use cardinality for work-level-rels in WS/2

### DIFF
--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -582,7 +582,8 @@ sub load_relationships {
         if ($c->stash->{inc}->work_level_rels)
         {
             push(@entities_with_rels, @works); 
-            $c->model('Relationship')->load_subset($types, @works);
+            # Avoid returning recording-work relationships for other recordings
+            $c->model('Relationship')->load_subset_cardinal($types, @works);
         }
         $self->linked_works($c, $stash, \@works);
 

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -329,6 +329,11 @@ sub load_cardinal {
     return $self->_load_subset(\@RELATABLE_ENTITIES, 1, @objs);
 }
 
+sub load_subset_cardinal {
+    my ($self, $types, @objs) = @_;
+    return $self->_load_subset($types, 1, @objs);
+}
+
 sub generate_table_list {
     my ($self, $type, @end_types) = @_;
     # Generate a list of all possible type combinations


### PR DESCRIPTION
### Implement MBS-11127

This avoids returning all unrelated recording-work relationships for every release with work-level-rels inc, which in some cases
was over 90% of the size of the full response for no apparent benefit.

The only other relationship currently not returned because of cardinality is work-artist "artist was named after work", which also seems irrelevant to release responses anyway.

Note: we should make sure to notify users of this change when we release it (and possibly before?) in case someone specifically expected and made use of this behaviour. If needed, we could add a second, explicitly GIVE ME ALL inc that still works like before.