### PR TITLE
MBS-11387: Use l_relationships for "instrument" attribute name

### DIFF
--- a/root/static/scripts/common/i18n/localizeLinkAttributeTypeName.js
+++ b/root/static/scripts/common/i18n/localizeLinkAttributeTypeName.js
@@ -10,7 +10,7 @@
 import {INSTRUMENT_ROOT_ID} from '../../common/constants';
 
 function localizeLinkAttributeTypeName(type: LinkAttrTypeT): string {
-  if (type.root_id === INSTRUMENT_ROOT_ID) {
+  if (type.root_id === INSTRUMENT_ROOT_ID && type.id !== INSTRUMENT_ROOT_ID) {
     if (nonEmpty(type.instrument_comment)) {
       return lp_instruments(type.name, type.instrument_comment);
     }


### PR DESCRIPTION
### Fix MBS-11387

type.root_id === INSTRUMENT_ROOT_ID on itself sends all instruments to be translated by l_instruments... but also the actual instrument parent attribute itself, since root_id = id in that case. But "instrument" needs to use l_relationships since it is not currently itself in the instrument context.
