### PR TITLE
MBS-4782 / MBS-11333: Pass original MBID to AddCoverArt if no release

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
@@ -104,7 +104,11 @@ sub build_display_data {
     my ($self, $loaded) = @_;
 
     my $release = $loaded->{Release}{ $self->data->{entity}{id} } ||
-        Release->new( name => $self->data->{entity}{name} );
+        Release->new(
+            gid => $self->data->{entity}{mbid},
+            id => $self->data->{entity}{id},
+            name => $self->data->{entity}{name},
+        );
 
     my $suffix = $self->data->{cover_art_mime_type}
         ? $self->c->model('CoverArt')->image_type_suffix($self->data->{cover_art_mime_type})


### PR DESCRIPTION
### Fix MBS-4782 / MBS-11333

We store the original MBID, so we should use it. The TT used to use the original MBID straight from the data (not passing it to display data) for the filename display, but didn't use it for the actual cover art display, so that was broken. Passing the MBID to the Release->new call ensures both filename *and* image work.
