### PR TITLE
MBS-11130: Clarify it's not possible to subscribe to VA / [no label]

### DIFF
--- a/root/entity/Subscribers.js
+++ b/root/entity/Subscribers.js
@@ -10,11 +10,14 @@
 import * as React from 'react';
 
 import EditorLink from '../static/scripts/common/components/EditorLink';
+import isSpecialPurpose
+  from '../static/scripts/common/utility/isSpecialPurpose';
 import chooseLayoutComponent from '../utility/chooseLayoutComponent';
 
 type Props = {
   +$c: CatalystContextT,
   +entity: CoreEntityT | CollectionT | EditorT,
+  +isSpecialEntity: boolean,
   +privateEditors: number,
   +publicEditors: $ReadOnlyArray<EditorT>,
   +subscribed: boolean,
@@ -45,108 +48,116 @@ const Subscribers = ({
     >
       <h2>{l('Subscribers')}</h2>
 
-      {(publicEditors.length || (privateEditors > 0)) ? (
+      {isSpecialPurpose(entity) ? (
+        <p>
+          {l('This is a special entity and does not support subscriptions.')}
+        </p>
+      ) : (
         <>
-          <p>
-            {entityType === 'editor' ? (
-              viewingOwnProfile ? (
-                texp.ln(
-                  `There is currently {num} user subscribed to edits
-                   that you make:`,
-                  `There are currently {num} users subscribed to edits
-                   that you make:`,
-                  publicEditors.length + privateEditors,
-                  {
-                    num: publicEditors.length + privateEditors,
-                  },
+          {(publicEditors.length || (privateEditors > 0)) ? (
+            <>
+              <p>
+                {entityType === 'editor' ? (
+                  viewingOwnProfile ? (
+                    texp.ln(
+                      `There is currently {num} user subscribed to edits
+                        that you make:`,
+                      `There are currently {num} users subscribed to edits
+                        that you make:`,
+                      publicEditors.length + privateEditors,
+                      {
+                        num: publicEditors.length + privateEditors,
+                      },
+                    )
+                  ) : (
+                    texp.ln(
+                      `There is currently {num} user subscribed to edits
+                        that {user} makes:`,
+                      `There are currently {num} users subscribed to edits
+                        that {user} makes:`,
+                      publicEditors.length + privateEditors,
+                      {
+                        num: publicEditors.length + privateEditors,
+                        user: entity.name,
+                      },
+                    )
+                  )
+                ) : (
+                  texp.ln(
+                    'There is currently {num} user subscribed to {entity}:',
+                    'There are currently {num} users subscribed to {entity}:',
+                    publicEditors.length + privateEditors,
+                    {
+                      entity: entity.name,
+                      num: publicEditors.length + privateEditors,
+                    },
+                  )
+                )}
+              </p>
+              <ul>
+                {publicEditors.map(editor => (
+                  <li key={editor.id}>
+                    <EditorLink editor={editor} />
+                  </li>
+                ))}
+                {publicEditors.length && (privateEditors > 0) ? (
+                  <li>
+                    {texp.ln(
+                      'Plus {n} other anonymous user',
+                      'Plus {n} other anonymous users',
+                      privateEditors,
+                      {n: privateEditors},
+                    )}
+                  </li>
+                ) : (
+                  privateEditors > 0 ? (
+                    <li>
+                      {texp.ln(
+                        'An anonymous user',
+                        '{n} anonymous users',
+                        privateEditors,
+                        {n: privateEditors},
+                      )}
+                    </li>
+                  ) : null
+                )}
+              </ul>
+            </>
+          ) : (
+            <p>
+              {entityType === 'editor' ? (
+                viewingOwnProfile ? (
+                  l(`There are currently no users subscribed to edits
+                     that you make.`)
+                ) : (
+                  texp.l(`There are currently no users subscribed to edits
+                          that {user} makes.`,
+                         {user: entity.name})
                 )
               ) : (
-                texp.ln(
-                  `There is currently {num} user subscribed to edits
-                   that {user} makes:`,
-                  `There are currently {num} users subscribed to edits
-                   that {user} makes:`,
-                  publicEditors.length + privateEditors,
-                  {
-                    num: publicEditors.length + privateEditors,
-                    user: entity.name,
-                  },
-                )
-              )
-            ) : (
-              texp.ln(
-                'There is currently {num} user subscribed to {entity}:',
-                'There are currently {num} users subscribed to {entity}:',
-                publicEditors.length + privateEditors,
-                {
-                  entity: entity.name,
-                  num: publicEditors.length + privateEditors,
-                },
-              )
-            )}
-          </p>
-          <ul>
-            {publicEditors.map(editor => (
-              <li key={editor.id}>
-                <EditorLink editor={editor} />
-              </li>
-            ))}
-            {publicEditors.length && (privateEditors > 0) ? (
-              <li>
-                {texp.ln(
-                  'Plus {n} other anonymous user',
-                  'Plus {n} other anonymous users',
-                  privateEditors,
-                  {n: privateEditors},
-                )}
-              </li>
-            ) : (
-              privateEditors > 0 ? (
-                <li>
-                  {texp.ln(
-                    'An anonymous user',
-                    '{n} anonymous users',
-                    privateEditors,
-                    {n: privateEditors},
-                  )}
-                </li>
-              ) : null
-            )}
-          </ul>
-        </>
-      ) : (
-        <p>
-          {entityType === 'editor' ? (
-            viewingOwnProfile ? (
-              l(`There are currently no users subscribed to edits
-                 that you make.`)
-            ) : (
-              texp.l(`There are currently no users subscribed to edits
-                      that {user} makes.`,
-                     {user: entity.name})
-            )
-          ) : (
-            texp.l('There are currently no users subscribed to {entity}.',
-                   {entity: entity.name})
+                texp.l('There are currently no users subscribed to {entity}.',
+                       {entity: entity.name})
+              )}
+            </p>
           )}
-        </p>
-      )}
 
-      {viewingOwnProfile ? null : (
-        <p>
-          {subscribed ? (
-            exp.l('You are currently subscribed. {unsub|Unsubscribe}?',
-                  {unsub: unsubLink})
-          ) : (
-            (publicEditors.length + privateEditors === 0) ? (
-              exp.l('Be the first! {sub|Subscribe}?',
-                    {sub: subLink})
-            ) : (
-              exp.l('You are not currently subscribed. {sub|Subscribe}?',
-                    {sub: subLink})
-            )
+          {viewingOwnProfile ? null : (
+            <p>
+              {subscribed ? (
+                exp.l('You are currently subscribed. {unsub|Unsubscribe}?',
+                      {unsub: unsubLink})
+              ) : (
+                (publicEditors.length + privateEditors === 0) ? (
+                  exp.l('Be the first! {sub|Subscribe}?',
+                        {sub: subLink})
+                ) : (
+                  exp.l('You are not currently subscribed. {sub|Subscribe}?',
+                        {sub: subLink})
+                )
+              )}
+            </p>
           )}
-        </p>
+        </>
       )}
     </LayoutComponent>
   );

--- a/root/static/scripts/common/utility/isSpecialPurpose.js
+++ b/root/static/scripts/common/utility/isSpecialPurpose.js
@@ -16,7 +16,9 @@ import {
   VARTIST_GID,
 } from '../constants';
 
-export default function isSpecialPurpose(entity: ArtistT | LabelT): boolean {
+export default function isSpecialPurpose(
+  entity: CoreEntityT | CollectionT | EditorT,
+): boolean {
   if (entity.entityType === 'artist') {
     return !!(
       (entity.id === DARTIST_ID || entity.id === VARTIST_ID) ||


### PR DESCRIPTION
### Implement MBS-11130

While special entities don't show the subscribers link on the sidebar, it's still possible to navigate to /subscribers manually. There, a "Subscribe" link that did nothing could be found.

This makes it so that entities that do not support subscribing just state that on that page instead.

NB: A lot of the changes here are just extra indent.