### PR TITLE
MBS-9419: Hide more irrelevant work rels from GroupedTrackRels

### DIFF
--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -79,6 +79,22 @@ const renderWorkRelationship = (relationship: RelationshipT) => {
   );
 };
 
+const irrelevantLinkTypes = new Map([
+  // [id, is backward (direction)]
+  [239, true], // medleys including this
+  [241, false], // generic later versions
+  [281, false], // parts
+  [314, false], // works based on this
+  [315, false], // revisions
+  [316, false], // orchestrations
+  [350, false], // arrangements
+]);
+
+function isIrrelevantLinkType(relationship) {
+  return irrelevantLinkTypes.get(relationship.linkTypeID) ===
+    (relationship.direction === 'backward');
+}
+
 const GroupedTrackRelationships = ({
   source,
 }: Props): Array<React.Element<'dl'>> => {
@@ -94,11 +110,11 @@ const GroupedTrackRelationships = ({
     ) => {
       if (targetType === 'work') {
         /*
-         * Specifically ignore work parts, but still keep works this
-         * work is a part of.
+         * Specifically ignore rels that do not give information
+         * relevant to this track, such as other arrangements of the work
+         * or all the parts of the work linked.
          */
-        if (relationship.linkTypeID !== 281 ||
-            relationship.direction === 'backward') {
+        if (!isIrrelevantLinkType(relationship)) {
           workRelationships.push(relationship);
         }
         return false;


### PR DESCRIPTION
### Implement MBS-9419

This extends the existing check to skip showing work parts to all other current work-work rels, in the direction that is irrelevant to the recording in question: if the recording is of an arrangement or medley we care about the original works, but if, say, this work has been arranged elsewhere, we don't care about that.

Note: the previous code only applied to the inline view of the release page (on bottom view the parts are currently shown, see https://musicbrainz.org/release/316ffa1c-0bd8-4a54-9bc8-c28da0e01bf1 for an example). We might want to do the same in both places (but I'd rather only implement it for bottom-credits once we convert it to React, to avoid duplicating the code).

If this seems sensible, we might want to do the same for MBS-7859 (the recording equivalent). I started with this since we already half-did this for work rels :) 

For a comparison (with the release in the ticket, https://musicbrainz.org/release/ab422354-8684-4d76-9ba4-874d9e520861):
![Screenshot from 2021-05-26 20-58-43](https://user-images.githubusercontent.com/1069224/119708812-324fd880-be65-11eb-95cf-cb01c28e9b57.png)
![Screenshot from 2021-05-26 20-59-31](https://user-images.githubusercontent.com/1069224/119708910-4abff300-be65-11eb-844d-496153b34f02.png)
