### PR TITLE
MBS-11174: Swap Add release edit types (216,31 instead of 31,216)

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -401,8 +401,8 @@ const UserEditsProperty = ({
     : entityType === 'release' ? (
       // Also list historical edits
       [
-        TYPES.EDIT_RELEASE_CREATE,
         TYPES.EDIT_HISTORIC_ADD_RELEASE,
+        TYPES.EDIT_RELEASE_CREATE,
       ].join(',')
     ) : TYPES[`EDIT_${entityType.toUpperCase()}_CREATE`];
   const searchEditsURL = (createEditTypes => (


### PR DESCRIPTION
# Problem

Currently, the user profile links to [`31,216`](https://musicbrainz.org/search/edits?auto_edit_filter=&conditions.0.field=editor&conditions.0.operator=%3D&conditions.0.name=jesus2099&conditions.0.args.0=285909&combinator=and&conditions.1.field=type&conditions.1.operator=%3D&conditions.1.args=31,216&conditions.2.field=status&conditions.2.operator=%3D&conditions.2.args=2&negation=0&order=desc) so the **Add release** type select option filter (value `216,31`) is not selected in the refine edit search form.
So if you click Search button, you will get an error:

# Solution

Fixes [MBS-11174](https://tickets.metabrainz.org/browse/MBS-11174).

I have just swapped the types, to match the select option value: [`216,31`](https://musicbrainz.org/search/edits?auto_edit_filter=&conditions.0.field=editor&conditions.0.operator=%3D&conditions.0.name=jesus2099&conditions.0.args.0=285909&combinator=and&conditions.1.field=type&conditions.1.operator=%3D&conditions.1.args=216,31&conditions.2.field=status&conditions.2.operator=%3D&conditions.2.args=2&negation=0&order=desc) so
the **Add release** type (value same as request: `216,31`) is now selected and you will get no error if you refine the search by clicking Search button

# Action

It is just an addition to @reosarevok's 809526d122193b5b0d8dfcf287659ec2a4383608.

I could not test on my local server because I have no stats in user profiles (except a few Add cover art, don't know why).
But theoretically it should work.

If you have a local server with statistic data, please test for me, sorry.