### PR TITLE
MBS-11167: Normalize vk.com links to HTTPS

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2615,13 +2615,6 @@ const CLEANUPS = {
       return {result: false};
     },
   },
-  'socialnetwork': {
-    match: [
-      new RegExp('^(https?://)?([^/]+\\.)?vine\\.co/', 'i'),
-      new RegExp('^(https?://)?([^/]+\\.)?vk\\.com/', 'i'),
-    ],
-    type: LINK_TYPES.socialnetwork,
-  },
   'songfacts': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?songfacts\\.com/', 'i')],
     type: LINK_TYPES.songfacts,
@@ -2986,6 +2979,14 @@ const CLEANUPS = {
       url = url.replace(/\?.*/, '');
       return url;
     },
+  },
+  'vine': {
+    match: [new RegExp('^(https?://)?([^/]+\\.)?vine\\.co/', 'i')],
+    type: LINK_TYPES.socialnetwork,
+  },
+  'vk': {
+    match: [new RegExp('^(https?://)?([^/]+\\.)?vk\\.com/', 'i')],
+    type: LINK_TYPES.socialnetwork,
   },
   'weibo': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?weibo\\.com/', 'i')],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2987,6 +2987,9 @@ const CLEANUPS = {
   'vk': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?vk\\.com/', 'i')],
     type: LINK_TYPES.socialnetwork,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?vk\.com/, 'https://vk.com');
+    },
   },
   'weibo': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?weibo\\.com/', 'i')],

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3801,11 +3801,12 @@ const testData = [
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
   },
-  // VKontakte
+  // VK
   {
                      input_url: 'http://vk.com/tin_sontsya',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://vk.com/tin_sontsya',
   },
   // Weibo
   {


### PR DESCRIPTION
### Implement MBS-11167

AFAICT vk.com always redirects to HTTPS now.  Given there was no normalization at all before this, there's no downside I can see to standardising in the future.

MBBE-17 exists to convert preexisting VK links to HTTPS.