### PR TITLE
MBS-11393: Show SetTrackLengths edit in recording edit history

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
@@ -78,6 +78,28 @@ test 'Setting track lengths based on disc ID' => sub {
         'Thank you, your <a href="',
         'The user is notified that they entered an edit',
     );
+
+    my $edit_title = 'Edit #' . $edit->id;
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/edits',
+        'Fetch changed recording edit history',
+    );
+
+    $mech->content_contains(
+        $edit_title,
+        'The edit history for the changed recording includes the edit',
+    );
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b1/edits',
+        'Fetch unchanged recording edit history',
+    );
+
+    $mech->content_lacks(
+        $edit_title,
+        'The edit history for the unchanged recording does not include the edit',
+    );
 };
 
 1;

--- a/t/sql/controller_cdtoc.sql
+++ b/t/sql/controller_cdtoc.sql
@@ -19,6 +19,7 @@ INSERT INTO cdtoc (id, discid, freedb_id, track_count, leadout_offset, track_off
 INSERT INTO medium_cdtoc (id, medium, cdtoc) VALUES (1, 1, 1);
 
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES (1, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'The same track over and over', 1, NULL);
+INSERT INTO recording (id, gid, name, artist_credit, length) VALUES (2, '54b9d183-7dab-42ba-94a3-7388a66604b1', 'A track with the correct length already', 1, 372386);
 
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (1, '66c2ebff-86a8-4e12-a9a2-1650fb97d9d8', 1, 1, 1, 1, 'The same track over and over', 1, NULL);
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (2, 'b0caa7d1-0d1e-483e-b22b-ec6ab7fada06', 1, 2, 2, 1, 'The same track over and over', 1, NULL);
@@ -26,6 +27,6 @@ INSERT INTO track (id, gid, medium, position, number, recording, name, artist_cr
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (4, '6c04d03c-4995-43be-8530-215ca911dcbf', 1, 4, 4, 1, 'The same track over and over', 1, NULL);
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (5, '849dc232-c33a-4611-a6a5-5a0969d63422', 1, 5, 5, 1, 'The same track over and over', 1, NULL);
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (6, '72469a76-7c28-4a84-b7da-174c1034cd0a', 1, 6, 6, 1, 'The same track over and over', 1, NULL);
-INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (7, '5d54de57-561d-4ee2-9ced-af4327249d66', 1, 7, 7, 1, 'The same track over and over', 1, NULL);
+INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (7, '5d54de57-561d-4ee2-9ced-af4327249d66', 1, 7, 7, 2, 'A track with the correct length already', 1, 372386);
 
 


### PR DESCRIPTION
### Implement MBS-11393

If a medium edit changes the duration of a recording, it is shown on the recording's edit history. If a discID does (with a set track lengths edit), it does not, so it becomes hard to see where the set duration came from.

This will add the set track lenghts edit to the history of all recordings which are linked to a track that is changing duration.