### PR TITLE
MBS-11137: Show info on hover on frontpage's new releases

### DIFF
--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -28,12 +28,14 @@ function artworkHover(artwork: ArtworkT) {
 type Props = {
   +artwork: ArtworkT,
   +fallback?: string,
+  +hover?: string,
   +message?: string,
 };
 
 export const ArtworkImage = ({
   artwork,
   fallback,
+  hover,
   message,
 }: Props): React.Element<typeof React.Fragment> => (
   <>
@@ -48,7 +50,7 @@ export const ArtworkImage = ({
         ? message
         : l('Image not available yet, please try again in a few minutes.')}
       data-small-thumbnail={artwork.small_thumbnail}
-      data-title={artworkHover(artwork)}
+      data-title={nonEmpty(hover) ? hover : artworkHover(artwork)}
     />
   </>
 );
@@ -56,6 +58,7 @@ export const ArtworkImage = ({
 export const Artwork = ({
   artwork,
   fallback,
+  hover,
   message,
 }: Props): React.Element<'a'> => (
   <a
@@ -63,7 +66,7 @@ export const Artwork = ({
       ? 'artwork-pdf'
       : 'artwork-image'}
     href={artwork.image}
-    title={artworkHover(artwork)}
+    title={nonEmpty(hover) ? hover : artworkHover(artwork)}
   >
     {artwork.mime_type === 'application/pdf' ? (
       <div
@@ -79,6 +82,7 @@ export const Artwork = ({
     <ArtworkImage
       artwork={artwork}
       fallback={fallback}
+      hover={hover}
       message={message}
     />
   </a>

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -271,6 +271,7 @@ const ReleaseArtwork = ({
           <ArtworkImage
             artwork={artwork}
             fallback={release.cover_art_url || ''}
+            hover={releaseDescription}
           />
         </a>
       </div>


### PR DESCRIPTION
### Implements MBS-11137

I suspect having the release title and artist on the <a> title was meant to show it when hovering over the cover art, but it doesn't - we need to pass it down to ArtworkImage.
I also made Artwork itself support it, since we might as well want it later and it feels more consistent.
