### PR TITLE
MBS-10343 / MBS-11394: Deal with darkened cover art

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -86,11 +86,13 @@ after 'load' => sub {
         }
     }
 
-    my $artwork = $c->model('Artwork')->find_front_cover_by_release($release);
-    $c->stash->{release_artwork} = $artwork->[0];
+    if ($release->may_have_cover_art) {
+        my $artwork = $c->model('Artwork')->find_front_cover_by_release($release);
+        $c->stash->{release_artwork} = $artwork->[0];
 
-    my $artwork_count = $c->model('Artwork')->find_count_by_release($release->id);
-    $c->stash->{release_artwork_count} = $artwork_count;
+        my $artwork_count = $c->model('Artwork')->find_count_by_release($release->id);
+        $c->stash->{release_artwork_count} = $artwork_count;
+    }
 
     my $cdtoc_count = $c->model('MediumCDTOC')->find_count_by_release($release->id);
     $c->stash->{release_cdtoc_count} = $cdtoc_count;
@@ -610,8 +612,12 @@ sub cover_art : Chained('load') PathPart('cover-art') {
     my $release = $c->stash->{entity};
     $c->model('Release')->load_meta($release);
 
-    my $artwork = $c->model('Artwork')->find_by_release($release);
-    $c->model('CoverArtType')->load_for(@$artwork);
+    my $artwork = [];
+
+    if ($release->may_have_cover_art) {
+        $artwork = $c->model('Artwork')->find_by_release($release);
+        $c->model('CoverArtType')->load_for(@$artwork);
+    }
 
     $c->stash(
         # Needed for JSON-LD

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -110,9 +110,11 @@ function buildLinks(
 
   if (entityProperties.cover_art) {
     links.push(buildLink(
-      texp.l(
-        'Cover Art ({num})',
-        {num: $c.stash.release_artwork_count || 0},
+      entity.cover_art_presence === 'darkened' ? l('Cover Art') : (
+        texp.l(
+          'Cover Art ({num})',
+          {num: $c.stash.release_artwork_count || 0},
+        )
       ),
       entity,
       'cover-art',

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -98,39 +98,40 @@ const ReleaseSidebar = ({
               {all: entityHref(release, 'cover-art')},
             ))}
           />
-        ) : (
-          release.cover_art_presence !== 'darkened' &&
-            releaseCoverUrl
-            /* flow-include && releaseCoverHost === true */ ? (
-              <>
-                <img src={releaseCoverUrl} />
-                <span className="cover-art-note">
-                  {/(?:ssl-)?images-amazon\.com/.test(releaseCoverHost) ? (
-                    exp.l('Cover art from {cover|Amazon}', {
-                      cover: releaseCoverUrl,
-                    })
-                  ) : (
-                    exp.l('Cover art from {cover|{host}}', {
-                      cover: releaseCoverUrl,
-                      host: releaseCoverHost,
-                    })
-                  )}
-                </span>
-              </>
-            ) : (
-              <p className="cover-art-note" style={{textAlign: 'left'}}>
-                {release.cover_art_presence === 'present' ? (
-                  <>
-                    {l('No front cover image available.')}
-                    <br />
-                    <a href={entityHref(release, 'cover-art')}>
-                      {l('View all artwork')}
-                    </a>
-                  </>
-                ) : l('No cover art available.')}
-              </p>
-            )
-        )}
+        ) : release.cover_art_presence === 'darkened' ? (
+          l(`Cover art for this release has been hidden
+             by the Internet Archive because of a takedown request.`)
+        ) : releaseCoverUrl
+          /* flow-include && releaseCoverHost === true */ ? (
+            <>
+              <img src={releaseCoverUrl} />
+              <span className="cover-art-note">
+                {/(?:ssl-)?images-amazon\.com/.test(releaseCoverHost) ? (
+                  exp.l('Cover art from {cover|Amazon}', {
+                    cover: releaseCoverUrl,
+                  })
+                ) : (
+                  exp.l('Cover art from {cover|{host}}', {
+                    cover: releaseCoverUrl,
+                    host: releaseCoverHost,
+                  })
+                )}
+              </span>
+            </>
+          ) : (
+            <p className="cover-art-note" style={{textAlign: 'left'}}>
+              {release.cover_art_presence === 'present' ? (
+                <>
+                  {l('No front cover image available.')}
+                  <br />
+                  <a href={entityHref(release, 'cover-art')}>
+                    {l('View all artwork')}
+                  </a>
+                </>
+              ) : l('No cover art available.')}
+            </p>
+          )
+        }
       </div>
 
       <h2 className="release-information">

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -52,9 +52,18 @@ const CoverArt = ({
 
   return (
     <ReleaseLayout $c={$c} entity={release} page="cover-art" title={title}>
-      <h2>{title}</h2>
+      <h2>
+        {release.cover_art_presence === 'darkened'
+          ? l('Cannot show cover art')
+          : title}
+      </h2>
 
-      {coverArt.length ? (
+      {release.cover_art_presence === 'darkened' ? (
+        <p>
+          {l(`Cover art for this release has been hidden
+              by the Internet Archive because of a takedown request.`)}
+        </p>
+      ) : coverArt.length ? (
         <>
           {coverArt.map(artwork => (
             <div
@@ -136,8 +145,8 @@ const CoverArt = ({
         </>
       )}
 
-      {$c.user ? (
-        release.may_have_cover_art /*:: === true */ ? (
+      {release.may_have_cover_art /*:: === true */ ? (
+        $c.user ? (
           <div className="buttons ui-helper-clearfix">
             <EntityLink
               content={lp('Add Cover Art', 'button/menu')}
@@ -153,22 +162,11 @@ const CoverArt = ({
             ) : null}
           </div>
         ) : (
-          <>
-            <h2>{l('Cannot Add Cover Art')}</h2>
-            <p>
-              {l(
-                `The Cover Art Archive has had a takedown request
-                 in the past for this release,
-                 so we are unable to allow any more uploads.`,
-              )}
-            </p>
-          </>
+          <p>
+            <RequestLogin $c={$c} text={l('Log in to upload cover art')} />
+          </p>
         )
-      ) : (
-        <p>
-          <RequestLogin $c={$c} text={l('Log in to upload cover art')} />
-        </p>
-      )}
+      ) : null}
     </ReleaseLayout>
   );
 };

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -157,7 +157,7 @@ const CoverArt = ({
             <h2>{l('Cannot Add Cover Art')}</h2>
             <p>
               {l(
-                `The Cover Art Archive has had a take down request
+                `The Cover Art Archive has had a takedown request
                  in the past for this release,
                  so we are unable to allow any more uploads.`,
               )}

--- a/root/release/CoverArtDarkened.js
+++ b/root/release/CoverArtDarkened.js
@@ -26,7 +26,7 @@ const CoverArtDarkened = ({
     <ReleaseLayout $c={$c} entity={release} page="cover-art" title={title}>
       <h2>{title}</h2>
       <p>
-        {l(`The Cover Art Archive has had a take down request in the past
+        {l(`The Cover Art Archive has had a takedown request in the past
             for this release, so we are unable to allow any more uploads.`)}
       </p>
     </ReleaseLayout>


### PR DESCRIPTION
### Implement MBS-10343 / MBS-11394

See commit messages for more details.

Darkened status isn't currently being updated properly (MBS-6567), but at least with this it will show up as it should once that is fixed.