### PR TITLE
MBS-11290: Report of works of type X part of another work of type X 

### DIFF
--- a/lib/MusicBrainz/Server/Report/WorkReport.pm
+++ b/lib/MusicBrainz/Server/Report/WorkReport.pm
@@ -4,7 +4,11 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';
 
-sub _load_extra_work_info {}
+sub _load_extra_work_info {
+    my ($self, @works) = @_;
+
+    $self->c->model('WorkType')->load(@works);
+}
 
 around inflate_rows => sub {
     my $orig = shift;

--- a/lib/MusicBrainz/Server/Report/WorkSameTypeAsParent.pm
+++ b/lib/MusicBrainz/Server/Report/WorkSameTypeAsParent.pm
@@ -1,0 +1,35 @@
+package MusicBrainz::Server::Report::WorkSameTypeAsParent;
+use Moose;
+
+with 'MusicBrainz::Server::Report::WorkReport',
+     'MusicBrainz::Server::Report::FilterForEditor::WorkID';
+
+sub query {<<~'EOSQL'}
+    SELECT DISTINCT w.id AS work_id,
+           row_number() OVER (ORDER BY w.type, w.name COLLATE musicbrainz)
+    FROM work w
+    WHERE EXISTS (
+        SELECT 1
+        FROM l_work_work lww
+        JOIN link l ON lww.link = l.id
+        JOIN link_type lt ON l.link_type = lt.id
+        JOIN work w2 ON w2.id = lww.entity0
+        WHERE lww.entity1 = w.id
+        AND lt.gid = 'ca8d3642-ce5f-49f8-91f2-125d72524e6a' --parts
+        AND w2.type = w.type 
+    )
+    EOSQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -99,6 +99,7 @@ use MusicBrainz::Server::PagedReport;
     TracksWithoutTimes
     TracksWithSequenceIssues
     UnlinkedPseudoReleases
+    WorkSameTypeAsParent
 );
 
 use MusicBrainz::Server::Report::ASINsWithMultipleReleases;
@@ -190,6 +191,7 @@ use MusicBrainz::Server::Report::TracksNamedWithSequence;
 use MusicBrainz::Server::Report::TracksWithoutTimes;
 use MusicBrainz::Server::Report::TracksWithSequenceIssues;
 use MusicBrainz::Server::Report::UnlinkedPseudoReleases;
+use MusicBrainz::Server::Report::WorkSameTypeAsParent;
 
 my %all = map { $_ => 1 } @all;
 

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -540,6 +540,10 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           content={l('Works with annotations')}
           reportName="AnnotationsWorks"
         />
+        <ReportsIndexEntry
+          content={l('Works with the same type as their parent')}
+          reportName="WorkSameTypeAsParent"
+        />
       </ul>
 
       <h2>{l('URLs')}</h2>

--- a/root/report/WorkSameTypeAsParent.js
+++ b/root/report/WorkSameTypeAsParent.js
@@ -1,0 +1,44 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import WorkList from './components/WorkList';
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT, ReportWorkT} from './types';
+
+const WorkSameTypeAsParent = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportWorkT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={exp.l(
+      `This report shows works with at least one parent work that has the same
+       work type as them (such as a work marked as a sonata which is part of
+       another sonata). In most cases, that means these works should have
+       a different type or (most likely) no type at all, as per
+       {work_style_doc|the work guidelines}. Sometimes the parent work
+       type might be the one that needs to be changed.`,
+      {work_style_doc: '/doc/Style/Work'},
+    )}
+    entityType="work"
+    filtered={filtered}
+    generated={generated}
+    title={l('Works with the same type as their parent')}
+    totalEntries={pager.total_entries}
+  >
+    <WorkList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default WorkSameTypeAsParent;

--- a/root/report/components/WorkList.js
+++ b/root/report/components/WorkList.js
@@ -28,15 +28,23 @@ const WorkList = ({
       <thead>
         <tr>
           <th>{l('Work')}</th>
+          <th>{l('Type')}</th>
         </tr>
       </thead>
       <tbody>
         {items.map((item, index) => (
           <tr className={loopParity(index)} key={item.work_id}>
             {item.work ? (
-              <td>
-                <EntityLink entity={item.work} />
-              </td>
+              <>
+                <td>
+                  <EntityLink entity={item.work} />
+                </td>
+                <td>
+                  {nonEmpty(item.work.typeName)
+                    ? lp_attributes(item.work.typeName, 'work_type')
+                    : l('Unknown')}
+                </td>
+              </>
             ) : (
               <td>
                 {l('This work no longer exists.')}

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -240,6 +240,7 @@ module.exports = {
   'report/TracksWithSequenceIssues': require('../report/TracksWithSequenceIssues'),
   'report/TracksWithoutTimes': require('../report/TracksWithoutTimes'),
   'report/UnlinkedPseudoReleases': require('../report/UnlinkedPseudoReleases'),
+  'report/WorkSameTypeAsParent': require('../report/WorkSameTypeAsParent'),
   'search/SearchIndex': require('../search/SearchIndex'),
   'search/components/AnnotationResults': require('../search/components/AnnotationResults'),
   'search/components/AreaResults': require('../search/components/AreaResults'),


### PR DESCRIPTION
### Implement MBS-11290

There's plenty of cases where new users add every movement of a concerto (or sonata, or whatever) with the same type as the parent work.  That's pretty much never correct.

This shouldn't have many (if any) false positives from popular music, since part of work relationships are very uncommon there, and even then it seems unlikely that "Song is part of Song" is correct. We could always disable this for "Song" if needed, but that would also hide correct hits where someone has, say, selected "Song" for a parent "Song-Cycle" work so I'd rather avoid it unless users complain.

On top of #1787