### PR TITLE
MBS-11111: Set edit_pendings on recordings merged with release

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -181,6 +181,16 @@ sub initialize {
     $self->data(\%opts);
 }
 
+sub alter_edit_pending
+{
+    my $self = shift;
+    my @recording_ids = map { $_->{id} } map { $_->{destination}, @{ $_->{sources} } } @{ $self->recording_merges // [] };
+    return {
+        Release => [ $self->release_ids ],
+        @recording_ids ? (Recording => [ @recording_ids ]) : (),    
+    }
+}
+
 override build_display_data => sub
 {
     my ($self, $loaded) = @_;

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -159,6 +159,8 @@ test 'Linking Merge Release edits to recordings' => sub {
     # Use a set because the order can be different, but the elements should be the same.
     use Set::Scalar;
     is(Set::Scalar->new(2, 3)->compare(Set::Scalar->new(@{ $edit->related_entities->{recording} })), 'equal', "Related recordings are correct");
+    my $recording_in_merge = $c->model('Recording')->get_by_id(2);
+    is($recording_in_merge->edits_pending, 1, 'Recording has pending edits with MERGE_MERGE');
 
     $edit = $c->model('Edit')->create(
         edit_type => $EDIT_RELEASE_MERGE,


### PR DESCRIPTION
### Implement MBS-11111

If a release merge is going to merge recordings, we should also show those recordings as having pending edits, since otherwise it's easy to miss that they shouldn't be merged or whatnot separately.
