### PR TITLE
MBS-11410: Remove row lock on editor table when creating edits

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -544,10 +544,6 @@ sub create {
     $edit->auto_edit(1)
         if ($edit->editor_id == $EDITOR_MODBOT && $edit->modbot_auto_edit);
 
-    # Serialize transactions per-editor. Should only be necessary for autoedits,
-    # since only they update the editor table but for now we've enabled it for everything
-    $self->c->model('Editor')->lock_row($edit->editor_id);
-
     $edit->insert;
 
     my $duration = DateTime::Duration->new( days => $conditions->{duration} );

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -406,14 +406,6 @@ sub save_preferences
     }, $self->sql);
 }
 
-# Must be run in a transaction to actually do anything. Acquires a row-level lock for a given editor ID.
-sub lock_row
-{
-    my ($self, $editor_id) = @_;
-    my $query = "SELECT 1 FROM " . $self->_table . " WHERE id = ? FOR UPDATE";
-    $self->sql->do($query, $editor_id);
-}
-
 sub donation_check
 {
     my ($self, $obj) = @_;


### PR DESCRIPTION
Reverts the following commits:

e3db4d5491c9a56f50193fd03dd67356a2c19db2
77f04ca1fe86dc53168139ef30c5b76f64bb3066

These changes were made to resolve the type of deadlock described in MBS-3597. However, there is no longer any `edits_accepted` column on the editor table; it's been dropped since f4fccd56ff930b0f0610c57d2b751541fe030132 and unused since before that. So there is no present situation I can see where the mere *creation* of an edit requires a lock on the editor row.

More discussion of the original changes can be found here:
https://web.archive.org/web/20140602202250/http://codereview.musicbrainz.org/r/2043/

I was able to reproduce the issue in MBS-11410 simply by setting the `statement_timeout` of my local database to something small, like '1s', and adding a `sleep(10);` to `Data::Edit::_close`. With no `SELECT ... FOR UPDATE` to time out on, applying this patch fixed the issue locally.

However, I'm still not clear on what caused the initial issue in the approval edit:

```
ERROR:  could not obtain lock on row in relation "edit" [for
Statement "SELECT id FROM edit WHERE id = ? FOR UPDATE NOWAIT"
with ParamValues: 1='77663946']
```

This commit does not attempt to resolve that issue, but avoids further timeouts due to the `editor` row lock removed here.