### PR TITLE
MBS-11129: Display mediums as Medium # (Format)

### DIFF
--- a/root/cdtoc/AttachCDTocConfirmation.js
+++ b/root/cdtoc/AttachCDTocConfirmation.js
@@ -39,7 +39,8 @@ component AttachCDTocConfirmation(
       <p>
         {exp.l(
           `Are you sure that you wish to attach the disc ID
-           <code>{discid}</code> to {format} {pos} of {release} by {artist}?`,
+           <code>{discid}</code> to medium {pos} ({format})
+           of {release} by {artist}?`,
           {
             artist: <ArtistCreditLink artistCredit={release.artistCredit} />,
             discid: cdToc.discid,

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -420,7 +420,7 @@ END -%]
 [%~ MACRO format_length(n) BLOCK; n | format_length; END -%]
 
 [%~ MACRO medium_format_name(medium) BLOCK # Converted to React at root/static/scripts/common/utility/mediumFormatName.js -%]
-    [% medium.l_format_name or l("Medium") | html %]
+    [%- medium.l_format_name or l("Medium") | html -%]
 [%- END -%]
 
 [%~ MACRO release_countries_list(release_events) BLOCK;

--- a/root/static/scripts/common/components/MediumDescription.js
+++ b/root/static/scripts/common/components/MediumDescription.js
@@ -10,11 +10,32 @@
 import isolateText from '../utility/isolateText.js';
 import mediumFormatName from '../utility/mediumFormatName.js';
 
+export component MinimalMediumDescription(medium: MediumT) {
+  const mediumDescription = mediumFormatName(medium);
+  if (medium.name) {
+    return (
+      <>
+        {addColonText(mediumDescription)}
+        {' '}
+        <span className="medium-name">{isolateText(medium.name)}</span>
+      </>
+    );
+  }
+  return mediumDescription;
+}
+
 component MediumDescription(medium: MediumT) {
-  const formatAndPosition = texp.l('{medium_format} {position}', {
-    medium_format: mediumFormatName(medium),
-    position: medium.position,
-  });
+  const formatAndPosition = medium.format ? (
+    texp.l('Medium {position} ({medium_format})', {
+      medium_format: mediumFormatName(medium),
+      position: medium.position,
+    })
+  ) : (
+    texp.l('Medium {position}', {
+      position: medium.position,
+    })
+  );
+
   if (medium.name) {
     return (
       <>

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -18,7 +18,6 @@ import ArtistCreditLink from './components/ArtistCreditLink.js';
 import DescriptiveLink from './components/DescriptiveLink.js';
 import EditorLink from './components/EditorLink.js';
 import EntityLink from './components/EntityLink.js';
-import MediumDescription from './components/MediumDescription.js';
 import {bracketedText} from './utility/bracketed.js';
 import {getSourceEntityData} from './utility/catalyst.js';
 import clean from './utility/clean.js';
@@ -474,10 +473,6 @@ import MB from './MB.js';
       this.tracks = data.tracks
         ? data.tracks.map(x => new Track(x))
         : [];
-
-      this.positionName = ReactDOMServer.renderToString(
-        <MediumDescription medium={this} />,
-      );
     }
   }
 

--- a/root/static/scripts/common/hooks/usePagedMediumTable.js
+++ b/root/static/scripts/common/hooks/usePagedMediumTable.js
@@ -15,7 +15,7 @@ import mediumHasMultipleArtists
 import type {
   LazyReleaseActionT,
 } from '../../release/types.js';
-import MediumDescription from '../components/MediumDescription.js';
+import {MinimalMediumDescription} from '../components/MediumDescription.js';
 import {
   type LinkedEntitiesT,
   mergeLinkedEntities,
@@ -187,11 +187,12 @@ export default function usePagedMediumTable(
       id={'disc' + mediumPosition}
       onClick={handleMediumToggle}
     >
+      <span>{mediumPosition}</span>
       <span className="expand-triangle">
         {isExpanded ? '\u25BC' : '\u25B6'}
       </span>
       {' '}
-      <MediumDescription medium={medium} />
+      <MinimalMediumDescription medium={medium} />
     </a>
   );
 

--- a/root/static/scripts/common/hooks/usePagedMediumTable.js
+++ b/root/static/scripts/common/hooks/usePagedMediumTable.js
@@ -191,7 +191,6 @@ export default function usePagedMediumTable(
       <span className="expand-triangle">
         {isExpanded ? '\u25BC' : '\u25B6'}
       </span>
-      {' '}
       <MinimalMediumDescription medium={medium} />
     </a>
   );

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -853,6 +853,7 @@ table.tbl.medium {
 
     .expand-triangle {
         color: @musicbrainz-purple;
+        padding-right: 0.15em;
     }
 
     /* Visibly apparent for tracks with inline credits. */


### PR DESCRIPTION
### Implement MBS-11129

The current way (CD 1, DVD 2) kinda makes it sound like there should be a DVD 1.

For release tracklists, this just shows the medium position at the beginning of the header, then shows only medium format and name after the expand/collapse arrow.

Everywhere else, such as on edits, or on the relationship lists under the release, `Medium 1 (CD)`, `Medium 2 (DVD)`, etc. seems a lot less confusing and not too repetitive / silly.
