### PR TITLE
MBS-10976: Allow some private use characters

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -405,9 +405,9 @@ sub remove_invalid_characters {
     # - bom
     # - Other, control
     # - Other, surrogate
-    # - Other, private use
+    # - Supplementary private use areas
     # - Noncharacters
-    =~ s/[\x{200B}\x{00AD}\x{FEFF}\p{Cc}\p{Co}${noncharacter_pattern}]//gr
+    =~ s/[\x{200B}\x{00AD}\x{FEFF}\p{Cc}\x{F0000}-\x{FFFFF}\x{100000}-\x{10FFFF}${noncharacter_pattern}]//gr
 }
 
 sub type_to_model

--- a/lib/MusicBrainz/Server/Form/Field/Text.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Text.pm
@@ -1,13 +1,25 @@
 package MusicBrainz::Server::Form::Field::Text;
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Data::Utils;
+use MusicBrainz::Server::Translation qw( l );
 
 extends 'HTML::FormHandler::Field::Text';
 
-apply ([
-    {
-        transform => sub { MusicBrainz::Server::Data::Utils::trim(shift) }
+sub validate {
+    my $self = shift;
+
+    my $value = $self->value;
+    my $trimmed = MusicBrainz::Server::Data::Utils::trim($value);
+    if (length $value && !length $trimmed) {
+        # This error triggers if the entered text consists entirely of
+        # invalid characters. However, text that is only whitespace
+        # generally triggers the "Required field" error first.
+        return $self->push_errors(
+            l('The characters you’ve entered are invalid or not allowed.')
+        );
     }
-]);
+    $self->value($trimmed);
+    return 1;
+}
 
 1;


### PR DESCRIPTION
Allows the main PUA (U+E000..U+F8FF), but not any of the supplementary PUAs. This should at least cover the use case in the ticket (Klingon). If we want to be more restrictive, we could allow only (U+F8D0..U+F8FF) for Klingon, though there might be other use cases of the PUA that would be useful for MusicBrainz.

This commit also fixes an ISE that can be triggered by submitting a name consisting *only* of invalid characters. The message I added should very rarely be seen by any user; if they only enter whitespace, "Required field" is shown instead.