### PR TITLE
Use SameSite=Lax for login cookies (fixes MBS-11238)

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -495,7 +495,7 @@ around make_session_cookie => sub {
     my ($orig, $self, $sid, %attrs) = @_;
 
     my $cookie = $self->$orig($sid, %attrs);
-    $cookie->{samesite} = 'Strict';
+    $cookie->{samesite} = 'Lax';
     $cookie->{secure} = 1 if $self->req->secure;
     return $cookie;
 };
@@ -651,6 +651,19 @@ sub set_csp_headers {
             ))
         ),
     );
+}
+
+sub is_cross_origin {
+    my $self = shift;
+
+    my $origin = $self->req->header('Origin');
+    return 0 unless defined $origin;
+
+    my $mb_origin = DBDefs->SSL_REDIRECTS_ENABLED
+        ? ('https://' . DBDefs->WEB_SERVER_SSL)
+        : ('http://' . DBDefs->WEB_SERVER);
+
+    return $origin ne $mb_origin;
 }
 
 sub TO_JSON {

--- a/lib/MusicBrainz/Server/Controller/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/CDStub.pm
@@ -82,7 +82,7 @@ sub add : Path('add') DenyWhenReadonly
         }
     );
     $c->stash( template => 'cdstub/add.tt' );
-    if ($c->form_submitted_and_valid($form)) {
+    if ($c->form_posted_and_valid($form)) {
         my $form_val = $form->value;
         $c->model('CDStub')->insert({
             %$form_val,

--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -25,6 +25,10 @@ sub rate : Local RequireAuth DenyWhenReadonly
         $c->detach('/error_401');
     }
 
+    if ($c->is_cross_origin) {
+        $c->response->redirect($c->uri_for('/'));
+    }
+
     my $entity_type = $c->request->params->{entity_type};
     my $entity_id = $c->request->params->{entity_id};
     my $rating = $c->request->params->{rating};

--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -136,7 +136,7 @@ role {
         }
 
         my $check_form = $c->form(form => 'Merge');
-        if ($c->form_submitted_and_valid($check_form)) {
+        if ($c->form_posted_and_valid($check_form)) {
             # Ensure that we use the entities that appeared on the page and the right type,
             # in case the merger has changed since that page loaded (MBS-7057)
             @entities = values %{
@@ -178,7 +178,7 @@ role {
 
     method _validate_merge => sub {
         my ($self, $c, $form) = @_;
-        return $c->form_submitted_and_valid($form);
+        return $c->form_posted_and_valid($form);
     };
 
     method _merge_submit => sub {

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -319,29 +319,20 @@ sub begin : Private
 
     if (exists $attributes->{RequireAuth})
     {
-        if ($c->form_posted) {
-            my $external_origin = $c->req->header('Origin');
-            if (defined $external_origin) {
-                my $mb_origin = DBDefs->SSL_REDIRECTS_ENABLED
-                    ? ('https://' . DBDefs->WEB_SERVER_SSL)
-                    : ('http://' . DBDefs->WEB_SERVER);
-                my $post_params = $c->req->body_params;
-                if (
-                    $external_origin ne $mb_origin &&
-                    defined $post_params &&
-                    scalar(%$post_params)
-                ) {
-                    $c->set_csp_headers;
-                    $c->stash(
-                        current_view => 'Node',
-                        component_path => 'main/ConfirmSeed',
-                        component_props => {
-                            origin => $external_origin,
-                            postParameters => $post_params,
-                        },
-                    );
-                    $c->detach;
-                }
+        if ($c->form_posted && $c->is_cross_origin) {
+            my $post_params = $c->req->body_params;
+            if (defined $post_params && scalar(%$post_params)) {
+                my $external_origin = $c->req->header('Origin');
+                $c->set_csp_headers;
+                $c->stash(
+                    current_view => 'Node',
+                    component_path => 'main/ConfirmSeed',
+                    component_props => {
+                        origin => $external_origin,
+                        postParameters => $post_params,
+                    },
+                );
+                $c->detach;
             }
         }
         $c->forward('/user/do_login');

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -240,7 +240,7 @@ sub _renew_login_cookie
         value => $token
             ? encode('utf-8', join("\t", $cookie_version, $normalized_name, $token))
             : '',
-        samesite => 'Strict',
+        samesite => 'Lax',
         $c->req->secure ? (secure => 1) : (),
     };
 }

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -19,7 +19,7 @@ type Props = {
 
 const MergeHelper = ({$c, merger}: Props): React.Element<'div'> => (
   <div id="current-editing">
-    <form action={`/${merger.type}/merge`} method="get">
+    <form action={`/${merger.type}/merge`} method="post">
       <h2>{l('Merge Process')}</h2>
       <p>
         {l('You currently have the following entities selected for merging:')}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-11238

5ab8cfba261175f4712d89a230b2c8b0c2bc716a made it so that session/login cookies are only sent in first-party contexts from the same origin. This means the user will appear as logged out if they click on any links to MB from an external origin. In order to address this, we either have to downgrade to SameSite=Lax and ensure we don't allow any data modifications via GET requests, or add a separate non-strict cookie that points to a user session for display but doesn't authenticate as that user. I'm not sure how to do the latter with Catalyst without breaking a lot of assumptions we make throughout the codebase, so I'm "downgrading" the cookies to Lax mode and tweaking a couple cases where it might be possible to submit changes via a GET request. This is still an improvement over the pre-5ab8cfb behavior of SameSite=None and fulfills the spirit of that commit.