### PR TITLE
MBS-11225: Autoselect IROMBOOK images

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1754,6 +1754,15 @@ const CLEANUPS = {
       return {result: false};
     },
   },
+  'irombook': {
+    match: [new RegExp('^https://staticbrainz\\.org/irombook/')],
+    type: LINK_TYPES.image,
+    validate: function (url, id) {
+      return {
+        result: id === LINK_TYPES.image.instrument,
+      };
+    },
+  },
   'itunes': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?itunes\\.apple\\.com/', 'i')],
     type: LINK_TYPES.downloadpurchase,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1836,6 +1836,13 @@ const testData = [
             expected_clean_url: 'https://www.irishtune.info/tune/1499/',
        only_valid_entity_types: ['work'],
   },
+  // IROMBOOK images (StaticBrainz)
+  {
+                     input_url: 'https://staticbrainz.org/irombook/sitar/sitar.png',
+             input_entity_type: 'instrument',
+    expected_relationship_type: 'image',
+       only_valid_entity_types: ['instrument'],
+  },
   // (Apple) iTunes
   {
                      input_url: 'http://itunes.apple.com/artist/hangry-angry-f/id444923726',


### PR DESCRIPTION
### Implement MBS-11225

This autoselects IROMBOOK images on StaticBrainz as image links for instruments (and only for instruments).
