### PR TITLE
MBS-11304: Add recordings’ first release date to release lookup

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -135,6 +135,7 @@ sub release_toplevel {
 
         my @recordings = $c->model('Recording')->load(@tracks);
         $c->model('Recording')->load_meta(@recordings);
+        $c->model('Recording')->load_first_release_date(@recordings);
 
         my $inc_artist_credits = $inc->artist_credits;
         if ($inc_artist_credits) {

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Recording.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/2/Recording.pm
@@ -36,7 +36,6 @@ sub serialize
     }
 
     if (
-        $toplevel &&
         DBDefs->ACTIVE_SCHEMA_SEQUENCE == 26 &&
         defined $entity->first_release_date
     ) {

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -606,7 +606,6 @@ sub _serialize_recording
         $self->_serialize_artist_credit($rec_node, $recording->artist_credit, $inc, $stash, $inc->artists)
             if $inc->artists || $inc->artist_credits;
 
-
         if (
             DBDefs->ACTIVE_SCHEMA_SEQUENCE == 26 &&
             defined $recording->first_release_date
@@ -621,6 +620,13 @@ sub _serialize_recording
     {
         $self->_serialize_artist_credit($rec_node, $recording->artist_credit, $inc, $stash)
             if $inc->artist_credits;
+
+        if (
+            DBDefs->ACTIVE_SCHEMA_SEQUENCE == 26 &&
+            defined $recording->first_release_date
+        ) {
+            $rec_node->appendTextChild('first-release-date', $recording->first_release_date->format);
+        }
     }
 
     $self->_serialize_alias_list($rec_node, $opts->{aliases}, $inc, $opts)

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupISRC.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupISRC.pm
@@ -20,6 +20,7 @@ test 'basic isrc lookup' => sub {
                 length => 289946,
                 title => 'Hey Boy Hey Girl',
                 video => JSON::false,
+                "first-release-date" => '1999-06-21',
             },
         ],
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
@@ -482,6 +482,7 @@ test 'release lookup with labels and recordings' => sub {
                                 length => 243000,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2004-03-17',
                             }
                         },
                         {
@@ -496,6 +497,7 @@ test 'release lookup with labels and recordings' => sub {
                                 length => 222000,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2004-03-17',
                             }
                         },
                         {
@@ -510,6 +512,7 @@ test 'release lookup with labels and recordings' => sub {
                                 length => 333000,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2004-03-17',
                             }
                         }]
                 }],
@@ -778,6 +781,7 @@ test 'release lookup with discids' => sub {
                                 length => 296026,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2001-07-04',
                             }
                         },
                         {
@@ -792,6 +796,7 @@ test 'release lookup with discids' => sub {
                                 length => 213106,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2001-07-04',
                             }
                         },
                         {
@@ -806,6 +811,7 @@ test 'release lookup with discids' => sub {
                                 length => 292800,
                                 disambiguation => "",
                                 video => JSON::false,
+                                "first-release-date" => '2001-07-04',
                             }
                         }]
                 }]
@@ -1102,7 +1108,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         ],
                         tags => [],
                         genres => [],
-                        title => 'On My Bus'
+                        title => 'On My Bus',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'On My Bus'
                 },
@@ -1140,7 +1147,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Top & Low Rent'
+                        title => 'Top & Low Rent',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Top & Low Rent'
                 },
@@ -1178,7 +1186,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Plock'
+                        title => 'Plock',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Plock'
                 },
@@ -1216,7 +1225,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Marbles'
+                        title => 'Marbles',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Marbles'
                 },
@@ -1254,7 +1264,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Busy Working'
+                        title => 'Busy Working',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Busy Working'
                 },
@@ -1292,7 +1303,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'The Greek Alphabet'
+                        title => 'The Greek Alphabet',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'The Greek Alphabet'
                 },
@@ -1330,7 +1342,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Press a Key'
+                        title => 'Press a Key',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Press a Key'
                 },
@@ -1368,7 +1381,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Bibi Plone'
+                        title => 'Bibi Plone',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Bibi Plone'
                 },
