### PR TITLE
MBS-11140: Build Jed language bundles in prod

### DIFF
--- a/docker/templates/Dockerfile.website.m4
+++ b/docker/templates/Dockerfile.website.m4
@@ -8,9 +8,9 @@ copy_common_mbs_files
 
 git_info
 
-install_javascript_and_templates(` --only=production')
-
 install_translations()
+
+install_javascript_and_templates(` --only=production')
 
 COPY \
     docker/musicbrainz-website/consul-template-template-renderer.conf \


### PR DESCRIPTION
Language packs /probably/ need to be installed before compile_resources.sh is run in order for translations to work. Just a guess.

Broken in aed356a10c0551d26f585d03a30a95918231f9c9