### PR TITLE
MBS-10187: "Merge artists" edit is stuck

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -17,6 +17,7 @@ use MusicBrainz::Server::Data::Edit;
 use MusicBrainz::Server::Data::Utils qw(
     is_special_artist
     add_partial_date_to_row
+    conditional_merge_column_query
     defined_hash
     get_area_containment_query
     hash_to_row
@@ -339,9 +340,32 @@ sub merge
     $self->c->model('Collection')->merge_entities('artist', $new_id, @$old_ids);
     $self->c->model('Relationship')->merge_entities('artist', $new_id, $old_ids, rename_credits => $opts{rename});
 
+    # We detect cases where a merged artist type or gender is dropped due to
+    # it conflicting with a type or gender on the target or elsewhere (since
+    # only persons can have a gender). In Edit::Artist::Merge, we use the
+    # result of %dropped_columns to inform users of what information was
+    # dropped. This is done as opposed to failing the edit outright, since
+    # that's arguably more annoying for the editor. See MBS-10187.
+    my %dropped_columns;
     unless (is_special_artist($new_id)) {
-        my $merge_columns = [ qw( area begin_area end_area type ) ];
-        my $artist_type = $self->sql->select_single_value('SELECT type FROM artist WHERE id = ?', $new_id);
+        my $merge_columns = [ qw( area begin_area end_area ) ];
+        my $target_row = $self->sql->select_single_row_hash('SELECT gender, type FROM artist WHERE id = ?', $new_id);
+        my $target_type = $target_row->{type};
+        my $target_gender = $target_row->{gender};
+        my $merged_type = $target_type;
+        my $merged_gender = $target_gender;
+
+        if (!$merged_type) {
+            my ($query, $args) = conditional_merge_column_query(
+                'artist', 'type', $new_id, [$new_id, @$old_ids], 'IS NOT NULL');
+            $merged_type = $self->c->sql->select_single_value($query, @$args);
+        }
+
+        if (!$merged_gender) {
+            my ($query, $args) = conditional_merge_column_query(
+                'artist', 'gender', $new_id, [$new_id, @$old_ids], 'IS NOT NULL');
+            $merged_gender = $self->c->sql->select_single_value($query, @$args);
+        }
 
         my $group_types = $self->sql->select_single_column_array(q{
             WITH RECURSIVE atp(id) AS (
@@ -353,13 +377,29 @@ sub merge
             ) SELECT * FROM atp
         }, $ARTIST_TYPE_GROUP);
 
-        my $artist_type_is_group =
-            defined $artist_type &&
-            any { $artist_type eq $_ } @$group_types;
+        my $merged_type_is_group =
+            defined $merged_type &&
+            any { $merged_type eq $_ } @$group_types;
 
-        if (!defined $artist_type || !$artist_type_is_group) {
-            push @$merge_columns, 'gender';
+        if ($merged_type_is_group && $merged_gender) {
+            my $target_type_is_group =
+                defined $target_type &&
+                any { $target_type eq $_ } @$group_types;
+
+            if ($target_type_is_group) {
+                $dropped_columns{gender} = $merged_gender;
+                push @$merge_columns, 'type';
+            } elsif ($target_gender) {
+                $dropped_columns{type} = $merged_type;
+                push @$merge_columns, 'gender';
+            } else {
+                $dropped_columns{gender} = $merged_gender;
+                $dropped_columns{type} = $merged_type;
+            }
+        } else {
+            push @$merge_columns, qw( gender type );
         }
+
         merge_table_attributes(
             $self->sql => (
                 table => 'artist',
@@ -379,7 +419,7 @@ sub merge
     }
 
     $self->_delete_and_redirect_gids('artist', $new_id, @$old_ids);
-    return 1;
+    return (1, \%dropped_columns);
 }
 
 sub _hash_to_row

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -42,6 +42,7 @@ our @EXPORT_OK = qw(
     boolean_from_json
     boolean_to_json
     check_data
+    conditional_merge_column_query
     copy_escape
     coordinates_to_hash
     datetime_to_iso8601
@@ -510,32 +511,49 @@ sub _merge_attributes {
     $sql->do($query_generator->($table, $new_id, $old_ids, $all_ids, \%named_params));
 }
 
+sub conditional_merge_column_query {
+    my ($table, $column, $new_id, $all_ids, $condition, $default) = @_;
+
+    my @args = ($new_id, $all_ids);
+    my $query =
+        "(SELECT new_val
+            FROM (SELECT (id = ?) AS first, $column AS new_val
+                    FROM $table
+                   WHERE $column $condition
+                     AND id = any(?)
+                   ORDER BY first DESC
+                   LIMIT 1) s)";
+    if (defined $default) {
+        $query = "coalesce($query, ?)";
+        push @args, $default;
+    }
+    return ($query, \@args);
+}
 
 sub _conditional_merge {
     my ($condition, %opts) = @_;
 
-    my $wrap_coalesce = sub {
-        my ($inner, $wrap) = @_;
-        if ($wrap) { return "coalesce(" . $inner . ",?)" }
-        else { return $inner }
-    };
-
     return sub {
-            my ($table, $new_id, $old_ids, $all_ids, $named_params) = @_;
-            my $columns = $named_params->{columns} or confess 'Missing parameter columns';
-            ("UPDATE $table SET " .
-             join(',', map {
-                 "$_ = " . $wrap_coalesce->("(SELECT new_val FROM (
-                      SELECT (id = ?) AS first, $_ AS new_val
-                        FROM $table
-                       WHERE $_ $condition
-                         AND id IN (" . placeholders(@$all_ids) . ")
-                    ORDER BY first DESC
-                       LIMIT 1
-                       ) s)", exists $opts{default});
-             } @$columns) . '
-             WHERE id = ?',
-             (@$all_ids, $new_id) x @$columns, (exists $opts{default} ? $opts{default} : ()), $new_id)}
+        my ($table, $new_id, $old_ids, $all_ids, $named_params) = @_;
+        my $columns = $named_params->{columns} or confess 'Missing parameter columns';
+        my @assignment_args;
+        my $column_assignments = join(', ', map {
+            my $column = $_;
+            my ($column_query, $column_args) =
+                conditional_merge_column_query(
+                    $table,
+                    $column,
+                    $new_id,
+                    $all_ids,
+                    $condition,
+                    $opts{default},
+                );
+            push @assignment_args, @{$column_args};
+            "$column = ($column_query)"
+         } @$columns);
+        ("UPDATE $table SET $column_assignments WHERE id = ?",
+            @assignment_args, $new_id);
+    };
 }
 
 sub merge_table_attributes {

--- a/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Relationship/LinkAttributeType/Edit.pm
@@ -67,7 +67,7 @@ test 'GET /relationship/attribute/edit for invalid attribute types' => sub {
         '/relationship-attribute/77a0f1d3-beee-4055-a6e7-24d7258c21f7/edit');
 
     is($mech->status, 404,
-       'Returns 404 when trying to edit a non-existant relationship attribute');
+       'Returns 404 when trying to edit a non-existent relationship attribute');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -61,7 +61,7 @@ test 'Remember me tokens' => sub {
        'Remember me tokens with improper capitalization can\'t be consumed');
 
     ok(!exception { $model->consume_remember_me_token('Unknown User', $token) },
-       'It is not an exception to attempt to consume tokens for non-existant users');
+       'It is not an exception to attempt to consume tokens for non-existent users');
 
     is($model->allocate_remember_me_token('Unknown User'), undef,
        'Allocating tokens for unknown users returns undefined');

