### PR TITLE
Upgrade Flow to 0.141.0 (fixes issues with new generics)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.140.0",
+    "flow-bin": "0.141.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "jsdom": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.139.0",
+    "flow-bin": "0.140.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "jsdom": "13.2.0",

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -48,11 +48,19 @@ function showExtraInfoLine(children, className = 'comment') {
   );
 }
 
-function formatName(entity) {
+function formatName<+T: EntityItem>(entity: Item<T>) {
   return unwrapNl<string>(entity.name);
 }
 
-function formatGeneric(entity, extraInfo) {
+function formatGeneric(
+  entity: | ArtistT
+          | EventT
+          | InstrumentT
+          | PlaceT
+          | ReleaseT
+          | WorkT,
+  extraInfo: ?((Array<string>) => void),
+) {
   const name = formatName(entity);
   const info = [];
 
@@ -60,7 +68,7 @@ function formatGeneric(entity, extraInfo) {
     info.push(entity.primaryAlias);
   }
 
-  if (entity.comment) {
+  if (nonEmpty(entity.comment)) {
     info.push(entity.comment);
   }
 
@@ -78,7 +86,7 @@ function formatGeneric(entity, extraInfo) {
   );
 }
 
-function formatArtist(artist) {
+function formatArtist(artist: ArtistT) {
   const sortName = artist.sort_name;
   let extraInfo;
   if (
@@ -87,7 +95,9 @@ function formatArtist(artist) {
     !nonEmpty(artist.primaryAlias) &&
     isNonLatin(artist.name)
   ) {
-    extraInfo = (info) => info.unshift(sortName);
+    extraInfo = (info) => {
+      info.unshift(sortName);
+    };
   }
   return formatGeneric(artist, extraInfo);
 }
@@ -184,7 +194,9 @@ function formatInstrument(instrument: InstrumentT) {
 
   return (
     <>
-      {formatGeneric(instrument, (info) => info.push(...extraInfo))}
+      {formatGeneric(instrument, (info) => {
+        info.push(...extraInfo);
+      })}
       {description ? showExtraInfoLine(description) : null}
     </>
   );

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -80,8 +80,24 @@ export type ActionItem<+T: EntityItem> = {
   +separator?: boolean,
 };
 
+/*
+ * This is basically CoreEntityT without UrlT (since those aren't
+ * searchable), plus EditorT (which isn't a core entity, but is
+ * searchable).
+ */
 export type EntityItem =
-  | CoreEntityT
-  | EditorT;
+  | AreaT
+  | ArtistT
+  | EditorT
+  | EventT
+  | GenreT
+  | InstrumentT
+  | LabelT
+  | PlaceT
+  | RecordingT
+  | ReleaseGroupT
+  | ReleaseT
+  | SeriesT
+  | WorkT;
 
 export type Item<+T: EntityItem> = T | ActionItem<T>;

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -146,6 +146,7 @@ function pushChild<T>(
   if (lastIndex >= 0 &&
       typeof match === 'string' &&
       typeof children[lastIndex] === 'string') {
+    // $FlowIssue[incompatible-type]
     children[lastIndex] += match;
   } else {
     children.push(match);
@@ -153,7 +154,15 @@ function pushChild<T>(
   return children;
 }
 
-function concatArrayMatch<T>(
+/*
+ * `MatchUpperBoundT` is used as the upper bound of `T` below, meaning
+ * `T` can be any subtype of `MatchUpperBoundT`. Generally parsers will
+ * produce strings/numbers, but they can also output React elements and
+ * other object types, so `{...}` must be included too.
+ */
+type MatchUpperBoundT = StrOrNum | {...};
+
+function concatArrayMatch<T: MatchUpperBoundT>(
   children: Array<T> | NO_MATCH,
   match: Array<T> | T,
 ): Array<T> {
@@ -170,7 +179,7 @@ function concatArrayMatch<T>(
   return children;
 }
 
-function parseContinuousArray<T, V>(
+function parseContinuousArray<T: MatchUpperBoundT, V>(
   parsers: $ReadOnlyArray<Parser<Array<T> | T | NO_MATCH, V>>,
   args: VarArgs<V>,
 ): Array<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,10 +3265,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.139.0:
-  version "0.139.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.139.0.tgz#3ad6c75460be45b64f00521035c5affb3c440df5"
-  integrity sha512-eilVetLwztYtKjRj//4OsJ7aw47hsUZ8GTINxaZHWhpqiFikErQL0sV/3hQtpm54w9FuS2PO4yvbU0pWrtckqg==
+flow-bin@0.140.0:
+  version "0.140.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.140.0.tgz#bf1a2984a0e5604daa0d1e0432138d9897af65bb"
+  integrity sha512-9P/VciKACXocClhLiDg/p1ntYmgCEEc9QrNOoTqTi2SEdEZDTiAmJLONRJfw4uglPVRZ1p/esWF9KlbZiuxqVw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,10 +3265,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.140.0:
-  version "0.140.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.140.0.tgz#bf1a2984a0e5604daa0d1e0432138d9897af65bb"
-  integrity sha512-9P/VciKACXocClhLiDg/p1ntYmgCEEc9QrNOoTqTi2SEdEZDTiAmJLONRJfw4uglPVRZ1p/esWF9KlbZiuxqVw==
+flow-bin@0.141.0:
+  version "0.141.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.141.0.tgz#f9e33ad29392824823c97b6db7de5ab972c7f872"
+  integrity sha512-NxaECTjIWfs2Y91GuA1PlgPd5uCulZcqR9wiXRg6n7/AbmvVetM2ewoGxCKxJm7wIml3f0/5KXIZvZa/3msqXg==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
This resolves some issues that have arisen due to the new generics implementation. See https://medium.com/flow-type/flows-improved-handling-of-generic-types-b5909cc5e3c5 for more information.

`./node_modules/.bin/flow` passes locally.