### PR TITLE
MBS-9695: Allow editing LinkAttributeType creditable/free_text via UI

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/AddLinkAttribute.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/AddLinkAttribute.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Edit::Relationship::AddLinkAttribute;
 use Moose;
-use MooseX::Types::Structured qw( Dict );
-use MooseX::Types::Moose qw( Int Str );
+use MooseX::Types::Structured qw( Dict Optional );
+use MooseX::Types::Moose qw( Bool Int Str );
 use MusicBrainz::Server::Constants qw( $EDIT_RELATIONSHIP_ADD_ATTRIBUTE );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
@@ -22,7 +23,9 @@ has '+data' => (
         name        => Str,
         parent_id   => Nullable[Int],
         description => Nullable[Str],
-        child_order => Str
+        child_order => Str,
+        creditable => Optional[Bool],
+        free_text => Optional[Bool],
     ]
 );
 
@@ -43,7 +46,9 @@ sub build_display_data
         child_order => $self->data->{child_order},
         description => $self->data->{description},
         name => $self->data->{name},
-        parent => defined $parent_id ? to_json_object($loaded->{LinkAttributeType}{$parent_id}) : undef
+        parent => defined $parent_id ? to_json_object($loaded->{LinkAttributeType}{$parent_id}) : undef,
+        creditable => boolean_to_json($self->data->{creditable}),
+        free_text => boolean_to_json($self->data->{free_text}),
     }
 }
 

--- a/lib/MusicBrainz/Server/Edit/Relationship/EditLinkAttribute.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/EditLinkAttribute.pm
@@ -1,8 +1,10 @@
 package MusicBrainz::Server::Edit::Relationship::EditLinkAttribute;
 use Moose;
 use MooseX::Types::Structured qw( Dict Optional );
-use MooseX::Types::Moose qw( Int Str );
+use MooseX::Types::Moose qw( Bool Int Str );
+use Data::Compare;
 use MusicBrainz::Server::Constants qw( $EDIT_RELATIONSHIP_ATTRIBUTE );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Edit::Utils qw( changed_display_data );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
@@ -23,8 +25,24 @@ sub change_fields
         name        => Optional[Str],
         description => Nullable[Str],
         parent_id   => Nullable[Int],
-        child_order => Optional[Int]
+        child_order => Optional[Int],
+        creditable => Optional[Bool],
+        free_text => Optional[Bool],
     ]
+}
+
+sub to_hash {
+    my $data = shift->data;
+
+    for ($data->{old}, $data->{new}) {
+        $_->{creditable} = boolean_to_json($_->{creditable}) if exists $_->{creditable};
+        $_->{free_text} = boolean_to_json($_->{free_text}) if exists $_->{free_text};
+    }
+
+    MusicBrainz::Server::Edit::Exceptions::NoChanges->throw
+        if Compare($data->{old}, $data->{new});
+
+    return $data;
 }
 
 has '+data' => (
@@ -52,6 +70,8 @@ sub build_display_data
         name        => 'name',
         description => 'description',
         child_order => 'child_order',
+        creditable  => 'creditable',
+        free_text   => 'free_text',
     );
 
     my $data = changed_display_data($self->data, $loaded, %map);

--- a/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/LinkAttributeType.pm
@@ -8,7 +8,7 @@ use MusicBrainz::Server::Translation qw( l );
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
 
-sub edit_field_names { qw( parent_id child_order name description ) }
+sub edit_field_names { qw( parent_id child_order name description creditable free_text ) }
 
 has '+name' => ( default => 'linkattrtype' );
 
@@ -29,6 +29,14 @@ has_field 'name' => (
 
 has_field 'description' => (
     type => 'Text',
+);
+
+has_field creditable => (
+    type => 'Boolean'
+);
+
+has_field free_text => (
+    type => 'Boolean'
 );
 
 sub options_parent_id

--- a/lib/MusicBrainz/Server/Plugin/FormRenderer.pm
+++ b/lib/MusicBrainz/Server/Plugin/FormRenderer.pm
@@ -62,6 +62,7 @@ sub _render_input
             value => '' . $field->fif,
             name => $field->html_name,
             class => $class . ($field->has_errors ? ' error' : ''),
+            disabled => $field->disabled,
             %attrs
         });
 }

