### PR TITLE
MBS-11059: Indicate which release groups have CAA art in listings

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -255,6 +255,8 @@ sub show : PathPart('') Chained('load')
         $c->model('ReleaseGroup')->rating->load_user_ratings($c->user->id, @$release_groups);
     }
 
+    $c->model('ReleaseGroup')->load_has_cover_art(@$release_groups);
+
     $c->model('ArtistCredit')->load(@$release_groups);
     $c->model('ArtistType')->load(map { map { $_->artist } $_->artist_credit->all_names} @$release_groups);
     $c->model('ReleaseGroupType')->load(@$release_groups);

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -147,6 +147,7 @@ sub show : Chained('load') PathPart('') {
         $c->model('ArtistCredit')->load(@$entities);
         $c->model('ReleaseGroupType')->load(@$entities);
         $c->model('ReleaseGroupSecondaryType')->load_for_release_groups(@$entities);
+        $c->model('ReleaseGroup')->load_has_cover_art(@$entities);
     } elsif ($entity_type eq 'event') {
         $c->model('EventType')->load(@$entities);
         $model->load_performers(@$entities);

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -130,6 +130,7 @@ sub direct : Private
         }
         when ('release_group') {
             $c->model('ReleaseGroupType')->load(@entities);
+            $c->model('ReleaseGroup')->load_has_cover_art(@entities);
         }
         when ('release') {
             $c->model('Language')->load(@entities);

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -99,6 +99,7 @@ sub show : PathPart('') Chained('load') {
         $c->model('ReleaseGroupType')->load(@entities);
         $c->model('ReleaseGroup')->load_meta(@entities);
         $c->model('ReleaseGroup')->rating->load_user_ratings($c->user->id, @entities) if $c->user_exists;
+        $c->model('ReleaseGroup')->load_has_cover_art(@entities);
     }
 
     if ($series->type->item_entity_type eq 'work') {

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -10,6 +10,7 @@ use MusicBrainz::Server::Data::Utils qw(
     hash_to_row
     load_subobjects
     merge_table_attributes
+    object_to_ids
     order_by
     placeholders
 );
@@ -155,6 +156,34 @@ sub has_materialized_artist_release_group_data {
         'SELECT 1 FROM artist_release_group LIMIT 1',
     ) ? 1 : 0;
     return $has_data;
+}
+
+sub load_has_cover_art {
+    my ($self, @release_groups) = @_;
+    my %id_to_rg = object_to_ids(@release_groups);
+    my @ids = keys %id_to_rg;
+
+    return unless @ids; # nothing to do
+
+    my $query = <<~'SQL';
+        SELECT release.release_group
+          FROM release
+          JOIN cover_art_archive.cover_art ca ON ca.release = release.id
+          JOIN cover_art_archive.cover_art_type cat ON cat.id = ca.id
+          JOIN release_meta ON release_meta.id = release.id
+         WHERE release.release_group = any(?)
+           AND cat.type_id = 1
+           AND ca.mime_type != 'application/pdf'
+           AND release_meta.cover_art_presence != 'darkened'
+        SQL
+
+    my $ids_with_art = $self->sql->select_single_column_array($query, \@ids);
+
+    for my $id (@{ $ids_with_art }) {
+        for my $rg (@{ $id_to_rg{$id} }) {
+            $rg->has_cover_art(1);
+        }
+    }
 }
 
 sub pick_status_condition
@@ -716,6 +745,31 @@ sub _hash_to_row
     });
 
     return $row;
+}
+
+=method load_ids
+Load internal IDs for release group objects that only have GIDs.
+=cut
+
+sub load_ids
+{
+    my ($self, @rgs) = @_;
+
+    my @gids = map { $_->gid } @rgs;
+    return () unless @gids;
+
+    my $query = <<~'SQL';
+        SELECT gid, id
+        FROM release_group
+        WHERE gid = any(?)
+        SQL
+
+    my %map = map { $_->[0] => $_->[1] }
+        @{ $self->sql->select_list_of_lists($query, \@gids) };
+
+    for my $rg (@rgs) {
+        $rg->id($map{$rg->gid}) if exists $map{$rg->gid};
+    }
 }
 
 sub load_meta

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -926,6 +926,13 @@ sub external_search
             $self->c->model('Area')->load_containment(@entities);
         }
 
