### PR TITLE
MBS-9706: Normalize OCRemix URLs (including HTTPS)

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/OCReMix.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/OCReMix.pm
@@ -5,6 +5,10 @@ use Moose;
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 
+override href_url => sub {
+    shift->url->as_string =~ s{^http:}{https:}r;
+};
+
 sub sidebar_name { 'OC ReMix' }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2397,6 +2397,13 @@ const CLEANUPS = {
       return {result: false};
     },
   },
+  'ocremix': {
+    match: [new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i')],
+    type: LINK_TYPES.otherdatabases,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?ocremix\.org\//, 'https://ocremix.org/');
+    },
+  },
   'offiziellecharts': {
     match: [new RegExp(
       '^(https?://)?([^/]+\\.)?offiziellecharts\\.de/',
@@ -2479,7 +2486,6 @@ const CLEANUPS = {
       new RegExp('^(https?://)?(www\\.)?spirit-of-metal\\.com/', 'i'),
       new RegExp('^(https?://)?(www\\.)?lortel\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?theatricalia\\.com/', 'i'),
-      new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i'),
       new RegExp('^(https?://)?(www\\.)?imvdb\\.com', 'i'),
       new RegExp('^(https?://)?(www\\.)?vkdb\\.jp', 'i'),
       new RegExp('^(https?://)?(www\\.)?ci\\.nii\\.ac\\.jp', 'i'),

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2520,7 +2520,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?overture\\.doremus\\.org/', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?overture\.doremus\.org\/$/, 'https://overture.doremus.org/');
+      return url.replace(/^(?:https?:\/\/)?overture\.doremus\.org\//, 'https://overture.doremus.org/');
     },
     validate: function (url, id) {
       const m = /^https:\/\/overture\.doremus\.org\/(artist|expression|performance)\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.exec(url);

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2401,7 +2401,9 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?ocremix\\.org/', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?ocremix\.org\//, 'https://ocremix.org/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ocremix\.org\//, 'https://ocremix.org/');
+      url = url.replace(/^https:\/\/ocremix\.org\/(album|artist|game|org|remix|song)\/([^\/?#]+).*$/, 'https://ocremix.org/$1/$2/');
+      return url;
     },
   },
   'offiziellecharts': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2743,6 +2743,13 @@ const testData = [
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://trove.nla.gov.au/work/9438679',
   },
+  // OC ReMix
+  {
+                     input_url: 'http://www.ocremix.org/artist/4792/oneup',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/artist/4792/oneup',
+  },
   // Offizielle Deutsche Charts
   {
                      input_url: 'http://offiziellecharts.de/album-details-392697/?ref=foo',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2839,7 +2839,7 @@ const testData = [
   },
   // Overture by Doremus
   {
-                     input_url: 'https://overture.doremus.org/artist/dc9b7eb2-7727-3d97-9ea5-7861ac99ea6a',
+                     input_url: 'http://overture.doremus.org/artist/dc9b7eb2-7727-3d97-9ea5-7861ac99ea6a',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://overture.doremus.org/artist/dc9b7eb2-7727-3d97-9ea5-7861ac99ea6a',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2748,7 +2748,37 @@ const testData = [
                      input_url: 'http://www.ocremix.org/artist/4792/oneup',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/artist/4792/oneup',
+            expected_clean_url: 'https://ocremix.org/artist/4792/',
+  },
+  {
+                     input_url: 'https://ocremix.org/org/2/nintendo',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/org/2/',
+  },
+  {
+                     input_url: 'https://ocremix.org/album/46/final-fantasy-vi-balance-and-ruin',
+             input_entity_type: 'release',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/album/46/',
+  },
+  {
+                     input_url: 'https://ocremix.org/remix/OCR00002#tab-details',
+             input_entity_type: 'release',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/remix/OCR00002/',
+  },
+  {
+                     input_url: 'http://ocremix.org/game/512/jade-cocoon-story-of-the-tamamayu-ps1',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/game/512/',
+  },
+  {
+                     input_url: 'http://ocremix.org/song/1033',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://ocremix.org/song/1033/',
   },
   // Offizielle Deutsche Charts
   {


### PR DESCRIPTION
### Implement MBS-9706

Validation is MBS-7674 but there's (old) discussion there about whether /remix pages should be freedownload instead. Will do that later once we have more feedback.