### PR TITLE
MBS-11329: Return privileges as a number in internal editor JSON

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -163,18 +163,6 @@ sub is_newbie
       ) == -1;
 }
 
-sub is_admin
-{
-    my $self = shift;
-    return (
-        $self->is_account_admin ||
-        $self->is_banner_editor ||
-        $self->is_location_editor ||
-        $self->is_relationship_editor ||
-        $self->is_wiki_transcluder
-    );
-}
-
 has 'preferences' => (
     is => 'rw',
     lazy => 1,
@@ -307,21 +295,12 @@ sub _unsanitized_json {
         gender                      => $self->gender,
         has_confirmed_email_address => boolean_to_json($self->has_confirmed_email_address),
         has_email_address           => boolean_to_json($self->has_email_address),
-        is_account_admin            => boolean_to_json($self->is_account_admin),
-        is_adding_notes_disabled    => boolean_to_json($self->is_adding_notes_disabled),
-        is_admin                    => boolean_to_json($self->is_admin),
-        is_auto_editor              => boolean_to_json($self->is_auto_editor),
-        is_banner_editor            => boolean_to_json($self->is_banner_editor),
-        is_bot                      => boolean_to_json($self->is_bot),
         is_charter                  => boolean_to_json($self->is_charter),
-        is_editing_disabled         => boolean_to_json($self->is_editing_disabled),
         is_limited                  => boolean_to_json($self->is_limited),
-        is_location_editor          => boolean_to_json($self->is_location_editor),
-        is_relationship_editor      => boolean_to_json($self->is_relationship_editor),
-        is_wiki_transcluder         => boolean_to_json($self->is_wiki_transcluder),
         languages                   => $self->languages,
         last_login_date             => datetime_to_iso8601($self->last_login_date),
         preferences                 => $self->preferences->TO_JSON,
+        privileges                  => $self->privileges,
         registration_date           => datetime_to_iso8601($self->registration_date),
         website                     => $self->website,
     };

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -12,6 +12,8 @@ import * as React from 'react';
 import Layout from '../../layout';
 import Table from '../../components/Table';
 import bracketed from '../../static/scripts/common/utility/bracketed';
+import {isWikiTranscluder}
+  from '../../static/scripts/common/utility/privileges';
 
 import type {WikiDocT} from './types';
 
@@ -45,7 +47,7 @@ const WikiDocTable = ({
         accessor: 'version',
         cellProps: {
           className: 'c transcluded-version',
-          style: (updatesRequired && $c.user?.is_wiki_transcluder)
+          style: (updatesRequired && isWikiTranscluder($c.user))
             ? {textAlign: 'right'}
             : null,
         },
@@ -123,7 +125,7 @@ const WikiDocTable = ({
         nameColumn,
         transcludedVersionColumn,
         wikiVersionColumn,
-        ...($c.user?.is_wiki_transcluder ? [actionsColumn] : []),
+        ...(isWikiTranscluder($c.user) ? [actionsColumn] : []),
       ];
     },
     [
@@ -153,7 +155,7 @@ const WikiDocIndex = (props: PropsT): React.Element<typeof Layout> => (
           {doc: '/doc/WikiDocs'},
         )}
       </p>
-      {props.$c.user?.is_wiki_transcluder ? (
+      {isWikiTranscluder(props.$c.user) ? (
         <>
           <ul>
             <li key="create">

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -11,16 +11,21 @@ import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import entityHref from '../../static/scripts/common/utility/entityHref';
+import {
+  isEditingEnabled,
+  isLocationEditor,
+  isRelationshipEditor,
+} from '../../static/scripts/common/utility/privileges';
 
 import AliasTable from './AliasTable';
 
 function canEdit($c: CatalystContextT, entityType: string) {
-  if ($c.user && !$c.user.is_editing_disabled) {
+  if (isEditingEnabled($c.user)) {
     switch (entityType) {
       case 'area':
-        return $c.user.is_location_editor;
+        return isLocationEditor($c.user);
       case 'instrument':
-        return $c.user.is_relationship_editor;
+        return isRelationshipEditor($c.user);
       default:
         return true;
     }

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -13,6 +13,10 @@ import {CatalystContext} from '../context';
 import {ENTITIES} from '../static/scripts/common/constants';
 import isSpecialPurpose
   from '../static/scripts/common/utility/isSpecialPurpose';
+import {
+  isLocationEditor,
+  isRelationshipEditor,
+} from '../static/scripts/common/utility/privileges';
 
 import Tabs from './Tabs';
 import EntityTabLink from './EntityTabLink';
@@ -55,12 +59,12 @@ function showEditTab(
 ): boolean {
   switch (entity.entityType) {
     case 'area':
-      return user ? user.is_location_editor : false;
+      return isLocationEditor(user);
     case 'artist':
       return !isSpecialPurpose(entity);
     case 'genre':
     case 'instrument':
-      return user ? user.is_relationship_editor : false;
+      return isRelationshipEditor(user);
     case 'label':
       return !isSpecialPurpose(entity);
     default:

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -26,6 +26,7 @@ export type AccountLayoutUserT = {
     +public_subscriptions: boolean,
     +public_tags: boolean,
   },
+  +privileges: number,
 };
 
 type Props = {

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {CatalystContext} from '../context';
 import DBDefs from '../static/scripts/common/DBDefs';
+import {isAccountAdmin} from '../static/scripts/common/utility/privileges';
 import buildTab from '../utility/buildTab';
 
 import Tabs from './Tabs';
@@ -22,7 +23,7 @@ function buildTabs(
   page: string,
 ): $ReadOnlyArray<React.Element<'li'>> {
   const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
-  const showAdmin = Boolean($c.user && $c.user.is_account_admin);
+  const showAdmin = isAccountAdmin($c.user);
   const showPrivate = showAdmin || viewingOwnProfile;
 
   const userName = encodeURIComponent(user.name);

--- a/root/constants.js
+++ b/root/constants.js
@@ -55,3 +55,23 @@ export const QUALITY_UNKNOWN_MAPPED = 1;
 export const QUALITY_LOW = 0;
 export const QUALITY_NORMAL = 1;
 export const QUALITY_HIGH = 2;
+
+export const AUTO_EDITOR_FLAG: 1 = 1;
+export const BOT_FLAG: 2 = 2;
+export const UNTRUSTED_FLAG: 4 = 4;
+export const RELATIONSHIP_EDITOR_FLAG: 8 = 8;
+export const DONT_NAG_FLAG: 16 = 16;
+export const WIKI_TRANSCLUSION_FLAG: 32 = 32;
+export const MBID_SUBMITTER_FLAG: 64 = 64;
+export const ACCOUNT_ADMIN_FLAG: 128 = 128;
+export const LOCATION_EDITOR_FLAG: 256 = 256;
+export const BANNER_EDITOR_FLAG: 512 = 512;
+export const EDITING_DISABLED_FLAG: 1024 = 1024;
+export const ADDING_NOTES_DISABLED_FLAG: 2048 = 2048;
+export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
+                                    BOT_FLAG &
+                                    RELATIONSHIP_EDITOR_FLAG &
+                                    WIKI_TRANSCLUSION_FLAG &
+                                    ACCOUNT_ADMIN_FLAG &
+                                    LOCATION_EDITOR_FLAG &
+                                    BANNER_EDITOR_FLAG;

--- a/root/elections/ElectionVoting.js
+++ b/root/elections/ElectionVoting.js
@@ -11,6 +11,9 @@ import * as React from 'react';
 
 import {canCancel, canSecond, canVote, isInvolved}
   from '../utility/voting';
+import {
+  isAutoEditor,
+} from '../static/scripts/common/utility/privileges';
 
 type PropsT = {
   +$c: CatalystContextT,
@@ -24,7 +27,7 @@ const ElectionVoting = ({$c, election}: PropsT): React.MixedElement => {
   );
   const user = $c.user;
   if (user) {
-    if (!user.is_auto_editor) {
+    if (!isAutoEditor(user)) {
       message = l(
         `You cannot vote for this candidate,
          because you are not an auto-editor.`,

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -11,6 +11,14 @@ import * as React from 'react';
 
 import RequestLogin from '../../components/RequestLogin';
 import returnUri, {returnToCurrentPage} from '../../utility/returnUri';
+import {
+  isAccountAdmin,
+  isAdmin,
+  isBannerEditor,
+  isLocationEditor,
+  isRelationshipEditor,
+  isWikiTranscluder,
+} from '../../static/scripts/common/utility/privileges';
 
 import Search from './Search';
 
@@ -111,13 +119,13 @@ const AdminMenu = ({user}: UserProp) => (
       {'\xA0\u25BE'}
     </span>
     <ul>
-      {user.is_location_editor ? (
+      {isLocationEditor(user) ? (
         <li>
           <a href="/area/create">{lp('Add Area', 'button/menu')}</a>
         </li>
       ) : null}
 
-      {user.is_relationship_editor ? (
+      {isRelationshipEditor(user) ? (
         <>
           <li>
             <a href="/instrument/create">
@@ -133,19 +141,19 @@ const AdminMenu = ({user}: UserProp) => (
         </>
       ) : null}
 
-      {user.is_wiki_transcluder ? (
+      {isWikiTranscluder(user) ? (
         <li>
           <a href="/admin/wikidoc">{l('Transclude WikiDocs')}</a>
         </li>
       ) : null}
 
-      {user.is_banner_editor ? (
+      {isBannerEditor(user) ? (
         <li>
           <a href="/admin/banner/edit">{l('Edit Banner Message')}</a>
         </li>
       ) : null}
 
-      {user.is_account_admin ? (
+      {isAccountAdmin(user) ? (
         <>
           <li>
             <a href="/admin/attributes">{l('Edit Attributes')}</a>
@@ -165,7 +173,7 @@ const UserMenu = ({$c}) => (
       <>
         <AccountMenu $c={$c} user={$c.user} />
         <DataMenu user={$c.user} />
-        {$c.user.is_admin ? <AdminMenu user={$c.user} /> : null}
+        {isAdmin($c.user) ? <AdminMenu user={$c.user} /> : null}
       </>
     ) : (
       <>

--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -11,6 +11,8 @@ import * as React from 'react';
 
 import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
+import {isLocationEditor}
+  from '../../../static/scripts/common/utility/privileges';
 import * as age from '../../../utility/age';
 import ExternalLinks from '../ExternalLinks';
 
@@ -103,7 +105,7 @@ const AreaSidebar = ({$c, area}: Props): React.Element<'div'> => {
       <ExternalLinks empty entity={area} />
 
       <EditLinks $c={$c} entity={area}>
-        {$c.user && $c.user.is_location_editor ? (
+        {isLocationEditor($c.user) ? (
           <>
             <AnnotationLinks $c={$c} entity={area} />
 

--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -9,6 +9,8 @@
 
 import * as React from 'react';
 
+import {isRelationshipEditor}
+  from '../../../static/scripts/common/utility/privileges';
 
 import LastUpdated from './LastUpdated';
 import RemoveLink from './RemoveLink';
@@ -21,7 +23,7 @@ type Props = {
 const GenreSidebar = ({$c, genre}: Props): React.Element<'div'> => {
   return (
     <div id="sidebar">
-      {$c.user?.is_relationship_editor ? (
+      {isRelationshipEditor($c.user) ? (
         <>
           <h2 className="editing">{l('Editing')}</h2>
           <ul className="links">

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -13,6 +13,8 @@ import CommonsImage
   from '../../../static/scripts/common/components/CommonsImage';
 import IrombookImage
   from '../../../static/scripts/common/components/IrombookImage';
+import {isRelationshipEditor}
+  from '../../../static/scripts/common/utility/privileges';
 import ExternalLinks from '../ExternalLinks';
 
 import AnnotationLinks from './AnnotationLinks';
@@ -64,7 +66,7 @@ const InstrumentSidebar = ({$c, instrument}: Props): React.Element<'div'> => {
       <ExternalLinks empty entity={instrument} />
 
       <EditLinks $c={$c} entity={instrument}>
-        {$c.user?.is_relationship_editor ? (
+        {isRelationshipEditor($c.user) ? (
           <>
             <AnnotationLinks $c={$c} entity={instrument} />
 

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -13,6 +13,10 @@ import {formatUserDateObject} from '../utility/formatUserDate';
 import getRequestCookie from '../utility/getRequestCookie';
 import {RT_SLAVE} from '../static/scripts/common/constants';
 import DBDefs from '../static/scripts/common/DBDefs';
+import {
+  isAddingNotesDisabled,
+  isEditingDisabled,
+} from '../static/scripts/common/utility/privileges';
 
 import Footer from './components/Footer';
 import Header from './components/Header';
@@ -126,11 +130,11 @@ const Layout = ({
     <body>
       <Header $c={$c} />
 
-      {$c.user?.is_editing_disabled || $c.user?.is_adding_notes_disabled ? (
+      {isEditingDisabled($c.user) || isAddingNotesDisabled($c.user) ? (
         <div className="banner editing-disabled">
           <p>
-            {$c.user?.is_editing_disabled ? (
-              $c.user?.is_adding_notes_disabled ? (
+            {isEditingDisabled($c.user) ? (
+              isAddingNotesDisabled($c.user) ? (
                 exp.l(
                   `You’re currently not allowed to edit, vote or leave edit
                    notes because an admin has revoked your privileges.

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesIndex.js
@@ -13,6 +13,8 @@ import Layout from '../../layout';
 import expand2react from '../../static/scripts/common/i18n/expand2react';
 import bracketed, {bracketedText}
   from '../../static/scripts/common/utility/bracketed';
+import {isRelationshipEditor}
+  from '../../static/scripts/common/utility/privileges';
 import {upperFirst} from '../../static/scripts/common/utility/strings';
 import compareChildren from '../utility/compareChildren';
 import RelationshipsHeader from '../RelationshipsHeader';
@@ -47,7 +49,7 @@ const AttributeDetails = ({
     : bracketed(translatedDescription);
 
   return (
-    $c.user?.is_relationship_editor ? (
+    isRelationshipEditor($c.user) ? (
       <>
         {descriptionSection}
         {' '}
@@ -159,7 +161,7 @@ const RelationshipAttributeTypesIndex = ({
   <Layout $c={$c} fullWidth noIcons title={l('Relationship Attributes')}>
     <div id="content">
       <RelationshipsHeader page="attributes" />
-      {$c.user?.is_relationship_editor ? (
+      {isRelationshipEditor($c.user) ? (
         <p>
           <a href="/relationship-attributes/create">
             {l('Create a new relationship attribute')}

--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -22,6 +22,8 @@ import localizeLinkAttributeTypeName
   from '../../static/scripts/common/i18n/localizeLinkAttributeTypeName';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
+import {isRelationshipEditor}
+  from '../../static/scripts/common/utility/privileges';
 import {upperFirst} from '../../static/scripts/common/utility/strings';
 
 type Props = {
@@ -75,7 +77,7 @@ const RelationshipTypeIndex = ({
           </p>
         ) : null}
 
-        {$c.user?.is_relationship_editor ? (
+        {isRelationshipEditor($c.user) ? (
           <span className="buttons" style={{float: 'right'}}>
             <a href={'/relationship/' + relType.gid + '/edit'}>
               {l('Edit')}
@@ -106,7 +108,7 @@ const RelationshipTypeIndex = ({
               {' '}
               {relType.id}
               <br />
-              {$c.user?.is_relationship_editor ? (
+              {isRelationshipEditor($c.user) ? (
                 <>
                   <strong>{l('Child order:')}</strong>
                   {' '}

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -16,6 +16,8 @@ import expand2react from '../../static/scripts/common/i18n/expand2react';
 import bracketed from '../../static/scripts/common/utility/bracketed';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
+import {isRelationshipEditor}
+  from '../../static/scripts/common/utility/privileges';
 import compareChildren from '../utility/compareChildren';
 import RelationshipsHeader from '../RelationshipsHeader';
 
@@ -50,7 +52,7 @@ const RelationshipTypeDetails = ({
         className="reldetails"
         style={{marginLeft: '20px', padding: '3px'}}
       >
-        {$c.user?.is_relationship_editor ? (
+        {isRelationshipEditor($c.user) ? (
           <>
             <strong>{l('Child order:')}</strong>
             {' '}
@@ -111,7 +113,7 @@ const RelationshipTypeDetails = ({
         <br />
 
         {'[ '}
-        {$c.user?.is_relationship_editor ? (
+        {isRelationshipEditor($c.user) ? (
           <>
             <a href={'/relationship/' + relType.gid + '/edit'}>
               {l('Edit')}
@@ -191,7 +193,7 @@ const RelationshipTypePairTree = ({
           )}
         </h2>
 
-        {$c.user?.is_relationship_editor ? (
+        {isRelationshipEditor($c.user) ? (
           <p>
             <a href={'/relationships/' + type0 + '-' + type1 + '/create'}>
               {exp.l(

--- a/root/report/LimitedEditors.js
+++ b/root/report/LimitedEditors.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import Layout from '../layout';
+import {isAccountAdmin} from '../static/scripts/common/utility/privileges';
 import formatUserDate from '../utility/formatUserDate';
 
 import EditorList from './components/EditorList';
@@ -39,7 +40,7 @@ const LimitedEditors = ({
       </li>
     </ul>
 
-    {$c.user?.is_account_admin ? (
+    {isAccountAdmin($c.user) ? (
       <EditorList items={items} pager={pager} />
     ) : (
       <p>{l('Sorry, you are not authorized to view this page.')}</p>

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import Layout from '../layout';
+import {isAccountAdmin} from '../static/scripts/common/utility/privileges';
 
 type Props = {
   +$c: CatalystContextT,
@@ -101,7 +102,7 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
         </li>
       </ul>
 
-      {$c.user?.is_account_admin ? (
+      {isAccountAdmin($c.user) ? (
         <>
           <h2>{l('Editors')}</h2>
 

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -15,6 +15,8 @@ import formatDate from '../../static/scripts/common/utility/formatDate';
 import formatEndDate from '../../static/scripts/common/utility/formatEndDate';
 import primaryAreaCode
   from '../../static/scripts/common/utility/primaryAreaCode';
+import {isLocationEditor}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
 
@@ -67,7 +69,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user?.is_location_editor ? (
+    {isLocationEditor($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new area}.', {
           uri: '/area/create?edit-area.name=' + encodeURIComponent(query),

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -11,6 +11,8 @@ import * as React from 'react';
 
 import ArtistListEntry
   from '../../static/scripts/common/components/ArtistListEntry';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import type {
   InlineResultsPropsWithContextT,
   ResultsPropsWithContextT,
@@ -80,7 +82,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new artist}.', {
           uri: '/artist/create?edit-artist.name=' + encodeURIComponent(query),

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -15,6 +15,8 @@ import EventLocations
   from '../../static/scripts/common/components/EventLocations';
 import formatDatePeriod
   from '../../static/scripts/common/utility/formatDatePeriod';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
 
@@ -73,7 +75,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new event}.', {
           uri: '/event/create?edit-event.name=' + encodeURIComponent(query),

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -11,6 +11,8 @@ import * as React from 'react';
 
 import InstrumentListEntry
   from '../../static/scripts/common/components/InstrumentListEntry';
+import {isRelationshipEditor}
+  from '../../static/scripts/common/utility/privileges';
 import type {ResultsPropsWithContextT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
@@ -54,7 +56,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user?.is_relationship_editor ? (
+    {isRelationshipEditor($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new instrument}.', {
           uri: '/instrument/create?edit-instrument.name=' +

--- a/root/search/components/LabelResults.js
+++ b/root/search/components/LabelResults.js
@@ -12,6 +12,8 @@ import * as React from 'react';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import formatEndDate from '../../static/scripts/common/utility/formatEndDate';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import formatLabelCode from '../../utility/formatLabelCode';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
@@ -71,7 +73,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new label}.', {
           uri: '/label/create?edit-label.name=' + encodeURIComponent(query),

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -12,6 +12,8 @@ import * as React from 'react';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import formatEndDate from '../../static/scripts/common/utility/formatEndDate';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
 
@@ -68,7 +70,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new place}.', {
           uri: '/place/create?edit-place.name=' + encodeURIComponent(query),

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -13,6 +13,8 @@ import EntityLink from '../../static/scripts/common/components/EntityLink';
 import TaggerIcon from '../../static/scripts/common/components/TaggerIcon';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {
   InlineResultsPropsWithContextT,
@@ -156,7 +158,7 @@ React.Element<typeof ResultsLayout> => {
         query={query}
         results={results}
       />
-      {$c.user && !$c.user.is_editing_disabled ? (
+      {isEditingEnabled($c.user) ? (
         <p>
           {exp.l('Alternatively, you may {uri|add a new recording}.', {
             uri: '/recording/create?edit-recording.name=' +

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -12,6 +12,8 @@ import * as React from 'react';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
 
@@ -66,7 +68,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new release group}.', {
           uri: '/release-group/create?edit-release-group.name=' +

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -16,6 +16,8 @@ import ReleaseEvents
   from '../../static/scripts/common/components/ReleaseEvents';
 import TaggerIcon from '../../static/scripts/common/components/TaggerIcon';
 import formatBarcode from '../../static/scripts/common/utility/formatBarcode';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import ReleaseCatnoList from '../../components/ReleaseCatnoList';
 import ReleaseLabelList from '../../components/ReleaseLabelList';
@@ -139,7 +141,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new release}.', {
           uri: '/release/add',

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -10,6 +10,8 @@
 import * as React from 'react';
 
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import loopParity from '../../utility/loopParity';
 import type {ResultsPropsWithContextT} from '../types';
 
@@ -56,7 +58,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new series}.', {
           uri: '/series/create?edit-series.name=' + encodeURIComponent(query),

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -11,6 +11,8 @@ import * as React from 'react';
 
 import WorkListEntry
   from '../../static/scripts/common/components/WorkListEntry';
+import {isEditingEnabled}
+  from '../../static/scripts/common/utility/privileges';
 import type {ResultsPropsWithContextT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
@@ -58,7 +60,7 @@ React.Element<typeof ResultsLayout> => (
       query={query}
       results={results}
     />
-    {$c.user && !$c.user.is_editing_disabled ? (
+    {isEditingEnabled($c.user) ? (
       <p>
         {exp.l('Alternatively, you may {uri|add a new work}.', {
           uri: '/work/create?edit-work.name=' + encodeURIComponent(query),

--- a/root/static/scripts/common/utility/privileges.js
+++ b/root/static/scripts/common/utility/privileges.js
@@ -1,0 +1,124 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {
+  ACCOUNT_ADMIN_FLAG,
+  ADDING_NOTES_DISABLED_FLAG,
+  AUTO_EDITOR_FLAG,
+  BANNER_EDITOR_FLAG,
+  BOT_FLAG,
+  DONT_NAG_FLAG,
+  EDITING_DISABLED_FLAG,
+  LOCATION_EDITOR_FLAG,
+  MBID_SUBMITTER_FLAG,
+  RELATIONSHIP_EDITOR_FLAG,
+  UNTRUSTED_FLAG,
+  WIKI_TRANSCLUSION_FLAG,
+} from '../../../../constants';
+
+type EditorPropT = ?(EditorT | UnsanitizedEditorT);
+
+export function isAutoEditor(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & AUTO_EDITOR_FLAG) > 0;
+}
+
+export function isBot(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & BOT_FLAG) > 0;
+}
+
+export function isUntrusted(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & UNTRUSTED_FLAG) > 0;
+}
+
+export function isNagFree(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & DONT_NAG_FLAG) > 0;
+}
+
+export function isRelationshipEditor(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & RELATIONSHIP_EDITOR_FLAG) > 0;
+}
+
+export function isWikiTranscluder(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & WIKI_TRANSCLUSION_FLAG) > 0;
+}
+
+export function isMbidSubmitter(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & MBID_SUBMITTER_FLAG) > 0;
+}
+
+export function isAccountAdmin(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & ACCOUNT_ADMIN_FLAG) > 0;
+}
+
+export function isLocationEditor(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & LOCATION_EDITOR_FLAG) > 0;
+}
+
+export function isBannerEditor(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & BANNER_EDITOR_FLAG) > 0;
+}
+
+export function isEditingDisabled(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & EDITING_DISABLED_FLAG) > 0;
+}
+
+export function isEditingEnabled(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & EDITING_DISABLED_FLAG) === 0;
+}
+
+export function isAddingNotesDisabled(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & ADDING_NOTES_DISABLED_FLAG) > 0;
+}
+
+export function isAdmin(editor: EditorPropT): boolean {
+  return isAccountAdmin(editor) ||
+         isBannerEditor(editor) ||
+         isLocationEditor(editor) ||
+         isRelationshipEditor(editor) ||
+         isWikiTranscluder(editor);
+}

--- a/root/types.js
+++ b/root/types.js
@@ -433,22 +433,13 @@ declare type UnsanitizedEditorT = $ReadOnly<{
   +gravatar: string,
   +has_confirmed_email_address: boolean,
   +has_email_address: boolean,
-  +is_account_admin: boolean,
-  +is_adding_notes_disabled: boolean,
-  +is_admin: boolean,
-  +is_auto_editor: boolean,
-  +is_banner_editor: boolean,
-  +is_bot: boolean,
   +is_charter: boolean,
-  +is_editing_disabled: boolean,
   +is_limited: boolean,
-  +is_location_editor: boolean,
-  +is_relationship_editor: boolean,
-  +is_wiki_transcluder: boolean,
   +languages: $ReadOnlyArray<EditorLanguageT> | null,
   +last_login_date: string | null,
   +name: string,
   +preferences: UnsanitizedEditorPreferencesT,
+  +privileges: number,
   +registration_date: string,
   +website: string | null,
 }>;
@@ -1026,6 +1017,7 @@ declare type ActiveEditorT = {
   +has_confirmed_email_address: boolean,
   +name: string,
   +preferences: ActiveEditorPreferencesT,
+  +privileges: number,
 };
 
 declare type EditorT = {
@@ -1033,6 +1025,7 @@ declare type EditorT = {
   +deleted: boolean,
   +gravatar: string,
   +name: string,
+  +privileges: number,
 };
 
 declare type ScriptT = {

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -23,6 +23,14 @@ import bracketed, {bracketedText}
 import * as TYPES from '../static/scripts/common/constants/editTypes';
 import escapeRegExp from '../static/scripts/common/utility/escapeRegExp';
 import nonEmpty from '../static/scripts/common/utility/nonEmpty';
+import {
+  isAccountAdmin,
+  isAutoEditor,
+  isBot,
+  isLocationEditor,
+  isRelationshipEditor,
+  isWikiTranscluder,
+} from '../static/scripts/common/utility/privileges';
 import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList';
 import {formatCount, formatPercentage} from '../statistics/utilities';
 import formatUserDate from '../utility/formatUserDate';
@@ -45,28 +53,28 @@ function generateUserTypesList(user: UnsanitizedEditorT) {
   if (user.deleted) {
     typesList.push(l('Deleted User'));
   }
-  if (user.is_auto_editor) {
+  if (isAutoEditor(user)) {
     typesList.push(exp.l(
       '{doc|Auto-Editor}',
       {doc: '/doc/Editor#Auto-editors'},
     ));
   }
-  if (user.is_bot) {
+  if (isBot(user)) {
     typesList.push(l('Internal/Bot'));
   }
-  if (user.is_relationship_editor) {
+  if (isRelationshipEditor(user)) {
     typesList.push(exp.l(
       '{doc|Relationship Editor}',
       {doc: '/doc/Editor#Relationship_editors'},
     ));
   }
-  if (user.is_wiki_transcluder) {
+  if (isWikiTranscluder(user)) {
     typesList.push(exp.l(
       '{doc|Transclusion Editor}',
       {doc: '/doc/Editor#Transclusion_editors'},
     ));
   }
-  if (user.is_location_editor) {
+  if (isLocationEditor(user)) {
     typesList.push(exp.l(
       '{doc|Location Editor}',
       {doc: '/doc/Editor#Location_editors'},
@@ -156,11 +164,7 @@ const UserProfileInformation = ({
     languages,
   } = user;
 
-  /*
-   * Whether the user making the request is an account admin (not
-   * the user whose profile is being viewed).
-   */
-  const isAccountAdmin = !!($c.user?.is_account_admin);
+  const viewingUser = $c.user;
 
   return (
     <>
@@ -198,7 +202,7 @@ const UserProfileInformation = ({
                         {l('send email')}
                       </a>,
                     )}
-                    {(nonEmpty(email) && isAccountAdmin) ? (
+                    {(nonEmpty(email) && isAccountAdmin(viewingUser)) ? (
                       <form action="/admin/email-search" method="post">
                         <input
                           name="emailsearch.email"
@@ -261,7 +265,7 @@ const UserProfileInformation = ({
           {memberSince}
         </UserProfileProperty>
 
-        {(viewingOwnProfile || isAccountAdmin) ? (
+        {(viewingOwnProfile || isAccountAdmin(viewingUser)) ? (
           <UserProfileProperty name={l('Last login:')}>
             {nonEmpty(user.last_login_date)
               ? formatUserDate($c, user.last_login_date)
@@ -357,7 +361,7 @@ const UserProfileInformation = ({
           </UserProfileProperty>
         ) : null}
 
-        {$c.user?.is_account_admin && ipHashes.length ? (
+        {isAccountAdmin($c.user) && ipHashes.length ? (
           <UserProfileProperty name={addColonText(l('IP lookup'))}>
             <ul className="inline">
               {commaOnlyList(ipHashes.map(ipHash => (

--- a/root/utility/activeSanitizedEditor.js
+++ b/root/utility/activeSanitizedEditor.js
@@ -23,6 +23,7 @@ function activeSanitizedEditor(
       datetime_format: editor.preferences.datetime_format,
       timezone: editor.preferences.timezone,
     },
+    privileges: editor.privileges,
   };
 }
 

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -23,6 +23,11 @@ import {
   EDIT_RELATIONSHIP_DELETE,
   EDIT_SERIES_EDIT,
 } from '../static/scripts/common/constants/editTypes';
+import {
+  isAutoEditor,
+  isBot,
+  isEditingEnabled,
+} from '../static/scripts/common/utility/privileges';
 
 const EXPIRE_ACTIONS = {
   [EDIT_EXPIRE_ACCEPT]:   N_l('Accept upon closing'),
@@ -110,8 +115,8 @@ export function editorMayApprove(
   const minimalRequirements = (
     !!editor &&
     edit.status === EDIT_STATUS_OPEN &&
-    editor.is_auto_editor &&
-    !editor.is_editing_disabled
+    isAutoEditor(editor) &&
+    isEditingEnabled(editor)
   );
 
   if (!minimalRequirements) {
@@ -161,8 +166,8 @@ export function editorMayVote(
     edit.status === EDIT_STATUS_OPEN &&
     editor.id !== edit.editor_id &&
     !editor.is_limited &&
-    !editor.is_bot &&
-    !editor.is_editing_disabled
+    !isBot(editor) &&
+    isEditingEnabled(editor)
   );
 }
 

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -46,6 +46,7 @@ if (__DEV__) {
     'gravatar',
     'id',
     'name',
+    'privileged',
   ]);
 
   const suspectKeyPattern = /(?:birth|email|password)/;

--- a/root/utility/sanitizedEditor.js
+++ b/root/utility/sanitizedEditor.js
@@ -10,6 +10,18 @@
 // NOTE: Don't convert to an ES module; this is used by root/server.js.
 /* eslint-disable import/no-commonjs */
 
+const publicFlags = 1 & // AUTO_EDITOR_FLAG
+                    2 & // BOT_FLAG
+                    8 & // RELATIONSHIP_EDITOR_FLAG
+                    32 & // WIKI_TRANSCLUSION_FLAG
+                    128 & // ACCOUNT_ADMIN_FLAG
+                    256 & // LOCATION_EDITOR_FLAG
+                    512; // BANNER_EDITOR_FLAG
+
+function sanitizePrivileges(privileges /*: number */) /*: number */ {
+  return (privileges & publicFlags);
+}
+
 function sanitizedEditor(
   editor /*: UnsanitizedEditorT | EditorT */,
 ) /*: EditorT */ {
@@ -25,6 +37,7 @@ function sanitizedEditor(
     gravatar: editor.gravatar,
     id: editor.id,
     name: editor.name,
+    privileges: sanitizePrivileges(editor.privileges),
   };
 }
 

--- a/root/utility/voting.js
+++ b/root/utility/voting.js
@@ -7,6 +7,11 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import {
+  isAutoEditor,
+  isBot,
+} from '../static/scripts/common/utility/privileges';
+
 export function isInvolved(
   election: AutoEditorElectionT,
   user: ?UnsanitizedEditorT,
@@ -31,16 +36,16 @@ export function canVote(
   election: AutoEditorElectionT,
   user: ?UnsanitizedEditorT,
 ): boolean {
-  return (!!user && election.is_open && user.is_auto_editor &&
-    !user.is_bot && !isInvolved(election, user));
+  return (!!user && election.is_open && isAutoEditor(user) &&
+    !isBot(user) && !isInvolved(election, user));
 }
 
 export function canSecond(
   election: AutoEditorElectionT,
   user: ?UnsanitizedEditorT,
 ): boolean {
-  return (!!user && election.is_pending && user.is_auto_editor &&
-    !user.is_bot && !isInvolved(election, user));
+  return (!!user && election.is_pending && isAutoEditor(user) &&
+    !isBot(user) && !isInvolved(election, user));
 }
 
 export function canCancel(
@@ -54,6 +59,6 @@ export function canNominate(
   nominator: ?UnsanitizedEditorT,
   nominee: ?UnsanitizedEditorT,
 ): boolean {
-  return (!!nominator && !!nominee && nominator.is_auto_editor &&
-    !nominee.is_auto_editor && !nominee.deleted);
+  return (!!nominator && !!nominee && isAutoEditor(nominator) &&
+    !isAutoEditor(nominee) && !nominee.deleted);
 }


### PR DESCRIPTION
### Implement MBS-11329

We return all of them for unsanitized editors. For sanitized editors, we clear all the values except the ones that are public in /privileged (bot, admin and whatnot, but not untrusted, for example).

Navigated around a bit to check that the general flow seems to work fine (edits_disabled users still see the banner, the admin menu has stuff when you're an admin) but didn't test every use by hand.