### PR TITLE
MBS-9826: Show more realistic edit closing time overviews

### DIFF
--- a/root/components/VotingPeriod.js
+++ b/root/components/VotingPeriod.js
@@ -28,11 +28,11 @@ const VotingPeriod = ({
 
   if (date > now) {
     const durationSeconds = Math.floor((date - now) / 1000);
-    const durationMinutes = Math.floor(durationSeconds / 60);
-    const durationHours = Math.floor(durationMinutes / 60);
-    const durationDays = Math.floor(durationHours / 24);
+    const durationMinutes = Math.round(durationSeconds / 60);
+    const durationHours = Math.round(durationMinutes / 60);
+    const durationDays = Math.round(durationHours / 24);
 
-    if (durationDays > 0) {
+    if (durationHours > 23) {
       return exp.ln(
         `Closes in
          <span class="tooltip" title="{exactdate}">{num} day</span>`,
@@ -41,7 +41,7 @@ const VotingPeriod = ({
         durationDays,
         {exactdate: userDate, num: durationDays},
       );
-    } else if (durationHours > 0) {
+    } else if (durationMinutes > 59) {
       return exp.ln(
         `Closes in
          <span class="tooltip" title="{exactdate}">{num} hour</span>`,


### PR DESCRIPTION
### Implement MBS-9826

It's quite misleading to say "closes in 6 days" as soon as an edit is entered, given that it's really 6 days, 23 hours and 50-something minutes. Yes, we have a tooltip with the date, but still.

Instead of using floor, this uses round - it seems more sensible to say 7 days when it's more than 6 and a half, etc.

I start displaying hours once they hit 23 (rounded, so at 23 h and 30 minutes left), rather than still saying 1 day until there's only 12 hours left like elsewhere.