### PR TITLE
MBS-8820: Show explanation if relationships tab shows no rels

### DIFF
--- a/root/artist/ArtistRelationships.js
+++ b/root/artist/ArtistRelationships.js
@@ -11,7 +11,6 @@ import * as React from 'react';
 
 import Relationships from '../components/Relationships';
 import RelationshipsTable from '../components/RelationshipsTable';
-import EntityLink from '../static/scripts/common/components/EntityLink';
 
 import ArtistLayout from './ArtistLayout';
 
@@ -34,19 +33,7 @@ const ArtistRelationships = ({
     title={l('Relationships')}
   >
     {pagedLinkTypeGroup ? null : (
-      artist.relationships?.length ? (
-        <Relationships source={artist} />
-      ) : (
-        <>
-          <h2 className="relationships">{l('Relationships')}</h2>
-          <p>
-            {exp.l(
-              '{link} has no relationships.',
-              {link: <EntityLink entity={artist} />},
-            )}
-          </p>
-        </>
-      )
+      <Relationships showIfEmpty source={artist} />
     )}
     <RelationshipsTable
       $c={$c}

--- a/root/components/Relationships.js
+++ b/root/components/Relationships.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {PART_OF_SERIES_LINK_TYPES} from '../static/scripts/common/constants';
+import EntityLink from '../static/scripts/common/components/EntityLink';
 import linkedEntities from '../static/scripts/common/linkedEntities';
 import groupRelationships, {type RelationshipTargetTypeGroupT}
   from '../utility/groupRelationships';
@@ -68,16 +69,18 @@ export function isNotSeriesPart(r: RelationshipT): boolean {
 type PropsT = {
   +noRelationshipsHeading?: boolean,
   +relationships?: $ReadOnlyArray<RelationshipTargetTypeGroupT>,
+  +showIfEmpty?: boolean,
   +source: CoreEntityT,
 };
 
 const Relationships = (React.memo<PropsT>(({
   noRelationshipsHeading = false,
   relationships,
+  showIfEmpty = false,
   source,
 }: PropsT): React.Element<typeof React.Fragment> => {
+  let srcRels = source.relationships;
   if (!relationships) {
-    let srcRels = source.relationships;
     if (srcRels && source.entityType === 'series') {
       srcRels = srcRels.filter(isNotSeriesPart);
     }
@@ -91,17 +94,40 @@ const Relationships = (React.memo<PropsT>(({
     ? {names: [{artist: source, joinPhrase: '', name: source.name}]}
     : (source.artistCredit || null);
 
+  const heading = noRelationshipsHeading
+    ? null
+    : <h2 className="relationships">{l('Relationships')}</h2>;
+
   return (
     <>
       {relationships.length ? (
         <>
-          {noRelationshipsHeading ? null : (
-            <h2 className="relationships">{l('Relationships')}</h2>
-          )}
+          {heading}
           <StaticRelationshipsDisplay
             hiddenArtistCredit={hiddenArtistCredit}
             relationships={relationships}
           />
+        </>
+      ) : source.entityType === 'artist' && srcRels?.length ? (
+        <>
+          {heading}
+          <p>
+            {exp.l(
+              `{link} only has event relationships,
+               which are displayed in the Events tab.`,
+              {link: <EntityLink entity={source} />},
+            )}
+          </p>
+        </>
+      ) : showIfEmpty ? (
+        <>
+          {heading}
+          <p>
+            {exp.l(
+              '{link} has no relationships.',
+              {link: <EntityLink entity={source} />},
+            )}
+          </p>
         </>
       ) : null}
       {source.entityType === 'recording' && source.related_works.length ? (

--- a/root/label/LabelRelationships.js
+++ b/root/label/LabelRelationships.js
@@ -11,7 +11,6 @@ import * as React from 'react';
 
 import Relationships from '../components/Relationships';
 import RelationshipsTable from '../components/RelationshipsTable';
-import EntityLink from '../static/scripts/common/components/EntityLink';
 
 import LabelLayout from './LabelLayout';
 
@@ -34,19 +33,7 @@ const LabelRelationships = ({
     title={l('Relationships')}
   >
     {pagedLinkTypeGroup ? null : (
-      label.relationships?.length ? (
-        <Relationships source={label} />
-      ) : (
-        <>
-          <h2 className="relationships">{l('Relationships')}</h2>
-          <p>
-            {exp.l(
-              '{link} has no relationships.',
-              {link: <EntityLink entity={label} />},
-            )}
-          </p>
-        </>
-      )
+      <Relationships showIfEmpty source={label} />
     )}
     <RelationshipsTable
       $c={$c}


### PR DESCRIPTION
### Fix MBS-8820

For an artist that only has event relationships (or, I assume, a label that only has relationships of a type that gets filtered out by groupRelationships), the relationships tab is currently just empty.
This changes it so that Relationships displays an informative message if all existing relationships have been filtered out. While at it, I also got rid of the separate "no rels" message on ArtistRelationships and LabelRelationships, and moved that to Relationships as well.

Tested locally by creating the appropriate situations (artist without any rels, artist with only event rels) and navigating around to see that the changes didn't seem to affect other relationship displays.