### PR TITLE
MBS-11268 / MBS-11349 / MBS-11463: Improvements related to medium duration

### DIFF
--- a/admin/sql/CreateViews.sql
+++ b/admin/sql/CreateViews.sql
@@ -83,6 +83,16 @@ CREATE OR REPLACE VIEW work_series AS
     LEFT OUTER JOIN link_attribute_text_value latv ON (latv.attribute_type = s.ordering_attribute AND latv.link = l.id)
     ORDER BY series, link_order;
 
+CREATE OR REPLACE VIEW medium_track_durations AS
+    SELECT
+        medium.id AS medium,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position = 0) AS pregap_length,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position > 0 AND track.is_data_track = false) AS cdtoc_track_lengths,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.is_data_track = true) AS data_track_lengths
+    FROM medium
+    JOIN track ON track.medium = medium.id
+    GROUP BY medium.id;
+
 COMMIT;
 
 -- vi: set ts=4 sw=4 et :

--- a/admin/sql/DropViews.sql
+++ b/admin/sql/DropViews.sql
@@ -2,6 +2,7 @@
 \unset ON_ERROR_STOP
 
 DROP VIEW event_series;
+DROP VIEW medium_track_durations;
 DROP VIEW recording_series;
 DROP VIEW release_event;
 DROP VIEW release_group_series;

--- a/admin/sql/updates/20200914-oauth-pkce.sql
+++ b/admin/sql/updates/20200914-oauth-pkce.sql
@@ -2,8 +2,6 @@
 
 BEGIN;
 
-SET search_path = musicbrainz, public;
-
 CREATE TYPE oauth_code_challenge_method AS ENUM ('plain', 'S256');
 ALTER TABLE editor_oauth_token ADD COLUMN code_challenge TEXT;
 ALTER TABLE editor_oauth_token ADD COLUMN code_challenge_method oauth_code_challenge_method;

--- a/admin/sql/updates/20201028-mbs-1424-fks.sql
+++ b/admin/sql/updates/20201028-mbs-1424-fks.sql
@@ -1,7 +1,5 @@
 \set ON_ERROR_STOP 1
 
-SET search_path = musicbrainz;
-
 BEGIN;
 
 ALTER TABLE release_first_release_date

--- a/admin/sql/updates/20201028-mbs-1424.sql
+++ b/admin/sql/updates/20201028-mbs-1424.sql
@@ -1,7 +1,5 @@
 \set ON_ERROR_STOP 1
 
-SET search_path = musicbrainz;
-
 BEGIN;
 
 CREATE TABLE release_first_release_date (

--- a/admin/sql/updates/20210215-mbs-11268.sql
+++ b/admin/sql/updates/20210215-mbs-11268.sql
@@ -1,0 +1,15 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+CREATE OR REPLACE VIEW medium_track_durations AS
+    SELECT
+        medium.id AS medium,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position = 0) AS pregap_length,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position > 0 AND track.is_data_track = false) AS cdtoc_track_lengths,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.is_data_track = true) AS data_track_lengths
+    FROM medium
+    JOIN track ON track.medium = medium.id
+    GROUP BY medium.id;
+
+COMMIT;

--- a/admin/sql/updates/schema-change/26.slave.sql
+++ b/admin/sql/updates/schema-change/26.slave.sql
@@ -81,8 +81,6 @@ $$ LANGUAGE 'plpgsql';
 SELECT '20200914-oauth-pkce.sql';
 
 
-SET search_path = musicbrainz, public;
-
 CREATE TYPE oauth_code_challenge_method AS ENUM ('plain', 'S256');
 ALTER TABLE editor_oauth_token ADD COLUMN code_challenge TEXT;
 ALTER TABLE editor_oauth_token ADD COLUMN code_challenge_method oauth_code_challenge_method;
@@ -93,8 +91,6 @@ ALTER TABLE editor_oauth_token ADD CONSTRAINT valid_code_challenge CHECK (
 
 --------------------------------------------------------------------------------
 SELECT '20201028-mbs-1424.sql';
-
-SET search_path = musicbrainz;
 
 
 CREATE TABLE release_first_release_date (

--- a/admin/sql/updates/schema-change/26.slave.sql
+++ b/admin/sql/updates/schema-change/26.slave.sql
@@ -2,6 +2,7 @@
 -- 20200512-mbs-10821-orphaned-recording-collection.sql
 -- 20200914-oauth-pkce.sql
 -- 20201028-mbs-1424.sql
+-- 20210215-mbs-11268.sql
 -- 20210309-mbs-11431.sql
 -- 20210319-mbs-11453.sql
 -- 20210319-mbs-11464.sql
@@ -336,6 +337,20 @@ BEGIN
   RETURN NULL;
 END;
 $$ LANGUAGE 'plpgsql';
+
+--------------------------------------------------------------------------------
+SELECT '20210215-mbs-11268.sql';
+
+
+CREATE OR REPLACE VIEW medium_track_durations AS
+    SELECT
+        medium.id AS medium,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position = 0) AS pregap_length,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.position > 0 AND track.is_data_track = false) AS cdtoc_track_lengths,
+        array_agg(track.length ORDER BY track.position) FILTER (WHERE track.is_data_track = true) AS data_track_lengths
+    FROM medium
+    JOIN track ON track.medium = medium.id
+    GROUP BY medium.id;
 
 --------------------------------------------------------------------------------
 SELECT '20210309-mbs-11431.sql';

