### PR TITLE
MBS-11358: Allow alias sort name to be blank

### DIFF
--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -273,10 +273,7 @@ const AliasEditForm = ({
     dispatch({action, type: 'update-date-range'});
   }, [dispatch]);
 
-  const missingRequired = state.isTypeSearchHint
-    ? isBlank(state.form.field.name.value)
-    : isBlank(state.form.field.name.value) ||
-      isBlank(state.form.field.sort_name.value);
+  const missingRequired = isBlank(state.form.field.name.value);
 
   const hasErrors = missingRequired || hasSubfieldErrors(state.form);
 

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -31,6 +31,7 @@ type PropsT = {
   +entity: SortNamedEntityT,
   +field: ReadOnlyFieldT<string | null>,
   +label?: string,
+  +required?: boolean,
 };
 
 export type StateT = {
@@ -75,6 +76,7 @@ export const FormRowSortNameWithGuessCase = ({
   entity,
   field,
   label = addColonText(l('Sort name')),
+  required = false,
 }: PropsT): React.Element<typeof FormRowText> => {
   const handleSortNameChange = React.useCallback((
     event: SyntheticKeyboardEvent<HTMLInputElement>,
@@ -100,7 +102,7 @@ export const FormRowSortNameWithGuessCase = ({
       field={field}
       label={label}
       onChange={handleSortNameChange}
-      required
+      required={required}
     >
       <button
         className="guesscase-title icon"


### PR DESCRIPTION
### Fix MBS-11358

The backend already copies the name to the sort name if left blank, so this was never intended to be marked required here. Making required an optional boolean since we will want it to remain required for artist editing.
