### PR TITLE
MBS-11436: Don't try to call method public on unblessed JSON

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -24,16 +24,6 @@ with 'MusicBrainz::Server::Controller::User::SubscriptionsRole' => {
     type => 'series',
 };
 
-after collection => sub {
-    my ($self, $c) = @_;
-
-    my $private_collection_count = scalar(grep { !${$_->{public}} } @{ $c->stash->{component_props}{entities} });
-    $c->stash->{component_props}{privateCollectionCount} = $private_collection_count;
-
-    my @public_collections = grep { ${$_->{public}} } @{ $c->stash->{component_props}{entities} };
-    $c->stash->{component_props}{entities} = to_json_array(\@public_collections);
-};
-
 sub subscriptions : Chained('/user/load') {
     my ($self, $c) = @_;
     my $user = $c->stash->{user};

--- a/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -27,10 +27,10 @@ with 'MusicBrainz::Server::Controller::User::SubscriptionsRole' => {
 after collection => sub {
     my ($self, $c) = @_;
 
-    my $private_collection_count = scalar(grep { !$_->public } @{ $c->stash->{component_props}{entities} });
+    my $private_collection_count = scalar(grep { !${$_->{public}} } @{ $c->stash->{component_props}{entities} });
     $c->stash->{component_props}{privateCollectionCount} = $private_collection_count;
 
-    my @public_collections = grep { $_->public } @{ $c->stash->{component_props}{entities} };
+    my @public_collections = grep { ${$_->{public}} } @{ $c->stash->{component_props}{entities} };
     $c->stash->{component_props}{entities} = to_json_array(\@public_collections);
 };
 

--- a/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
+++ b/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
@@ -37,6 +37,12 @@ role {
         my $entities = $self->_load_paged($c, sub {
             $c->model(type_to_model($type))->find_by_subscribed_editor($user->id, shift, shift);
         });
+        my %extra_props;
+
+        if ($type eq 'collection') {
+            $extra_props{privateCollectionCount} = scalar(grep { !$_->public } @{$entities});
+            $entities = [grep { $_->public } @{$entities}]
+        }
 
         $c->stash(
             current_view => 'Node',
@@ -47,6 +53,7 @@ role {
                 summary   => $c->model('Editor')->subscription_summary($user->id),
                 type      => $type,
                 pager     => serialize_pager($c->stash->{pager}),
+                %extra_props,
             },
         );
     };


### PR DESCRIPTION
### Fix MBS-11436

These used to be blessed collections but are now JSON, so {public} is JSON::true/false. Dereferencing it to see if true/false.

Tested by making one of my own collections private and making sure it matched prod (so you can test with `pink` data from http://localhost:5000/user/reosarevok/subscriptions/collection).