+        if ($type eq 'release-group')
+        {
+            my @entities = map { $_->entity } @results;
+            $self->c->model('ReleaseGroup')->load_ids(@entities);
+            $self->c->model('Artwork')->load_for_release_groups(@entities);
+        }
+
         my $pager = Data::Page->new;
         $pager->current_page($page);
         $pager->entries_per_page($limit);

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -193,7 +193,7 @@ has [qw( cover_art_url info_url amazon_asin amazon_store )] => (
 has 'cover_art' => (
     isa       => 'MusicBrainz::Server::CoverArt',
     is        => 'rw',
-    predicate => 'has_cover_art',
+    predicate => 'has_loaded_cover_art',
 );
 
 has 'cover_art_presence' => (

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
@@ -4,6 +4,7 @@ use Moose;
 
 use DBDefs;
 use List::AllUtils qw( any );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
@@ -73,11 +74,16 @@ has 'release_count' => (
 has 'cover_art' => (
     isa       => 'MusicBrainz::Server::Entity::Artwork::ReleaseGroup',
     is        => 'rw',
-    predicate => 'has_cover_art',
+    predicate => 'has_loaded_cover_art',
+);
+
+has 'has_cover_art' => (
+    is  => 'rw',
+    isa => 'Bool',
 );
 
 # Cannot set cover art if none of the associated releases has cover art.
-sub can_set_cover_art { return shift->has_cover_art; }
+sub can_set_cover_art { return shift->has_loaded_cover_art; }
 
 has 'review_count' => (
     is => 'rw',
@@ -127,6 +133,7 @@ around TO_JSON => sub {
         %{ $self->$orig },
         $self->has_cover_art ? (cover_art => to_json_object($self->cover_art)) : (),
         firstReleaseDate    => $self->first_release_date ? $self->first_release_date->format : undef,
+        hasCoverArt         => boolean_to_json($self->has_cover_art),
         # TODO: remove this once Autocomplete.js can use $c and releaseGroupType.js
         l_type_name         => $self->l_type_name,
         release_count       => $self->release_count,

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -86,6 +86,7 @@ export const ReleaseGroupListTable = ({
       const nameColumn = defineNameColumn<ReleaseGroupT>({
         descriptive: false, // since ACs are in the next column
         order: order,
+        showCaaPresence: true,
         sortable: sortable,
         title: l('Title'),
       });

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -31,7 +31,7 @@ function buildResult(result, index) {
       key={releaseGroup.id}
     >
       <td>
-        <EntityLink entity={releaseGroup} />
+        <EntityLink entity={releaseGroup} showCaaPresence />
       </td>
       <td>
         <ArtistCreditLink artistCredit={releaseGroup.artistCredit} />

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -292,20 +292,35 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     );
   }
 
-  if (showCaaPresence &&
-    entity.entityType === 'release' &&
-    entity.cover_art_presence === 'present') {
-    content = (
-      <>
-        <a href={'/release/' + entity.gid + '/cover-art'}>
+  if (showCaaPresence) {
+    if (entity.entityType === 'release' &&
+        entity.cover_art_presence === 'present') {
+      content = (
+        <>
+          <a href={'/release/' + entity.gid + '/cover-art'}>
+            <span
+              className="caa-icon"
+              title={l('This release has artwork in the Cover Art Archive')}
+            />
+          </a>
+          {content}
+        </>
+      );
+    }
+
+    if (entity.entityType === 'release_group' && entity.hasCoverArt) {
+      content = (
+        <>
           <span
             className="caa-icon"
-            title={l('This release has artwork in the Cover Art Archive')}
+            title={l(
+              'This release group has artwork in the Cover Art Archive',
+            )}
           />
-        </a>
-        {content}
-      </>
-    );
+          {content}
+        </>
+      );
+    }
   }
 
   if (!subPath && entity.entityType === 'release') {

--- a/root/types/releasegroup.js
+++ b/root/types/releasegroup.js
@@ -20,6 +20,7 @@ declare type ReleaseGroupT = $ReadOnly<{
   ...TypeRoleT<ReleaseGroupTypeT>,
   +cover_art?: ArtworkT,
   +firstReleaseDate: string | null,
+  +hasCoverArt: boolean,
   +l_type_name: string | null,
   +primaryAlias?: string | null,
   +release_count: number,

--- a/t/lib/t/MusicBrainz/Server/Data/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/CoverArt.pm
@@ -32,7 +32,7 @@ test 'Parses valid cover art relationships' => sub {
     my $release = make_release('cover art link', 'http://www.archive.org/download/CoverArtsForVariousAlbum/karenkong-mulakan.jpg');
 
     $test->c->model('CoverArt')->load($release);
-    ok($release->has_cover_art);
+    ok($release->has_loaded_cover_art);
     is($release->cover_art->provider->name, 'archive.org');
     is($release->cover_art->image_uri, 'http://www.archive.org/download/CoverArtsForVariousAlbum/karenkong-mulakan.jpg');
 
@@ -44,7 +44,7 @@ test 'Doesnt parse invalid cover art relationships' => sub {
     my $release = make_release('cover art link', 'http://www.link.example');
 
     $test->c->model('CoverArt')->load($release);
-    ok(!$release->has_cover_art);
+    ok(!$release->has_loaded_cover_art);
 
 };
 
@@ -57,7 +57,7 @@ test 'Handles Amazon ASINs' => sub {
     my $release = make_release('amazon asin', 'http://www.amazon.com/gp/product/B000003TA4');
 
     $test->c->model('CoverArt')->load($release);
-    ok($release->has_cover_art);
+    ok($release->has_loaded_cover_art);
     ok($test->ua->get($release->cover_art->image_uri)->is_success);
 
 };
@@ -71,7 +71,7 @@ test 'Handles Amazon ASINs for downloads' => sub {
     my $release = make_release('amazon asin', 'http://www.amazon.com/gp/product/B00544JMLA');
 
     $test->c->model('CoverArt')->load($release);
-    ok($release->has_cover_art);
+    ok($release->has_loaded_cover_art);
     ok($test->ua->get($release->cover_art->image_uri)->is_success);
 };
 


### PR DESCRIPTION
### Implement MBS-11059

Similar to https://github.com/metabrainz/musicbrainz-server/pull/1866

We don't have a great way currently to check whether a RG has cover art without loading it. If loading the cover art for all RGs in, say, a page of search results or an artist index seems like a problem we could always add a separate query that checks existence only.

