### PR TITLE
MBS-11126: display track lengths of 0 ms or -1 ms as unknown

### DIFF
--- a/root/edit/details/historic/AddTrackKV.js
+++ b/root/edit/details/historic/AddTrackKV.js
@@ -35,6 +35,13 @@ type Props = {
 const AddTrackKV = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
   const artist = display.artist;
+  /*
+   * Some lengths of -1 or 0 ms are stored, which is nonsensical
+   * and probably meant as a placeholder for unknown duration
+   */
+  const length = (display.length != null && display.length <= 0)
+    ? null
+    : display.length;
 
   return (
     <table className="details add-track">
@@ -66,7 +73,7 @@ const AddTrackKV = ({edit}: Props): React.Element<'table'> => {
 
       <tr>
         <th>{addColonText(l('Length'))}</th>
-        <td>{formatTrackLength(display.length)}</td>
+        <td>{formatTrackLength(length)}</td>
       </tr>
     </table>
   );


### PR DESCRIPTION
### Fix MBS-11126

This doesn't seem to make any sense, I assume it's either an error or a placeholder. At least in one case ([edit 8513870](https://musicbrainz.org/edit/8513870)) the track length originally shown here as 0 ms is shown as ?:?? when being edited in a further edit. See also [edit 8934453](https://musicbrainz.org/edit/8934453) (-1).