### PR TITLE
MBS-10478: Show useful message if too large search result page requested

### DIFF
--- a/root/search/components/PaginatedSearchResults.js
+++ b/root/search/components/PaginatedSearchResults.js
@@ -9,8 +9,10 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import PaginatedResults from '../../components/PaginatedResults';
 import {type SearchResultT} from '../types';
+import uriWith from '../../utility/uriWith';
 
 type Props<T> = {
   +buildResult: (SearchResultT<T>, number) => React.Node,
@@ -27,6 +29,12 @@ const PaginatedSearchResults = <T>({
   query,
   results,
 }: Props<T>): React.Element<typeof PaginatedResults | 'p'> => {
+  const $c = React.useContext(CatalystContext);
+  const hasLastPage = pager.total_entries > 0;
+  const lastPageUrl = hasLastPage
+    ? uriWith($c.req.uri, {page: pager.last_page})
+    : null;
+
   return results.length ? (
     <PaginatedResults pager={pager} query={query} search>
       <table className="tbl">
@@ -40,6 +48,13 @@ const PaginatedSearchResults = <T>({
         </tbody>
       </table>
     </PaginatedResults>
+  ) : nonEmpty(lastPageUrl) ? (
+    <p>
+      {exp.l(
+        'The last page of results is page {last_page}.',
+        {last_page: <a href={lastPageUrl}>{pager.last_page}</a>},
+      )}
+    </p>
   ) : <p>{l('No results found. Try refining your search query.')}</p>;
 };
 


### PR DESCRIPTION
### Implement MBS-10478

This currently loads the page and just says "no results", which is quite misleading and also useless. We have all the info to show something useful, so we should do that and at least tell the user which page is the last they can go to.

![Screenshot from 2022-07-27 21-51-20](https://user-images.githubusercontent.com/1069224/181350542-487a626a-92b9-4f04-8123-5df778932349.png)
