### PR TITLE
MBS-11432: Allow also linking places and works to Operabase

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2467,13 +2467,22 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?operabase\\.com', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\/(?:a\/[^\/?#]+|artists)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/artists/$1');
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?operabase\.com\/(artists|venues\/[\w-]+|works)\/(?:[^0-9]+)?([0-9]+).*$/, 'https://operabase.com/$1/$2');
     },
     validate: function (url, id) {
-      return {
-        result: id === LINK_TYPES.otherdatabases.artist &&
-          /^https:\/\/operabase\.com\/artists\/[0-9]+$/.test(url),
-      };
+      const m = /^https:\/\/operabase\.com\/(artists|venues|works)\//.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.otherdatabases.artist:
+            return {result: prefix === 'artists'};
+          case LINK_TYPES.otherdatabases.place:
+            return {result: prefix === 'venues'};
+          case LINK_TYPES.otherdatabases.work:
+            return {result: prefix === 'works'};
+        }
+      }
+      return {result: false};
     },
   },
   'otherdatabases': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2836,18 +2836,25 @@ const testData = [
   },
   // Operabase
   {
-                     input_url: 'www.operabase.com/a/Risto_Joost/21715/future',
-             input_entity_type: 'label',
-    expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://operabase.com/artists/21715',
-       only_valid_entity_types: ['artist'],
-  },
-  {
                      input_url: 'https://www.operabase.com/artists/megan-esther-grey-101303/en',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://operabase.com/artists/101303',
        only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'operabase.com/venues/united-states/abravanel-hall-5916/en',
+             input_entity_type: 'place',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://operabase.com/venues/united-states/5916',
+       only_valid_entity_types: ['place'],
+  },
+  {
+                     input_url: 'https://www.operabase.com/works/porgupohja-uus-vanapagan-7623/en',
+             input_entity_type: 'work',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://operabase.com/works/7623',
+       only_valid_entity_types: ['work'],
   },
   {
                      input_url: 'http://operabase.com/listart.cgi?name=Risto+Joost&acts=+Schedule+',


### PR DESCRIPTION
### Implement MBS-11432

I'm removing the cleanup for the old artist format because it hasn't been used for years, so it seems useless by now.

Works are just like artists, and can be reduced to works/id.
Places require the country name on the URL, so they can only be reduced to venues/country/id.
