### PR TITLE
MBS-11335: Report for reused Wikidata items

### DIFF
--- a/lib/MusicBrainz/Server/Report/WikidataLinksWithMultipleEntities.pm
+++ b/lib/MusicBrainz/Server/Report/WikidataLinksWithMultipleEntities.pm
@@ -1,0 +1,44 @@
+package MusicBrainz::Server::Report::WikidataLinksWithMultipleEntities;
+use Moose;
+
+with 'MusicBrainz::Server::Report::URLReport';
+
+sub query {
+    my ($self) = @_;
+
+    my @tables = $self->c->model('Relationship')->generate_table_list('url');
+
+    my $inner_table = join(
+        ' UNION ',
+        map {<<~"EOSQL"} @tables
+            SELECT link_type.id AS link_type_id, l_table.id AS rel_id, ${\$_->[1]} AS url
+            FROM link_type
+            JOIN link ON link.link_type = link_type.id
+            JOIN ${\$_->[0]} l_table ON l_table.link = link.id
+            EOSQL
+    );
+
+    my $query = <<~"EOSQL";
+        SELECT url.id AS url_id, count(*) AS count, row_number() OVER (ORDER BY count(*) DESC, url.id DESC)
+        FROM url JOIN ($inner_table) l ON l.url = url.id
+        WHERE url.url LIKE 'https://www.wikidata.org%'
+        GROUP BY url_id
+        HAVING count(*) > 1
+        EOSQL
+
+    return $query
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -99,6 +99,7 @@ use MusicBrainz::Server::PagedReport;
     TracksWithoutTimes
     TracksWithSequenceIssues
     UnlinkedPseudoReleases
+    WikidataLinksWithMultipleEntities
     WorkSameTypeAsParent
 );
 
@@ -191,6 +192,7 @@ use MusicBrainz::Server::Report::TracksNamedWithSequence;
 use MusicBrainz::Server::Report::TracksWithoutTimes;
 use MusicBrainz::Server::Report::TracksWithSequenceIssues;
 use MusicBrainz::Server::Report::UnlinkedPseudoReleases;
+use MusicBrainz::Server::Report::WikidataLinksWithMultipleEntities;
 use MusicBrainz::Server::Report::WorkSameTypeAsParent;
 
 my %all = map { $_ => 1 } @all;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -553,8 +553,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           content={l('URLs with deprecated relationships')}
           reportName="DeprecatedRelationshipURLs"
         />
+        <ReportsIndexEntry
+          content={l('Wikidata URLs linked to multiple entities')}
+          reportName="WikidataLinksWithMultipleEntities"
+        />
       </ul>
-
 
       <h2>{l('ISRCs')}</h2>
 

--- a/root/report/WikidataLinksWithMultipleEntities.js
+++ b/root/report/WikidataLinksWithMultipleEntities.js
@@ -1,0 +1,93 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import PaginatedResults from '../components/PaginatedResults';
+import {CatalystContext} from '../context';
+import {formatCount} from '../statistics/utilities';
+import loopParity from '../utility/loopParity';
+
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT} from './types';
+
+type ReportEntryT = {
+  +count: number,
+  +row_number: number,
+  +url: ?UrlT,
+  +url_id: number,
+};
+
+const WikidataLinksWithMultipleEntities = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportEntryT>): React.Element<typeof ReportLayout> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows Wikidata URLs that are linked to multiple
+         entities. In general, Wikidata entities should match 1 to 1
+         with MusicBrainz entities, so most of these should indicate
+         either an error in MusicBrainz or a too-wide Wikidata page.`,
+      )}
+      entityType="url"
+      filtered={filtered}
+      generated={generated}
+      title={l('Wikidata URLs linked to multiple entities')}
+      totalEntries={pager.total_entries}
+    >
+      <PaginatedResults pager={pager}>
+        <table className="tbl">
+          <thead>
+            <tr>
+              <th>{l('URL')}</th>
+              <th>{l('URL Entity')}</th>
+              <th>{l('Usage count')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => (
+              <tr className={loopParity(index)} key={item.url_id}>
+                {item.url ? (
+                  <>
+                    <td>
+                      <a href={item.url.name}>
+                        {item.url.name}
+                      </a>
+                    </td>
+                    <td>
+                      <a href={'/url/' + item.url.gid}>
+                        {item.url.gid}
+                      </a>
+                    </td>
+                    <td>
+                      {formatCount($c, item.count)}
+                    </td>
+                  </>
+                ) : (
+                  <td colSpan="3">
+                    {l('This URL no longer exists.')}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </PaginatedResults>
+    </ReportLayout>
+  );
+};
+
+export default WikidataLinksWithMultipleEntities;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -242,6 +242,7 @@ module.exports = {
   'report/TracksWithSequenceIssues': require('../report/TracksWithSequenceIssues'),
   'report/TracksWithoutTimes': require('../report/TracksWithoutTimes'),
   'report/UnlinkedPseudoReleases': require('../report/UnlinkedPseudoReleases'),
+  'report/WikidataLinksWithMultipleEntities': require('../report/WikidataLinksWithMultipleEntities'),
   'report/WorkSameTypeAsParent': require('../report/WorkSameTypeAsParent'),
   'search/SearchIndex': require('../search/SearchIndex'),
   'search/components/AnnotationResults': require('../search/components/AnnotationResults'),


### PR DESCRIPTION
### Implement MBS-11335

Chose to implement one big report rather than one per entity because a common use case of this will be "same link for type: single RG and work", because of how WD works or used to work.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1787 and https://github.com/metabrainz/musicbrainz-server/pull/1869