### PR TITLE
MBS-11503: Block smart links: trac.co

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -652,6 +652,7 @@ const URL_SHORTENERS = [
   'tiny.cc',
   'tinyurl.com',
   'tourlink.to',
+  'trac.co', // Host links can be legitimate; non-root paths are aggregators
   'u.nu',
   'unitedmasters.com',
   'untd.io',


### PR DESCRIPTION
### Implement MBS-11503

https://beny.trac.co/ seems to be a legit page, but https://beny.trac.co/benyslowmotion is effectively a smart link.
Since our implementation only blocks links with a subpath, it's fine to block this here, but adding a comment in case we eventually change the blocking method.
