### PR TITLE
MBS-11150: Don't send artist gid if none selected

### DIFF
--- a/root/cdtoc/attach_filter_artist.tt
+++ b/root/cdtoc/attach_filter_artist.tt
@@ -51,7 +51,7 @@
   <p>[% l("If you don't see the artist you are looking for, you can still add a new release.
            This will allow you to create this artist and a release at the same time") %]</p>
 
-  <form action="[% c.uri_for('/release/add', { artist => artist.gid }) %]" method="post">
+  <form action="[% c.uri_for('/release/add') %]" method="post">
     <input type="hidden" name="artist_credit.names.0.name"
            value="[% query_artist.field('query').value %]" />
     <input type="hidden" name="mediums.0.toc" value="[% toc %]" />


### PR DESCRIPTION
### Fix MBS-11150

This was sending artist.gid, but that button is meant to be used "if you don't see the artist you are looking for", so submitting any gid is contrary to the intent anyway.

Since artist got loaded in a foreach earlier, this was just submitting the MBID of the last artist in the foreach loop.
