### PR TITLE
MBS-9573: Sort edit type keys in edit search select option values

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -229,7 +229,7 @@ sub search : Path('/search/edits')
     $c->stash(
         edit_types => [
             map [
-                join(',', map { $_->edit_type } @{ $grouped{$_} }) => $_
+                join(',', sort { $a <=> $b } map { $_->edit_type } @{ $grouped{$_} }) => $_
             ], sort_by { $coll->getSortKey($_) } keys %grouped
         ],
         status => status_names(),


### PR DESCRIPTION

# Problem

[MBS-9573](https://tickets.metabrainz.org/browse/MBS-9573): **_Search for Edits: Looses track of type criteria_** (2017)

In https://musicbrainz.org/search/edits **Type** criteria, edit type keys were not sorted:

**Edit release**:
- 201,32,312,33,208,273,226,244
- 244,273,32,201,312,33,226,208
- **random** at each page load

So the more legacy keys an edit type had,
The more likely query parameters found no match in the select option
values.


# Solution

Now they are sorted, subsequent form submits will always work.

**Edit release**:
- 32,33,201,208,226,244,273,312
- predictive **numeric sort**

# Action

It is not necessay to numeric sort, so if `sort` is better, performance wise, than `sort { $a <=> $b }` we would be OK with:

**Edit release**:
- 201,208,226,244,273,312,32,33
- predictive **ASCII sort**

I no nothing about Perl so, in case it's useful, here is how I found the solution, thanks to @yvanzo and @reosarevok:

1. https://tickets.metabrainz.org/browse/MBS-9573
2. https://github.com/metabrainz/musicbrainz-server/pull/1897#issuecomment-775046188
2. https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/4740171/