### PR TITLE
MBS-11163: Show type descriptions when editing more entities

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -368,6 +368,12 @@ for my $method (qw( create edit merge merge_queue delete add_alias edit_alias de
     };
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %area_types = map {$_->id => $_} $c->model('AreaType')->get_all();
+    $c->stash->{area_types} = \%area_types;
+};
+
 sub _merge_load_entities
 {
     my ($self, $c, @areas) = @_;

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -610,6 +610,12 @@ with 'MusicBrainz::Server::Controller::Role::Merge' => {
     merge_form => 'Merge::Artist'
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %artist_types = map {$_->id => $_} $c->model('ArtistType')->get_all();
+    $c->stash->{artist_types} = \%artist_types;
+};
+
 sub _merge_load_entities {
     my ($self, $c, @artists) = @_;
 

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -110,4 +110,10 @@ with 'MusicBrainz::Server::Controller::Role::Delete' => {
     edit_type      => $EDIT_EVENT_DELETE,
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %event_types = map {$_->id => $_} $c->model('EventType')->get_all();
+    $c->stash->{event_types} = \%event_types;
+};
+
 1;

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -215,6 +215,12 @@ with 'MusicBrainz::Server::Controller::Role::Merge' => {
     edit_type => $EDIT_PLACE_MERGE,
 };
 
+before qw( create edit ) => sub {
+    my ($self, $c) = @_;
+    my %place_types = map {$_->id => $_} $c->model('PlaceType')->get_all();
+    $c->stash->{place_types} = \%place_types;
+};
+
 sub _merge_load_entities
 {
     my ($self, $c, @places) = @_;

--- a/lib/MusicBrainz/Server/Entity/AreaType.pm
+++ b/lib/MusicBrainz/Server/Entity/AreaType.pm
@@ -16,6 +16,11 @@ sub l_name {
     return lp($self->name, 'area_type')
 }
 
+sub l_description {
+    my $self = shift;
+    return lp($self->description, 'area_type');
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/ArtistType.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistType.pm
@@ -16,6 +16,11 @@ sub l_name {
     return lp($self->name, 'artist_type')
 }
 
+sub l_description {
+    my $self = shift;
+    return lp($self->description, 'artist_type');
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/Entity/PlaceType.pm
+++ b/lib/MusicBrainz/Server/Entity/PlaceType.pm
@@ -16,6 +16,11 @@ sub l_name {
     return lp($self->name, 'place_type')
 }
 
+sub l_description {
+    my $self = shift;
+    return lp($self->description, 'place_type');
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/root/area/edit_form.tt
+++ b/root/area/edit_form.tt
@@ -25,11 +25,16 @@
 
     [%- INCLUDE 'forms/edit-note.tt' -%]
     [%- enter_edit() -%]
-
   </div>
+
+  <div class="documentation">
+    [%- type_bubble(form.field('type_id'), area_types) -%]
+  </div>
+
 </form>
 
 [%- guesscase_options() -%]
+[% script_manifest('area.js') %]
 
 <script type="text/javascript">
   (function () {

--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -99,11 +99,14 @@
 
   <div class="documentation">
     [%- area_bubble() -%]
+
+    [%- type_bubble(form.field('type_id'), artist_types) -%]
   </div>
 
 </form>
 
 [%- guesscase_options() -%]
+[% script_manifest('artist.js') %]
 
 <script type="text/javascript">
   (function () {

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -343,6 +343,21 @@
     </div>
 [%- END -%]
 
+[%- MACRO type_bubble(form, types) BLOCK -%]
+    <div class="bubble" id="type-bubble">
+      <span id="type-bubble-default" [% IF form.value %] style="display:none" [% END %]>
+        [%- l('Select any type from the list to see its description. If the work
+               doesn’t seem to match any type, just leave this blank.') -%]
+      </span>
+      [% FOREACH id IN form.options %]
+         [%- id = id.value -%]
+         <span [% IF form.value != id %] style="display:none" [% END %] class="type-bubble-description" id="type-bubble-description-[% id %]">
+           <strong>[%- add_colon(l('Description')) -%] </strong>[%- types.$id.l_description -%]
+         </span>
+      [% END %]
+    </div>
+[%- END -%]
+
 [%- MACRO external_links_editor BLOCK -%]
   <div id="external-links-editor-container"></div>
 [%- END -%]

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -352,7 +352,12 @@
       [% FOREACH id IN form.options %]
          [%- id = id.value -%]
          <span [% IF form.value != id %] style="display:none" [% END %] class="type-bubble-description" id="type-bubble-description-[% id %]">
-           <strong>[%- add_colon(l('Description')) -%] </strong>[%- types.$id.l_description -%]
+           <strong>[%- add_colon(l('Description')) -%] </strong>
+           [% IF types.$id.l_description %]
+             [%- types.$id.l_description -%]
+           [% ELSE %]
+             [%- lp('(none)', 'description') -%]
+           [% END %]
          </span>
       [% END %]
     </div>

--- a/root/event/edit_form.tt
+++ b/root/event/edit_form.tt
@@ -51,11 +51,14 @@
 
   <div class="documentation">
     [%- guesscase_bubble(1) -%]
+
+    [%- type_bubble(form.field('type_id'), event_types) -%]
   </div>
 
 </form>
 
 [%- guesscase_options() -%]
+[% script_manifest('event.js') %]
 
 <script type="text/javascript">
   (function () {

--- a/root/place/edit_form.tt
+++ b/root/place/edit_form.tt
@@ -51,6 +51,8 @@
         <div id="largemap"></div>
         [% script_manifest('place/map.js', { 'data-args' => map_data_args }) %]
     </div>
+
+    [%- type_bubble(form.field('type_id'), place_types) -%]
   </div>
 
 </form>

--- a/root/static/scripts/area.js
+++ b/root/static/scripts/area.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import typeBubble from './edit/typeBubble';
+
+const typeIdField = 'select[name=edit-area\\.type_id]';
+typeBubble(typeIdField);

--- a/root/static/scripts/artist.js
+++ b/root/static/scripts/artist.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import typeBubble from './edit/typeBubble';
+
+const typeIdField = 'select[name=edit-artist\\.type_id]';
+typeBubble(typeIdField);

--- a/root/static/scripts/edit/typeBubble.js
+++ b/root/static/scripts/edit/typeBubble.js
@@ -1,0 +1,26 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import $ from 'jquery';
+
+import {initializeBubble} from '../edit/MB/Control/Bubble';
+
+export default function typeBubble(typeIdField: string): void {
+  initializeBubble('#type-bubble', typeIdField);
+  $(typeIdField).on('change', function () {
+    if (this.value.match(/\S/g)) {
+      $('#type-bubble-default').hide();
+      $('.type-bubble-description').hide();
+      $(`#type-bubble-description-${this.value}`).show();
+    } else {
+      $('.type-bubble-description').hide();
+      $('#type-bubble-default').show();
+    }
+  });
+}

--- a/root/static/scripts/event.js
+++ b/root/static/scripts/event.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import typeBubble from './edit/typeBubble';
+
+const typeIdField = 'select[name=edit-event\\.type_id]';
+typeBubble(typeIdField);

--- a/root/static/scripts/place.js
+++ b/root/static/scripts/place.js
@@ -14,6 +14,7 @@ import isBlank from './common/utility/isBlank';
 import initializeDuplicateChecker from './edit/check-duplicates';
 import {initializeArea} from './edit/MB/Control/Area';
 import {initializeBubble} from './edit/MB/Control/Bubble';
+import typeBubble from './edit/typeBubble';
 import {errorField} from './edit/validation';
 import {initializeGuessCase} from './guess-case/MB/Control/GuessCase';
 import {map, marker} from './place/map';
@@ -100,3 +101,6 @@ $('input[name=edit-place\\.coordinates]').on('input', function () {
     });
   }
 });
+
+const typeIdField = 'select[name=edit-place\\.type_id]';
+typeBubble(typeIdField);

--- a/root/static/scripts/work.js
+++ b/root/static/scripts/work.js
@@ -20,6 +20,7 @@ import subfieldErrors from '../../utility/subfieldErrors';
 import {groupBy} from './common/utility/arrays';
 import getScriptArgs from './common/utility/getScriptArgs';
 import {buildOptionsTree} from './edit/forms';
+import typeBubble from './edit/typeBubble';
 import {initializeBubble} from './edit/MB/Control/Bubble';
 import {createCompoundField} from './edit/utility/createField';
 import {pushCompoundField, pushField} from './edit/utility/pushField';
@@ -303,14 +304,4 @@ renderWorkLanguages();
 initializeBubble('#iswcs-bubble', 'input[name=edit-work\\.iswcs\\.0]');
 
 const typeIdField = 'select[name=edit-work\\.type_id]';
-initializeBubble('#type-bubble', typeIdField);
-$(typeIdField).on('change', function () {
-  if (this.value.match(/\S/g)) {
-    $('#type-bubble-default').hide();
-    $('.type-bubble-description').hide();
-    $(`#type-bubble-description-${this.value}`).show();
-  } else {
-    $('.type-bubble-description').hide();
-    $('#type-bubble-default').show();
-  }
-});
+typeBubble(typeIdField);

--- a/root/work/edit_form.tt
+++ b/root/work/edit_form.tt
@@ -99,18 +99,7 @@
   <div class="documentation">
     [%- iswc_bubble(link_entity(work)) -%]
 
-    <div class="bubble" id="type-bubble">
-      <span id="type-bubble-default" [% IF form.field('type_id').value %] style="display:none" [% END %]>
-        [%- l('Select any type from the list to see its description. If the work
-               doesn’t seem to match any type, just leave this blank.') -%]
-      </span>
-      [% FOREACH id IN form.field('type_id').options %]
-         [%- id = id.value -%]
-         <span [% IF form.field('type_id').value != id %] style="display:none" [% END %] class="type-bubble-description" id="type-bubble-description-[% id %]">
-           <strong>[%- add_colon(l('Description')) -%] </strong>[%- work_types.$id.l_description -%]
-         </span>
-      [% END %]
-    </div>
+    [%- type_bubble(form.field('type_id'), work_types) -%]
   </div>
 
 </form>

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -40,6 +40,7 @@ const entries = [
   'common',
   'edit',
   'edit/notes-received',
+  'event',
   'event/index',
   'instrument/index',
   'jed-data',

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -33,6 +33,7 @@ const entries = [
   'account/applications/register',
   'account/edit',
   'account/preferences',
+  'area',
   'area/index',
   'area/places-map',
   'artist/index',

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -36,6 +36,7 @@ const entries = [
   'area',
   'area/index',
   'area/places-map',
+  'artist',
   'artist/index',
   'collection/edit',
   'common',


### PR DESCRIPTION
### Implement MBS-11163

We currently show work type descriptions when adding / editing works, but we don't do the same for other entities with types that already have descriptions, such as area, artist (ok, that didn't have them, I just added it), event, place. This extends that code to these four entities. 

Series already has the same kind of popup, implemented somewhat differently. If desired, I can try to replace the implementation there with this same one.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1740