### PR TITLE
MBS-11514 / MBS-11515 / MBS-11516 / MBS-11517: Use React.useContext in more places rather than passing $c around

### DIFF
--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -59,7 +59,7 @@ const EmailSearch = ({
         </div>
 
         {results?.length ? (
-          <UserList $c={$c} users={results} />
+          <UserList users={results} />
         ) : null}
       </form>
     </div>

--- a/root/admin/IpLookup.js
+++ b/root/admin/IpLookup.js
@@ -31,7 +31,7 @@ const IpLookup = ({
         {l('IP hash:') + ' ' + ipHash}
       </p>
       {users.length ? (
-        <UserList $c={$c} users={users} />
+        <UserList users={users} />
       ) : (
         <p>
           {l('No results')}

--- a/root/admin/components/UserList.js
+++ b/root/admin/components/UserList.js
@@ -9,55 +9,61 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import EditorLink from '../../static/scripts/common/components/EditorLink';
 import bracketed from '../../static/scripts/common/utility/bracketed';
 import formatUserDate from '../../utility/formatUserDate';
 import loopParity from '../../utility/loopParity';
 
 type Props = {
-  +$c: CatalystContextT,
   +users: $ReadOnlyArray<UnsanitizedEditorT>,
 };
 
-const UserList = ({$c, users}: Props): React.Element<'table'> => (
-  <table className="tbl">
-    <thead>
-      <tr>
-        <th>{l('Editor')}</th>
-        <th>{l('Member since')}</th>
-        <th>{l('Email')}</th>
-        <th>{l('Verified on')}</th>
-        <th>{l('Last login')}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {users.map((user, index) => (
-        <tr className={loopParity(index)} key={user.name}>
-          <td>
-            <EditorLink editor={user} />
-            {' '}
-            {bracketed(
-              <a href={'/admin/user/delete/' + encodeURIComponent(user.name)}>
-                {l('delete')}
-              </a>,
-            )}
-          </td>
-          <td>{formatUserDate($c, user.registration_date)}</td>
-          <td>{user.email}</td>
-          <td>
-            {nonEmpty(user.email_confirmation_date) ? (
-              formatUserDate($c, user.email_confirmation_date)
-            ) : null}
-          </td>
-          <td>
-            {nonEmpty(user.last_login_date) ? (
-              formatUserDate($c, user.last_login_date)
-            ) : null}
-          </td>
+const UserList = ({users}: Props): React.Element<'table'> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          <th>{l('Editor')}</th>
+          <th>{l('Member since')}</th>
+          <th>{l('Email')}</th>
+          <th>{l('Verified on')}</th>
+          <th>{l('Last login')}</th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody>
+        {users.map((user, index) => (
+          <tr className={loopParity(index)} key={user.name}>
+            <td>
+              <EditorLink editor={user} />
+              {' '}
+              {bracketed(
+                <a
+                  href={'/admin/user/delete/' + encodeURIComponent(user.name)}
+                >
+                  {l('delete')}
+                </a>,
+              )}
+            </td>
+            <td>{formatUserDate($c, user.registration_date)}</td>
+            <td>{user.email}</td>
+            <td>
+              {nonEmpty(user.email_confirmation_date) ? (
+                formatUserDate($c, user.email_confirmation_date)
+              ) : null}
+            </td>
+            <td>
+              {nonEmpty(user.last_login_date) ? (
+                formatUserDate($c, user.last_login_date)
+              ) : null}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 export default UserList;

--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -38,7 +38,6 @@ const AreaArtists = ({
       >
         <PaginatedResults pager={pager}>
           <ArtistList
-            $c={$c}
             artists={artists}
             checkboxes="add-to-merge"
             showBeginEnd

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -38,7 +38,6 @@ const AreaEvents = ({
       >
         <PaginatedResults pager={pager}>
           <EventList
-            $c={$c}
             checkboxes="add-to-merge"
             events={events}
             showArtists

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -38,7 +38,6 @@ const AreaLabels = ({
       >
         <PaginatedResults pager={pager}>
           <LabelList
-            $c={$c}
             checkboxes="add-to-merge"
             labels={labels}
             showRatings

--- a/root/area/AreaLayout.js
+++ b/root/area/AreaLayout.js
@@ -42,7 +42,7 @@ const AreaLayout = ({
       <AreaHeader area={area} page={page} />
       {children}
     </div>
-    {fullWidth ? null : <AreaSidebar $c={$c} area={area} />}
+    {fullWidth ? null : <AreaSidebar area={area} />}
   </Layout>
 );
 

--- a/root/area/AreaMerge.js
+++ b/root/area/AreaMerge.js
@@ -37,7 +37,6 @@ const AreaMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <AreaList
-          $c={$c}
           areas={sortByEntityName(toMerge)}
           mergeForm={form}
         />

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -56,7 +56,6 @@ const AreaPlaces = ({
         >
           <PaginatedResults pager={pager}>
             <PlaceList
-              $c={$c}
               checkboxes="add-to-merge"
               places={places}
             />

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -42,11 +42,7 @@ const AreaReleases = ({
             method="post"
           >
             <PaginatedResults pager={pager}>
-              <ReleaseList
-                $c={$c}
-                checkboxes="add-to-merge"
-                releases={releases}
-              />
+              <ReleaseList checkboxes="add-to-merge" releases={releases} />
             </PaginatedResults>
             {$c.user ? (
               <div className="row">

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -38,7 +38,6 @@ const ArtistEvents = ({
       >
         <PaginatedResults pager={pager}>
           <EventList
-            $c={$c}
             artist={artist}
             artistRoles
             checkboxes="add-to-merge"

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -286,7 +286,6 @@ const ArtistIndex = ({
         >
           <PaginatedResults pager={pager}>
             <ReleaseGroupList
-              $c={$c}
               checkboxes="add-to-merge"
               releaseGroups={existingReleaseGroups}
               showRatings
@@ -307,7 +306,6 @@ const ArtistIndex = ({
         >
           <PaginatedResults pager={pager}>
             <RecordingList
-              $c={$c}
               checkboxes="add-to-merge"
               recordings={existingRecordings}
               showRatings

--- a/root/artist/ArtistLayout.js
+++ b/root/artist/ArtistLayout.js
@@ -39,7 +39,7 @@ const ArtistLayout = ({
       <ArtistHeader artist={artist} page={page} />
       {children}
     </div>
-    {fullWidth ? null : <ArtistSidebar $c={$c} artist={artist} />}
+    {fullWidth ? null : <ArtistSidebar artist={artist} />}
   </Layout>
 );
 

--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -38,7 +38,6 @@ const ArtistMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <ArtistList
-          $c={$c}
           artists={sortByEntityName(toMerge)}
           mergeForm={form}
         />

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -155,7 +155,6 @@ const ArtistRecordings = ({
       >
         <PaginatedResults pager={pager}>
           <RecordingList
-            $c={$c}
             checkboxes="add-to-merge"
             recordings={recordings}
             showRatings

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -56,11 +56,7 @@ const ArtistReleases = ({
         method="post"
       >
         <PaginatedResults pager={pager}>
-          <ReleaseList
-            $c={$c}
-            checkboxes="add-to-merge"
-            releases={releases}
-          />
+          <ReleaseList checkboxes="add-to-merge" releases={releases} />
         </PaginatedResults>
         {$c.user ? (
           <div className="row">

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -38,7 +38,6 @@ const ArtistWorks = ({
       >
         <PaginatedResults pager={pager}>
           <WorkList
-            $c={$c}
             checkboxes="add-to-merge"
             showRatings
             works={works}

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -53,12 +53,10 @@ type Props =
   | PropsForEntity<WorkT>;
 
 const listPicker = (
-  $c: CatalystContextT,
   props: Props,
   canRemoveFromCollection: boolean,
 ) => {
   const sharedProps = {
-    $c,
     checkboxes: canRemoveFromCollection ? 'remove' : '',
     order: props.order,
     sortable: true,
@@ -84,7 +82,6 @@ const listPicker = (
     case 'event':
       return (
         <EventList
-          $c={$c}
           events={props.entities}
           showArtists
           showLocation
@@ -204,7 +201,7 @@ React.Element<typeof CollectionLayout> => {
       {entities.length > 0 ? (
         <form action={$c.req.uri} method="post">
           <PaginatedResults pager={pager}>
-            {listPicker($c, props, canRemoveFromCollection)}
+            {listPicker(props, canRemoveFromCollection)}
           </PaginatedResults>
           {canRemoveFromCollection ? (
             <FormRow>

--- a/root/collection/CollectionLayout.js
+++ b/root/collection/CollectionLayout.js
@@ -50,9 +50,7 @@ const CollectionLayout = ({
         />
         {children}
       </div>
-      {fullWidth ? null : (
-        <CollectionSidebar $c={$c} collection={collection} />
-      )}
+      {fullWidth ? null : <CollectionSidebar collection={collection} />}
     </Layout>
   );
 };

--- a/root/components/list/AreaList.js
+++ b/root/components/list/AreaList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineCheckboxColumn,
@@ -18,7 +19,6 @@ import {
 } from '../../utility/tableColumns';
 
 type Props = {
-  +$c: CatalystContextT,
   +areas: $ReadOnlyArray<AreaT>,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
@@ -27,13 +27,14 @@ type Props = {
 };
 
 const AreaList = ({
-  $c,
   areas,
   checkboxes,
   mergeForm,
   order,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineCheckboxColumn,
@@ -25,7 +26,6 @@ import {
 
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +artists: $ReadOnlyArray<ArtistT>,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
@@ -38,7 +38,6 @@ type Props = {
 };
 
 const ArtistList = ({
-  $c,
   artists,
   checkboxes,
   instrumentCreditsAndRelTypes,
@@ -50,6 +49,8 @@ const ArtistList = ({
   showSortName = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList';
@@ -29,7 +30,6 @@ import {
 
 type Props = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +artist?: ArtistT,
   +artistRoles?: boolean,
   +checkboxes?: string,
@@ -44,7 +44,6 @@ type Props = {
 };
 
 const EventList = ({
-  $c,
   artist,
   artistRoles = false,
   checkboxes,
@@ -58,6 +57,8 @@ const EventList = ({
   showType = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/InstrumentList.js
+++ b/root/components/list/InstrumentList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineCheckboxColumn,
@@ -19,7 +20,6 @@ import {
 } from '../../utility/tableColumns';
 
 type Props = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +instruments: $ReadOnlyArray<InstrumentT>,
   +mergeForm?: MergeFormT,
@@ -28,13 +28,14 @@ type Props = {
 };
 
 const InstrumentList = ({
-  $c,
   checkboxes,
   instruments,
   mergeForm,
   order,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import formatLabelCode from '../../utility/formatLabelCode';
 import {
@@ -24,7 +25,6 @@ import {
 } from '../../utility/tableColumns';
 
 type Props = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +labels: $ReadOnlyArray<LabelT>,
   +mergeForm?: MergeFormT,
@@ -34,7 +34,6 @@ type Props = {
 };
 
 const LabelList = ({
-  $c,
   checkboxes,
   labels,
   mergeForm,
@@ -42,6 +41,8 @@ const LabelList = ({
   showRatings = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineCheckboxColumn,
@@ -22,7 +23,6 @@ import {
 } from '../../utility/tableColumns';
 
 type Props = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
   +order?: string,
@@ -31,13 +31,14 @@ type Props = {
 };
 
 const PlaceList = ({
-  $c,
   checkboxes,
   mergeForm,
   order,
   places,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
@@ -29,7 +30,6 @@ import hydrate from '../../utility/hydrate';
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +lengthClass?: string,
   +mergeForm?: MergeFormT,
@@ -43,7 +43,6 @@ type Props = {
 };
 
 const RecordingList = ({
-  $c,
   checkboxes,
   instrumentCreditsAndRelTypes,
   lengthClass,
@@ -57,6 +56,8 @@ const RecordingList = ({
   showRatings = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const acoustIdsColumn = useAcoustIdsColumn(
     recordings,
     showAcoustIds,

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import releaseGroupType from '../../utility/releaseGroupType';
 import {groupBy} from '../../static/scripts/common/utility/arrays';
@@ -26,7 +27,6 @@ import {
 
 type ReleaseGroupListTableProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
   +order?: string,
@@ -38,7 +38,6 @@ type ReleaseGroupListTableProps = {
 
 type ReleaseGroupListProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
   +order?: string,
@@ -48,7 +47,6 @@ type ReleaseGroupListProps = {
 };
 
 export const ReleaseGroupListTable = ({
-  $c,
   checkboxes,
   mergeForm,
   order,
@@ -58,6 +56,8 @@ export const ReleaseGroupListTable = ({
   showType = true,
   sortable,
 }: ReleaseGroupListTableProps): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   function getFirstReleaseYear(entity: ReleaseGroupT) {
     if (!nonEmpty(entity.firstReleaseDate)) {
       return '—';
@@ -144,7 +144,6 @@ export const ReleaseGroupListTable = ({
 };
 
 const ReleaseGroupList = ({
-  $c,
   checkboxes,
   mergeForm,
   order,
@@ -166,7 +165,6 @@ const ReleaseGroupList = ({
             }
           </h3>
           <ReleaseGroupListTable
-            $c={$c}
             checkboxes={checkboxes}
             mergeForm={mergeForm}
             order={order}

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import filterReleaseLabels
   from '../../static/scripts/common/utility/filterReleaseLabels';
@@ -31,7 +32,6 @@ import {
 type Props = {
   ...InstrumentCreditsAndRelTypesRoleT,
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +filterLabel?: LabelT,
   +order?: string,
@@ -45,7 +45,6 @@ type Props = {
 };
 
 const ReleaseList = ({
-  $c,
   checkboxes,
   filterLabel,
   instrumentCreditsAndRelTypes,
@@ -59,6 +58,8 @@ const ReleaseList = ({
   showType = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && nonEmpty(checkboxes)

--- a/root/components/list/SeriesList.js
+++ b/root/components/list/SeriesList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineCheckboxColumn,
@@ -19,7 +20,6 @@ import {
 } from '../../utility/tableColumns';
 
 type Props = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
   +order?: string,
@@ -28,13 +28,14 @@ type Props = {
 };
 
 const SeriesList = ({
-  $c,
   checkboxes,
   mergeForm,
   order,
   series,
   sortable,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Table from '../Table';
 import {
   defineArtistRolesColumn,
@@ -26,7 +27,6 @@ import {
 
 type Props = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +mergeForm?: MergeFormT,
   +order?: string,
@@ -36,7 +36,6 @@ type Props = {
 };
 
 const WorkList = ({
-  $c,
   checkboxes,
   mergeForm,
   order,
@@ -45,6 +44,8 @@ const WorkList = ({
   sortable,
   works,
 }: Props): React.Element<typeof Table> => {
+  const $c = React.useContext(CatalystContext);
+
   const columns = React.useMemo(
     () => {
       const checkboxColumn = $c.user && (nonEmpty(checkboxes) || mergeForm)

--- a/root/edit/details/MergeAreas.js
+++ b/root/edit/details/MergeAreas.js
@@ -20,25 +20,21 @@ type MergeAreasEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeAreasEditT,
 };
 
-const MergeAreas = ({
-  $c,
-  edit,
-}: Props): React.Element<'table'> => (
+const MergeAreas = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-areas">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <AreaList $c={$c} areas={edit.display_data.old} />
+        <AreaList areas={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <AreaList $c={$c} areas={[edit.display_data.new]} />
+        <AreaList areas={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergeArtists.js
+++ b/root/edit/details/MergeArtists.js
@@ -22,22 +22,21 @@ type MergeArtistsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeArtistsEditT,
 };
 
-const MergeArtists = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeArtists = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-artists">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <ArtistList $c={$c} artists={edit.display_data.old} showBeginEnd />
+        <ArtistList artists={edit.display_data.old} showBeginEnd />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <ArtistList $c={$c} artists={[edit.display_data.new]} showBeginEnd />
+        <ArtistList artists={[edit.display_data.new]} showBeginEnd />
       </td>
     </tr>
     <tr className="rename-artist-credits">

--- a/root/edit/details/MergeEvents.js
+++ b/root/edit/details/MergeEvents.js
@@ -20,17 +20,15 @@ type MergeEventsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeEventsEditT,
 };
 
-const MergeEvents = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeEvents = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-events">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
         <EventList
-          $c={$c}
           events={edit.display_data.old}
           showArtists
           showLocation
@@ -42,7 +40,6 @@ const MergeEvents = ({$c, edit}: Props): React.Element<'table'> => (
       <th>{l('Into:')}</th>
       <td>
         <EventList
-          $c={$c}
           events={[edit.display_data.new]}
           showArtists
           showLocation

--- a/root/edit/details/MergeInstruments.js
+++ b/root/edit/details/MergeInstruments.js
@@ -20,22 +20,21 @@ type MergeInstrumentsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeInstrumentsEditT,
 };
 
-const MergeInstruments = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeInstruments = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-instruments">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <InstrumentList $c={$c} instruments={edit.display_data.old} />
+        <InstrumentList instruments={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <InstrumentList $c={$c} instruments={[edit.display_data.new]} />
+        <InstrumentList instruments={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergeLabels.js
+++ b/root/edit/details/MergeLabels.js
@@ -20,22 +20,21 @@ type MergeLabelsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeLabelsEditT,
 };
 
-const MergeLabels = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeLabels = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-labels">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <LabelList $c={$c} labels={edit.display_data.old} />
+        <LabelList labels={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <LabelList $c={$c} labels={[edit.display_data.new]} />
+        <LabelList labels={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergePlaces.js
+++ b/root/edit/details/MergePlaces.js
@@ -20,22 +20,21 @@ type MergePlacesEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergePlacesEditT,
 };
 
-const MergePlaces = ({$c, edit}: Props): React.Element<'table'> => (
+const MergePlaces = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-place">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <PlaceList $c={$c} places={edit.display_data.old} />
+        <PlaceList places={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <PlaceList $c={$c} places={[edit.display_data.new]} />
+        <PlaceList places={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergeRecordings.js
+++ b/root/edit/details/MergeRecordings.js
@@ -21,17 +21,15 @@ type MergeRecordingsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeRecordingsEditT,
 };
 
-const MergeRecordings = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeRecordings = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-recordings">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
         <RecordingList
-          $c={$c}
           lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
           recordings={edit.display_data.old}
           showExpandedArtistCredits
@@ -42,7 +40,6 @@ const MergeRecordings = ({$c, edit}: Props): React.Element<'table'> => (
       <th>{l('Into:')}</th>
       <td>
         <RecordingList
-          $c={$c}
           lengthClass={edit.display_data.large_spread ? 'warn-lengths' : ''}
           recordings={[edit.display_data.new]}
           showExpandedArtistCredits

--- a/root/edit/details/MergeReleaseGroups.js
+++ b/root/edit/details/MergeReleaseGroups.js
@@ -20,28 +20,21 @@ type MergeReleaseGroupsEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeReleaseGroupsEditT,
 };
 
-const MergeReleaseGroups = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeReleaseGroups = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-release-groups">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <ReleaseGroupListTable
-          $c={$c}
-          releaseGroups={edit.display_data.old}
-        />
+        <ReleaseGroupListTable releaseGroups={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <ReleaseGroupListTable
-          $c={$c}
-          releaseGroups={[edit.display_data.new]}
-        />
+        <ReleaseGroupListTable releaseGroups={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergeSeries.js
+++ b/root/edit/details/MergeSeries.js
@@ -20,25 +20,21 @@ type MergeSeriesEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeSeriesEditT,
 };
 
-const MergeSeries = ({
-  $c,
-  edit,
-}: Props): React.Element<'table'> => (
+const MergeSeries = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-series">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <SeriesList $c={$c} series={edit.display_data.old} />
+        <SeriesList series={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <SeriesList $c={$c} series={[edit.display_data.new]} />
+        <SeriesList series={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/edit/details/MergeWorks.js
+++ b/root/edit/details/MergeWorks.js
@@ -20,22 +20,21 @@ type MergeWorksEditT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: MergeWorksEditT,
 };
 
-const MergeWorks = ({$c, edit}: Props): React.Element<'table'> => (
+const MergeWorks = ({edit}: Props): React.Element<'table'> => (
   <table className="details merge-works">
     <tr>
       <th>{l('Merge:')}</th>
       <td>
-        <WorkList $c={$c} works={edit.display_data.old} />
+        <WorkList works={edit.display_data.old} />
       </td>
     </tr>
     <tr>
       <th>{l('Into:')}</th>
       <td>
-        <WorkList $c={$c} works={[edit.display_data.new]} />
+        <WorkList works={[edit.display_data.new]} />
       </td>
     </tr>
   </table>

--- a/root/event/EventLayout.js
+++ b/root/event/EventLayout.js
@@ -39,7 +39,7 @@ const EventLayout = ({
       <EventHeader event={event} page={page} />
       {children}
     </div>
-    {fullWidth ? null : <EventSidebar $c={$c} event={event} />}
+    {fullWidth ? null : <EventSidebar event={event} />}
   </Layout>
 );
 

--- a/root/event/EventMerge.js
+++ b/root/event/EventMerge.js
@@ -37,7 +37,6 @@ const EventMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <EventList
-          $c={$c}
           events={sortByEntityName(toMerge)}
           mergeForm={form}
           showArtists

--- a/root/genre/GenreLayout.js
+++ b/root/genre/GenreLayout.js
@@ -36,7 +36,7 @@ const GenreLayout = ({
       <GenreHeader genre={genre} page={page} />
       {children}
     </div>
-    {fullWidth ? null : <GenreSidebar $c={$c} genre={genre} />}
+    {fullWidth ? null : <GenreSidebar genre={genre} />}
   </Layout>
 );
 

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -45,7 +45,6 @@ const InstrumentArtists = ({
       >
         <PaginatedResults pager={pager}>
           <ArtistList
-            $c={$c}
             artists={artists}
             checkboxes="add-to-merge"
             instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}

--- a/root/instrument/InstrumentLayout.js
+++ b/root/instrument/InstrumentLayout.js
@@ -51,9 +51,7 @@ const InstrumentLayout = ({
         <InstrumentHeader instrument={instrument} page={page} />
         {children}
       </div>
-      {fullWidth ? null : (
-        <InstrumentSidebar $c={$c} instrument={instrument} />
-      )}
+      {fullWidth ? null : <InstrumentSidebar instrument={instrument} />}
     </Layout>
   );
 };

--- a/root/instrument/InstrumentMerge.js
+++ b/root/instrument/InstrumentMerge.js
@@ -37,7 +37,6 @@ const InstrumentMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <InstrumentList
-          $c={$c}
           instruments={sortByEntityName(toMerge)}
           mergeForm={form}
         />

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -45,7 +45,6 @@ const InstrumentRecordings = ({
       >
         <PaginatedResults pager={pager}>
           <RecordingList
-            $c={$c}
             checkboxes="add-to-merge"
             instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
             recordings={recordings}

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -45,7 +45,6 @@ const InstrumentReleases = ({
       >
         <PaginatedResults pager={pager}>
           <ReleaseList
-            $c={$c}
             checkboxes="add-to-merge"
             instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
             releases={releases}

--- a/root/iswc/Index.js
+++ b/root/iswc/Index.js
@@ -63,7 +63,6 @@ const Index = ({$c, iswcs, works}: Props): React.Element<typeof Layout> => {
           <tbody>
             {works.map((work, index) => (
               <WorkListEntry
-                $c={$c}
                 checkboxes="add-to-merge"
                 index={index}
                 key={work.id}

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -63,7 +63,6 @@ const LabelIndex = ({
       >
         <PaginatedResults pager={pager}>
           <ReleaseList
-            $c={$c}
             checkboxes="add-to-merge"
             filterLabel={label}
             releases={releases}

--- a/root/label/LabelLayout.js
+++ b/root/label/LabelLayout.js
@@ -39,7 +39,7 @@ const LabelLayout = ({
       <LabelHeader label={label} page={page} />
       {children}
     </div>
-    {fullWidth ? null : <LabelSidebar $c={$c} label={label} />}
+    {fullWidth ? null : <LabelSidebar label={label} />}
   </Layout>
 );
 

--- a/root/label/LabelMerge.js
+++ b/root/label/LabelMerge.js
@@ -37,7 +37,6 @@ const LabelMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <LabelList
-          $c={$c}
           labels={sortByEntityName(toMerge)}
           mergeForm={form}
         />

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import {VARTIST_GID} from '../../static/scripts/common/constants';
 import {capitalize} from '../../static/scripts/common/utility/strings';
 import {returnToCurrentPage} from '../../utility/returnUri';
@@ -309,11 +310,8 @@ const DocumentationMenu = () => (
   </li>
 );
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const BottomMenu = ({$c}: Props): React.Element<'div'> => {
+const BottomMenu = (): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const serverLanguages = $c.stash.server_languages;
   return (
     <div className="bottom">

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -9,17 +9,15 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import DBDefs from '../../static/scripts/common/DBDefs';
 import {DONATE_URL} from '../../constants';
 import bracketed from '../../static/scripts/common/utility/bracketed';
 import formatUserDate from '../../utility/formatUserDate';
 import {returnToCurrentPage} from '../../utility/returnUri';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const Footer = ({$c}: Props): React.Element<'div'> => {
+const Footer = (): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const stash = $c.stash;
   return (
     <div id="footer">

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import * as manifest from '../../static/manifest';
 import DBDefs from '../../static/scripts/common/DBDefs';
 import escapeClosingTags from '../../utility/escapeClosingTags';
@@ -18,7 +19,6 @@ import FaviconLinks from './FaviconLinks';
 import MetaDescription from './MetaDescription';
 
 export type HeadProps = {
-  +$c: CatalystContextT,
   +homepage?: boolean,
   +noIcons?: boolean,
   +pager?: PagerT,
@@ -62,93 +62,97 @@ const CanonicalLink = ({requestUri}) => {
   return null;
 };
 
-const Head = ({$c, ...props}: HeadProps): React.Element<'head'> => (
-  <head>
-    <meta charSet="utf-8" />
-    <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
-    <meta content="width=device-width, initial-scale=1" name="viewport" />
-    <FaviconLinks />
+const Head = ({...props}: HeadProps): React.Element<'head'> => {
+  const $c = React.useContext(CatalystContext);
 
-    <MetaDescription entity={$c.stash.entity} />
+  return (
+    <head>
+      <meta charSet="utf-8" />
+      <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
+      <meta content="width=device-width, initial-scale=1" name="viewport" />
+      <FaviconLinks />
 
-    <title>{getTitle(props)}</title>
+      <MetaDescription entity={$c.stash.entity} />
 
-    <CanonicalLink requestUri={$c.req.uri} />
+      <title>{getTitle(props)}</title>
 
-    <link
-      href={require('../../static/styles/common.less')}
-      rel="stylesheet"
-      type="text/css"
-    />
+      <CanonicalLink requestUri={$c.req.uri} />
 
-    {props.noIcons ? null : (
       <link
-        href={require('../../static/styles/icons.less')}
+        href={require('../../static/styles/common.less')}
         rel="stylesheet"
         type="text/css"
       />
-    )}
 
-    <link
-      href="/static/search_plugins/opensearch/musicbrainz_artist.xml"
-      rel="search"
-      title={l('MusicBrainz: Artist')}
-      type="application/opensearchdescription+xml"
-    />
-    <link
-      href="/static/search_plugins/opensearch/musicbrainz_label.xml"
-      rel="search"
-      title={l('MusicBrainz: Label')}
-      type="application/opensearchdescription+xml"
-    />
-    <link
-      href="/static/search_plugins/opensearch/musicbrainz_release.xml"
-      rel="search"
-      title={l('MusicBrainz: Release')}
-      type="application/opensearchdescription+xml"
-    />
-    <link
-      href="/static/search_plugins/opensearch/musicbrainz_track.xml"
-      rel="search"
-      title={l('MusicBrainz: Track')}
-      type="application/opensearchdescription+xml"
-    />
+      {props.noIcons ? null : (
+        <link
+          href={require('../../static/styles/icons.less')}
+          rel="stylesheet"
+          type="text/css"
+        />
+      )}
 
-    <noscript>
       <link
-        href={require('../../static/styles/noscript.less')}
-        rel="stylesheet"
-        type="text/css"
+        href="/static/search_plugins/opensearch/musicbrainz_artist.xml"
+        rel="search"
+        title={l('MusicBrainz: Artist')}
+        type="application/opensearchdescription+xml"
       />
-    </noscript>
-
-    {globalsScript}
-
-    {manifest.js('runtime')}
-
-    {manifest.js('common-chunks')}
-
-    {manifest.js('jed-data')}
-
-    {$c.stash.current_language === 'en'
-      ? null
-      : manifest.js('jed-' + $c.stash.current_language)}
-
-    {manifest.js('common', {
-      'data-args': JSON.stringify({
-        user: $c.user ? {id: $c.user.id, name: $c.user.name} : null,
-      }),
-    })}
-
-    {$c.stash.jsonld_data ? (
-      <script
-        dangerouslySetInnerHTML={
-          {__html: escapeClosingTags(JSON.stringify($c.stash.jsonld_data))}
-        }
-        type="application/ld+json"
+      <link
+        href="/static/search_plugins/opensearch/musicbrainz_label.xml"
+        rel="search"
+        title={l('MusicBrainz: Label')}
+        type="application/opensearchdescription+xml"
       />
-    ) : null}
-  </head>
-);
+      <link
+        href="/static/search_plugins/opensearch/musicbrainz_release.xml"
+        rel="search"
+        title={l('MusicBrainz: Release')}
+        type="application/opensearchdescription+xml"
+      />
+      <link
+        href="/static/search_plugins/opensearch/musicbrainz_track.xml"
+        rel="search"
+        title={l('MusicBrainz: Track')}
+        type="application/opensearchdescription+xml"
+      />
+
+      <noscript>
+        <link
+          href={require('../../static/styles/noscript.less')}
+          rel="stylesheet"
+          type="text/css"
+        />
+      </noscript>
+
+      {globalsScript}
+
+      {manifest.js('runtime')}
+
+      {manifest.js('common-chunks')}
+
+      {manifest.js('jed-data')}
+
+      {$c.stash.current_language === 'en'
+        ? null
+        : manifest.js('jed-' + $c.stash.current_language)}
+
+      {manifest.js('common', {
+        'data-args': JSON.stringify({
+          user: $c.user ? {id: $c.user.id, name: $c.user.name} : null,
+        }),
+      })}
+
+      {$c.stash.jsonld_data ? (
+        <script
+          dangerouslySetInnerHTML={
+            {__html: escapeClosingTags(JSON.stringify($c.stash.jsonld_data))}
+          }
+          type="application/ld+json"
+        />
+      ) : null}
+    </head>
+  );
+};
 
 export default Head;

--- a/root/layout/components/Header.js
+++ b/root/layout/components/Header.js
@@ -13,18 +13,14 @@ import HeaderLogo from './HeaderLogo';
 import TopMenu from './TopMenu';
 import BottomMenu from './BottomMenu';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const Header = ({$c}: Props): React.Element<'div'> => (
+const Header = (): React.Element<'div'> => (
   <div className="header">
     <a className="logo" href="/" title="MusicBrainz">
       <HeaderLogo />
     </a>
     <div className="right">
-      <TopMenu $c={$c} />
-      <BottomMenu $c={$c} />
+      <TopMenu />
+      <BottomMenu />
     </div>
   </div>
 );

--- a/root/layout/components/MergeHelper.js
+++ b/root/layout/components/MergeHelper.js
@@ -9,77 +9,82 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 import {returnToCurrentPage} from '../../utility/returnUri';
 
 type Props = {
-  +$c: CatalystContextT,
   +merger: MergeQueueT,
 };
 
-const MergeHelper = ({$c, merger}: Props): React.Element<'div'> => (
-  <div id="current-editing">
-    <form
-      action={`/${merger.type}/merge?` + returnToCurrentPage($c)}
-      method="post"
-    >
-      <h2>{l('Merge Process')}</h2>
-      <p>
-        {l('You currently have the following entities selected for merging:')}
-      </p>
-      <ul>
-        {$c.stash.to_merge?.map(entity => (
-          <li key={entity.id}>
-            <input
-              id={`remove.${entity.id}`}
-              name="remove"
-              type="checkbox"
-              value={entity.id}
-            />
-            <label htmlFor={`remove.${entity.id}`}>
-              <DescriptiveLink entity={entity} />
-            </label>
-          </li>
-        ))}
-      </ul>
-      <p>
-        {merger.ready_to_merge
-          ? l(
-            `When you are ready to merge these, just click the Merge button.
-             You may still add more to this merge queue by simply browsing to
-             the entities page and following the merge link.`,
-          )
-          : l(
-            `Please navigate to the pages of other entities you wish to merge
-             and select the "merge" link.`,
-          )
-        }
-      </p>
-      <div className="buttons" style={{display: 'table-cell'}}>
-        {merger.ready_to_merge &&
+const MergeHelper = ({merger}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <div id="current-editing">
+      <form
+        action={`/${merger.type}/merge?` + returnToCurrentPage($c)}
+        method="post"
+      >
+        <h2>{l('Merge Process')}</h2>
+        <p>
+          {l(`You currently have the following entities
+              selected for merging:`)}
+        </p>
+        <ul>
+          {$c.stash.to_merge?.map(entity => (
+            <li key={entity.id}>
+              <input
+                id={`remove.${entity.id}`}
+                name="remove"
+                type="checkbox"
+                value={entity.id}
+              />
+              <label htmlFor={`remove.${entity.id}`}>
+                <DescriptiveLink entity={entity} />
+              </label>
+            </li>
+          ))}
+        </ul>
+        <p>
+          {merger.ready_to_merge
+            ? l(
+              `When you are ready to merge these, just click the Merge button.
+               You may still add more to this merge queue by simply browsing
+               to the entities page and following the merge link.`,
+            )
+            : l(
+              `Please navigate to the pages of other entities you wish
+               to merge and select the "merge" link.`,
+            )
+          }
+        </p>
+        <div className="buttons" style={{display: 'table-cell'}}>
+          {merger.ready_to_merge &&
+            <button
+              className="positive"
+              name="submit"
+              type="submit"
+              value="merge"
+            >
+              {l('Merge')}
+            </button>}
+          <button name="submit" type="submit" value="remove">
+            {l('Remove selected entities')}
+          </button>
           <button
-            className="positive"
+            className="negative"
             name="submit"
             type="submit"
-            value="merge"
+            value="cancel"
           >
-            {l('Merge')}
-          </button>}
-        <button name="submit" type="submit" value="remove">
-          {l('Remove selected entities')}
-        </button>
-        <button
-          className="negative"
-          name="submit"
-          type="submit"
-          value="cancel"
-        >
-          {l('Cancel')}
-        </button>
-      </div>
-    </form>
-  </div>
-);
+            {l('Cancel')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
 
 export default MergeHelper;

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import RequestLogin from '../../components/RequestLogin';
 import returnUri, {returnToCurrentPage} from '../../utility/returnUri';
 import {
@@ -167,37 +168,36 @@ const AdminMenu = ({user}: UserProp) => (
   </li>
 );
 
-const UserMenu = ({$c}) => (
-  <ul className="menu" tabIndex="-1">
-    {$c.user ? (
-      <>
-        <AccountMenu $c={$c} user={$c.user} />
-        <DataMenu user={$c.user} />
-        {isAdmin($c.user) ? <AdminMenu user={$c.user} /> : null}
-      </>
-    ) : (
-      <>
-        <li>
-          <RequestLogin $c={$c} text={l('Log In')} />
-        </li>
-        <li>
-          <a href={returnUri($c, '/register')}>
-            {l('Create Account')}
-          </a>
-        </li>
-      </>
-    )}
-  </ul>
-);
-
-type Props = {
-  +$c: CatalystContextT,
+const UserMenu = () => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ul className="menu" tabIndex="-1">
+      {$c.user ? (
+        <>
+          <AccountMenu $c={$c} user={$c.user} />
+          <DataMenu user={$c.user} />
+          {isAdmin($c.user) ? <AdminMenu user={$c.user} /> : null}
+        </>
+      ) : (
+        <>
+          <li>
+            <RequestLogin $c={$c} text={l('Log In')} />
+          </li>
+          <li>
+            <a href={returnUri($c, '/register')}>
+              {l('Create Account')}
+            </a>
+          </li>
+        </>
+      )}
+    </ul>
+  );
 };
 
-const TopMenu = ({$c}: Props): React.Element<'div'> => (
+const TopMenu = (): React.Element<'div'> => (
   <div className="top">
     <div className="links-container">
-      <UserMenu $c={$c} />
+      <UserMenu />
     </div>
     <div className="search-container">
       <Search />

--- a/root/layout/components/sidebar/AnnotationLinks.js
+++ b/root/layout/components/sidebar/AnnotationLinks.js
@@ -9,40 +9,43 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import entityHref from '../../../static/scripts/common/utility/entityHref';
 import returnUri from '../../../utility/returnUri';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
 };
 
 const AnnotationLinks = ({
-  $c,
   entity,
-}: Props): React.Element<typeof React.Fragment> => (
-  <>
-    <li>
-      <a
-        href={returnUri(
-          $c,
-          entityHref(entity, 'edit_annotation'),
-          $c.req.uri,
-        )}
-      >
-        {entity.latest_annotation && entity.latest_annotation.text
-          ? l('Edit annotation')
-          : l('Add annotation')}
-      </a>
-    </li>
-    {$c.stash.number_of_revisions ? (
+}: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <>
       <li>
-        <a href={entityHref(entity, 'annotations')}>
-          {l('View annotation history')}
+        <a
+          href={returnUri(
+            $c,
+            entityHref(entity, 'edit_annotation'),
+            $c.req.uri,
+          )}
+        >
+          {entity.latest_annotation && entity.latest_annotation.text
+            ? l('Edit annotation')
+            : l('Add annotation')}
         </a>
       </li>
-    ) : null}
-  </>
-);
+      {$c.stash.number_of_revisions ? (
+        <li>
+          <a href={entityHref(entity, 'annotations')}>
+            {l('View annotation history')}
+          </a>
+        </li>
+      ) : null}
+    </>
+  );
+};
 
 export default AnnotationLinks;

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import {isLocationEditor}
@@ -30,11 +31,11 @@ import SidebarTags from './SidebarTags';
 import SidebarType from './SidebarType';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
 };
 
-const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
+const AreaSidebar = ({area}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const areaAge = age.age(area);
 
   return (

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -107,7 +107,7 @@ const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
       <EditLinks entity={area}>
         {isLocationEditor($c.user) ? (
           <>
-            <AnnotationLinks $c={$c} entity={area} />
+            <AnnotationLinks entity={area} />
 
             <MergeLink entity={area} />
 

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -94,13 +94,7 @@ const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
         ))}
       </SidebarProperties>
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={area}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={area} />
 
       <ExternalLinks empty entity={area} />
 

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -118,7 +118,7 @@ const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
         ) : null}
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={area} />
+      <CollectionLinks entity={area} />
 
       <SidebarLicenses entity={area} />
 

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -104,7 +104,7 @@ const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={area} />
 
-      <EditLinks $c={$c} entity={area}>
+      <EditLinks entity={area}>
         {isLocationEditor($c.user) ? (
           <>
             <AnnotationLinks $c={$c} entity={area} />

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -189,7 +189,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
         <SubscriptionLinks $c={$c} entity={artist} />
       )}
 
-      <CollectionLinks $c={$c} entity={artist} />
+      <CollectionLinks entity={artist} />
 
       <SidebarLicenses entity={artist} />
 

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -186,7 +186,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
       </EditLinks>
 
       {isSpecialPurposeArtist ? null : (
-        <SubscriptionLinks $c={$c} entity={artist} />
+        <SubscriptionLinks entity={artist} />
       )}
 
       <CollectionLinks entity={artist} />

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -177,7 +177,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
         )}
 
         {isSpecialPurposeArtist ? null : (
-          <AnnotationLinks $c={$c} entity={artist} />
+          <AnnotationLinks entity={artist} />
         )}
 
         <MergeLink entity={artist} />

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -137,7 +137,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={artist} />
 
-      <EditLinks $c={$c} entity={artist}>
+      <EditLinks entity={artist}>
         {isSpecialPurposeArtist ? null : (
           <>
             <li>

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import {
   artistBeginAreaLabel,
   artistBeginLabel,
@@ -43,11 +44,11 @@ import SidebarType from './SidebarType';
 import SubscriptionLinks from './SubscriptionLinks';
 
 type Props = {
-  +$c: CatalystContextT,
   +artist: ArtistT,
 };
 
-const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
+const ArtistSidebar = ({artist}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const artistAge = age.age(artist);
   const gid = encodeURIComponent(artist.gid);
   const isSpecialPurposeArtist = isSpecialPurpose(artist);

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -127,13 +127,7 @@ const ArtistSidebar = ({$c, artist}: Props): React.Element<'div'> => {
 
       <SidebarRating entity={artist} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={artist}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={artist} />
 
       <ExternalLinks empty entity={artist} />
 

--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -9,19 +9,19 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 
 import CollectionList from './CollectionList';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
 };
 
 const CollectionLinks = ({
-  $c,
   entity,
 }: Props): React.Element<typeof CollectionList> | null => {
+  const $c = React.useContext(CatalystContext);
   const numberOfCollections = $c.stash.number_of_collections || 0;
   if (!$c.user) {
     return null;

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import EditorLink from '../../../static/scripts/common/components/EditorLink';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import {formatCount} from '../../../statistics/utilities';
@@ -17,14 +18,13 @@ import {returnToCurrentPage} from '../../../utility/returnUri';
 import {SidebarProperties, SidebarProperty} from './SidebarProperties';
 
 type Props = {
-  +$c: CatalystContextT,
   +collection: CollectionT,
 };
 
 const CollectionSidebar = ({
-  $c,
   collection,
 }: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const typeName = collection.typeName;
 
   return (

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -9,47 +9,50 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import RequestLogin from '../../../components/RequestLogin';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +children?: React.Node,
   +entity: CoreEntityT,
 };
 
 const EditLinks = ({
-  $c,
   children,
   entity,
-}: Props): React.Element<typeof React.Fragment> => (
-  <>
-    <h2 className="editing">{l('Editing')}</h2>
-    <ul className="links">
-      {$c.user ? children : (
-        <>
-          <li>
-            <RequestLogin $c={$c} text={l('Log in to edit')} />
-          </li>
-          <li className="separator" role="separator" />
-        </>
-      )}
-      <li>
-        <EntityLink
-          content={l('Open edits')}
-          entity={entity}
-          subPath="open_edits"
-        />
-      </li>
-      <li>
-        <EntityLink
-          content={l('Editing history')}
-          entity={entity}
-          subPath="edits"
-        />
-      </li>
-    </ul>
-  </>
-);
+}: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <>
+      <h2 className="editing">{l('Editing')}</h2>
+      <ul className="links">
+        {$c.user ? children : (
+          <>
+            <li>
+              <RequestLogin $c={$c} text={l('Log in to edit')} />
+            </li>
+            <li className="separator" role="separator" />
+          </>
+        )}
+        <li>
+          <EntityLink
+            content={l('Open edits')}
+            entity={entity}
+            subPath="open_edits"
+          />
+        </li>
+        <li>
+          <EntityLink
+            content={l('Editing history')}
+            entity={entity}
+            subPath="edits"
+          />
+        </li>
+      </ul>
+    </>
+  );
+};
 
 export default EditLinks;

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -84,7 +84,7 @@ const EventSidebar = ({$c, event}: Props): React.Element<'div'> => {
       <EditLinks entity={event}>
         {$c.user ? (
           <>
-            <AnnotationLinks $c={$c} entity={event} />
+            <AnnotationLinks entity={event} />
 
             <MergeLink entity={event} />
 

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -71,13 +71,7 @@ const EventSidebar = ({$c, event}: Props): React.Element<'div'> => {
 
       <SidebarRating entity={event} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={event}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={event} />
 
       <ExternalLinks empty entity={event} />
 

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import isDateEmpty from '../../../static/scripts/common/utility/isDateEmpty';
@@ -29,11 +30,11 @@ import SidebarTags from './SidebarTags';
 import SidebarType from './SidebarType';
 
 type Props = {
-  +$c: CatalystContextT,
   +event: EventT,
 };
 
-const EventSidebar = ({$c, event}: Props): React.Element<'div'> => {
+const EventSidebar = ({event}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const hasBegin = !isDateEmpty(event.begin_date);
   const hasEnd = !isDateEmpty(event.end_date);
 

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -93,7 +93,7 @@ const EventSidebar = ({$c, event}: Props): React.Element<'div'> => {
         ) : null}
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={event} />
+      <CollectionLinks entity={event} />
 
       <SidebarLicenses entity={event} />
 

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -81,7 +81,7 @@ const EventSidebar = ({$c, event}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={event} />
 
-      <EditLinks $c={$c} entity={event}>
+      <EditLinks entity={event}>
         {$c.user ? (
           <>
             <AnnotationLinks $c={$c} entity={event} />

--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import {isRelationshipEditor}
   from '../../../static/scripts/common/utility/privileges';
 
@@ -16,11 +17,12 @@ import LastUpdated from './LastUpdated';
 import RemoveLink from './RemoveLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +genre: GenreT,
 };
 
-const GenreSidebar = ({$c, genre}: Props): React.Element<'div'> => {
+const GenreSidebar = ({genre}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
+
   return (
     <div id="sidebar">
       {isRelationshipEditor($c.user) ? (

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -55,13 +55,7 @@ const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
         </>
       )}
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={instrument}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={instrument} />
 
       <ExternalLinks empty entity={instrument} />
 

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import IrombookImage
@@ -29,11 +30,12 @@ import SidebarTags from './SidebarTags';
 import SidebarType from './SidebarType';
 
 type Props = {
-  +$c: CatalystContextT,
   +instrument: InstrumentT,
 };
 
-const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
+const InstrumentSidebar = ({instrument}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
+
   return (
     <div id="sidebar">
       <CommonsImage

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -68,7 +68,7 @@ const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
       <EditLinks entity={instrument}>
         {isRelationshipEditor($c.user) ? (
           <>
-            <AnnotationLinks $c={$c} entity={instrument} />
+            <AnnotationLinks entity={instrument} />
 
             <MergeLink entity={instrument} />
 

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -79,7 +79,7 @@ const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
         ) : null}
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={instrument} />
+      <CollectionLinks entity={instrument} />
 
       <SidebarLicenses entity={instrument} />
 

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -65,7 +65,7 @@ const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={instrument} />
 
-      <EditLinks $c={$c} entity={instrument}>
+      <EditLinks entity={instrument}>
         {isRelationshipEditor($c.user) ? (
           <>
             <AnnotationLinks $c={$c} entity={instrument} />

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -111,7 +111,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
 
         <li className="separator" role="separator" />
 
-        <AnnotationLinks $c={$c} entity={label} />
+        <AnnotationLinks entity={label} />
 
         <MergeLink entity={label} />
 

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -102,7 +102,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={label} />
 
-      <EditLinks $c={$c} entity={label}>
+      <EditLinks entity={label}>
         <li>
           <a href={`/release/add?label=${gid}`}>
             {l('Add release')}

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -122,7 +122,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
 
       {isSpecialPurposeLabel
         ? null
-        : <SubscriptionLinks $c={$c} entity={label} />}
+        : <SubscriptionLinks entity={label} />}
 
       <CollectionLinks entity={label} />
 

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import DescriptiveLink
@@ -37,11 +38,11 @@ import SidebarType from './SidebarType';
 import SubscriptionLinks from './SubscriptionLinks';
 
 type Props = {
-  +$c: CatalystContextT,
   +label: LabelT,
 };
 
-const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
+const LabelSidebar = ({label}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const labelAge = age.age(label);
   const gid = encodeURIComponent(label.gid);
   const area = label.area;

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -124,7 +124,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
         ? null
         : <SubscriptionLinks $c={$c} entity={label} />}
 
-      <CollectionLinks $c={$c} entity={label} />
+      <CollectionLinks entity={label} />
 
       <SidebarLicenses entity={label} />
 

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -92,13 +92,7 @@ const LabelSidebar = ({$c, label}: Props): React.Element<'div'> => {
 
       <SidebarRating entity={label} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={label}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={label} />
 
       <ExternalLinks empty entity={label} />
 

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import DescriptiveLink
@@ -31,11 +32,11 @@ import SidebarTags from './SidebarTags';
 import SidebarType from './SidebarType';
 
 type Props = {
-  +$c: CatalystContextT,
   +place: PlaceT,
 };
 
-const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
+const PlaceSidebar = ({place}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const placeAge = age.age(place);
   const gid = encodeURIComponent(place.gid);
   const {area, coordinates} = place;

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -106,7 +106,7 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={place} />
 
-      <EditLinks $c={$c} entity={place}>
+      <EditLinks entity={place}>
         <li>
           <a
             href={

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -126,7 +126,7 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={place} />
+      <CollectionLinks entity={place} />
 
       <SidebarLicenses entity={place} />
 

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -119,7 +119,7 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
 
         <li className="separator" role="separator" />
 
-        <AnnotationLinks $c={$c} entity={place} />
+        <AnnotationLinks entity={place} />
 
         <MergeLink entity={place} />
 

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -96,13 +96,7 @@ const PlaceSidebar = ({$c, place}: Props): React.Element<'div'> => {
         ) : null}
       </SidebarProperties>
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={place}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={place} />
 
       <ExternalLinks empty entity={place} />
 

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -30,12 +30,12 @@ import SidebarRating from './SidebarRating';
 import SidebarTags from './SidebarTags';
 
 type Props = {
-  +$c: CatalystContextT,
   +recording: RecordingWithArtistCreditT,
 };
 
-const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
+const RecordingSidebar = ({recording}: Props): React.Element<'div'> => {
   const firstReleaseYear = recording.first_release_date?.year;
+
   return (
     <div id="sidebar">
       <h2 className="recording-information">

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -77,13 +77,7 @@ const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
 
       <SidebarRating entity={recording} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={recording}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={recording} />
 
       <ExternalLinks empty entity={recording} />
 

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -88,7 +88,7 @@ const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
       <ExternalLinks empty entity={recording} />
 
       <EditLinks entity={recording}>
-        <AnnotationLinks $c={$c} entity={recording} />
+        <AnnotationLinks entity={recording} />
 
         <MergeLink entity={recording} />
 

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -87,7 +87,7 @@ const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={recording} />
 
-      <EditLinks $c={$c} entity={recording}>
+      <EditLinks entity={recording}>
         <AnnotationLinks $c={$c} entity={recording} />
 
         <MergeLink entity={recording} />

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -97,7 +97,7 @@ const RecordingSidebar = ({$c, recording}: Props): React.Element<'div'> => {
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={recording} />
+      <CollectionLinks entity={recording} />
 
       <SidebarLicenses entity={recording} />
 

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -27,14 +27,10 @@ import SidebarRating from './SidebarRating';
 import SidebarTags from './SidebarTags';
 
 type Props = {
-  +$c: CatalystContextT,
   +releaseGroup: ReleaseGroupT,
 };
 
-const ReleaseGroupSidebar = ({
-  $c,
-  releaseGroup,
-}: Props): React.Element<'div'> => {
+const ReleaseGroupSidebar = ({releaseGroup}: Props): React.Element<'div'> => {
   const gid = encodeURIComponent(releaseGroup.gid);
   const typeName = releaseGroupType(releaseGroup);
 

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -89,7 +89,7 @@ const ReleaseGroupSidebar = ({
           </a>
         </li>
 
-        <AnnotationLinks $c={$c} entity={releaseGroup} />
+        <AnnotationLinks entity={releaseGroup} />
 
         <MergeLink entity={releaseGroup} />
 

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -96,7 +96,7 @@ const ReleaseGroupSidebar = ({
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={releaseGroup} />
+      <CollectionLinks entity={releaseGroup} />
 
       <SidebarLicenses entity={releaseGroup} />
 

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -74,7 +74,7 @@ const ReleaseGroupSidebar = ({
 
       <ExternalLinks empty entity={releaseGroup} />
 
-      <EditLinks $c={$c} entity={releaseGroup}>
+      <EditLinks entity={releaseGroup}>
         <li>
           <a href={`/release/add?release-group=${gid}`}>
             {l('Add release')}

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -64,13 +64,7 @@ const ReleaseGroupSidebar = ({
 
       <SidebarRating entity={releaseGroup} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={releaseGroup}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={releaseGroup} />
 
       <ExternalLinks empty entity={releaseGroup} />
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -280,7 +280,7 @@ const ReleaseSidebar = ({
         heading={l('Release group external links')}
       />
 
-      <EditLinks $c={$c} entity={release}>
+      <EditLinks entity={release}>
         <li>
           <a href={entityHref(release, 'edit-relationships')}>
             {l('Edit relationships')}

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 
 import {QUALITY_UNKNOWN} from '../../../constants';
+import {CatalystContext} from '../../../context';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import ReleaseEvents
   from '../../../static/scripts/common/components/ReleaseEvents';
@@ -46,14 +47,12 @@ import SidebarRating from './SidebarRating';
 import SidebarTags from './SidebarTags';
 
 type Props = {
-  +$c: CatalystContextT,
   +release: ReleaseT,
 };
 
-const ReleaseSidebar = ({
-  $c,
-  release,
-}: Props): React.Element<'div'> | null => {
+const ReleaseSidebar = ({release}: Props): React.Element<'div'> | null => {
+  const $c = React.useContext(CatalystContext);
+
   const releaseGroup = release.releaseGroup;
   if (!releaseGroup) {
     return null;

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -302,7 +302,7 @@ const ReleaseSidebar = ({
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={release} />
+      <CollectionLinks entity={release} />
 
       <SidebarLicenses entity={release} />
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -264,13 +264,7 @@ const ReleaseSidebar = ({
         </>
       )}
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={release}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={release} />
 
       <ExternalLinks empty entity={release} />
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -293,7 +293,7 @@ const ReleaseSidebar = ({
           </a>
         </li>
 
-        <AnnotationLinks $c={$c} entity={release} />
+        <AnnotationLinks entity={release} />
 
         <MergeLink entity={release} />
 

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -79,7 +79,7 @@ const SeriesSidebar = ({
 
       <SubscriptionLinks $c={$c} entity={series} />
 
-      <CollectionLinks $c={$c} entity={series} />
+      <CollectionLinks entity={series} />
 
       <SidebarLicenses entity={series} />
 

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -69,7 +69,7 @@ const SeriesSidebar = ({
 
       <ExternalLinks empty entity={series} />
 
-      <EditLinks $c={$c} entity={series}>
+      <EditLinks entity={series}>
         <AnnotationLinks $c={$c} entity={series} />
 
         <MergeLink entity={series} />

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -70,7 +70,7 @@ const SeriesSidebar = ({
       <ExternalLinks empty entity={series} />
 
       <EditLinks entity={series}>
-        <AnnotationLinks $c={$c} entity={series} />
+        <AnnotationLinks entity={series} />
 
         <MergeLink entity={series} />
 

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -59,13 +59,7 @@ const SeriesSidebar = ({
         </SidebarProperty>
       </SidebarProperties>
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={series}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={series} />
 
       <ExternalLinks empty entity={series} />
 

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -77,7 +77,7 @@ const SeriesSidebar = ({
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <SubscriptionLinks $c={$c} entity={series} />
+      <SubscriptionLinks entity={series} />
 
       <CollectionLinks entity={series} />
 

--- a/root/layout/components/sidebar/SeriesSidebar.js
+++ b/root/layout/components/sidebar/SeriesSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import linkedEntities from '../../../static/scripts/common/linkedEntities';
@@ -26,14 +27,12 @@ import SidebarType from './SidebarType';
 import SubscriptionLinks from './SubscriptionLinks';
 
 type Props = {
-  +$c: CatalystContextT,
   +series: SeriesT,
 };
 
-const SeriesSidebar = ({
-  $c,
-  series,
-}: Props): React.Element<'div'> => {
+const SeriesSidebar = ({series}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
+
   return (
     <div id="sidebar">
       <CommonsImage

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import {SidebarTagEditor}
   from '../../../static/scripts/common/components/TagEditor';
@@ -22,11 +23,7 @@ type TagListProps = {
 };
 
 type SidebarTagsProps = {
-  +$c: CatalystContextT,
-  +aggregatedTags?: $ReadOnlyArray<AggregatedTagT> | void,
   +entity: CoreEntityT,
-  +more: boolean,
-  +userTags?: $ReadOnlyArray<UserTagT> | void,
 };
 
 const TagList = ({
@@ -46,58 +43,61 @@ const TagList = ({
 };
 
 const SidebarTags = ({
-  $c,
-  aggregatedTags,
   entity,
-  more,
-  userTags,
-}: SidebarTagsProps): React.Element<typeof React.Fragment> | null => (
-  $c.action.name === 'tags' ? null : (
-    <>
-      {($c.user?.has_confirmed_email_address &&
-        aggregatedTags && userTags) ? (
-          <SidebarTagEditor
-            $c={$c}
-            aggregatedTags={aggregatedTags}
-            entity={entity}
-            genreMap={$c.stash.genre_map}
-            more={more}
-            userTags={userTags}
-          />
-        ) : (
-          <div id="sidebar-tags">
-            <h2>{l('Genres')}</h2>
-            <div className="genre-list">
+}: SidebarTagsProps): React.Element<typeof React.Fragment> | null => {
+  const $c = React.useContext(CatalystContext);
+  const aggregatedTags = $c.stash.top_tags;
+  const more = Boolean($c.stash.more_tags);
+  const userTags = $c.stash.user_tags;
+
+  return (
+    $c.action.name === 'tags' ? null : (
+      <>
+        {($c.user?.has_confirmed_email_address &&
+          aggregatedTags && userTags) ? (
+            <SidebarTagEditor
+              $c={$c}
+              aggregatedTags={aggregatedTags}
+              entity={entity}
+              genreMap={$c.stash.genre_map}
+              more={more}
+              userTags={userTags}
+            />
+          ) : (
+            <div id="sidebar-tags">
+              <h2>{l('Genres')}</h2>
+              <div className="genre-list">
+                <p>
+                  <TagList
+                    entity={entity}
+                    isGenreList
+                    tags={aggregatedTags}
+                  />
+                </p>
+              </div>
+
+              <h2>{l('Other tags')}</h2>
+              <div id="sidebar-tag-list">
+                <p>
+                  <TagList
+                    entity={entity}
+                    tags={aggregatedTags}
+                  />
+                </p>
+              </div>
+
               <p>
-                <TagList
+                <EntityLink
+                  content={l('See all tags')}
                   entity={entity}
-                  isGenreList
-                  tags={aggregatedTags}
+                  subPath="tags"
                 />
               </p>
             </div>
-
-            <h2>{l('Other tags')}</h2>
-            <div id="sidebar-tag-list">
-              <p>
-                <TagList
-                  entity={entity}
-                  tags={aggregatedTags}
-                />
-              </p>
-            </div>
-
-            <p>
-              <EntityLink
-                content={l('See all tags')}
-                entity={entity}
-                subPath="tags"
-              />
-            </p>
-          </div>
-        )}
-    </>
-  )
-);
+          )}
+      </>
+    )
+  );
+};
 
 export default SidebarTags;

--- a/root/layout/components/sidebar/SubscriptionLinks.js
+++ b/root/layout/components/sidebar/SubscriptionLinks.js
@@ -9,18 +9,18 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import {returnToCurrentPage} from '../../../utility/returnUri';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
 };
 
 const SubscriptionLinks = ({
-  $c,
   entity,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const id = encodeURIComponent(String(entity.id));
   const urlPrefix = `/account/subscriptions/${entityType}`;

--- a/root/layout/components/sidebar/UrlSidebar.js
+++ b/root/layout/components/sidebar/UrlSidebar.js
@@ -20,7 +20,7 @@ type Props = {
 const UrlSidebar = ({$c, url}: Props): React.Element<'div'> => {
   return (
     <div id="sidebar">
-      <EditLinks $c={$c} entity={url} />
+      <EditLinks entity={url} />
 
       <LastUpdated entity={url} />
     </div>

--- a/root/layout/components/sidebar/UrlSidebar.js
+++ b/root/layout/components/sidebar/UrlSidebar.js
@@ -13,11 +13,10 @@ import EditLinks from './EditLinks';
 import LastUpdated from './LastUpdated';
 
 type Props = {
-  +$c: CatalystContextT,
   +url: UrlT,
 };
 
-const UrlSidebar = ({$c, url}: Props): React.Element<'div'> => {
+const UrlSidebar = ({url}: Props): React.Element<'div'> => {
   return (
     <div id="sidebar">
       <EditLinks entity={url} />

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context';
 import LinkSearchableLanguage
   from '../../../components/LinkSearchableLanguage';
 import CodeLink from '../../../static/scripts/common/components/CodeLink';
@@ -31,11 +32,11 @@ import SidebarTags from './SidebarTags';
 import SidebarType from './SidebarType';
 
 type Props = {
-  +$c: CatalystContextT,
   +work: WorkT,
 };
 
-const WorkSidebar = ({$c, work}: Props): React.Element<'div'> => {
+const WorkSidebar = ({work}: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const {attributes, iswcs, languages, typeID} = work;
   const showInfo = Boolean(
     attributes.length ||

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -126,7 +126,7 @@ const WorkSidebar = ({$c, work}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={work} />
 
-      <EditLinks $c={$c} entity={work}>
+      <EditLinks entity={work}>
         <AnnotationLinks $c={$c} entity={work} />
 
         <MergeLink entity={work} />

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -116,13 +116,7 @@ const WorkSidebar = ({$c, work}: Props): React.Element<'div'> => {
 
       <SidebarRating entity={work} />
 
-      <SidebarTags
-        $c={$c}
-        aggregatedTags={$c.stash.top_tags}
-        entity={work}
-        more={!!$c.stash.more_tags}
-        userTags={$c.stash.user_tags}
-      />
+      <SidebarTags entity={work} />
 
       <ExternalLinks empty entity={work} />
 

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -127,7 +127,7 @@ const WorkSidebar = ({$c, work}: Props): React.Element<'div'> => {
       <ExternalLinks empty entity={work} />
 
       <EditLinks entity={work}>
-        <AnnotationLinks $c={$c} entity={work} />
+        <AnnotationLinks entity={work} />
 
         <MergeLink entity={work} />
 

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -134,7 +134,7 @@ const WorkSidebar = ({$c, work}: Props): React.Element<'div'> => {
         <li className="separator" role="separator" />
       </EditLinks>
 
-      <CollectionLinks $c={$c} entity={work} />
+      <CollectionLinks entity={work} />
 
       <SidebarLicenses entity={work} />
 

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -105,6 +105,7 @@ const ServerDetailsBanner = () => {
 
 export type Props = $ReadOnly<{
   ...HeadProps,
+  +$c: CatalystContextT,
   children: React$Node,
   fullWidth?: boolean,
 }>;
@@ -120,7 +121,6 @@ const Layout = ({
 }: Props): React.Element<'html'> => (
   <html lang={$c.stash.current_language_html}>
     <Head
-      $c={$c}
       homepage={homepage}
       noIcons={noIcons}
       pager={pager}

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -128,7 +128,7 @@ const Layout = ({
     />
 
     <body>
-      <Header $c={$c} />
+      <Header />
 
       {isEditingDisabled($c.user) || isAddingNotesDisabled($c.user) ? (
         <div className="banner editing-disabled">

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -239,7 +239,7 @@ const Layout = ({
       {($c.session?.merger && !$c.stash.hide_merge_helper /*:: === true */) &&
         <MergeHelper $c={$c} merger={$c.session.merger} />}
 
-      <Footer $c={$c} />
+      <Footer />
     </body>
   </html>
 );

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -237,7 +237,7 @@ const Layout = ({
       </div>
 
       {($c.session?.merger && !$c.stash.hide_merge_helper /*:: === true */) &&
-        <MergeHelper $c={$c} merger={$c.session.merger} />}
+        <MergeHelper merger={$c.session.merger} />}
 
       <Footer />
     </body>

--- a/root/otherlookup/OtherLookupReleaseResults.js
+++ b/root/otherlookup/OtherLookupReleaseResults.js
@@ -27,7 +27,6 @@ const OtherLookupReleaseResults = ({
     <h1>{l('Search Results')}</h1>
     {results.length ? (
       <ReleaseList
-        $c={$c}
         releases={results}
         showLanguages
         showStatus

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -38,7 +38,6 @@ const PlaceEvents = ({
       >
         <PaginatedResults pager={pager}>
           <EventList
-            $c={$c}
             checkboxes="add-to-merge"
             events={events}
             showArtists

--- a/root/place/PlaceLayout.js
+++ b/root/place/PlaceLayout.js
@@ -39,7 +39,7 @@ const PlaceLayout = ({
       <PlaceHeader page={page} place={place} />
       {children}
     </div>
-    {fullWidth ? null : <PlaceSidebar $c={$c} place={place} />}
+    {fullWidth ? null : <PlaceSidebar place={place} />}
   </Layout>
 );
 

--- a/root/place/PlaceMerge.js
+++ b/root/place/PlaceMerge.js
@@ -37,7 +37,6 @@ const PlaceMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <PlaceList
-          $c={$c}
           mergeForm={form}
           places={sortByEntityName(toMerge)}
         />

--- a/root/recording/RecordingLayout.js
+++ b/root/recording/RecordingLayout.js
@@ -50,9 +50,7 @@ const RecordingLayout = ({
         <RecordingHeader page={page} recording={recording} />
         {children}
       </div>
-      {fullWidth
-        ? null
-        : <RecordingSidebar $c={$c} recording={recording} />}
+      {fullWidth ? null : <RecordingSidebar recording={recording} />}
     </Layout>
   );
 };

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -52,7 +52,6 @@ const RecordingMerge = ({
       ) : null}
       <form action={$c.req.uri} method="post">
         <RecordingList
-          $c={$c}
           mergeForm={form}
           recordings={sortByEntityName(toMerge)}
           showAcoustIds

--- a/root/release/ReleaseLayout.js
+++ b/root/release/ReleaseLayout.js
@@ -46,7 +46,7 @@ const ReleaseLayout = ({
         <ReleaseHeader page={page} release={release} />
         {children}
       </div>
-      {fullWidth ? null : <ReleaseSidebar $c={$c} release={release} />}
+      {fullWidth ? null : <ReleaseSidebar release={release} />}
     </Layout>
   );
 };

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -47,9 +47,7 @@ const ReleaseGroupLayout = ({
         <ReleaseGroupHeader page={page} releaseGroup={releaseGroup} />
         {children}
       </div>
-      {fullWidth ? null : (
-        <ReleaseGroupSidebar $c={$c} releaseGroup={releaseGroup} />
-      )}
+      {fullWidth ? null : <ReleaseGroupSidebar releaseGroup={releaseGroup} />}
     </Layout>
   );
 };

--- a/root/release_group/ReleaseGroupMerge.js
+++ b/root/release_group/ReleaseGroupMerge.js
@@ -38,7 +38,6 @@ const ReleaseGroupMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <ReleaseGroupListTable
-          $c={$c}
           mergeForm={form}
           releaseGroups={sortByEntityName(toMerge)}
         />

--- a/root/report/IswcsWithManyWorks.js
+++ b/root/report/IswcsWithManyWorks.js
@@ -86,10 +86,7 @@ const IswcsWithManyWorks = ({
                     {item.work ? (
                       <>
                         <td />
-                        <WorkListRow
-                          $c={$c}
-                          work={item.work}
-                        />
+                        <WorkListRow work={item.work} />
                       </>
                     ) : (
                       <>

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -21,13 +21,12 @@ import type {
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
 
-function buildResult($c, result, index) {
+function buildResult(result, index) {
   const artist = result.entity;
   const score = result.score;
 
   return (
     <ArtistListEntry
-      $c={$c}
       artist={artist}
       index={index}
       key={artist.id}
@@ -39,14 +38,13 @@ function buildResult($c, result, index) {
 }
 
 export const ArtistResultsInline = ({
-  $c,
   pager,
   query,
   results,
 }: InlineResultsPropsWithContextT<ArtistT>):
 React.Element<typeof PaginatedSearchResults> => (
   <PaginatedSearchResults
-    buildResult={(result, index) => buildResult($c, result, index)}
+    buildResult={(result, index) => buildResult(result, index)}
     columns={
       <>
         <th>{l('Name')}</th>
@@ -77,7 +75,6 @@ const ArtistResults = ({
 React.Element<typeof ResultsLayout> => (
   <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
     <ArtistResultsInline
-      $c={$c}
       pager={pager}
       query={query}
       results={results}

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import TaggerIcon from '../../static/scripts/common/components/TaggerIcon';
 import formatTrackLength
@@ -113,32 +114,35 @@ function buildResult($c, result) {
 }
 
 export const RecordingResultsInline = ({
-  $c,
   pager,
   query,
   results,
 }: InlineResultsPropsWithContextT<RecordingWithArtistCreditT>):
-React.Element<typeof PaginatedSearchResults> => (
-  <PaginatedSearchResults
-    buildResult={result => buildResult($c, result)}
-    columns={
-      <>
-        <th>{l('Name')}</th>
-        <th className="treleases">{l('Length')}</th>
-        <th>{l('Artist')}</th>
-        <th>{l('ISRCs')}</th>
-        <th>{l('Release')}</th>
-        {$c?.session?.tport == null ? null : <th>{l('Tagger')}</th>}
-        <th className="t pos">{l('Track')}</th>
-        <th>{l('Medium')}</th>
-        <th>{l('Type')}</th>
-      </>
-    }
-    pager={pager}
-    query={query}
-    results={results}
-  />
-);
+React.Element<typeof PaginatedSearchResults> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <PaginatedSearchResults
+      buildResult={result => buildResult($c, result)}
+      columns={
+        <>
+          <th>{l('Name')}</th>
+          <th className="treleases">{l('Length')}</th>
+          <th>{l('Artist')}</th>
+          <th>{l('ISRCs')}</th>
+          <th>{l('Release')}</th>
+          {$c?.session?.tport == null ? null : <th>{l('Tagger')}</th>}
+          <th className="t pos">{l('Track')}</th>
+          <th>{l('Medium')}</th>
+          <th>{l('Type')}</th>
+        </>
+      }
+      pager={pager}
+      query={query}
+      results={results}
+    />
+  );
+};
 
 const RecordingResults = ({
   $c,
@@ -153,7 +157,6 @@ React.Element<typeof ResultsLayout> => {
   return (
     <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
       <RecordingResultsInline
-        $c={$c}
         pager={pager}
         query={query}
         results={results}

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
@@ -83,37 +84,40 @@ function buildResult($c, result, index) {
 }
 
 export const ReleaseResultsInline = ({
-  $c,
   pager,
   query,
   results,
 }: InlineResultsPropsWithContextT<ReleaseT>):
-React.Element<typeof PaginatedSearchResults> => (
-  <PaginatedSearchResults
-    buildResult={(result, index) => buildResult($c, result, index)}
-    columns={
-      <>
-        <th>{l('Name')}</th>
-        <th>{l('Artist')}</th>
-        <th>{l('Format')}</th>
-        <th>{l('Tracks')}</th>
-        <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
-        <th>{l('Label')}</th>
-        <th>{l('Catalog#')}</th>
-        <th>{l('Barcode')}</th>
-        <th>{l('Language')}</th>
-        <th>{l('Type')}</th>
-        <th>{l('Status')}</th>
-        {$c?.session?.tport == null
-          ? null
-          : <th>{l('Tagger')}</th>}
-      </>
-    }
-    pager={pager}
-    query={query}
-    results={results}
-  />
-);
+React.Element<typeof PaginatedSearchResults> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <PaginatedSearchResults
+      buildResult={(result, index) => buildResult($c, result, index)}
+      columns={
+        <>
+          <th>{l('Name')}</th>
+          <th>{l('Artist')}</th>
+          <th>{l('Format')}</th>
+          <th>{l('Tracks')}</th>
+          <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
+          <th>{l('Label')}</th>
+          <th>{l('Catalog#')}</th>
+          <th>{l('Barcode')}</th>
+          <th>{l('Language')}</th>
+          <th>{l('Type')}</th>
+          <th>{l('Status')}</th>
+          {$c?.session?.tport == null
+            ? null
+            : <th>{l('Tagger')}</th>}
+        </>
+      }
+      pager={pager}
+      query={query}
+      results={results}
+    />
+  );
+};
 
 const ReleaseResults = ({
   $c,
@@ -126,7 +130,6 @@ const ReleaseResults = ({
 React.Element<typeof ResultsLayout> => (
   <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
     <ReleaseResultsInline
-      $c={$c}
       pager={pager}
       query={query}
       results={results}

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -18,13 +18,12 @@ import type {ResultsPropsWithContextT} from '../types';
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
 
-function buildResult($c, result, index) {
+function buildResult(result, index) {
   const work = result.entity;
   const score = result.score;
 
   return (
     <WorkListEntry
-      $c={$c}
       index={index}
       key={work.id}
       score={score}
@@ -45,7 +44,7 @@ const WorkResults = ({
 React.Element<typeof ResultsLayout> => (
   <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
-      buildResult={(result, index) => buildResult($c, result, index)}
+      buildResult={(result, index) => buildResult(result, index)}
       columns={
         <>
           <th>{l('Name')}</th>

--- a/root/search/types.js
+++ b/root/search/types.js
@@ -15,7 +15,6 @@ export type InlineResultsPropsT<T> = {
 };
 
 export type InlineResultsPropsWithContextT<T> = {
-  +$c: CatalystContextT,
   +pager: PagerT,
   +query: string,
   +results: $ReadOnlyArray<SearchResultT<T>>,

--- a/root/series/SeriesIndex.js
+++ b/root/series/SeriesIndex.js
@@ -28,26 +28,22 @@ import SeriesLayout from './SeriesLayout';
 
 type ListPickerProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +entities: $ReadOnlyArray<CoreEntityT>,
   +seriesEntityType: CoreEntityTypeT,
 };
 
 const listPicker = ({
-  $c,
   entities,
   seriesEntityType,
   seriesItemNumbers,
 }: ListPickerProps) => {
   const sharedProps = {
-    $c,
     seriesItemNumbers: seriesItemNumbers,
   };
   switch (seriesEntityType) {
     case 'event':
       return (
         <EventList
-          $c={$c}
           events={((entities: any): $ReadOnlyArray<EventT>)}
           showArtists
           showLocation
@@ -137,7 +133,6 @@ const SeriesIndex = ({
       {existingEntities ? (
         <PaginatedResults pager={pager}>
           {listPicker({
-            $c,
             entities: existingEntities,
             seriesEntityType,
             seriesItemNumbers,

--- a/root/series/SeriesLayout.js
+++ b/root/series/SeriesLayout.js
@@ -39,7 +39,7 @@ const SeriesLayout = ({
       <SeriesHeader page={page} series={series} />
       {children}
     </div>
-    {fullWidth ? null : <SeriesSidebar $c={$c} series={series} />}
+    {fullWidth ? null : <SeriesSidebar series={series} />}
   </Layout>
 );
 

--- a/root/series/SeriesMerge.js
+++ b/root/series/SeriesMerge.js
@@ -37,7 +37,6 @@ const SeriesMerge = ({
       </p>
       <form action={$c.req.uri} method="post">
         <SeriesList
-          $c={$c}
           mergeForm={form}
           series={sortByEntityName(toMerge)}
         />

--- a/root/static/scripts/common/components/ArtistListEntry.js
+++ b/root/static/scripts/common/components/ArtistListEntry.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../../context';
 import InstrumentRelTypes
   from '../../../../components/InstrumentRelTypes';
 import RemoveFromMergeTableCell
@@ -24,7 +25,6 @@ import DescriptiveLink from './DescriptiveLink';
 
 type ArtistListRowProps = {
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +artist: ArtistT,
   +artistList?: $ReadOnlyArray<ArtistT>,
   +checkboxes?: string,
@@ -38,7 +38,6 @@ type ArtistListRowProps = {
 
 type ArtistListEntryProps = {
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +artist: ArtistT,
   +artistList?: $ReadOnlyArray<ArtistT>,
   +checkboxes?: string,
@@ -52,7 +51,6 @@ type ArtistListEntryProps = {
 };
 
 const ArtistListRow = ({
-  $c,
   artist,
   artistList,
   checkboxes,
@@ -63,79 +61,82 @@ const ArtistListRow = ({
   showInstrumentCreditsAndRelTypes = false,
   showRatings = false,
   showSortName = false,
-}: ArtistListRowProps) => (
-  <>
-    {$c.user && (nonEmpty(checkboxes) || mergeForm) ? (
-      <td>
-        {mergeForm
-          ? renderMergeCheckboxElement(artist, mergeForm, index)
-          : (
-            <input
-              name={checkboxes}
-              type="checkbox"
-              value={artist.id}
-            />
-          )}
-      </td>
-    ) : null}
-    <td>
-      <DescriptiveLink entity={artist} />
-    </td>
-    {showSortName ? <td>{artist.sort_name}</td> : null}
-    <td>
-      {nonEmpty(artist.typeName)
-        ? lp_attributes(artist.typeName, 'artist_type')
-        : null}
-    </td>
-    <td>
-      {artist.gender
-        ? lp_attributes(artist.gender.name, 'gender')
-        : null}
-    </td>
-    <td>
-      {artist.area ? <DescriptiveLink entity={artist.area} /> : null}
-    </td>
-    {showBeginEnd ? (
-      <>
-        <td>{formatDate(artist.begin_date)}</td>
+}: ArtistListRowProps) => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <>
+      {$c.user && (nonEmpty(checkboxes) || mergeForm) ? (
         <td>
-          {artist.begin_area
-            ? <DescriptiveLink entity={artist.begin_area} />
-            : null}
+          {mergeForm
+            ? renderMergeCheckboxElement(artist, mergeForm, index)
+            : (
+              <input
+                name={checkboxes}
+                type="checkbox"
+                value={artist.id}
+              />
+            )}
         </td>
-        <td>{formatEndDate(artist)}</td>
-        <td>
-          {artist.end_area
-            ? <DescriptiveLink entity={artist.end_area} />
-            : null}
-        </td>
-      </>
-    ) : null}
-    {showRatings ? (
+      ) : null}
       <td>
-        <RatingStars entity={artist} />
+        <DescriptiveLink entity={artist} />
       </td>
-    ) : null}
-    {showInstrumentCreditsAndRelTypes ? (
+      {showSortName ? <td>{artist.sort_name}</td> : null}
       <td>
-        <InstrumentRelTypes
+        {nonEmpty(artist.typeName)
+          ? lp_attributes(artist.typeName, 'artist_type')
+          : null}
+      </td>
+      <td>
+        {artist.gender
+          ? lp_attributes(artist.gender.name, 'gender')
+          : null}
+      </td>
+      <td>
+        {artist.area ? <DescriptiveLink entity={artist.area} /> : null}
+      </td>
+      {showBeginEnd ? (
+        <>
+          <td>{formatDate(artist.begin_date)}</td>
+          <td>
+            {artist.begin_area
+              ? <DescriptiveLink entity={artist.begin_area} />
+              : null}
+          </td>
+          <td>{formatEndDate(artist)}</td>
+          <td>
+            {artist.end_area
+              ? <DescriptiveLink entity={artist.end_area} />
+              : null}
+          </td>
+        </>
+      ) : null}
+      {showRatings ? (
+        <td>
+          <RatingStars entity={artist} />
+        </td>
+      ) : null}
+      {showInstrumentCreditsAndRelTypes ? (
+        <td>
+          <InstrumentRelTypes
+            entity={artist}
+            instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+          />
+        </td>
+      ) : null}
+      {mergeForm && artistList ? (
+        <RemoveFromMergeTableCell
+          $c={$c}
           entity={artist}
-          instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+          toMerge={artistList}
         />
-      </td>
-    ) : null}
-    {mergeForm && artistList ? (
-      <RemoveFromMergeTableCell
-        $c={$c}
-        entity={artist}
-        toMerge={artistList}
-      />
-    ) : null}
-  </>
-);
+      ) : null}
+    </>
+  );
+};
 
 const ArtistListEntry = ({
-  $c,
   artist,
   artistList,
   checkboxes,
@@ -150,7 +151,6 @@ const ArtistListEntry = ({
 }: ArtistListEntryProps): React.Element<'tr'> => (
   <tr className={loopParity(index)} data-score={score ?? null}>
     <ArtistListRow
-      $c={$c}
       artist={artist}
       artistList={artistList}
       checkboxes={checkboxes}

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../../context';
 import RatingStars from '../../../../components/RatingStars';
 import loopParity from '../../../../utility/loopParity';
 
@@ -20,7 +21,6 @@ import WorkArtists from './WorkArtists';
 
 type WorkListRowProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +showAttributes?: boolean,
   +showIswcs?: boolean,
@@ -30,7 +30,6 @@ type WorkListRowProps = {
 
 type WorkListEntryProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +index: number,
   +score?: number,
@@ -41,79 +40,81 @@ type WorkListEntryProps = {
 };
 
 export const WorkListRow = ({
-  $c,
   checkboxes,
   seriesItemNumbers,
   showAttributes = false,
   showIswcs = false,
   showRatings = false,
   work,
-}: WorkListRowProps): React.Element<typeof React.Fragment> => (
-  <>
-    {$c.user && nonEmpty(checkboxes) ? (
+}: WorkListRowProps): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <>
+      {$c.user && nonEmpty(checkboxes) ? (
+        <td>
+          <input
+            name={checkboxes}
+            type="checkbox"
+            value={work.id}
+          />
+        </td>
+      ) : null}
+      {seriesItemNumbers ? (
+        <td style={{width: '1em'}}>
+          {seriesItemNumbers[work.id]}
+        </td>
+      ) : null}
+      <td><EntityLink entity={work} /></td>
       <td>
-        <input
-          name={checkboxes}
-          type="checkbox"
-          value={work.id}
-        />
+        <ArtistRoles relations={work.writers} />
       </td>
-    ) : null}
-    {seriesItemNumbers ? (
-      <td style={{width: '1em'}}>
-        {seriesItemNumbers[work.id]}
+      <td>
+        <WorkArtists artists={work.artists} />
       </td>
-    ) : null}
-    <td><EntityLink entity={work} /></td>
-    <td>
-      <ArtistRoles relations={work.writers} />
-    </td>
-    <td>
-      <WorkArtists artists={work.artists} />
-    </td>
-    {showIswcs ? (
+      {showIswcs ? (
+        <td>
+          <ul>
+            {work.iswcs.map((iswc, i) => (
+              <li key={i}>
+                <CodeLink code={iswc} />
+              </li>
+            ))}
+          </ul>
+        </td>
+      ) : null}
+      <td>
+        {nonEmpty(work.typeName)
+          ? lp_attributes(work.typeName, 'work_type')
+          : null}
+      </td>
       <td>
         <ul>
-          {work.iswcs.map((iswc, i) => (
-            <li key={i}>
-              <CodeLink code={iswc} />
+          {work.languages.map(language => (
+            <li
+              data-iso-639-3={language.language.iso_code_3}
+              key={language.language.id}
+            >
+              {l_languages(language.language.name)}
             </li>
           ))}
         </ul>
       </td>
-    ) : null}
-    <td>
-      {nonEmpty(work.typeName)
-        ? lp_attributes(work.typeName, 'work_type')
-        : null}
-    </td>
-    <td>
-      <ul>
-        {work.languages.map(language => (
-          <li
-            data-iso-639-3={language.language.iso_code_3}
-            key={language.language.id}
-          >
-            {l_languages(language.language.name)}
-          </li>
-        ))}
-      </ul>
-    </td>
-    {showAttributes ? (
-      <td>
-        <AttributeList entity={work} />
-      </td>
-    ) : null}
-    {showRatings ? (
-      <td>
-        <RatingStars entity={work} />
-      </td>
-    ) : null}
-  </>
-);
+      {showAttributes ? (
+        <td>
+          <AttributeList entity={work} />
+        </td>
+      ) : null}
+      {showRatings ? (
+        <td>
+          <RatingStars entity={work} />
+        </td>
+      ) : null}
+    </>
+  );
+};
 
 const WorkListEntry = ({
-  $c,
   checkboxes,
   index,
   score,
@@ -125,7 +126,6 @@ const WorkListEntry = ({
 }: WorkListEntryProps): React.Element<'tr'> => (
   <tr className={loopParity(index)} data-score={score ?? null}>
     <WorkListRow
-      $c={$c}
       checkboxes={checkboxes}
       seriesItemNumbers={seriesItemNumbers}
       showAttributes={showAttributes}

--- a/root/taglookup/ArtistResults.js
+++ b/root/taglookup/ArtistResults.js
@@ -19,7 +19,6 @@ const TagLookupArtistResults = (
 ): React.Element<typeof TagLookupResults> => (
   <TagLookupResults {...props}>
     <ArtistResultsInline
-      $c={props.$c}
       pager={props.pager}
       query={props.query}
       results={props.results}

--- a/root/taglookup/RecordingResults.js
+++ b/root/taglookup/RecordingResults.js
@@ -19,7 +19,6 @@ const TagLookupRecordingResults = (
 ): React.Element<typeof TagLookupResults> => (
   <TagLookupResults {...props}>
     <RecordingResultsInline
-      $c={props.$c}
       pager={props.pager}
       query={props.query}
       results={props.results}

--- a/root/taglookup/ReleaseResults.js
+++ b/root/taglookup/ReleaseResults.js
@@ -19,7 +19,6 @@ const TagLookupReleaseResults = (
 ): React.Element<typeof TagLookupResults> => (
   <TagLookupResults {...props}>
     <ReleaseResultsInline
-      $c={props.$c}
       pager={props.pager}
       query={props.query}
       results={props.results}

--- a/root/url/UrlLayout.js
+++ b/root/url/UrlLayout.js
@@ -36,7 +36,7 @@ const UrlLayout = ({
       <UrlHeader page={page} url={url} />
       {children}
     </div>
-    {fullWidth ? null : <UrlSidebar $c={$c} url={url} />}
+    {fullWidth ? null : <UrlSidebar url={url} />}
   </Layout>
 );
 

--- a/root/work/WorkLayout.js
+++ b/root/work/WorkLayout.js
@@ -46,7 +46,7 @@ const WorkLayout = ({
         <WorkHeader page={page} work={work} />
         {children}
       </div>
-      {fullWidth ? null : <WorkSidebar $c={$c} work={work} />}
+      {fullWidth ? null : <WorkSidebar work={work} />}
     </Layout>
   );
 };

--- a/root/work/WorkMerge.js
+++ b/root/work/WorkMerge.js
@@ -51,7 +51,6 @@ const WorkMerge = ({
       ) : null}
       <form action={$c.req.uri} method="post">
         <WorkList
-          $c={$c}
           mergeForm={form}
           works={sortByEntityName(toMerge)}
         />


### PR DESCRIPTION
### Implements MBS-11514 / MBS-11515 / MBS-11516 / MBS-11517

Some big chunks (like Layout) left for a second PR to avoid making this huge. Reports bits done in https://github.com/metabrainz/musicbrainz-server/pull/1787 since that already refactors the whole thing.

This shaves some lines, but more importantly it makes it easier to understand and follow and avoids passing $c down several components just to reach the one N steps down the line.

I'd suggest reviewing with the whitespace ignore on, since most changes other than just the $c bit itself are to indent some components because of adding return () to them.

Tested by navigating around locally, but not extensively - plus Flow to ensure I didn't keep passing $c where I shouldn't anymore.