### PR TITLE
MBS-11446: Keep blank lines in annotation

### DIFF
--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -367,10 +367,13 @@ sub trim_multiline_text {
 
     $t = NFC($t);
     $t = remove_invalid_characters($t);
-    # Not trimming starting spaces to avoid breaking
-    # either list formatting in Wikitext
-    # or block in Markdown.
-    $t =~ s/\s+$//gm;
+
+    # Trimming each line to remove trailing spaces (or similar)
+    # - Not trimming starting spaces to avoid breaking
+    #   either list formatting in Wikitext
+    #   or block in Markdown.
+    # - Splitting on \n so that \s doesn’t match any \n
+    $t = join ("\n", map { $_ =~ s/\s+$//r } (split "\n", $t));
 
     return $t;
 }

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -375,6 +375,9 @@ sub trim_multiline_text {
     # - Splitting on \n so that \s doesn’t match any \n
     $t = join ("\n", map { $_ =~ s/\s+$//r } (split "\n", $t));
 
+    # Merge consecutive blank lines together
+    $t =~ s/\n+(\n\n)/$1/g;
+
     return $t;
 }
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -22,7 +22,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for an artist  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for an artist  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -22,7 +22,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for an artist  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for an artist  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -35,7 +35,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Test Artist',
     },
-    text => "    * Test annotation for an artist\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+    text => "    * Test annotation for an artist\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -32,7 +32,7 @@ is_deeply($edit->data, {
         id => 3,
         name => 'Another Label'
     },
-    text => "    * Test annotation for a label\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+    text => "    * Test annotation for a label\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Dancing Queen'
     },
-    text => "    * Test annotation for a recording\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+    text => "    * Test annotation for a recording\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 2,
         name => 'Aerial'
     },
-    text => "    * Test annotation for a release\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+    text => "    * Test annotation for a release\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 
@@ -30,7 +30,7 @@ is_deeply($edit->data, {
         id => 1,
         name => 'Arrival'
     },
-    text => "    * Test annotation for a release group\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+    text => "    * Test annotation for a release group\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
     editor_id => 1
 });

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -20,7 +20,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
     $mech->submit_form(
         with_fields => {
-            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
             'edit-annotation.changelog' => 'And a changelog',
         });
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -20,7 +20,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
     $mech->submit_form(
         with_fields => {
-            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
             'edit-annotation.changelog' => 'And a changelog',
         });
 
@@ -35,7 +35,7 @@ test all => sub {
             id => 1,
             name => 'Test Recording Series'
         },
-        text => "    * Test annotation for a series\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+        text => "    * Test annotation for a series\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'And a changelog',
         editor_id => 1
     });

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -660,7 +660,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     my $annotation_edits = [ {
         edit_type       => $EDIT_RELEASE_ADD_ANNOTATION,
         entity          => $release_id,
-        text            => "    * Test annotation\x{0007} in release editor  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        text            => "    * Test annotation\x{0007} in release editor  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
     } ];
 
     @edits = capture_edits {
@@ -674,7 +674,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     cmp_deeply($edits[0]->data, {
         editor_id       => 1,
         entity          => { id => $release_id, name => 'Vision Creation Newsun' },
-        text            => "    * Test annotation in release editor\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+        text            => "    * Test annotation in release editor\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     });
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -660,7 +660,7 @@ test 'previewing/creating/editing a release group and release' => sub {
     my $annotation_edits = [ {
         edit_type       => $EDIT_RELEASE_ADD_ANNOTATION,
         entity          => $release_id,
-        text            => "    * Test annotation\x{0007} in release editor  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        text            => "    * Test annotation\x{0007} in release editor  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
     } ];
 
     @edits = capture_edits {

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok("/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation");
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     }
 );

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -19,7 +19,7 @@ $mech->submit_form( with_fields => { username => 'new_editor', password => 'pass
 $mech->get_ok("/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation");
 $mech->submit_form(
     with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
         'edit-annotation.changelog' => 'Changelog here',
     }
 );
@@ -33,7 +33,7 @@ is_deeply(
             id => 1,
             name => 'Dancing Queen'
         },
-        text => "    * Test annotation for a work\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+        text => "    * Test annotation for a work\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'Changelog here',
         editor_id => 1
     }


### PR DESCRIPTION
# Fix MBS-11446: Annotation trimming removes blank lines

Since commit 43b9dd787947471b6dbddf15baf98947fe916d2c, blank lines were removed from edited annotations because `\s` matches `\n` too.

This pull request amends that commit by not removing consecutive `\n` but if there are more than two.

Update tests accordingly.