### PR TITLE
MBS-11324: Trim input in the barcode otherlookups field

### DIFF
--- a/lib/MusicBrainz/Server/Form/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Form/OtherLookup.pm
@@ -10,6 +10,12 @@ has_field 'catno' => (
 
 has_field 'barcode'  => (
     type => '+MusicBrainz::Server::Form::Field::Barcode',
+    trim => { transform => sub {
+        my $string = shift;
+        # Remove all spaces for barcode search since we don't store them
+        $string =~ s/\s+//g;
+        return $string;
+    } }
 );
 
 has_field 'url'  => (


### PR DESCRIPTION
### Implement MBS-11324

We remove all spaces when a barcode is pasted on the RE and store them without spaces. As such, we should do the same when a user pastes, say, " 9 78849 2540655" in the barcode search, so that the actual search submitted ("barcode:9788492540655") can find results.

Tested manually with the barcode above.