### PR TITLE
MBS-11430: Convert format_setlist to Javascript

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,7 +30,6 @@ module.exports = function (api) {
     ['@babel/plugin-transform-react-jsx', {
       runtime: 'automatic',
     }],
-    '@babel/plugin-transform-react-constant-elements',
     ['@babel/plugin-transform-runtime', {
       corejs: false,
       helpers: true,

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -18,7 +18,6 @@ use MooseX::Types::Structured qw( Dict );
 use MooseX::Types::Moose qw( ArrayRef Object Str );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json non_empty );
 use MusicBrainz::Server::Entity::Util::JSON qw( add_linked_entity to_json_object );
-use MusicBrainz::Server::Filters qw( format_setlist );
 use MusicBrainz::Server::Types qw( Time );
 use List::UtilsBy qw( uniq_by );
 
@@ -130,7 +129,7 @@ around TO_JSON => sub {
             entity => to_json_object($_->{entity}),
         }, $self->all_places],
         related_series => [map { $_->id } @related_series],
-        (non_empty($setlist) ? (setlist => format_setlist($setlist)) : ()),
+        (non_empty($setlist) ? (setlist => $setlist) : ()),
         time => $self->formatted_time,
     };
 };

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -16,67 +16,13 @@ use Try::Tiny;
 use URI::Escape;
 
 use Sub::Exporter -setup => {
-    exports => [qw( format_editnote format_setlist format_wikitext )]
+    exports => [qw( format_editnote format_wikitext )]
 };
 
 sub format_length
 {
     my $ms = shift;
     return MusicBrainz::Server::Track::FormatTrackLength($ms);
-}
-
-sub format_setlist {
-    my ($text) = @_;
-
-    # Encode < and >
-    $text =~ s/</&lt;/g;
-    $text =~ s/>/&gt;/g;
-
-    # Lines starting with @ are artists
-    $text =~ s/^@ ([^\r\n]*)/format_setlist_artist($1)/meg;
-
-    # Lines starting with * are works
-    $text =~ s/^\* ([^\r\n]*)/format_setlist_work($1)/meg;
-
-    # Lines starting with # are comments
-    $text =~ s/^# ([^\r\n]*)/<span class=\"comment\">$1<\/span>/mg;
-
-    # Fix newlines
-    $text =~ s/(\015\012|\012\015|\012|\015)/<br\/>/g;
-
-    return $text;
-}
-
-sub format_setlist_artist {
-    my ($line) = @_;
-
-    $line =~ s/
-      \[
-      ([0-9a-f]{8} -
-       [0-9a-f]{4} -
-       [0-9a-f]{4} -
-       [0-9a-f]{4} -
-       [0-9a-f]{12})(?:\|([^\]]+))?\]
-    /_make_link("artist",$1,$2)/eixg;
-
-    $line = "<strong>Artist: $line</strong>";
-
-    return $line;
-}
-
-sub format_setlist_work {
-    my ($line) = @_;
-
-    $line =~ s/
-      \[
-      ([0-9a-f]{8} -
-       [0-9a-f]{4} -
-       [0-9a-f]{4} -
-       [0-9a-f]{4} -
-       [0-9a-f]{12})(?:\|([^\]]+))?\]
-    /_make_link("work",$1,$2)/eixg;
-
-    return $line;
 }
 
 sub format_wikitext

--- a/root/event/EventIndex.js
+++ b/root/event/EventIndex.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import Annotation from '../static/scripts/common/components/Annotation';
 import WikipediaExtract
   from '../static/scripts/common/components/WikipediaExtract';
-import expand2react from '../static/scripts/common/i18n/expand2react';
+import formatSetlist from '../static/scripts/common/utility/formatSetlist';
 import CleanupBanner from '../components/CleanupBanner';
 import Relationships from '../components/Relationships';
 import * as manifest from '../static/manifest';
@@ -56,7 +56,7 @@ const EventIndex = ({
         <>
           <h2 className="setlist">{l('Setlist')}</h2>
           <p className="setlist">
-            {expand2react(setlist)}
+            {formatSetlist(setlist)}
           </p>
         </>
       ) : null}

