### PR TITLE
ORG-44: Update readme to mention the blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ For more information, [visit our website](https://musicbrainz.org/doc/About).
 
 To get help, please join #metabrainz on irc.freenode.net
 
+Breaking changes to the database schema or our API / web service will be announced on
+[our blog](https://blog.metabrainz.org/category/musicbrainz+breaking-changes/),
+so consider following that.
+
 Installation
 ------------
 


### PR DESCRIPTION
### Implement ORG-44

Since we announce breaking changes in our blog, it makes sense to specify this in our readme.
