### PR TITLE
MBS-11370: display track lengths of 0 ms or -1 ms as unknown 

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/AddTrackKV.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/AddTrackKV.pm
@@ -45,6 +45,12 @@ sub build_display_data
 {
     my ($self, $loaded) = @_;
     my @release_ids = @{ $self->data->{release_ids} };
+
+    # Some lengths of -1 or 0 ms are stored, which is nonsensical
+    # and probably meant as a placeholder for unknown duration
+    my $length = $self->data->{length};
+    my $display_length = $length <= 0 ? undef : $length;
+
     return {
         releases => [
             map {
@@ -55,7 +61,7 @@ sub build_display_data
         ],
         position  => $self->data->{position},
         name      => $self->data->{name},
-        length    => $self->data->{length},
+        length    => $display_length,
         artist    => $loaded->{Artist}->{ $self->data->{artist_id} },
         recording => $loaded->{Recording}->{ $self->data->{recording_id} }
             || Recording->new( name => $self->data->{name} ),

--- a/lib/MusicBrainz/Server/Edit/Historic/EditTrackLength.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/EditTrackLength.pm
@@ -34,12 +34,20 @@ sub foreign_keys
 sub build_display_data
 {
     my ($self, $loaded) = @_;
+
+    # Some lengths of -1 or 0 ms are stored, which is nonsensical
+    # and probably meant as a placeholder for unknown duration
+    my $old_length = $self->data->{old}->{length};
+    my $old_display_length = $old_length <= 0 ? undef : $old_length;
+    my $new_length = $self->data->{new}->{length};
+    my $new_display_length = $new_length <= 0 ? undef : $new_length;
+
     return {
         recording => $loaded->{Recording}->{ $self->data->{recording_id} } ||
                     Recording->new( id => $self->data->{recording_id} ),
         length => {
-            old => $self->data->{old}->{length},
-            new => $self->data->{new}->{length},
+            old => $old_display_length,
+            new => $new_display_length,
         }
     };
 }

--- a/root/edit/details/historic/AddTrackKV.js
+++ b/root/edit/details/historic/AddTrackKV.js
@@ -35,13 +35,6 @@ type Props = {
 const AddTrackKV = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
   const artist = display.artist;
-  /*
-   * Some lengths of -1 or 0 ms are stored, which is nonsensical
-   * and probably meant as a placeholder for unknown duration
-   */
-  const length = (display.length != null && display.length <= 0)
-    ? null
-    : display.length;
 
   return (
     <table className="details add-track">
@@ -73,7 +66,7 @@ const AddTrackKV = ({edit}: Props): React.Element<'table'> => {
 
       <tr>
         <th>{addColonText(l('Length'))}</th>
-        <td>{formatTrackLength(length)}</td>
+        <td>{formatTrackLength(display.length)}</td>
       </tr>
     </table>
   );


### PR DESCRIPTION
### Implement MBS-11370

Same issue as https://github.com/metabrainz/musicbrainz-server/pull/1783 but on another edit type. I'm also moving that PR's check from JS to Perl.