### PR TITLE
MBS-8232: Support more Unicode quotation marks in guess case

### DIFF
--- a/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Handler/Base.js
@@ -113,7 +113,7 @@ MB.GuessCase.Handler.Base = function (gc) {
        */
       var handled = false;
       if (!gc.re.SPECIALCASES) {
-        gc.re.SPECIALCASES = /(&|¿|¡|\?|\!|;|:|'|‘|’|"|\-|\+|,|\*|\.|#|%|\/|\(|\)|\{|\}|\[|\])/;
+        gc.re.SPECIALCASES = /(&|¿|¡|\?|\!|;|:|'|‘|’|‹|›|"|“|”|„|“|«|»|\-|\+|,|\*|\.|#|%|\/|\(|\)|\{|\}|\[|\])/;
       }
       if (gc.i.matchCurrentWord(gc.re.SPECIALCASES)) {
         handled = !!(
@@ -389,7 +389,7 @@ MB.GuessCase.Handler.Base = function (gc) {
   // Deal with double quotes (")
   self.doDoubleQuote = function () {
     if (!gc.re.DOUBLEQUOTE) {
-      gc.re.DOUBLEQUOTE = '"';
+      gc.re.DOUBLEQUOTE = /["“”„“«»]/;
     }
     if (gc.i.matchCurrentWord(gc.re.DOUBLEQUOTE)) {
       // Changed 05/2006: do not force capitalization before quotes
@@ -412,7 +412,7 @@ MB.GuessCase.Handler.Base = function (gc) {
    */
   self.doSingleQuote = function () {
     if (!gc.re.SINGLEQUOTE) {
-      gc.re.SINGLEQUOTE = /['‘’]/;
+      gc.re.SINGLEQUOTE = /['‘’‹›]/;
     }
 
     if (gc.i.matchCurrentWord(gc.re.SINGLEQUOTE)) {

--- a/root/static/scripts/guess-case/MB/GuessCase/Input.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Input.js
@@ -194,7 +194,7 @@ MB.GuessCase.Input = function (gc) {
     var splitwords = [];
     var word = [];
     if (!gc.re.SPLITWORDSANDPUNCTUATION) {
-      gc.re.SPLITWORDSANDPUNCTUATION = /[^!¿¡\"%&'´`‘’()\[\]\{\}\*\+,-\.\/:;<=>\?\s#]/;
+      gc.re.SPLITWORDSANDPUNCTUATION = /[^!¿¡\"%&'´`‘’‹›“”„“«»()\[\]\{\}\*\+,-\.\/:;<=>\?\s#]/;
     }
     for (var i = 0; i < chars.length; i++) {
       if (chars[i].match(gc.re.SPLITWORDSANDPUNCTUATION)) {

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -209,7 +209,7 @@ test('Work', function (t) {
     },
     {
       input: 'acte 1, no. 7: chœur: «voyons brigadier»',
-      expected: 'Acte 1, no. 7 : Chœur : « voyons brigadier »',
+      expected: 'Acte 1, no. 7 : Chœur : « Voyons brigadier »',
       mode: 'French',
       roman: false,
       keepuppercase: false,
@@ -358,7 +358,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(24);
+  t.plan(26);
 
   const tests = [
     {
@@ -505,7 +505,18 @@ test('BugFixes', function (t) {
       bug: 'MBS-10138',
       mode: 'English',
     },
-
+    {
+      input: '«quoted stuff»',
+      expected: '« Quoted stuff »',
+      bug: 'MBS-8232',
+      mode: 'French',
+    },
+    {
+      input: '“quoted stuff”',
+      expected: '“Quoted Stuff”',
+      bug: 'MBS-8232',
+      mode: 'English',
+    },
     /*
      * There is no fix for these yet.
      * {


### PR DESCRIPTION
### Fix MBS-8232

This adds support for most Unicode quotation marks, to avoid the word just after the quotation mark being lowercased.