--- a/t/lib/t/MusicBrainz/Server/Data/ISWC.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ISWC.pm
@@ -137,7 +137,7 @@ test 'Test find_by_iswc' => sub {
 
     {
         my @iswcs = $test->c->model('Work')->find_by_iswc('T-111.222.331-0');
-        is(@iswcs, 0, 'Found 0 ISWCs for non-existant ISWC');
+        is(@iswcs, 0, 'Found 0 ISWCs for non-existent ISWC');
     }
 };
 

--- a/t/lib/t/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -58,7 +58,7 @@ is($link_attr_type, undef);
 
 };
 
-test 'get_by_gid with non existant GID' => sub {
+test 'get_by_gid with non existent GID' => sub {
     my $test = shift;
     MusicBrainz::Server::Test->prepare_test_database($test->c, '+relationships');
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Constants qw( $EDIT_ARTIST_MERGE );
 use MusicBrainz::Server::Constants qw( :edit_status );
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
-test 'Non-existant merge target' => sub {
+test 'Non-existent merge target' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -1,4 +1,5 @@
 package t::MusicBrainz::Server::Edit::Artist::Merge;
+use utf8;
 use Test::Routine;
 use Test::More;
 use Test::Fatal;
@@ -28,13 +29,13 @@ test 'Non-existent merge target' => sub {
     ok(defined $c->model('Artist')->get_by_id(3));
 };
 
-test 'Merge Person with gender into Group' => sub {
+test 'Merging a person with a gender into a group' => sub {
     my $test = shift;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+edit_artist_merge');
     $c->sql->do(<<'EOSQL');
-UPDATE artist SET type = 2 WHERE id = 4;
+UPDATE artist SET type = 2, gender = NULL WHERE id = 4;
 UPDATE artist SET type = 1, gender = 2 WHERE id = 3;
 EOSQL
 
@@ -42,7 +43,165 @@ EOSQL
     my $edit = create_edit($c);
 
     ok(!exception { accept_edit($c, $edit) },
-       'Edit merging person with gender to group does not cause exception');
+       'Edit merging a person with a gender into a group does not cause an exception');
+
+    my $row = $c->sql->select_single_row_hash('SELECT * FROM artist WHERE id = 4');
+    is($row->{type}, 2, 'The resulting type is a group');
+    is($row->{gender}, undef, 'The resulting gender is null');
+
+    $c->model('EditNote')->load_for_edits($edit);
+    is(scalar $edit->all_edit_notes, 1);
+
+    my $note = scalar($edit->all_edit_notes) ? $edit->edit_notes->[0] : undef;
+    is(
+        defined $note && $note->localize,
+        'The “Female” gender has not been added to the ' .
+        'destination artist because it conflicted with the ' .
+        'group type of one of the artists here. Group artists ' .
+        'cannot have a gender.',
+    );
+};
+
+test 'Merging an artist with no type and a gender into a group' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_artist_merge');
+    $c->sql->do(<<'EOSQL');
+UPDATE artist SET type = 2, gender = NULL WHERE id = 4;
+UPDATE artist SET type = NULL, gender = 2 WHERE id = 3;
+EOSQL
+
+    # merge 3 -> 4
+    my $edit = create_edit($c);
+
+    ok(!exception { accept_edit($c, $edit) },
+       'Edit merging a person with no type and a gender into a group does not cause an exception');
+
+    my $row = $c->sql->select_single_row_hash('SELECT * FROM artist WHERE id = 4');
+    is($row->{type}, 2, 'The resulting type is a group');
+    is($row->{gender}, undef, 'The resulting gender is null');
+
+    $c->model('EditNote')->load_for_edits($edit);
+    is(scalar $edit->all_edit_notes, 1);
+
+    my $note = scalar($edit->all_edit_notes) ? $edit->edit_notes->[0] : undef;
+    is(
+        defined $note && $note->localize,
+        'The “Female” gender has not been added to the ' .
+        'destination artist because it conflicted with the ' .
+        'group type of one of the artists here. Group artists ' .
+        'cannot have a gender.',
+    );
+};
+
+test 'Merging a group into an artist with no type and a gender' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_artist_merge');
+    $c->sql->do(<<'EOSQL');
+UPDATE artist SET type = NULL, gender = 2 WHERE id = 4;
+UPDATE artist SET type = 2, gender = NULL WHERE id = 3;
+EOSQL
+
+    # merge 3 -> 4
+    my $edit = create_edit($c);
+
+    ok(!exception { accept_edit($c, $edit) },
+       'Edit merging a group into an artist with no type and a gender does not cause an exception');
+
+    my $row = $c->sql->select_single_row_hash('SELECT * FROM artist WHERE id = 4');
+    is($row->{type}, undef, 'The resulting type is null');
+    is($row->{gender}, 2, 'The resulting gender is female');
+
+    $c->model('EditNote')->load_for_edits($edit);
+    is(scalar $edit->all_edit_notes, 1);
+
+    my $note = scalar($edit->all_edit_notes) ? $edit->edit_notes->[0] : undef;
+    is(
+        defined $note && $note->localize,
+        'The “Group” type has not been added to the ' .
+        'destination artist because it conflicted with the ' .
+        'gender setting of one of the artists here. Group ' .
+        'artists cannot have a gender.',
+    );
+};
+
+test 'Merging a group into a person with a gender' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_artist_merge');
+    $c->sql->do(<<'EOSQL');
+UPDATE artist SET type = 1, gender = 2 WHERE id = 4;
+UPDATE artist SET type = 2, gender = NULL WHERE id = 3;
+EOSQL
+
+    # merge 3 -> 4
+    my $edit = create_edit($c);
+
+    ok(!exception { accept_edit($c, $edit) },
+       'Edit merging a group into a person with a gender does not cause an exception');
+
+    my $row = $c->sql->select_single_row_hash('SELECT * FROM artist WHERE id = 4');
+    is($row->{type}, 1, 'The resulting type is person');
+    is($row->{gender}, 2, 'The resulting gender is female');
+
+    $c->model('EditNote')->load_for_edits($edit);
+    is(scalar $edit->all_edit_notes, 0);
+};
+
+test 'Merging a group, and an artist with no type and a gender, into an artist with no type or gender' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_artist_merge');
+    $c->sql->do(<<'EOSQL');
+UPDATE artist SET type = NULL, gender = NULL WHERE id = 4;
+UPDATE artist SET type = 2, gender = NULL WHERE id = 3;
+UPDATE artist SET type = NULL, gender = 1 WHERE id = 5;
+EOSQL
+
+    # merge 3 & 5 -> 4
+    my $edit = $c->model('Edit')->create(
+        edit_type => $EDIT_ARTIST_MERGE,
+        editor_id => 1,
+        old_entities => [
+            { id => 3, name => 'Old Artist' },
+            { id => 5, name => 'Another Old Artist' },
+        ],
+        new_entity => { id => 4, name => 'New Artist' },
+        rename => 0,
+    );
+
+    ok(!exception { accept_edit($c, $edit) },
+       'Edit merging a group, and an artist with no type and a gender, into an artist with no type or gender does not cause an exception');
+
+    my $row = $c->sql->select_single_row_hash('SELECT * FROM artist WHERE id = 4');
+    # In this case we drop both columns, since it's not clear which to use.
+    is($row->{type}, undef, 'The resulting type is null');
+    is($row->{gender}, undef, 'The resulting gender is null');
+
+    $c->model('EditNote')->load_for_edits($edit);
+    is(scalar $edit->all_edit_notes, 2);
+
+    my $note = scalar($edit->all_edit_notes) ? $edit->edit_notes->[0] : undef;
+    is(
+        defined $note && $note->localize,
+        'The “Group” type has not been added to the ' .
+        'destination artist because it conflicted with the ' .
+        'gender setting of one of the artists here. Group ' .
+        'artists cannot have a gender.',
+    );
+    $note = scalar($edit->all_edit_notes) > 1 ? $edit->edit_notes->[1] : undef;
+    is(
+        defined $note && $note->localize,
+        'The “Male” gender has not been added to the ' .
+        'destination artist because it conflicted with the ' .
+        'group type of one of the artists here. Group artists ' .
+        'cannot have a gender.',
+    );
 };
 
 # The name of this test may be confusing, since the code should do the opposite

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
@@ -34,7 +34,7 @@ SQL
     is($medium_cdtoc->medium->release->edits_pending, 0);
 };
 
