### PR TITLE
MBS-10726: Use "medium", not "disc", as a generic term in RE buttons

### DIFF
--- a/root/release/edit/layout.tt
+++ b/root/release/edit/layout.tt
@@ -63,7 +63,7 @@
       <!-- For release adds, we want to make sure the user at least sees release duplicates -->
       <button type="button" data-bind="visible: (activeTabIndex() > 0 || action === 'edit') && (activeTabIndex() < tabCount - 1)" data-click="lastTab">[% l('Finish') | html_entity %]</button>
 
-      <!-- ko template: { if: activeTabID() === "#tracklist", data: addDiscDialog } -->
+      <!-- ko template: { if: activeTabID() === "#tracklist", data: addMediumDialog } -->
         <button type="button" data-click="open">[% l('Add Medium') %]</button>
       <!-- /ko -->
 

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -1,5 +1,5 @@
 <script type="text/html" id="template.track-parser">
-  [%# the track-parser-dialog is a simplified version of the add-disc-dialog. %]
+  [%# the track-parser-dialog is a simplified version of the add-medium-dialog. %]
   <p>[% l('Enter a tracklist below:') %]</p>
 
   <textarea class="tracklist" data-bind="value: toBeParsed"></textarea>
@@ -226,32 +226,32 @@
   </div>
 </div>
 
-<div id="add-disc-dialog" style="display: none;" data-bind="with: $root.addDiscDialog, delegatedHandler: ['click', 'keydown']">
+<div id="add-medium-dialog" style="display: none;" data-bind="with: $root.addMediumDialog, delegatedHandler: ['click', 'keydown']">
   <p>[% l('To create a new tracklist, use an existing medium or import a disc from a CD stub, select the appropriate tab.') %]</p>
 
   <ul>
-    <li><a href="#add-disc-parser">[% l('Manual entry') %]</a></li>
-    <li><a href="#add-disc-medium">[% l('Existing medium') %]</a></li>
-    <li><a href="#add-disc-cdstub">[% l('CD stub import') %]</a></li>
+    <li><a href="#add-medium-parser">[% l('Manual entry') %]</a></li>
+    <li><a href="#add-medium-existing">[% l('Existing medium') %]</a></li>
+    <li><a href="#add-medium-cdstub">[% l('CD stub import') %]</a></li>
   </ul>
 
-  <div id="add-disc-parser">
+  <div id="add-medium-parser">
     <!-- ko template: { name: "template.track-parser", data: trackParser } --><!-- /ko -->
   </div>
 
-  <div id="add-disc-medium">
+  <div id="add-medium-existing">
     <p>[% l('Use the following fields to search for an existing medium.') %]</p>
     <!-- ko template: { name: "template.medium-search", data: mediumSearch } --><!-- /ko -->
   </div>
 
-  <div id="add-disc-cdstub">
+  <div id="add-medium-cdstub">
     <p>[% l('Use the following fields to search for a CD stub.') %]</p>
     <!-- ko template: { name: "template.medium-search", data: cdstubSearch } --><!-- /ko -->
   </div>
 
   <div class="buttons">
     <button type="button" class="negative" id="close-add-medium" data-click="close">[% l('Close') %]</button>
-    <button type="button" style="float: right" class="positive" data-click="addDisc" data-bind="enable: currentTab().result()">[% l('Add Medium') %]</button>
+    <button type="button" style="float: right" class="positive" data-click="addMedium" data-bind="enable: currentTab().result()">[% l('Add Medium') %]</button>
   </div>
 </div>
 
@@ -279,18 +279,18 @@
   <!-- /ko -->
 
   <!-- ko loop: { items: mediums, id: 'uniqueID' } -->
-  <fieldset class="advanced-disc">
+  <fieldset class="advanced-medium">
     <legend data-bind="text: formattedName()"></legend>
 
     <table class="advanced-format">
       <tr>
         <td class="icon">
-          <button type="button" class="icon collapse-disc" data-click="toggleMedium" data-bind="css: { 'expand-disc': collapsed, 'collapse-disc': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand medium') %]' : '[% l('Collapse medium') %]' }"></button>
+          <button type="button" class="icon collapse-medium" data-click="toggleMedium" data-bind="css: { 'expand-medium': collapsed, 'collapse-medium': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand medium') %]' : '[% l('Collapse medium') %]' }"></button>
         </td>
 
         <td class="format">
-          <label data-bind="attr: { for: 'disc-format-' + uniqueID }">[% l('Format:') %]</label>
-          <select data-bind="value: formatID, attr: { id: 'disc-format-' + uniqueID }">
+          <label data-bind="attr: { for: 'medium-format-' + uniqueID }">[% l('Format:') %]</label>
+          <select data-bind="value: formatID, attr: { id: 'medium-format-' + uniqueID }">
             <option value="" selected="selected">—</option>
             [%- FOR format=formats %]
             <option value="[% format.value %]">[% format.label %]</option>
@@ -302,8 +302,8 @@
           </label>
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
-            <label data-bind="attr: { for: 'disc-title-' + uniqueID }">[% l('Medium title:') %]</label>
-            <input type="text" data-bind="value: name, attr: { id: 'disc-title-' + uniqueID }" />
+            <label data-bind="attr: { for: 'medium-title-' + uniqueID }">[% l('Medium title:') %]</label>
+            <input type="text" data-bind="value: name, attr: { id: 'medium-title-' + uniqueID }" />
             <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-click="guessCaseMediumName"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">
@@ -312,8 +312,8 @@
         </td>
 
         <td class="align-right icon" >
-          <button type="button" class="icon disc-down" title="[% l('Move medium down') %]" data-click="moveMediumDown"></button>
-          <button type="button" class="icon disc-up" title="[% l('Move medium up') %]" data-click="moveMediumUp"></button>
+          <button type="button" class="icon medium-down" title="[% l('Move medium down') %]" data-click="moveMediumDown"></button>
+          <button type="button" class="icon medium-up" title="[% l('Move medium up') %]" data-click="moveMediumUp"></button>
           <button type="button" class="icon remove-item" title="[% l('Remove medium') %]" style="margin-left: 16px" data-click="removeMedium"></button>
         </td>
       </tr>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -285,7 +285,7 @@
     <table class="advanced-format">
       <tr>
         <td class="icon">
-          <button type="button" class="icon collapse-disc" data-click="toggleMedium" data-bind="css: { 'expand-disc': collapsed, 'collapse-disc': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand Disc') %]' : '[% l('Collapse Disc') %]' }"></button>
+          <button type="button" class="icon collapse-disc" data-click="toggleMedium" data-bind="css: { 'expand-disc': collapsed, 'collapse-disc': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand medium') %]' : '[% l('Collapse medium') %]' }"></button>
         </td>
 
         <td class="format">
@@ -302,9 +302,9 @@
           </label>
           (<a href="[% c.uri_for('/doc/Release/Format') %]" target="_blank">[% l('help') %]</a>)
           <!-- ko if: release.mediums().length > 1 || name() -->
-            <label data-bind="attr: { for: 'disc-title-' + uniqueID }">[% l('Disc title:') %]</label>
+            <label data-bind="attr: { for: 'disc-title-' + uniqueID }">[% l('Medium title:') %]</label>
             <input type="text" data-bind="value: name, attr: { id: 'disc-title-' + uniqueID }" />
-            <button type="button" class="icon guesscase-title" title="[% l('Guess case disc title') %]" data-click="guessCaseMediumName"></button>
+            <button type="button" class="icon guesscase-title" title="[% l('Guess case medium title') %]" data-click="guessCaseMediumName"></button>
           <!-- /ko -->
           <p class="error field-error" style="padding-left: 1em" data-bind="showErrorWhenTabIsSwitched: needsFormat">
             [%~ l('A format is required. If you don’t know it, tick the “I don’t know” checkbox next to the format dropdown.') %]
@@ -312,9 +312,9 @@
         </td>
 
         <td class="align-right icon" >
-          <button type="button" class="icon disc-down" title="[% l('Move disc down') %]" data-click="moveMediumDown"></button>
-          <button type="button" class="icon disc-up" title="[% l('Move disc up') %]" data-click="moveMediumUp"></button>
-          <button type="button" class="icon remove-item" title="[% l('Remove disc') %]" style="margin-left: 16px" data-click="removeMedium"></button>
+          <button type="button" class="icon disc-down" title="[% l('Move medium down') %]" data-click="moveMediumDown"></button>
+          <button type="button" class="icon disc-up" title="[% l('Move medium up') %]" data-click="moveMediumUp"></button>
+          <button type="button" class="icon remove-item" title="[% l('Remove medium') %]" style="margin-left: 16px" data-click="removeMedium"></button>
         </td>
       </tr>
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -221,7 +221,7 @@ const actions = {
 
   removeTrack: function (track) {
     var focus = track.next() || track.previous();
-    var $medium = $('#' + track.elementID).parents('.advanced-disc');
+    var $medium = $('#' + track.elementID).parents('.advanced-medium');
     var medium = track.medium;
     var tracks = medium.tracks;
     var index = tracks.indexOf(track);

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -65,7 +65,7 @@ Object.assign(trackParserDialog, {
     !error && medium.tracks(newTracks);
   },
 
-  addDisc: function () {
+  addMedium: function () {
     this.parse();
     return this.error() ? null : this.medium;
   },
@@ -251,14 +251,14 @@ class SearchTab {
     this.searchResults(results.map(x => new SearchResult(this, x)));
   }
 
-  addDisc() {
+  addMedium() {
     const release = releaseEditor.rootField.release();
     const medium = new fields.Medium(this.result(), release);
 
     medium.name('');
 
-    if (this._addDisc) {
-      this._addDisc(medium);
+    if (this._addMedium) {
+      this._addMedium(medium);
     }
 
     return medium;
@@ -287,7 +287,7 @@ Object.assign(mediumSearchTab, {
     return [this.endpoint, result.medium_id].join('/');
   },
 
-  _addDisc(medium) {
+  _addMedium(medium) {
     medium.loaded(true);
     medium.collapsed(false);
   },
@@ -305,10 +305,10 @@ Object.assign(cdstubSearchTab, {
 });
 
 
-export const addDiscDialog = releaseEditor.addDiscDialog = new Dialog();
+export const addMediumDialog = releaseEditor.addMediumDialog = new Dialog();
 
-Object.assign(addDiscDialog, {
-  element: '#add-disc-dialog',
+Object.assign(addMediumDialog, {
+  element: '#add-medium-dialog',
   title: l('Add Medium'),
 
   trackParser: trackParserDialog,
@@ -336,15 +336,15 @@ Object.assign(addDiscDialog, {
     Dialog.prototype.open.apply(this, arguments);
   },
 
-  addDisc: function () {
-    var medium = this.currentTab().addDisc();
+  addMedium: function () {
+    var medium = this.currentTab().addMedium();
     if (!medium) {
       return;
     }
 
     var release = releaseEditor.rootField.release();
 
-    // If there's only one empty disc, replace it.
+    // If there's only one empty medium, replace it.
     if (release.hasOneEmptyMedium()) {
       medium.position(1);
 
@@ -372,13 +372,13 @@ Object.assign(addDiscDialog, {
 
 
 $(function () {
-  $('#add-disc-parser').data('model', addDiscDialog.trackParser);
-  $('#add-disc-medium').data('model', mediumSearchTab);
-  $('#add-disc-cdstub').data('model', cdstubSearchTab);
+  $('#add-medium-parser').data('model', addMediumDialog.trackParser);
+  $('#add-medium-existing').data('model', mediumSearchTab);
+  $('#add-medium-cdstub').data('model', cdstubSearchTab);
 
-  $(addDiscDialog.element).tabs({
+  $(addMediumDialog.element).tabs({
     activate: function (event, ui) {
-      addDiscDialog.currentTab(ui.newPanel.data('model'));
+      addMediumDialog.currentTab(ui.newPanel.data('model'));
     },
   });
 });

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -226,12 +226,12 @@ releaseEditor.init = function (options) {
   });
 
   /*
-   * Handle showing/hiding the AddDisc dialog when the user switches to/from
+   * Handle showing/hiding the AddMedium dialog when the user switches to/from
    * the tracklist tab.
    */
 
   utils.withRelease(function (release) {
-    self.autoOpenTheAddDiscDialog(release);
+    self.autoOpenTheAddMediumDialog(release);
   });
 
   // Keep track of recordings associated with the current release group.
@@ -391,21 +391,21 @@ releaseEditor.createExternalLinksEditor = function (data, mountPoint) {
   return this.externalLinks;
 };
 
-releaseEditor.autoOpenTheAddDiscDialog = function (release) {
-  var addDiscUI = $(this.addDiscDialog.element).data('ui-dialog');
+releaseEditor.autoOpenTheAddMediumDialog = function (release) {
+  var addMediumUI = $(this.addMediumDialog.element).data('ui-dialog');
   var trackParserUI = $(this.trackParserDialog.element).data('ui-dialog');
 
   // Show the dialog if there's no non-empty disc.
   if (this.activeTabID() === '#tracklist') {
-    var dialogIsOpen = (addDiscUI && addDiscUI.isOpen()) ||
+    var dialogIsOpen = (addMediumUI && addMediumUI.isOpen()) ||
         (trackParserUI && trackParserUI.isOpen());
 
     if (!dialogIsOpen && release.hasOneEmptyMedium() &&
                             !release.mediums()[0].loading()) {
-      this.addDiscDialog.open();
+      this.addMediumDialog.open();
     }
-  } else if (addDiscUI) {
-    addDiscUI.close();
+  } else if (addMediumUI) {
+    addMediumUI.close();
   }
 };
 

--- a/root/static/scripts/tests/release-editor/dialogs.js
+++ b/root/static/scripts/tests/release-editor/dialogs.js
@@ -12,7 +12,7 @@ import test from 'tape';
 import '../../../lib/jquery-ui';
 
 import {
-  addDiscDialog,
+  addMediumDialog,
   mediumSearchTab,
   trackParserDialog,
 } from '../../release-editor/dialogs';
@@ -45,7 +45,7 @@ function dialogTest(name, callback) {
       .attr('id', 'fixture')
       .appendTo('body')
       .append(
-        $('<div>').attr('id', 'add-disc-dialog').hide(),
+        $('<div>').attr('id', 'add-medium-dialog').hide(),
         $('<div>').attr('id', 'track-parser-dialog').hide(),
       );
 
@@ -58,7 +58,7 @@ function dialogTest(name, callback) {
 }
 
 dialogTest((
-  'adding an empty medium via the add-disc dialog is allowed (MBS-7221)'
+  'adding an empty medium via the add-medium dialog is allowed (MBS-7221)'
 ), function (t, release) {
   t.plan(3);
 
@@ -75,35 +75,35 @@ dialogTest((
     'first medium has tracks after using track parser',
   );
 
-  addDiscDialog.open();
-  addDiscDialog.currentTab(trackParserDialog);
-  addDiscDialog.trackParser.toBeParsed('\n\t\n');
-  addDiscDialog.addDisc();
+  addMediumDialog.open();
+  addMediumDialog.currentTab(trackParserDialog);
+  addMediumDialog.trackParser.toBeParsed('\n\t\n');
+  addMediumDialog.addMedium();
 
   t.ok(!mediums()[1].hasTracks(), 'new empty medium was added');
 });
 
 dialogTest((
-  'switching to the tracklist tab opens the add-disc dialog if there’s only one empty medium'
+  'switching to the tracklist tab opens the add-medium dialog if there’s only one empty medium'
 ), function (t, release) {
   t.plan(3);
 
   releaseEditor.activeTabID('#tracklist');
-  releaseEditor.autoOpenTheAddDiscDialog(release);
+  releaseEditor.autoOpenTheAddMediumDialog(release);
 
-  var uiDialog = $(addDiscDialog.element).data('ui-dialog');
+  var uiDialog = $(addMediumDialog.element).data('ui-dialog');
 
   t.ok(
     uiDialog.isOpen(),
-    'add-disc dialog is open after switching to the tracklist tab',
+    'add-medium dialog is open after switching to the tracklist tab',
   );
 
   releaseEditor.activeTabID('#information');
-  releaseEditor.autoOpenTheAddDiscDialog(release);
+  releaseEditor.autoOpenTheAddMediumDialog(release);
 
   t.ok(
     !uiDialog.isOpen(),
-    'add-disc dialog is closed after switching back to the information tab',
+    'add-medium dialog is closed after switching back to the information tab',
   );
 
   release.mediums()[0].tracks.push(
@@ -111,16 +111,16 @@ dialogTest((
   );
 
   releaseEditor.activeTabID('#information');
-  releaseEditor.autoOpenTheAddDiscDialog(release);
+  releaseEditor.autoOpenTheAddMediumDialog(release);
 
   t.ok(
     !uiDialog.isOpen(),
-    'add-disc dialog remains closed after switching to the tracklist tab with a non-empty medium',
+    'add-medium dialog remains closed after switching to the tracklist tab with a non-empty medium',
   );
 });
 
 dialogTest((
-  'clearing the tracks of an existing medium via the track parser doesn’t cause the add-disc dialog to open'
+  'clearing the tracks of an existing medium via the track parser doesn’t cause the add-medium dialog to open'
 ), function (t, release) {
   t.plan(3);
 
@@ -136,12 +136,12 @@ dialogTest((
   trackParserDialog.open(medium);
   trackParserDialog.toBeParsed('');
   trackParserDialog.parse();
-  releaseEditor.autoOpenTheAddDiscDialog(release);
+  releaseEditor.autoOpenTheAddMediumDialog(release);
 
   t.ok(!medium.hasTracks(), 'medium does not have tracks');
 
-  var uiDialog = $(addDiscDialog.element).data('ui-dialog');
-  t.ok(!uiDialog, 'add-disc dialog is not open');
+  var uiDialog = $(addMediumDialog.element).data('ui-dialog');
+  t.ok(!uiDialog, 'add-medium dialog is not open');
 });
 
 dialogTest((
@@ -155,10 +155,10 @@ dialogTest((
   delete testMediumCopy.id;
 
   release.mediums([new fields.Medium(testMediumCopy, release)]);
-  addDiscDialog.open();
-  addDiscDialog.currentTab(mediumSearchTab);
+  addMediumDialog.open();
+  addMediumDialog.currentTab(mediumSearchTab);
   mediumSearchTab.result({ position: 1, tracks: [{ name: 'foo' }] });
-  addDiscDialog.addDisc();
+  addMediumDialog.addMedium();
 
   common.createMediums(release);
 

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -73,23 +73,23 @@ div.half-width {
        TRACKLIST TAB
    __________________________________ */
 
-fieldset.advanced-disc {
+fieldset.advanced-medium {
     &.expanded div.icon { display: block; }
 
     button {
-        &.collapse-disc {
+        &.collapse-medium {
             background-image: data-uri('../images/icons/collapse.png');
         }
 
-        &.expand-disc {
+        &.expand-medium {
             background-image: data-uri('../images/icons/expand.png');
         }
 
-        &.disc-down {
+        &.medium-down {
             background-image: data-uri('../images/icons/down.png');
         }
 
-        &.disc-up {
+        &.medium-up {
             background-image: data-uri('../images/icons/up.png');
         }
     }
@@ -269,7 +269,7 @@ div.changes div.warning { margin: 1em auto; }
     TRACK PARSER/ADD DISC DIALOG
    __________________________________ */
 
-#track-parser-dialog, #add-disc-dialog {
+#track-parser-dialog, #add-medium-dialog {
     textarea { width: 100%; height: 250px; }
 
     table.track-parser-options {
@@ -294,7 +294,7 @@ div.changes div.warning { margin: 1em auto; }
     div.buttons { margin: 1em 0; float: left; width: 100%; }
 }
 
-#add-disc-dialog {
+#add-medium-dialog {
     .search-result .ui-icon {
         display: inline-block;
         vertical-align: bottom;

--- a/t/selenium/Artist_Credit_Editor.json5
+++ b/t/selenium/Artist_Credit_Editor.json5
@@ -307,7 +307,7 @@
     },
     {
       command: 'click',
-      target: 'css=.ui-dialog[aria-describedby=add-disc-dialog] button.ui-dialog-titlebar-close',
+      target: 'css=.ui-dialog[aria-describedby=add-medium-dialog] button.ui-dialog-titlebar-close',
       value: '',
     },
     {

--- a/t/selenium/release-editor/Duplicate_Selection.json5
+++ b/t/selenium/release-editor/Duplicate_Selection.json5
@@ -161,7 +161,7 @@
     },
     {
       command: 'sendKeys',
-      target: 'css=#add-disc-dialog a[href="#add-disc-parser"]',
+      target: 'css=#add-medium-dialog a[href="#add-medium-parser"]',
       value: '${KEY_ESC}',
     },
     {

--- a/t/selenium/release-editor/MBS-11156.json5
+++ b/t/selenium/release-editor/MBS-11156.json5
@@ -38,42 +38,42 @@
     },
     {
       command: 'uncheck',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='lines-have-numbers']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='lines-have-numbers']",
       value: '',
     },
     {
       command: 'uncheck',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='lines-have-artists']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='lines-have-artists']",
       value: '',
     },
     {
       command: 'uncheck',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-numbers']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-numbers']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-titles']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-titles']",
       value: '',
     },
     {
       command: 'uncheck',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-lengths']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-lengths']",
       value: '',
     },
     {
       command: 'type',
-      target: "xpath=//div[@id='add-disc-parser']//textarea[contains(@class, 'tracklist')]",
+      target: "xpath=//div[@id='add-medium-parser']//textarea[contains(@class, 'tracklist')]",
       value: 'test',
     },
     {
       command: 'click',
-      target: "xpath=//div[@id='add-disc-dialog']//button[contains(text(), 'Add Medium')]",
+      target: "xpath=//div[@id='add-medium-dialog']//button[contains(text(), 'Add Medium')]",
       value: '',
     },
     {
       command: 'select',
-      target: "xpath=(//select[contains(@id, 'disc-format-')])[1]",
+      target: "xpath=(//select[contains(@id, 'medium-format-')])[1]",
       value: 'label=Vinyl',
     },
     // Check that the parsed track does use "Various Artists" from the release artist.

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -214,47 +214,47 @@
     // Paste half of the tracklist into the track parser.
     {
       command: 'type',
-      target: "xpath=//div[@id='add-disc-parser']//textarea[contains(@class, 'tracklist')]",
+      target: "xpath=//div[@id='add-medium-parser']//textarea[contains(@class, 'tracklist')]",
       value: 'A1 Mr Self Destruct - nin 4:31\nA2 Piggy - nin 4:24\nA3 Heresy - nin 3:54\nA4 March of the Pigs - nin 2:58\nA5 Closer - nin 6:13\nA6 Ruiner - nin 4:59\nA7 The Becoming - nin 5:32',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='lines-have-numbers']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='lines-have-numbers']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='enable-vinyl-numbers']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='enable-vinyl-numbers']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='lines-have-artists']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='lines-have-artists']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-numbers']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-numbers']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-artists']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-artists']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-titles']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-titles']",
       value: '',
     },
     {
       command: 'check',
-      target: "xpath=//div[@id='add-disc-dialog']//input[@name='use-lengths']",
+      target: "xpath=//div[@id='add-medium-dialog']//input[@name='use-lengths']",
       value: '',
     },
     {
       command: 'click',
-      target: "xpath=//div[@id='add-disc-dialog']//button[contains(text(), 'Add Medium')]",
+      target: "xpath=//div[@id='add-medium-dialog']//button[contains(text(), 'Add Medium')]",
       value: '',
     },
     // Fill in the track artists.
@@ -1160,7 +1160,7 @@
     },
     {
       command: 'select',
-      target: 'id=disc-format-1',
+      target: 'id=medium-format-1',
       value: 'label=CD',
     },
     {


### PR DESCRIPTION
### Implement MBS-10726

These can apply to mediums that are not discs. The pregap / data track strings only apply to actual discs, so not changing those for now.
