### PR TITLE
MBS-11291: Fix wrong bootleg check in ReleasesSameBarcode

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesSameBarcode.pm
@@ -21,7 +21,7 @@ sub query {
         AND EXISTS (
             SELECT 1 FROM release r2
                 WHERE r.barcode = r2.barcode
-                AND r.status != 3 -- skip bootlegs
+                AND r2.status != 3 -- skip bootlegs
                 AND r.release_group != r2.release_group
         )
     "


### PR DESCRIPTION
### Fix MBS-11291

We were checking the same release twice, instead of checking whether both releases were not bootlegs.
