### PR TITLE
Beta: Amend #1795 (MBS-11234): Fix validating WhoSampled URL relationships

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3249,8 +3249,8 @@ const CLEANUPS = {
                 error: l(
                   `Please do not link directly to WhoSampled
                    “{unwanted_url_pattern}” pages.
-                   Link to the appropriate artist, recording
-                   or release page instead.`,
+                   Link to the appropriate WhoSampled artist, track
+                   or album page instead.`,
                   {
                     unwanted_url_pattern: (
                       <span className="url-quote">
@@ -3295,7 +3295,7 @@ const CLEANUPS = {
                 }
                 return {
                   error: l(
-                    'Please link WhoSampled song pages to recordings.',
+                    'Please link WhoSampled track pages to recordings.',
                   ),
                   result: false,
                 };

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3245,9 +3245,15 @@ const CLEANUPS = {
             case 'sample':
               return {
                 error: l(
-                  `Please do not link directly to WhoSampled sample pages.
+                  `Please do not link directly to WhoSampled
+                   “{unwanted_url_pattern}” pages.
                    Link to the appropriate artist, recording
                    or release page instead.`,
+                  {
+                    unwanted_url_pattern: (
+                      <span className="url-quote">{'/sample'}</span>
+                    ),
+                  },
                 ),
                 result: false,
               };
@@ -3256,8 +3262,14 @@ const CLEANUPS = {
                 return {result: true};
               }
               return {
-                error: l(
-                  'Please link WhoSampled album pages to release groups.',
+                error: exp.l(
+                  `Please link WhoSampled “{album_url_pattern}” pages to
+                   release groups.`,
+                  {
+                    album_url_pattern: (
+                      <span className="url-quote">{'/album'}</span>
+                    ),
+                  },
                 ),
                 result: false,
               };

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3235,48 +3235,57 @@ const CLEANUPS = {
           result: false,
         };
       }
-      if (/^https:\/\/www\.whosampled\.com\/sample\//.test(url)) {
-        return {
-          error: l(
-            `Please do not link directly to WhoSampled sample pages.
-             Link to the appropriate artist, recording
-             or release page instead.`,
-          ),
-          result: false,
-        };
-      }
-      if (/^https:\/\/www\.whosampled\.com\/album\//.test(url)) {
-        if (id === LINK_TYPES.otherdatabases.release_group) {
-          return {result: true};
+      const m = /^https:\/\/www\.whosampled\.com(\/[^?#]+)$/.exec(url);
+      if (m) {
+        const path = m[1];
+        const mp = /^\/([^\/]+)/.exec(path);
+        if (mp) {
+          const topLevelSegment = mp[1];
+          switch (topLevelSegment) {
+            case 'sample':
+              return {
+                error: l(
+                  `Please do not link directly to WhoSampled sample pages.
+                   Link to the appropriate artist, recording
+                   or release page instead.`,
+                ),
+                result: false,
+              };
+            case 'album':
+              if (id === LINK_TYPES.otherdatabases.release_group) {
+                return {result: true};
+              }
+              return {
+                error: l(
+                  'Please link WhoSampled album pages to release groups.',
+                ),
+                result: false,
+              };
+            default:
+              if (/^\/[^/]+(?:\/)?$/.test(path)) {
+                if (id === LINK_TYPES.otherdatabases.artist) {
+                  return {result: true};
+                }
+                return {
+                  error: l(
+                    'Please link WhoSampled artist pages to artists.',
+                  ),
+                  result: false,
+                };
+              }
+              if (/^\/[^/]+\/[^/]+(?:\/)?$/.test(path)) {
+                if (id === LINK_TYPES.otherdatabases.recording) {
+                  return {result: true};
+                }
+                return {
+                  error: l(
+                    'Please link WhoSampled song pages to recordings.',
+                  ),
+                  result: false,
+                };
+              }
+          }
         }
-        return {
-          error: l(
-            'Please link WhoSampled album pages to release groups.',
-          ),
-          result: false,
-        };
-      }
-      if (/^https:\/\/www\.whosampled\.com\/(?!(?:album|sample))[^/]+(?:\/)?$/.test(url)) {
-        if (id === LINK_TYPES.otherdatabases.artist) {
-          return {result: true};
-        }
-        return {
-          error: l(
-            'Please link WhoSampled artist pages to artists.',
-          ),
-          result: false,
-        };
-      }
-      if (/^https:\/\/www\.whosampled\.com\/(?!(?:album|sample))[^/]+\/[^/]+(?:\/)?$/.test(url)) {
-        if (id === LINK_TYPES.otherdatabases.recording) {
-          return {result: true};
-        }
-        return {
-          error: l(
-            'Please link WhoSampled song pages to recordings.',
-          ),
-          result: false,
-        };
       }
       return {result: false};
     },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3242,6 +3242,8 @@ const CLEANUPS = {
         if (mp) {
           const topLevelSegment = mp[1];
           switch (topLevelSegment) {
+            case 'cover':
+            case 'remix':
             case 'sample':
               return {
                 error: l(
@@ -3251,7 +3253,9 @@ const CLEANUPS = {
                    or release page instead.`,
                   {
                     unwanted_url_pattern: (
-                      <span className="url-quote">{'/sample'}</span>
+                      <span className="url-quote">
+                        {'/' + topLevelSegment}
+                      </span>
                     ),
                   },
                 ),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3939,6 +3939,20 @@ const testData = [
        only_valid_entity_types: [],
   },
   {
+                     input_url: 'https://www.whosampled.com/cover/575868/Ghost-It%27s-a-Sin-Pet-Shop-Boys-It%27s-a-Sin/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/cover/575868/Ghost-It%27s-a-Sin-Pet-Shop-Boys-It%27s-a-Sin/',
+       only_valid_entity_types: [],
+  },
+  {
+                     input_url: 'https://www.whosampled.com/remix/43901/Pet-Shop-Boys-Can-You-Forgive-Her%3F-(Rollo-Dub)-Pet-Shop-Boys-Can-You-Forgive-Her%3F/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.whosampled.com/remix/43901/Pet-Shop-Boys-Can-You-Forgive-Her%3F-(Rollo-Dub)-Pet-Shop-Boys-Can-You-Forgive-Her%3F/',
+       only_valid_entity_types: [],
+  },
+  {
                      input_url: 'https://www.whosampled.com/sample/127347/Death-Grips-5D-Pet-Shop-Boys-West-End-Girls/',
              input_entity_type: 'recording',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since the pull request #1795 for MBS-11234 has been merged:
* WhoSampled `/cover` and `/remix` URLs are incorrectly accepted for artists and recordings;
* Error message is incorrectly referring to “release” instead of WhoSampled “album”.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Deduplicate matching top level segment of path to safely handle extra `cover` and `remix` cases,
  (and add corresponding tests)
* Fix error message for blocked URL,
* Refer to WhoSampled “tracks” (used in their pages) instead of “songs” (used in their sections),
* Improve formatting of error message.