### PR TITLE
MBS-10830: Only show Remove link if entity can be removed

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -705,6 +705,7 @@ sub TO_JSON {
 
     # Whitelist of keys that we use in the templates.
     my @stash_keys = qw(
+        can_delete
         collaborative_collections
         commons_image
         containment

--- a/lib/MusicBrainz/Server/Controller/Role/Delete.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Delete.pm
@@ -25,7 +25,7 @@ role {
         ($params->create_edit_type ? (create_edit_type => $params->create_edit_type) : ())
     );
 
-    after 'show' => sub {
+    after 'load' => sub {
         my ($self, $c) = @_;
         my $entity_name = $self->{entity_name};
         my $entity = $c->stash->{ $entity_name };

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -115,7 +115,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
 
         <MergeLink entity={label} />
 
-        {isSpecialPurposeLabel ? null : <RemoveLink entity={label} />}
+        <RemoveLink entity={label} />
 
         <li className="separator" role="separator" />
       </EditLinks>

--- a/root/layout/components/sidebar/RemoveLink.js
+++ b/root/layout/components/sidebar/RemoveLink.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import entityHref from '../../../static/scripts/common/utility/entityHref';
 
 type Props = {
@@ -21,12 +22,19 @@ type Props = {
     | ReleaseT,
 };
 
-const RemoveLink = ({entity}: Props): React.Element<'li'> => (
-  <li>
-    <a href={entityHref(entity, 'delete')}>
-      {l('Remove')}
-    </a>
-  </li>
-);
+const RemoveLink = ({entity}: Props): React.Element<'li'> | null => {
+  const $c = React.useContext(CatalystContext);
+  if (!$c.stash.can_delete /*:: === true */) {
+    return null;
+  }
+
+  return (
+    <li>
+      <a href={entityHref(entity, 'delete')}>
+        {l('Remove')}
+      </a>
+    </li>
+  );
+};
 
 export default RemoveLink;

--- a/root/types.js
+++ b/root/types.js
@@ -219,6 +219,7 @@ declare type CatalystSessionT = {
 declare type CatalystStashT = {
   +alert?: string,
   +alert_mtime?: number | null,
+  +can_delete?: boolean,
   +collaborative_collections?: $ReadOnlyArray<CollectionT>,
   +commons_image?: CommonsImageT | null,
   +containment?: {


### PR DESCRIPTION
### Implement MBS-10830

Passing can_delete through $c.stash seemed like the most straightforward option, but open to other better possibilities.