### PR TITLE
MBS-11275: Load recordings for cdtoc move

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -417,6 +417,7 @@ sub move : Local Edit
             my @mediums = grep { !$_->format || $_->format->has_discids }
                 map { $_->all_mediums } @releases;
             $c->model('Track')->load_for_mediums(@mediums);
+            $c->model('Recording')->load(map { $_->all_tracks } @mediums);
             $c->stash(
                 template => 'cdtoc/attach_filter_release.tt',
                 cdtoc_action => 'move',


### PR DESCRIPTION
### Fix MBS-11275

We load these when we have a medium param, but not otherwise.
