### PR TITLE
MBS-10312: Remove tracking parameters from URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -325,6 +325,47 @@ function findAmazonTld(url) {
   return tld;
 }
 
+const TRACKING_PARAMS = [
+  // https://en.wikipedia.org/wiki/Click_identifier
+  'dclid',
+  'gclid',
+  'gclsrc',
+  'msclkid',
+  'zanpid',
+  // https://fbclid.com
+  'fbclid',
+  // https://support.google.com/analytics/answer/1033863#parameters
+  'utm_campaign',
+  'utm_content',
+  'utm_medium',
+  'utm_source',
+  'utm_term',
+];
+
+function stripTrackingParams(url) {
+  let urlObject;
+
+  // do nothing if the URL is invalid or URL() is unsupported (IE11)
+  try {
+    urlObject = new URL(url);
+  } catch (_) {
+    return url;
+  }
+
+  const params = urlObject.searchParams;
+  const paramKeys = new Set(params.keys());
+  let changed = false;
+
+  for (const param of paramKeys) {
+    if (TRACKING_PARAMS.includes(param)) {
+      params.delete(param);
+      changed = true;
+    }
+  }
+
+  return changed ? urlObject.href : url;
+}
+
 const linkToChannelMsg = N_l(
   `Please link to a channel, not a specific video.
    Videos should be linked to the appropriate
@@ -3650,7 +3691,7 @@ export function guessType(sourceType, currentURL) {
 }
 
 export function cleanURL(dirtyURL) {
-  dirtyURL = dirtyURL.trim().replace(/(%E2%80%8E|\u200E)$/, '');
+  dirtyURL = stripTrackingParams(dirtyURL.trim().replace(/(%E2%80%8E|\u200E)$/, ''));
 
   const cleanup = CLEANUP_ENTRIES.find(function (cleanup) {
     return cleanup.clean && testAll(cleanup.match, dirtyURL);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4402,6 +4402,35 @@ const testData = [
        input_relationship_type: 'youtube',
        only_valid_entity_types: [],
   },
+  // Tracking parameter removal
+  {
+                     input_url: 'https://example.com/track/rotational-squelch?from=fanpub_fnb_trk&utm_source=track_release&utm_medium=email&utm_content=fanpub_fnb_trk&utm_campaign=pyecorneraudio+track+rotational-squelch',
+            expected_clean_url: 'https://example.com/track/rotational-squelch?from=fanpub_fnb_trk',
+  },
+  {
+                     input_url: 'https://example.com/foo/?fbclid=IwAR2wZYFDYjeQMBFKyI06in-7NH3fNSFpc6bborfUrMwwjQVFOnMMXIzHR6k',
+            expected_clean_url: 'https://example.com/foo/',
+  },
+  {
+                     input_url: 'https://www.demorgen.be/tv-cultuur/studio-brussel-presentator-christophe-lambrecht-overleden~bc83b530/?utm_medium=email&utm_content=breaking&utm_userid=&ctm_ctid=5a536e7b4c4b6ead8590b8a296ff5796',
+            expected_clean_url: 'https://www.demorgen.be/tv-cultuur/studio-brussel-presentator-christophe-lambrecht-overleden~bc83b530/?utm_userid=&ctm_ctid=5a536e7b4c4b6ead8590b8a296ff5796',
+  },
+  {
+                     input_url: 'https://example.com/release/110221-dopplereffekt-athanatos?utm_source=Bleep&utm_campaign=1f6171e682-Dopplereffekt+-+Athanatos+(Leisure+System)&utm_medium=email&utm_term=0_db8ca97389-1f6171e682-1595401',
+            expected_clean_url: 'https://example.com/release/110221-dopplereffekt-athanatos',
+  },
+  {
+                     input_url: 'https://www.animate-onlineshop.jp/pd/1651937/?utm_source=Official&utm_medium=banner&utm_campaign=audio_pd1651937_190523',
+            expected_clean_url: 'https://www.animate-onlineshop.jp/pd/1651937/',
+  },
+  {
+                     input_url: 'https://song.link/s/06R9ZdwT1LavtD2X0AgVK4?fbclid=IwAR298WbFpP4fPP32zAzc6QiGf37EvBxTkBDcaYMA9EHdnLWXw5yZ2hktTNc',
+            expected_clean_url: 'https://song.link/s/06R9ZdwT1LavtD2X0AgVK4',
+  },
+  {
+                     input_url: 'https://preorder.pl/muzyka/polska/elwis-picasso-deluxe?gclid=EAIaIQobChMIu6mmte-C5QIVjLHtCh0f8w1SEAAYASAAEgKCzvD_BwE&gclsrc=aw.ds',
+           expected_clean_url: 'https://preorder.pl/muzyka/polska/elwis-picasso-deluxe',
+  },
 ];
 /* eslint-enable indent, max-len, sort-keys */
 


### PR DESCRIPTION
The functionality added here will not work in IE11 due to the use of the `URL()` constructor, however it should fail gracefully and just return the original URL in such cases. I feel this is a reasonable compromise, as the functionality is not crucial and the alternative would be to implement a clunky regexp based parameter parser.