### PR TITLE
MBS-11162: Show correct work type description if preselected

### DIFF
--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -100,13 +100,13 @@
     [%- iswc_bubble(link_entity(work)) -%]
 
     <div class="bubble" id="type-bubble">
-      <span id="type-bubble-default">
+      <span id="type-bubble-default" [% IF form.field('type_id').value %] style="display:none" [% END %]>
         [%- l('Select any type from the list to see its description. If the work
                doesn’t seem to match any type, just leave this blank.') -%]
       </span>
       [% FOREACH id IN form.field('type_id').options %]
          [%- id = id.value -%]
-         <span style="display:none" class="type-bubble-description" id="type-bubble-description-[% id %]">
+         <span [% IF form.field('type_id').value != id %] style="display:none" [% END %] class="type-bubble-description" id="type-bubble-description-[% id %]">
            <strong>[%- add_colon(l('Description')) -%] </strong>[%- work_types.$id.l_description -%]
          </span>
       [% END %]


### PR DESCRIPTION
### Fix MBS-11162

If the work already has a work type selected then its description, rather than the default "select any type to see the description" text, should be shown from the beginning.
