### PR TITLE
MBS-10367: Allow requesting copy of sent report when reporting

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -654,6 +654,7 @@ sub report : Chained('load') RequireAuth HiddenOnSlaves SecureForm {
                 reason          => $form->value->{reason},
                 message         => $form->value->{message},
                 reveal_address  => $form->value->{reveal_address},
+                send_to_self    => $form->value->{send_to_self},
             );
         } catch {
             log_debug { "Couldn't send email: $_" } $_;

--- a/lib/MusicBrainz/Server/Form/User/Report.pm
+++ b/lib/MusicBrainz/Server/Form/User/Report.pm
@@ -25,6 +25,10 @@ has_field 'reveal_address' => (
     default => 1,
 );
 
+has_field 'send_to_self' => (
+    type => 'Boolean',
+);
+
 Readonly our %REASONS => (
     'spam' => N_l('Editor is spamming'),
     'unresponsiveness' => N_l('Editor is unresponsive to edit notes'),

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -35,6 +35,7 @@ type Props = {
     +message: FieldT<string>,
     +reason: FieldT<ReportReasonT>,
     +reveal_address: FieldT<boolean>,
+    +send_to_self: FieldT<boolean>,
   }>,
   +user: AccountLayoutUserT,
 };
@@ -164,6 +165,12 @@ const ReportUser = ({
               </p>
             }
             label={l('Reveal my email address')}
+            uncontrolled
+          />
+
+          <FormRowCheckbox
+            field={form.field.send_to_self}
+            label={l('Send a copy to my own email address')}
             uncontrolled
           />
 


### PR DESCRIPTION
### Implement MBS-10367

This allows a reporter to save a copy of the reports they have sent, if so desired. That might be helpful to, for example, remember if you have already reported a user recently but the report still hasn't been acted on, and as such avoid sending another report on the same issue.

Tested only by printing the email to be sent with Data::Dumper, since I don't have email sending set up locally. All of the headers seemed correct to me though. If any of you do have this set up, can you test the actual email sending?