### PR TITLE
MBS-11375: Use top-align for release event tables in Edit release

### DIFF
--- a/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
+++ b/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
@@ -116,7 +116,7 @@ const ReleaseEventsDiff = ({
   }
 
   return (
-    <tr>
+    <tr className="release-events-diff">
       <th>{l('Release events:')}</th>
       <td className="old">
         <ul>

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -504,3 +504,12 @@ div.editimage.selected p.currently-selected { display: block; }
     h3 { margin-top: 0; }
     h3, p { margin-left: 0; }
 }
+
+/*
+  Release event diff
+  ================================================
+*/
+
+tr.release-events-diff {
+    td { vertical-align: top; }
+}


### PR DESCRIPTION
### Implement MBS-11375

MBS-11369 changed the vertical align and in most places that's for the best, but release event diff tables are better with top align. Otherwise, a long list being turned into a small one (e.g. [edit #74086408](https://beta.musicbrainz.org/edit/74086408)) has the smaller value way down the page and makes understanding the change a lot harder.
