### PR TITLE
MBS-11136: Support HTML in admin/attribute descriptions

### DIFF
--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 
 import Layout from '../../layout';
 import {compare} from '../../static/scripts/common/i18n';
+import expand2react from '../../static/scripts/common/i18n/expand2react';
 import yesNo from '../../static/scripts/common/utility/yesNo';
 import loopParity from '../../utility/loopParity';
 
@@ -112,7 +113,7 @@ const Attribute = ({
             <tr className={loopParity(index)} key={attribute.id}>
               <td>{attribute.id}</td>
               <td>{attribute.name}</td>
-              <td>{attribute.description}</td>
+              <td>{expand2react(attribute.description)}</td>
               <td>{attribute.child_order}</td>
               <td>{attribute.parent_id}</td>
               {renderAttributes(attribute)}


### PR DESCRIPTION
### Implement MBS-11136

While the descriptions for things like EventType (the one I actually added an HTML description for) don't actually show anywhere except the admin/attribute page yet AFAICT, it still probably makes sense to show them as intended here.

Hopefully we will eventually also display them elsewhere when relevant, so that most users can see them.
