### PR TITLE
MBS-11310: Clarify when discid would cause subsecond changes

### DIFF
--- a/root/cdtoc/set_durations.tt
+++ b/root/cdtoc/set_durations.tt
@@ -13,7 +13,26 @@
   </tbody></table>
 
   <h2>[% l('Changes') %]</h2>
-  [%- track_duration_changes([1 .. medium.cdtoc_tracks.size], medium.cdtoc_tracks, cdtoc.track_details, 'length', 'length_time') -%]
+  [% old_lengths = BLOCK;
+       FOR track=medium.cdtoc_tracks;
+         track.length | format_length;
+         ' ';
+       END;
+     END;
+     new_lengths = BLOCK;
+       FOR track=cdtoc.track_details;
+         track.length_time | format_length;
+         ' ';
+       END;
+     END %]
+
+  [% IF old_lengths == new_lengths %]
+    <p>
+      [% l('This edit would only make subsecond changes to track lengths.') %]
+    </p>
+  [% ELSE %]
+    [%- track_duration_changes([1 .. medium.cdtoc_tracks.size], medium.cdtoc_tracks, cdtoc.track_details, 'length', 'length_time') -%]
+  [% END %]
 
   <p>
     [%~ l('The medium you are altering is part of the following release: {release}',


### PR DESCRIPTION
### Implement MBS-11310

This is currently confusing because it seems that there would be no changes at all if the edit was entered. In reality, it will cause sub-second changes, and we should specify that for clarity.
