### PR TITLE
MBS-11443: Add option to sort edits by edit note date

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -23,6 +23,7 @@
       <option value="closed_asc"' _ selected_if_matches('closed_asc', query.order) _ '>' _ l('earliest closed first')     _ '</option>
       <option value="vote_closing_asc"' _ selected_if_matches('vote_closing_asc', query.order) _ '>' _ l('voting closing sooner first')     _ '</option>
       <option value="vote_closing_desc"' _ selected_if_matches('vote_closing_desc', query.order) _ '>' _ l('voting closing later first')     _ '</option>
+      <option value="latest_note"' _ selected_if_matches('latest_note', query.order) _ '>' _ l('with recent edit notes first')     _ '</option>
       <option value="rand"' _ selected_if_matches('rand', query.order) _ '>' _ l('randomly')     _ '</option>
     </select>' -%]
     [%- match_or_negation_block = '<select name="negation">


### PR DESCRIPTION
### Implement MBS-11443

I'm specifically excluding edits where the max is null, since those are very old anyway (so, generally irrelevant to a query for latest edit notes) but were sorting above the ones with dates.

I'm expecting this will time out on large queries, but that's already the case for a lot of edit searches. Seems to work, otherwise.