### PR TITLE
Upgrade to Flow 0.136.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.135.0",
+    "flow-bin": "0.136.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "jsdom": "13.2.0",

--- a/root/components/Table.js
+++ b/root/components/Table.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {useTable} from 'react-table';
+import {useTable, type Row} from 'react-table';
 
 import loopParity from '../utility/loopParity';
 
@@ -32,7 +32,7 @@ const renderTableCell = (cell) => (
   </td>
 );
 
-const renderTableRow = (row, i) => (
+const renderTableRow = <D>(row: Row<D>, i: number) => (
   <tr {...row.getRowProps({className: loopParity(i)})}>
     {row.cells.map(renderTableCell)}
   </tr>

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -13,7 +13,15 @@ import SearchIcon from '../../static/scripts/common/components/SearchIcon';
 import DBDefs from '../../static/scripts/common/DBDefs';
 import {compare} from '../../static/scripts/common/i18n';
 
-const TYPE_OPTION_GROUPS = [
+type SearchOptionValueT =
+  (() => string) | null;
+
+type SearchOptionGroupT = {
+  +[optionName: string]: SearchOptionValueT,
+  ...
+};
+
+const TYPE_OPTION_GROUPS: $ReadOnlyArray<SearchOptionGroupT> = [
   {
     artist:        N_l('Artist'),
   },
@@ -46,34 +54,39 @@ const TYPE_OPTION_GROUPS = [
   },
 ];
 
-function localizedTypeOption(group, key) {
-  const option = group[key];
+function localizedTypeOption(option: SearchOptionValueT) {
   return option ? option() : '';
+}
+
+function compareTypeOptionEntries(
+  a: [string, SearchOptionValueT],
+  b: [string, SearchOptionValueT],
+) {
+  return compare(
+    localizedTypeOption(a[1]),
+    localizedTypeOption(b[1]),
+  );
 }
 
 const SearchOptions = () => (
   <select id="headerid-type" name="type">
-    {TYPE_OPTION_GROUPS.map(<TogT: {...}>(group: TogT, groupIndex) => (
-      Object.keys(group).sort(function (a, b) {
-        return compare(
-          localizedTypeOption(group, a),
-          localizedTypeOption(group, b),
-        );
-      }).map(function (key, index) {
-        const text = localizedTypeOption(group, key);
-        if (!text) {
-          return null;
-        }
-        return (
-          <option
-            key={groupIndex + '.' + index}
-            value={key}
-          >
-            {text}
-          </option>
-        );
-      })
-    ))}
+    {TYPE_OPTION_GROUPS.map((group) => (
+      Object.entries(group)
+        // $FlowIssue[incompatible-call]
+        .sort(compareTypeOptionEntries)
+        .map(([key: string, option: SearchOptionValueT]) => {
+          // $FlowIssue[incompatible-call]
+          const text = localizedTypeOption(option);
+          if (!text) {
+            return null;
+          }
+          return (
+            <option key={key} value={key}>
+              {text}
+            </option>
+          );
+        })
+      ))}
   </select>
 );
 

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -289,6 +289,9 @@ type AutocompleteItemsProps<T: EntityItem> = {
   selectItem: (Item<T>) => void,
 };
 
+type AutocompleteItemComponent<T> =
+  React$AbstractComponent<AutocompleteItemProps<T>, void>;
+
 function AutocompleteItems<T: EntityItem>({
   autocompleteId,
   dispatch,
@@ -296,10 +299,10 @@ function AutocompleteItems<T: EntityItem>({
   items,
   selectedItem,
   selectItem,
-}: AutocompleteItemsProps<T>) {
+}: AutocompleteItemsProps<T>):
+  $ReadOnlyArray<React.Element<AutocompleteItemComponent<T>>> {
   // XXX Until Flow supports https://github.com/facebook/flow/issues/7672
-  const AutocompleteItemWithType:
-    React$AbstractComponent<AutocompleteItemProps<T>, void> =
+  const AutocompleteItemWithType: AutocompleteItemComponent<T> =
     (AutocompleteItem: any);
 
   const children = [];

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -17,13 +17,17 @@ import {
 import {EMPTY_ARRAY, MENU_ITEMS} from './constants';
 import type {
   Actions,
+  ActionItem,
   EntityItem,
   Item,
   SearchAction,
   State,
 } from './types';
 
-function initSearch(state, action: SearchAction) {
+function initSearch<+T: EntityItem>(
+  state: {...State<T>},
+  action: SearchAction,
+) {
   if (action.indexed !== undefined) {
     state.indexedSearch = action.indexed;
   }
@@ -48,7 +52,7 @@ function initSearch(state, action: SearchAction) {
   state.pendingSearch = searchTerm;
 }
 
-function resetPage(state) {
+function resetPage<+T: EntityItem>(state: {...State<T>}) {
   state.highlightedItem = null;
   state.isOpen = false;
   state.items = EMPTY_ARRAY;
@@ -72,11 +76,14 @@ function selectItem<+T: EntityItem>(
 
   if (item.name !== state.inputValue) {
     state.inputValue = item.name;
-    resetPage(state);
+    resetPage<T>(state);
   }
 }
 
-function showError(state, error) {
+function showError<+T: EntityItem>(
+  state: {...State<T>},
+  error: ActionItem<T>,
+) {
   state.highlightedItem = null;
   state.isOpen = true;
   state.items = [error];
@@ -93,7 +100,7 @@ export function runReducer<+T: EntityItem>(
     case 'change-entity-type': {
       state.entityType = action.entityType;
       state.selectedItem = null;
-      resetPage(state);
+      resetPage<T>(state);
       break;
     }
 
@@ -131,7 +138,7 @@ export function runReducer<+T: EntityItem>(
 
     case 'search-after-timeout':
       state.page = 1;
-      initSearch(state, action);
+      initSearch<T>(state, action);
       break;
 
     case 'select-item':
@@ -143,12 +150,12 @@ export function runReducer<+T: EntityItem>(
       break;
 
     case 'show-lookup-error': {
-      showError(state, MENU_ITEMS.LOOKUP_ERROR);
+      showError<T>(state, MENU_ITEMS.LOOKUP_ERROR);
       break;
     }
 
     case 'show-lookup-type-error': {
-      showError(state, MENU_ITEMS.LOOKUP_TYPE_ERROR);
+      showError<T>(state, MENU_ITEMS.LOOKUP_TYPE_ERROR);
       break;
     }
 
@@ -184,7 +191,7 @@ export function runReducer<+T: EntityItem>(
     }
 
     case 'show-search-error': {
-      showError(state, MENU_ITEMS.SEARCH_ERROR);
+      showError<T>(state, MENU_ITEMS.SEARCH_ERROR);
       state.items = unwrapProxy(state.items).concat(
         state.indexedSearch
           ? MENU_ITEMS.ERROR_TRY_AGAIN_DIRECT
@@ -196,7 +203,7 @@ export function runReducer<+T: EntityItem>(
 
     case 'show-more-results':
       state.page++;
-      initSearch(state, SEARCH_AGAIN);
+      initSearch<T>(state, SEARCH_AGAIN);
       break;
 
     case 'stop-search':
@@ -206,7 +213,7 @@ export function runReducer<+T: EntityItem>(
     case 'toggle-indexed-search':
       state.indexedSearch = !state.indexedSearch;
       state.page = 1;
-      initSearch(state, SEARCH_AGAIN);
+      initSearch<T>(state, SEARCH_AGAIN);
       break;
 
     case 'type-value':
@@ -216,7 +223,7 @@ export function runReducer<+T: EntityItem>(
       state.statusMessage = '';
 
       if (!state.inputValue) {
-        resetPage(state);
+        resetPage<T>(state);
       }
 
       break;

--- a/root/static/scripts/common/hooks/useEventTrap.js
+++ b/root/static/scripts/common/hooks/useEventTrap.js
@@ -9,8 +9,12 @@
 
 import {useEffect} from 'react';
 
+type ActionFnT = ((Event) => void) | null;
+
+type TargetRefsT = Map<{+current: HTMLElement | null}, ActionFnT>;
+
 // Actions by event type name.
-const EVENTS = new Map();
+const EVENTS = new Map<string, TargetRefsT>();
 
 function setupEventHandler(eventType) {
   const cachedTargetActions = EVENTS.get(eventType);
@@ -50,7 +54,7 @@ function setupEventHandler(eventType) {
 export default function useEventTrap<T: HTMLElement>(
   eventType: FocusEventTypes | KeyboardEventTypes | MouseEventTypes,
   targetRef: {current: T | null},
-  action: ((Event) => void) | null,
+  action: ActionFnT,
   cleanup?: () => void,
 ) {
   if (typeof document === 'undefined') {

--- a/root/static/scripts/common/utility/cloneDeep.js
+++ b/root/static/scripts/common/utility/cloneDeep.js
@@ -10,7 +10,10 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-disable multiline-comment-style */
 
-function _cloneDeep(value, seen)/*: any */ {
+function _cloneDeep/*:: <+T> */(
+  value/*: T */,
+  seen/*: WeakMap<any, any> */,
+)/*: any */ {
   if (value != null && typeof value === 'object') {
     const clone = seen.get(value);
     if (clone) {
@@ -32,7 +35,7 @@ function _cloneArrayDeep/*:: <+T> */(
   seen.set(array, clone);
   const size = array.length;
   for (let i = 0; i < size; i++) {
-    clone.push(_cloneDeep(array[i], seen));
+    clone.push(_cloneDeep/*:: <T> */(array[i], seen));
   }
   return clone;
 }

--- a/root/static/scripts/edit/utility/editDiff.js
+++ b/root/static/scripts/edit/utility/editDiff.js
@@ -42,7 +42,7 @@ export type EditDiff<+T> = {
   +type: EditType,
 };
 
-function getChangeType(diff) {
+function getChangeType<+T>(diff: GenericEditDiff<T>) {
   if (!diff.added && !diff.removed) {
     return EQUAL;
   }
@@ -62,7 +62,7 @@ export default function editDiff<T>(
   for (let i = 0; i < diffs.length; i++) {
     const diff = diffs[i];
 
-    let changeType = getChangeType(diff);
+    let changeType = getChangeType<T>(diff);
 
     let nextDiff;
     if ((i + 1) < diffs.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,10 +3265,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.135.0:
-  version "0.135.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.135.0.tgz#70bcd7bae0231777dd05cc8707ff34b37824bbad"
-  integrity sha512-E0JIKWopjULE/fl1X+j7rh0zgcgD5nubLs3HWYeYPo+nWFy8dALvrQbFcCFoPePrkhY/fffhN28t8P1zBxB2Yg==
+flow-bin@0.136.0:
+  version "0.136.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.136.0.tgz#2c1be64496d791ea3160047ce22968ef166835f1"
+  integrity sha512-Z0sycQDyWXiNsGAhOBUrvHPzz7Q4g38BT57+YzZGffbaBmWRNC6MGZb+R6XTzeWb30bZin5V21nPQZezJzm9cQ==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
It's now an error for generics to escape outside of the scope they're defined in. Which usually just means that if a variable's type contains a generic type variable, then we can't pass that variable around without also passing the associated generic.