### PR TITLE
MBS-10117: Fix broken maxlength password message on register page

### DIFF
--- a/lib/MusicBrainz/Server/Form/User/Register.pm
+++ b/lib/MusicBrainz/Server/Form/User/Register.pm
@@ -10,11 +10,27 @@ with 'MusicBrainz::Server::Form::Role::CSRFToken';
 
 has '+name' => ( default => 'register' );
 
+my $text_too_long_message = N_l('The value of this field cannot be longer than {max} characters, but you entered {actual}.');
+
+sub localize_method_with_text_maxlength {
+    my ($self, $message, @args) = @_;
+    
+    if ($message eq $text_too_long_message) {
+        return l($message, { max => $args[0], actual => $args[1] });
+    }
+
+    return l($message);
+}
+
 has_field 'username' => (
     type      => 'Text',
     required  => 1,
     maxlength => 64,
     validate_method => \&validate_username,
+    messages  => {
+        text_maxlength => $text_too_long_message,
+    },
+    localize_meth => \&localize_method_with_text_maxlength,
 );
 
 has_field 'password' => (
@@ -22,8 +38,11 @@ has_field 'password' => (
     required  => 1,
     minlength => 1,
     maxlength => 64,
-    messages  => { required => N_l('Please enter a password in this field') },
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); }
+    messages  => {
+        required => N_l('Please enter a password in this field'),
+        text_maxlength => $text_too_long_message,
+    },
+    localize_meth => \&localize_method_with_text_maxlength,
 );
 
 has_field 'confirm_password' => (


### PR DESCRIPTION
### Fix MBS-10117

Trying to pass the default message through l() breaks it, displaying "Field should not exceed [quant,_1,character]. You entered [_2]". It also can't be translated anyway, since it's not exported to .pot files. So I'm adding a custom error message that can be used for text_maxlength for both password and username, which fixes the issue and should also allow translating it. It seems unneeded to have separate error messages just changing the field name, since these get displayed just under the relevant field anyway.