### PR TITLE
MBS-9836: Guess Case: stop uppercasing "the" in artist names

### DIFF
--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Artist.js
@@ -168,19 +168,5 @@ MB.GuessCase.Handler.Artist = function (gc) {
     });
   };
 
-  var baseProcess = self.process;
-
-  self.process = function (is) {
-    var isLowerCaseWord = gc.mode.isLowerCaseWord;
-
-    gc.mode.isLowerCaseWord = function (w) {
-      return w === 'the' ? false : isLowerCaseWord.call(gc.mode, w);
-    };
-
-    var os = baseProcess.call(self, is);
-    gc.mode.isLowerCaseWord = isLowerCaseWord;
-    return os;
-  };
-
   return self;
 };

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -114,8 +114,8 @@ test('Artist', function (t) {
     },
     {
       input: 'Peggy Sue And The Pirates',
-      expected: 'Peggy Sue and The Pirates',
-      bug: 'MBS-1370',
+      expected: 'Peggy Sue and the Pirates',
+      bug: 'MBS-1370 / MBS-9836',
       mode: 'Artist',
     },
   ];


### PR DESCRIPTION
### Implement MBS-9836

There's no documentation about why this was done this way in the first place, but most likely it was because of pre-NGS artists which would have two or more different, full artist names as part of a collaboration artist name. This is fairly uncommon with NGS, while artists which just have "the" in their names (think "Tyler, the Creator") and where "the" should be lowercase are reasonably common.

I asked the community and most feedback suggested dropping this unexplained / unexpected difference between artist guess case and guess case for other entities.