### PR TITLE
MBS-11362: Avoid autovivification leading to broken edit data

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -644,9 +644,21 @@ before restore => sub {
         $data->{old}{name} //= '';
     }
 
-    for my $track (@{ $data->{new}{tracklist} }, @{ $data->{old}{tracklist} }) {
-        for my $artist_credit_name (@{ $track->{artist_credit}{names} }) {
-            $artist_credit_name->{join_phrase} //= '';
+    # Some old edits have undef join phrases. Two loops and checks to avoid
+    # autovivification causing weird issues.
+    if (exists $data->{new}{tracklist}) {
+        for my $new_track (@{ $data->{new}{tracklist} }) {
+            for my $artist_credit_name (@{ $new_track->{artist_credit}{names} }) {
+                $artist_credit_name->{join_phrase} //= '';
+            }
+        }
+    }
+
+    if (exists $data->{old}{tracklist}) {
+        for my $old_track (@{ $data->{old}{tracklist} }) {
+            for my $artist_credit_name (@{ $old_track->{artist_credit}{names} }) {
+                $artist_credit_name->{join_phrase} //= '';
+            }
         }
     }
 };


### PR DESCRIPTION
### Fix MBS-11362

Without this check Perl autovivifies the tracklists, leading to edits which show tracklist changes despite only changing the edit name.
