### PR TITLE
MBS-10664: Allow more tags in expand2react

### DIFF
--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -46,7 +46,7 @@ const condSubstThenTextContent = /^[^<>{}|]+/;
 const percentSign = /(%)/;
 const linkSubstStart = /^\{([0-9A-z_]+)\|/;
 const htmlTagStart = /^<(?=[a-z])/;
-const htmlTagName = /^(a|abbr|br|code|em|li|p|span|strong|ul)(?=[\s\/>])/;
+const htmlTagName = /^(a|abbr|br|code|em|h1|h2|h3|h4|h5|h6|hr|li|ol|p|span|strong|ul)(?=[\s\/>])/;
 const htmlTagEnd = /^>/;
 const htmlSelfClosingTagEnd = /^\s*\/>/;
 const htmlAttrStart = /^\s+(?=[a-z])/;


### PR DESCRIPTION
### Fix MBS-10664

This adds html tags legitimately generated by our MediaWiki syntax (annotations, bios, etc) to htmlTagName. While the
MediaWiki syntax parser sometimes generates invalid tags or puts them in the wrong order, this should unbreak some bios and cause no problems.

Originally part of https://github.com/metabrainz/musicbrainz-server/pull/1653