### PR TITLE
MBS-9851: Allow finding edits w/ edit notes by not original editor

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
@@ -32,6 +32,7 @@ role {
             'me' => 0,
             'not_me' => 0,
             'limited' => 0,
+            'not_edit_author' => 0,
         );
     };
 
@@ -76,6 +77,15 @@ role {
               )
             ";
             $query->add_where([ $sql, [ $EDITOR_MODBOT, $STATUS_APPLIED ] ]);
+        } elsif ($self->operator eq 'not_edit_author') {
+            $query->add_where([
+                'EXISTS (
+                    SELECT TRUE FROM edit_note
+                        WHERE edit_note.edit = edit.id
+                        AND edit_note.editor != edit.editor
+                )',
+                [ ]
+            ]);
         } else {
             $query->add_where([ $sql, [ $self->arguments ] ]);
         }

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -345,6 +345,7 @@
                    [ 'subscribed', l('include an editor in my subscriptions') ]
                    [ 'not_subscribed', l('do not include editors in my subscriptions') ]
                    [ 'limited', l('include a beginner editor') ]
+                   [ 'not_edit_author', l('include someone other than the edit author') ]
                 ], field_contents) %]
   [% ELSE %]
     [% operators([ [ '=', l('is') ]


### PR DESCRIPTION
### Implement MBS-9851

It can be very useful to find out edits where discussion of some sort is happening.
This operator will never apply to any other Role::User predicates than EditNoteAuthor, but I didn't find a way to add it only for that one - it's still only exposed for that one though.

Tested by searching and making sure all results seem legit.

Do let me know if you can think of a way to actually limit this to only EditNoteAuthor.