### PR TITLE
MBS-11470: Ensure to_json_object(type) does run in Area::Edit

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -116,7 +116,7 @@ sub build_display_data
         $data->{ended}{new} = boolean_to_json($data->{ended}{new});
     }
 
-    if (exists $self->data->{new}{type}) {
+    if (exists $self->data->{new}{type_id}) {
         $data->{type}{old} = to_json_object($data->{type}{old});
         $data->{type}{new} = to_json_object($data->{type}{new});
     }


### PR DESCRIPTION
### Fix MBS-11470

This is checking $self->data->{new}{type} to see whether to run to_json_object on the type data, but the edit data does not have types, it has type_id from which the type is loaded for display.
