### PR TITLE
MBS-11241: Seed annotation, edit_note with textarea

### DIFF
--- a/root/components/PostParameters.js
+++ b/root/components/PostParameters.js
@@ -21,6 +21,8 @@ type PropsT = {
   +params: PostParametersT,
 };
 
+const textAreaRegExp = /(^|\.)(annotation|edit_note)$/;
+
 const PostParameters = ({
   params,
 }: PropsT): React.MixedElement => {
@@ -55,13 +57,21 @@ const PostParameters = ({
                   </label>
                 </td>
                 <td>
-                  <input
-                    defaultValue={value}
-                    id={id}
-                    name={param}
-                    size="50"
-                    type="text"
-                  />
+                  {textAreaRegExp.test(param) ? (
+                    <textarea
+                      defaultValue={value}
+                      id={id}
+                      name={param}
+                      rows="10"
+                    />
+                  ) : (
+                    <input
+                      defaultValue={value}
+                      id={id}
+                      name={param}
+                      type="text"
+                    />
+                  )}
                 </td>
               </tr>
             );

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -836,4 +836,9 @@ button.guess-timezone {
     table.all-collapsed {
         display: none;
     }
+    input, textarea {
+        font-family: sans-serif;
+        font-size: 1rem;
+        width: 50ch;
+    }
 }


### PR DESCRIPTION
This should preserve newlines in the input.

The CSS changes are required in order to make the inputs and textareas have identical widths. Setting size=50 and cols=50 wasn't sufficient because the font families and font sizes were different for some reason.