### PR TITLE
MBS-6322: Add report for releases with same barcodes in diff RGs

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
@@ -1,0 +1,43 @@
+package MusicBrainz::Server::Report::ReleasesSameBarcode;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::ReleaseGroupReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub table { 'releases_same_barcode' }
+sub component_name { 'ReleasesSameBarcode' }
+
+sub query {
+    "
+        SELECT DISTINCT ON (r.id)
+            r.barcode AS barcode, r.id AS release_id, r.release_group AS release_group_id,
+            row_number() OVER (ORDER BY r.barcode, r.name COLLATE musicbrainz)
+        FROM
+            release r
+        WHERE r.barcode IS NOT NULL -- skip unset
+        AND r.barcode != '' -- skip [none]
+        AND r.status != 3 -- skip bootlegs
+        AND EXISTS (
+            SELECT 1 FROM release r2
+                WHERE r.barcode = r2.barcode
+                AND r.status != 3 -- skip bootlegs
+                AND r.release_group != r2.release_group
+        )
+    "
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -74,6 +74,7 @@ use MusicBrainz::Server::PagedReport;
     ReleasesInCAAWithCoverArtRelationships
     ReleaseLabelSameArtist
     ReleaseRGDifferentName
+    ReleasesSameBarcode
     ReleasesToConvert
     ReleasesWithCAANoTypes
     ReleasesWithDownloadRelationships
@@ -159,6 +160,7 @@ use MusicBrainz::Server::Report::ReleasesInCAAWithCoverArtRelationships;
 use MusicBrainz::Server::Report::ReleaseLabelSameArtist;
 use MusicBrainz::Server::Report::ReleaseRGDifferentName;
 use MusicBrainz::Server::Report::ReleasesToConvert;
+use MusicBrainz::Server::Report::ReleasesSameBarcode;
 use MusicBrainz::Server::Report::ReleasesWithCAANoTypes;
 use MusicBrainz::Server::Report::ReleasesWithDownloadRelationships;
 use MusicBrainz::Server::Report::ReleasesWithNoMediums;

--- a/root/report/ReleasesSameBarcode.js
+++ b/root/report/ReleasesSameBarcode.js
@@ -1,0 +1,107 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+import PaginatedResults from '../components/PaginatedResults';
+import loopParity from '../utility/loopParity';
+import EntityLink from '../static/scripts/common/components/EntityLink';
+import formatBarcode from '../static/scripts/common/utility/formatBarcode';
+
+import FilterLink from './FilterLink';
+import type {ReportDataT} from './types';
+
+type ReportRowT = {
+  +barcode: string,
+  +release: ?ReleaseT,
+  +release_group: ?ReleaseGroupT,
+  +release_group_id: number,
+  +release_id: number,
+  +row_number: number,
+};
+
+const ReleasesSameBarcode = ({
+  $c,
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRowT>): React.Element<typeof Layout> => (
+  <Layout
+    $c={$c}
+    fullWidth
+    title={l('Releases with the same barcode in different release groups')}
+  >
+    <h1>{l('Releases with the same barcode in different release groups')}</h1>
+
+    <ul>
+      <li>
+        {l(`This report shows non-bootleg releases which have
+            the same barcode, yet are placed in different release groups.
+            Chances are that the releases are duplicates or parts of a set,
+            or at least that the release groups should be merged.`)}
+      </li>
+      <li>
+        {texp.l('Total releases found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+
+      {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
+    </ul>
+
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Barcode')}</th>
+            <th>{l('Release')}</th>
+            <th>{l('Release Group')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <tr className={loopParity(index)} key={item.release_id}>
+              <td className="barcode-cell">
+                {formatBarcode(item.barcode)}
+              </td>
+              {item.release ? (
+                <td>
+                  <EntityLink entity={item.release} />
+                </td>
+              ) : (
+                <td>
+                  {l('This release no longer exists.')}
+                </td>
+              )}
+              {item.release_group ? (
+                <td>
+                  <EntityLink entity={item.release_group} />
+                </td>
+              ) : (
+                <td>
+                  {l('This release group no longer exists.')}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </PaginatedResults>
+
+  </Layout>
+);
+
+export default ReleasesSameBarcode;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -415,6 +415,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
             {l('Releases with a different name than their release group')}
           </a>
         </li>
+        <li>
+          <a href="/report/ReleasesSameBarcode">
+            {l('Releases with the same barcode in different release groups')}
+          </a>
+        </li>
       </ul>
 
       <h2>{l('Recordings')}</h2>

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -194,6 +194,7 @@ module.exports = {
   'report/ReleasesInCaaWithCoverArtRelationships': require('../report/ReleasesInCaaWithCoverArtRelationships'),
   'report/ReleasesMissingDiscIds': require('../report/ReleasesMissingDiscIds'),
   'report/ReleasesConflictingDiscIds': require('../report/ReleasesConflictingDiscIds'),
+  'report/ReleasesSameBarcode': require('../report/ReleasesSameBarcode'),
   'report/ReleasesToConvert': require('../report/ReleasesToConvert'),
   'report/ReleasesWithCaaNoTypes': require('../report/ReleasesWithCaaNoTypes'),
   'report/ReleasesWithDownloadRelationships': require('../report/ReleasesWithDownloadRelationships'),


### PR DESCRIPTION
### Implement MBS-6322

This should almost never happen, unless the label made a mistake. This skips bootleg releases, since those sometimes intentionally are all given the same barcode anyway by the bootleg label.