### PR TITLE
Align comments with new code (very minor low priority PR)

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
@@ -15,7 +15,7 @@ role {
 =method can_amend
 
 Check if an editor is still allowed to amend an entity, that is,
-if it has been created by the same editor less than an hour ago.
+if it has been created by the same editor less than one day ago.
 
 =cut
 


### PR DESCRIPTION
# Problem

MBS-9505's 618e9109d151562e7787a1f76d87b75916d8117f changed auto edit grace period from 1h to 1 day but associated comment (just for coders) is still mentioning 1h.

# Solution

I just updated the comments

It should have no impact on MBS runtime.