### PR TITLE
Remove span.name-variation around "see all" releases link

### DIFF
--- a/root/release/ReleaseHeader.js
+++ b/root/release/ReleaseHeader.js
@@ -44,6 +44,7 @@ const ReleaseHeader = ({
             <EntityLink
               content={rgLink}
               entity={release.releaseGroup}
+              nameVariation={false}
             />,
           )}
         </span>


### PR DESCRIPTION
Amend d17a2fd: Drop name-variation from "see all"

Remove span with class name-variation around "see all" releases link.

We did this once before for MBS-10536, but we've since changed the behaviour while implementing MBS-11107 so that it is shown if nameVariation is undefined and the content is not the entity name. As such, explicitly state we do not want nameVariation here.