### PR TITLE
MBS-10416: Remove invalid characters from edited annotations

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -38,6 +38,7 @@ use MusicBrainz::Server::Data::Utils qw(
     sanitize
     trim
     trim_comment
+    trim_multiline_text
     non_empty
 );
 use MusicBrainz::Server::Renderer qw( render_component );
@@ -131,7 +132,7 @@ our $data_processors = {
     $EDIT_RELEASE_ADD_ANNOTATION => sub {
         my ($c, $loader, $data) = @_;
 
-        process_release_label($c, $loader, $data);
+        process_annotation($c, $loader, $data);
         load_entity_prop($loader, $data, 'entity', 'Release');
     },
 
@@ -211,6 +212,17 @@ our $data_processors = {
 sub trim_string {
     my ($data, $name) = @_;
     $data->{$name} = trim($data->{$name}) if $data->{$name};
+}
+
+sub trim_multiline_string {
+    my ($data, $name) = @_;
+    $data->{$name} = trim_multiline_text($data->{$name}) if $data->{$name};
+}
+
+sub process_annotation {
+    my ($c, $loader, $data) = @_;
+
+    trim_multiline_string($data, 'text');
 }
 
 sub process_entity {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -129,6 +129,7 @@ our $data_processors = {
         load_entity_prop($loader, $data, 'label', 'Label') if $data->{label};
     },
 
+    # MBS-11428: Keep it synced with MusicBrainz::Server::Form::Annotation
     $EDIT_RELEASE_ADD_ANNOTATION => sub {
         my ($c, $loader, $data) = @_;
 
@@ -177,6 +178,7 @@ our $data_processors = {
         load_entity_prop($loader, $data, 'release', 'Release');
     },
 
+    # MBS-11428: Keep it synced with MusicBrainz::Server::Form::Recording
     $EDIT_RECORDING_EDIT => sub {
         my ($c, $loader, $data) = @_;
 
@@ -194,8 +196,10 @@ our $data_processors = {
         load_entity_prop($loader, $data, 'release', 'Release');
     },
 
+    # MBS-11428: Keep it synced with MusicBrainz::Server::Form::ReleaseGroup
     $EDIT_RELEASEGROUP_CREATE => \&process_entity,
 
+    # MBS-11428: Keep it synced with MusicBrainz::Server::Form::ReleaseGroup
     $EDIT_RELEASEGROUP_EDIT => sub {
         my ($c, $loader, $data) = @_;
 
@@ -205,6 +209,7 @@ our $data_processors = {
         load_entity_prop($loader, $data, 'to_edit', 'ReleaseGroup');
     },
 
+    # MBS-11428: Keep it synced with MusicBrainz::Server::Form::Work
     $EDIT_WORK_CREATE => \&process_entity,
 };
 

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -365,9 +365,10 @@ sub trim_comment {
 sub trim_multiline_text {
     my $t = shift;
 
-    # Not trimming starting spaces to avoid breaking list formatting,
-    # consider trimming again once this uses Markdown
-    $t =~ s/\s+$//;
+    # Not trimming starting spaces to avoid breaking
+    # either list formatting in Wikitext
+    # or block in Markdown.
+    $t =~ s/\s+$//gm;
 
     return $t;
 }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -334,6 +334,7 @@ sub sanitize {
     # into U+0020 (or else they'll be removed).
     $t = collapse_whitespace($t);
     $t = remove_invalid_characters($t);
+    $t = remove_lineformatting_characters($t);
     $t = remove_direction_marks($t);
     # Collapse spaces again, since characters may have been removed.
     $t = collapse_whitespace($t);
@@ -397,17 +398,23 @@ my $noncharacter_pattern = '\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}';
 
 sub remove_invalid_characters {
     shift
-    # trim XML-invalid characters
+    # trim XML-invalid characters, among them:
+    # - Other, surrogate (which are UTF-16, not valid UTF-8)
     =~ s/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]//gor
     # trim other undesirable characters:
-    # - zwsp
-    # - shy
     # - bom
-    # - Other, control
-    # - Other, surrogate
     # - Supplementary private use areas
     # - Noncharacters
-    =~ s/[\x{200B}\x{00AD}\x{FEFF}\p{Cc}\x{F0000}-\x{FFFFF}\x{100000}-\x{10FFFF}${noncharacter_pattern}]//gr
+    =~ s/[\x{FEFF}\x{F0000}-\x{FFFFF}\x{100000}-\x{10FFFF}${noncharacter_pattern}]//gr
+}
+
+sub remove_lineformatting_characters {
+    shift
+    # trim lasting line-formatting characters:
+    # - zwsp
+    # - shy
+    # - Other, control (including TAB \x09, LF \x0A, and CR \x0D)
+    =~ s/[\x{200B}\x{00AD}\p{Cc}]//gr
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -76,6 +76,7 @@ our @EXPORT_OK = qw(
     take_while
     trim
     trim_comment
+    trim_multiline_text
     type_to_model
     split_relationship_by_attributes
 );
@@ -359,6 +360,16 @@ sub trim_comment {
     $t =~ s/^\s*\(([^()]+)\)\s*$/$1/;
 
     return trim($t);
+}
+
+sub trim_multiline_text {
+    my $t = shift;
+
+    # Not trimming starting spaces to avoid breaking list formatting,
+    # consider trimming again once this uses Markdown
+    $t =~ s/\s+$//;
+
+    return $t;
 }
 
 sub remove_direction_marks {

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -365,6 +365,8 @@ sub trim_comment {
 sub trim_multiline_text {
     my $t = shift;
 
+    $t = NFC($t);
+    $t = remove_invalid_characters($t);
     # Not trimming starting spaces to avoid breaking
     # either list formatting in Wikitext
     # or block in Markdown.

--- a/lib/MusicBrainz/Server/Form/Annotation.pm
+++ b/lib/MusicBrainz/Server/Form/Annotation.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Form::Annotation;
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Data::Utils qw( trim_multiline_text );
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 
@@ -7,13 +8,7 @@ has '+name' => (default => 'edit-annotation');
 
 has_field 'text' => (
     type     => 'Text',
-    trim => { transform => sub {
-        my $string = shift;
-        # Not trimming starting spaces to avoid breaking list formatting,
-        # consider trimming again once this uses Markdown 
-        $string =~ s/\s+$//;
-        return $string;
-    } }
+    trim => { transform => sub { trim_multiline_text(shift) } }
 );
 
 has_field 'changelog' => (

--- a/lib/MusicBrainz/Server/Form/Annotation.pm
+++ b/lib/MusicBrainz/Server/Form/Annotation.pm
@@ -4,6 +4,9 @@ use MusicBrainz::Server::Data::Utils qw( trim_multiline_text );
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 
+# MBS-11428: When making changes to this module, please make sure to
+# keep MusicBrainz::Server::Controller::WS::js::Edit in sync with it
+
 has '+name' => (default => 'edit-annotation');
 
 has_field 'text' => (

--- a/lib/MusicBrainz/Server/Form/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Recording.pm
@@ -9,6 +9,9 @@ extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 with 'MusicBrainz::Server::Form::Role::Relationships';
 
+# MBS-11428: When making changes to this module, please make sure to
+# keep MusicBrainz::Server::Controller::WS::js::Edit in sync with it
+
 has '+name' => ( default => 'edit-recording' );
 
 has_field 'name' => (

--- a/lib/MusicBrainz/Server/Form/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Form/ReleaseGroup.pm
@@ -7,6 +7,9 @@ extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 with 'MusicBrainz::Server::Form::Role::Relationships';
 
+# MBS-11428: When making changes to this module, please make sure to
+# keep MusicBrainz::Server::Controller::WS::js::Edit in sync with it
+
 has '+name' => ( default => 'edit-release-group' );
 
 has_field 'primary_type_id' => (

--- a/lib/MusicBrainz/Server/Form/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Work.pm
@@ -10,6 +10,9 @@ extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 with 'MusicBrainz::Server::Form::Role::Relationships';
 
+# MBS-11428: When making changes to this module, please make sure to
+# keep MusicBrainz::Server::Controller::WS::js::Edit in sync with it
+
 has '+name' => ( default => 'edit-work' );
 
 has_field 'type_id' => (

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -22,7 +22,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for an artist\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for an artist  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -35,7 +35,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Test Artist',
     },
-    text => "    * Test annotation for an artist\r\n    * This annotation has two bullets",
+    text => "    * Test annotation for an artist\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -22,7 +22,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for an artist  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for an artist  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -35,7 +35,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Test Artist',
     },
-    text => "    * Test annotation for an artist\n    * This annotation has two bullets",
+    text => "    * Test annotation for an artist\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -22,7 +22,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => 'Test annotation 1. This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for an artist\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -35,7 +35,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Test Artist',
     },
-    text => 'Test annotation 1. This is my annotation',
+    text => "    * Test annotation for an artist\r\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => 'Test annotation 2. This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for a label\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -32,7 +32,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Another Label'
     },
-    text => 'Test annotation 2. This is my annotation',
+    text => "    * Test annotation for a label\r\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a label  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -32,7 +32,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Another Label'
     },
-    text => "    * Test annotation for a label\n    * This annotation has two bullets",
+    text => "    * Test annotation for a label\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a label\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for a label  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -32,7 +32,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Another Label'
     },
-    text => "    * Test annotation for a label\r\n    * This annotation has two bullets",
+    text => "    * Test annotation for a label\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a recording\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for a recording  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Dancing Queen'
     },
-    text => "    * Test annotation for a recording\r\n    * This annotation has two bullets",
+    text => "    * Test annotation for a recording\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a recording  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Dancing Queen'
     },
-    text => "    * Test annotation for a recording\n    * This annotation has two bullets",
+    text => "    * Test annotation for a recording\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => 'Test annotation 3. This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for a recording\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Dancing Queen'
     },
-    text => 'Test annotation 3. This is my annotation',
+    text => "    * Test annotation for a recording\r\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a release\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for a release  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 2,
         name => 'Aerial'
     },
-    text => "    * Test annotation for a release\r\n    * This annotation has two bullets",
+    text => "    * Test annotation for a release\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => 'This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for a release\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 2,
         name => 'Aerial'
     },
-    text => 'This is my annotation',
+    text => "    * Test annotation for a release\r\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a release  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 2,
         name => 'Aerial'
     },
-    text => "    * Test annotation for a release\n    * This annotation has two bullets",
+    text => "    * Test annotation for a release\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => 'Test annotation 5. This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for a release group\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Arrival'
     },
-    text => 'Test annotation 5. This is my annotation',
+    text => "    * Test annotation for a release group\r\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a release group  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Arrival'
     },
-    text => "    * Test annotation for a release group\n    * This annotation has two bullets",
+    text => "    * Test annotation for a release group\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a release group\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for a release group  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Arrival'
     },
