### PR TITLE
MBS-11447: Use to_json_object on language in Work::Create

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -71,7 +71,7 @@ sub build_display_data
         if ($language->iso_code_3 eq "zxx") {
             $language->name(l("[No lyrics]"));
         }
-        $display->{language} = $language;
+        $display->{language} = to_json_object($language);
     }
 
     if (defined $data->{languages}) {


### PR DESCRIPTION
### Fix MBS-11447