### PR TITLE
MBS-11194: Fix ISE when historic EditRelationship data is broken 

### DIFF
--- a/root/edit/details/historic/EditRelationship.js
+++ b/root/edit/details/historic/EditRelationship.js
@@ -130,7 +130,16 @@ const EditRelationship = ({
           <td>
             <ul>
               {newRels.map((newRel, index) => {
-                const oldRel = oldRels[index];
+                /*
+                 * Some relationships seem to have broken data where oldRel
+                 * might not exist for every newRel. In those cases, we
+                 * display newRel unchanged (diff with itself) in order
+                 * to show *something* in the least bad way possible.
+                 */
+                let oldRel = oldRels[index];
+                if (isDataBroken && !oldRel) {
+                  oldRel = newRel;
+                }
                 const oldLinkType =
                   linkedEntities.link_type[oldRel.linkTypeID];
                 const newLinkType =

--- a/root/edit/details/historic/EditRelationship.js
+++ b/root/edit/details/historic/EditRelationship.js
@@ -71,12 +71,10 @@ const EditRelationship = ({
                   linkedEntities.link_type[oldRel.linkTypeID];
                 const oldSource =
                   linkedEntities[oldLinkType.type0][oldRel.entity0_id];
-                const newLinkType = newRel
-                  ? linkedEntities.link_type[newRel.linkTypeID]
-                  : oldLinkType;
-                const newSource = newLinkType
-                  ? linkedEntities[newLinkType.type0][newRel.entity0_id]
-                  : oldSource;
+                const newLinkType =
+                  linkedEntities.link_type[newRel.linkTypeID];
+                const newSource =
+                  linkedEntities[newLinkType.type0][newRel.entity0_id];
                 return (
                   <li key={oldRel.id}>
                     <span
@@ -105,8 +103,7 @@ const EditRelationship = ({
                     <span
                       className={oldRel.target.id === newRel.target.id
                         ? null
-                        : 'diff-only-a'
-                      }
+                        : 'diff-only-a'}
                     >
                       <DescriptiveLink entity={oldRel.target} />
                     </span>


### PR DESCRIPTION
### Fix MBS-11194

We fixed this for missing newRel with MBS-10901 (https://github.com/metabrainz/musicbrainz-server/pull/1575) but apparently it also happens the other way around in some cases.

Also reverting a couple changes from that PR that seem unneeded.