### PR TITLE
MBS-8028: Allow editing series type to any with same entity type

### DIFF
--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -154,10 +154,16 @@ sub update {
     my $series = $self->c->model('Series')->get_by_id($series_id);
     $self->c->model('SeriesType')->load($series);
 
-    if (defined($row->{type}) && $series->type_id != $row->{type}) {
-        my ($items, $hits) = $self->c->model('Series')->get_entities($series, 1, 0);
+    if (defined($row->{type})) {
+        my $existing_entity_type = $series->type->item_entity_type;
+        my $new_series_type = $self->c->model('SeriesType')->get_by_id($row->{type});
+        my $new_entity_type = $new_series_type->item_entity_type;
 
-        die "Cannot change the type of a non-empty series" if scalar(@$items);
+        if ($existing_entity_type ne $new_entity_type) {
+            my ($items, $hits) = $self->c->model('Series')->get_entities($series, 1, 0);
+
+            die "Cannot change the entity type of a non-empty series" if scalar(@$items);
+        }
     }
 
     $self->sql->update_row('series', $row, { id => $series_id }) if %$row;

--- a/root/static/scripts/series.js
+++ b/root/static/scripts/series.js
@@ -8,19 +8,22 @@ import initializeDuplicateChecker from './edit/check-duplicates';
 $(function () {
   var $type = $('#id-edit-series\\.type_id');
   var $orderingType = $('#id-edit-series\\.ordering_type_id');
+  const $type_options = $('#id-edit-series\\.type_id > option');
 
-  // Type can be disabled, but is a required field, so use a hidden input.
-  var $hiddenType = $('<input>')
-    .attr({type: 'hidden', name: $type[0].name})
-    .val($type.val())
-    .insertAfter($type.removeAttr('name'));
+  function updateAllowedTypes(seriesHasItems) {
+    $type_options.each(function () {
+      const type = MB.seriesTypesByID[this.value];
+      if (seriesHasItems &&
+          type.item_entity_type !== series.type().item_entity_type) {
+        this.setAttribute('disabled', 'disabled');
+      } else {
+        this.removeAttribute('disabled');
+      }
+    });
+  }
 
   var series = MB.entityCache[MB.sourceEntityGID];
   series.typeID($type.val());
-
-  series.typeID.subscribe(function (typeID) {
-    $hiddenType.val(typeID);
-  });
 
   series.orderingTypeID($orderingType.val());
 
@@ -47,10 +50,13 @@ $(function () {
     return series.getSeriesItems(MB.sourceRelationshipEditor).length > 0;
   });
 
+  updateAllowedTypes(seriesHasItems());
+
+  seriesHasItems.subscribe((hasItems) => updateAllowedTypes(hasItems));
+
   ko.applyBindingsToNode($type[0], {
     value: series.typeID,
     controlsBubble: series.typeBubble,
-    disable: seriesHasItems,
   }, series);
 
   ko.applyBindingsToNode($orderingType[0], {


### PR DESCRIPTION
### Implement MBS-8028

While there's an obvious reason why you can't change the type of a series from, say, "Work series" to "Release series" once it has any items, there's no reason we shouldn't allow changing from "Work series" to "Catalogue", since both are series of works.
