### PR TITLE
MBS-11420: "Paste Credits" doesn't apply credited name

### DIFF
--- a/root/static/scripts/common/components/Autocomplete.js
+++ b/root/static/scripts/common/components/Autocomplete.js
@@ -47,7 +47,6 @@ class Autocomplete extends React.Component {
     const nextProps = this.props;
 
     this._subscription.dispose();
-    this._subscription = this._currentSelection.subscribe(nextProps.onChange);
 
     const prev = prevProps.currentSelection;
     const next = nextProps.currentSelection;
@@ -60,6 +59,8 @@ class Autocomplete extends React.Component {
         autocomplete._dataToEntity(nextProps.currentSelection),
       );
     }
+
+    this._subscription = this._currentSelection.subscribe(nextProps.onChange);
 
     autocomplete.element.prop('disabled', !!nextProps.disabled);
     if (next && autocomplete.element.val() !== next.name) {


### PR DESCRIPTION
The basic flow leading to the issue is this:

  * `this.setState` in `pasteArtistCredit` is called.
  * `componentDidUpdate` is triggered on the artist Autocomplete.
  * Since the artist changed, this sets the observable `autocomplete.currentSelection` to the new artist. This observable has a subscription, `this.props.onChange`, which updates the artist again on the parent (even though it already knows about this change).

The bit that screws up the credited name is the last point, because when the "duplicate" update winds up in `handleArtistChange`, it doesn't know about the credited name from the original update -- it thinks we're changing the artist only, so acts to keep the credited name in sync as it usually does.

We can avoid this by not re-attaching the observable subscription until after we update the observable. I cannot think of any reason this wasn't done before, other than oversight.