### PR TITLE
MBS-5680: Allow inc=artist-credits in combination with rels incs that have ACs

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -53,8 +53,11 @@ our %relation_types = (
 # helps validate the second case (inc=recordings).
 our %extra_inc = (
     'recordings' => [ qw( artist-credits puids isrcs ) ],
+    'recording-rels' => [ qw( artist-credits ) ],
     'releases' => [ qw( artist-credits discids media type status ) ],
+    'release-rels' => [ qw( artist-credits ) ],
     'release-groups' => [ qw( artist-credits type ) ],
+    'release-group-rels' => [ qw( artist-credits ) ],
     'works' => [ qw( artist-credits ) ],
 );
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRecording.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRecording.pm
@@ -283,11 +283,25 @@ test 'recording lookup with release relationships' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
 
-    ws_test_json 'recording lookup with release relationships',
-    '/recording/37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9?inc=release-rels' =>
+    ws_test_json 'recording lookup with release relationships and artist credits',
+    '/recording/37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9?inc=release-rels+artist-credits' =>
         {
             id => "37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9",
             title => "Dear Diary",
+            "artist-credit" => [
+                {
+                    name => "Wedlock",
+                    artist => {
+                        id => "6fe9f838-112e-44f1-af83-97464f08285b",
+                        name => "Wedlock",
+                        "sort-name" => "Wedlock",
+                        disambiguation => "USA electro pop",
+                        "type" => "Group",
+                        "type-id" => 'e431f5f6-b5d2-343d-8b36-72607fffb74b',
+                    },
+                    joinphrase => "",
+                },
+            ],
             disambiguation => "",
             length => 86666,
             video => JSON::false,
@@ -304,6 +318,20 @@ test 'recording lookup with release relationships' => sub {
                         barcode => '634479663338',
                         country => 'US',
                         date => '2007-11-08',
+                        "artist-credit" => [
+                            {
+                                name => "Paul Allgood",
+                                artist => {
+                                    id => "05d83760-08b5-42bb-a8d7-00d80b3bf47c",
+                                    name => "Paul Allgood",
+                                    "sort-name" => "Allgood, Paul",
+                                    disambiguation => "",
+                                    "type" => JSON::null,
+                                    "type-id" => JSON::null,
+                                },
+                                joinphrase => "",
+                            },
+                        ],
                         "release-events" => [{
                             area => {
                               disambiguation => '',

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRecording.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRecording.pm
@@ -221,12 +221,21 @@ ws_test 'recording lookup with puids (no-op) and isrcs',
     </recording>
 </metadata>';
 
-ws_test 'recording lookup with release relationships',
-    '/recording/37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9?inc=release-rels' =>
+ws_test 'recording lookup with release relationships and artist credits',
+    '/recording/37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9?inc=release-rels+artist-credits' =>
     '<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
     <recording id="37a8d72a-a9c9-4edc-9ecf-b5b58e6197a9">
         <title>Dear Diary</title>
+        <artist-credit>
+            <name-credit>
+                <artist id="6fe9f838-112e-44f1-af83-97464f08285b" type="Group" type-id="e431f5f6-b5d2-343d-8b36-72607fffb74b">
+                    <name>Wedlock</name>
+                    <sort-name>Wedlock</sort-name>
+                    <disambiguation>USA electro pop</disambiguation>
+                </artist>
+            </name-credit>
+        </artist-credit>
         <length>86666</length>
         <first-release-date>2008-04-29</first-release-date>
         <relation-list target-type="release">
@@ -236,6 +245,14 @@ ws_test 'recording lookup with release relationships',
                 <begin>2008</begin>
                 <release id="4ccb3e54-caab-4ad4-94a6-a598e0e52eec">
                     <title>An Inextricable Tale Audiobook</title>
+                    <artist-credit>
+                        <name-credit>
+                            <artist id="05d83760-08b5-42bb-a8d7-00d80b3bf47c">
+                                <name>Paul Allgood</name>
+                                <sort-name>Allgood, Paul</sort-name>
+                            </artist>
+                        </name-credit>
+                    </artist-credit>
                     <quality>normal</quality>
                     <text-representation>
                         <language>eng</language>


### PR DESCRIPTION
### Implement MBS-5680

Currently, you can do a query including recording-rels for an artist, or a work, but the returned related recordings will not include their artist credit. You also can't just add artist-credits to the inc, because the validator rejects that.
This isn't reasonable - it's perfectly legitimate to ask for artist-credits when requesting recording, release or release group rels, since all of those have artist credits.
