### PR TITLE
MBS-11348: New report about discIDs attached to a medium but not applied

### DIFF
--- a/lib/MusicBrainz/Server/Report/CDTOCNotApplied.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCNotApplied.pm
@@ -1,0 +1,62 @@
+package MusicBrainz::Server::Report::CDTOCNotApplied;
+use Moose;
+
+with 'MusicBrainz::Server::Report::CDTOCReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub table { 'cd_toc_not_applied' }
+sub component_name { 'CDTocNotApplied' }
+
+sub query {
+    q{
+        WITH
+        mc AS (
+            SELECT
+                UNNEST(ARRAY_AGG(cdtoc)) AS cdtoc,
+                medium
+            FROM
+                medium_cdtoc
+            GROUP BY
+                medium
+            HAVING
+                COUNT(medium) = 1
+        ),
+        disc AS (
+            SELECT DISTINCT
+                c.id AS cdtoc_id,
+                c.discid,
+                mc.medium
+            FROM
+                cdtoc AS c
+                JOIN mc ON c.id = mc.cdtoc
+                JOIN track AS t ON t.medium = mc.medium
+            WHERE
+                t.length IS NULL
+                AND NOT t.is_data_track
+        )
+        SELECT
+            cdtoc_id,
+            r.id AS release_id,
+            row_number() OVER (ORDER BY r.name)
+        FROM
+            disc
+            JOIN medium AS m ON m.id = disc.medium
+            JOIN release AS r ON r.id = m.release
+        ORDER BY
+            r.name
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 Jerome Roy
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Report/CDTOCReport.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCReport.pm
@@ -13,10 +13,17 @@ around inflate_rows => sub {
         map { $_->{cdtoc_id} } @$items
     );
 
+    my $releases = $self->c->model('Release')->get_by_ids(
+        map { $_->{release_id} } @$items
+    );
+
+    $self->c->model('ArtistCredit')->load(values %$releases);
+
     return [
         map +{
             %$_,
             cdtoc => $cdtocs->{ $_->{cdtoc_id} },
+            release => $releases->{ $_->{release_id} }
         }, @$items
     ];
 };

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -23,6 +23,7 @@ use MusicBrainz::Server::PagedReport;
     CatNoLooksLikeASIN
     CatNoLooksLikeLabelCode
     CDTOCDubiousLength
+    CDTOCNotApplied
     CollaborationRelationships
     CoverArtRelationships
     DeprecatedRelationshipArtists
@@ -109,6 +110,7 @@ use MusicBrainz::Server::Report::BadAmazonURLs;
 use MusicBrainz::Server::Report::CatNoLooksLikeASIN;
 use MusicBrainz::Server::Report::CatNoLooksLikeLabelCode;
 use MusicBrainz::Server::Report::CDTOCDubiousLength;
+use MusicBrainz::Server::Report::CDTOCNotApplied;
 use MusicBrainz::Server::Report::CollaborationRelationships;
 use MusicBrainz::Server::Report::CoverArtRelationships;
 use MusicBrainz::Server::Report::DeprecatedRelationshipArtists;

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -26,7 +26,7 @@
            classes = [];
            classes.push(loop.parity);
            classes.push('mp') IF medium_cdtoc.edits_pending > 0; %]
-        <tr class="[% classes.join(' ') %]">
+        <tr class="[% classes.join(' ') %]" id="[% release.gid %]">
             <td>
               [% medium.position %]/[% release.medium_count %]
               [% tracklist_toggle %]

