### PR TITLE
MBS-11139: Use HTTPS for display on Library of Congress links

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/LoC.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/LoC.pm
@@ -5,6 +5,12 @@ use Moose;
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
+override href_url => sub {
+    # Turn the official permalink into what LoC currently redirects to.
+    shift->url->as_string =~
+        s{^http://id.loc.gov}{https://id.loc.gov}r;
+};
+
 sub sidebar_name { 'Library of Congress' }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
### Implement MBS-11139

We want to keep the URI as HTTP because that seems to be their official permalink, but they redirect to HTTPS so it makes sense for us to do the same.