### PR TITLE
Beta: Fix load_first_release_date for empty recording lists

### DIFF
--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -424,6 +424,7 @@ sub load_first_release_date {
 
     my %recording_map = object_to_ids(@recordings);
     my @ids = keys %recording_map;
+    return unless @ids;
 
     my $release_dates = $self->sql->select_list_of_hashes(
         'SELECT * FROM recording_first_release_date ' .


### PR DESCRIPTION
If `@ids` is empty, this errors with `invalid input syntax for type integer: ""`.

For example, on: https://beta.musicbrainz.org/ws/2/recording?artist=93ce655f-d54f-435f-a13c-0c6fb1f10a96&inc=work-rels&limit=100&offset=0