### PR TITLE
MBS-6502: Surround catno search with quotes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/OtherLookup.pm
@@ -9,6 +9,29 @@ extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
+sub build_term {
+    my ($self, $value) = @_;
+
+    # We want to turn the given value into a valid Lucene term so
+    # the search server understands it properly.
+    # As such, we quote it to make it a Lucene phrase,
+    # except if it is a regular expression or the user already entered
+    # a Lucene phrase (i.e. the value is already in quotes).
+    # See https://lucene.apache.org/core/7_7_2/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Terms
+    my $is_regex = $value =~ /^\/.*\/$/;
+    my $is_quoted = $value =~ /^".*"$/;
+
+    # We escape any quotes inside the actual value so that they are
+    # still searched for when we turn it into a phrase.
+    my $escaped_value = $value =~ s/"/\\"/gr;
+
+    my $term = ($is_regex || $is_quoted)
+        ? $value
+        : "\"$escaped_value\"";
+
+    return $term;
+}
+
 sub lookup_handler {
     my ($name, $code) = @_;
 
@@ -43,7 +66,7 @@ lookup_handler 'catno' => sub {
 
     $c->response->redirect(
         $c->uri_for_action('/search/search', {
-            query => 'catno:' . $cat_no,
+            query => 'catno:' . $self->build_term($cat_no),
             type => 'release',
             advanced => '1',
         }));

--- a/lib/MusicBrainz/Server/Controller/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/OtherLookup.pm
@@ -27,7 +27,7 @@ sub build_term {
 
     my $term = ($is_regex || $is_quoted)
         ? $value
-        : "\"$escaped_value\"";
+        : qq("$escaped_value");
 
     return $term;
 }


### PR DESCRIPTION
### Fix MBS-6502

CRD 3443 is a valid catalog number we should support, and in fact our search supports it. But by sending 'catno:CRD 3443' we actually search 3443 as a title!

Since there's one use case that quotes break (searching for a regex, where the string must start and end with slashes), we avoid quoting any query that starts and ends with slashes.