### PR TITLE
Convert form_row_name_with_guesscase to React

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 .cpanm/**/*.js
+flow-typed/npm/@sentry/*.js
 perl_modules/**/*.js
 root/static/build/**/*.js
 root/static/lib/**/*.js

--- a/flow-typed/npm/@sentry/browser_v5.x.x.js
+++ b/flow-typed/npm/@sentry/browser_v5.x.x.js
@@ -1,0 +1,439 @@
+// flow-typed signature: 2fc805a0cc6a4c4f229f1ab5259c37a3
+// flow-typed version: 40038b550b/@sentry/browser_v5.x.x/flow_>=v0.90.x
+
+// @flow
+
+declare module '@sentry/browser' {
+    declare export function addGlobalEventProcessor(callback: EventProcessor): void;
+    declare export function addBreadcrumb(breadcrumb: Breadcrumb): void;
+    declare export function captureException(
+        message: mixed,
+        severity?: $Values<typeof Severity>,
+    ): void;
+    declare export function captureMessage(
+        message: mixed,
+        severity?: $Values<typeof Severity>,
+    ): void;
+    declare export function configureScope((Scope) => void): void;
+    declare export function getCurrentHub(): Hub;
+    declare export function getHubFromCarrier(carrier: Carrier): Hub;
+
+    declare export class Hub {
+        constructor(client: BrowserClient<Options>): Hub;
+        isOlderThan(version: number): boolean;
+        bindClient(client?: BrowserClient<Options>): void;
+        pushScope(): Scope;
+        popScope(): boolean;
+        withScope(callback: (scope: Scope) => void): void;
+        getClient(): BrowserClient<Options> | void;
+        captureException(exception: mixed, hint?: EventHint): string;
+        captureMessage(message: string, level?: $Values<typeof Severity>, hint?: EventHint): string;
+        captureEvent(event: Event, hint?: EventHint): string;
+        lastEventId(): string | void;
+        addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
+        setUser(user: User | null): void;
+        setTags(tags: { [key: string]: string, ... }): void;
+        setTag(key: string, value: string): void;
+        setExtra(key: string, extra: any): void;
+        setExtras(extras: { [key: string]: any, ... }): void;
+        setContext(name: string, context: { [key: string]: mixed, ... } | null): void;
+        configureScope(callback: (scope: Scope) => void): void;
+        run(callback: (hub: Hub) => void): void;
+        getIntegration<T>(integration: Class<Integration<T>>): Integration<T> | null;
+        traceHeaders(): { [key: string]: string, ... };
+        startSpan(span?: SpanContext, forceNoChild?: boolean): Span;
+        startTransaction(context: TransactionContext): Transaction;
+    }
+
+    declare export class Scope {
+        addEventProcessor(callback: EventProcessor): void;
+        setUser(user: User | null): void;
+        setTags(tags: {| [key: string]: string |}): void;
+        setTag(key: string, value: string): void;
+        setExtras(extras: { [key: string]: any, ... }): void;
+        setExtra(key: string, extra: any): void;
+        setFingerprint(fingerprint: $ReadOnlyArray<string>): void;
+        setLevel(level: $Values<typeof Severity>): void;
+        setTransaction(transaction?: string): void;
+        setContext(name: string, context: {| [key: string]: mixed |}): void;
+        setSpan(span?: Span): void;
+        clear(): void;
+        addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): void;
+        clearBreadcrumbs(): void;
+    }
+
+    declare export function setContext(
+        name: string,
+        context: {| [key: string]: mixed |} | null,
+    ): void;
+    declare export function setExtra(key: string, extra: any): void;
+    declare export function setExtras(extras: { [key: string]: any, ... }): void;
+    declare export function setTag(key: string, value: string): void;
+    declare export function setTags(tags: {| [key: string]: string |}): void;
+    declare export function setUser(user: User | null): void;
+    declare export function withScope(callback: (scope: Scope) => void): void;
+
+    declare export class BrowserClient<O: Options = Options> {
+        constructor(options: O): BrowserClient<O>;
+        captureException(exception: mixed, hint?: EventHint, scope?: Scope): string | void;
+        captureMessage(
+            message: string,
+            level?: $Values<typeof Severity>,
+            hint?: EventHint,
+            scope?: Scope,
+        ): string | void;
+        captureEvent(event: SentryEvent, hint?: EventHint, scope?: Scope): string | void;
+        getDsn(): Dsn | void;
+        getOptions(): O;
+        close(timeout?: number): Promise<boolean>;
+        flush(timeout?: number): Promise<boolean>;
+        getIntegration<T>(integration: Class<Integration<T>>): Integration<T> | null;
+    }
+
+    declare export var defaultIntegrations: $ReadOnlyArray<Integration<any>>;
+    declare export function forceLoad(): void;
+    declare export function init(Options): void;
+    declare export function lastEventId(): string | void;
+    declare export function onLoad(callback: () => void): void;
+    declare export function showReportDialog(options: ReportDialogOptions): void;
+    declare export function flush(timeout?: number): Promise<boolean>;
+    declare export function close(timeout?: number): Promise<boolean>;
+    declare export function wrap(fn: mixed): mixed;
+
+    declare export var SDK_NAME: string;
+    declare export var SDK_VERSION: string;
+
+    declare export var Severity: {|
+        +Fatal: 'fatal',
+        +Error: 'error',
+        +Warning: 'warning',
+        +Log: 'log',
+        +Info: 'info',
+        +Debug: 'debug',
+        +Critical: 'critical',
+    |};
+    declare export var Integrations: {|
+        // Core
+        +InboundFilters: Class<Integration<>>,
+        +FunctionToString: Class<Integration<>>,
+
+        // Browser
+        +GlobalHandlers: Class<Integration<{|
+            onerror?: boolean,
+            onunhandledrejection?: boolean,
+        |}>>,
+        +TryCatch: Class<Integration<>>,
+        +Breadcrumbs: Class<Integration<{|
+            beacon?: boolean,
+            console?: boolean,
+            dom?: boolean,
+            fetch?: boolean,
+            history?: boolean,
+            sentry?: boolean,
+            xhr?: boolean,
+        |}>>,
+        +LinkedErrors: Class<Integration<{|
+            key?: string,
+            limit?: number,
+        |}>>,
+        +UserAgent: Class<Integration<>>,
+    |};
+    declare export var Transports: {|
+        +BaseTransport: Class<Transport>,
+        +FetchTransport: Class<Transport>,
+        +XHRTransport: Class<Transport>,
+    |};
+
+    declare class Integration<O = {||}> {
+        constructor(options?: O): Integration<O>;
+        name: string;
+        setupOnce(
+            addGlobalEventProcessor: (callback: EventProcessor) => void,
+            getCurrentHub: () => Hub,
+        ): void;
+    }
+
+    declare export type LogLevel = {|
+        +None: 0,
+        +Error: 1,
+        +Debug: 2,
+        +Verbose: 3,
+    |};
+    declare export type Breadcrumb = {|
+        +type?: 'default' | 'http' | 'error',
+        +level?: $Values<typeof Severity>,
+        +event_id?: string,
+        +category?: string,
+        +message?: string,
+        +data?: { [string]: mixed, ... },
+        +timestamp?: number,
+    |};
+    declare export type BreadcrumbHint = {| [key: string]: mixed |};
+    declare export type User = {
+        [key: string]: mixed,
+        // At least one of these must be present, but there's no way to represent that in Flow without
+        // enumerating every possible combination.
+        +id?: string | number,
+        +username?: string,
+        +email?: string,
+        +ip_address?: string,
+        ...
+    };
+    declare export type SpanStatus = {|
+        +Ok: 'ok',
+        +DealineExceeded: 'deadline_exceeded',
+        +Unauthenticated: 'unauthenticated',
+        +PermissionDenied: 'permission_denied',
+        +NotFound: 'not_found',
+        +ResourceExhausted: 'resource_exhausted',
+        +InvalidArgument: 'invalid_argument',
+        +Unimplemented: 'unimplemented',
+        +Unavailable: 'unavailable',
+        +InternalError: 'internal_error',
+        +UnknownError: 'unknown_error',
+        +Cancelled: 'cancelled',
+        +AlreadyExists: 'already_exists',
+        +FailedPrecondition: 'failed_precondition',
+        +Aborted: 'aborted',
+        +OutOfRange: 'out_of_range',
+        +DataLoss: 'data_loss',
+    |};
+    declare export type Mechanism = {|
+        +type: string,
+        +handled: boolean,
+        +data?: { [key: string]: string | boolean, ... },
+        +synthetic?: boolean,
+    |};
+    declare export type StackFrame = {|
+        +filename?: string,
+        +function?: string,
+        +module?: string,
+        +platform?: string,
+        +lineno?: number,
+        +colno?: number,
+        +abs_path?: string,
+        +context_line?: string,
+        +pre_context?: $ReadOnlyArray<string>,
+        +post_context?: $ReadOnlyArray<string>,
+        +in_app?: boolean,
+        +vars?: { [key: string]: mixed, ... },
+    |};
+    declare export type Stacktrace = {|
+        +frames?: $ReadOnlyArray<StackFrame>,
+        +frames_omitted?: [number, number],
+    |};
+    declare export type Exception = {|
+        +type?: string,
+        +value?: string,
+        +mechanism?: Mechanism,
+        +module?: string,
+        +thread_id?: number,
+        +stacktrace?: Stacktrace,
+    |};
+
+    declare export type SpanContext = {|
+        description?: string;
+        op?: string;
+        status?: string;
+        parentSpanId?: string;
+        sampled?: boolean;
+        spanId?: string;
+        traceId?: string;
+        tags?: { [key: string]: string, ... };
+        data?: { [key: string]: any, ... };
+        startTimestamp?: number;
+        endTimestamp?: number;
+    |};
+    declare export type Span = {|
+        ...SpanContext,
+        finish(useLastSpanTimestamp?: boolean): string | void,
+        toTraceparent(): string,
+        getTraceContext(): {| [key: string]: mixed |},
+        toJSON(): {| [key: string]: mixed |},
+        setTag(key: string, value: string): void,
+        setData(key: string, value: mixed): void,
+        setStatus(status: $Values<SpanStatus>): void,
+        setHttpStatus(httpStatus: number): void,
+        isSuccess(): boolean,
+    |};
+    declare export type TransactionContext = {|
+        ...SpanContext,
+        name: string;
+        trimEnd?: boolean;
+    |};
+
+    declare export type Transaction = {|
+        ...TransactionContext,
+        ...Span,
+        spanId: string;
+        traceId: string;
+        startTimestamp: number;
+        tags: { [key: string]: string, ... };
+        data: { [key: string]: any, ... };
+        setName(name: string): void;
+    |};
+
+    declare export type DsnProtocol = 'http' | 'https';
+    declare export type DsnComponents = {|
+        +protocol: DsnProtocol,
+        +user: string,
+        +pass?: string,
+        +host: string,
+        +port?: string,
+        +path?: string,
+        +projectId: string,
+    |};
+    declare export type DsnLike = string | DsnComponents;
+    declare export type Dsn = { toString(withPassword: boolean): string, ...DsnComponents, ... };
+    declare class Transport {
+        constructor(options: TransportOptions): Transport;
+        sendEvent(event: Event): Promise<SentryResponse>;
+        close(timeout?: number): Promise<boolean>;
+    }
+    declare export type TransportOptions = {|
+        +dsn: DsnLike,
+        +headers?: { [key: string]: string, ... },
+        +httpProxy?: string,
+        +httpsProxy?: string,
+        +caCerts?: string,
+    |};
+
+    declare export type Status = {|
+      +Unknown: 'unknown',
+      +Skipped: 'skipped',
+      +Success: 'success',
+      +RateLimit: 'rate_limit',
+      +Invalid: 'invalid',
+      +Failed: 'failed',
+    |};
+    declare export type SentryRequest = {|
+        +url?: string,
+        +method?: string,
+        +data?: mixed,
+        +query_string?: string,
+        +cookies?: { [key: string]: string, ... },
+        +env?: { [key: string]: string, ... },
+        +headers?: { [key: string]: string, ... },
+    |};
+    declare export type SentryResponse = {|
+        +status: $Values<Status>,
+        +event?: SentryEvent,
+        +reason?: string,
+    |};
+    declare export type EventType = 'transaction';
+    declare export type SentryEvent = {|
+        +event_id?: string,
+        +message?: string,
+        +timestamp?: number,
+        +start_timestamp?: number,
+        +level?: $Values<typeof Severity>,
+        +platform?: string,
+        +logger?: string,
+        +server_name?: string,
+        +release?: string,
+        +dist?: string,
+        +environment?: string,
+        +sdk?: SdkInfo,
+        +request?: SentryRequest,
+        +transaction?: string,
+        +modules?: { [key: string]: string, ... },
+        +fingerprint?: $ReadOnlyArray<string>,
+        +exception?: { values?: $ReadOnlyArray<Exception>, ... },
+        +stacktrace?: Stacktrace,
+        +breadcrumbs?: $ReadOnlyArray<Breadcrumb>,
+        +contexts?: {| [key: string]: { ... } |},
+        +tags?: {| [key: string]: string |},
+        +extra?: {| [key: string]: any |},
+        +user?: User,
+        +type?: EventType,
+        +spans?: $ReadOnlyArray<Span>,
+    |};
+    declare export type EventHint = {|
+        +event_id?: string,
+        +syntheticException?: Error | null,
+        +originalException?: Error | string | null,
+        +data?: mixed,
+    |};
+    declare export type EventProcessor = (
+        event: SentryEvent,
+        hint?: EventHint,
+    ) => Promise<SentryEvent | null> | SentryEvent | null;
+    declare export type Package = {|
+        +name: string,
+        +version: string,
+    |};
+    declare export type SdkInfo = {|
+        +name: string,
+        +version: string,
+        +integrations?: $ReadOnlyArray<string>,
+        +packages?: $ReadOnlyArray<Package>,
+    |};
+    declare export type Carrier = {|
+        +__SENTRY__?: {|
+            hub?: Hub,
+            extensions?: { [key: string]: mixed, ... },
+        |},
+    |};
+
+    declare export type Options = {|
+        +debug?: boolean,
+        +enabled?: boolean,
+        +dsn?: string,
+        +defaultIntegrations?: false,
+        +ignoreErrors?: $ReadOnlyArray<string | RegExp>,
+        +transport?: Class<Transport>,
+        +transportOptions?: TransportOptions,
+        +release?: string,
+        +environment?: string,
+        +dist?: string,
+        +maxBreadcrumbs?: number,
+        +logLevel?: $Values<LogLevel>,
+        +sampleRate?: number,
+        +tracesSampleRate?: number,
+        +attachStacktrace?: boolean,
+        +maxValueLength?: number,
+        +beforeSend?: (
+            event: SentryEvent,
+            hint?: EventHint,
+        ) => Promise<SentryEvent | null> | SentryEvent | null,
+
+        +denyUrls?: $ReadOnlyArray<string | RegExp>,
+        +allowUrls?: $ReadOnlyArray<string | RegExp>,
+        // Deprecated as of 5.18.0, prefer the allowUrls/denyUrls instead
+        +blacklistUrls?: $ReadOnlyArray<string | RegExp>,
+        +whitelistUrls?: $ReadOnlyArray<string | RegExp>,
+        // This really should be typed as:
+        //    | $ReadOnlyArray<Integration<any>>
+        //    | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>)
+        // but we must support integrations from @sentry/integrations as well
+        // as custom integrations. Since cross-package imports aren't allowed
+        // and classes are nominally typed, using `any` seems like our only
+        // option here.
+        +integrations?: any,
+        +beforeBreadcrumb?: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => Breadcrumb | null,
+        +_experiments?: { [key: string]: mixed, ... },
+    |};
+
+    declare export type ReportDialogOptions = {|
+        [key: string]: mixed,
+        +eventId?: string,
+        +dsn?: DsnLike,
+        +user?: {|
+            email?: string,
+            name?: string,
+        |},
+        +lang?: string,
+        +title?: string,
+        +subtitle?: string,
+        +subtitle2?: string,
+        +labelName?: string,
+        +labelEmail?: string,
+        +labelComments?: string,
+        +labelClose?: string,
+        +labelSubmit?: string,
+        +errorGeneric?: string,
+        +errorFormEntry?: string,
+        +successMessage?: string,
+        +onLoad?: () => void,
+    |};
+}

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -55,6 +55,7 @@ __PACKAGE__->config(
             boolean_to_json
             comma_list
             comma_only_list
+            form_to_json
         )],
         FILTERS => {
             'format_length' => \&MusicBrainz::Server::Filters::format_length,

--- a/lib/MusicBrainz/Server/Test/HTML5.pm
+++ b/lib/MusicBrainz/Server/Test/HTML5.pm
@@ -43,6 +43,7 @@ sub ignore_warning
         '^Element .input. with attribute .type. whose value is .button.',
         '^Element .* not allowed as child of element .* in this context.',
         '^Bad value .X-UA-Compatible. for attribute .http-equiv. on element .meta..',
+        '^Bad value .dialog. for attribute .aria-haspopup. on element .button..',
     );
 
     for my $test (@ignored)

