### PR TITLE
MBS-11485: Allow irc(s):// links on expand2react

### DIFF
--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -52,7 +52,7 @@ const htmlSelfClosingTagEnd = /^\s*\/>/;
 const htmlAttrStart = /^\s+(?=[a-z])/;
 const htmlAttrName = /^(class|href|id|key|rel|target|title)="/;
 const htmlAttrTextContent = /^[^{}"]+/;
-const hrefValueStart = /^(?:\/|https?:\/\/)/;
+const hrefValueStart = /^(?:\/|https?:\/\/|ircs?:\/\/)/;
 
 function handleTextContentText(text: string) {
   if (typeof state.replacement === 'string') {


### PR DESCRIPTION
### Implement MBS-11485

A user bio repeatedly fails to parse because it has some irc:// links. Unless I'm missing some reason why these are a security risk, we should allow users to link to IRC, especially given we use IRC all the time.

User in question: https://musicbrainz.org/user/xps2