### PR TITLE
MBS-9388: Show relationship credits on Aliases tab

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -6,6 +6,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller'; }
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Area',
     relationships   => {
+        all         => ['aliases'],
         cardinal    => ['edit'],
         subset      => {
             show => [qw( area artist label place series instrument release_group url )],

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -9,7 +9,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller'; }
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Artist',
     relationships   => {
-        all         => ['relationships'],
+        all         => ['aliases', 'relationships'],
         cardinal    => ['edit'],
         subset      => { split => ['artist'], show => ['artist', 'url'] },
         default     => ['url']

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -17,7 +17,11 @@ use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Instrument',
     entity_name     => 'instrument',
-    relationships   => { cardinal => ['show', 'edit'], default => ['url'] },
+    relationships   => {
+        all         => ['aliases'],
+        cardinal    => ['show', 'edit'],
+        default     => ['url'],
+    },
 };
 with 'MusicBrainz::Server::Controller::Role::LoadWithRowID';
 with 'MusicBrainz::Server::Controller::Role::Annotation';

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -7,7 +7,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Label',
     entity_name     => 'label',
     relationships   => {
-        all => ['relationships'],
+        all => ['aliases', 'relationships'],
         cardinal => ['edit'],
         default => ['url'],
         subset => { show => ['artist', 'url'] }

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -9,8 +9,9 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         cardinal    => ['edit'],
         default     => ['url'],
         subset      => {
-            show => [qw( area artist label place url work series instrument )],
-            performances => [qw( release release_group recording work url )],
+            all             => ['aliases'],
+            show            => [qw( area artist label place url work series instrument )],
+            performances    => [qw( release release_group recording work url )],
         }
     },
 };

--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -1,5 +1,9 @@
 package MusicBrainz::Server::Controller::Role::Alias;
 use Moose::Role -traits => 'MooseX::MethodAttributes::Role::Meta::Role';
+use List::AllUtils qw( uniq );
+use MusicBrainz::Server::Constants qw(
+    %ENTITIES_WITH_RELATIONSHIP_CREDITS
+);
 use MusicBrainz::Server::ControllerUtils::Delete qw( cancel_or_action );
 
 requires 'load';
@@ -47,6 +51,16 @@ sub aliases : Chained('load') PathPart('aliases')
         aliases => $aliases,
         entity => $entity,
     );
+
+    if ($ENTITIES_WITH_RELATIONSHIP_CREDITS{$self->{entity_name}}) {
+        my $relationships = $entity->{relationships};
+        my @relationship_credits = uniq sort {$a cmp $b} grep { $_ ne '' } map {
+            $_->direction == 2
+                ? $_->entity1_credit
+                : $_->entity0_credit
+        } @$relationships;
+        $props{relationshipCredits} = \@relationship_credits;
+    }
 
     $c->stash(
         # "aliases" needs to remain here for JSON-LD serialization

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -31,7 +31,8 @@ const ArtistCreditList = ({
       <p>
         {exp.l(
           `This is a list of all the different ways {artist} is credited
-           in the database. View the {doc|artist credit documentation}
+           as the artist in tracks, recordings, releases and release groups.
+           View the {doc|artist credit documentation}
            for more details.`,
           {
             artist: <EntityLink entity={entity} />,

--- a/root/components/Aliases/RelationshipCreditList.js
+++ b/root/components/Aliases/RelationshipCreditList.js
@@ -1,0 +1,59 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import EntityLink from '../../static/scripts/common/components/EntityLink';
+import loopParity from '../../utility/loopParity';
+
+type Props = {
+  +entity: CoreEntityT,
+  +relationshipCredits: $ReadOnlyArray<string>,
+};
+
+const RelationshipCreditList = ({
+  entity,
+  relationshipCredits,
+}: Props): React.Element<typeof React.Fragment> => {
+  return (
+    <>
+      <h2>{l('Relationship credits')}</h2>
+      <p>
+        {exp.l(
+          `This is a list of all the different ways {artist} is credited
+           in relationships.`,
+          {
+            artist: <EntityLink entity={entity} />,
+          },
+        )}
+      </p>
+
+      <table className="tbl artist-credits">
+        <thead>
+          <tr>
+            <th>
+              {l('Name')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {relationshipCredits.map((credit, index) => (
+            <tr className={loopParity(index)} key={'rel-credit-' + index}>
+              <td>
+                {credit}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+export default RelationshipCreditList;

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -12,12 +12,15 @@ import * as React from 'react';
 import chooseLayoutComponent from '../utility/chooseLayoutComponent';
 import AliasesComponent from '../components/Aliases';
 import ArtistCreditList from '../components/Aliases/ArtistCreditList';
+import RelationshipCreditList
+  from '../components/Aliases/RelationshipCreditList';
 
 type Props = {
   +$c: CatalystContextT,
   +aliases: $ReadOnlyArray<AliasT>,
   +artistCredits?: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
   +entity: CoreEntityT,
+  +relationshipCredits?: $ReadOnlyArray<string>,
 };
 
 const Aliases = ({
@@ -25,6 +28,7 @@ const Aliases = ({
   aliases,
   artistCredits,
   entity,
+  relationshipCredits,
 }: Props): React.MixedElement => {
   const entityType = entity.entityType;
   const LayoutComponent = chooseLayoutComponent(entityType);
@@ -42,6 +46,12 @@ const Aliases = ({
           $c={$c}
           artistCredits={artistCredits}
           entity={entity}
+        />
+      ) : null}
+      {relationshipCredits?.length ? (
+        <RelationshipCreditList
+          entity={entity}
+          relationshipCredits={relationshipCredits}
         />
       ) : null}
     </LayoutComponent>


### PR DESCRIPTION
### Implement MBS-9388

Two commits here.

The first we should change for sure. It changes the blurb of the artist credits section of the aliases page to make it less misleading: we also have relationship credits, which are not artist credits, so we shouldn't claim this is "all the ways the artist is credited in the database".

The second adds a list of relationship credits to the same page. We display all other names given to the entity in the DB there, so it probably makes sense to display these too. I do somewhat worry that it will make alias pages for artists and areas with tons of relationships pretty slow though.
