### PR TITLE
Prevent linking release to Wikidata/Wikipedia

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3561,76 +3561,49 @@ Object.values(LINK_TYPES).forEach(function (linkType) {
   });
 });
 
-// avoid Wikipedia/Wikidata being added as release-level discography entry
-const discographyRule = validationRules[LINK_TYPES.discographyentry.release];
-validationRules[LINK_TYPES.discographyentry.release] = function (url) {
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikipedia is not a discography entry. Please add this Wikipedia link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikidata is not a discography entry. Please add this Wikidata link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  return discographyRule(url);
-};
+const relationshipTypesByEntityType = Object.entries(LINK_TYPES).reduce(
+  function (
+    results,
+    [/* relationshipType */, relUuidByEntityType],
+  ) {
+    for (const entityType of Object.keys(relUuidByEntityType)) {
+      (results[entityType] || (results[entityType] = []))
+        .push(relUuidByEntityType[entityType]);
+    }
+    return results;
+  },
+  {},
+);
 
-// avoid Wikipedia/Wikidata being added as release-level license entry
-const licenseRule = validationRules[LINK_TYPES.license.release];
-validationRules[LINK_TYPES.license.release] = function (url) {
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikipedia is not a license page. Please add this Wikipedia link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikidata is not a license page. Please add this Wikidata link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  return licenseRule(url);
-};
-
-// avoid Wikipedia/Wikidata being added as release-level show notes entry
-validationRules[LINK_TYPES.shownotes.release] = function (url) {
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikipedia is not a page of show notes. Please add this Wikipedia link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
-    return {
-      error: l(
-        `Wikidata is not a page of show notes. Please add this Wikidata link
-         to the release group instead.`,
-      ),
-      result: false,
-    };
-  }
-  return {result: true};
-};
+// Avoid Wikipedia/Wikidata being added as release-level relationship
+for (const relUuid of relationshipTypesByEntityType.release) {
+  const relRule = validationRules[relUuid];
+  validationRules[relUuid] = function (url) {
+    if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\//.test(url)) {
+      return {
+        error: l(
+          `Wikipedia normally has no entries for specific releases,
+           so adding Wikipedia links to a release is currently blocked.
+           Please add this Wikipedia link to the release group instead,
+           if appropriate.`,
+        ),
+        result: false,
+      };
+    }
+    if (/^(https?:\/\/)?([^.\/]+\.)?wikidata\.org\//.test(url)) {
+      return {
+        error: l(
+          `Wikidata normally has no entries for specific releases,
+           so adding Wikidata links to a release is currently blocked.
+           Please add this Wikidata link to the release group instead,
+           if appropriate.`,
+        ),
+        result: false,
+      };
+    }
+    return relRule(url);
+  };
+}
 
 export function guessType(sourceType, currentURL) {
   const cleanup = CLEANUP_ENTRIES.find(function (cleanup) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4094,20 +4094,6 @@ const testData = [
        input_relationship_type: 'discographyentry',
        only_valid_entity_types: [],
   },
-  {
-                     input_url: 'https://www.wikidata.org/wiki/Q43',
-             input_entity_type: 'release',
-    expected_relationship_type: undefined,
-       input_relationship_type: 'license',
-       only_valid_entity_types: ['recording'],
-  },
-  {
-                     input_url: 'https://www.wikidata.org/wiki/Q44',
-             input_entity_type: 'release',
-    expected_relationship_type: undefined,
-       input_relationship_type: 'shownotes',
-       only_valid_entity_types: [],
-  },
   // Wikimedia Commons
   {
                      input_url: 'https://commons.wikimedia.org/wiki/File:NIN2008.jpg',
@@ -4216,20 +4202,6 @@ const testData = [
              input_entity_type: 'release',
     expected_relationship_type: undefined,
        input_relationship_type: 'discographyentry',
-       only_valid_entity_types: [],
-  },
-  {
-                     input_url: 'https://en.wikipedia.org/wiki/Another_Album',
-             input_entity_type: 'release',
-    expected_relationship_type: undefined,
-       input_relationship_type: 'license',
-       only_valid_entity_types: ['recording'],
-  },
-  {
-                     input_url: 'https://en.wikipedia.org/wiki/Yet_Another_Album',
-             input_entity_type: 'release',
-    expected_relationship_type: undefined,
-       input_relationship_type: 'shownotes',
        only_valid_entity_types: [],
   },
   // Wikisource


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Only “discography entry”, “license”, and “show notes” relationship types used to be blocked at release level because these were the most common. It doesn’t prevent adding Wikidata/Wikipedia using other free relationship types such as streaming and so on.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch prevents Wikidata/Wikipedia links from being added to release using any relationship type. Would it be allowed to in the future, a dedicated relationship type should be created in the meantime.


# How to test

Edit a release, try adding links such as `https://www.wikidata.org/wiki/Special:EntityPage/Q14005` and  `https://en.wikipedia.org/wiki/MusicBrainz`. Selecting any relationship type should throw an error.

Edit an entity of any other type, adding the same links should auto-select the appropriate relationship type and be accepted.
