### PR TITLE
MBS-11256: Make adding tracklist to empty medium an autoedit

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -555,6 +555,9 @@ sub allow_auto_edit
     return 0 if exists $self->data->{old}{position};
 
     if ($self->data->{old}{tracklist}) {
+        # If there's no old tracklist, allow adding one as an autoedit 
+        return 1 if scalar @{ $self->data->{old}{tracklist} } == 0;
+
         my @changes =
             grep { $_->[0] ne 'u' }
             @{ sdiff(

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -233,6 +233,7 @@ test 'Accept/failure conditions regarding links' => sub {
         $c->model('Track')->load_for_mediums($medium);
         $c->model('ArtistCredit')->load($medium->all_tracks);
 
+        # Add track to medium without any tracklist
         my $edit = $c->model('Edit')->create(
             editor_id => 1,
             edit_type => $EDIT_MEDIUM_EDIT,
@@ -256,14 +257,20 @@ test 'Accept/failure conditions regarding links' => sub {
             ]
         );
 
-        ok !exception { $edit->accept };
-
         $c->model('Edit')->load_all($edit);
         is(@{ $edit->display_data->{tracklist_changes} }, 1, '1 tracklist change');
         is($edit->display_data->{tracklist_changes}->[0][0], '+', 'tracklist change is an addition');
 
         is(@{ $edit->display_data->{artist_credit_changes} }, 1, '1 artist credit change');
         is($edit->display_data->{artist_credit_changes}->[0][0], '+', 'artist credit change is an addition');
+
+        # Reload for renewed edit and track data
+        $medium = $c->model('Medium')->get_by_id(1);
+        $c->model('Track')->load_for_mediums($medium);
+
+        is($medium->edits_pending, 0, "Adding first track is an autoedit");
+        # Can't accept since it's already applied
+        ok exception { $edit->accept };
     };
 
     subtest 'Can change the recording to another existing recording' => sub {
@@ -343,6 +350,7 @@ test 'Accept/failure conditions regarding links' => sub {
         $medium = $c->model('Medium')->get_by_id(1);
         $c->model('Track')->load_for_mediums($medium);
         $c->model('ArtistCredit')->load($medium->all_tracks);
+        my $old_edits_pending = $medium->edits_pending;
 
         my $edit = $c->model('Edit')->create(
             editor_id => 1,
@@ -369,7 +377,10 @@ test 'Accept/failure conditions regarding links' => sub {
             ]
         );
 
-        $edit->accept;
+        $medium = $c->model('Medium')->get_by_id(1);
+        is($medium->edits_pending, $old_edits_pending + 1, "Adding a second track is not an autoedit");
+
+        ok !exception { $edit->accept };
 
         $c->model('Edit')->load_all($edit);
         is((grep { $_->[0] ne 'u' } @{ $edit->display_data->{tracklist_changes} }), 1, '1 tracklist change');


### PR DESCRIPTION
### Implement MBS-11256

We generally make adding something where nothing existed an autoedit. I see no reason why this shouldn't also apply to adding a tracklist if it was previously unknown.
