### PR TITLE
MBS-11396: Show item_entity_type on Series/CollectionType admin tables

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CollectionType.pm
+++ b/lib/MusicBrainz/Server/Entity/CollectionType.pm
@@ -21,6 +21,15 @@ sub l_name {
     return lp($self->name, 'collection_type')
 }
 
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    return {
+        %{ $self->$orig },
+        item_entity_type => $self->item_entity_type,
+    };
+};
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -74,7 +74,7 @@ const renderAttributes = (attribute) => {
     }
     case 'series_type':
     case 'collection_type': {
-      return <td>{attribute.entityType}</td>;
+      return <td>{attribute.item_entity_type}</td>;
     }
     case 'work_attribute_type': {
       return <td>{yesNo(attribute.free_text)}</td>;


### PR DESCRIPTION
### Fix MBS-11396

Obviously the point of these was not to show "series_type" or "collection_type" for every row, but to show item_entity_type - what type of entities are allowed as part of the series or collection.