--- a/admin/sql/updates/schema-change/26.standalone.sql
+++ b/admin/sql/updates/schema-change/26.standalone.sql
@@ -8,8 +8,6 @@ SET LOCAL statement_timeout = 0;
 --------------------------------------------------------------------------------
 SELECT '20201028-mbs-1424-fks.sql';
 
-SET search_path = musicbrainz;
-
 
 ALTER TABLE release_first_release_date
    ADD CONSTRAINT release_first_release_date_fk_release

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -144,6 +144,7 @@ sub discids : Chained('load') {
     my $release = $c->stash->{release};
     my @medium_cdtocs = $c->model('MediumCDTOC')->load_for_mediums($release->all_mediums);
     $c->model('CDTOC')->load(@medium_cdtocs);
+    $c->model('Medium')->load(@medium_cdtocs);
     $c->stash( has_cdtocs => scalar(@medium_cdtocs) > 0 );
 }
 

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -18,13 +18,14 @@ use Scalar::Util qw( weaken );
 
 sub _table
 {
-    return 'medium';
+    return 'medium LEFT JOIN medium_track_durations mtd ON mtd.medium = medium.id';
 }
 
 sub _columns
 {
     return 'medium.id, release, position, format, medium.name,
             medium.edits_pending, track_count,
+            mtd.pregap_length, mtd.cdtoc_track_lengths, mtd.data_track_lengths,
             COALESCE((SELECT true FROM track WHERE medium = medium.id AND position = 0), false) AS has_pregap,
             (SELECT count(*) FROM track WHERE medium = medium.id AND position > 0 AND is_data_track = false) AS cdtoc_track_count';
 }
@@ -46,6 +47,9 @@ sub _column_mapping
         edits_pending       => 'edits_pending',
         has_pregap          => 'has_pregap',
         cdtoc_track_count   => 'cdtoc_track_count',
+        cdtoc_track_lengths => 'cdtoc_track_lengths',
+        data_track_lengths  => 'data_track_lengths',
+        pregap_length       => 'pregap_length',
     };
 }
 

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -143,6 +143,21 @@ has 'cdtoc_track_count' => (
     isa => 'Int',
 );
 
