### PR TITLE
MBS-11360: Work around unconsistent name for RG type

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -72,9 +72,10 @@ sub add_alias : Chained('load') PathPart('add-alias') Edit
     my $entity = $c->stash->{ $type };
     my $form_type = 'add';
     my $alias_model = $c->model( $self->{model} )->alias;
+    my $entity_type = $type eq 'rg' ? 'release_group' : $type;
 
     my %props = (
-        type => $type,
+        type => $entity_type,
         entity => $entity,
         formType => $form_type,
     );
@@ -156,8 +157,9 @@ sub edit_alias : Chained('alias') PathPart('edit') Edit
     my $entity = $c->stash->{ $type };
     my $form_type = 'edit';
     my $alias_model = $c->model( $self->{model} )->alias;
+    my $entity_type = $type eq 'rg' ? 'release_group' : $type;
     my %props = (
-        type => $type,
+        type => $entity_type,
         entity => $entity,
         formType => $form_type
     );


### PR DESCRIPTION
### Fix MBS-11360

For some reason, the entity_name for release group is 'rg' in Controller::ReleaseGroup, despite its ENTITIES entry being 'release_group'. This seems very weird to me but it'd probably be a mess to change it now, so I just massage it into what the JS code expects instead so that the RG alias form will work.