--- a/lib/MusicBrainz/Server/View/Default.pm
+++ b/lib/MusicBrainz/Server/View/Default.pm
@@ -45,4 +45,9 @@ sub comma_only_list {
     MusicBrainz::Server::Translation::comma_only_list(@$items);
 }
 
+sub form_to_json {
+    my ($self, $c, $form_or_field) = @_;
+    MusicBrainz::Server::Form::Role::ToJSON::TO_JSON($form_or_field);
+}
+
 1;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/preset-flow": "7.10.4",
     "@babel/register": "7.11.5",
     "@babel/runtime": "7.11.2",
+    "@popperjs/core": "2.5.3",
     "@sentry/browser": "5.10.2",
     "@sentry/node": "5.10.2",
     "babel-loader": "8.1.0",

--- a/root/components/FormRowText.js
+++ b/root/components/FormRowText.js
@@ -13,9 +13,10 @@ import FieldErrors from './FieldErrors';
 import FormRow from './FormRow';
 import FormLabel from './FormLabel';
 
-type InputOnChange = (SyntheticEvent<HTMLInputElement>) => void;
+type InputOnChange = (SyntheticKeyboardEvent<HTMLInputElement>) => void;
 
 type InputProps = {
+  +className?: string,
   defaultValue?: string,
   +id: string,
   +name: string,
@@ -27,6 +28,8 @@ type InputProps = {
 };
 
 type CommonProps = {
+  +children?: React.Node,
+  +className?: string,
   +field: ReadOnlyFieldT<?string>,
   +label: string,
   +required?: boolean,
@@ -50,6 +53,7 @@ const FormRowText = (props: Props): React.Element<typeof FormRow> => {
   const required = props.required ?? false;
 
   const inputProps: InputProps = {
+    className: props.className,
     id: 'id-' + field.html_name,
     name: field.html_name,
     required: required,
@@ -70,6 +74,7 @@ const FormRowText = (props: Props): React.Element<typeof FormRow> => {
     <FormRow>
       <FormLabel forField={field} label={props.label} required={required} />
       <input {...inputProps} />
+      {props.children}
       <FieldErrors field={field} />
     </FormRow>
   );

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -228,7 +228,7 @@
     [% END %]
 [%- END -%]
 
-[%- MACRO form_row_name_with_guesscase(r, options) BLOCK -%]
+[%- MACRO form_row_name_with_guesscase(r, options) BLOCK # Converted to React at root/static/scripts/edit/components/FormRowNameWithGuessCase.js -%]
   [% WRAPPER form_row %]
     [% r.label('name', options.label || l('Name:')) %]
     [% r.text('name', { class => 'with-guesscase' _ (options.guessfeat ? '-guessfeat' : '') }) %]

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -12,6 +12,7 @@
 </div>
 
 [% script_manifest('edit.js') %]
+[% script_manifest('recording/form.js', {async => 'async'}) %]
 
 <p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => doc_link('Recording'), doc_styleguide => doc_link('Style/Recording')}) -%]</p>
 
@@ -21,7 +22,9 @@
   <div class="half-width">
     <fieldset>
       <legend>[% l('Recording Details') %]</legend>
-      [%- form_row_name_with_guesscase(r, { guessfeat => 1 }) -%]
+      [% React.embed(c, 'static/scripts/recording/RecordingName', {
+           field => form_to_json(form.field('name')),
+         }) %]
       <div id="artist-credit-editor"></div>
       [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
       [%- IF !form.used_by_tracks || form.field('length').has_errors -%]
@@ -53,10 +56,7 @@
   <div class="documentation">
     [%- isrc_bubble(link_entity(recording)) -%]
   </div>
-
 </form>
-
-[%- guesscase_options() -%]
 
 <script type="text/javascript">
   $(function () {
@@ -64,7 +64,6 @@
       [% closing_tag_escape(form.to_encoded_json) %],
       [% closing_tag_escape(form.field('artist_credit').json) %]
     );
-    MB.Control.initializeGuessCase("recording", "id-edit-recording");
     MB.Control.initGuessFeatButton('edit-recording');
     MB.Control.initializeBubble("#isrcs-bubble", "input[name=edit-recording\\.isrcs\\.0]");
   });

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -398,10 +398,12 @@ module.exports = {
   'static/scripts/common/components/WikipediaExtract': require('../static/scripts/common/components/WikipediaExtract'),
   'static/scripts/common/components/WorkArtists': require('../static/scripts/common/components/WorkArtists'),
   'static/scripts/edit/components/AddIcon': require('../static/scripts/edit/components/AddIcon'),
+  'static/scripts/edit/components/FormRowNameWithGuessCase': require('../static/scripts/edit/components/FormRowNameWithGuessCase'),
   'static/scripts/edit/components/GuessCaseIcon': require('../static/scripts/edit/components/GuessCaseIcon'),
   'static/scripts/edit/components/InformationIcon': require('../static/scripts/edit/components/InformationIcon'),
   'static/scripts/edit/components/edit/RelationshipDiff': require('../static/scripts/edit/components/edit/RelationshipDiff'),
   'static/scripts/edit/components/edit/ReleaseEventsDiff': require('../static/scripts/edit/components/edit/ReleaseEventsDiff'),
+  'static/scripts/recording/RecordingName': require('../static/scripts/recording/RecordingName'),
   'url/UrlHeader': require('../url/UrlHeader'),
   'work/WorkHeader': require('../work/WorkHeader'),
 };

--- a/root/static/scripts/common/components/ButtonPopover.js
+++ b/root/static/scripts/common/components/ButtonPopover.js
@@ -1,0 +1,107 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import useOutsideClickEffect from '../hooks/useOutsideClickEffect';
+import useReturnFocus from '../hooks/useReturnFocus';
+import {unwrapNl} from '../i18n';
+
+import Popover from './Popover';
+
+type PropsT = {
+  +buildChildren: (() => void) => React.Node,
+  +buttonContent: React.Node,
+  +buttonProps?: {
+    className?: string,
+    title?: string | (() => string),
+  },
+  +buttonRef: {current: HTMLButtonElement | null},
+  +className?: string,
+  +id: string,
+  +isOpen: boolean,
+  +toggle: (boolean) => void,
+};
+
+const ButtonPopover = (props: PropsT): React.MixedElement => {
+  const {
+    buttonContent,
+    buttonProps = null,
+    buttonRef,
+    isOpen,
+    toggle,
+    ...dialogProps
+  } = props;
+  const buttonTitle = buttonProps?.title;
+
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
+
+  useOutsideClickEffect(
+    dialogRef,
+    (event) => {
+      /*
+       * Clicking the opener again registers as an outside
+       * click, but is already handled separately.
+       */
+      if (event.target !== buttonRef.current) {
+        /*
+         * Don't return focus here, since the user maybe be clicking
+         * on an unrelated field in the page.
+         */
+        toggle(false);
+      }
+    },
+  );
+
+  const returnFocusToButton = useReturnFocus(buttonRef);
+
+  /*
+   * Triggered when the user (1) toggles the opener button,
+   * (2) hits escape, or (3) tabs out. Returns focus to the opening
+   * button in all three cases.
+   */
+  const closeAndReturnFocus = React.useCallback(() => {
+    returnFocusToButton.current = true;
+    toggle(false);
+  }, [returnFocusToButton, toggle]);
+
+  return (
+    <>
+      <button
+        aria-controls={isOpen ? dialogProps.id : null}
+        aria-haspopup="dialog"
+        className={buttonProps?.className}
+        onClick={() => {
+          if (isOpen) {
+            closeAndReturnFocus();
+          } else {
+            toggle(true);
+          }
+        }}
+        ref={buttonRef}
+        title={buttonTitle == null ? null : unwrapNl(buttonTitle)}
+        type="button"
+      >
+        {buttonContent}
+      </button>
+      {isOpen
+        ? (
+          <Popover
+            buttonRef={buttonRef}
+            closeAndReturnFocus={closeAndReturnFocus}
+            dialogRef={dialogRef}
+            {...dialogProps}
+          />
+        )
+        : null}
+    </>
+  );
+};
+
+export default ButtonPopover;

--- a/root/static/scripts/common/components/Dialog.js
+++ b/root/static/scripts/common/components/Dialog.js
@@ -1,0 +1,180 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {
+  detectIfAnchorIsTabbable,
+  findFirstTabbableElement,
+  handleTabKeyPress,
+} from '../utility/focusManagement';
+
+import ErrorBoundary from './ErrorBoundary';
+
+export type RequiredPropsT = {
+  +children: React.Node,
+  +dialogRef: {current: HTMLDivElement | null},
+  +id: string,
+  +onEscape: (Event | SyntheticEvent<>) => void,
+};
+
+export type PropsT = $ReadOnly<{
+  ...RequiredPropsT,
+  +activeElementRef?: {-current: HTMLElement},
+  +className?: string,
+  +siblings?: React.Node,
+  +trapFocus?: boolean,
+}>;
+
+export function getDialogRootNode(
+  id: string,
+): HTMLDivElement {
+  const rootId = id + '-root';
+  let dialogRoot = document.getElementById(rootId);
+  if (dialogRoot) {
+    if (!(dialogRoot instanceof HTMLDivElement)) {
+      throw new Error('Dialog root <div> not found');
+    }
+  } else {
+    dialogRoot = document.createElement('div');
+    dialogRoot.setAttribute('id', rootId);
+    dialogRoot.classList.add('dialog-root');
+    document.body?.appendChild(dialogRoot);
+  }
+  return dialogRoot;
+}
+
+export function getElementFromRef<T: HTMLElement>(
+  ref: {current: T | null},
+): T {
+  const element = ref.current;
+  if (!element) {
+    throw new Error('Ref is null');
+  }
+  return element;
+}
+
+const Dialog = ({
+  activeElementRef,
+  children,
+  className,
+  dialogRef,
+  id,
+  onEscape,
+  siblings,
+  trapFocus = false,
+}: PropsT): React.Element<'div'> => {
+  const tabbableElementRef = React.useRef(null);
+
+  React.useLayoutEffect(() => {
+    const dialogNode = getElementFromRef(dialogRef);
+    dialogNode.style.visibility = 'visible';
+    dialogNode.removeAttribute('aria-hidden');
+
+    /*
+     * The delay prevents iOS 14 from scrolling to (0, 0) and auto-opening
+     * the <select> options list.
+     */
+    const tid = setTimeout(() => {
+      const toFocus = findFirstTabbableElement(dialogNode);
+      if (toFocus) {
+        toFocus.focus();
+      }
+    }, 1);
+
+    return () => {
+      clearTimeout(tid);
+      dialogNode.style.visibility = 'hidden';
+      dialogNode.setAttribute('aria-hidden', 'true');
+    };
+  }, [dialogRef, id]);
+
+  const handleFocus = React.useCallback((
+    event: SyntheticKeyboardEvent<HTMLElement>,
+  ) => {
+    const eventTarget = event.target;
+    if (activeElementRef && eventTarget instanceof HTMLElement) {
+      activeElementRef.current = eventTarget;
+    }
+    detectIfAnchorIsTabbable(
+      event,
+      tabbableElementRef.current,
+    );
+  }, [activeElementRef]);
+
+  const handleKeyDown = React.useCallback((
+    event: SyntheticKeyboardEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    if (event.defaultPrevented) {
+      return false;
+    }
+
+    switch (event.key) {
+      case 'Tab': {
+        const dialogNode = getElementFromRef(dialogRef);
+        const tabbableElement = handleTabKeyPress(
+          event,
+          dialogNode,
+          trapFocus,
+        );
+        tabbableElementRef.current = tabbableElement;
+        if (!tabbableElement) {
+          /*
+           * Prevent focus from moving to whatever element is next in the
+           * document order, so that the handler can decide what to do.
+           */
+          event.preventDefault();
+          onEscape(event);
+        }
+        break;
+      }
+      case 'Escape': {
+        event.stopPropagation();
+        onEscape(event);
+        break;
+      }
+    }
+
+    return true;
+  }, [
+    dialogRef,
+    onEscape,
+    trapFocus,
+  ]);
+
+  const handleKeyUp = React.useCallback(() => {
+    tabbableElementRef.current = null;
+  }, []);
+
+  return (
+    <div
+      className={'dialog' + (nonEmpty(className) ? ' ' + className : '')}
+      id={id}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      ref={dialogRef}
+      role="dialog"
+      /*
+       * The negative tab index ensures that clicking the dialog keeps focus
+       * inside the dialog, and doesn't return it to the <body>.
+       */
+      tabIndex="-1"
+    >
+      <div className="dialog-content">
+        <ErrorBoundary>
+          {children}
+        </ErrorBoundary>
+      </div>
+      {siblings}
+    </div>
+  );
+};
+
+export default Dialog;

--- a/root/static/scripts/common/components/ErrorBoundary.js
+++ b/root/static/scripts/common/components/ErrorBoundary.js
@@ -1,0 +1,45 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+import * as Sentry from '@sentry/browser';
+
+type Props = {
+  +children: React$Node,
+};
+
+type State = {
+  errorMessage: string,
+};
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  static getDerivedStateFromError(error: Error): {+errorMessage: string} {
+    return {errorMessage: error.message ?? String(error)};
+  }
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {errorMessage: ''};
+  }
+
+  componentDidCatch(error: Error, info: {componentStack: string, ...}) {
+    Sentry.withScope(function (scope) {
+      scope.setExtra('componentStack', info.componentStack);
+      Sentry.captureException(error);
+    });
+  }
+
+  render(): React.Node {
+    const errorMessage = this.state.errorMessage;
+    if (errorMessage) {
+      return <div className="error">{errorMessage}</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/root/static/scripts/common/components/Modal.js
+++ b/root/static/scripts/common/components/Modal.js
@@ -1,0 +1,70 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+import {createPortal} from 'react-dom';
+
+import useEventTrap from '../hooks/useEventTrap';
+
+import Dialog, {
+  getDialogRootNode,
+  getElementFromRef,
+  type RequiredPropsT as DialogPropsT,
+} from './Dialog';
+
+const Modal = (props: DialogPropsT): React.Portal => {
+  const {dialogRef, id} = props;
+
+  const activeElementRef = React.useRef<HTMLElement | null>(null);
+
+  const returnFocusToDialog = (event) => {
+    const dialogNode = getElementFromRef(dialogRef);
+    event.preventDefault();
+    const activeElement = activeElementRef.current ?? dialogNode;
+    activeElement.focus();
+  };
+
+  useEventTrap(
+    'focusin',
+    dialogRef,
+    returnFocusToDialog,
+  );
+
+  useEventTrap(
+    'keydown',
+    dialogRef,
+    returnFocusToDialog,
+  );
+
+  React.useLayoutEffect(() => {
+    const {scrollX, scrollY} = window;
+
+    const dialogNode = getElementFromRef(dialogRef);
+    dialogNode.style.left = String(scrollX + 16) + 'px';
+    dialogNode.style.top = String(scrollY + 16) + 'px';
+  });
+
+  return createPortal(
+    <>
+      <div
+        className="modal-backdrop"
+        onClick={returnFocusToDialog}
+      />
+      <Dialog
+        {...props}
+        activeElementRef={activeElementRef}
+        className="modal"
+        trapFocus
+      />
+    </>,
+    getDialogRootNode(id),
+  );
+};
+
+export default Modal;

--- a/root/static/scripts/common/components/Popover.js
+++ b/root/static/scripts/common/components/Popover.js
@@ -1,0 +1,86 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import arrow from '@popperjs/core/lib/modifiers/arrow';
+import flip from '@popperjs/core/lib/modifiers/flip';
+import offset from '@popperjs/core/lib/modifiers/offset';
+import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow';
+import {createPopper} from '@popperjs/core/lib/popper-lite';
+import * as React from 'react';
+import {createPortal} from 'react-dom';
+
+import Dialog, {
+  getDialogRootNode,
+  getElementFromRef,
+} from './Dialog';
+
+const POPPER_OPTIONS = {
+  modifiers: [
+    {
+      enabled: false,
+      name: 'eventListeners',
+    },
+    flip,
+    preventOverflow,
+    arrow,
+    {
+      ...offset,
+      options: {
+        offset: () => [0, 12],
+      },
+    },
+  ],
+  placement: 'right',
+};
+
+type PropsT = {
+  +buildChildren: (() => void) => React.Node,
+  +buttonRef: {current: HTMLButtonElement | null},
+  +className?: string,
+  +closeAndReturnFocus: () => void,
+  +dialogRef: {current: HTMLDivElement | null},
+  +id: string,
+};
+
+const Popover = (props: PropsT): React.Portal => {
+  const {
+    buildChildren,
+    buttonRef,
+    closeAndReturnFocus,
+    dialogRef,
+    ...dialogProps
+  } = props;
+
+  React.useLayoutEffect(() => {
+    const popper = createPopper(
+      buttonRef.current,
+      getElementFromRef(dialogRef),
+      POPPER_OPTIONS,
+    );
+    return () => {
+      popper.destroy();
+    };
+  }, [dialogRef, buttonRef]);
+
+  return createPortal(
+    <Dialog
+      {...dialogProps}
+      className="popover"
+      dialogRef={dialogRef}
+      onEscape={closeAndReturnFocus}
+      siblings={<div data-popper-arrow />}
+      trapFocus={false}
+    >
+      {buildChildren(closeAndReturnFocus)}
+    </Dialog>,
+    getDialogRootNode(dialogProps.id),
+  );
+};
+
+export default Popover;

--- a/root/static/scripts/common/hooks/useEventTrap.js
+++ b/root/static/scripts/common/hooks/useEventTrap.js
@@ -1,0 +1,72 @@
+/*
+ * @flow strict
+ * Copyright (C) 2019 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {useEffect} from 'react';
+
+// Actions by event type name.
+const EVENTS = new Map();
+
+function setupEventHandler(eventType) {
+  const cachedTargetActions = EVENTS.get(eventType);
+  if (cachedTargetActions) {
+    return cachedTargetActions;
+  }
+
+  const targetActions = new Map();
+  EVENTS.set(eventType, targetActions);
+
+  document.addEventListener((
+    eventType
+  ), (event: FocusEvent | KeyboardEvent | MouseEvent) => {
+    const eventTarget = event.target;
+    if (!(eventTarget instanceof Node)) {
+      return;
+    }
+    /*
+     * N.B. It's possible for action() to cause a component to re-render that
+     * then calls `useOutsideClickEffect` again, mutating `TARGET_REFS`. Thus
+     * it's important that we wrap the iterator in `Array.from()`.
+     */
+    for (const [ref, action] of Array.from(targetActions.entries())) {
+      if (action == null) {
+        continue;
+      }
+      const target = ref.current;
+      if (target && !target.contains(eventTarget)) {
+        action(event);
+      }
+    }
+  });
+
+  return targetActions;
+}
+
+export default function useEventTrap<T: HTMLElement>(
+  eventType: FocusEventTypes | KeyboardEventTypes | MouseEventTypes,
+  targetRef: {current: T | null},
+  action: ((Event) => void) | null,
+  cleanup?: () => void,
+) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const targetActions = setupEventHandler(eventType);
+
+  /* eslint-disable-next-line react-hooks/rules-of-hooks */
+  useEffect(() => {
+    targetActions.set(targetRef, action);
+    return () => {
+      targetActions.delete(targetRef);
+      if (cleanup) {
+        cleanup();
+      }
+    };
+  }, [action, cleanup, targetActions, targetRef]);
+}

