### PR TITLE
MBS-11195: Convert the artist-credit-renamer to React

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -72,24 +72,13 @@
       </fieldset>
 
       [% IF artist_credits.size %]
-      <fieldset id="artist-credit-renamer">
-        <legend>[% l('Artist Credits') %]</legend>
-        <p>
-            [%- l('Please select the {doc|artist credits} that you want to rename to follow the new artist name.', {doc => doc_link('Artist Credits')}) -%]
-        </p>
-        <p>
-            [%- l('This will enter additional edits to change each specific credit to use the new name. Only use this if you are sure the existing credits are incorrect (e.g. for typos).') -%]
-        </p>
-        <p>
-            [%- l('Keep in mind artist credits should generally follow what is printed on releases. If an artist has changed their name, but old releases were credited to the existing name, do not change the artist credit.') -%]
-        </p>
-        <p>
-            [%- selected_acs = form.rename_artist_credit_set() -%]
-            [% FOR ac IN artist_credits %]
-            <span class="rename-artist-credit"><input type="checkbox" name="edit-artist.rename_artist_credit" value="[% ac.id %]" [% IF selected_acs.item(ac.id) %]checked="checked"[% END %] />[% artist_credit(ac) %]<span class="ac-preview" style="display:none"><br />([% l('preview:') %] [% artist_credit(ac) %])</span></span><br />
-            [% END %]
-        </p>
-      </fieldset>
+      [% React.embed(c, 'static/scripts/artist/components/ArtistCreditRenamer', {
+        artistCredits => artist_credits,
+        artistMbid => artist.gid,
+        artistName => artist.name,
+        initialArtistName => form.field('name').value,
+        initialSelectedArtistCreditIds => form.rename_artist_credit_set(),
+      }) %]
       [% END %]
 
       [% INCLUDE 'forms/edit-note.tt' %]
