### PR TITLE
MBS-9884: Use "Created" for character-type artist begin dates

### DIFF
--- a/root/artist/utils.js
+++ b/root/artist/utils.js
@@ -28,6 +28,8 @@ export function artistBeginLabel(typeId: ?number): string {
     case 5:
     case 6:
       return addColonText(lp('Founded', 'group artist'));
+    case 4:
+      return addColonText(lp('Created', 'character artist'));
     default:
       return l('Begin date:');
   }


### PR DESCRIPTION
### Implement MBS-9884

The documentation says "Begin date represents the date (in real life) when the character concept was created." As such, "Created" is the best option for this, much better than "Begin date".

The docs also say "The End date should not be set", so no point setting a specific label for that.