### PR TITLE
MBS-11267: Always show artwork info when adding/reordering

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -226,6 +226,7 @@ sub add_cover_art : Chained('load') PathPart('add-cover-art') Edit {
     my @mime_types = map { $_->{mime_type} } @{ $c->model('CoverArt')->mime_types };
 
     my @artwork = @{ $c->model('Artwork')->find_by_release($entity) };
+    $c->model('CoverArtType')->load_for(@artwork);
 
     my $count = 1;
     my @positions = map {

--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -120,6 +120,14 @@
         [%- FOR image = images -%]
           <div class="thumb-position">
             [%- display_artwork(image) -%]
+            <div style="display: flex; justify-content: space-around;">
+              <button type="button" class="left">&larr;</button>
+              [% React.embed(c, 'static/scripts/edit/components/InformationIcon', {
+                style => {'align-self' => 'flex-start'},
+                title => l('Types:') _ ' ' _ (comma_only_list(image.l_types) || '-') _ 
+                        (image.comment ? (' / ' _ l('Comment:') _ ' ' _ image.comment) : '')}) %]
+              <button type="button" class="right" style="float: right;">&rarr;</button>
+            </div>
           </div>
         [%- END -%]
 

--- a/root/release/reorder_cover_art.tt
+++ b/root/release/reorder_cover_art.tt
@@ -13,9 +13,13 @@
       [%- SET count = 0 -%]
       [% FOR image = images %]
         <div class="editimage thumb-position">
-          [%- display_artwork(image, undef, undef) -%]
-          <div>
+          [%- display_artwork(image) -%]
+          <div style="display: flex; justify-content: space-around;">
             <button type="button" class="left">&larr;</button>
+            [% React.embed(c, 'static/scripts/edit/components/InformationIcon', {
+              style => {'align-self' => 'flex-start'},
+              title => l('Types:') _ ' ' _ (comma_only_list(image.l_types) || '-') _ 
+                       (image.comment ? (' / ' _ l('Comment:') _ ' ' _ image.comment) : '')}) %]
             <button type="button" class="right" style="float: right;">&rarr;</button>
           </div>
           <input type="hidden" value="[% image.id %]" class="id"


### PR DESCRIPTION
### Implement MBS-11267

While generally you can see the types and comment for a specific image when hovering over the image, that's not too clear in general and it doesn't help at all when the thumbnail hasn't been generated yet (since there's no image to hover over).

This adds an information icon that displays the data on hover, and also shows if there's no thumbnail yet.

Additionally, we weren't loading types for add_cover_art.

Sample:

![Screenshot from 2020-12-07 21-32-31](https://user-images.githubusercontent.com/1069224/101396271-be7c3c80-38d3-11eb-8b2e-a8f2d5cadd27.png)
