### PR TITLE
MBS-11289: Stop autocleaning YouTube Music -> YouTube

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3376,7 +3376,7 @@ const CLEANUPS = {
   },
   'youtube': {
     match: [new RegExp(
-      '^(https?://)?([^/]+\\.)?(youtube\\.com/|youtu\\.be/)',
+      '^(https?://)?(((?!music)[^/])+\\.)?(youtube\\.com/|youtu\\.be/)',
       'i',
     )],
     type: {...LINK_TYPES.streamingfree, ...LINK_TYPES.youtube},

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4208,6 +4208,14 @@ const testData = [
             expected_clean_url: 'https://www.youtube.com/playlist?list=PL43OynbWaTMKSxLVnUF0HbHHiXEgAVm3Q',
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
+  {
+                     input_url: 'https://music.youtube.com/browse/MPREb_0bOFkwXrX2x',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://music.youtube.com/browse/MPREb_0bOFkwXrX2x',
+       input_relationship_type: 'youtube',
+       only_valid_entity_types: [],
+  },
 ];
 /* eslint-enable indent, max-len, sort-keys */
 


### PR DESCRIPTION
### Fix MBS-11289

YouTube Music links shouldn't be converted to YouTube links, since they're intended to be a different thing and, in some cases, are not available to anyone else to YouTube Music subscribers.

For now I'm not making them autoselect paid or free streaming, since most of them *can* be streamed for free with ads, but some are strictly limited to paid streaming only.