@@ -1406,7 +1420,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Be Rude to Your School'
+                        title => 'Be Rude to Your School',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Be Rude to Your School'
                 },
@@ -1444,7 +1459,8 @@ test 'release lookup, related artists have no tags/genres' => sub {
                         } ],
                         tags => [],
                         genres => [],
-                        title => 'Summer Plays Out'
+                        title => 'Summer Plays Out',
+                        "first-release-date" => '1999-09-13',
                     },
                     title => 'Summer Plays Out'
                 }

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelationship.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelationship.pm
@@ -285,6 +285,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="5a0b7a30-4297-3cda-ba0f-2547c4b7ae9b">
@@ -302,6 +303,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="a5b038bf-6e36-362b-9397-9cecda03e9bc">
@@ -319,6 +321,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="7c66606c-8a1b-3407-a856-21e4622da140">
@@ -336,6 +339,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="2d11d4ec-b9c0-3bfe-86d9-df5034e2522e">
@@ -353,6 +357,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="3ec79596-482b-3d1b-8f48-325a1b332366">
@@ -361,6 +366,7 @@ ws_test 'release lookup with recording-level relationships',
                         <recording id="9815c3e5-f842-41c2-bb5c-bcd0dd97dbe5">
                             <title>Discopharma</title>
                             <length>236666</length>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="baaa07d9-6c32-31e6-bbea-1796fd79a8f1">
@@ -378,6 +384,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="61add1a9-5a53-3eb3-afa6-fb503998a909">
@@ -410,6 +417,7 @@ ws_test 'release lookup with recording-level relationships',
                                     </work>
                                 </relation>
                             </relation-list>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                     <track id="8cef791e-3363-3c36-8b29-1f5dd2982902">
@@ -418,6 +426,7 @@ ws_test 'release lookup with recording-level relationships',
                         <recording id="15918f5f-20b1-4e1a-888d-8762790017a9">
                             <title>Just Because</title>
                             <length>249653</length>
+                            <first-release-date>2008-04-29</first-release-date>
                         </recording>
                     </track>
                 </track-list>

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -366,6 +366,7 @@ ws_test 'release lookup with labels, recordings and tags',
                         <length>243000</length>
                         <recording id="0cf3008f-e246-428f-abc1-35f87d584d60">
                             <title>the Love Bug</title><length>243000</length>
+                            <first-release-date>2004-03-17</first-release-date>
                             <tag-list>
                                 <tag count="1"><name>kpop</name></tag>
                             </tag-list>
@@ -376,6 +377,7 @@ ws_test 'release lookup with labels, recordings and tags',
                         <length>222000</length>
                         <recording id="84c98ebf-5d40-4a29-b7b2-0e9c26d9061d">
                             <title>the Love Bug (Big Bug NYC remix)</title><length>222000</length>
+                            <first-release-date>2004-03-17</first-release-date>
                             <tag-list>
                                 <tag count="1"><name>jpop</name></tag>
                             </tag-list>
@@ -386,6 +388,7 @@ ws_test 'release lookup with labels, recordings and tags',
                         <length>333000</length>
                         <recording id="3f33fc37-43d0-44dc-bfd6-60efd38810c5">
                             <title>the Love Bug (cover)</title><length>333000</length>
+                            <first-release-date>2004-03-17</first-release-date>
                             <tag-list>
                                 <tag count="1"><name>c-pop</name></tag>
                             </tag-list>
@@ -510,18 +513,21 @@ ws_test 'release lookup with discids and recordings',
                         <position>1</position><number>1</number><title>Summer Reggae! Rainbow</title><length>296026</length>
                         <recording id="162630d9-36d2-4a8d-ade1-1c77440b34e7">
                             <title>サマーれげぇ!レインボー</title><length>296026</length>
