### PR TITLE
MBS-11357: Allow linking RateYourMusic to release groups

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2680,6 +2680,7 @@ const CLEANUPS = {
           case LINK_TYPES.otherdatabases.place:
             return {result: prefix === 'venue'};
           case LINK_TYPES.otherdatabases.release:
+          case LINK_TYPES.otherdatabases.release_group:
             return {result: prefix === 'release'};
           case LINK_TYPES.otherdatabases.series:
             return {result: prefix === 'classifiers'};

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3004,10 +3004,17 @@ const testData = [
   },
   {
                      input_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale/',
-             input_entity_type: 'release',
+             input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale/',
-        only_valid_entity_types: ['release'],
+        only_valid_entity_types: ['release', 'release_group'],
+  },
+  {
+                     input_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale.p/',
+             input_entity_type: 'release',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale.p/',
+        only_valid_entity_types: ['release', 'release_group'],
   },
   {
                      input_url: 'https://rateyourmusic.com/classifiers/Nonesuch+Explorer+Series/',


### PR DESCRIPTION
### Fix MBS-11357

Forgot to allow for RGs in 9f56fea514cf49d2a276c5338c1961044d67d670

The difference between releases and RG links can't be determined from the URL as far as I can tell. Some include a dot (like in the test example) but some just append "_f1" or whatever to the RG URL.
