### PR TITLE
MBS-11173: Turn pending votes by deleted editor to Abstain

### DIFF
--- a/root/admin/delete_user.tt
+++ b/root/admin/delete_user.tt
@@ -21,6 +21,10 @@
            { uri => 'http://wiki.musicbrainz.org/Account_FAQ#How_do_I_delete_my_account.3F' }) %]
     </p>
 
+    <p>
+      [% l('This will also cancel all your open edits and change all of your votes on any edits currently open to Abstain.') %]
+    </p>
+
     <p>[% l('Are you sure you want to delete your account? This cannot be undone!')%]</p>
     <form action="[% c.req.uri %]" method="post" id="delete-account-form">
       [% form_csrf_token %]

--- a/t/sql/vote.sql
+++ b/t/sql/vote.sql
@@ -1,5 +1,8 @@
 SET client_min_messages TO 'warning';
 
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 1);
+
 INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_since) VALUES
     (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), now()),
     (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-01'),


### PR DESCRIPTION
### Implement MBS-11173

In some cases, a rage-quitting editor might go out with a barrage of No votes (or, more insidiously, incorrect Yes votes).

In the same way we already cancel the editor's open edits upon deletion, this also changes their votes on edits currently open from Yes or No to Abstain.