--- a/root/static/scripts/common/hooks/useOutsideClickEffect.js
+++ b/root/static/scripts/common/hooks/useOutsideClickEffect.js
@@ -7,50 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import {useEffect} from 'react';
-
-const TARGET_REFS = new Map();
-
-if (typeof document !== 'undefined') {
-  document.addEventListener('mouseup', function (event: MouseEvent) {
-    const eventTarget = event.target;
-    if (!(eventTarget instanceof Node)) {
-      return;
-    }
-    /*
-     * N.B. It's possible for action() to cause a component to re-render that
-     * then calls `useOutsideClickEffect` again, mutating `TARGET_REFS`. Thus
-     * it's important that we wrap the iterator in `Array.from()`.
-     */
-    for (const [ref, action] of Array.from(TARGET_REFS.entries())) {
-      if (action == null) {
-        continue;
-      }
-      const target = ref.current;
-      if (target && !target.contains(eventTarget)) {
-        action(eventTarget);
-      }
-    }
-  });
-}
+import useEventTrap from './useEventTrap';
 
 export default function useOutsideClickEffect<T: HTMLElement>(
   targetRef: {current: T | null},
-  action: ((EventTarget) => void) | null,
+  action: ((Event) => void) | null,
   cleanup?: () => void,
-) {
-  if (typeof document === 'undefined') {
-    return;
-  }
-
-  /* eslint-disable-next-line react-hooks/rules-of-hooks */
-  useEffect(() => {
-    TARGET_REFS.set(targetRef, action);
-    return () => {
-      TARGET_REFS.delete(targetRef);
-      if (cleanup) {
-        cleanup();
-      }
-    };
-  }, [action, cleanup, targetRef]);
+): void {
+  useEventTrap('mouseup', targetRef, action, cleanup);
 }