--- a/root/static/scripts/common/utility/formatSetlist.js
+++ b/root/static/scripts/common/utility/formatSetlist.js
@@ -1,0 +1,83 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import expand2react from '../i18n/expand2react';
+
+function setlistLink(entityType, entityGid, content) {
+  let formattedContent = content;
+  if (!nonEmpty(formattedContent)) {
+    formattedContent = entityType + ':' + entityGid;
+  }
+
+  return `<a href="/${entityType}/${entityGid}">${formattedContent}</a>`;
+}
+
+function replaceSetlistMbids(entityType, setlistLine) {
+  const formattedLine = setlistLine.replace(
+    /\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\|([^\]]+))?\]/ig,
+    function (match, p1, p2) {
+      return setlistLink(entityType, p1, p2);
+    },
+  );
+
+  return formattedLine;
+}
+
+function formatSetlistArtist(setlistLine) {
+  const artistLineLabel = addColonText(l('Artist'));
+  const artistLineContent = replaceSetlistMbids('artist', setlistLine);
+
+  const artistLine =
+    `<strong>${artistLineLabel} ${artistLineContent}</strong>`;
+
+  return artistLine;
+}
+
+function formatSetlistWork(setlistLine) {
+  return replaceSetlistMbids('work', setlistLine);
+}
+
+export default function formatSetlist(
+  setlistText: string,
+): Expand2ReactOutput {
+  let formattedText = setlistText;
+
+  // Encode < and >
+  formattedText = formattedText.replace(/</g, '&lt;');
+  formattedText = formattedText.replace(/>/g, '&gt;');
+
+  // Lines starting with @ are artists
+  formattedText = formattedText.replace(
+    /^@ ([^\r\n]*)/gm,
+    function (match, p1) {
+      return formatSetlistArtist(p1);
+    },
+  );
+
+  // Lines starting with * are works
+  formattedText = formattedText.replace(
+    /^\* ([^\r\n]*)/gm,
+    function (match, p1) {
+      return formatSetlistWork(p1);
+    },
+  );
+
+  // Lines starting with # are comments
+  formattedText = formattedText.replace(
+    /^# ([^\r\n]*)/gm,
+    function (match, p1) {
+      return '<span class=\"comment\">' + p1 + '<\/span>';
+    },
+  );
+
+  // Fix newlines
+  formattedText = formattedText.replace(/(\015\012|\012\015|\012|\015)/g, '<br \/>');
+
+  return expand2react(formattedText);
+}

--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -6,6 +6,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as ReactDOMServer from 'react-dom/server';
 import test from 'tape';
 
 import formatDate from '../common/utility/formatDate';
@@ -15,6 +16,7 @@ import compareDates, {
   compareDatePeriods,
 } from '../common/utility/compareDates';
 import formatDatePeriod from '../common/utility/formatDatePeriod';
+import formatSetlist from '../common/utility/formatSetlist';
 import formatTrackLength from '../common/utility/formatTrackLength';
 import parseDate from '../common/utility/parseDate';
 import * as dates from '../edit/utility/dates';
@@ -561,5 +563,42 @@ test('formatUserDate', function (t) {
     ),
     '2021-05-13 00:05 GMT+2',
     '%H ranges from 00-23',
+  );
+});
+
+test('formatSetlist', function (t) {
+  t.plan(1);
+
+  const setlist =
+    '@ pre-text [e1af2f0d-c685-4e83-a27d-b27e79787aab|artist 1] mid-text ' +
+      '[0eda70b7-c77b-4775-b1db-5b0e5a3ca4c1|artist 2] post-text\n\r\n' +
+    '* e [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|work 1] [not a link]\r' +
+    '@ plain text artist\n' +
+    '# comment [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|not a link]\r\n' +
+    '# comment <a href="#">also not a link</a>\r\n' +
+    '@ nor a link <a href="#">here</a>\n\r' +
+    '* plain text work\n' +
+    'ignored!\r\n';
+
+  t.equal(
+    ReactDOMServer.renderToStaticMarkup(formatSetlist(setlist)),
+    'pre-text <strong>' +
+      'Artist: ' +
+      '<a href="/artist/e1af2f0d-c685-4e83-a27d-b27e79787aab">artist 1</a>' +
+    '</strong> mid-text ' +
+    '<strong>Artist: ' +
+      '<a href="/artist/0eda70b7-c77b-4775-b1db-5b0e5a3ca4c1">artist 2</a>' +
+    '</strong> post-text<br/><br/>' +
+    'e <a href="/work/b831b5a4-e1a9-4516-bb50-b6eed446fc9b">work 1</a> ' +
+      '[not a link]<br/>' +
+    'plain text artist<br/>' +
+    '<span class="comment">' +
+      'comment [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|not a link]' +
+    '</span><br/>' +
+    '<span class="comment">' +
+      'comment &lt;a href=&quot;#&quot;&gt;also not a link&lt;/a&gt;' +
+    '</span><br/>' +
+    'nor a link &lt;a href=&quot;#&quot;&gt;here&lt;/a&gt;<br/>' +
+    'plain text work<br/><br/><br/>',
   );
 });


### PR DESCRIPTION
### Implement MBS-11430

This is only used on the React layer anyway (for display), and having it be JS will later make it easier to generate a preview client-side from a not-yet-submitted setlist (MBS-8085).
