### PR TITLE
MBS-9674: Support internationalized domains in URL forms

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
@@ -18,10 +18,5 @@ sub validate
     $self->_set_value($url->as_string);
 }
 
-sub deflate {
-    my ($self, $value) = @_;
-    return $value->as_string;
-}
-
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -7,6 +7,10 @@ use MusicBrainz::Server::Validation qw( is_valid_url );
 
 extends 'HTML::FormHandler::Field::Text';
 
+has '+deflate_method' => (
+    default => sub { \&deflate_url }
+);
+
 my %ALLOWED_PROTOCOLS = map { $_ => 1 } qw( http https ftp );
 
 sub validate
@@ -27,9 +31,10 @@ sub validate
     $self->_set_value($url->as_string);
 }
 
-sub deflate {
+sub deflate_url {
     my ($self, $value) = @_;
-    return $value->as_string;
+
+    return $value->as_iri;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "pg": "8.3.3",
     "pg-cursor": "2.3.3",
     "po2json": "0.4.1",
+    "punycode": "2.1.1",
     "querystring": "0.2.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import punycode from 'punycode';
+
 import $ from 'jquery';
 import ko from 'knockout';
 import * as React from 'react';
@@ -103,9 +105,10 @@ export class ExternalLinksEditor
   handleUrlBlur(index: number, event: SyntheticEvent<HTMLInputElement>) {
     const url = event.currentTarget.value;
     const trimmed = url.trim();
+    const unicodeUrl = getUnicodeUrl(trimmed);
 
-    if (url !== trimmed) {
-      this.setLinkState(index, {url: trimmed});
+    if (url !== unicodeUrl) {
+      this.setLinkState(index, {url: unicodeUrl});
     }
   }
 
@@ -230,6 +233,7 @@ export class ExternalLinksEditor
             const isNewLink = !isPositiveInteger(link.relationship);
             const linkChanged = oldLink && link.url !== oldLink.url;
             const linkTypeChanged = oldLink && +link.type !== +oldLink.type;
+            link.url = getUnicodeUrl(link.url);
 
             if (isEmpty(link)) {
               error = '';
@@ -527,13 +531,27 @@ export function parseRelationships(
 const protocolRegex = /^(https?|ftp):$/;
 const hostnameRegex = /^(([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])\.)*([A-z\d]|[A-z\d][A-z\d\-]*[A-z\d])$/;
 
+export function getUnicodeUrl(url: string): string {
+  if (!isValidURL(url)) {
+    return url;
+  }
+
+  const urlObject = new URL(url);
+  const unicodeHostname = punycode.toUnicode(urlObject.hostname);
+  const unicodeUrl = url.replace(urlObject.hostname, unicodeHostname);
+
+  return unicodeUrl;
+}
+
 function isValidURL(url) {
   const a = document.createElement('a');
   a.href = url;
 
   const hostname = a.hostname;
 
-  if (url.indexOf(hostname) < 0) {
+  // To compare with the url we need to decode the Punycode if present
+  const unicodeHostname = punycode.toUnicode(hostname);
+  if (url.indexOf(hostname) < 0 && url.indexOf(unicodeHostname) < 0) {
     return false;
   }
 

--- a/root/static/scripts/url.js
+++ b/root/static/scripts/url.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import ko from 'knockout';
 
 import MB from './common/MB';
+import {getUnicodeUrl} from './edit/externalLinks';
 import {registerEvents} from './edit/URLCleanup';
 
 $(function () {
@@ -14,6 +15,7 @@ $(function () {
   source.name = ko.observable(source.name);
 
   $urlControl.on('change', function () {
+    this.value = getUnicodeUrl(this.value);
     source.name(this.value);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5616,15 +5616,15 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
+punycode@2.1.1, punycode@^2.1.0, punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@~6.4.0:
   version "6.4.0"


### PR DESCRIPTION
### Fix MBS-9674

This was failing because, unsurprisingly, it couldn't find the ASCII hostname in the Unicode URL. I used punycode (which we already installed as a dependency, but I added as a requirement) to decode the punycode back into the original unicode URL for hostname comparison. 

During the last Monday meeting we also agreed to always display international URLs as Unicode (which we already did when prettifying but not in the links editor). This makes the relevant changes to externalLinks and to URL forms.