### PR TITLE
MBS-11405: Don't show ended URL rels in DeprecatedRelationship reports

### DIFF
--- a/lib/MusicBrainz/Server/Report/DeprecatedRelationshipReport.pm
+++ b/lib/MusicBrainz/Server/Report/DeprecatedRelationshipReport.pm
@@ -10,24 +10,32 @@ sub query {
     my ($self) = @_;
     my $entity_type = $self->entity_type;
     my $name_sort = $entity_type ne 'url' ? 'entity.name COLLATE musicbrainz' : 'entity.url';
-    my $extra_conditions = $entity_type eq 'url' ? ' AND link.ended IS FALSE' : '';
     my @tables = $self->c->model('Relationship')->generate_table_list($entity_type);
+    my @url_table_names = map { $_->[0] } $self->c->model('Relationship')->generate_table_list('url');
     my $query = "SELECT l.name AS link_name, l.gid AS link_gid, entity.id AS ${entity_type}_id, row_number() OVER (ORDER BY l.name, $name_sort)" .
                 "FROM $entity_type AS entity JOIN (";
     my $first = 1;
     foreach my $t (@tables) {
         my ($table, $type_column) = @$t;
+
         if ($first) {
             $first = 0;
         } else {
             $query .= " UNION ";
         }
+
         $query .= "SELECT link_type.name AS name, link_type.gid AS gid, $type_column AS entity
                    FROM link_type
                    JOIN link ON link.link_type = link_type.id
                    JOIN $table l_table ON l_table.link = link.id
-                   WHERE (link_type.is_deprecated OR link_type.description = '')
-                   $extra_conditions";
+                   WHERE (link_type.is_deprecated OR link_type.description = '')";
+        
+        # For URL relationships, ignore ended ones (that means the link is no longer
+        # valid, yet being kept for history)
+        if (grep(/^$table/, @url_table_names)) {
+            $query .= ' AND link.ended IS FALSE';
+        }
+        
     }
     $query .= ") l ON l.entity = entity.id";
     return $query;


### PR DESCRIPTION
### Implement MBS-11405

This generalizes MBS-11336 to not only hide ended URL rels in DeprecatedRelationshipURLs, but also on all other DeprecatedRelationship reports. URL rels set as 'ended' are just kept for historical reasons, so we do not want people to remove them or change them.

Tested by running the reports again and comparing.