### PR TITLE
MBS-11426: Use medium's position, not array position, to load it

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -119,7 +119,8 @@ before show => sub {
         my @mediums = $c->stash->{release}->all_mediums;
 
         if (@mediums > $MAX_INITIAL_MEDIUMS) {
-            my $medium = $mediums[$position - 1] if looks_like_number($position);
+            my %mediums_by_position = map { $_->position => $_ } @mediums;
+            my $medium = $mediums_by_position{$position} if looks_like_number($position);
 
             if ($medium) {
                 my $user_id = $c->user->id if $c->user_exists;


### PR DESCRIPTION
### Fix MBS-11426

This was causing an issue where if a release doesn't have consecutive mediums, "disc/10" would load the 10th medium on the release, whatever its position, rather than the medium set to position 10.

Tested (with `pink` data) using the release given on the ticket. Alternatively, I guess you could add a release with 10+ mediums and ensure there's position gaps.