### PR TITLE
MBS-11317: Avoid breaking annotation formatting in RE

### DIFF
--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -47,8 +47,8 @@ import request from '../../common/utility/request';
       return {
         entity: nullableString(entity.gid),
 
-        // Don't clean()!
-        text: String(value(entity.annotation) || '').trim(),
+        // We trim the end only to ensure formatting doesn't break
+        text: String(value(entity.annotation) || '').trimEnd(),
       };
     },
 

--- a/root/static/scripts/tests/release-editor/edits.js
+++ b/root/static/scripts/tests/release-editor/edits.js
@@ -77,6 +77,23 @@ editReleaseTest((
 });
 
 editReleaseTest((
+  'Annotation trimming does not break list syntax'
+), function (t, release) {
+  t.plan(1);
+
+  release.annotation('    * A list item    ');
+
+  t.deepEqual(releaseEditor.edits.annotation(release), [
+    {
+      entity: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+      text: '    * A list item',
+      edit_type: 35,
+      hash: 'b88b6f09ec059793cb98c03c2420cf7b2a47e692',
+    },
+  ]);
+});
+
+editReleaseTest((
   'releaseDeleteReleaseLabel edit is generated for existing release'
 ), function (t, release) {
   t.plan(1);


### PR DESCRIPTION
### Fix MBS-11317

We changed this in the main annotation form with MBS-4091 but the release editor doesn't use that code.

Tested manually, plus added test for it.