### PR TITLE
MBS-7219: Hide links to empty ArtistRecording subsets

### DIFF
--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -302,6 +302,21 @@ sub _merge_impl
     return 1;
 }
 
+sub has_standalone
+{
+    my ($self, $artist_id) = @_;
+    my $query ='
+        SELECT EXISTS (
+            SELECT 1
+            FROM recording
+            JOIN artist_credit_name acn
+                ON acn.artist_credit = recording.artist_credit
+            WHERE acn.artist = ?
+            AND NOT EXISTS (SELECT 1 FROM track WHERE track.recording = recording.id)
+        )';
+    $self->sql->select_single_value($query, $artist_id);
+}
+
 sub find_standalone
 {
     my ($self, $artist_id, $limit, $offset) = @_;
@@ -316,6 +331,21 @@ sub find_standalone
            AND acn.artist = ?
       ORDER BY recording.name COLLATE musicbrainz';
     $self->query_to_list_limited($query, [$artist_id], $limit, $offset);
+}
+
+sub has_video
+{
+    my ($self, $artist_id) = @_;
+    my $query ='
+        SELECT EXISTS (
+            SELECT 1
+            FROM recording
+            JOIN artist_credit_name acn
+                ON acn.artist_credit = recording.artist_credit
+            WHERE acn.artist = ?
+            AND recording.video IS TRUE
+        )';
+    $self->sql->select_single_value($query, $artist_id);
 }
 
 sub find_video

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -15,8 +15,17 @@ import PaginatedResults from '../components/PaginatedResults';
 import Filter from '../static/scripts/common/components/Filter';
 import {type FilterFormT}
   from '../static/scripts/common/components/FilterForm';
+import bracketed from '../static/scripts/common/utility/bracketed';
 
 import ArtistLayout from './ArtistLayout';
+
+type FooterSwitchProps = {
+  +artist: ArtistT,
+  +hasStandalone: boolean,
+  +hasVideo: boolean,
+  +standaloneOnly: boolean,
+  +videoOnly: boolean,
+};
 
 type Props = {
   +$c: CatalystContextT,
@@ -24,10 +33,92 @@ type Props = {
   +artist: ArtistT,
   +filterForm: ?FilterFormT,
   +hasFilter: boolean,
+  +hasStandalone: boolean,
+  +hasVideo: boolean,
   +pager: PagerT,
   +recordings: $ReadOnlyArray<RecordingT>,
   +standaloneOnly: boolean,
   +videoOnly: boolean,
+};
+
+const FooterSwitch = ({
+  artist,
+  hasStandalone,
+  hasVideo,
+  standaloneOnly,
+  videoOnly,
+}: FooterSwitchProps): React.Element<'p'> => {
+  const showingAllText = l('Showing all recordings');
+  const showingStandaloneText = l('Showing only standalone recordings');
+  const showingVideosText = l('Showing only videos');
+  const showAllLink = exp.l(
+    '{show_all|Show all recordings}',
+    {show_all: `/artist/${artist.gid}/recordings`},
+  );
+  const showStandaloneLink = exp.l(
+    '{show_sa|Show only standalone recordings}',
+    {show_sa: `/artist/${artist.gid}/recordings?standalone=1`},
+  );
+  const showVideosLink = exp.l(
+    '{show_vid|Show only videos}',
+    {show_vid: `/artist/${artist.gid}/recordings?video=1`},
+  );
+
+  return (
+    <p>
+      {standaloneOnly ? (
+        <>
+          {showingStandaloneText}
+          {' '}
+          {bracketed(
+            <>
+              {showAllLink}
+              {hasVideo ? (
+                <>
+                  {' / '}
+                  {showVideosLink}
+                </>
+              ) : null}
+            </>
+          )}
+        </>
+      ) : videoOnly ? (
+        <>
+          {showingVideosText}
+          {' '}
+          {bracketed(
+            <>
+              {showAllLink}
+              {hasStandalone ? (
+                <>
+                  {' / '}
+                  {showStandaloneLink}
+                </>
+              ) : null}
+            </>
+          )}
+        </>
+      ) : (
+        <>
+          {showingAllText}
+          {' '}
+          {hasStandalone && hasVideo ? (
+            bracketed(
+              <>
+                {showStandaloneLink}
+                {' / '}
+                {showVideosLink}
+              </>
+            )
+          ) : hasStandalone ? (
+            bracketed(showStandaloneLink)
+          ) : hasVideo ? (
+            bracketed(showVideosLink)
+          ) : null}
+        </>
+      )}
+    </p>
+  );
 };
 
 const ArtistRecordings = ({
@@ -36,6 +127,8 @@ const ArtistRecordings = ({
   artist,
   filterForm,
   hasFilter,
+  hasStandalone,
+  hasVideo,
   pager,
   recordings,
   standaloneOnly,
@@ -78,36 +171,13 @@ const ArtistRecordings = ({
       </p>
     )}
 
-    {standaloneOnly ? (
-      <p>
-        {exp.l(
-          `Showing only standalone recordings.
-           {show_all|Show all recordings instead}.`,
-          {show_all: `/artist/${artist.gid}/recordings?standalone=0`},
-        )}
-      </p>
-
-    ) : videoOnly ? (
-      <p>
-        {exp.l(
-          'Showing only videos. {show_all|Show all recordings instead}.',
-          {show_all: `/artist/${artist.gid}/recordings?video=0`},
-        )}
-      </p>
-
-    ) : (
-      <p>
-        {exp.l(
-          `Showing all recordings.
-           {show_sa|Show only standalone recordings instead}, or
-           {show_vid|show only videos}.`,
-          {
-            show_sa: `/artist/${artist.gid}/recordings?standalone=1`,
-            show_vid: `/artist/${artist.gid}/recordings?video=1`,
-          },
-        )}
-      </p>
-    )}
+    <FooterSwitch
+      artist={artist}
+      hasStandalone={hasStandalone}
+      hasVideo={hasVideo}
+      standaloneOnly={standaloneOnly}
+      videoOnly={videoOnly}
+    />
   </ArtistLayout>
 );
 


### PR DESCRIPTION
### Implement MBS-7219

If there are no standalone recordings or no videos then there is no good reason to actually give the user links to such subset pages.

I hope making this check every time a recording page is loaded isn't too bad given that I'm specifically limiting it to 1 - I can't see a good way to do this otherwise.