### PR TITLE
MBS-11373: Overwrite empty dates in relationship merges

### DIFF
--- a/root/static/scripts/common/utility/isDateEmpty.js
+++ b/root/static/scripts/common/utility/isDateEmpty.js
@@ -7,6 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+export function isDateObservableEmpty(
+  date: {
+    day: KnockoutObservable<string | null>,
+    month: KnockoutObservable<string | null>,
+    year: KnockoutObservable<string | null>,
+  },
+): boolean {
+  return !(
+    nonEmpty(date.year()) ||
+    nonEmpty(date.month()) ||
+    nonEmpty(date.day())
+  );
+}
+
 export default function isDateEmpty(date: ?PartialDateT): boolean {
   return (date == null) ||
     (date.year == null && date.month == null && date.day == null);

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -247,7 +247,7 @@ relationshipEditorTest('link phrase interpolation', function (t) {
 });
 
 relationshipEditorTest('merging duplicate relationships', function (t) {
-  t.plan(8);
+  t.plan(10);
 
   var vm = setupReleaseRelationshipEditor();
 
@@ -376,6 +376,64 @@ relationshipEditorTest('merging duplicate relationships', function (t) {
 
   laterRelationship.remove();
   earlierRelationship.remove();
+
+  var emptyDatesRelationship = vm.getRelationship({
+    target: target,
+    linkTypeID: 148,
+    attributes: ids2attrs([123, 194, 277]),
+    begin_date: null,
+    end_date: null,
+    ended: false,
+  }, source);
+
+  var newDatedRelationship = vm.getRelationship({
+    target: target,
+    linkTypeID: 148,
+    attributes: ids2attrs([123, 194, 277]),
+    begin_date: { year: 2000 },
+    end_date: { year: 2000 },
+    ended: true,
+  }, source);
+
+  emptyDatesRelationship.show();
+  newDatedRelationship.show();
+
+  t.ok(
+    source.mergeRelationship(newDatedRelationship),
+    'relationships were merged when one date period was empty',
+  );
+
+  emptyDatesRelationship.remove();
+  newDatedRelationship.remove();
+
+  var emptyDatesEndedRelationship = vm.getRelationship({
+    target: target,
+    linkTypeID: 148,
+    attributes: ids2attrs([123, 194, 277]),
+    begin_date: null,
+    end_date: null,
+    ended: true,
+  }, source);
+
+  var newDatedNonEndedRelationship = vm.getRelationship({
+    target: target,
+    linkTypeID: 148,
+    attributes: ids2attrs([123, 194, 277]),
+    begin_date: { year: 2000 },
+    end_date: null,
+    ended: false,
+  }, source);
+
+  emptyDatesEndedRelationship.show();
+  newDatedNonEndedRelationship.show();
+
+  t.ok(
+    !source.mergeRelationship(newDatedNonEndedRelationship),
+    'relationships were not merged when original was ended even if date period is empty',
+  );
+
+  emptyDatesEndedRelationship.remove();
+  newDatedNonEndedRelationship.remove();
 });
 
 relationshipEditorTest('dialog backwardness', function (t) {


### PR DESCRIPTION
### Fix MBS-11373

I implemented MBS-11181 a bit too overzealously. If we add an ended relationship on top of one with completely empty dates, we should still overwrite it - otherwise it kinda makes the whole system useless.
