### PR TITLE
MBS-11476: Don't show own open edits in /edit/open

### DIFF
--- a/lib/MusicBrainz/Server/Data/Edit.pm
+++ b/lib/MusicBrainz/Server/Data/Edit.pm
@@ -289,6 +289,7 @@ sub find_open_for_editor
         'SELECT ' . $self->_columns . '
            FROM ' . $self->_table . '
           WHERE status = ?
+            AND editor != ?
             AND NOT EXISTS (
                 SELECT TRUE FROM vote
                  WHERE vote.edit = edit.id
@@ -300,7 +301,7 @@ sub find_open_for_editor
 
     $self->query_to_list_limited(
         $query,
-        [$STATUS_OPEN, $editor_id],
+        [$STATUS_OPEN, $editor_id, $editor_id],
         $limit,
         $offset,
     );

--- a/t/lib/t/Edit.pm
+++ b/t/lib/t/Edit.pm
@@ -9,7 +9,8 @@ around run_test => sub {
     $self->c->sql->do(<<'EOSQL');
 INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
 VALUES
-  (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo@example.com', now());
+  (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo@example.com', now()),
+  (200, 'editor200', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo2@example.com', now());
 EOSQL
 
     $self->$orig(@_);

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Open.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Open.pm
@@ -58,7 +58,7 @@ has edit => (
     lazy => 1,
     default => sub {
         shift->c->model('Edit')->create(
-            editor_id => 1,
+            editor_id => 200,
             edit_type => $mock_edit_class
         );
     }


### PR DESCRIPTION
### Implement MBS-11476

We already filter edits the editor has voted on, so obviously this is meant for voting. As such, it is useless to show open edits by that specific editor.