### PR TITLE
MBS-8700: List genres in JSON-LD

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -26,7 +26,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}
+    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'area'

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -34,7 +34,8 @@ with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
                                           {from => 'recordings_jsonld', to => 'recordings'},
                                           {from => 'identities', to => 'identities'},
                                           {from => 'legal_name', to => 'legal_name'},
-                                          {from => 'other_identities', to => 'other_identities'}]},
+                                          {from => 'other_identities', to => 'other_identities'},
+                                          'top_tags']},
                   recordings => {copy_stash => [{from => 'recordings_jsonld', to => 'recordings'}]},
                   relationships => {},
                   aliases => {copy_stash => ['aliases']}}

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -28,7 +28,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}]},
+    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags']},
                   aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -25,7 +25,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}
+    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'place'

--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -17,7 +17,7 @@ with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}
+    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'recording'

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -18,7 +18,7 @@ with 'MusicBrainz::Server::Controller::Role::EditListing';
 with 'MusicBrainz::Server::Controller::Role::Tag';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
     endpoints => {
-        show => {copy_stash => ['release_artwork']},
+        show => {copy_stash => ['release_artwork', 'top_tags']},
         aliases => {copy_stash => ['aliases']},
         cover_art => {copy_stash => ['cover_art']},
     },

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -29,7 +29,8 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::Cleanup';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}]}, aliases => {copy_stash => ['aliases']}}
+    endpoints => {show => {copy_stash => [{from => 'releases_jsonld', to => 'releases'}, 'top_tags']},
+                  aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_name => 'rg',

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -35,7 +35,7 @@ with 'MusicBrainz::Server::Controller::Role::WikipediaExtract';
 with 'MusicBrainz::Server::Controller::Role::CommonsImage';
 with 'MusicBrainz::Server::Controller::Role::EditRelationships';
 with 'MusicBrainz::Server::Controller::Role::JSONLD' => {
-    endpoints => {show => {}, aliases => {copy_stash => ['aliases']}}
+    endpoints => {show => {copy_stash => ['top_tags']}, aliases => {copy_stash => ['aliases']}}
 };
 with 'MusicBrainz::Server::Controller::Role::Collection' => {
     entity_type => 'work'

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Area.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Area.pm
@@ -4,6 +4,7 @@ use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_e
 use MusicBrainz::Server::Constants qw( $AREA_TYPE_COUNTRY $AREA_TYPE_CITY );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 # Role::LifeSpan is not included here because schema.org does not have

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Artist.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Artist.pm
@@ -12,6 +12,7 @@ use MusicBrainz::Server::Data::Utils qw( non_empty );
 use List::MoreUtils qw( uniq );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::LifeSpan' =>

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Label.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Label.pm
@@ -3,6 +3,7 @@ use Moose;
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_entity list_or_single format_date );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::LifeSpan';

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Place.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Place.pm
@@ -3,6 +3,7 @@ use Moose;
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_entity );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::LifeSpan';

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Recording.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Recording.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::Data::Utils qw( non_empty );
 use List::MoreUtils qw( uniq );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Length';

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
@@ -5,6 +5,7 @@ use List::AllUtils qw( uniq );
 use List::UtilsBy qw( uniq_by );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Length';

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/ReleaseGroup.pm
@@ -5,6 +5,7 @@ use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_e
 use List::AllUtils qw( uniq );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Aliases';

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Genre.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Genre.pm
@@ -1,0 +1,33 @@
+package MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre;
+use Moose::Role;
+use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( list_or_single serialize_entity );
+
+around serialize => sub {
+    my ($orig, $self, $entity, $inc, $stash, $toplevel) = @_;
+    my $ret = $self->$orig($entity, $inc, $stash, $toplevel);
+
+    my $tags = $stash->store($entity)->{top_tags};
+    my @genres = map {
+        my $genre = $_->{tag}->genre;
+        $genre ? (DBDefs->CANONICAL_SERVER . '/genre/' . $genre->gid) : ()
+    } @$tags;
+
+    if (@genres) {
+        $ret->{genre} = list_or_single(@genres);
+    }
+
+    return $ret;
+};
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2020 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Work.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Work.pm
@@ -4,6 +4,7 @@ use Moose;
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( list_or_single serialize_entity );
 
 extends 'MusicBrainz::Server::WebService::Serializer::JSON::LD';
+with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Genre';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::GID';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Name';
 with 'MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Aliases';

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
@@ -201,6 +201,50 @@ EOSQL
     };
 };
 
+test 'Embedded JSON-LD `genre` property' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    $c->sql->do(<<'EOSQL');
+    INSERT INTO artist (id, gid, name, sort_name)
+        VALUES (1, 'dcb48a49-b17d-49b9-aee5-4f168d8004d9', 'Group', 'Group');
+
+    INSERT INTO tag (id, name, ref_count)
+        VALUES (30, 'dubstep', 347), (31, 'debstup', 33);
+
+    INSERT INTO genre (id, gid, name)
+        VALUES (1, '1b50083b-1afa-4778-82c8-548b309af783', 'dubstep'),
+               (2, '2b50083b-1afa-4778-82c8-548b309af783', 'debstup');
+
+    INSERT INTO artist_tag (artist, count, last_updated, tag) VALUES (1, 3, '2011-01-18 15:21:33.71184+00', 30);
+
+EOSQL
+
+    $mech->get_ok('/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9');
+    page_test_jsonld $mech => {
+        'name' => 'Group',
+        '@type' => 'MusicGroup',
+        '@id' => 'https://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
+        'genre' => 'https://musicbrainz.org/genre/1b50083b-1afa-4778-82c8-548b309af783',
+        '@context' => 'http://schema.org'
+    };
+
+    $c->sql->do(<<~'EOSQL');
+        INSERT INTO artist_tag (artist, count, last_updated, tag)
+            VALUES (1, 2, '2011-01-18 15:21:33.71184+00', 31);
+        EOSQL
+
+    $mech->get_ok('/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9');
+    page_test_jsonld $mech => {
+        'name' => 'Group',
+        '@type' => 'MusicGroup',
+        '@id' => 'https://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
+        'genre' => ['https://musicbrainz.org/genre/1b50083b-1afa-4778-82c8-548b309af783','https://musicbrainz.org/genre/2b50083b-1afa-4778-82c8-548b309af783'],
+        '@context' => 'http://schema.org'
+    };
+};
+
 test 'Embedded JSON-LD sameAs & performsAs' => sub {
     my $test = shift;
     my $mech = $test->mech;


### PR DESCRIPTION
### Implement MBS-8700

This uses only the genres on top_tags (so, the ones that would be displayed on the sidebar). This sounds sensible enough to me, since if someone has added 100 genres to an artist we probably don't want to show them all.

https://schema.org/genre specifically allows only Text or URL for genre, so I went with URL to at least be able to pass an MBID for it. Ideally we would serialize a genre object with ID and name, but that doesn't seem to be supported.

I've never knowingly touched JSON-LD stuff before, so do let me know if something here seems dumb :) 