### PR TITLE
MBS-11340: Allow more characters on Spotify user URLs

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Spotify.pm
@@ -10,7 +10,7 @@ with 'MusicBrainz::Server::Entity::URL::Sidebar';
 sub sidebar_name {
     my $self = shift;
 
-    if ($self->url =~ m{^(?:https?:)?//(?:[^/]+.)?spotify.com/user/[^/?&#]+/?}i) {
+    if ($self->url =~ m{^(?:https?:)?//(?:[^/]+.)?spotify.com/user/[^/?#]+/?}i) {
         return l('Playlists at Spotify');
     } else {
         return l('Stream at Spotify');

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2866,12 +2866,12 @@ const CLEANUPS = {
           case LINK_TYPES.songkick.artist:
             return {result: prefix === 'artists'};
           case LINK_TYPES.songkick.event:
-            return  {result: prefix === 'concerts' || prefix === 'festivals'};
+            return {result: prefix === 'concerts' || prefix === 'festivals'};
           case LINK_TYPES.songkick.place:
-            return  {result: prefix === 'venues'};
+            return {result: prefix === 'venues'};
         }
       }
-      return  {result: false};
+      return {result: false};
     },
   },
   'soundcloud': {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2941,11 +2941,11 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?(spotify\\.com)/user', 'i')],
     type: LINK_TYPES.socialnetwork,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/user\/([a-zA-Z0-9_-]+)\/?(?:[?#].*)?$/, 'https://open.spotify.com/user/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:play|open)\.spotify\.com\/user\/([^\/?#]+)\/?(?:[?#].*)?$/, 'https://open.spotify.com/user/$1');
       return url;
     },
     validate: function (url) {
-      return {result: /^https:\/\/open\.spotify\.com\/user\/[a-zA-Z0-9_-]+$/.test(url)};
+      return {result: /^https:\/\/open\.spotify\.com\/user\/[^\/?#]+$/.test(url)};
     },
   },
   'thesession': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3490,6 +3490,27 @@ const testData = [
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'https://open.spotify.com/user/hitradio%C3%B63',
+             input_entity_type: 'label',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://open.spotify.com/user/hitradio%C3%B63',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://open.spotify.com/user/%21k7',
+             input_entity_type: 'label',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://open.spotify.com/user/%21k7',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://open.spotify.com/user/testspiel.de',
+             input_entity_type: 'label',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://open.spotify.com/user/testspiel.de',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
                      input_url: 'https://play.spotify.com/user/1254688529/playlist/0MRy5cv9ZktSjysDEIP72H',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',


### PR DESCRIPTION
### Fix MBS-11340

As per the URLs added to the tests, there's a lot more characters allowed in these URLs than just what we were limiting them to.