### PR TITLE
MBS-11268: Show "Set track durations" on release/discids

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -140,6 +140,7 @@ sub discids : Chained('load') {
     my $release = $c->stash->{release};
     my @medium_cdtocs = $c->model('MediumCDTOC')->load_for_mediums($release->all_mediums);
     $c->model('CDTOC')->load(@medium_cdtocs);
+    $c->model('Medium')->load(@medium_cdtocs);
     $c->stash( has_cdtocs => scalar(@medium_cdtocs) > 0 );
 }
 

--- a/root/release/discids.tt
+++ b/root/release/discids.tt
@@ -30,6 +30,12 @@
                     <td>[% medium_cdtoc.cdtoc.length | format_length %]</td>
                     [% IF c.user_exists %]
                     <td>
+                      [%- IF !medium_cdtoc.is_perfect_match %]
+                        <a href="[% c.uri_for_action('/cdtoc/set_durations',
+                                        [ medium_cdtoc.cdtoc.discid ], { medium => medium.id }) %]">
+                          [% l('Set track durations') %]
+                        </a> |
+                      [%- END %]
                       <a href="[% c.uri_for_action('cdtoc/remove',
                                                    { cdtoc_id  => medium_cdtoc.cdtoc.id,
                                                      medium_id => medium.id }) %]">


### PR DESCRIPTION
### Implement MBS-11268

We didn't use to show this, probably because IIRC  there was no indication at all of how a disc id's track times matched the medium's when applying the edit (so it made sense to force users to always go through the specific discID page). This has been changed though, so we can display the links here, the user can click them and then compare the durations on the next page. The user will still need to go through two pages to get all the info, but it makes the links easier to find (many people are unlikely to have realized you could do this by clicking the weird discid title).