--- a/root/static/scripts/common/hooks/useReturnFocus.js
+++ b/root/static/scripts/common/hooks/useReturnFocus.js
@@ -1,0 +1,27 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+export default function useReturnFocus<T: HTMLElement>(
+  target: {current: T | null},
+): {current: boolean} {
+  const shouldReturnFocus = React.useRef(false);
+
+  React.useEffect(() => {
+    if (shouldReturnFocus.current) {
+      if (target.current) {
+        target.current.focus();
+      }
+      shouldReturnFocus.current = false;
+    }
+  });
+
+  return shouldReturnFocus;
+}

--- a/root/static/scripts/common/utility/focusManagement.js
+++ b/root/static/scripts/common/utility/focusManagement.js
@@ -1,0 +1,218 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+function isElementVisible(element: HTMLElement) {
+  let currentElement = element;
+  while (currentElement) {
+    const style = currentElement instanceof HTMLElement
+      ? currentElement.style
+      : null;
+    if (style && (
+      style.visibility === 'hidden' ||
+      style.display === 'none'
+    )) {
+      return false;
+    }
+    currentElement = currentElement.parentElement;
+  }
+  return true;
+}
+
+/*
+ * The default behavior on Windows/Linux, in most cases, is that the tab
+ * key navigates to and focuses on links. Not so on macOS, unless
+ * "Use keyboard navigation to move focus between controls" is enabled
+ * under System Preferences -> Keyboard.
+ */
+let IS_ANCHOR_TABBABLE = true;
+
+function isElementTabbable(element: HTMLElement) {
+  if (!isElementVisible(element)) {
+    return false;
+  }
+  switch (element.nodeName) {
+    case 'A':
+      if (!IS_ANCHOR_TABBABLE) {
+        return false;
+      }
+      // $FlowIssue[prop-missing]
+      return element.href !== '' || element.tabIndex >= 0;
+    case 'BUTTON':
+    case 'INPUT':
+    case 'SELECT':
+    case 'TEXTAREA':
+      // $FlowIssue[prop-missing]
+      return !element.disabled;
+    default:
+      return element.tabIndex >= 0;
+  }
+}
+
+export function detectIfAnchorIsTabbable(
+  focusEvent: SyntheticKeyboardEvent<HTMLElement>,
+  expectedElement: ?HTMLElement,
+): void {
+  if (expectedElement && expectedElement.nodeName === 'A') {
+    IS_ANCHOR_TABBABLE =
+      (expectedElement === focusEvent.target);
+  }
+}
+
+export function getNextElement(
+  containerElement: HTMLElement,
+  currentElement: Element | null,
+): Element | null {
+  if (!currentElement) {
+    return null;
+  }
+  switch (currentElement.nodeName) {
+    case 'SELECT':
+      break;
+    default: {
+      const children = currentElement.children;
+      if (children.length) {
+        return children[0];
+      }
+    }
+  }
+  let nextElement = currentElement.nextElementSibling;
+  if (nextElement) {
+    return nextElement;
+  }
+  let parent = currentElement.parentElement;
+  while (parent && parent !== containerElement) {
+    nextElement = parent.nextElementSibling;
+    if (nextElement) {
+      break;
+    }
+    parent = parent.parentElement;
+  }
+  return nextElement ?? null;
+}
+
+function findLastElementDepthFirst(
+  element: Element,
+): Element {
+  switch (element.nodeName) {
+    case 'SELECT':
+      return element;
+    default: {
+      let lastElement = element;
+      let children = lastElement.children;
+      while (children.length) {
+        lastElement = children[children.length - 1];
+        children = lastElement.children;
+      }
+      return lastElement;
+    }
+  }
+}
+
+export function getPreviousElement(
+  containerElement: HTMLElement,
+  currentElement: Element | null,
+): Element | null {
+  if (!currentElement) {
+    return null;
+  }
+  const previousElement = currentElement.previousElementSibling;
+  if (previousElement) {
+    return findLastElementDepthFirst(previousElement);
+  }
+  const parentElement = currentElement.parentElement;
+  if (parentElement && parentElement !== containerElement) {
+    return parentElement;
+  }
+  return null;
+}
+
+export function findTabbableElement(
+  containerElement: HTMLElement,
+  startingElement: Element | null,
+  elementGetter: (HTMLElement, Element | null) => Element | null,
+  includeStartingElement?: boolean = false,
+): HTMLElement | null {
+  if (startingElement === containerElement) {
+    return null;
+  }
+  /*
+   * We do not respect the tabIndex order here.
+   * Do not make use of tabIndex in any dialog components.
+   */
+  let currentElement = startingElement;
+
+  if (!includeStartingElement) {
+    currentElement = elementGetter(containerElement, currentElement);
+  }
+
+  while (currentElement) {
+    const thisElement = currentElement;
+    if (thisElement instanceof HTMLElement) {
+      if (isElementTabbable(thisElement)) {
+        return thisElement;
+      }
+    }
+    currentElement = elementGetter(containerElement, thisElement);
+  }
+
+  return null;
+}
+
+export function findFirstTabbableElement(
+  container: HTMLElement,
+): HTMLElement | null {
+  return findTabbableElement(
+    container,
+    container.firstElementChild ?? null,
+    getNextElement,
+    true,
+  );
+}
+
+export function findLastTabbableElement(
+  container: HTMLElement,
+): HTMLElement | null {
+  const lastElement = container.lastElementChild;
+  return findTabbableElement(
+    container,
+    lastElement
+      ? findLastElementDepthFirst(lastElement)
+      : null,
+    getPreviousElement,
+    true,
+  );
+}
+
+export function handleTabKeyPress(
+  event: SyntheticKeyboardEvent<HTMLElement>,
+  container: HTMLElement,
+  trapFocus?: boolean = false,
+): HTMLElement | null {
+  const activeElement = document.activeElement;
+  if (activeElement && container.contains(activeElement)) {
+    let tabbableElement = findTabbableElement(
+      container,
+      activeElement,
+      event.shiftKey ? getPreviousElement : getNextElement,
+    );
+    if (!tabbableElement && trapFocus) {
+      tabbableElement = (
+        event.shiftKey
+          ? findLastTabbableElement
+          : findFirstTabbableElement
+      )(container);
+      if (tabbableElement) {
+        event.preventDefault();
+        tabbableElement.focus();
+      }
+    }
+    return tabbableElement;
+  }
+  return null;
+}

