### PR TITLE
MBS-11221 / MBS-11234: Normalize whosampled.com links to HTTPS and add validation

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3215,6 +3215,62 @@ const CLEANUPS = {
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?whosampled\.com\/(.+)$/, 'https://www.whosampled.com/$1');
     },
+    validate: function (url, id) {
+      if (/[?#]/.test(url)) {
+        return {
+          error: l(
+            `There is an unencoded “?” or “#” character in this URL.
+             Please check whether it is useless and should be removed,
+             or whether it is an error and the URL is misencoded.`,
+          ),
+          result: false,
+        };
+      }
+      if (/^https:\/\/www\.whosampled\.com\/sample\//.test(url)) {
+        return {
+          error: l(
+            `Please do not link directly to WhoSampled sample pages.
+             Link to the appropriate artist, recording
+             or release page instead.`,
+          ),
+          result: false,
+        };
+      }
+      if (/^https:\/\/www\.whosampled\.com\/album\//.test(url)) {
+        if (id === LINK_TYPES.otherdatabases.release_group) {
+          return {result: true};
+        }
+        return {
+          error: l(
+            'Please link WhoSampled album pages to release groups.',
+          ),
+          result: false,
+        };
+      }
+      if (/^https:\/\/www\.whosampled\.com\/(?!(?:album|sample))[^/]+(?:\/)?$/.test(url)) {
+        if (id === LINK_TYPES.otherdatabases.artist) {
+          return {result: true};
+        }
+        return {
+          error: l(
+            'Please link WhoSampled artist pages to artists.',
+          ),
+          result: false,
+        };
+      }
+      if (/^https:\/\/www\.whosampled\.com\/(?!(?:album|sample))[^/]+\/[^/]+(?:\/)?$/.test(url)) {
+        if (id === LINK_TYPES.otherdatabases.recording) {
+          return {result: true};
+        }
+        return {
+          error: l(
+            'Please link WhoSampled song pages to recordings.',
+          ),
+          result: false,
+        };
+      }
+      return {result: false};
+    },
   },
   'wikidata': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?wikidata\\.org', 'i')],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2464,7 +2464,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?lortel\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?theatricalia\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?whosampled\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?imvdb\\.com', 'i'),
       new RegExp(
         '^(https?://)?(www\\.)?residentadvisor\\.net/(?!review)',
@@ -3208,6 +3207,13 @@ const CLEANUPS = {
     type: LINK_TYPES.socialnetwork,
     clean: function (url) {
       return url.replace(/^(?:https?:\/\/)?(?:[^/]+\.)?weibo\.com\/(u\/)?([^\/?#]+)(?:.*)$/, 'https://www.weibo.com/$1$2');
+    },
+  },
+  'whosampled': {
+    match: [new RegExp('^(https?://)?(www\\.)?whosampled\\.com', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?whosampled\.com\/(.+)$/, 'https://www.whosampled.com/$1');
     },
   },
   'wikidata': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3891,10 +3891,39 @@ const testData = [
   },
   // WhoSampled
   {
+                     input_url: 'https://www.whosampled.com/Death-Grips/',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/Death-Grips/',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://www.whosampled.com/Just-to-Get-a-Rep/Gang-Starr/',
              input_entity_type: 'recording',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://www.whosampled.com/Just-to-Get-a-Rep/Gang-Starr/',
+       only_valid_entity_types: ['recording'],
+  },
+  {
+                     input_url: 'https://www.whosampled.com/album/Pet-Shop-Boys/Very/',
+             input_entity_type: 'release_group',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/album/Pet-Shop-Boys/Very/',
+       only_valid_entity_types: ['release_group'],
+  },
+  {
+                     input_url: 'https://www.whosampled.com/Pet-Shop-Boys/Can-You-Forgive-Her?/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/Pet-Shop-Boys/Can-You-Forgive-Her?/',
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://www.whosampled.com/sample/127347/Death-Grips-5D-Pet-Shop-Boys-West-End-Girls/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/sample/127347/Death-Grips-5D-Pet-Shop-Boys-West-End-Girls/',
+       only_valid_entity_types: [],
   },
   // Fandom (old Wikia)
   {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3894,6 +3894,7 @@ const testData = [
                      input_url: 'http://www.whosampled.com/Just-to-Get-a-Rep/Gang-Starr/',
              input_entity_type: 'recording',
     expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/Just-to-Get-a-Rep/Gang-Starr/',
   },
   // Fandom (old Wikia)
   {


### PR DESCRIPTION
### Implement MBS-11221 / MBS-11234

They redirect to HTTPS (with www.) so we should do the same. MBBE-25 will convert existing links.

Also added validation for different sorts of links I could find.