### PR TITLE
MBS-10004: JSON-LD MBID URIs should be HTTP

### DIFF
--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -116,6 +116,9 @@ sub WEB_SERVER_USED_IN_EMAIL  { my $self = shift; $self->WEB_SERVER }
 sub IS_BETA                   { 0 }
 sub BETA_REDIRECT_HOSTNAME    { '' }
 
+# The base URI to use for JSON-LD (RDF) identifiers. Includes scheme.
+sub JSON_LD_ID_BASE_URI       { "http://musicbrainz.org" }
+
 # The server to use for rel="canonical" links. Includes scheme.
 sub CANONICAL_SERVER          { "https://musicbrainz.org" }
 

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/GID.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/GID.pm
@@ -13,7 +13,7 @@ around serialize => sub {
     my $entity_type = ref_to_type($entity);
     my $entity_url = $ENTITIES{$entity_type}{url} // $entity_type;
 
-    $ret->{'@id'} = DBDefs->CANONICAL_SERVER . '/' . $entity_url . '/' . $entity->gid;
+    $ret->{'@id'} = DBDefs->JSON_LD_ID_BASE_URI . '/' . $entity_url . '/' . $entity->gid;
 
     return $ret;
 };

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/SameAs.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/SameAs.pm
@@ -23,12 +23,12 @@ around serialize => sub {
     my $entity_url = $ENTITIES{$entity_type}{url} // $entity_type;
 
     if ($entity->can('all_gid_redirects') && $entity->all_gid_redirects) {
-        push(@urls, map { DBDefs->CANONICAL_SERVER . '/' . $entity_url . '/' . $_ } $entity->all_gid_redirects);
+        push(@urls, map { DBDefs->JSON_LD_ID_BASE_URI . '/' . $entity_url . '/' . $_ } $entity->all_gid_redirects);
     }
 
     if ($stash->store($entity)->{identities}) {
         my @identities = @{ $stash->store($entity)->{identities} };
-        push(@urls, map { DBDefs->CANONICAL_SERVER . '/' . $entity_url . '/' . $_->gid } @identities);
+        push(@urls, map { DBDefs->JSON_LD_ID_BASE_URI . '/' . $entity_url . '/' . $_->gid } @identities);
     }
 
     if (@urls) {

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
@@ -16,7 +16,7 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        '@id' => 'https://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',
+        '@id' => 'http://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',
         'alternateName' => ["\x{30aa}\x{30fc}\x{30b9}\x{30c8}\x{30e9}\x{30ea}\x{30a2}"],
         '@context' => 'http://schema.org',
         'name' => 'Australia',

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
@@ -16,12 +16,12 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        '@id' => 'https://musicbrainz.org/area/3f179da4-83c6-4a28-a627-e46b4a8ff1ed',
+        '@id' => 'http://musicbrainz.org/area/3f179da4-83c6-4a28-a627-e46b4a8ff1ed',
         '@context' => 'http://schema.org',
         'name' => 'Sydney',
         '@type' => 'City',
         'containedIn' => {
-            '@id' => 'https://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',
+            '@id' => 'http://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',
             '@type' => 'Country',
             'name' => 'Australia',
         },

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
@@ -24,23 +24,23 @@ $mech->content_contains('2005-05-06', 'has alias end date');
 
 page_test_jsonld $mech => {
     '@context' => 'http://schema.org',
-    '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+    '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
     '@type' => ['Person', 'MusicGroup'],
     'alternateName' => ['Test Alias'],
     'birthDate' => '2008-01-02',
     'birthPlace' => {
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country',
         'name' => 'United Kingdom',
     },
     'deathPlace' => {
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country',
         'name' => 'United Kingdom',
     },
     'deathDate' => '2009-03-04',
     'location' => {
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country',
         'name' => 'United Kingdom',
     },
@@ -54,7 +54,7 @@ $mech->content_unlike(qr/Test Alias/, 'other artist pages do not have the alias'
 page_test_jsonld $mech => {
     '@context' => 'http://schema.org',
     '@type' => 'MusicGroup',
-    '@id' => 'https://musicbrainz.org/artist/60e5d080-c964-11de-8a39-0800200c9a66',
+    '@id' => 'http://musicbrainz.org/artist/60e5d080-c964-11de-8a39-0800200c9a66',
     'name' => 'Empty Artist'
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
@@ -29,30 +29,30 @@ page_test_jsonld $mech => {
     'track' => {
         'duration' => 'PT02M03S',
         '@type' => 'MusicRecording',
-        '@id' => 'https://musicbrainz.org/recording/123c079d-374e-4436-9448-da92dedef3ce',
+        '@id' => 'http://musicbrainz.org/recording/123c079d-374e-4436-9448-da92dedef3ce',
         'name' => 'Test Recording'
     },
     'name' => 'Test Artist',
     'location' => {
         'name' => 'United Kingdom',
         '@type' => 'Country',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed'
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed'
     },
     '@type' => ['Person', 'MusicGroup'],
     '@context' => 'http://schema.org',
     'birthDate' => '2008-01-02',
     'birthPlace' => {
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country',
         'name' => 'United Kingdom'
     },
     'deathDate' => '2009-03-04',
     'deathPlace' => {
         '@type' => 'Country',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         'name' => 'United Kingdom'
     },
-    '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce'
+    '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce'
 };
 
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
@@ -24,7 +24,7 @@ $mech->content_contains('/recording/123c079d-374e-4436-9448-da92dedef3ce');
 page_test_jsonld $mech => {
     'location' => {
         'name' => 'United Kingdom',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country'
     },
     '@context' => 'http://schema.org',
@@ -32,17 +32,17 @@ page_test_jsonld $mech => {
     'birthDate' => '2008-01-02',
     'birthPlace' => {
         '@type' => 'Country',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         'name' => 'United Kingdom'
     },
     'name' => 'Test Artist',
     'deathDate' => '2009-03-04',
     'deathPlace' => {
         'name' => 'United Kingdom',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country'
     },
-    '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce'
+    '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce'
 };
 
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
@@ -48,21 +48,21 @@ page_test_jsonld $mech => {
     'deathPlace' => {
         'name' => 'United Kingdom',
         '@type' => 'Country',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed'
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed'
     },
     'birthDate' => '2008-01-02',
     'name' => 'Test Artist',
-    'sameAs' => 'https://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
+    'sameAs' => 'http://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
     'location' => {
         '@type' => 'Country',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         'name' => 'United Kingdom'
     },
     'alternateName' => ['Seekrit Identity'],
-    '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+    '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
     '@context' => 'http://schema.org',
     'birthPlace' => {
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country',
         'name' => 'United Kingdom'
     },
@@ -70,34 +70,34 @@ page_test_jsonld $mech => {
         {
             'albumProductionType' => 'http://schema.org/StudioAlbum',
             '@type' => 'MusicAlbum',
-            '@id' => 'https://musicbrainz.org/release-group/ecc33260-454c-11de-8a39-0800200c9a66',
+            '@id' => 'http://musicbrainz.org/release-group/ecc33260-454c-11de-8a39-0800200c9a66',
             'name' => 'Test RG 1',
             'creditedTo' => 'Test Artist',
             'byArtist' => {
                 '@type' => ['Person', 'MusicGroup'],
-                '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+                '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
                 'name' => 'Test Artist',
-                'sameAs' => 'https://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
+                'sameAs' => 'http://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
             },
             'albumReleaseType' => 'http://schema.org/AlbumRelease'
         },
         {
             '@type' => 'MusicAlbum',
             'albumProductionType' => 'http://schema.org/StudioAlbum',
-            '@id' => 'https://musicbrainz.org/release-group/7348f3a0-454e-11de-8a39-0800200c9a66',
+            '@id' => 'http://musicbrainz.org/release-group/7348f3a0-454e-11de-8a39-0800200c9a66',
             'name' => 'Test RG 2',
             'creditedTo' => 'Test Artist',
             'albumReleaseType' => 'http://schema.org/AlbumRelease',
             'byArtist' => {
                 'name' => 'Test Artist',
-                '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+                '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
                 '@type' => ['Person', 'MusicGroup'],
-                'sameAs' => 'https://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
+                'sameAs' => 'http://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
             }
         }
     ],
     'performsAs' => {
-        '@id' => 'https://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
+        '@id' => 'http://musicbrainz.org/artist/089302a3-dda1-4bdf-b996-c2e941b5c41f',
         '@type' => 'MusicGroup',
         'name' => 'Seekrit Identity',
     },
@@ -130,7 +130,7 @@ EOSQL
     page_test_jsonld $mech => {
         'name' => 'Group',
         '@type' => 'MusicGroup',
-        '@id' => 'https://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
+        '@id' => 'http://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
         'member' => [
             {
                 'roleName' => [],
@@ -140,12 +140,12 @@ EOSQL
                 'member' => {
                     'name' => 'Person A',
                     '@type' => 'MusicGroup',
-                    '@id' => 'https://musicbrainz.org/artist/2a62773a-cdbf-44c6-a700-50f931504054'
+                    '@id' => 'http://musicbrainz.org/artist/2a62773a-cdbf-44c6-a700-50f931504054'
                 }
             },
             {
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/efac67ce-33ae-4949-8fc8-3d2aeafcbefb',
+                    '@id' => 'http://musicbrainz.org/artist/efac67ce-33ae-4949-8fc8-3d2aeafcbefb',
                     'name' => 'Person B',
                     '@type' => 'MusicGroup'
                 },
@@ -182,17 +182,17 @@ EOSQL
     page_test_jsonld $mech => {
         'name' => 'Group',
         '@type' => 'MusicGroup',
-        '@id' => 'https://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
+        '@id' => 'http://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
         'track' => [
             {
                 'duration' => 'PT05M00S',
-                '@id' => 'https://musicbrainz.org/recording/7af3d92f-5ef4-4ed4-bbbb-728928984d9c',
+                '@id' => 'http://musicbrainz.org/recording/7af3d92f-5ef4-4ed4-bbbb-728928984d9c',
                 'name' => 'R1',
                 '@type' => 'MusicRecording'
             },
             {
                 'duration' => 'PT04M10S',
-                '@id' => 'https://musicbrainz.org/recording/67f09ef6-0704-4841-935c-01c5b247574c',
+                '@id' => 'http://musicbrainz.org/recording/67f09ef6-0704-4841-935c-01c5b247574c',
                 'name' => 'R2',
                 '@type' => 'MusicRecording'
             }
@@ -211,33 +211,33 @@ test 'Embedded JSON-LD sameAs & performsAs' => sub {
     $mech->get_ok('/artist/960db060-0ba8-4f6c-9770-49b81dc6e5ea');
     page_test_jsonld $mech => {
         '@context' => 'http://schema.org',
-        '@id' => 'https://musicbrainz.org/artist/960db060-0ba8-4f6c-9770-49b81dc6e5ea',
+        '@id' => 'http://musicbrainz.org/artist/960db060-0ba8-4f6c-9770-49b81dc6e5ea',
         '@type' => ['Person', 'MusicGroup'],
         'alternateName' => ['Calvin Broadus', 'Snoop Dogg'],
         'birthDate' => '1971-10-20',
         'birthPlace' => {
-            '@id' => 'https://musicbrainz.org/area/e183ffae-1d35-4c78-b552-957535e40af1',
+            '@id' => 'http://musicbrainz.org/area/e183ffae-1d35-4c78-b552-957535e40af1',
             '@type' => 'City',
             'name' => 'Long Beach'
         },
         'location' => {
-            '@id' => 'https://musicbrainz.org/area/489ce91b-6658-3307-9877-795b68554c98',
+            '@id' => 'http://musicbrainz.org/area/489ce91b-6658-3307-9877-795b68554c98',
             '@type' => 'Country',
             'name' => 'United States'
         },
         'name' => 'Snoop Lion',
         'performsAs' => {
-            '@id' => 'https://musicbrainz.org/artist/f90e8b26-9e52-4669-a5c9-e28529c47894',
+            '@id' => 'http://musicbrainz.org/artist/f90e8b26-9e52-4669-a5c9-e28529c47894',
             '@type' => ['Person', 'MusicGroup'],
             'name' => 'Snoop Dogg',
         },
         'sameAs' => [
             'http://en.wikipedia.org/wiki/Snoop_Dogg',
+            'http://musicbrainz.org/artist/965f5705-6eb1-49a1-b312-cd3d65bcc7c9',
+            'http://musicbrainz.org/artist/f90e8b26-9e52-4669-a5c9-e28529c47894',
             'http://snooplion.com/',
             'http://www.discogs.com/artist/2859872',
             'http://www.wikidata.org/wiki/Q6096',
-            'https://musicbrainz.org/artist/965f5705-6eb1-49a1-b312-cd3d65bcc7c9',
-            'https://musicbrainz.org/artist/f90e8b26-9e52-4669-a5c9-e28529c47894',
             'https://www.allmusic.com/artist/mn0002979185',
         ]
     };
@@ -253,22 +253,22 @@ test 'Embedded JSON-LD dates & origins for people' => sub {
     $mech->get_ok('/artist/b972f589-fb0e-474e-b64a-803b0364fa75');
     page_test_jsonld $mech => {
         '@context' => 'http://schema.org',
-        '@id' => 'https://musicbrainz.org/artist/b972f589-fb0e-474e-b64a-803b0364fa75',
+        '@id' => 'http://musicbrainz.org/artist/b972f589-fb0e-474e-b64a-803b0364fa75',
         '@type' => ['Person', 'MusicGroup'],
         'birthDate' => '1756-01-27',
         'birthPlace' => {
-            '@id' => 'https://musicbrainz.org/area/f0590317-8b42-4498-a2e4-34cc5562fcf8',
+            '@id' => 'http://musicbrainz.org/area/f0590317-8b42-4498-a2e4-34cc5562fcf8',
             '@type' => 'City',
             'name' => 'Salzburg',
         },
         'deathDate' => '1791-12-05',
         'deathPlace' => {
-            '@id' => 'https://musicbrainz.org/area/afff1a94-a98b-4322-8874-3148139ab6da',
+            '@id' => 'http://musicbrainz.org/area/afff1a94-a98b-4322-8874-3148139ab6da',
             '@type' => 'City',
             'name' => 'Wien',
         },
         'location' => {
-            '@id' => 'https://musicbrainz.org/area/caac77d1-a5c8-3e6e-8e27-90b44dcc1446',
+            '@id' => 'http://musicbrainz.org/area/caac77d1-a5c8-3e6e-8e27-90b44dcc1446',
             '@type' => 'Country',
             'name' => 'Austria',
         },
@@ -301,17 +301,17 @@ test 'Embedded JSON-LD for groups' => sub {
     $mech->get_ok('/artist/b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d');
     page_test_jsonld $mech => {
         '@context' => 'http://schema.org',
-        '@id' => 'https://musicbrainz.org/artist/b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d',
+        '@id' => 'http://musicbrainz.org/artist/b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d',
         '@type' => 'MusicGroup',
         'dissolutionDate' => '1970-04-10',
         'foundingDate' => '1957-03',
         'groupOrigin' => {
-            '@id' => 'https://musicbrainz.org/area/c249c30e-88ab-4b2f-a745-96a25bd7afee',
+            '@id' => 'http://musicbrainz.org/area/c249c30e-88ab-4b2f-a745-96a25bd7afee',
             '@type' => 'City',
             'name' => 'Liverpool',
         },
         'location' => {
-            '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+            '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
             '@type' => 'Country',
             'name' => 'United Kingdom',
         },
@@ -320,7 +320,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1962-08-16',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/0d4ab0f9-bbda-4ab1-ae2c-f772ffcfbea9',
+                    '@id' => 'http://musicbrainz.org/artist/0d4ab0f9-bbda-4ab1-ae2c-f772ffcfbea9',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Pete Best'
                 },
@@ -331,7 +331,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1970-04-10',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/300c4c73-33ac-4255-9d57-4e32627f5e13',
+                    '@id' => 'http://musicbrainz.org/artist/300c4c73-33ac-4255-9d57-4e32627f5e13',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Ringo Starr'
                 },
@@ -342,7 +342,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1970-04-10',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/42a8f507-8412-4611-854f-926571049fa0',
+                    '@id' => 'http://musicbrainz.org/artist/42a8f507-8412-4611-854f-926571049fa0',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'George Harrison',
                 },
@@ -353,7 +353,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1962',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/49a51491-650e-44b3-8085-2f07ac2986dd',
+                    '@id' => 'http://musicbrainz.org/artist/49a51491-650e-44b3-8085-2f07ac2986dd',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Stuart Sutcliffe',
                 },
@@ -364,7 +364,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1970-04-10',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/4d5447d7-c61c-4120-ba1b-d7f471d385b9',
+                    '@id' => 'http://musicbrainz.org/artist/4d5447d7-c61c-4120-ba1b-d7f471d385b9',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'John Lennon',
                 },
@@ -374,7 +374,7 @@ test 'Embedded JSON-LD for groups' => sub {
                 '@type' => 'OrganizationRole',
                 'endDate' => '1970-04-10',
                 'member' => {
-                    '@id' => 'https://musicbrainz.org/artist/ba550d0e-adac-4864-b88b-407cab5e76af',
+                    '@id' => 'http://musicbrainz.org/artist/ba550d0e-adac-4864-b88b-407cab5e76af',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Paul McCartney',
                 },

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
@@ -20,14 +20,14 @@ test all => sub {
     page_test_jsonld $mech => {
         'foundingDate' => '1989-02-03',
         'dissolutionDate' => '2008-05-19',
-        'sameAs' => 'https://musicbrainz.org/label/efdf3fe9-c293-4acd-b4b2-8d2a7d4f9592',
+        'sameAs' => 'http://musicbrainz.org/label/efdf3fe9-c293-4acd-b4b2-8d2a7d4f9592',
         'name' => 'Warp Records',
         'foundingLocation' => {
             'name' => 'United Kingdom',
-            '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+            '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
             '@type' => 'Country'
         },
-        '@id' => 'https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+        '@id' => 'http://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
         '@type' => 'MusicLabel',
         '@context' => 'http://schema.org',
         'alternateName' => ['Test Label Alias']

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
@@ -37,17 +37,17 @@ page_test_jsonld $mech => {
     'releasePublished' => [
         {
             'name' => 'Aerial',
-            '@id' => 'https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
+            '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
             '@type' => 'MusicRelease'
         },
         {
-            '@id' => 'https://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
+            '@id' => 'http://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
             '@type' => 'MusicRelease',
             'name' => 'Aerial'
         },
         {
             'name' => 'Arrival',
-            '@id' => 'https://musicbrainz.org/release/f34c079d-374e-4436-9448-da92dedef3ce',
+            '@id' => 'http://musicbrainz.org/release/f34c079d-374e-4436-9448-da92dedef3ce',
             '@type' => 'MusicRelease'
         }
     ],
@@ -55,7 +55,7 @@ page_test_jsonld $mech => {
         {
             '@type' => 'Role',
             'artistSigned' => {
-                '@id' => 'https://musicbrainz.org/artist/fa263cb3-205f-4a7f-91e1-94e3df52abe8',
+                '@id' => 'http://musicbrainz.org/artist/fa263cb3-205f-4a7f-91e1-94e3df52abe8',
                 '@type' => ['Person', 'MusicGroup'],
                 'name' => 'Jimmy Edgar',
             },
@@ -64,7 +64,7 @@ page_test_jsonld $mech => {
         {
             '@type' => 'Role',
             'artistSigned' => {
-                '@id' => 'https://musicbrainz.org/artist/e4787c4e-0b1a-48bd-b9a0-b0427391d293',
+                '@id' => 'http://musicbrainz.org/artist/e4787c4e-0b1a-48bd-b9a0-b0427391d293',
                 '@type' => ['Person', 'MusicGroup'],
                 'name' => 'patten',
             },
@@ -73,14 +73,14 @@ page_test_jsonld $mech => {
     ],
     'foundingLocation' => {
         'name' => 'United Kingdom',
-        '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+        '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
         '@type' => 'Country'
     },
     'name' => 'Warp Records',
     'foundingDate' => '1989-02-03',
     'dissolutionDate' => '2008-05-19',
-    'sameAs' => 'https://musicbrainz.org/label/efdf3fe9-c293-4acd-b4b2-8d2a7d4f9592',
-    '@id' => 'https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+    'sameAs' => 'http://musicbrainz.org/label/efdf3fe9-c293-4acd-b4b2-8d2a7d4f9592',
+    '@id' => 'http://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
     '@type' => 'MusicLabel'
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
@@ -20,7 +20,7 @@ test all => sub {
         'foundingDate' => '2013',
         'containedIn' => {
             '@type' => 'Country',
-            '@id' => 'https://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
+            '@id' => 'http://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
             'name' => 'Europe'
         },
         'alternateName' => ['A Test Alias'],
@@ -32,7 +32,7 @@ test all => sub {
         'name' => 'A Test Place',
         '@context' => 'http://schema.org',
         '@type' => 'Place',
-        '@id' => 'https://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
+        '@id' => 'http://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
     };
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
@@ -19,7 +19,7 @@ test all => sub {
     page_test_jsonld $mech => {
         'containedIn' => {
             'name' => 'Europe',
-            '@id' => 'https://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
+            '@id' => 'http://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
             '@type' => 'Country'
         },
         'name' => 'A Test Place',
@@ -31,7 +31,7 @@ test all => sub {
         '@type' => 'Place',
         '@context' => 'http://schema.org',
         'foundingDate' => '2013',
-        '@id' => 'https://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
+        '@id' => 'http://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
     };
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
@@ -16,7 +16,7 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        '@id' => 'https://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
+        '@id' => 'http://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
         'alternateName' => ['King of the Mt.'],
         'isrcCode' => 'DEE250800230',
         '@type' => 'MusicRecording',

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Show.pm
@@ -35,10 +35,10 @@ $mech->content_contains('Test annotation 3', 'has annotation');
 
 page_test_jsonld $mech => {
     'isrcCode' => 'DEE250800231',
-    '@id' => 'https://musicbrainz.org/recording/123c079d-374e-4436-9448-da92dedef3ce',
+    '@id' => 'http://musicbrainz.org/recording/123c079d-374e-4436-9448-da92dedef3ce',
     '@context' => 'http://schema.org',
     '@type' => 'MusicRecording',
-    'sameAs' => 'https://musicbrainz.org/recording/0986e67c-6b7a-40b7-b4ba-c9d7583d6426',
+    'sameAs' => 'http://musicbrainz.org/recording/0986e67c-6b7a-40b7-b4ba-c9d7583d6426',
     'name' => 'Dancing Queen',
     'duration' => 'PT02M03S'
 };
@@ -56,13 +56,13 @@ test 'Embedded JSON-LD' => sub {
 
     page_test_jsonld $mech => {
         '@context' => 'http://schema.org',
-        '@id' => 'https://musicbrainz.org/recording/6b517117-8b98-463b-9457-f8e3a08d1f49',
+        '@id' => 'http://musicbrainz.org/recording/6b517117-8b98-463b-9457-f8e3a08d1f49',
         '@type' => 'MusicRecording',
         'contributor' => [
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/001363e3-f643-4aca-bb95-3075cdcf62c8',
+                    '@id' => 'http://musicbrainz.org/artist/001363e3-f643-4aca-bb95-3075cdcf62c8',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Lori Holton-Nash'
                 },
@@ -71,7 +71,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/0a51af30-5e31-470e-abd2-dd979a3e3d80',
+                    '@id' => 'http://musicbrainz.org/artist/0a51af30-5e31-470e-abd2-dd979a3e3d80',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Donnie Lyle'
                 },
@@ -80,7 +80,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/134d3aac-76f7-4652-993e-932d01256d49',
+                    '@id' => 'http://musicbrainz.org/artist/134d3aac-76f7-4652-993e-932d01256d49',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Yvonne Gage'
                 },
@@ -89,7 +89,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/19c882f5-a6ec-488f-b6ad-ab489eddc655',
+                    '@id' => 'http://musicbrainz.org/artist/19c882f5-a6ec-488f-b6ad-ab489eddc655',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Kendall Nesbitt'
                 },
@@ -98,7 +98,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/1c7a3225-2c5a-402e-a988-786b06ef5013',
+                    '@id' => 'http://musicbrainz.org/artist/1c7a3225-2c5a-402e-a988-786b06ef5013',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Steve Robinson'
                 },
@@ -107,7 +107,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/2373f554-6a1e-46f9-bac2-8bab5e86b7de',
+                    '@id' => 'http://musicbrainz.org/artist/2373f554-6a1e-46f9-bac2-8bab5e86b7de',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Percy Bady'
                 },
@@ -116,7 +116,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/2387a257-4b30-4af0-af33-d7e5eaa0b5f9',
+                    '@id' => 'http://musicbrainz.org/artist/2387a257-4b30-4af0-af33-d7e5eaa0b5f9',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Paul Riser'
                 },
@@ -125,7 +125,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/273d6cda-312f-41fa-bf7e-837d51181172',
+                    '@id' => 'http://musicbrainz.org/artist/273d6cda-312f-41fa-bf7e-837d51181172',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Felicia Coleman-Evans'
                 },
@@ -134,7 +134,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/2c92addd-868b-4c3c-b886-0ed7a6ee3a6b',
+                    '@id' => 'http://musicbrainz.org/artist/2c92addd-868b-4c3c-b886-0ed7a6ee3a6b',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Jeffrey W. Morrow'
                 },
@@ -143,7 +143,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/3de09330-f53d-4faa-ae92-726866ab9c96',
+                    '@id' => 'http://musicbrainz.org/artist/3de09330-f53d-4faa-ae92-726866ab9c96',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Deletrice Alexander'
                 },
@@ -152,7 +152,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/5f906ee6-fc04-4e90-8141-66f32e5da3cf',
+                    '@id' => 'http://musicbrainz.org/artist/5f906ee6-fc04-4e90-8141-66f32e5da3cf',
                     '@type' => 'MusicGroup',
                     'name' => 'Walt Whitman & The Soul Children of Chicago'
                 },
@@ -161,7 +161,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/690d39ad-7512-4abd-82b8-1885ed255a4b',
+                    '@id' => 'http://musicbrainz.org/artist/690d39ad-7512-4abd-82b8-1885ed255a4b',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Paul Mabin'
                 },
@@ -170,7 +170,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/99c9d990-6b02-4600-93a2-66ff9c078f34',
+                    '@id' => 'http://musicbrainz.org/artist/99c9d990-6b02-4600-93a2-66ff9c078f34',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Robin Robinson'
                 },
@@ -179,7 +179,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/b7ce9a76-0abc-4f3a-b841-4a7b06f56268',
+                    '@id' => 'http://musicbrainz.org/artist/b7ce9a76-0abc-4f3a-b841-4a7b06f56268',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Joan Collaso'
                 },
@@ -188,7 +188,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/c7ea517c-efbb-453b-abd2-5e368f6e5475',
+                    '@id' => 'http://musicbrainz.org/artist/c7ea517c-efbb-453b-abd2-5e368f6e5475',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'John Rutledge'
                 },
@@ -197,7 +197,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/c84ebed5-c70c-454f-9a66-31030d311e75',
+                    '@id' => 'http://musicbrainz.org/artist/c84ebed5-c70c-454f-9a66-31030d311e75',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Hart Hollman'
                 }
@@ -205,7 +205,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/eb65b73a-00f8-475b-beb4-a09cf5cd7a00',
+                    '@id' => 'http://musicbrainz.org/artist/eb65b73a-00f8-475b-beb4-a09cf5cd7a00',
                     '@type' => 'MusicGroup',
                     'name' => 'The Motown Romance Orchestra'
                 },
@@ -214,7 +214,7 @@ test 'Embedded JSON-LD' => sub {
             {
                 '@type' => 'OrganizationRole',
                 'contributor' => {
-                    '@id' => 'https://musicbrainz.org/artist/f9231d98-6e7d-4afd-b2cf-9a656a260f85',
+                    '@id' => 'http://musicbrainz.org/artist/f9231d98-6e7d-4afd-b2cf-9a656a260f85',
                     '@type' => ['Person', 'MusicGroup'],
                     'name' => 'Simbryt Whittington'
                 },
@@ -225,12 +225,12 @@ test 'Embedded JSON-LD' => sub {
         'isrcCode' => 'USJI10100576',
         'name' => 'The World\'s Greatest',
         'producer' => {
-            '@id' => 'https://musicbrainz.org/artist/c2d25856-a09a-4d15-b404-77dd19c19e63',
+            '@id' => 'http://musicbrainz.org/artist/c2d25856-a09a-4d15-b404-77dd19c19e63',
             '@type' => ['Person', 'MusicGroup'],
             'name' => 'R. Kelly'
         },
         'recordingOf' => {
-            '@id' => 'https://musicbrainz.org/work/2025da95-23f1-31ae-b991-088834e6ce2f',
+            '@id' => 'http://musicbrainz.org/work/2025da95-23f1-31ae-b991-088834e6ce2f',
             '@type' => 'MusicComposition',
             'name' => 'The World\'s Greatest'
         }

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -22,26 +22,26 @@ test all => sub {
         'recordLabel' => {
             'name' => 'Warp Records',
             '@type' => 'MusicLabel',
-            '@id' => 'https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190'
+            '@id' => 'http://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190'
         },
         'releaseOf' => {
             'albumReleaseType' => 'http://schema.org/AlbumRelease',
             'byArtist' => {
-                '@id' => 'https://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
+                '@id' => 'http://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
                 '@type' => ['Person', 'MusicGroup'],
                 'name' => 'Kate Bush',
             },
             'creditedTo' => 'Kate Bush',
             'name' => 'Aerial',
             '@type' => 'MusicAlbum',
-            '@id' => 'https://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
+            '@id' => 'http://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
             'albumProductionType' => 'http://schema.org/StudioAlbum'
         },
         'hasReleaseRegion' => [
             {
                 'releaseCountry' => {
                     '@type' => 'Country',
-                    '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+                    '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
                     'name' => 'United Kingdom'
                 },
                 '@type' => 'CreativeWorkReleaseRegion',
@@ -50,7 +50,7 @@ test all => sub {
         ],
         '@type' => 'MusicRelease',
         'catalogNumber' => '343 960 2',
-        '@id' => 'https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
+        '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
         'name' => 'Aerial',
         'musicReleaseFormat' => 'http://schema.org/CDFormat',
         '@context' => 'http://schema.org'

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
@@ -23,16 +23,16 @@ test all => sub {
             'albumProductionType' => 'http://schema.org/StudioAlbum',
             'byArtist' => {
                 'name' => 'Artist',
-                '@id' => 'https://musicbrainz.org/artist/945c079d-374e-4436-9448-da92dedef3cf',
+                '@id' => 'http://musicbrainz.org/artist/945c079d-374e-4436-9448-da92dedef3cf',
                 '@type' => 'MusicGroup',
             },
             'creditedTo' => 'Artist',
-            '@id' => 'https://musicbrainz.org/release-group/54b9d183-7dab-42ba-94a3-7388a66604b8',
+            '@id' => 'http://musicbrainz.org/release-group/54b9d183-7dab-42ba-94a3-7388a66604b8',
             'name' => 'Release'
         },
         'name' => 'Release',
         'creditedTo' => 'Artist',
-        '@id' => 'https://musicbrainz.org/release/14b9d183-7dab-42ba-94a3-7388a66604b8',
+        '@id' => 'http://musicbrainz.org/release/14b9d183-7dab-42ba-94a3-7388a66604b8',
         '@type' => 'MusicRelease',
         'image' => {
             'contentUrl' => DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . '/release/14b9d183-7dab-42ba-94a3-7388a66604b8/12345.jpg',

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
@@ -26,25 +26,25 @@ $mech->content_contains('/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
 
 page_test_jsonld $mech => {
     'catalogNumber' => '343 960 2',
-    '@id' => 'https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
+    '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
     'releaseOf' => {
         'name' => 'Aerial',
         'byArtist' => {
-            '@id' => 'https://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
+            '@id' => 'http://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
             '@type' => ['Person', 'MusicGroup'],
             'name' => 'Kate Bush',
         },
         'creditedTo' => 'Kate Bush',
         'albumReleaseType' => 'http://schema.org/AlbumRelease',
         'albumProductionType' => 'http://schema.org/StudioAlbum',
-        '@id' => 'https://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
+        '@id' => 'http://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
         '@type' => 'MusicAlbum'
     },
     'name' => 'Aerial',
     'musicReleaseFormat' => 'http://schema.org/CDFormat',
     'recordLabel' => {
         'name' => 'Warp Records',
-        '@id' => 'https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+        '@id' => 'http://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
         '@type' => 'MusicLabel'
     },
     '@type' => 'MusicRelease',
@@ -54,13 +54,13 @@ page_test_jsonld $mech => {
         {
             'duration' => 'PT04M54S',
             'name' => 'King of the Mountain',
-            '@id' => 'https://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
+            '@id' => 'http://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
             'trackNumber' => '1.1',
             'contributor' => [
                 {
                     '@type' => 'OrganizationRole',
                     'contributor' => {
-                        '@id' => 'https://musicbrainz.org/artist/2fed031c-0e89-406e-b9f0-3d192637907a',
+                        '@id' => 'http://musicbrainz.org/artist/2fed031c-0e89-406e-b9f0-3d192637907a',
                         'name' => 'Test Alias',
                         '@type' => 'MusicGroup'
                     },
@@ -70,7 +70,7 @@ page_test_jsonld $mech => {
                     'roleName' => 'guitar',
                     '@type' => 'OrganizationRole',
                     'contributor' => {
-                        '@id' => 'https://musicbrainz.org/artist/e2a083a9-9942-4d6e-b4d2-8397320b95f7',
+                        '@id' => 'http://musicbrainz.org/artist/e2a083a9-9942-4d6e-b4d2-8397320b95f7',
                         'name' => 'Test Alias',
                         '@type' => 'MusicGroup'
                     }
@@ -80,7 +80,7 @@ page_test_jsonld $mech => {
             'isrcCode' => 'DEE250800230'
         },
         {
-            '@id' => 'https://musicbrainz.org/recording/659f405b-b4ee-4033-868a-0daa27784b89',
+            '@id' => 'http://musicbrainz.org/recording/659f405b-b4ee-4033-868a-0daa27784b89',
             'duration' => 'PT06M10S',
             'name' => "\x{3c0}",
             '@type' => 'MusicRecording',
@@ -90,7 +90,7 @@ page_test_jsonld $mech => {
                     '@type' => 'OrganizationRole',
                     'contributor' => {
                         '@type' => 'MusicGroup',
-                        '@id' => 'https://musicbrainz.org/artist/e2a083a9-9942-4d6e-b4d2-8397320b95f7',
+                        '@id' => 'http://musicbrainz.org/artist/e2a083a9-9942-4d6e-b4d2-8397320b95f7',
                         'name' => 'Test Alias'
                     },
                     'roleName' => 'plucked string instruments'
@@ -102,31 +102,31 @@ page_test_jsonld $mech => {
             '@type' => 'MusicRecording',
             'duration' => 'PT04M19S',
             'name' => 'Bertie',
-            '@id' => 'https://musicbrainz.org/recording/ae674299-2824-4500-9516-653ac1bc6f80'
+            '@id' => 'http://musicbrainz.org/recording/ae674299-2824-4500-9516-653ac1bc6f80'
         },
         {
             'trackNumber' => '1.4',
             '@type' => 'MusicRecording',
             'duration' => 'PT05M59S',
             'name' => 'Mrs. Bartolozzi',
-            '@id' => 'https://musicbrainz.org/recording/b1d58a57-a0f3-4db8-aa94-868cdc7bc3bb'
+            '@id' => 'http://musicbrainz.org/recording/b1d58a57-a0f3-4db8-aa94-868cdc7bc3bb'
         },
         {
             'trackNumber' => '1.5',
             '@type' => 'MusicRecording',
             'duration' => 'PT05M33S',
             'name' => 'How to Be Invisible',
-            '@id' => 'https://musicbrainz.org/recording/44f52946-0c98-47ba-ba60-964774db56f0'
+            '@id' => 'http://musicbrainz.org/recording/44f52946-0c98-47ba-ba60-964774db56f0'
         },
         {
             'duration' => 'PT04M56S',
             'name' => 'Joanni',
-            '@id' => 'https://musicbrainz.org/recording/07614140-8bb8-4db9-9dcc-0917c3a8471b',
+            '@id' => 'http://musicbrainz.org/recording/07614140-8bb8-4db9-9dcc-0917c3a8471b',
             'trackNumber' => '1.6',
             '@type' => 'MusicRecording'
         },
         {
-            '@id' => 'https://musicbrainz.org/recording/1eb4f672-5ee3-454f-9a67-db85a4478fea',
+            '@id' => 'http://musicbrainz.org/recording/1eb4f672-5ee3-454f-9a67-db85a4478fea',
             'duration' => 'PT06M12S',
             'name' => 'A Coral Room',
             '@type' => 'MusicRecording',
@@ -135,14 +135,14 @@ page_test_jsonld $mech => {
         {
             'name' => 'Prelude',
             'duration' => 'PT01M26S',
-            '@id' => 'https://musicbrainz.org/recording/91028302-a466-4557-a19b-a26584564daa',
+            '@id' => 'http://musicbrainz.org/recording/91028302-a466-4557-a19b-a26584564daa',
             'trackNumber' => '2.1',
             '@type' => 'MusicRecording'
         },
         {
             '@type' => 'MusicRecording',
             'trackNumber' => '2.2',
-            '@id' => 'https://musicbrainz.org/recording/9560a5ac-d980-41fe-be7f-a6cb4a0cd91b',
+            '@id' => 'http://musicbrainz.org/recording/9560a5ac-d980-41fe-be7f-a6cb4a0cd91b',
             'name' => 'Prologue',
             'duration' => 'PT05M42S'
         },
@@ -151,24 +151,24 @@ page_test_jsonld $mech => {
             '@type' => 'MusicRecording',
             'duration' => 'PT04M50S',
             'name' => 'An Architect\'s Dream',
-            '@id' => 'https://musicbrainz.org/recording/2ed42694-7b28-433e-9cf0-1e14a25babfe'
+            '@id' => 'http://musicbrainz.org/recording/2ed42694-7b28-433e-9cf0-1e14a25babfe'
         },
         {
             'duration' => 'PT01M36S',
             'name' => 'The Painter\'s Link',
-            '@id' => 'https://musicbrainz.org/recording/3bf4cbea-f963-4d75-bac5-351a29c60575',
+            '@id' => 'http://musicbrainz.org/recording/3bf4cbea-f963-4d75-bac5-351a29c60575',
             'trackNumber' => '2.4',
             '@type' => 'MusicRecording'
         },
         {
-            '@id' => 'https://musicbrainz.org/recording/33137503-0ebf-4b6b-a7ce-cc71df5865df',
+            '@id' => 'http://musicbrainz.org/recording/33137503-0ebf-4b6b-a7ce-cc71df5865df',
             'duration' => 'PT05M59S',
             'name' => 'Sunset',
             '@type' => 'MusicRecording',
             'trackNumber' => '2.5'
         },
         {
-            '@id' => 'https://musicbrainz.org/recording/2c89d9f6-fd0e-4e79-a654-828fbcf4656d',
+            '@id' => 'http://musicbrainz.org/recording/2c89d9f6-fd0e-4e79-a654-828fbcf4656d',
             'name' => 'Aerial Tal',
             'duration' => 'PT01M01S',
             '@type' => 'MusicRecording',
@@ -177,7 +177,7 @@ page_test_jsonld $mech => {
         {
             'duration' => 'PT05M01S',
             'name' => 'Somewhere in Between',
-            '@id' => 'https://musicbrainz.org/recording/61b13b9d-e839-4ea9-8453-208eaafb75bf',
+            '@id' => 'http://musicbrainz.org/recording/61b13b9d-e839-4ea9-8453-208eaafb75bf',
             'trackNumber' => '2.7',
             '@type' => 'MusicRecording'
         },
@@ -186,12 +186,12 @@ page_test_jsonld $mech => {
             '@type' => 'MusicRecording',
             'name' => 'Nocturn',
             'duration' => 'PT08M35S',
-            '@id' => 'https://musicbrainz.org/recording/d328d709-609c-4b88-90be-95815f041524'
+            '@id' => 'http://musicbrainz.org/recording/d328d709-609c-4b88-90be-95815f041524'
         },
         {
             '@type' => 'MusicRecording',
             'trackNumber' => '2.9',
-            '@id' => 'https://musicbrainz.org/recording/1539ac10-5081-4469-b8f2-c5896132724e',
+            '@id' => 'http://musicbrainz.org/recording/1539ac10-5081-4469-b8f2-c5896132724e',
             'name' => 'Aerial',
             'duration' => 'PT07M53S'
         }
@@ -201,7 +201,7 @@ page_test_jsonld $mech => {
         {
             'releaseCountry' => {
                 '@type' => 'Country',
-                '@id' => 'https://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+                '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
                 'name' => 'United Kingdom'
             },
             'releaseDate' => '2005-11-07',

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
@@ -17,11 +17,11 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        '@id' => 'https://musicbrainz.org/release-group/ecc33260-454c-11de-8a39-0800200c9a66',
+        '@id' => 'http://musicbrainz.org/release-group/ecc33260-454c-11de-8a39-0800200c9a66',
         'albumReleaseType' => 'http://schema.org/AlbumRelease',
         'byArtist' => {
             '@type' => ['Person', 'MusicGroup'],
-            '@id' => 'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+            '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
             'name' => 'Test Artist'
         },
         'creditedTo' => 'Test Artist',

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
@@ -29,20 +29,20 @@ page_test_jsonld $mech => {
     'albumProductionType' => 'http://schema.org/StudioAlbum',
     'byArtist' => {
         'name' => 'ABBA',
-        '@id' => 'https://musicbrainz.org/artist/a45c079d-374e-4436-9448-da92dedef3cf',
+        '@id' => 'http://musicbrainz.org/artist/a45c079d-374e-4436-9448-da92dedef3cf',
         '@type' => 'MusicGroup'
     },
     'albumRelease' => {
         'name' => 'Arrival',
         '@type' => 'MusicRelease',
-        '@id' => 'https://musicbrainz.org/release/f34c079d-374e-4436-9448-da92dedef3ce'
+        '@id' => 'http://musicbrainz.org/release/f34c079d-374e-4436-9448-da92dedef3ce'
     },
     'albumReleaseType' => 'http://schema.org/AlbumRelease',
     'name' => 'Arrival',
-    '@id' => 'https://musicbrainz.org/release-group/234c079d-374e-4436-9448-da92dedef3ce',
+    '@id' => 'http://musicbrainz.org/release-group/234c079d-374e-4436-9448-da92dedef3ce',
     'creditedTo' => 'ABBA',
     '@type' => 'MusicAlbum',
-    'sameAs' => 'https://musicbrainz.org/release-group/77637e8c-be66-46ea-87b3-73addc722fc9'
+    'sameAs' => 'http://musicbrainz.org/release-group/77637e8c-be66-46ea-87b3-73addc722fc9'
 };
 
 $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5', 'fetch Aerial release group');
@@ -72,10 +72,10 @@ page_test_jsonld $mech => {
         {
             '@type' => 'MusicRelease',
             'name' => 'Aerial',
-            '@id' => 'https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80'
+            '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80'
         },
         {
-            '@id' => 'https://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
+            '@id' => 'http://musicbrainz.org/release/9b3d9383-3d2a-417f-bfbb-56f7c15f075b',
             'name' => 'Aerial',
             '@type' => 'MusicRelease'
         }
@@ -83,12 +83,12 @@ page_test_jsonld $mech => {
     'albumProductionType' => 'http://schema.org/StudioAlbum',
     'byArtist' => {
         '@type' => ['Person', 'MusicGroup'],
-        '@id' => 'https://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
+        '@id' => 'http://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
         'name' => 'Kate Bush'
     },
     '@context' => 'http://schema.org',
     'name' => 'Aerial',
-    '@id' => 'https://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
+    '@id' => 'http://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
     'albumReleaseType' => 'http://schema.org/AlbumRelease',
     'creditedTo' => 'Kate Bush',
     '@type' => 'MusicAlbum'

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
@@ -16,9 +16,9 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        'sameAs' => 'https://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
+        'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
         '@context' => 'http://schema.org',
-        '@id' => 'https://musicbrainz.org/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e',
+        '@id' => 'http://musicbrainz.org/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e',
         'iswcCode' => ['T-000.000.001-0', 'T-000.000.002-0'],
         'alternateName' => ['WA1', 'WA2'],
         'inLanguage' => 'en',

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Show.pm
@@ -23,10 +23,10 @@ test all => sub {
     page_test_jsonld $mech => {
         '@type' => 'MusicComposition',
         'iswcCode' => 'T-000.000.001-0',
-        'sameAs' => 'https://musicbrainz.org/work/28e73402-5666-4d74-80ab-c3734dc699ea',
+        'sameAs' => 'http://musicbrainz.org/work/28e73402-5666-4d74-80ab-c3734dc699ea',
         '@context' => 'http://schema.org',
         'name' => 'Dancing Queen',
-        '@id' => 'https://musicbrainz.org/work/745c079d-374e-4436-9448-da92dedef3ce'
+        '@id' => 'http://musicbrainz.org/work/745c079d-374e-4436-9448-da92dedef3ce'
     };
 
     # Missing
@@ -49,41 +49,41 @@ test 'Embedded JSON-LD' => sub {
 
     page_test_jsonld $mech => {
         '@type' => 'MusicComposition',
-        '@id' => 'https://musicbrainz.org/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e',
+        '@id' => 'http://musicbrainz.org/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e',
         'name' => 'W1',
         'recordedAs' => {
             '@type' => 'MusicRecording',
-            '@id' => 'https://musicbrainz.org/recording/aeb9b50a-e14a-4330-a2e6-7c8a311a9822',
+            '@id' => 'http://musicbrainz.org/recording/aeb9b50a-e14a-4330-a2e6-7c8a311a9822',
             'name' => 'R',
             'duration' => 'PT05M00S'
         },
-        'sameAs' => 'https://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
+        'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
         '@context' => 'http://schema.org',
         'musicArrangement' => [
             {
-                '@id' => 'https://musicbrainz.org/work/a72c9be6-5ef9-4bdf-afa1-6a3db697ff62',
+                '@id' => 'http://musicbrainz.org/work/a72c9be6-5ef9-4bdf-afa1-6a3db697ff62',
                 'name' => 'W4',
                 '@type' => 'MusicComposition'
             },
             {
-              '@id' => 'https://musicbrainz.org/work/5c089ef8-ada9-4dc0-a2bc-f4d7e84df840',
+              '@id' => 'http://musicbrainz.org/work/5c089ef8-ada9-4dc0-a2bc-f4d7e84df840',
               '@type' => 'MusicComposition',
               'name' => 'W5',
             },
         ],
         'publisher' => {
             '@type' => 'MusicGroup',
-            '@id' => 'https://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
+            '@id' => 'http://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
             'name' => 'A'
         },
         'composer' => [
             {
-                '@id' => 'https://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
+                '@id' => 'http://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
                 '@type' => 'MusicGroup',
                 'name' => 'A',
             },
             {
-                '@id' => 'https://musicbrainz.org/artist/213d688f-2a10-463a-86b8-d50a1ae624ee',
+                '@id' => 'http://musicbrainz.org/artist/213d688f-2a10-463a-86b8-d50a1ae624ee',
                 '@type' => 'MusicGroup',
                 'name' => 'B',
             },
@@ -91,18 +91,18 @@ test 'Embedded JSON-LD' => sub {
         'iswcCode' => ['T-000.000.001-0', 'T-000.000.002-0'],
         'lyricist' => {
             'name' => 'A',
-            '@id' => 'https://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
+            '@id' => 'http://musicbrainz.org/artist/e46bb5a2-f4df-44a1-aafe-d07f4c998ba0',
             '@type' => 'MusicGroup'
         },
         'includedComposition' => [
             {
                 '@type' => 'MusicComposition',
-                '@id' => 'https://musicbrainz.org/work/aff4e1f7-d3dd-4621-bd4c-25d1b87bb286',
+                '@id' => 'http://musicbrainz.org/work/aff4e1f7-d3dd-4621-bd4c-25d1b87bb286',
                 'name' => 'W2'
             },
             {
                 '@type' => 'MusicComposition',
-                '@id' => 'https://musicbrainz.org/work/11d4a39f-ee76-459f-aaf5-b84131d867f2',
+                '@id' => 'http://musicbrainz.org/work/11d4a39f-ee76-459f-aaf5-b84131d867f2',
                 'name' => 'W3'
             },
         ],


### PR DESCRIPTION
### Implement MBS-10004

These are documented as HTTP, formatted by Wikidata as HTTP, and as such generally expected to have this as the base.
