### PR TITLE
MBS-11397: Show place-series rels on series page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -16,7 +16,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'series',
     relationships => {
         cardinal => ['edit'],
-        subset => {show => ['artist', 'label', 'series', 'url']},
+        subset => {show => ['artist', 'label', 'place', 'series', 'url']},
         default => ['url']
     },
 };


### PR DESCRIPTION
### Fix MBS-11397

I just added the first place-series rel type, so we should show it.
