### PR TITLE
MBS-9876: Stop redirecting tag search to direct search

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -47,7 +47,7 @@ sub search : Path('')
                 if $form->field('method')->value eq 'direct';
             $c->forward('external');
         }
-        elsif ($type eq 'tag')
+        elsif ($type eq 'tag' && DBDefs->SEARCH_ENGINE eq 'LUCENE')
         {
             $form->field('method')->value('direct');
             $c->forward('direct');

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -863,7 +863,7 @@ sub external_search
             undef;
 
         # Use types as provided by jsonnew format
-        if ($type ~~ [qw(area artist event instrument label place recording release release-group work annotation cdstub editor)]) {
+        if ($type ~~ [qw(area artist event instrument label place recording release release-group work annotation cdstub editor tag)]) {
             $xmltype .= "s";
         }
 
@@ -873,7 +873,9 @@ sub external_search
             push @results, MusicBrainz::Server::Entity::SearchResult->new(
                     position => $pos++,
                     score  => $t->{score},
-                    entity => $entity_model->new($t),
+                    entity => $type eq 'tag'
+                        ? $self->c->model('Tag')->get_by_name($t->{name})
+                        : $entity_model->new($t),
                     extra  => $t->{_extra} || []   # Not all data fits into the object model, this is for those cases
                 );
         }
@@ -909,6 +911,12 @@ sub external_search
             my @entities = map { $_->entity } @results;
             $self->c->model('Release')->load_ids(@entities);
             $self->c->model('Release')->load_meta(@entities);
+        }
+
+        if ($type eq 'tag')
+        {
+            my @entities = map { $_->entity } @results;
+            $self->c->model('Genre')->load(@entities);
         }
 
         my $pager = Data::Page->new;


### PR DESCRIPTION
### Implement MBS-9876

We support searching for tags with SOLR, so we should probably allow doing that. Because the response does not include tag ID, we just load the tag based on the returned name.

For what it's worth, the results are currently significantly worse than with direct search. We might want to try and improve that.
![Screenshot from 2021-02-25 21-12-18](https://user-images.githubusercontent.com/1069224/109204922-9c95a600-77ae-11eb-9b44-05366b6dbef8.png)

