### PR TITLE
MBS-11183: Always preserve merged entity name as alias

### DIFF
--- a/lib/MusicBrainz/Server/Data/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Alias.pm
@@ -216,11 +216,15 @@ sub merge
         "INSERT INTO $table (name, $type, sort_name)
             SELECT DISTINCT ON (old_entity.name) old_entity.name, new_entity.id, old_entity.$sortnamecol
               FROM $type old_entity
-         LEFT JOIN $table alias ON alias.name = old_entity.name
               JOIN $type new_entity ON (new_entity.id = ?)
              WHERE old_entity.id = any(?)
-               AND alias.id IS NULL
-               AND old_entity.name != new_entity.name",
+               AND old_entity.name != new_entity.name
+               AND NOT EXISTS (
+                   SELECT TRUE FROM $table
+                    WHERE $type = new_entity.id
+                      AND name = old_entity.name
+                    LIMIT 1
+               )",
         $new_id, [ @old_ids ]
     );
 }


### PR DESCRIPTION
### Fix MBS-11183

The code always added the name of any entities being merged as an alias to the destination entity, with one exception: if the same name was already used as an alias for any other entity of the same type.

This probably dates back to when we only allowed each alias to be used once across the DB, but we stopped doing that ages ago. As such, the commit changes it to only skip adding the name as an alias if the destination entity *already* has that name as an alias.
