### PR TITLE
MBS-11346: Lower duration threshold on dubious duration discID report

### DIFF
--- a/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
@@ -20,8 +20,12 @@ sub query {
             JOIN medium ON medium_cdtoc.medium = medium.id
             JOIN medium_format ON medium.format = medium_format.id
         WHERE
-            leadout_offset > 75 * 60 * 88 -- cutoff 88 minutes
-            AND medium_format.name != 'CD-R'
+            -- cutoff 88 minutes
+            (leadout_offset > 75 * 60 * 88
+                AND medium_format.name != 'CD-R')
+            OR
+            (medium_format.name = '8cm CD'
+                AND leadout_offset > 75 * 60 * 30)
         ORDER BY
             medium_format.name,
             cdtoc.leadout_offset DESC

--- a/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
@@ -21,6 +21,7 @@ sub query {
             JOIN medium_format ON medium.format = medium_format.id
         WHERE
             leadout_offset > 75 * 60 * 88 -- cutoff 88 minutes
+            AND medium_format.name != 'CD-R'
         ORDER BY
             medium_format.name,
             cdtoc.leadout_offset DESC

--- a/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
@@ -20,7 +20,7 @@ sub query {
             JOIN medium ON medium_cdtoc.medium = medium.id
             JOIN medium_format ON medium.format = medium_format.id
         WHERE
-            leadout_offset > 75 * 60 * 100 -- cutoff 100 minutes
+            leadout_offset > 75 * 60 * 88 -- cutoff 88 minutes
         ORDER BY
             medium_format.name,
             cdtoc.leadout_offset DESC

--- a/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCDubiousLength.pm
@@ -20,11 +20,13 @@ sub query {
             JOIN medium ON medium_cdtoc.medium = medium.id
             JOIN medium_format ON medium.format = medium_format.id
         WHERE
-            -- cutoff 88 minutes
+            -- default cutoff 88 minutes
             (leadout_offset > 75 * 60 * 88
-                AND medium_format.name != 'CD-R')
+                -- no limit for CD-R
+                AND medium_format.id != 33)
             OR
-            (medium_format.name = '8cm CD'
+            -- custom cutoff 30 minutes for 8cm CDs
+            (medium_format.id = 34
                 AND leadout_offset > 75 * 60 * 30)
         ORDER BY
             medium_format.name,

--- a/root/report/CDTocDubiousLength.js
+++ b/root/report/CDTocDubiousLength.js
@@ -27,7 +27,7 @@ const CDTocDubiousLength = ({
     <ul>
       <li>
         {l(`This report shows disc IDs indicating a total duration much longer
-        than what a standard CD allows (at least 100 minutes). This usually
+        than what a standard CD allows (at least 88 minutes). This usually
         means a disc ID was created for the wrong format (SACD) or with a
         buggy tool. These disc IDs can safely be removed.`)}
       </li>

--- a/root/report/CDTocDubiousLength.js
+++ b/root/report/CDTocDubiousLength.js
@@ -27,9 +27,9 @@ const CDTocDubiousLength = ({
     <ul>
       <li>
         {l(`This report shows disc IDs indicating a total duration much longer
-        than what a standard CD allows (at least 88 minutes). This usually
-        means a disc ID was created for the wrong format (SACD) or with a
-        buggy tool. These disc IDs can safely be removed.`)}
+        than what a standard CD allows (at least 88 minutes for a CD, or 30
+        minutes for a mini-CD). This usually means a disc ID was created for
+        the wrong format (SACD) or with a buggy tool.`)}
       </li>
       <li>
         {texp.l('Total releases found: {count}',


### PR DESCRIPTION
Implement MBS-11346

The report (discIDs durations > 100 minutes) is now empty, Setting to 88 minutes to get more results and avoid too many false positive.