-    text => "    * Test annotation for a release group\r\n    * This annotation has two bullets",
+    text => "    * Test annotation for a release group\n    * This annotation has two bullets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -20,7 +20,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
     $mech->submit_form(
         with_fields => {
-            'edit-annotation.text' => "    * Test annotation for a series  \r\n    * This annotation has two bullets  \t\t",
+            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
             'edit-annotation.changelog' => 'And a changelog',
         });
 
@@ -35,7 +35,7 @@ test all => sub {
             id => 1,
             name => 'Test Recording Series'
         },
-        text => "    * Test annotation for a series\n    * This annotation has two bullets",
+        text => "    * Test annotation for a series\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'And a changelog',
         editor_id => 1
     });

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -20,7 +20,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
     $mech->submit_form(
         with_fields => {
-            'edit-annotation.text' => 'Very short annotation',
+            'edit-annotation.text' => "    * Test annotation for a series\r\n    * This annotation has two bullets  \t\t",
             'edit-annotation.changelog' => 'And a changelog',
         });
 
@@ -35,7 +35,7 @@ test all => sub {
             id => 1,
             name => 'Test Recording Series'
         },
-        text => 'Very short annotation',
+        text => "    * Test annotation for a series\r\n    * This annotation has two bullets",
         changelog => 'And a changelog',
         editor_id => 1
     });

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -20,7 +20,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
     $mech->submit_form(
         with_fields => {
-            'edit-annotation.text' => "    * Test annotation for a series\r\n    * This annotation has two bullets  \t\t",
+            'edit-annotation.text' => "    * Test annotation for a series  \r\n    * This annotation has two bullets  \t\t",
             'edit-annotation.changelog' => 'And a changelog',
         });
 
