### PR TITLE
MBS-10312: Fix tracking parameter removal in Firefox 44

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -353,17 +353,12 @@ function stripTrackingParams(url) {
   }
 
   const params = urlObject.searchParams;
-  const paramKeys = new Set(params.keys());
-  let changed = false;
 
-  for (const param of paramKeys) {
-    if (TRACKING_PARAMS.includes(param)) {
-      params.delete(param);
-      changed = true;
-    }
-  }
+  TRACKING_PARAMS.forEach(function (param) {
+    params.delete(param);
+  });
 
-  return changed ? urlObject.href : url;
+  return urlObject.href;
 }
 
 const linkToChannelMsg = N_l(


### PR DESCRIPTION
This commit fixes issues with the tracking parameter removal functionality in Firefox 44.

Unfortunately I've been unable to test the changes as I'm having issues initialising the database in my MB Docker instance.