+                            <first-release-date>2001-07-04</first-release-date>
                         </recording>
                     </track>
                     <track id="c7c21691-6f85-3ec7-9b08-e431c3b310a5">
                         <position>2</position><number>2</number><title>Hello! Mata Aou Ne (7nin Matsuri version)</title><length>213106</length>
                         <recording id="487cac92-eed5-4efa-8563-c9a818079b9a">
                             <title>HELLO! また会おうね (7人祭 version)</title><length>213106</length>
+                            <first-release-date>2001-07-04</first-release-date>
                         </recording>
                     </track>
                     <track id="e436c057-ca19-36c6-9f1e-dc4ada2604b0">
                         <position>3</position><number>3</number><title>Summer Reggae! Rainbow (Instrumental)</title><length>292800</length>
                         <recording id="eb818aa4-d472-4d2b-b1a9-7fe5f1c7d26e">
                             <title>サマーれげぇ!レインボー (instrumental)</title><length>292800</length>
+                            <first-release-date>2001-07-04</first-release-date>
                         </recording>
                     </track>
                 </track-list>
@@ -804,6 +810,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="f38b8e31-a10d-3973-8c1f-10923ee61adc">
@@ -819,6 +826,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="d17bed32-940a-3fcc-9210-a5d7c516b4bb">
@@ -834,6 +842,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="001bc675-ba25-32bc-9914-d5d9e22c3c44">
@@ -849,6 +858,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="c009176f-ff26-3f5f-bd16-46cede30ebe6">
@@ -864,6 +874,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="70454e43-b39b-3ca7-8c50-ae235b5ef358">
@@ -879,6 +890,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="1b5da50c-e20f-3762-839c-5a0eea89d6a5">
@@ -894,6 +906,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="f1b5bd23-ad01-3c0c-a49a-cf8e99088369">
@@ -909,6 +922,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="928f2274-5694-35f9-92da-a1fc565867cf">
@@ -924,6 +938,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="40727388-237d-34b2-8a3a-288878e5c883">
@@ -939,6 +954,7 @@ ws_test 'release lookup, related artists have no tags',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
         </track-list>
@@ -1050,6 +1066,7 @@ ws_test 'release lookup, track artists have no aliases',
                   </artist>
                 </relation>
               </relation-list>
+              <first-release-date>2004-03-17</first-release-date>
             </recording>
           </track>
           <track id="2519283c-93d9-30de-a0ba-75f99ca25604">
@@ -1078,6 +1095,7 @@ ws_test 'release lookup, track artists have no aliases',
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>2004-03-17</first-release-date>
             </recording>
           </track>
           <track id="4ffc18f0-96cc-3e1f-8192-cf0d0c489beb">
@@ -1091,6 +1109,7 @@ ws_test 'release lookup, track artists have no aliases',
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>2004-03-17</first-release-date>
             </recording>
           </track>
         </track-list>
@@ -1207,6 +1226,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="f38b8e31-a10d-3973-8c1f-10923ee61adc">
@@ -1247,6 +1267,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="d17bed32-940a-3fcc-9210-a5d7c516b4bb">
@@ -1287,6 +1308,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="001bc675-ba25-32bc-9914-d5d9e22c3c44">
@@ -1327,6 +1349,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="c009176f-ff26-3f5f-bd16-46cede30ebe6">
@@ -1367,6 +1390,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="70454e43-b39b-3ca7-8c50-ae235b5ef358">
@@ -1407,6 +1431,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="1b5da50c-e20f-3762-839c-5a0eea89d6a5">
@@ -1447,6 +1472,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="f1b5bd23-ad01-3c0c-a49a-cf8e99088369">
@@ -1487,6 +1513,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="928f2274-5694-35f9-92da-a1fc565867cf">
@@ -1527,6 +1554,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
           <track id="40727388-237d-34b2-8a3a-288878e5c883">
@@ -1567,6 +1595,7 @@ ws_test 'release lookup, tags are not duplicated for artists that are both relea
                   </artist>
                 </name-credit>
               </artist-credit>
+              <first-release-date>1999-09-13</first-release-date>
             </recording>
           </track>
         </track-list>


### PR DESCRIPTION
### Implement MBS-11304

Release is needed for Picard. 
