### PR TITLE
MBS-11296 / MBS-11297: More blocks for Wikipedia/Wikidata at release level

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3470,7 +3470,7 @@ Object.values(LINK_TYPES).forEach(function (linkType) {
 });
 
 // avoid Wikipedia/Wikidata being added as release-level discography entry
-const originalRule = validationRules[LINK_TYPES.discographyentry.release];
+const discographyRule = validationRules[LINK_TYPES.discographyentry.release];
 validationRules[LINK_TYPES.discographyentry.release] = function (url) {
   if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
     return {
@@ -3490,7 +3490,31 @@ validationRules[LINK_TYPES.discographyentry.release] = function (url) {
       result: false,
     };
   }
-  return originalRule(url);
+  return discographyRule(url);
+};
+
+// avoid Wikipedia/Wikidata being added as release-level license entry
+const licenseRule = validationRules[LINK_TYPES.license.release];
+validationRules[LINK_TYPES.license.release] = function (url) {
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
+    return {
+      error: l(
+        `Wikipedia is not a license page. Please add this Wikipedia link
+         to the release group instead.`,
+      ),
+      result: false,
+    };
+  }
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
+    return {
+      error: l(
+        `Wikidata is not a license page. Please add this Wikidata link
+         to the release group instead.`,
+      ),
+      result: false,
+    };
+  }
+  return licenseRule(url);
 };
 
 // avoid Wikipedia/Wikidata being added as release-level show notes entry

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -179,6 +179,9 @@ export const LINK_TYPES = {
     place: '751e8fb1-ed8d-4a94-b71b-a38065054f5d',
     series: 'de143a8b-ea80-4b26-9246-f1ce498d4b01',
   },
+  shownotes: {
+    release: '2d24d075-9943-4c4d-a659-8ce52e6e6b57',
+  },
   socialnetwork: {
     artist: '99429741-f3f6-484b-84f8-23af51991770',
     event: '68f5fcaa-b58c-3bfe-9b7c-75c2b56e839a',
@@ -3488,6 +3491,29 @@ validationRules[LINK_TYPES.discographyentry.release] = function (url) {
     };
   }
   return originalRule(url);
+};
+
+// avoid Wikipedia/Wikidata being added as release-level show notes entry
+validationRules[LINK_TYPES.shownotes.release] = function (url) {
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
+    return {
+      error: l(
+        `Wikipedia is not a page of show notes. Please add this Wikipedia link
+         to the release group instead.`,
+      ),
+      result: false,
+    };
+  }
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
+    return {
+      error: l(
+        `Wikidata is not a page of show notes. Please add this Wikidata link
+         to the release group instead.`,
+      ),
+      result: false,
+    };
+  }
+  return {result: true};
 };
 
 export function guessType(sourceType, currentURL) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3466,13 +3466,22 @@ Object.values(LINK_TYPES).forEach(function (linkType) {
   });
 });
 
-// avoid Wikipedia being added as release-level discography entry
+// avoid Wikipedia/Wikidata being added as release-level discography entry
 const originalRule = validationRules[LINK_TYPES.discographyentry.release];
 validationRules[LINK_TYPES.discographyentry.release] = function (url) {
   if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
     return {
       error: l(
         `Wikipedia is not a discography entry. Please add this Wikipedia link
+         to the release group instead.`,
+      ),
+      result: false,
+    };
+  }
+  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
+    return {
+      error: l(
+        `Wikidata is not a discography entry. Please add this Wikidata link
          to the release group instead.`,
       ),
       result: false,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4001,6 +4001,13 @@ const testData = [
        input_relationship_type: 'discographyentry',
        only_valid_entity_types: [],
   },
+  {
+                     input_url: 'https://www.wikidata.org/wiki/Q43',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'shownotes',
+       only_valid_entity_types: [],
+  },
   // Wikimedia Commons
   {
                      input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',
@@ -4109,6 +4116,13 @@ const testData = [
              input_entity_type: 'release',
     expected_relationship_type: undefined,
        input_relationship_type: 'discographyentry',
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://en.wikipedia.org/wiki/Another_Album',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'shownotes',
        only_valid_entity_types: [],
   },
   // Wikisource

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4005,6 +4005,13 @@ const testData = [
                      input_url: 'https://www.wikidata.org/wiki/Q43',
              input_entity_type: 'release',
     expected_relationship_type: undefined,
+       input_relationship_type: 'license',
+       only_valid_entity_types: ['recording'],
+  },
+  {
+                     input_url: 'https://www.wikidata.org/wiki/Q44',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
        input_relationship_type: 'shownotes',
        only_valid_entity_types: [],
   },
@@ -4120,6 +4127,13 @@ const testData = [
   },
   {
                      input_url: 'https://en.wikipedia.org/wiki/Another_Album',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'license',
+       only_valid_entity_types: ['recording'],
+  },
+  {
+                     input_url: 'https://en.wikipedia.org/wiki/Yet_Another_Album',
              input_entity_type: 'release',
     expected_relationship_type: undefined,
        input_relationship_type: 'shownotes',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3994,6 +3994,13 @@ const testData = [
        input_relationship_type: 'wikidata',
        only_valid_entity_types: [],
   },
+  {
+                     input_url: 'https://www.wikidata.org/wiki/Q42',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'discographyentry',
+       only_valid_entity_types: [],
+  },
   // Wikimedia Commons
   {
                      input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',


### PR DESCRIPTION
### Implement MBS-11296 / MBS-11297

I looked at the most common misuses of these links on the release level and added errors rejecting them and telling the users to add them to the RG level (as we already did for the Wikipedia / Discography entry combo).