### PR TITLE
MBS-11368: Set nameVariation in EditMedium if rec name != track name

### DIFF
--- a/root/edit/details/EditMedium.js
+++ b/root/edit/details/EditMedium.js
@@ -257,6 +257,7 @@ const TracklistChangesChange = ({
         <EntityLink
           content={oldNameDiff}
           entity={oldTrack.recording}
+          nameVariation={oldTrack.name !== oldTrack.recording.name}
         />
       </td>
       <td>
@@ -286,6 +287,7 @@ const TracklistChangesChange = ({
           allowNew={newTrack && !newTrack.recording.id}
           content={newNameDiff}
           entity={newTrack.recording}
+          nameVariation={newTrack.name !== newTrack.recording.name}
         />
       </td>
       <td>


### PR DESCRIPTION
### Fix MBS-11368

This used to work, but broke on React conversion because content is no longer a string, but a React element. The easiest way to do this seems to be to just compare the two names when calling EntityLink.