### PR TITLE
MBS-11197: Add validation for Mainly Norfolk links and normalize

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1933,6 +1933,22 @@ const CLEANUPS = {
       url = url.replace(/^https:\/\/mainlynorfolk\.info\/([^/]+)(?:\/index\.html)?$/, 'https://mainlynorfolk.info/$1/');
       return url;
     },
+    validate: function (url, id) {
+      if (id === LINK_TYPES.otherdatabases.artist) {
+        return {result: /^https:\/\/mainlynorfolk\.info\/(?:[^/]+)\/$/.test(url)};
+      }
+      const m = /^https:\/\/mainlynorfolk\.info\/(?:[^/]+)\/(records|songs)\/(?:[^/]+)$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.release:
+            return {result: prefix === 'records'};
+          case LINK_TYPES.otherdatabases.work:
+            return {result: prefix === 'songs'};
+        }
+      }
+      return {result: false};
+    },
   },
   'maniadb': {
     match: [new RegExp('^(https?://)?(www\\.)?maniadb\\.com', 'i')],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1925,6 +1925,15 @@ const CLEANUPS = {
     ],
     type: LINK_TYPES.lyrics,
   },
+  'mainlynorfolk': {
+    match: [new RegExp('^(https?://)?(www\\.)?mainlynorfolk\\.info', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?mainlynorfolk\.info\//, 'https://mainlynorfolk.info/');
+      url = url.replace(/^https:\/\/mainlynorfolk\.info\/([^/]+)(?:\/index\.html)?$/, 'https://mainlynorfolk.info/$1/');
+      return url;
+    },
+  },
   'maniadb': {
     match: [new RegExp('^(https?://)?(www\\.)?maniadb\\.com', 'i')],
     type: LINK_TYPES.otherdatabases,
@@ -2303,7 +2312,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www22\\.)?big\\.or\\.jp', 'i'),
       new RegExp('^(https?://)?(www\\.)?japanesemetal\\.gooside\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?d-nb\\.info', 'i'),
-      new RegExp('^(https?://)?(www\\.)?mainlynorfolk\\.info', 'i'),
       new RegExp('^(https?://)?(www\\.)?tedcrane\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?thedancegypsy\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?bibliotekapiosenki\\.pl', 'i'),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2188,9 +2188,16 @@ const testData = [
   },
   // Mainly Norfolk
   {
-                     input_url: 'http://mainlynorfolk.info/martin.carthy/records/themoraloftheelephant.html',
+                     input_url: 'https://www.mainlynorfolk.info/watersons/index.html',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://mainlynorfolk.info/watersons/',
+  },
+  {
+                     input_url: 'http://www.mainlynorfolk.info/martin.carthy/records/themoraloftheelephant.html',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://mainlynorfolk.info/martin.carthy/records/themoraloftheelephant.html',
   },
   // maniadb
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2192,12 +2192,21 @@ const testData = [
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://mainlynorfolk.info/watersons/',
+       only_valid_entity_types: ['artist'],
   },
   {
                      input_url: 'http://www.mainlynorfolk.info/martin.carthy/records/themoraloftheelephant.html',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://mainlynorfolk.info/martin.carthy/records/themoraloftheelephant.html',
+       only_valid_entity_types: ['release'],
+  },
+  {
+                     input_url: 'https://www.mainlynorfolk.info/watersons/songs/countrylife.html',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://mainlynorfolk.info/watersons/songs/countrylife.html',
+       only_valid_entity_types: ['work'],
   },
   // maniadb
   {


### PR DESCRIPTION
### Implements MBS-11197

The site redirects to HTTPS. I'm also normalizing to drop www. since both options are valid and the vast majority of our links don't include it (the site just accepts either without redirecting).

Works and artists are straightforward. I chose release rather than release group for 'records' because the site gives a format and catno, from what I can see.

This drops index.hml from artist pages because it's unneeded. It does not drop #sections because it seems in some cases different album pages are actually sections of a larger discography but we might still want to link to them.
