### PR TITLE
MBS-11313: Fix OAuth PKCE S256 verification

### DIFF
--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -9,7 +9,7 @@ use Digest::SHA qw( sha256 );
 use URI;
 use URI::QueryParam;
 use JSON;
-use MIME::Base64 qw( decode_base64url encode_base64url );
+use MIME::Base64 qw( encode_base64url );
 use MusicBrainz::Server::Constants qw( :access_scope );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use Readonly;
@@ -527,7 +527,7 @@ sub _check_pkce_verifier {
             $code_challenge eq $code_verifier) ||
         ($code_challenge_method eq 'S256' &&
             $code_challenge eq
-            encode_base64url(sha256(decode_base64url($code_verifier))))
+            encode_base64url(sha256($code_verifier)))
     );
 }
 

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -11,7 +11,7 @@ use URI::QueryParam;
 use JSON;
 use MusicBrainz::Server::Test qw( html_ok );
 use Digest::SHA qw( sha256 );
-use MIME::Base64 qw( decode_base64url encode_base64url );
+use MIME::Base64 qw( encode_base64url );
 
 with 't::Context', 't::Mechanize';
 
@@ -630,7 +630,7 @@ test 'Authorize web workflow online with PKCE' => sub {
     is($response->{error}, 'invalid_grant');
     is($response->{error_description}, 'Invalid PKCE verifier');
 
-    my $code_challenge = encode_base64url(sha256($code_verifier_raw));
+    my $code_challenge = encode_base64url(sha256($code_verifier));
     $test->mech->get($common_auth_params .
         "&code_challenge=$code_challenge&code_challenge_method=S256");
     # No confirmation since we're pre-authorized.


### PR DESCRIPTION
As the ticket describes, the code verifier is not meant to be base64url-decoded during verification; the encoding when generating the verifier is only to transform the initial random octets into something URL safe. The encoded string is in fact the code verifier and not the initial random octets.

I fixed the automated tests and ran `prove -vl t/tests.t :: --tests Controller::OAuth2` to check the change.