### PR TITLE
MBS-11363: Fix broken returnto in merge-helper.tt

### DIFF
--- a/root/layout/merge-helper.tt
+++ b/root/layout/merge-helper.tt
@@ -1,5 +1,5 @@
 <div id="current-editing">
-  <form action="[% merge_link %]&amp;[% c.returnto_relative_uri %]" method="post">
+  <form action="[% merge_link %]?[% c.returnto_relative_uri %]" method="post">
     <h2>[% l('Merge Process') %]</h2>
     <p>[% l('You currently have the following entities selected
       for merging:') %]</p>


### PR DESCRIPTION
## Fix MBS-11363: Regression: Bad request when cancelling a merge

returnto should be prefixed by ? not & since it's the start of the query parameters