### PR TITLE
MBS-11384 / MBS-11385: Ensure all country context names are translated

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Area.pm
+++ b/lib/MusicBrainz/Server/Entity/Area.pm
@@ -21,8 +21,9 @@ sub entity_type { 'area' }
 
 sub l_name {
     my $self = shift;
-    my $type = defined $self->type ? $self->type->id : $self->type_id;
-    if (defined $type && $type == $AREA_TYPE_COUNTRY) {
+    # Areas with iso_3166_1 codes are the ones we export for translation
+    # in the countries domain. See po/extract_pot_db.
+    if (scalar $self->iso_3166_1_codes > 0) {
         return l($self->name);
     } else {
         return $self->name;

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -169,6 +169,7 @@ import formatTrackLength from './utility/formatTrackLength';
               entityType: json.entityType,
               gid: json.gid,
               href_url: json.href_url,
+              iso_3166_1_codes: json.iso_3166_1_codes,
               name: json.name,
               pretty_name: json.pretty_name,
               sort_name: json.sort_name,
@@ -256,6 +257,13 @@ import formatTrackLength from './utility/formatTrackLength';
   Label.prototype.entityType = 'label';
 
   class Area extends CoreEntity {
+    toJSON() {
+      return Object.assign(
+        super.toJSON(),
+        {iso_3166_1_codes: this.iso_3166_1_codes},
+      );
+    }
+
     selectionMessage() {
       return ReactDOMServer.renderToStaticMarkup(
         exp.l(

--- a/root/static/scripts/common/i18n/localizeAreaName.js
+++ b/root/static/scripts/common/i18n/localizeAreaName.js
@@ -1,5 +1,5 @@
 /*
- * @flow strict-local
+ * @flow strict
  * Copyright (C) 2019 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -7,11 +7,12 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import {AREA_TYPE_COUNTRY} from '../constants';
-
 function localizeAreaName(area: AreaT): string {
-  const areaType = area.typeID;
-  if (areaType === AREA_TYPE_COUNTRY) {
+  /*
+   * Areas with iso_3166_1 codes are the ones we export for translation
+   * in the countries domain. See po/extract_pot_db.
+   */
+  if (area.iso_3166_1_codes.length) {
     return l_countries(area.name);
   }
   return area.name;


### PR DESCRIPTION
### Fix MBS-11384 / MBS-11385

The existence of iso_3166_1 (not the area having the country type) is what matters for whether we make the area name available for translation. As such, that's also what we should be checking for.
