### PR TITLE
MBS-11407: Make Controller->error use React errors

### DIFF
--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -260,8 +260,11 @@ sub error {
     my $status = $args{status} || 500;
     $c->response->status($status);
     $c->stash(
-        template => "main/$status.tt",
-        message => $args{message}
+        current_view => 'Node',
+        component_path => "main/error/Error$status",
+        component_props => {
+            message => $args{message}
+        }
     );
     $c->detach;
 }


### PR DESCRIPTION
### Fix MBS-11407

This got missed when we did the conversion, and .tt error templates no longer exist.
