### PR TITLE
MBS-10012: Treat http and https version of link as same for adding

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -480,7 +480,13 @@ function newLinkState(state: $Shape<LinkStateT>) {
 }
 
 function linkTypeAndUrlString(link) {
-  return (link.type || '') + '\0' + link.url;
+  /*
+   * There's no reason why we should allow adding the same relationship
+   * twice when the only difference is http vs https, so normalize this
+   * for the check.
+   */
+  const httpUrl = link.url.replace(/^https/, 'http');
+  return (link.type || '') + '\0' + httpUrl;
 }
 
 function isEmpty(link) {


### PR DESCRIPTION
### Implement MBS-10012

There's no reason I can see why we shouldn't block adding a http link if https exists already, and vice versa. I haven't seen any side effects of just making linkTypeAndUrlString normalize it.

Tested by both trying to add the two links from the ticket (http://www.example.com/path/object vs https://www.example.com/path/object) on artist creation and release creation, and by adding both to an artist (temporarily the code disallowing this) and then checking that they are detected as duplicates on loading the artist edit page once the code is changed back.