### PR TITLE
MBS-11510: Stop overwriting titles in disableBecauseDiscIDs

### DIFF
--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -28,7 +28,7 @@ ko.bindingHandlers.disableBecauseDiscIDs = {
         disabled
           ? l(`This medium has one or more discids
                which prevent this information from being changed.`)
-          : '',
+          : element.title,
       );
   },
 };


### PR DESCRIPTION
### Fix MBS-11510

We were setting a title here, and then overwriting it with an empty string with the disableBecauseDiscIDs.update function. Obviously we want to keep the title if we don't need to overwrite it.
