### PR TITLE
MBS-11320 / MBS-11321: Don't add new medium if empty medium existed

### DIFF
--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -344,8 +344,12 @@ Object.assign(addMediumDialog, {
 
     var release = releaseEditor.rootField.release();
 
-    // If there's only one empty medium, replace it.
-    if (release.hasOneEmptyMedium()) {
+    /*
+     * If there's only one empty medium, replace it
+     * (unless it was a previously existing medium with unknown tracklist)
+     */
+    if (release.hasOneEmptyMedium() &&
+        !release.mediums()[0].tracksWereUnknownToUser) {
       medium.position(1);
 
       // Keep the existing formatID if there's not a new one.

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -358,6 +358,7 @@ class Medium {
     var tracks = data.tracks;
     this.tracks = ko.observableArray(utils.mapChild(this, tracks, Track));
     this.tracksUnknownToUser = ko.observable(false);
+    this.tracksWereUnknownToUser = false;
 
     var self = this;
 
@@ -695,6 +696,7 @@ class Medium {
 
     if (this.tracks().length === 0) {
       this.tracksUnknownToUser(true);
+      this.tracksWereUnknownToUser = true;
     }
     this.loaded(true);
     this.loading(false);

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -402,7 +402,13 @@ releaseEditor.autoOpenTheAddMediumDialog = function (release) {
 
     if (!dialogIsOpen && release.hasOneEmptyMedium() &&
                             !release.mediums()[0].loading()) {
-      this.addMediumDialog.open();
+      if (release.mediums()[0].tracksWereUnknownToUser) {
+        // If we had a medium without tracklist, edit that tracklist
+        this.trackParserDialog.open(release.mediums()[0]);
+      } else {
+        // Otherwise, prepare to add a new medium
+        this.addMediumDialog.open();
+      }
     }
   } else if (addMediumUI) {
     addMediumUI.close();


### PR DESCRIPTION
### Fix MBS-11320 / MBS-11321

For cases where an existing empty medium is already present, present the track parser (rather than the Add disc dialog) if the user disables the "tracklist is unknown" checkbox, and don't overwrite the medium if using Add medium.
