### PR TITLE
MBS-11437: Beta: work-level rels not shown on release pages

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Role/Linkable.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Linkable.pm
@@ -75,19 +75,19 @@ sub relationships_by_link_type_names
     } $self->all_relationships ];
 }
 
-my $_serialize_relationships = 1;
+our $_relationships_depth = 0;
 
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
 
-    if ($_serialize_relationships && $self->has_loaded_relationships) {
+    # Allow a depth of up to 2, which should cover work relationships
+    # linked via a release.
+    if ($_relationships_depth < 2 && $self->has_loaded_relationships) {
         $json->{relationships} = [map {
-            $_serialize_relationships = 0;
-            my $result = $_->TO_JSON;
-            $_serialize_relationships = 1;
-            $result;
+            local $_relationships_depth = $_relationships_depth + 1;
+            $_->TO_JSON
         } $self->all_relationships];
     }
 


### PR DESCRIPTION
68f8ae8a49aaa22e49c4982c0ecd0563f8e8dae4 broke this for obvious reasons. Since I'm not comfortable reverting that (I did run into a case where infinite recursion was triggered -- just not sure where), I increased the max allowed depth instead.