### PR TITLE
MBS-11262: Fix l_attributes translation calls

### DIFF
--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -170,8 +170,9 @@ const ReleaseSidebar = ({
 
         {packagingId == null ? null : (
           <SidebarProperty className="packaging" label={l('Packaging:')}>
-            {l_attributes(
+            {lp_attributes(
               linkedEntities.release_packaging[packagingId].name,
+              'release_packaging',
             )}
           </SidebarProperty>
         )}
@@ -181,8 +182,9 @@ const ReleaseSidebar = ({
             className="status"
             label={lp('Status:', 'release status')}
           >
-            {l_attributes(
+            {lp_attributes(
               linkedEntities.release_status[statusId].name,
+              'release_status',
             )}
           </SidebarProperty>
         )}

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -52,8 +52,9 @@ const SeriesSidebar = ({
           className="series-code"
           label={addColonText(l('Ordering Type'))}
         >
-          {l_attributes(
+          {lp_attributes(
             linkedEntities.series_ordering_type[series.orderingTypeID].name,
+            'series_ordering_type',
           )}
         </SidebarProperty>
       </SidebarProperties>

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -806,7 +806,7 @@ export function buildTypeStats(typeData) {
 
   for (const key in countries) {
     const country = countries[key];
-    const countryName = l_attributes(country.name);
+    const countryName = l_countries(country.name);
     const countryArg = {country: countryName};
 
     stats[`count.artist.country.${key}`] = {
@@ -833,7 +833,7 @@ export function buildTypeStats(typeData) {
 
   for (const key in formats) {
     const format = formats[key];
-    const formatArg = {name: l_attributes(format.name)};
+    const formatArg = {name: lp_attributes(format.name, 'medium_format')};
 
     stats[`count.release.format.${key}`] = {
       category: 'formats',
@@ -852,7 +852,7 @@ export function buildTypeStats(typeData) {
 
   for (const key in languages) {
     const language = languages[key];
-    const languageName = l_attributes(language.name);
+    const languageName = l_languages(language.name);
 
     stats[`count.release.language.${key}`] = {
       category: 'release-languages',
@@ -880,7 +880,7 @@ export function buildTypeStats(typeData) {
 
   for (const key in scripts) {
     const script = scripts[key];
-    const scriptName = l_attributes(script.name);
+    const scriptName = l_scripts(script.name);
 
     stats[`count.release.script.${key}`] = {
       category: 'release-scripts',


### PR DESCRIPTION
### Fix MBS-11262

Unless I'm very wrong, l_attributes should basically never be called on its own, but as lp_attributes with the specific context. Some of these aren't even in the attributes context at all.
