### PR TITLE
MBS-11337: Always link to URL entity page and link on URL reports 

### DIFF
--- a/root/report/components/ArtistUrlList.js
+++ b/root/report/components/ArtistUrlList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import bracketed from '../../static/scripts/common/utility/bracketed';
 import type {ReportArtistUrlT} from '../types';
 
 type Props = {
@@ -44,10 +45,15 @@ const ArtistUrlList = ({
                 {lastGID === item.url.gid ? null : (
                   <tr className="even" key={item.url.gid}>
                     <td colSpan="2">
-                      <EntityLink
-                        content={item.url.href_url}
-                        entity={item.url}
-                      />
+                      <a href={item.url.name}>
+                        {item.url.name}
+                      </a>
+                      {' '}
+                      {bracketed(
+                        <a href={'/url/' + item.url.gid}>
+                          {item.url.gid}
+                        </a>,
+                      )}
                     </td>
                   </tr>
                 )}

--- a/root/report/components/LabelUrlList.js
+++ b/root/report/components/LabelUrlList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import bracketed from '../../static/scripts/common/utility/bracketed';
 import type {ReportLabelUrlT} from '../types';
 
 type Props = {
@@ -44,10 +45,15 @@ const LabelUrlList = ({
                 {lastGID === item.url.gid ? null : (
                   <tr className="even" key={item.url.gid}>
                     <td colSpan="2">
-                      <EntityLink
-                        content={item.url.href_url}
-                        entity={item.url}
-                      />
+                      <a href={item.url.name}>
+                        {item.url.name}
+                      </a>
+                      {' '}
+                      {bracketed(
+                        <a href={'/url/' + item.url.gid}>
+                          {item.url.gid}
+                        </a>,
+                      )}
                     </td>
                   </tr>
                 )}

--- a/root/report/components/ReleaseGroupUrlList.js
+++ b/root/report/components/ReleaseGroupUrlList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import bracketed from '../../static/scripts/common/utility/bracketed';
 import type {ReportReleaseGroupUrlT} from '../types';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
@@ -47,10 +48,15 @@ const ReleaseGroupUrlList = ({
                 {lastGID === item.url.gid ? null : (
                   <tr className="even" key={item.url.gid}>
                     <td colSpan="3">
-                      <EntityLink
-                        content={item.url.href_url}
-                        entity={item.url}
-                      />
+                      <a href={item.url.name}>
+                        {item.url.name}
+                      </a>
+                      {' '}
+                      {bracketed(
+                        <a href={'/url/' + item.url.gid}>
+                          {item.url.gid}
+                        </a>,
+                      )}
                     </td>
                   </tr>
                 )}

--- a/root/report/components/ReleaseUrlList.js
+++ b/root/report/components/ReleaseUrlList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
+import bracketed from '../../static/scripts/common/utility/bracketed';
 import type {ReportReleaseUrlT} from '../types';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
@@ -47,10 +48,15 @@ const ReleaseUrlList = ({
                 {lastGID === item.url.gid ? null : (
                   <tr className="even" key={item.url.gid}>
                     <td colSpan="3">
-                      <EntityLink
-                        content={item.url.decoded}
-                        entity={item.url}
-                      />
+                      <a href={item.url.name}>
+                        {item.url.name}
+                      </a>
+                      {' '}
+                      {bracketed(
+                        <a href={'/url/' + item.url.gid}>
+                          {item.url.gid}
+                        </a>,
+                      )}
                     </td>
                   </tr>
                 )}

--- a/root/report/components/UrlRelationshipList.js
+++ b/root/report/components/UrlRelationshipList.js
@@ -12,7 +12,6 @@ import * as React from 'react';
 import {l_relationships}
   from '../../static/scripts/common/i18n/relationships';
 import PaginatedResults from '../../components/PaginatedResults';
-import EntityLink from '../../static/scripts/common/components/EntityLink';
 import loopParity from '../../utility/loopParity';
 import type {ReportUrlRelationshipT} from '../types';
 
@@ -31,6 +30,7 @@ const UrlRelationshipList = ({
         <tr>
           <th>{l('Relationship Type')}</th>
           <th>{l('URL')}</th>
+          <th>{l('URL Entity')}</th>
         </tr>
       </thead>
       <tbody>
@@ -41,13 +41,24 @@ const UrlRelationshipList = ({
                 {l_relationships(item.link_name)}
               </a>
             </td>
-            <td>
-              {item.url ? (
-                <EntityLink entity={item.url} />
-              ) : (
-                l('This URL no longer exists.')
-              )}
-            </td>
+            {item.url ? (
+              <>
+                <td>
+                  <a href={item.url.name}>
+                    {item.url.name}
+                  </a>
+                </td>
+                <td>
+                  <a href={'/url/' + item.url.gid}>
+                    {item.url.gid}
+                  </a>
+                </td>
+              </>
+            ) : (
+              <td colSpan="2">
+                {l('This URL no longer exists.')}
+              </td>
+            )}
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
### Implement MBS-11337

On reports about URLs, it makes sense to always link to the URL entity (since that's where you can fix the problems). It still makes sense to have a link to the actual destination though.

At the moment UrlRelationshipList showed URLs in the same way as elsewhere on the site (destination link on click + [info] link to the entity) while the other lists being changed here only linked to the entity but did not allow following the link.

This makes both of these show both the URL link and a link to the URL entity (shown as the MBID), which allows visiting both links as needed without having to click the tiny info link that moves line by line depending on URL length.