### PR TITLE
MBS-8371: Add searching in edit notes to the edit search

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
@@ -1,0 +1,42 @@
+package MusicBrainz::Server::EditSearch::Predicate::EditNoteContent;
+use Moose;
+
+with 'MusicBrainz::Server::EditSearch::Predicate';
+
+sub operator_cardinality_map {
+  return (
+      'includes' => undef,
+  )
+}
+
+sub combine_with_query {
+    my ($self, $query) = @_;
+
+    my @patterns = map {
+      $_ =~ s/\\/\\\\/g;
+      $_ =~ s/_/\\_/g;
+      $_ =~ s/%/\\%/g;
+      '%' . $_ . '%'
+    } @{ $self->sql_arguments };
+
+    $query->add_where([
+        'EXISTS (
+          SELECT TRUE FROM edit_note
+          WHERE edit_note.text ILIKE ?
+            AND edit_note.edit = edit.id
+        )',
+        \@patterns,
+    ]);
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2015-2017 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -22,6 +22,7 @@ use MusicBrainz::Server::EditSearch::Predicate::LabelArea;
 use MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry;
 use MusicBrainz::Server::EditSearch::Predicate::RelationshipType;
 use MusicBrainz::Server::EditSearch::Predicate::EditNoteAuthor;
+use MusicBrainz::Server::EditSearch::Predicate::EditNoteContent;
 use MusicBrainz::Server::Log 'log_warning';
 use Try::Tiny;
 
@@ -44,6 +45,7 @@ my %field_map = (
     editor_flag => 'MusicBrainz::Server::EditSearch::Predicate::EditorFlag',
     applied_edits => 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits',
     edit_note_author => 'MusicBrainz::Server::EditSearch::Predicate::EditNoteAuthor',
+    edit_note_content => 'MusicBrainz::Server::EditSearch::Predicate::EditNoteContent',
 
     entities_with(['mbid', 'relatable'],
         take => sub {

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -60,6 +60,8 @@
                  CASE 'status';
                    predicate_set(field.field_name, status, field, 8);
                END;
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::EditNoteContent';
+               predicate_edit_note_content(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality';
                predicate_set(field.field_name, quality, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::Date';
@@ -251,6 +253,7 @@
 [% MACRO predicate_edit_notes BLOCK %]
   [%~ IF c.user_exists ~%]
     [% predicate_user('edit_note_author') %]
+    [% predicate_edit_note_content('edit_note_content') %]
   [%~ ELSE ~%]
     [% WRAPPER wfield predicate="set" %]
       [%~ needs_login() ~%]
@@ -365,6 +368,14 @@
   </span>
 [% END %]
 
+[% MACRO predicate_edit_note_content(field, field_contents) WRAPPER wfield predicate="edit_note_content" %]
+  [% operators([ [ 'includes', l('includes') ]
+               ], field_contents) %]
+  <span class="arg">
+    <input type="text" class="name" name="args.0" value="[% html_escape(field_contents.argument(0)) %]" style="width: 170px;" />
+  </span>
+[% END %]
+
 [% MACRO predicate_editor_flag(field, field_contents) WRAPPER wfield predicate="set" %]
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
@@ -404,6 +415,7 @@
                    [ 'type', l('Type') ],
                    [ 'vote_count', l('Vote tally') ],
                    [ 'edit_note_author', l('Edit Note Authors'), {requires_login => 1} ],
+                   [ 'edit_note_content', l('Edit Note Content'), {requires_login => 1} ],
                    [ 'area', l('Area') ],
                    [ 'artist', l('Artist') ],
                    [ 'event', l('Event') ],

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -15,6 +15,9 @@ $(function () {
       // Not directly true, but it here it means "show one argument control"
       '=': 1, '!=': 1,
     },
+    edit_note_content: {
+      includes: 1,
+    },
     voter: {
       '=': 1,
       '!=': 1,


### PR DESCRIPTION
### Implement MBS-8371

This seems kinda-sorta slow but probably not insanely so (no timeout), and given we have no other way to do anything like it, users probably will be willing to wait a bit for results.

For an example of usage I could imagine, something like http://localhost:5000/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and&conditions.0.field=edit_note_content&conditions.0.operator=includes&conditions.0.args.0=fuck+you&conditions.8.field=vote_count&conditions.8.vote=0&conditions.8.operator=%3E&conditions.8.args.0=0&conditions.8.args.1= (on the mirror DB in pink) will show 12 edits that got downvotes *and* have edit notes including "fuck you", so would be useful for the community manager to review.