### PR TITLE
MBS-11204: Avoid crashing if entity1_id is missing

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Relationship.pm
@@ -220,7 +220,7 @@ sub _display_relationships {
             my $model0 = type_to_model( $_->{entity0_type} );
             my $model1 = type_to_model( $_->{entity1_type} );
             my $entity0_id = $_->{entity0_id} // $fake_entity_id++;
-            my $entity1_id = $_->{entity1_id};
+            my $entity1_id = $_->{entity1_id} // $fake_entity_id++;
             my $entity0 = $loaded->{ $model0 }{ $entity0_id } ||
                 $self->c->model($model0)->_entity_class->new(
                     id => $entity0_id,


### PR DESCRIPTION
### Fix MBS-11204

Equivalent of MBS-10833 (https://github.com/metabrainz/musicbrainz-server/pull/1543) for entity0_id.

Some old edits (at least edit 6774077) are missing this. Since this is later loaded via linkedEntities, we need to use the same "fake entity ID" method we use for entity0 to access it (and since _display_relationships could hit several cases where this is needed, the fake ID needs to be distinct every time).
