### PR TITLE
MBS-11227: Ensure /release-group/merge also works

### DIFF
--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -142,6 +142,13 @@ with 'MusicBrainz::Server::Controller::Role::Merge' => {
     edit_type => $EDIT_RELEASEGROUP_MERGE,
 };
 
+sub forward_merge : Chained('/') PathPart('release-group/merge') {
+    # Since Role::Merge is generic it uses release_group rather than release-group
+    # like elsewhere. We should make sure nothing breaks if we expect release-group somewhere
+    my ($self, $c) = @_;    
+    $c->forward('/release_group/merge');
+}
+
 sub _merge_load_entities
 {
     my ($self, $c, @rgs) = @_;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -312,6 +312,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   "Controller::ReleaseGroup::base",
   "Controller::ReleaseGroup::details",
   "Controller::ReleaseGroup::edits",
+  "Controller::ReleaseGroup::forward_merge",
   "Controller::ReleaseGroup::latest_annotation",
   "Controller::ReleaseGroup::open_edits",
   "Controller::ReleaseGroup::ratings",


### PR DESCRIPTION
### Fix MBS-11227

The URL for RGs is usually release-group (see entities.json) but following the url in ENTITIES fails for merge because of it being defined in a generic role. This adds forwarding so that /release-group/merge works and just forwards to /release_group/merge.
