### PR TITLE
MBS-11354: Don't show arrows unless we want ordering

### DIFF
--- a/root/forms/relationship-editor.tt
+++ b/root/forms/relationship-editor.tt
@@ -29,7 +29,7 @@
           <div>
             <button type="button" class="icon remove-item" data-click="removeRelationship"></button>
             <button type="button" class="icon edit-item" data-bind="disable: removed" data-click="openEditDialog"></button>
-            <!-- ko if: $parent.canBeOrdered() -->
+            <!-- ko if: $parent.canBeOrdered() && $parent.hasOrdering() -->
               <button type="button" class="icon move-down" title="[% l('Move entity down') %]" data-click="moveEntityDown"></button>
               <button type="button" class="icon move-up" title="[% l('Move entity up') %]" data-click="moveEntityUp"></button>
             <!-- /ko -->


### PR DESCRIPTION
### Fix MBS-11354

This was changed with 72ce47118a42097872d4a15bb2407e1c9d14c9b9 in a way that caused the arrows to always show for orderable relationship types. It used to only show once there were at least two relationships and the user selected that they wanted them to be ordered (hasOrdering). The old way seems more sensible to me.