--- a/root/static/scripts/edit/MB/Control/Bubble.js
+++ b/root/static/scripts/edit/MB/Control/Bubble.js
@@ -117,12 +117,6 @@ class BubbleBase {
 BubbleBase.prototype.activeBubbles = {};
 
 /*
- * Whether the bubble should close when we click outside of it. Used for
- * track artist credit bubbles.
- */
-BubbleBase.prototype.closeWhenFocusIsLost = false;
-
-/*
  * BubbleDoc turns a documentation div into a bubble pointing at an
  * input to the left of it.
  */
@@ -266,24 +260,6 @@ function bubbleControlHandler(event) {
   var bubble = control.bubbleDoc;
 
   if (!bubble) {
-    // If the user clicked outside of the active bubble, hide it.
-    var $active = $('div.bubble:visible:eq(0)');
-
-    if ($active.length && !$active.has(control).length) {
-      bubble = $active[0].bubbleDoc;
-
-      if (bubble && bubble.closeWhenFocusIsLost &&
-          !event.isDefaultPrevented() &&
-
-          /*
-           * Close unless focus was moved to a dialog above this
-           * one, i.e. when adding a new entity.
-           */
-          !$(event.target).parents('.ui-dialog').length) {
-
-        bubble.hide(false);
-      }
-    }
     return undefined;
   }
 

--- a/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowNameWithGuessCase.js
@@ -1,0 +1,106 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import FormRowText from '../../../../components/FormRowText';
+
+import type {
+  ActionT as GuessCaseOptionsActionT,
+  StateT as GuessCaseOptionsStateT,
+} from './GuessCaseOptions';
+import GuessCaseOptionsPopover from './GuessCaseOptionsPopover';
+
+/* eslint-disable flowtype/sort-keys */
+export type ActionT =
+  | {+type: 'guess-case'}
+  | {+type: 'open-guess-case-options'}
+  | {+type: 'close-guess-case-options'}
+  | {+type: 'update-guess-case-options', +action: GuessCaseOptionsActionT}
+  | {+type: 'set-name', +name: string};
+/* eslint-enable flowtype/sort-keys */
+
+type PropsT = {
+  +dispatch: (ActionT) => void,
+  +field: ReadOnlyFieldT<string | null>,
+  +guessCaseOptions: GuessCaseOptionsStateT,
+  +guessFeat?: boolean,
+  +isGuessCaseOptionsOpen: boolean,
+  +label?: string,
+};
+
+export const FormRowNameWithGuessCase = ({
+  dispatch,
+  field,
+  guessCaseOptions,
+  guessFeat = false,
+  isGuessCaseOptionsOpen = false,
+  label = addColonText(l('Name')),
+}: PropsT): React.Element<typeof FormRowText> => {
+  function handleNameChange(event: SyntheticKeyboardEvent<HTMLInputElement>) {
+    dispatch({
+      name: event.currentTarget.value,
+      type: 'set-name',
+    });
+  }
+
+  function handleGuessCase() {
+    dispatch({type: 'guess-case'});
+  }
+
+  const toggleGuessCaseOptions = React.useCallback((
+    open: boolean,
+  ) => {
+    if (open) {
+      dispatch({type: 'open-guess-case-options'});
+    } else {
+      dispatch({type: 'close-guess-case-options'});
+    }
+  }, [dispatch]);
+
+  const guessCaseOptionsDispatch = React.useCallback(
+    (action: GuessCaseOptionsActionT) => {
+      dispatch({action, type: 'update-guess-case-options'});
+    },
+    [dispatch],
+  );
+
+  return (
+    <FormRowText
+      className={'with-guesscase' + (guessFeat ? '-guessfeat' : '')}
+      field={field}
+      label={label}
+      onChange={handleNameChange}
+      required
+    >
+      <button
+        className="guesscase-title icon"
+        onClick={handleGuessCase}
+        title={l('Guess case')}
+        type="button"
+      />
+      {guessFeat ? (
+        <button
+          className="guessfeat icon"
+          title={l('Guess feat. artists')}
+          type="button"
+        />
+      ) : null}
+
+      <GuessCaseOptionsPopover
+        dispatch={guessCaseOptionsDispatch}
+        isOpen={isGuessCaseOptionsOpen}
+        toggle={toggleGuessCaseOptions}
+        {...guessCaseOptions}
+      />
+    </FormRowText>
+  );
+};
+
+export default FormRowNameWithGuessCase;

--- a/root/static/scripts/edit/components/GuessCaseOptions.js
+++ b/root/static/scripts/edit/components/GuessCaseOptions.js
@@ -1,0 +1,148 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import expand2react from '../../common/i18n/expand2react';
+import bracketed from '../../common/utility/bracketed';
+import getBooleanCookie from '../../common/utility/getBooleanCookie';
+import setCookie from '../../common/utility/setCookie';
+import * as modes from '../../guess-case/modes';
+import gc from '../../guess-case/MB/GuessCase/Main';
+
+/* eslint-disable flowtype/sort-keys */
+export type ActionT =
+  | {+type: 'set-mode', +mode: string}
+  | {+type: 'set-keep-upper-case', +enabled: boolean}
+  | {+type: 'set-upper-case-roman', +enabled: boolean};
+/* eslint-enable flowtype/sort-keys */
+
+export type DispatchT = (ActionT) => void;
+
+export type StateT = {
+  +keepUpperCase: boolean,
+  +mode: string,
+  +upperCaseRoman: boolean,
+};
+
+export type WritableStateT = {
+  ...StateT,
+};
+
+export type PropsT = $ReadOnly<{
+  ...StateT,
+  +dispatch: (ActionT) => void,
+}>;
+
+export function createInitialState(): StateT {
+  return {
+    keepUpperCase: gc.CFG_UC_UPPERCASED,
+    mode: gc.modeName,
+    upperCaseRoman: getBooleanCookie('guesscase_roman'),
+  };
+}
+
+export function runReducer(
+  state: WritableStateT,
+  action: ActionT,
+): void {
+  switch (action.type) {
+    case 'set-mode': {
+      const modeName = action.mode;
+      gc.modeName = modeName;
+      const mode = modes[modeName];
+      gc.mode = mode;
+      setCookie('guesscase_mode', modeName);
+      state.mode = modeName;
+      break;
+    }
+    case 'set-keep-upper-case': {
+      const enabled = action.enabled;
+      gc.CFG_UC_UPPERCASED = enabled;
+      setCookie('guesscase_keepuppercase', enabled);
+      state.keepUpperCase = enabled;
+      break;
+    }
+    case 'set-upper-case-roman': {
+      const enabled = action.enabled;
+      setCookie('guesscase_roman', enabled);
+      state.upperCaseRoman = enabled;
+      break;
+    }
+  }
+}
+
+const GuessCaseOptions = ({
+  dispatch,
+  keepUpperCase,
+  mode: modeName,
+  upperCaseRoman,
+}: PropsT): React.Element<'div'> => {
+  function handleModeChange(event) {
+    const newModeName = event.target.value;
+
+    if (newModeName !== gc.modeName) {
+      dispatch({mode: newModeName, type: 'set-mode'});
+    }
+  }
+
+  function handleKeepUpperCaseChanged(event) {
+    dispatch({
+      enabled: event.target.checked,
+      type: 'set-keep-upper-case',
+    });
+  }
+
+  function handleUpperCaseRomanChanged(event) {
+    dispatch({
+      enabled: event.target.checked,
+      type: 'set-upper-case-roman',
+    });
+  }
+
+  return (
+    <div id="guesscase-options">
+      <h1>{l('Guess case options')}</h1>
+      <select onChange={handleModeChange} value={modeName}>
+        <option value="English">{l('English')}</option>
+        <option value="Sentence">{l('Sentence')}</option>
+        <option value="French">{l('French')}</option>
+        <option value="Turkish">{l('Turkish')}</option>
+      </select>
+      {' '}
+      {bracketed(
+        <a href="/doc/Guess_Case" target="_blank">
+          {l('help')}
+        </a>,
+      )}
+      <p>
+        {expand2react(gc.mode?.description ?? '')}
+      </p>
+      <label>
+        <input
+          checked={keepUpperCase}
+          onChange={handleKeepUpperCaseChanged}
+          type="checkbox"
+        />
+        {l('Keep all-uppercase words uppercased')}
+      </label>
+      <br />
+      <label>
+        <input
+          checked={upperCaseRoman}
+          onChange={handleUpperCaseRomanChanged}
+          type="checkbox"
+        />
+        {l('Uppercase Roman numerals')}
+      </label>
+    </div>
+  );
+};
+
+export default GuessCaseOptions;

--- a/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
+++ b/root/static/scripts/edit/components/GuessCaseOptionsPopover.js
@@ -1,0 +1,92 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ButtonPopover from '../../common/components/ButtonPopover';
+
+import GuessCaseOptions, {
+  type PropsT as GuessCaseOptionsPropsT,
+} from './GuessCaseOptions';
+
+type Props = $ReadOnly<{
+  +isOpen: boolean,
+  +toggle: (boolean) => void,
+  ...GuessCaseOptionsPropsT,
+}>;
+
+const buttonProps = {
+  className: 'guesscase-options icon',
+  title: N_l('Guess case options'),
+};
+
+const GuessCaseOptionsPopover = (React.memo(({
+  dispatch,
+  isOpen,
+  keepUpperCase,
+  mode,
+  toggle,
+  upperCaseRoman,
+}: Props): React.Element<typeof ButtonPopover> => {
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+
+  const buildChildren = React.useCallback((
+    closeAndReturnFocus: () => void,
+  ) => (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        closeAndReturnFocus();
+      }}
+    >
+      <GuessCaseOptions
+        dispatch={dispatch}
+        keepUpperCase={keepUpperCase}
+        mode={mode}
+        upperCaseRoman={upperCaseRoman}
+      />
+      <div
+        className="buttons"
+        style={{marginTop: '1em'}}
+      >
+        <div
+          className="buttons-right"
+          style={{float: 'right', textAlign: 'right'}}
+        >
+          <button
+            className="positive"
+            onClick={closeAndReturnFocus}
+            type="button"
+          >
+            {l('Done')}
+          </button>
+        </div>
+      </div>
+    </form>
+  ), [
+    dispatch,
+    keepUpperCase,
+    mode,
+    upperCaseRoman,
+  ]);
+
+  return (
+    <ButtonPopover
+      buildChildren={buildChildren}
+      buttonContent={null}
+      buttonProps={buttonProps}
+      buttonRef={buttonRef}
+      id="gc-options-dialog"
+      isOpen={isOpen}
+      toggle={toggle}
+    />
+  );
+}): React.AbstractComponent<Props, void>);
+
+export default GuessCaseOptionsPopover;

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -239,8 +239,6 @@ export default function guessFeat(entity) {
 
 // For use outside of the release editor.
 MB.Control.initGuessFeatButton = function (formName) {
-  const nameInput = document.getElementById('id-' + formName + '.name');
-
   const augmentedEntity = Object.assign(
     Object.create(MB.sourceRelationshipEditor.source),
     {
@@ -249,8 +247,14 @@ MB.Control.initGuessFeatButton = function (formName) {
        * to the name input directly.
        */
       name: function () {
+        const nameInput = document.getElementById('id-' + formName + '.name');
         if (arguments.length) {
-          nameInput.value = arguments[0];
+          // XXX Allows React to see the input value change.
+          Object.getOwnPropertyDescriptor(
+            window.HTMLInputElement.prototype,
+            'value',
+          ).set.call(nameInput, arguments[0]);
+          nameInput.dispatchEvent(new Event('input', {bubbles: true}));
           return undefined;
         }
         return nameInput.value;

--- a/root/static/scripts/empty.js
+++ b/root/static/scripts/empty.js
@@ -1,0 +1,11 @@
+/*
+ * Modules that are not meant to execute the server (jQuery, Popper.js, ...)
+ * yet are imported from isomorphic components are mapped to here. See the
+ * `NormalModuleReplacementPlugin` configuration in webpack.server.config.js.
+ *
+ * The named `noop` exports prevent Webpack from warning about missing
+ * exports at build time.
+ */
+const noop = () => undefined;
+export const createPopper = noop;
+export default {};

--- a/root/static/scripts/recording/RecordingName.js
+++ b/root/static/scripts/recording/RecordingName.js
@@ -1,0 +1,117 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import mutate from 'mutate-cow';
+import * as React from 'react';
+
+import hydrate from '../../../utility/hydrate';
+import MB from '../common/MB';
+import FormRowNameWithGuessCase, {
+  type ActionT as NameActionT,
+} from '../edit/components/FormRowNameWithGuessCase';
+import {
+  createInitialState as createGuessCaseOptionsState,
+  runReducer as runGuessCaseOptionsReducer,
+  type StateT as GuessCaseOptionsStateT,
+  type WritableStateT as WritableGuessCaseOptionsStateT,
+} from '../edit/components/GuessCaseOptions';
+
+type Props = {
+  +field: ReadOnlyFieldT<string>,
+};
+
+/*
+ * State must be moved higher up in the component hierarchy once more
+ * of the page is converted to React.
+ */
+type StateT = {
+  +field: ReadOnlyFieldT<string | null>,
+  +guessCaseOptions: GuessCaseOptionsStateT,
+  +isGuessCaseOptionsOpen: boolean,
+};
+
+type WritableStateT = {
+  ...StateT,
+  field: FieldT<string | null>,
+  guessCaseOptions: WritableGuessCaseOptionsStateT,
+};
+
+function createInitialState(field) {
+  return {
+    field,
+    guessCaseOptions: createGuessCaseOptionsState(),
+    isGuessCaseOptionsOpen: false,
+  };
+}
+
+function reducer(state: StateT, action: NameActionT): StateT {
+  return mutate<WritableStateT, StateT>(state, newState => {
+    switch (action.type) {
+      case 'set-name': {
+        newState.field.value = action.name;
+        break;
+      }
+      case 'guess-case': {
+        newState.field.value =
+          (MB.GuessCase: any).recording.guess(
+            state.field.value ?? '',
+          );
+        break;
+      }
+      case 'open-guess-case-options': {
+        newState.isGuessCaseOptionsOpen = true;
+        break;
+      }
+      case 'close-guess-case-options': {
+        newState.isGuessCaseOptionsOpen = false;
+        break;
+      }
+      case 'update-guess-case-options': {
+        runGuessCaseOptionsReducer(
+          newState.guessCaseOptions,
+          action.action,
+        );
+        break;
+      }
+    }
+  });
+}
+
+export const RecordingName = ({
+  field,
+}: Props): React.Element<typeof FormRowNameWithGuessCase> => {
+  /*
+   * State must be moved higher up in the component hierarchy once more
+   * of the page is converted to React.
+   */
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    field,
+    createInitialState,
+  );
+
+  return (
+    <FormRowNameWithGuessCase
+      dispatch={dispatch}
+      field={state.field}
+      guessCaseOptions={state.guessCaseOptions}
+      guessFeat
+      isGuessCaseOptionsOpen={state.isGuessCaseOptionsOpen}
+    />
+  );
+};
+
+/*
+ * Hydration must be moved higher up in the component hierarchy once
+ * more of the page is converted to React.
+ */
+export default (hydrate<Props>(
+  'div.recording-name',
+  RecordingName,
+): React.AbstractComponent<Props, void>);

--- a/root/static/scripts/recording/form.js
+++ b/root/static/scripts/recording/form.js
@@ -1,0 +1,10 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import './RecordingName';

--- a/root/static/scripts/tests/dialog.html
+++ b/root/static/scripts/tests/dialog.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dialog Test</title>
+    <link rel="stylesheet/less" type="text/css" href="../../../static/styles/autocomplete2.less" />
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
+  </head>
+  <body>
+    <h1>Dialog Test</h1>
+    <script src="../../build/dialog-test.js"></script>
+  </body>
+</html>

--- a/root/static/scripts/tests/dialog.js
+++ b/root/static/scripts/tests/dialog.js
@@ -1,0 +1,153 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/* eslint-disable import/no-commonjs */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const Modal = require('../common/components/Modal').default;
+const ButtonPopover = require('../common/components/ButtonPopover').default;
+const useReturnFocus = require('../common/hooks/useReturnFocus').default;
+
+const container = document.createElement('div');
+document.body?.insertBefore(container, document.getElementById('page'));
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'toggle-modal':
+      return {
+        ...state,
+        isModalOpen: action.open,
+      };
+    case 'toggle-popover':
+      return {
+        ...state,
+        isPopoverOpen: action.open,
+      };
+  }
+  return state;
+}
+
+function createInitialState() {
+  return {
+    isModalOpen: false,
+    isPopoverOpen: false,
+  };
+}
+
+const DialogTest = () => {
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    null,
+    createInitialState,
+  );
+
+  const modalButtonRef = React.useRef(null);
+  const popoverButtonRef = React.useRef(null);
+  const modalDialogRef = React.useRef(null);
+  const focusModalButton = useReturnFocus(modalButtonRef);
+
+  const openModal = React.useCallback(() => {
+    dispatch({
+      open: true,
+      type: 'toggle-modal',
+    });
+  }, []);
+
+  const closeModal = React.useCallback(() => {
+    focusModalButton.current = true;
+    dispatch({
+      open: false,
+      type: 'toggle-modal',
+    });
+  }, [focusModalButton]);
+
+  const togglePopover = React.useCallback((open: boolean) => {
+    dispatch({open, type: 'toggle-popover'});
+  }, []);
+
+  const buildPopoverChildren = React.useCallback((
+    closeAndReturnFocus,
+  ) => (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        closeAndReturnFocus();
+      }}
+    >
+      <p>{'Pop'}</p>
+      <p>
+        <a href="#">{'Pop'}</a>
+      </p>
+      <p>
+        <input defaultValue="Pop" type="text" />
+      </p>
+      <button
+        onClick={closeAndReturnFocus}
+        type="button"
+      >
+        {'Goodbye'}
+      </button>
+    </form>
+  ), []);
+
+  return (
+    <>
+      <textarea defaultValue="noop" />
+      <h2>{'Modal'}</h2>
+      <p>
+        <button
+          onClick={openModal}
+          ref={modalButtonRef}
+          type="button"
+        >
+          {'Open Modal'}
+        </button>
+        {state.isModalOpen ? (
+          <Modal
+            dialogRef={modalDialogRef}
+            id="modal-test"
+            onEscape={closeModal}
+          >
+            <p>{'Hello!'}</p>
+            <p>
+              <a href="#">{'Hello!'}</a>
+            </p>
+            <p>
+              <input defaultValue="Hello!" type="text" />
+            </p>
+            <button
+              onClick={closeModal}
+              type="button"
+            >
+              {'Goodbye'}
+            </button>
+          </Modal>
+        ) : null}
+      </p>
+      <h2>{'Popover'}</h2>
+      <p>
+        <ButtonPopover
+          buildChildren={buildPopoverChildren}
+          buttonContent="Open Popover"
+          buttonRef={popoverButtonRef}
+          id="popover-test"
+          isOpen={state.isPopoverOpen}
+          toggle={togglePopover}
+        />
+      </p>
+      <p>
+        <textarea defaultValue="noop" />
+      </p>
+    </>
+  );
+};
+
+ReactDOM.render(<DialogTest />, container);

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -751,3 +751,76 @@ div.rel-editor-dialog {
 button.guess-timezone {
     background-image: data-uri('../images/icons/magnet.png');
 }
+
+.dialog-root {
+    .modal-backdrop {
+        background: #000;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0.1;
+    }
+}
+
+.dialog {
+    visibility: hidden;
+    padding: 1em;
+    position: absolute;
+    background: @text-white;
+    border: 1px solid #AAA;
+    top: 0;
+    left: 0;
+    filter: drop-shadow(2px 2px 4px @very-dark-grey);
+    -webkit-filter: drop-shadow(2px 2px 4px @very-dark-grey);
+
+    h1 {
+        color: @musicbrainz-orange;
+        margin-bottom: 1em;
+    }
+
+    &.modal {
+        max-width: 500px;
+
+        @media @wide {
+            max-width: 700px;
+        }
+    }
+
+    &.popover {
+        max-width: 500px;
+        .border-radius(12px);
+
+        div[data-popper-arrow] {
+            z-index: -1;
+        }
+
+        div[data-popper-arrow]::before {
+            content: "";
+            transform: rotate(45deg);
+            top: 0px;
+            left: 0px;
+            width: 16px;
+            height: 16px;
+            background: @text-white;
+            display: block;
+        }
+
+        &[data-popper-placement^="left"] > div[data-popper-arrow] {
+            right: -9px;
+            &::before {
+                border-right: 1px solid #AAA;
+                border-top: 1px solid #AAA;
+            }
+        }
+
+        &[data-popper-placement^="right"] > div[data-popper-arrow] {
+            left: -9px;
+            &::before {
+                border-left: 1px solid #AAA;
+                border-bottom: 1px solid #AAA;
+            }
+        }
+    }
+}

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -75,6 +75,11 @@ form div.row.no-label label {
     float: none;
 }
 
+form div.row button.icon {
+    margin-left: 2px;
+    vertical-align: text-top;
+}
+
 div.form-row-text-list, div.form-row-select-list {
     margin-left: @form-label-width + @form-margin;
 
@@ -277,10 +282,6 @@ div.checkbox {
 
           Guess Case
    __________________________________ */
-
-#guesscase-options {
-    display: none;
-}
 
 button.guesscase-title, button.guesscase-sortname {
     background-image: data-uri('../images/icons/guesscase.png');

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -50,6 +50,7 @@ const entries = [
   'place',
   'place/index',
   'place/map',
+  'recording/form',
   'recording/merge',
   'release-editor',
   'release-group/index',

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -38,7 +38,14 @@ module.exports = {
   },
 
   externals: [
-    nodeExternals({modulesFromFile: true}),
+    nodeExternals({
+      /*
+       * @popperjs is resolved to root/static/scripts/empty.js on the server.
+       * See NormalModuleReplacementPlugin below.
+       */
+      whitelist: [/@popperjs/],
+      modulesFromFile: true,
+    }),
 
     function (context, request, callback) {
       const resolvedRequest = path.resolve(context, request);
@@ -70,6 +77,10 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /@popperjs/,
+      path.resolve(dirs.SCRIPTS, 'empty.js'),
+    ),
     new webpack.DefinePlugin(definePluginConfig),
     new webpack.IgnorePlugin({resourceRegExp: /jquery/}),
     new webpack.ProvidePlugin(providePluginConfig),

--- a/webpack.tests.config.js
+++ b/webpack.tests.config.js
@@ -32,6 +32,7 @@ const baseTestsConfig = {
 const webTestsConfig = {
   entry: {
     'autocomplete2': path.resolve(dirs.SCRIPTS, 'tests', 'autocomplete2.js'),
+    'dialog-test': path.resolve(dirs.SCRIPTS, 'tests', 'dialog.js'),
     'web-tests': path.resolve(dirs.SCRIPTS, 'tests', 'browser-runner.js'),
   },
 

--- a/webpack/babel-ignored.js
+++ b/webpack/babel-ignored.js
@@ -4,7 +4,7 @@ module.exports = [
    * to the node_modules exclusion. These most likely use language features
    * that aren't supported in IE11.
    */
-  /node_modules\/(?!@babel\/runtime|jed|mutate-cow|react)/,
+  /node_modules\/(?!@babel\/runtime|@popperjs|jed|mutate-cow|react)/,
   /root\/static\/scripts\/tests\/typeInfo\.js/,
   /root\/static\/build\/jed-[A-z_-]+?\.source\.js$/,
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,6 +1124,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@popperjs/core@2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
+  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+
 "@sentry/apm@5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.10.2.tgz#41a401b3964b68514439f8a595b12c6fd05ab21a"


### PR DESCRIPTION
Also converts the guess case options dialog with it.

I've only used the new components in the recording edit form as an initial test.

The state handling is a bit messy at the moment, since we don't have a top-level `RecordingForm` component yet (which is where the state would normally go). But eventually things should work themselves out.

~This is marked as WIP because I haven't tested it thoroughly and might want to make changes to the state handling. Also, the style of GC dialog clashes with the bubble doc style, which we may want to rectify, though the popper stuff will be used in the relationship editor too where it more closely matches the current dialog style there...so not sure.~