### PR TITLE
MBS-9871: Display all useful series relationships in RelatedSeries

### DIFF
--- a/root/components/RelatedSeries.js
+++ b/root/components/RelatedSeries.js
@@ -13,9 +13,8 @@ import EntityLink from '../static/scripts/common/components/EntityLink';
 import linkedEntities from '../static/scripts/common/linkedEntities';
 import groupRelationships from '../utility/groupRelationships';
 
+import {isNotSeriesPart} from './Relationships';
 import StaticRelationshipsDisplay from './StaticRelationshipsDisplay';
-
-const targetEntityTypes = ['url'];
 
 type Props = {
   +seriesIds: $ReadOnlyArray<number>,
@@ -38,7 +37,11 @@ const RelatedSeries = ({seriesIds}: Props): React.MixedElement => {
       </h3>,
       <StaticRelationshipsDisplay
         relationships={
-          groupRelationships(series.relationships, targetEntityTypes)
+          groupRelationships(
+            series.relationships,
+            undefined,
+            isNotSeriesPart,
+          )
         }
       />,
     );

--- a/root/components/Relationships.js
+++ b/root/components/Relationships.js
@@ -61,7 +61,7 @@ const seriesPartLinkTypes = new Set(
   Object.values(PART_OF_SERIES_LINK_TYPES),
 );
 
-function isNotSeriesPart(r: RelationshipT) {
+export function isNotSeriesPart(r: RelationshipT): boolean {
   return !seriesPartLinkTypes.has(linkedEntities.link_type[r.linkTypeID].gid);
 }
 


### PR DESCRIPTION
### Implement MBS-9871

The only thing we want to avoid here is showing all the part-of-series rels on the page for every entity in a series. But for that there is no need to limit the rels shown to URLs - we have a perfectly effective `isNotSeriesPart` function we already use for series pages.