### PR TITLE
MBS-11506: Redirect 'data' link on home page

### DIFF
--- a/root/main/index.js
+++ b/root/main/index.js
@@ -56,7 +56,7 @@ const Homepage = ({
                by allowing anyone to contribute and releasing the {doc|data}
                under {doc2|open licenses}.`,
               {
-                doc: '/doc/MusicBrainz_Documentation',
+                doc: '/doc/MusicBrainz_Database',
                 doc2: '/doc/About/Data_License',
               },
             )}


### PR DESCRIPTION
Fixes MBS-11506 to point the MB 'data' link on the website home page from https://musicbrainz.org/doc/MusicBrainz_Documentation to https://musicbrainz.org/doc/MusicBrainz_Database.