### PR TITLE
MBS-11369: Revert to middle vertical alignment for table.details data

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -859,8 +859,6 @@ table.details {
     }
 
     td {
-        vertical-align: top;
-
         span.new, span.old,
         &.new, &.old {
             border: 1px solid @medium-border;


### PR DESCRIPTION
# Problem

Detail table rows begin with colon-terminated headers which can easily wrap onto multiple lines. When this occurs, the value associated with the header (which follows in the next cell) can appear far above where the header ends when the value's cell is top-aligned, potentially making the value appear unrelated to the header and harder to parse than it needs to be.

![Before](https://user-images.githubusercontent.com/757021/107155770-31587100-6972-11eb-89a3-284400ff74d4.png)

# Solution

Revert to the default theme's vertical alignment style for data cells which in most circumstances should more clearly delineate a row's values from any preceding or succeeding rows.

![After](https://user-images.githubusercontent.com/757021/107155852-a6c44180-6972-11eb-8c1b-a03f6357e418.png)
