### PR TITLE
MBS-10227: Display entity count on collection page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -26,6 +26,7 @@ after 'load' => sub {
             $c->user->id, $collection->id);
     }
 
+    $c->model('Collection')->load_entity_count($collection);
     # Load editor and collaborators
     $c->model('Editor')->load_for_collection($collection);
     $c->model('CollectionType')->load($collection);
@@ -273,8 +274,6 @@ sub edit : Chained('own_collection') RequireAuth {
     my $collection = $c->stash->{collection};
 
     my $form = $c->form( form => 'Collection', init_object => $collection );
-
-    $c->model('Collection')->load_entity_count($collection);
 
     if ($c->form_posted_and_valid($form)) {
         my %update = $self->_form_to_hash($form);

--- a/root/layout/components/sidebar/CollectionSidebar.js
+++ b/root/layout/components/sidebar/CollectionSidebar.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import EditorLink from '../../../static/scripts/common/components/EditorLink';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
+import {formatCount} from '../../../statistics/utilities';
 import {returnToCurrentPage} from '../../../utility/returnUri';
 
 import {SidebarProperties, SidebarProperty} from './SidebarProperties';
@@ -42,6 +43,13 @@ const CollectionSidebar = ({
             {lp_attributes(typeName, 'collection_type')}
           </SidebarProperty>
         ) : null}
+
+        <SidebarProperty
+          className=""
+          label={addColonText(l('Number of entities'))}
+        >
+          {formatCount($c, collection.entity_count)}
+        </SidebarProperty>
       </SidebarProperties>
 
       <h2 className="editing">{l('Editing')}</h2>


### PR DESCRIPTION
### Implement MBS-10227

This also changes it so that entity_count is loaded by default for collections, which was already expected by CollectionT.