### PR TITLE
MBS-11328: Regression: Approving an edit redirects to home page

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -257,9 +257,12 @@ sub redirect_back {
 
     if (
         $returnto eq '' ||
-        # Check that we weren't given an external URL. Only relative
-        # URLs are allowed.
-        $returnto->authority
+        # Check that we weren't given an external URL. Only URLs relative to
+        # the current domain are allowed.
+        (
+            $returnto->authority &&
+            $returnto->authority ne $c->req->uri->authority
+        )
     ) {
         $returnto->path_query('/');
         $returnto->fragment(undef);


### PR DESCRIPTION
This only occurred when approving from an edit page (e.g. /edit/123), not from an edit listing.

The issue is that while 69df512dc2c59af936a1291f0476e0acdf5d6aeb improved the security of `returnto` by preventing it from redirecting to external URLs, it did this by ignoring any URL with an authority set. We want to be a bit more lax and accept absolute URLs that point to musicbrainz.org or the current web server.

Tested the change manually on my mirror server.