@@ -35,7 +35,7 @@ test all => sub {
             id => 1,
             name => 'Test Recording Series'
         },
-        text => "    * Test annotation for a series\r\n    * This annotation has two bullets",
+        text => "    * Test annotation for a series\n    * This annotation has two bullets",
         changelog => 'And a changelog',
         editor_id => 1
     });

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -660,7 +660,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     my $annotation_edits = [ {
         edit_type       => $EDIT_RELEASE_ADD_ANNOTATION,
         entity          => $release_id,
-        text            => "    * Test annotation in release editor\n    * This annotation has two bullets  \t\t",
+        text            => "    * Test annotation in release editor  \r\n    * This annotation has two bullets  \t\t",
     } ];
 
     @edits = capture_edits {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -11,6 +11,7 @@ use MusicBrainz::Server::Constants qw(
     $EDIT_RECORDING_EDIT
     $EDIT_RELEASE_CREATE
     $EDIT_RELEASE_EDIT
+    $EDIT_RELEASE_ADD_ANNOTATION
     $EDIT_RELEASE_ADDRELEASELABEL
     $EDIT_RELEASEGROUP_CREATE
     $EDIT_RELEASEGROUP_EDIT
@@ -651,6 +652,29 @@ test 'previewing/creating/editing a release group and release' => sub {
         release         => { name => 'Vision Creation Newsun', id => 4, gid => ignore() },
         label           => { name => 'Warp Records', id => 2, gid => '46f0f4cd-8aab-4b33-b698-f459faf64190' },
         catalog_number  => undef,
+    });
+
+
+    # Add release annotation.
+
+    my $annotation_edits = [ {
+        edit_type       => $EDIT_RELEASE_ADD_ANNOTATION,
+        entity          => $release_id,
+        text            => "    * Test annotation in release editor\n    * This annotation has two bullets  \t\t",
+    } ];
+
+    @edits = capture_edits {
+        post_json($mech, '/ws/js/edit/create', encode_json({ edits => $annotation_edits }));
+    } $c;
+
+    is(scalar(@edits), 1);
+
+    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Release::AddAnnotation');
+
+    cmp_deeply($edits[0]->data, {
+        editor_id       => 1,
+        entity          => { id => $release_id, name => 'Vision Creation Newsun' },
+        text            => "    * Test annotation in release editor\n    * This annotation has two bullets",
     });
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -660,7 +660,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     my $annotation_edits = [ {
         edit_type       => $EDIT_RELEASE_ADD_ANNOTATION,
         entity          => $release_id,
-        text            => "    * Test annotation in release editor  \r\n    * This annotation has two bullets  \t\t",
+        text            => "    * Test annotation\x{0007} in release editor  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
     } ];
 
     @edits = capture_edits {
@@ -674,10 +674,9 @@ test 'previewing/creating/editing a release group and release' => sub {
     cmp_deeply($edits[0]->data, {
         editor_id       => 1,
         entity          => { id => $release_id, name => 'Vision Creation Newsun' },
-        text            => "    * Test annotation in release editor\n    * This annotation has two bullets",
+        text            => "    * Test annotation in release editor\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     });
 };
-
 
 test 'adding a relationship' => sub {
     my $test = shift;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok("/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation");
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a work\r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation for a work  \r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     }
 );
@@ -33,7 +33,7 @@ is_deeply(
             id => 1,
             name => 'Dancing Queen'
         },
-        text => "    * Test annotation for a work\r\n    * This annotation has two bullets",
+        text => "    * Test annotation for a work\n    * This annotation has two bullets",
         changelog => 'Changelog here',
         editor_id => 1
     }

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok("/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation");
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text'      => 'Test annotation 6. This is my annotation',
+        'edit-annotation.text' => "    * Test annotation for a work\r\n    * This annotation has two bullets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     }
 );
@@ -33,7 +33,7 @@ is_deeply(
             id => 1,
             name => 'Dancing Queen'
         },
-        text      => 'Test annotation 6. This is my annotation',
+        text => "    * Test annotation for a work\r\n    * This annotation has two bullets",
         changelog => 'Changelog here',
         editor_id => 1
     }

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok("/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation");
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation for a work  \r\n    * This annotation has two bullets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     }
 );
@@ -33,7 +33,7 @@ is_deeply(
             id => 1,
             name => 'Dancing Queen'
         },
-        text => "    * Test annotation for a work\n    * This annotation has two bullets",
+        text => "    * Test annotation for a work\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'Changelog here',
         editor_id => 1
     }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-10416: Annotation with some control characters cannot be indexed for search


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Strip such characters (and other invalid characters) when entered in annotation.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Add test


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Clean the 216 existing annotations having such invalid characters.
