### PR TITLE
MBS-11454: Don't consider hasTooEarlyFormat a blocking error

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -1042,9 +1042,6 @@ class Release extends mbEntity.Release {
     this.hasUnconfirmedVariousArtists = errorField(
       this.mediums.any('hasUnconfirmedVariousArtists'),
     );
-    this.hasTooEarlyFormat = errorField(
-      this.mediums.any('hasTooEarlyFormat'),
-    );
     this.needsMediums = errorField(function () {
       return !(self.mediums().length || self.hasUnknownTracklist());
     });


### PR DESCRIPTION
### Fix MBS-11454

If a release already had a too early format before the editor started this release editor session, `hasTooEarlyFormat` is still set. As such, these lines were blocking editing even in that case.
The whole point of having `hasUnconfirmedEarlyFormat` as well was for that to be the one that triggers an error, while just `hasTooEarlyFormat` should not. Compare `hasUnconfirmedVariousArtists` vs `hasVariousArtists`.
