### PR TITLE
MBS-11390: Sum, don't overwrite, added entity counts

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -686,7 +686,13 @@ sub added_entities_counts {
     for my $row (@$rows) {
         my ($type, $count) = @$row;
         # We just ignore any edits that are not one of the desired types
-        $result{$type} = $count unless $type eq 'other';
+        if ($type ne 'other') {
+            if (defined $result{$type}) {
+                $result{$type} += $count;
+            } else {
+                $result{$type} = $count;
+            }
+        }
     }
 
     $self->c->cache->set($cache_key, \%result, 60 * 60 * 24);


### PR DESCRIPTION
### Fix MBS-11390

This was just having two rows for release, so the second would end up overwriting $result{release}. Both lines should be summed up instead.
