### PR TITLE
MBS-10470: Rename "IRC" link in footer to "Chat (IRC)"

### DIFF
--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -30,7 +30,9 @@ const Footer = ({$c}: Props): React.Element<'div'> => {
         {' | '}
         <a className="internal" href="https://community.metabrainz.org/">{l('Forums')}</a>
         {' | '}
-        <a className="internal" href="/doc/Communication/IRC">{l('IRC')}</a>
+        <a className="internal" href="/doc/Communication/IRC">
+          {l('Chat (IRC)')}
+        </a>
         {' | '}
         <a className="internal" href="http://tickets.metabrainz.org/">{l('Bug Tracker')}</a>
         {' | '}


### PR DESCRIPTION
### Implement MBS-10470

Suggestion was to make this "Chat" because it is more clear to new users. While that is probably true, other users might still search for "IRC", so I feel "Chat (IRC)" is short enough, clear enough for newbies and still useful for people who are searching for an IRC link.

I also re-ordered and slightly simplified the doc page it links to so that there's less to read before you figure out where to go to chat: https://wiki.musicbrainz.org/index.php?title=Communication%2FIRC&type=revision&diff=75211&oldid=74290 