--- a/root/report/CDTocNotApplied.js
+++ b/root/report/CDTocNotApplied.js
@@ -1,0 +1,55 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 Jerome Roy
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout';
+import formatUserDate from '../utility/formatUserDate';
+
+import CDTocReleaseList from './components/CDTocReleaseList';
+import FilterLink from './FilterLink';
+import type {ReportDataT, ReportCDTocReleaseT} from './types';
+
+const CDTocNotApplied = ({
+  $c,
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportCDTocReleaseT>): React.Element<typeof Layout> => (
+  <Layout $c={$c} fullWidth title={l('Disc IDs attached but not applied')}>
+    <h1>{l('Disc IDs attached but not applied')}</h1>
+
+    <ul>
+      <li>
+        {l(`This report shows disc IDs attached to a release but obviously not
+        applied because at last one track duration is unknown on the release.
+        The report is also restricted to mediums where only one discID is
+        attached, so it is highly likely that the discID can be applied
+        without a risk.`)}
+      </li>
+      <li>
+        {texp.l('Total discIDs found: {count}',
+                {count: pager.total_entries})}
+      </li>
+      <li>
+        {texp.l('Generated on {date}',
+                {date: formatUserDate($c, generated)})}
+      </li>
+
+      {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
+    </ul>
+
+    <CDTocReleaseList items={items} pager={pager} />
+
+  </Layout>
+);
+
+export default CDTocNotApplied;

--- a/root/report/CDTocNotApplied.js
+++ b/root/report/CDTocNotApplied.js
@@ -31,9 +31,10 @@ const CDTocNotApplied = ({
       <li>
         {l(`This report shows disc IDs attached to a release but obviously not
         applied because at last one track duration is unknown on the release.
-        The report is also restricted to mediums where only one discID is
-        attached, so it is highly likely that the discID can be applied
-        without a risk.`)}
+        The report is also restricted to mediums where only one disc ID is
+        attached, so it is highly likely that the disc ID can be applied
+        without any worries. Do make sure though that no existing durations
+        clash with the disc ID, or that any clashes are clear mistakes.`)}
       </li>
       <li>
         {texp.l('Total discIDs found: {count}',

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -584,6 +584,11 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
             {l('Disc IDs with dubious duration')}
           </a>
         </li>
+        <li>
+          <a href="/report/CDTOCNotApplied">
+            {l('Disc IDs attached but not applied')}
+          </a>
+        </li>
       </ul>
     </div>
   </Layout>

--- a/root/report/components/CDTocReleaseList.js
+++ b/root/report/components/CDTocReleaseList.js
@@ -1,0 +1,77 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 Jerome Roy
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import PaginatedResults from '../../components/PaginatedResults';
+import loopParity from '../../utility/loopParity';
+import type {ReportCDTocReleaseT} from '../types';
+import ArtistCreditLink
+  from '../../static/scripts/common/components/ArtistCreditLink';
+import CDTocLink
+  from '../../static/scripts/common/components/CDTocLink';
+import EntityLink from '../../static/scripts/common/components/EntityLink';
+
+type Props = {
+  +items: $ReadOnlyArray<ReportCDTocReleaseT>,
+  +pager: PagerT,
+};
+
+const CDTocReleaseList = ({
+  items,
+  pager,
+}: Props): React.Element<typeof PaginatedResults> => {
+  const colSpan = 3;
+
+  return (
+    <PaginatedResults pager={pager}>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th>{l('Disc ID')}</th>
+            <th>{l('Release')}</th>
+            <th>{l('Artist')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => {
+            return (
+              <tr className={loopParity(index)} key={item.cdtoc_id}>
+                {item.cdtoc && item.release ? (
+                  <>
+                    <td>
+                      <CDTocLink
+                        cdToc={item.cdtoc}
+                        content={item.cdtoc.discid}
+                      />
+                    </td>
+                    <td>
+                      <EntityLink entity={item.release} />
+                    </td>
+                    <td>
+                      <ArtistCreditLink
+                        artistCredit={item.release.artistCredit}
+                      />
+                    </td>
+                  </>
+                ) : (
+                  <td colSpan={colSpan}>
+                    {l('This Disc ID no longer exists.')}
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </PaginatedResults>
+  );
+};
+
+export default CDTocReleaseList;

--- a/root/report/components/CDTocReleaseList.js
+++ b/root/report/components/CDTocReleaseList.js
@@ -47,6 +47,7 @@ const CDTocReleaseList = ({
                   <>
                     <td>
                       <CDTocLink
+                        anchorPath={item.release.gid}
                         cdToc={item.cdtoc}
                         content={item.cdtoc.discid}
                       />

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -47,6 +47,14 @@ export type ReportCDTocT = {
   +row_number: number,
 };
 
+export type ReportCDTocReleaseT = {
+  +cdtoc: ?CDTocT,
+  +cdtoc_id: number,
+  +release: ?ReleaseT,
+  +release_id: number,
+  +row_number: number,
+};
+
 export type ReportCollaborationT = {
   +artist0: ?ArtistT,
   +artist1: ?ArtistT,

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -147,6 +147,7 @@ module.exports = {
   'report/CatNoLooksLikeAsin': require('../report/CatNoLooksLikeAsin'),
   'report/CatNoLooksLikeLabelCode': require('../report/CatNoLooksLikeLabelCode'),
   'report/CDTocDubiousLength': require('../report/CDTocDubiousLength'),
+  'report/CDTocNotApplied': require('../report/CDTocNotApplied'),
   'report/CollaborationRelationships': require('../report/CollaborationRelationships'),
   'report/CoverArtRelationships': require('../report/CoverArtRelationships'),
   'report/DeprecatedRelationshipArtists': require('../report/DeprecatedRelationshipArtists'),

--- a/root/static/scripts/common/components/CDTocLink.js
+++ b/root/static/scripts/common/components/CDTocLink.js
@@ -12,13 +12,16 @@ import * as React from 'react';
 import entityHref from '../utility/entityHref';
 
 type Props = {
+  +anchorPath?: string,
   +cdToc: CDTocT,
   +content: string,
   +subPath?: string,
 };
 
-const CDTocLink = ({cdToc, content, subPath}: Props): React.Element<'a'> => (
-  <a href={entityHref(cdToc, subPath)}>
+const CDTocLink = (
+  {cdToc, content, subPath, anchorPath}: Props,
+): React.Element<'a'> => (
+  <a href={entityHref(cdToc, subPath, anchorPath)}>
     <bdi>
       {content}
     </bdi>

--- a/root/static/scripts/common/utility/entityHref.js
+++ b/root/static/scripts/common/utility/entityHref.js
@@ -21,7 +21,7 @@ type LinkableEntity =
   | {+entityType: 'iswc', +iswc: string, ...}
   | {+entityType: CoreEntityTypeT | 'collection', +gid: string, ...};
 
-function generateHref(path, id, subPath) {
+function generateHref(path, id, subPath, anchorPath) {
   let href = '/' + path + '/';
 
   href += encodeURIComponent(id);
@@ -30,6 +30,12 @@ function generateHref(path, id, subPath) {
     subPath = subPath.replace(leadingSlash, '$1');
     if (subPath) {
       href += '/' + subPath;
+    }
+  }
+
+  if (nonEmpty(anchorPath)) {
+    if (anchorPath) {
+      href += '#' + anchorPath;
     }
   }
 
@@ -46,6 +52,7 @@ export function editHref(
 function entityHref(
   entity: LinkableEntity,
   subPath?: string,
+  anchorPath?: string,
 ): string {
   const entityProps = ENTITIES[entity.entityType];
   const path = entityProps.url;
@@ -75,7 +82,7 @@ function entityHref(
       }
   }
 
-  return generateHref(path, id, subPath);
+  return generateHref(path, id, subPath, anchorPath);
 }
 
 export default entityHref;


### PR DESCRIPTION
Implements MBS-11348

Find un-applied discIDs on releases where applying them should be a no-brainer: some track durations are unset on the release, and only discID is attached to the relevant medium.

# Checklist for author

PR ready to be merged, I think

# Action

Please check  lib/MusicBrainz/Server/Report/CDTOCReport.pm  which is used by both  CDTOCNotApplied.pm and CDTOCDubiousLength.pm

I modified generateHref() and entityHref() to be able to build urls with anchors, I think there are no side-effects but of course I might be wrong.
A far as I know urls with anchors are used to highlight track rows in releases (and it was probably never used with react), and I wanted to be able to highlight release rows on cdtoc pages too.
This last part is not required for the report and the two commits can be removed if needed.