### PR TITLE
MBS-11467: Use sort name to order lists of artists for tags

### DIFF
--- a/lib/MusicBrainz/Server/Data/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Data/CoreEntity.pm
@@ -128,11 +128,15 @@ sub get_by_ids_sorted_by_name
     @ids = grep { defined && $_ } @ids;
     return [] unless @ids;
 
+    my $ordering_condition = $self->_type eq 'artist'
+        ? 'sort_name COLLATE musicbrainz'
+        : 'name COLLATE musicbrainz';
+
     my $key = $self->_id_column;
     my $query = "SELECT " . $self->_columns .
                 " FROM " . $self->_table .
                 " WHERE $key IN (" . placeholders(@ids) . ") " .
-                " ORDER BY name COLLATE musicbrainz";
+                " ORDER BY $ordering_condition";
 
     my @result;
     for my $row (@{ $self->sql->select_list_of_hashes($query, @ids) }) {

--- a/lib/MusicBrainz/Server/Data/EntityTag.pm
+++ b/lib/MusicBrainz/Server/Data/EntityTag.pm
@@ -456,12 +456,15 @@ sub find_entities
 {
     my ($self, $tag_id, $limit, $offset) = @_;
     my $type = $self->type;
+    my $ordering_condition = $type eq 'artist'
+        ? 'sort_name COLLATE musicbrainz'
+        : 'name COLLATE musicbrainz';
     my $tag_table = $self->tag_table;
     my $query = "SELECT tt.count AS tt_count, " . $self->parent->_columns . "
                  FROM " . $self->parent->_table . "
                      JOIN $tag_table tt ON " . $self->parent->_id_column . " = tt.$type
                  WHERE tag = ?
-                 ORDER BY tt.count DESC, name COLLATE musicbrainz, " . $self->parent->_id_column;
+                 ORDER BY tt.count DESC, $ordering_condition, " . $self->parent->_id_column;
     $self->query_to_list_limited($query, [$tag_id], $limit, $offset, sub {
         my ($model, $row) = @_;
 


### PR DESCRIPTION
### Implement MBS-11467

It makes sense to use sort names for sorting artists also in tag lists.
This changes get_by_ids_sorted_by_name to use sort_name for artists, but this seems to be used for tags only anyway. In any case, I don't feel the name becomes incorrect, since the sort_name column is just meant as "the way to sort artists by name" in the first place.

Tested with http://localhost:5000/tag/classical/artist / http://localhost:5000/user/reosarevok/tag/classical (`pink` data).