### PR TITLE
MBS-11435: Don't modify data in build_display_data for EditReleaseLabel

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -114,14 +114,14 @@ sub build_display_data {
             new => $data->{new}{catalog_number},
             old => $data->{old}{catalog_number},
         },
-        extra => $data->{release}
+        barcode => $data->{release}{barcode}
     };
 
-    if ($display_data->{extra}{medium_formats}) {
-        $display_data->{extra}{combined_format} = $self->process_medium_formats($data->{extra}{medium_formats});
+    if ($data->{release}{medium_formats}) {
+        $display_data->{combined_format} = $self->process_medium_formats($data->{release}{medium_formats});
     }
 
-    $display_data->{extra}{events} = [
+    $display_data->{events} = [
         map {
             my $event_display = {};
 
@@ -135,14 +135,14 @@ sub build_display_data {
 
             $event_display->{date} = MusicBrainz::Server::Entity::PartialDate->new($_->{date});
             $event_display;
-        } @{ $display_data->{extra}{events} // [] }
+        } @{ $data->{release}{events} // [] }
     ];
 
-    $display_data->{extra}{events_json} = [
+    $display_data->{events_json} = [
         map +{
             country => to_json_object($_->{country}),
             date => to_json_object($_->{date}),
-        }, @{ $display_data->{extra}{events} }
+        }, @{ $display_data->{events} }
     ];
 
     for (qw( new old )) {

--- a/root/edit/details/edit_release_label.tt
+++ b/root/edit/details/edit_release_label.tt
@@ -31,43 +31,41 @@
      [% END %]
    [% END %]
 
-   [%- IF edit.display_data.defined('extra') -%]
-     [%- IF edit.display_data.extra.events.size <= 1 -%]
-         [%- IF edit.display_data.extra.events.0.date -%]
-         <tr>
-           <th>[% l('Date:') %]</th>
-           <td colspan="2">[% edit.display_data.extra.events.0.date.format %]</td>
-         </tr>
-         [%- END -%]
-         [%- IF edit.display_data.extra.events.0.country -%]
-         <tr>
-           <th>[% l('Country:') %]</th>
-           <td colspan="2">[% link_entity(edit.display_data.extra.events.0.country) %]</td>
-         </tr>
-         [%- END -%]
-     [%- ELSE -%]
-         <tr>
-           <th>[% l('Release events:') %]</th>
-           <td colspan="2">
-             [% React.embed(c, 'static/scripts/common/components/ReleaseEvents', {
-                  abbreviated => boolean_to_json(0),
-                  events => edit.display_data.extra.events_json,
-                }) %]
-           </td>
-         </tr>
-     [%- END -%]
-     [%- IF edit.display_data.extra.barcode -%]
-     <tr>
-       <th>[% l('Barcode:') %]</th>
-       <td colspan="2">[% edit.display_data.extra.barcode %]</td>
-     </tr>
-     [%- END -%]
-     [%- IF edit.display_data.extra.combined_format -%]
-     <tr>
-       <th>[% l('Format:') %]</th>
-       <td colspan="2">[% edit.display_data.extra.combined_format %]</td>
-     </tr>
-     [%- END -%]
-   [% END %]
+    [%- IF edit.display_data.events.size <= 1 -%]
+      [%- IF edit.display_data.events.0.date -%]
+      <tr>
+        <th>[% l('Date:') %]</th>
+        <td colspan="2">[% edit.display_data.events.0.date.format %]</td>
+      </tr>
+      [%- END -%]
+      [%- IF edit.display_data.events.0.country -%]
+      <tr>
+        <th>[% l('Country:') %]</th>
+        <td colspan="2">[% link_entity(edit.display_data.events.0.country) %]</td>
+      </tr>
+      [%- END -%]
+    [%- ELSE -%]
+      <tr>
+        <th>[% l('Release events:') %]</th>
+        <td colspan="2">
+          [% React.embed(c, 'static/scripts/common/components/ReleaseEvents', {
+              abbreviated => boolean_to_json(0),
+              events => edit.display_data.events_json,
+            }) %]
+        </td>
+      </tr>
+    [%- END -%]
+    [%- IF edit.display_data.barcode -%]
+    <tr>
+      <th>[% l('Barcode:') %]</th>
+      <td colspan="2">[% edit.display_data.barcode %]</td>
+    </tr>
+    [%- END -%]
+    [%- IF edit.display_data.combined_format -%]
+    <tr>
+      <th>[% l('Format:') %]</th>
+      <td colspan="2">[% edit.display_data.combined_format %]</td>
+    </tr>
+    [%- END -%]
 
 </table>


### PR DESCRIPTION
### Fix MBS-11435

This is causing the new modifications not to get converted to JSON, causing an ISE. There's also no good reason to do this at all, since we can easily pass only the data we need via build_display_data and we even limit the amount of bandwidth needed while at it.
