### PR TITLE
MBS-9866: Add bubbles explaining what IPI and ISNI are on add forms

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -90,6 +90,9 @@
     [%- area_bubble() -%]
 
     [%- type_bubble(form.field('type_id'), artist_types) -%]
+
+    [%- ipi_bubble() -%]
+    [%- isni_bubble() -%]
   </div>
 
 </form>
@@ -104,5 +107,8 @@
     MB.initializeDuplicateChecker('artist');
 
     MB.initializeTooShortYearChecks('artist');
+
+    MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-artist\\.ipi_codes\\.0]");
+    MB.Control.initializeBubble("#isni-bubble", "input[name=edit-artist\\.isni_codes\\.0]");
   }());
 </script>

--- a/root/components/forms.tt
+++ b/root/components/forms.tt
@@ -328,6 +328,24 @@
     </div>
 [%- END -%]
 
+[%- MACRO ipi_bubble BLOCK -%]
+    <div class="bubble" id="ipi-bubble">
+      <p>[% l('IPI codes are assigned by CISAC to “interested parties” in musical rights management.
+               Check {ipi_doc|the documentation} for more info.',
+            { ipi_doc => doc_link('IPI') }) %]</p>
+      <p>[% l('If you don’t know the code for this entity, just leave the field blank.') %]</p>
+    </div>
+[%- END -%]
+
+[%- MACRO isni_bubble BLOCK -%]
+    <div class="bubble" id="isni-bubble">
+      <p>[% l('ISNI codes are an ISO standard used to uniquely identify persons and organizations.
+               Check {isni_doc|the documentation} for more info.',
+            { isni_doc => doc_link('ISNI') }) %]</p>
+      <p>[% l('If you don’t know the code for this entity, just leave the field blank.') %]</p>
+    </div>
+[%- END -%]
+
 [%- MACRO area_bubble BLOCK -%]
     <div class="bubble" id="area-bubble">
       <!-- ko with: target() && target().area -->

--- a/root/label/edit_form.tt
+++ b/root/label/edit_form.tt
@@ -49,6 +49,8 @@
 
   <div class="documentation">
     [%- area_bubble() -%]
+    [%- ipi_bubble() -%]
+    [%- isni_bubble() -%]
   </div>
 
 </form>
@@ -62,5 +64,8 @@
     MB.Control.Area("span.area.autocomplete");
 
     MB.initializeDuplicateChecker('label');
+
+    MB.Control.initializeBubble("#ipi-bubble", "input[name=edit-label\\.ipi_codes\\.0]");
+    MB.Control.initializeBubble("#isni-bubble", "input[name=edit-label\\.isni_codes\\.0]");
   }());
 </script>


### PR DESCRIPTION
### Implement MBS-9866

It's hard to explain these in a very clear way, but really the most important thing here is to tell users that no, they really don't need to freak out about not being able to fill these.