--- a/root/edit/details/AddRelationshipAttribute.js
+++ b/root/edit/details/AddRelationshipAttribute.js
@@ -13,12 +13,15 @@ import IntentionallyRawIcon
   from '../components/IntentionallyRawIcon';
 import localizeLinkAttributeTypeName
   from '../../static/scripts/common/i18n/localizeLinkAttributeTypeName';
+import yesNo from '../../static/scripts/common/utility/yesNo';
 
 type AddRelationshipAttributeEditT = {
   ...EditT,
   +display_data: {
     +child_order: number,
+    +creditable: boolean,
     +description: string | null,
+    +free_text: boolean,
     +name: string,
     +parent?: LinkAttrTypeT,
   },
@@ -67,6 +70,14 @@ const AddRelationshipAttribute = ({edit}: Props): React.Element<'table'> => {
           <td>{localizeLinkAttributeTypeName(parent)}</td>
         </tr>
       ) : null}
+      <tr>
+        <th>{addColonText(l('Creditable'))}</th>
+        <td>{yesNo(display.creditable)}</td>
+      </tr>
+      <tr>
+        <th>{addColonText(l('Free text'))}</th>
+        <td>{yesNo(display.free_text)}</td>
+      </tr>
     </table>
   );
 };

--- a/root/edit/details/EditRelationshipAttribute.js
+++ b/root/edit/details/EditRelationshipAttribute.js
@@ -14,13 +14,18 @@ import IntentionallyRawIcon
 import expand2react from '../../static/scripts/common/i18n/expand2react';
 import localizeLinkAttributeTypeName
   from '../../static/scripts/common/i18n/localizeLinkAttributeTypeName';
+import FullChangeDiff from
+  '../../static/scripts/edit/components/edit/FullChangeDiff';
 import WordDiff from '../../static/scripts/edit/components/edit/WordDiff';
+import yesNo from '../../static/scripts/common/utility/yesNo';
 
 type EditRelationshipAttributeEditT = {
   ...EditT,
   +display_data: {
     +child_order?: CompT<number>,
+    +creditable?: CompT<boolean>,
     +description: CompT<string | null>,
+    +free_text?: CompT<boolean>,
     +name: CompT<string>,
     +original_description: string | null,
     +original_name: string,
@@ -40,6 +45,8 @@ const EditRelationshipAttribute = ({edit}: Props): React.Element<'table'> => {
   const descriptionChanges = newDescription !== oldDescription;
   const name = display.name;
   const parent = display.parent;
+  const creditable = display.creditable;
+  const freeText = display.free_text;
   const newParentName = parent?.new
     ? localizeLinkAttributeTypeName(parent.new)
     : '';
@@ -102,6 +109,22 @@ const EditRelationshipAttribute = ({edit}: Props): React.Element<'table'> => {
           label={addColonText(l('Child order'))}
           newText={childOrder.new.toString()}
           oldText={childOrder.old.toString()}
+        />
+      ) : null}
+
+      {creditable ? (
+        <FullChangeDiff
+          label={addColonText(l('Creditable'))}
+          newContent={yesNo(creditable.new)}
+          oldContent={yesNo(creditable.old)}
+        />
+      ) : null}
+
+      {freeText ? (
+        <FullChangeDiff
+          label={addColonText(l('Free text'))}
+          newContent={yesNo(freeText.new)}
+          oldContent={yesNo(freeText.old)}
         />
       ) : null}
     </table>

--- a/root/relationship/linkattributetype/form.tt
+++ b/root/relationship/linkattributetype/form.tt
@@ -17,6 +17,9 @@
         [% field_errors(form, 'description') %]
     [% END %]
 
+    [% form_row_checkbox(r, 'creditable', l('This attribute supports free text credits')) %]
+    [% form_row_checkbox(r, 'free_text', l('This attribute uses free text values')) %]
+
     <div class="row no-label">
         [% form_submit(l('Save')) %]
     </div>


### PR DESCRIPTION
### Implement MBS-9695

Since adding/removing free_text would probably make a mess of existing attribute uses, we disable that if the attribute is in use.
Same for removing creditable (since we wouldn't want to accidentally break existing attribute credits) - adding creditable should always be safe unless I'm missing something.

Tested by hand by adding and removing them locally from newly created attributes, and by trying to remove them from existing ones (Task should be in use in sample data).