@@ -110,11 +99,7 @@
 
 <script type="text/javascript">
   (function () {
-    var edit = MB.Control.ArtistEdit();
-
-    [% IF artist -%]
-      edit.initializeArtistCreditPreviews("[% artist.gid %]");
-    [%- END %]
+    MB.Control.ArtistEdit();
 
     MB.initializeDuplicateChecker('artist');
 

--- a/root/edit/details/EditArtistCredit.js
+++ b/root/edit/details/EditArtistCredit.js
@@ -28,15 +28,17 @@ const EditArtistCredit = ({edit}: Props): React.Element<'table'> => {
 
   return (
     <table className="details split-artist">
-      <tr>
-        <th>{addColonText(l('Artist Credit'))}</th>
-        <td className="old">
-          <ExpandedArtistCredit artistCredit={display.artist_credit.old} />
-        </td>
-        <td className="new">
-          <ExpandedArtistCredit artistCredit={display.artist_credit.new} />
-        </td>
-      </tr>
+      <tbody>
+        <tr>
+          <th>{addColonText(l('Artist Credit'))}</th>
+          <td className="old">
+            <ExpandedArtistCredit artistCredit={display.artist_credit.old} />
+          </td>
+          <td className="new">
+            <ExpandedArtistCredit artistCredit={display.artist_credit.new} />
+          </td>
+        </tr>
+      </tbody>
     </table>
   );
 };

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -387,6 +387,7 @@ module.exports = {
   'release/ReleaseHeader': require('../release/ReleaseHeader'),
   'release_group/ReleaseGroupHeader': require('../release_group/ReleaseGroupHeader'),
   'series/SeriesHeader': require('../series/SeriesHeader'),
+  'static/scripts/artist/components/ArtistCreditRenamer': require('../static/scripts/artist/components/ArtistCreditRenamer'),
   'static/scripts/common/components/Annotation': require('../static/scripts/common/components/Annotation'),
   'static/scripts/common/components/ArtistCreditLink': require('../static/scripts/common/components/ArtistCreditLink'),
   'static/scripts/common/components/CritiqueBrainzReview': require('../static/scripts/common/components/CritiqueBrainzReview'),

--- a/root/static/scripts/artist.js
+++ b/root/static/scripts/artist.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import './artist/components/ArtistCreditRenamer';
+
 import typeBubble from './edit/typeBubble';
 
 const typeIdField = 'select[name=edit-artist\\.type_id]';

--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -1,0 +1,304 @@
+/*
+ * @flow
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import $ from 'jquery';
+import * as React from 'react';
+
+import hydrate from '../../../../utility/hydrate';
+import ArtistCreditLink from '../../common/components/ArtistCreditLink';
+import {compare} from '../../common/i18n';
+import {reduceArtistCredit} from '../../common/immutable-entities';
+import {bracketedText} from '../../common/utility/bracketed';
+import {sortedIndexWith} from '../../common/utility/arrays';
+import diffArtistCredits from '../../edit/utility/diffArtistCredits';
+
+type ArtistCreditWithIdT = $ReadOnly<{
+  ...ArtistCreditT,
+  +id: number,
+}>;
+
+type ArtistCreditRowPropsT = {
+  +artistCredit: ArtistCreditWithIdT,
+  +dispatch: (ActionT) => void,
+  +isInitiallyChecked: boolean,
+};
+
+type ArtistCreditRenamerPropsT = {
+  +artistCredits: $ReadOnlyArray<ArtistCreditWithIdT>,
+  +artistMbid: string,
+  +artistName: string,
+  +initialArtistName: string,
+  +initialSelectedArtistCreditIds: {+[artistCreditId: number]: 1},
+};
+
+type StateT = {
+  +expanded: boolean,
+  +name: string,
+  +selection: Array<ArtistCreditWithIdT>,
+};
+
+/* eslint-disable flowtype/sort-keys */
+type ActionT =
+  | {
+      +type: 'set-expanded',
+      +expanded: boolean,
+    }
+  | {
+      +type: 'set-name',
+      +name: string,
+    }
+  | {
+      +type: 'toggle-artist-credit',
+      +artistCredit: ArtistCreditWithIdT,
+      +checked: boolean,
+    };
+/* eslint-enable flowtype/sort-keys */
+
+const MARGIN_1EM = {margin: '1em'};
+
+function compareArtistCredits(ac1, ac2) {
+  return compare(
+    reduceArtistCredit(ac1),
+    reduceArtistCredit(ac2),
+  );
+}
+
+function createInitialState(name: string): StateT {
+  return {expanded: false, name, selection: []};
+}
+
+function reducer(state: StateT, action: ActionT): StateT {
+  switch (action.type) {
+    case 'set-expanded': {
+      return {...state, expanded: action.expanded};
+    }
+    case 'set-name': {
+      return {...state, name: action.name};
+    }
+    case 'toggle-artist-credit': {
+      const selection = state.selection;
+      const {artistCredit, checked} = action;
+      if (checked) {
+        const [index] = sortedIndexWith(
+          selection,
+          artistCredit,
+          compareArtistCredits,
+        );
+        const newSelection = [...selection];
+        newSelection.splice(index, 0, artistCredit);
+        return {...state, selection: newSelection};
+      }
+      return {
+        ...state,
+        selection: selection.filter(x => x !== artistCredit),
+      };
+    }
+  }
+  return state;
+}
+
+const ArtistCreditRow = ({
+  artistCredit,
+  dispatch,
+  isInitiallyChecked,
+}: ArtistCreditRowPropsT) => {
+  const [isChecked, setChecked] = React.useState(isInitiallyChecked);
+  return (
+    <div>
+      <input
+        checked={isChecked}
+        name="edit-artist.rename_artist_credit"
+        onChange={(event) => {
+          const checked = event.target.checked;
+          setChecked(checked);
+          dispatch({
+            artistCredit,
+            checked,
+            type: 'toggle-artist-credit',
+          });
+        }}
+        type="checkbox"
+        value={artistCredit.id}
+      />
+      <ArtistCreditLink artistCredit={artistCredit} />
+    </div>
+  );
+};
+
+const ArtistCreditRenamer = ({
+  artistCredits,
+  artistMbid,
+  artistName,
+  initialArtistName,
+  initialSelectedArtistCreditIds,
+}: ArtistCreditRenamerPropsT): React.MixedElement | null => {
+  const rowsRef = React.useRef(null);
+
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    initialArtistName,
+    createInitialState,
+  );
+
+  if (!rowsRef.current) {
+    // Cache the element list for artists with hundreds of ACs.
+    rowsRef.current = artistCredits.map(artistCredit => {
+      const id = artistCredit.id;
+      const isChecked = !!initialSelectedArtistCreditIds[id];
+      if (isChecked) {
+        // This is only safe on first render!
+        state.selection.push(artistCredit);
+      }
+      return (
+        <ArtistCreditRow
+          artistCredit={artistCredit}
+          dispatch={dispatch}
+          isInitiallyChecked={isChecked}
+          key={id}
+        />
+      );
+    });
+  }
+
+  const rows = rowsRef.current;
+  const tooManyRows = rows.length > 10;
+  const installedArtistNameEvent = React.useRef(false);
+
+  const handleArtistNameChange = React.useCallback((event) => {
+    dispatch({name: event.target.value, type: 'set-name'});
+  }, [dispatch]);
+
+  React.useEffect(() => {
+    if (!installedArtistNameEvent.current) {
+      $(document).on(
+        'input',
+        '#id-edit-artist\\.name',
+        handleArtistNameChange,
+      );
+      installedArtistNameEvent.current = true;
+    }
+    return () => {
+      $(document).off(
+        'input',
+        '#id-edit-artist\\.name',
+        handleArtistNameChange,
+      );
+    };
+  }, [handleArtistNameChange]);
+
+  return (
+    <fieldset
+      id="artist-credit-renamer"
+      style={{display: artistName === state.name ? 'none' : 'block'}}
+    >
+      <legend>{l('Artist Credits')}</legend>
+      <p>
+        {exp.l(
+          `Please select the {doc|artist credits} that you want to
+           rename to follow the new artist name.`,
+          {doc: '/doc/Artist_Credits'},
+        )}
+      </p>
+      <p>
+        {l(`This will enter additional edits to change each specific
+            credit to use the new name. Only use this if you are sure
+            the existing credits are incorrect (e.g. for typos).`)}
+      </p>
+      <p>
+        {l(`Keep in mind artist credits should generally follow what is
+            printed on releases. If an artist has changed their name,
+            but old releases were credited to the existing name, do not
+            change the artist credit.`)}
+      </p>
+      <div
+        className={
+          'collapsible-body' +
+          ((tooManyRows && !state.expanded) ? ' collapsed' : '')}
+        key="artist-credits"
+        style={MARGIN_1EM}
+      >
+        {rows}
+      </div>
+      {tooManyRows ? (
+        state.expanded ? (
+          <div style={MARGIN_1EM}>
+            <a
+              href="#"
+              onClick={(event) => {
+                event.preventDefault();
+                dispatch({expanded: false, type: 'set-expanded'});
+              }}
+              role="button"
+              title={l('Show less artist credits')}
+            >
+              {bracketedText(l('Show less...'))}
+            </a>
+          </div>
+        ) : (
+          <div style={MARGIN_1EM}>
+            <a
+              href="#"
+              onClick={(event) => {
+                event.preventDefault();
+                dispatch({expanded: true, type: 'set-expanded'});
+              }}
+              role="button"
+              title={l('Show more artist credits')}
+            >
+              {bracketedText(l('Show more...'))}
+            </a>
+          </div>
+        )
+      ) : null}
+      {state.selection.length ? (
+        <>
+          <h2>{l('Preview')}</h2>
+          <table
+            className="details split-artist"
+            style={MARGIN_1EM}
+          >
+            <tbody>
+              {state.selection.map((artistCredit) => {
+                const newArtistCredit = {
+                  ...artistCredit,
+                  names: artistCredit.names.map(x => (
+                    x.artist.gid === artistMbid
+                      ? {...x, name: state.name}
+                      : x
+                  )),
+                };
+
+                const diff = diffArtistCredits(
+                  artistCredit,
+                  newArtistCredit,
+                );
+
+                return (
+                  <tr key={'preview-' + String(artistCredit.id)}>
+                    <td className="old">
+                      {diff.old}
+                    </td>
+                    <td className="new">
+                      {diff.new}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </>
+      ) : null}
+    </fieldset>
+  );
+};
+
+export default (hydrate<ArtistCreditRenamerPropsT>(
+  'div.artist-credit-renamer',
+  ArtistCreditRenamer,
+): React.AbstractComponent<ArtistCreditRenamerPropsT, void>);

--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -85,47 +85,6 @@ MB.Control.ArtistEdit = function () {
   self.typeChanged();
   self.$type.bind('change.mb', self.typeChanged);
 
-  self.initializeArtistCreditPreviews = function (gid) {
-    var artistRe = new RegExp('/artist/' + gid + '$');
-    $('span.rename-artist-credit').each(function () {
-      var $ac = $(this);
-      $ac.find('input').change(function () {
-        var checked = this.checked;
-        var newName = self.$name.val();
-        $ac.find('span.ac-preview')[checked ? 'show' : 'hide']();
-        $ac.find('span.ac-preview a').each(function () {
-          var $link = $(this);
-          if ($link.data('old_name')) {
-            $link.text(checked ? newName : $link.data('old_name'));
-          }
-        });
-      });
-      $ac.find('input').each(function () {
-        $ac.find('span.ac-preview')[this.checked ? 'show' : 'hide']();
-      });
-      $ac.find('span.ac-preview a').each(function () {
-        var $link = $(this);
-        if (artistRe.test($link.attr('href'))) {
-          $link.data('old_name', $link.text());
-        }
-      });
-    });
-    self.$name.change(function () {
-      var newName = self.$name.val();
-      $('span.rename-artist-credit').each(function () {
-        var $ac = $(this);
-        if ($ac.find('input:checked').length) {
-          $ac.find('span.ac-preview a').each(function () {
-            var $link = $(this);
-            if ($link.data('old_name')) {
-              $link.text(newName);
-            }
-          });
-        }
-      });
-    });
-  };
-
   MB.Control.RangeSelect(
     '#artist-credit-renamer span.rename-artist-credit input[type="checkbox"]',
   );

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -74,6 +74,10 @@ fieldset legend {
     font-weight: bold;
 }
 
+fieldset h2 {
+    margin-left: 1em;
+}
+
 #sidebar h2, .sidebar h2 {
     font-size: @medium-text;
     margin-left: -5px;
@@ -1048,17 +1052,26 @@ div.artwork { position: relative; width: 250px; }
     display: block;
 }
 
-.annotation-body, .review-body, .wikipedia-extract-body {
+.annotation-body,
+.review-body,
+.wikipedia-extract-body,
+.collapsible-body {
     position: relative;
     overflow: auto;
 }
 
-.annotation-collapsed, .review-collapsed, .wikipedia-extract-collapsed {
+.annotation-collapsed,
+.review-collapsed,
+.wikipedia-extract-collapsed,
+.collapsed {
     max-height: 100px;
     overflow: hidden;
 }
 
-.annotation-collapsed:after, .review-collapsed:after, .wikipedia-extract-collapsed:after {
+.annotation-collapsed:after,
+.review-collapsed:after,
+.wikipedia-extract-collapsed:after,
+.collapsed:after {
     display: block;
     position: absolute;
     bottom: 0;

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -40,10 +40,10 @@ module.exports = {
   externals: [
     nodeExternals({
       /*
-       * @popperjs is resolved to root/static/scripts/empty.js on the server.
-       * See NormalModuleReplacementPlugin below.
+       * jquery and @popperjs are resolved to root/static/scripts/empty.js
+       * on the server. See NormalModuleReplacementPlugin below.
        */
-      whitelist: [/@popperjs/],
+      whitelist: [/(jquery|@popperjs)/],
       modulesFromFile: true,
     }),
 
@@ -78,11 +78,10 @@ module.exports = {
 
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
-      /@popperjs/,
+      /(jquery|@popperjs)/,
       path.resolve(dirs.SCRIPTS, 'empty.js'),
     ),
     new webpack.DefinePlugin(definePluginConfig),
-    new webpack.IgnorePlugin({resourceRegExp: /jquery/}),
     new webpack.ProvidePlugin(providePluginConfig),
   ],
 


### PR DESCRIPTION
I tested with the extreme case of 9ddd7abc-9e1b-471d-8031-583bc6bc8be9 and tried to guarantee acceptable performance by caching the rows and keeping the checkbox state local.

Previews are now displayed at the bottom instead of inline, and use the `diffArtistCredits` utility.

The list is collapsed if there are more than 10 artist credits. (I've used the hide technique that annotations use, since actually adding/removing hundreds of items to the DOM is extremely slow.)

This also fixes MBS-6666 by hiding the fieldset if the artist name hasn't changed.