### PR TITLE
MBS-11473: Don't try to filter open edits for user if logged out

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -212,7 +212,11 @@ sub open : Local
     my ($self, $c) = @_;
 
     my $edits = $self->_load_paged($c, sub {
-         $c->model('Edit')->find_open_for_editor($c->user->id, shift, shift);
+        if ($c->user_exists) {
+            $c->model('Edit')->find_open_for_editor($c->user->id, shift, shift);
+        } else {
+            $c->model('Edit')->find_all_open(shift, shift);
+        }
     });
 
     $c->stash( edits => $edits ); # stash early in case an ISE occurs

--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -282,6 +282,24 @@ sub find_by_voter
     );
 }
 
+sub find_all_open
+{
+    my ($self, $limit, $offset) = @_;
+    my $query =
+        'SELECT ' . $self->_columns . '
+           FROM ' . $self->_table . '
+          WHERE status = ?
+       ORDER BY id ASC
+          LIMIT ' . $LIMIT_FOR_EDIT_LISTING;
+
+    $self->query_to_list_limited(
+        $query,
+        [$STATUS_OPEN],
+        $limit,
+        $offset,
+    );
+}
+
 sub find_open_for_editor
 {
     my ($self, $editor_id, $limit, $offset) = @_;


### PR DESCRIPTION
### Fix MBS-11473

Unsurprisingly, this was giving an ISE. I think just showing all open edits in this case makes the most sense.