### PR TITLE
MBS-11177: Drop "Description" label from type_bubble

### DIFF
--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -352,11 +352,10 @@
       [% FOREACH id IN form.options %]
          [%- id = id.value -%]
          <span [% IF form.value != id %] style="display:none" [% END %] class="type-bubble-description" id="type-bubble-description-[% id %]">
-           <strong>[%- add_colon(l('Description')) -%] </strong>
            [% IF types.$id.l_description %]
              [%- types.$id.l_description -%]
            [% ELSE %]
-             [%- lp('(none)', 'description') -%]
+             [%- l('No description available.') -%]
            [% END %]
          </span>
       [% END %]


### PR DESCRIPTION
### Implement MBS-11177

From context and the default message it's blindingly clear what these are supposed to be, so the header just takes space.