### PR TITLE
Add Flow helper to check the exhaustiveness of switch statements

### DIFF
--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -217,6 +217,9 @@ function reducer(state: StateT, action: ActionT): StateT {
         applyAllPendingErrors(newState.form);
         break;
       }
+      default: {
+        /*:: exhaustive(action); */
+      }
     }
   });
 }

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -229,6 +229,7 @@ export function runReducer<+T: EntityItem>(
       break;
 
     default:
+      /*:: exhaustive(action); */
       throw new Error('Unknown action: ' + action.type);
   }
 }

--- a/root/vars.js
+++ b/root/vars.js
@@ -106,3 +106,6 @@ declare var texp: {
     args: {+[arg: string]: StrOrNum, ...},
   ) => string,
 };
+
+// https://flow.org/en/docs/tips/switch-statement-exhaustiveness/
+declare var exhaustive: (action: empty) => void;


### PR DESCRIPTION
Calling this imaginary function from a 'flow-include' comment will cause a switch statement to error if you haven't handled all possible cases. This is especially useful for reducer functions that have many possible actions.

See https://flow.org/en/docs/tips/switch-statement-exhaustiveness/