### PR TITLE
MBS-11250 / MBS-11253: Properly support JSON user-rating / user-tags lookups

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
@@ -13,6 +13,7 @@ my $ws_defs = Data::OptList::mkopt([
      rating => {
                          method   => 'GET',
                          required => [ qw(id entity) ],
+                         optional => [ qw(fmt) ],
      },
      rating => {
                          method   => 'POST',

--- a/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
@@ -19,6 +19,7 @@ my $ws_defs = Data::OptList::mkopt([
      tag => {
                          method   => 'GET',
                          required => [ qw(id entity) ],
+                         optional => [ qw(fmt) ],
      },
      tag => {
                          method   => 'POST',

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -325,6 +325,16 @@ sub autocomplete_genre {
     return encode_json($output);
 }
 
+sub user_rating {
+    my ($self, $entity, $inc, $opts) = @_;
+
+    my $user_rating = $opts->store($entity)->{user_ratings};
+
+    return encode_json({
+        'user-rating' => {value => $user_rating},
+    });
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -335,6 +335,19 @@ sub user_rating {
     });
 }
 
+sub user_tag_list {
+    my ($self, $entity, $inc, $opts) = @_;
+
+    my $user_tags = $opts->store($entity)->{user_tags};
+
+    return encode_json({
+        'user-tags' => [
+            sort { $a->{name} cmp $b->{name} }
+            map +{ name => $_->tag->name }, @{ $user_tags }
+        ],
+    });
+}
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Authenticated.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Authenticated.pm
@@ -1,0 +1,41 @@
+package t::MusicBrainz::Server::Controller::WS::2::JSON::Authenticated;
+use utf8;
+use JSON;
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test ws_test_json => {
+    version => 2
+};
+
+with 't::Mechanize', 't::Context';
+
+test 'lookup rating for user' => sub {
+
+  my $test = shift;
+  my $c = $test->c;
+  my $mech = $test->mech;
+
+  MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+  MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
+    SELECT setval('tag_id_seq', (SELECT MAX(id) FROM tag));
+    INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
+    INSERT INTO artist_rating_raw (artist, editor, rating) VALUES (265420, 1, 80)
+EOSQL
+
+  ws_test_json 'ratings lookup for user rejected without authentication',
+  '/rating?id=802673f0-9b88-4e8a-bb5c-dd01d68b086f&entity=artist' =>
+      {
+        help => "For usage, please see: https://musicbrainz.org/development/mmd",
+        error => "You are not authorized to access this resource.",
+      }, { response_code => 401 };
+
+  ws_test_json 'ratings lookup for user succeeds after authentication',
+  '/rating?id=802673f0-9b88-4e8a-bb5c-dd01d68b086f&entity=artist' =>
+      {
+        'user-rating' => {
+          value => 80,
+        },
+      }, { username => 'new_editor', password => 'password' };
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Authenticated.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/Authenticated.pm
@@ -38,4 +38,34 @@ EOSQL
       }, { username => 'new_editor', password => 'password' };
 };
 
+test 'lookup tag for user' => sub {
+
+  my $test = shift;
+  my $c = $test->c;
+  my $mech = $test->mech;
+
+  MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+  MusicBrainz::Server::Test->prepare_test_database($c, <<'EOSQL');
+    SELECT setval('tag_id_seq', (SELECT MAX(id) FROM tag));
+    INSERT INTO editor (id, name, password, ha1) VALUES (1, 'new_editor', '{CLEARTEXT}password', 'e1dd8fee8ee728b0ddc8027d3a3db478');
+    INSERT INTO artist_tag (artist, count, last_updated, tag) VALUES (265420, 1, '2011-01-18 15:21:33.71184+00', 104);
+    INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (265420, 1, 104, 't')
+EOSQL
+
+  ws_test_json 'tag lookup for user rejected without authentication',
+  '/tag?id=802673f0-9b88-4e8a-bb5c-dd01d68b086f&entity=artist' =>
+      {
+        help => "For usage, please see: https://musicbrainz.org/development/mmd",
+        error => "You are not authorized to access this resource.",
+      }, { response_code => 401 };
+
+  ws_test_json 'tag lookup for user succeeds after authentication',
+  '/tag?id=802673f0-9b88-4e8a-bb5c-dd01d68b086f&entity=artist' =>
+      {
+        'user-tags' => [
+          {name => 'japanese'}
+        ],
+      }, { username => 'new_editor', password => 'password' };
+};
+
 1;


### PR DESCRIPTION
### Fix MBS-11250 / MBS-11253

Asking for this as JSON didn't error, but serialized the entity instead. This changes it so that you can actually query for the rating/tag as in XML.

Note this returns the rating in a 0-100 scale, while normally user-rating is returned on the 0-5 scale. This is inconsistent with the rest of MB but consistent with the XML version of this endpoint, so probably for the best.

Added tests and all since I was feeling responsible.