-test 'Cannot move to non-existant medium' => sub {
+test 'Cannot move to non-existent medium' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -156,7 +156,7 @@ test 'Parallel edits that dont conflict merge' => sub {
     is($rl->catalog_number, 'Woof!');
 };
 
-test 'Editing a non-existant release label fails' => sub {
+test 'Editing a non-existent release label fails' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/sql/edit_artist_merge.sql
+++ b/t/sql/edit_artist_merge.sql
@@ -2,7 +2,8 @@ SET client_min_messages TO 'warning';
 
 INSERT INTO artist (id, gid, name, sort_name, comment)
     VALUES (3, 'da34a170-7f7f-11de-8a39-0800200c9a66', 'Old Artist', 'Old Artist', 'Artist 3'),
-           (4, 'e9f5fc80-7f7f-11de-8a39-0800200c9a66', 'New Artist', 'New Artist', 'Artist 4');
+           (4, 'e9f5fc80-7f7f-11de-8a39-0800200c9a66', 'New Artist', 'New Artist', 'Artist 4'),
+           (5, 'a7829255-ade4-4611-ac3f-07192d21a947', 'Another Old Artist', 'Another Old Artist', 'Artist 5');
 
 INSERT INTO artist_ipi (artist, ipi) VALUES (3, '00151894163');
 INSERT INTO artist_ipi (artist, ipi) VALUES (3, '00145958831');


### PR DESCRIPTION
Artist merges can get stuck if their merged types and genders conflict: groups can't have a gender.

We now detect this case and drop any conflicting information. This is done as opposed to failing the edit because it's less annoying to the user. ModBot will leave a note explaining what information was lost.

This also handles the case where the target doesn't have a type or gender, but the resulting merged type & gender from the source artists would result in a conflict. In that case we drop both values and leave two notes.