### PR TITLE
Improve blog link format in releases on GitHub

### DIFF
--- a/script/tag.sh
+++ b/script/tag.sh
@@ -43,7 +43,7 @@ blog_url+="musicbrainz-server-update-$year-$month-$day/"
 read -e -i "$blog_url" -p 'Blog post URL? ' -r blog_url
 
 set -x
-git tag -u CE33CF04 "$tag" -m "$blog_url" production
+git tag -u CE33CF04 "$tag" -m "See $blog_url for details" production
 git push origin "$tag"
 
 # vi: set et sts=2 sw=2 ts=2 :


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

GitHub doesn’t create a hyperlink if git message is just a link.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Adding a few words make GitHub to better format releases list.

Actually, I have been adding them for six months already.

For comparison, see `v-2020-04-13` and `v-2020-03-31` from <https://github.com/metabrainz/musicbrainz-server/releases?after=v-2020-04-27>.