+has 'cdtoc_track_lengths' => (
+    is => 'rw',
+    isa => 'ArrayRef[Maybe[Int]]'
+);
+
+has 'data_track_lengths' => (
+    is => 'rw',
+    isa => 'ArrayRef[Maybe[Int]]'
+);
+
+has 'pregap_length' => (
+    is => 'rw',
+    isa => 'ArrayRef[Maybe[Int]]'
+);
+
 sub audio_tracks {
     my ($self) = @_;
     return [ grep { !$_->is_data_track } $self->all_tracks ];

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Entity::Medium;
 use Moose;
 
+use List::AllUtils qw( any sum );
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Translation qw( l );
@@ -96,40 +97,26 @@ sub may_have_discids {
 
 =head2 length
 
-Attempt to return the duration of the medium in microseconds.  This
-will return the length of the disc, by looking at the associated
-discids or tracklists.
-
-This will not load any data from the database, so make sure you load
-either the associated tracklists + tracks, the MediumCDTOC +
-CDTOC, or both.
+Returns the duration of the medium in microseconds, including
+possible pregap and data tracks.
+If we have some tracks for which we are missing the durations,
+returns undefined (since we don't actually know the true
+duration of the medium).
 
 =cut
 
 sub length {
     my $self = shift;
 
-    if (scalar $self->all_tracks > 0)
-    {
-        my $length = 0;
+    my @track_times = (
+        @{ $self->pregap_length // [] },
+        @{ $self->cdtoc_track_lengths // [] },
+        @{ $self->data_track_lengths // [] },
+    );
 
-        for my $trk ($self->all_tracks)
-        {
-            return undef unless defined $trk->length;
+    return undef if any { !defined $_ } @track_times;
 
-            $length += $trk->length;
-        }
-
-        return $length;
-    }
-    elsif ($self->cdtocs->[0] && $self->cdtocs->[0]->cdtoc)
-    {
-        return $self->cdtocs->[0]->cdtoc->length;
-    }
-    else
-    {
-        return undef;
-    }
+    return sum @track_times;
 }
 
 has 'has_pregap' => (

--- a/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
@@ -33,11 +33,11 @@ sub is_perfect_match {
     my ($self) = @_;
 
     my @cdtoc_info = @{ $self->cdtoc->track_details };
-    my @medium_tracks = @{ $self->medium->cdtoc_tracks };
+    my @medium_track_lengths = @{ $self->medium->cdtoc_track_lengths };
 
-    return (@cdtoc_info == @medium_tracks) && all {
-      defined $_->[1]->length && $_->[0]{length_time} == $_->[1]->length
-    } (pairs (zip @cdtoc_info, @medium_tracks));
+    return (@cdtoc_info == @medium_track_lengths) && all {
+      defined $_->[1] && $_->[0]{length_time} == $_->[1]
+    } (pairs (zip @cdtoc_info, @medium_track_lengths));
 }
 
 around TO_JSON => sub {

--- a/root/release/discids.tt
+++ b/root/release/discids.tt
@@ -30,6 +30,12 @@
                     <td>[% medium_cdtoc.cdtoc.length | format_length %]</td>
                     [% IF c.user_exists %]
                     <td>
+                      [%- IF !medium_cdtoc.is_perfect_match %]
+                        <a href="[% c.uri_for_action('/cdtoc/set_durations',
+                                        [ medium_cdtoc.cdtoc.discid ], { medium => medium.id }) %]">
+                          [% l('Set track durations') %]
+                        </a> |
+                      [%- END %]
                       <a href="[% c.uri_for_action('cdtoc/remove',
                                                    { cdtoc_id  => medium_cdtoc.cdtoc.id,
                                                      medium_id => medium.id }) %]">

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
@@ -38,12 +38,14 @@ page_test_jsonld $mech => {
         {
             'name' => 'Aerial',
             '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
-            '@type' => 'MusicRelease'
+            '@type' => 'MusicRelease',
+            'duration' => 'PT1H20M05S',
         },
         {
             '@id' => 'http://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
             '@type' => 'MusicRelease',
-            'name' => 'Aerial'
+            'name' => 'Aerial',
+            'duration' => 'PT1H20M05S',
         },
         {
             'name' => 'Arrival',

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -50,6 +50,7 @@ test all => sub {
         ],
         '@type' => 'MusicRelease',
         'catalogNumber' => '343 960 2',
+        'duration' => 'PT1H20M05S',
         '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
         'name' => 'Aerial',
         'musicReleaseFormat' => 'http://schema.org/CDFormat',

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
@@ -72,12 +72,14 @@ page_test_jsonld $mech => {
         {
             '@type' => 'MusicRelease',
             'name' => 'Aerial',
-            '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80'
+            '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
+            'duration' => 'PT1H20M05S',
         },
         {
             '@id' => 'http://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
             'name' => 'Aerial',
-            '@type' => 'MusicRelease'
+            '@type' => 'MusicRelease',
+            'duration' => 'PT1H20M05S',
         }
     ],
     'albumProductionType' => 'http://schema.org/StudioAlbum',

--- a/t/lib/t/MusicBrainz/Server/Data/Medium.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Medium.pm
@@ -54,7 +54,6 @@ test 'Insert medium' => sub {
     my $medium = $c->model('Medium')->get_by_id($created->{id});
     isa_ok($medium, 'MusicBrainz::Server::Entity::Medium');
 
-    $c->model('Track')->load_for_mediums($medium);
     is($medium->length, 330160 + 262000, "inserted medium has expected length");
 
     my $trackoffset0 = 150;

--- a/t/lib/t/MusicBrainz/Server/Entity/Medium.pm
+++ b/t/lib/t/MusicBrainz/Server/Entity/Medium.pm
@@ -13,19 +13,6 @@ use aliased 'MusicBrainz::Server::Entity::Recording';
 use aliased 'MusicBrainz::Server::Entity::Relationship';
 use aliased 'MusicBrainz::Server::Entity::Track';
 
-test 'length' => sub {
-
-    my $medium = Medium->new();
-
-    ok(!defined $medium->length, "empty medium has no length");
-
-    $medium->add_track(Track->new(name => 'Courtesy', length => 193000));
-    $medium->add_track(Track->new(name => 'Otis',     length => 156000));
-    $medium->add_track(Track->new(name => 'Focus',    length => 162000));
-
-    is($medium->length, 511000, "medium has correct length from tracks");
-};
-
 test 'combined_track_relationships' => sub {
     my $medium = Medium->new();
 

--- a/upgrade.json
+++ b/upgrade.json
@@ -82,6 +82,7 @@
     "slave": ["20200512-mbs-10821-orphaned-recording-collection.sql",
               "20200914-oauth-pkce.sql",
               "20201028-mbs-1424.sql",
+              "20210215-mbs-11268.sql",
               "20210309-mbs-11431.sql",
               "20210319-mbs-11453.sql",
               "20210319-mbs-11464.sql",


### PR DESCRIPTION
### Implement MBS-11268 / MBS-11463 and fix MBS-11349

This adds a view (MBS-11463) that allows us to access the durations of medium tracks without having to load all the data for every track in Moose.

Using this view, I re-implemented MBS-11268 (which seems to work fine now).

I also implemented MBS-11349 by replacing the complicated calculation of medium length based on either loaded tracks or discIDs with a calculation based on the values in this view.

A good place to test both of these seems to be http://localhost:5000/release/ab9e6f50-b248-4ed2-a591-1f175e609e44 (in the sample data).

NB: I wouldn't be surprised if there are some places where we loaded tracks or discIDs only to get medium durations, and if so those loads could now be removed. If you can think of any, do let me know! Guess there's no good way to find this programmatically.