### PR TITLE
MBS-11158: Make relationship type rowids visible to all

### DIFF
--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -96,12 +96,18 @@ const RelationshipTypeIndex = ({
             <p>{expand2react(l_relationships(relType.description))}</p>
 
             <p>
+              {/*
+                * We need to show this to users because it is needed
+                * for release editor seeding. Once that can be done
+                * with the MBID (MBS-11175), this should be hidden
+                * if the user is not a relationship editor.
+                */}
+              <strong>{l('ID:')}</strong>
+              {' '}
+              {relType.id}
+              <br />
               {$c.user?.is_relationship_editor ? (
                 <>
-                  <strong>{l('ID:')}</strong>
-                  {' '}
-                  {relType.id}
-                  <br />
                   <strong>{l('Child order:')}</strong>
                   {' '}
                   {relType.child_order}


### PR DESCRIPTION
### Implement MBS-11158

While this *should* be an internal ID only, sadly it's needed for release editor seeding, see the docs for that at https://musicbrainz.org/doc/Development/Release_Editor_Seeding
