### PR TITLE
MBS-11176: Fix missing nonEmpty ternary

### DIFF
--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -153,7 +153,7 @@ const ExternalLinks = ({
   return (
     <>
       <h2 className="external-links">
-        {nonEmpty(heading) || l('External links')}
+        {nonEmpty(heading) ? heading : l('External links')}
       </h2>
       <ul className="external_links">
         {links}


### PR DESCRIPTION
### Fix MBS-11176

I checked the rest of the nonEmpty now to make sure I didn't mess up more of these... this seems to be the last one.