### PR TITLE
MBS-11442: Adding tags on add-cover-art page disables submit

### DIFF
--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -1,5 +1,5 @@
 [%- WRAPPER "release/layout.tt" title=lp('Add Cover Art', 'header') page='add_cover_art' -%]
-  [%- script_manifest('edit.js') -%]
+  [%- script_manifest('release/coverart.js') -%]
 
   <script type="text/javascript">
     MB.cover_art_types_json = [% cover_art_types_json %];

--- a/root/release/reorder_cover_art.tt
+++ b/root/release/reorder_cover_art.tt
@@ -1,5 +1,5 @@
 [% WRAPPER "release/layout.tt" title=lp('Reorder Cover Art', 'header') page='reorder_cover_art' %]
-  [%- script_manifest('edit.js') -%]
+  [%- script_manifest('release/coverart.js') -%]
 
   <h2>[%- lp('Reorder Cover Art', 'header') -%]</h2>
 

--- a/root/static/scripts/edit.js
+++ b/root/static/scripts/edit.js
@@ -25,7 +25,6 @@ require('./edit/components/forms');
 require('./edit/MB/Control/ArtistEdit');
 require('./edit/MB/Control/Bubble');
 require('./edit/URLCleanup');
-require('./edit/MB/CoverArt');
 require('./edit/MB/edit');
 require('./edit/MB/reltypeslist');
 require('./edit/MB/TextList');

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -293,7 +293,10 @@ $(document).on(
   function () {
     if (!submissionInProgress) {
       submissionInProgress = true;
-      prepareSubmission($('#relationship-editor').data('form-name'));
+      const formName = $('#relationship-editor').data('form-name');
+      if (formName) {
+        prepareSubmission(formName);
+      }
     }
   },
 );

--- a/root/static/scripts/release/coverart.js
+++ b/root/static/scripts/release/coverart.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import '../edit/MB/CoverArt';

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -55,6 +55,7 @@ const entries = [
   'place/map',
   'recording/form',
   'recording/merge',
+  'release/coverart',
   'release-editor',
   'release-group/index',
   'series',


### PR DESCRIPTION
Surprisingly, this is due to some relationship editor code that's running. This shouldn't even be loaded on these pages, so I created a separate bundle for CoverArt.js. I also added a workaround in the relevant relationship editor code, just in case this affects other edit pages too.