### PR TITLE
MBS-11278: Also show rating info when there's only private ratings

### DIFF
--- a/root/entity/Ratings.js
+++ b/root/entity/Ratings.js
@@ -29,6 +29,7 @@ const Ratings = ({
 }: Props): React.MixedElement => {
   const entityType = entity.entityType;
   const LayoutComponent = chooseLayoutComponent(entityType);
+  const hasRatings = publicRatings.length || privateRatingCount > 0;
 
   return (
     <LayoutComponent
@@ -39,17 +40,19 @@ const Ratings = ({
     >
       <h2>{l('Ratings')}</h2>
 
-      {publicRatings.length ? (
+      {hasRatings ? (
         <>
-          <ul>
-            {publicRatings.map(rating => (
-              <li key={rating.editor.id}>
-                <StaticRatingStars rating={rating.rating} />
-                {' - '}
-                <EditorLink editor={rating.editor} />
-              </li>
-            ))}
-          </ul>
+          {publicRatings.length ? (
+            <ul>
+              {publicRatings.map(rating => (
+                <li key={rating.editor.id}>
+                  <StaticRatingStars rating={rating.rating} />
+                  {' - '}
+                  <EditorLink editor={rating.editor} />
+                </li>
+              ))}
+            </ul>
+          ) : null}
           {privateRatingCount > 0 ? (
             <p>
               {exp.ln(


### PR DESCRIPTION
### Fix MBS-11278

I chose the wrong conditional when original converting this, meaning an entity having only private ratings was displayed as having no ratings at all.
