### PR TITLE
Set SameSite=None on beta cookie

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -327,7 +327,15 @@ around dispatch => sub {
                       $c->req->cookies->{beta}->value eq 'on' &&
                       !DBDefs->IS_BETA);
     if ( $unset_beta ) {
-        $c->res->cookies->{beta} = { 'value' => '', 'path' => '/', 'expires' => time()-86400 };
+        $c->res->cookies->{beta} = {
+            'value' => '',
+            'path' => '/',
+            'expires' => time()-86400,
+            $c->req->secure ? (
+                'samesite' => 'None',
+                'secure' => '1',
+            ) : (),
+        };
     }
 
     if (DBDefs->BETA_REDIRECT_HOSTNAME &&

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -103,7 +103,15 @@ sub set_beta_preference : Path('set-beta-preference') Args(0)
         } elsif (!DBDefs->IS_BETA) {
             $new_url = $c->req->referer || $c->uri_for('/');
             # 1 year
-            $c->res->cookies->{beta} = { 'value' => 'on', 'path' => '/', 'expires' => time()+31536000 };
+            $c->res->cookies->{beta} = {
+                'value' => 'on',
+                'path' => '/',
+                'expires' => time()+31536000,
+                $c->req->secure ? (
+                    'samesite' => 'None',
+                    'secure' => '1',
+                ) : (),
+            };
         }
         # Munge URL to redirect server
         my $ws = DBDefs->WEB_SERVER;


### PR DESCRIPTION
If someone has the beta preference on and uses an external importer, the POST request won't include the beta cookie due to it using SameSite=Lax. This switches the beta cookie to use SameSite=None so that the 307 redirect is performed before the ConfirmSeed page is shown twice (first on the production site, then again on the beta site).