### PR TITLE
MBS-11389: Top-align edit medium Tracklist tables

### DIFF
--- a/root/edit/details/EditMedium.js
+++ b/root/edit/details/EditMedium.js
@@ -138,7 +138,7 @@ const TracklistChangesAdd = ({
 }: TracklistChangesAddProps): React.Element<'tr'> => {
   const track = change.new_track;
   return (
-    <tr className="diff-addition">
+    <tr className="diff-addition edit-medium-track">
       <td colSpan="4" />
       <td className="pos t">
         {track.number}
@@ -237,7 +237,7 @@ const TracklistChangesChange = ({
   );
 
   return (
-    <tr className={loopParity(index)}>
+    <tr className={'edit-medium-track ' + loopParity(index)}>
       <td className="pos t">
         {oldNumberDiff}
       </td>
@@ -311,7 +311,7 @@ const TracklistChangesRemove = ({
 }: TracklistChangesRemoveProps): React.Element<'tr'> => {
   const track = change.old_track;
   return (
-    <tr className="diff-removal">
+    <tr className="diff-removal edit-medium-track">
       <td className="pos t">
         {track.number}
       </td>

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -506,10 +506,11 @@ div.editimage.selected p.currently-selected { display: block; }
 }
 
 /*
-  Release event diff
+  Vertical align for specific edit tables
   ================================================
 */
 
-tr.release-events-diff {
+tr.release-events-diff,
+tr.edit-medium-track {
     td { vertical-align: top; }
 }


### PR DESCRIPTION
### Implement MBS-11389

This matches the display on release tracklists. It used to be this way here too until commit 50c8156d829221d623eb1c045dcbde13f695baf4
