### PR TITLE
MBS-9310: Link to relationship type in Add Relationship Type edits

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -392,7 +392,11 @@
             "id": 18
         },
         "last_updated_column": true,
-        "model": "LinkType"
+        "mbid": {
+            "relatable": false
+        },
+        "model": "LinkType",
+        "url": "relationship"
     },
     "medium": {"model": "Medium"},
     "medium_cdtoc": {"model": "MediumCDTOC"},

--- a/lib/MusicBrainz/Server/Edit/Relationship/AddLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/AddLinkType.pm
@@ -48,6 +48,7 @@ has '+data' => (
 sub foreign_keys {
     my $self = shift;
     return {
+        LinkType => [ $self->entity_id ],
         LinkAttributeType => [
             grep { defined }
             map { $_->{type} }
@@ -85,6 +86,10 @@ sub build_display_data {
         long_link_phrase => $self->data->{long_link_phrase},
         name => $self->data->{name},
         orderable_direction => $self->data->{orderable_direction},
+        defined($self->entity_id) ? (relationship_type => to_json_object(
+            $loaded->{LinkType}{ $self->entity_id } ||
+            MusicBrainz::Server::Entity::LinkType->new( name => $self->data->{name} ))
+        ) : (),
         reverse_link_phrase => $self->data->{reverse_link_phrase},
     }
 }

--- a/root/edit/details/AddRelationshipType.js
+++ b/root/edit/details/AddRelationshipType.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import IntentionallyRawIcon from '../components/IntentionallyRawIcon';
 import Cardinality from '../../static/scripts/common/components/Cardinality';
+import EntityLink from '../../static/scripts/common/components/EntityLink';
 import OrderableDirection
   from '../../static/scripts/common/components/OrderableDirection';
 import {ENTITY_NAMES} from '../../static/scripts/common/constants';
@@ -33,6 +34,7 @@ type AddRelationshipTypeEditT = {
     +long_link_phrase: string,
     +name: string,
     +orderable_direction?: number,
+    +relationship_type?: LinkTypeT,
     +reverse_link_phrase: string,
   },
 };
@@ -41,13 +43,16 @@ type Props = {
   +edit: AddRelationshipTypeEditT,
 };
 
-const AddRelationshipType = ({edit}: Props): React.Element<'table'> => {
+const AddRelationshipType = ({
+  edit,
+}: Props): React.Element<typeof React.Fragment> => {
   const display = edit.display_data;
   const entity0Type = ENTITY_NAMES[display.entity0_type]();
   const entity1Type = ENTITY_NAMES[display.entity1_type]();
   const entity0Cardinality = display.entity0_cardinality;
   const entity1Cardinality = display.entity1_cardinality;
   const orderableDirection = display.orderable_direction;
+  const relType = display.relationship_type;
 
   // Always display entity placeholders for ease of understanding
   let longLinkPhrase = display.long_link_phrase;
@@ -66,142 +71,155 @@ const AddRelationshipType = ({edit}: Props): React.Element<'table'> => {
   );
 
   return (
-    <table className="details add-relationship-type">
-      <tr>
-        <th>{addColonText(l('Name'))}</th>
-        <td>
-          {display.name}
-          {rawIconSection}
-        </td>
-      </tr>
+    <>
+      {relType ? (
+        <table className="details">
+          <tr>
+            <th>{addColon(l('Relationship Type'))}</th>
+            <td>
+              <EntityLink entity={relType} />
+            </td>
+          </tr>
+        </table>
+      ) : null}
 
-      <tr>
-        <th>{addColonText(l('Description'))}</th>
-        <td>
-          {nonEmpty(display.description)
-            ? (
-              <>
-                {display.description}
-                {rawIconSection}
-              </>
-            ) : lp('(none)', 'description')}
-          {}
-        </td>
-      </tr>
+      <table className="details add-relationship-type">
+        <tr>
+          <th>{addColonText(l('Name'))}</th>
+          <td>
+            {display.name}
+            {rawIconSection}
+          </td>
+        </tr>
 
-      <tr>
-        <th>
-          {addColon(exp.l('Type of {entity_placeholder}', {
-            entity_placeholder: <code>{'{entity0}'}</code>,
-          }))}
-        </th>
-        <td>{entity0Type}</td>
-      </tr>
+        <tr>
+          <th>{addColonText(l('Description'))}</th>
+          <td>
+            {nonEmpty(display.description)
+              ? (
+                <>
+                  {display.description}
+                  {rawIconSection}
+                </>
+              ) : lp('(none)', 'description')}
+            {}
+          </td>
+        </tr>
 
-      <tr>
-        <th>
-          {addColon(exp.l('Type of {entity_placeholder}', {
-            entity_placeholder: <code>{'{entity1}'}</code>,
-          }))}
-        </th>
-        <td>{entity1Type}</td>
-      </tr>
-
-      <tr>
-        <th>{l('Link phrase:')}</th>
-        <td>
-          {display.link_phrase}
-          {rawIconSection}
-        </td>
-      </tr>
-
-      <tr>
-        <th>{l('Reverse link phrase:')}</th>
-        <td>
-          {display.reverse_link_phrase}
-          {rawIconSection}
-        </td>
-      </tr>
-
-      <tr>
-        <th>{l('Long link phrase:')}</th>
-        <td>
-          {longLinkPhrase ? (
-            <>
-              {longLinkPhrase}
-              {rawIconSection}
-            </>
-          ) : lp('(none)', 'link_phrase')}
-        </td>
-      </tr>
-
-      {entity0Cardinality == null ? null : (
         <tr>
           <th>
-            {addColon(exp.l('Cardinality of {entity_placeholder}', {
+            {addColon(exp.l('Type of {entity_placeholder}', {
               entity_placeholder: <code>{'{entity0}'}</code>,
             }))}
           </th>
-          <td>
-            <Cardinality cardinality={entity0Cardinality} />
-          </td>
+          <td>{entity0Type}</td>
         </tr>
-      )}
 
-      {entity1Cardinality == null ? null : (
         <tr>
           <th>
-            {addColon(exp.l('Cardinality of {entity_placeholder}', {
+            {addColon(exp.l('Type of {entity_placeholder}', {
               entity_placeholder: <code>{'{entity1}'}</code>,
             }))}
           </th>
-          <td>
-            <Cardinality cardinality={entity1Cardinality} />
-          </td>
+          <td>{entity1Type}</td>
         </tr>
-      )}
 
-      {orderableDirection == null ? null : (
         <tr>
-          <th>{l('Orderable direction:')}</th>
+          <th>{l('Link phrase:')}</th>
           <td>
-            <OrderableDirection direction={orderableDirection} />
+            {display.link_phrase}
+            {rawIconSection}
           </td>
         </tr>
-      )}
 
-      {display.attributes.length > 0 ? (
         <tr>
-          <th>{addColonText(l('Attributes'))}</th>
+          <th>{l('Reverse link phrase:')}</th>
           <td>
-            <ul>
-              {display.attributes.map((attribute, index) => (
-                <li key={'attribute-' + index}>
-                  {addColon(l_relationships(attribute.typeName))}
-                  {' '}
-                  {attribute.min}
-                  {'-'}
-                  {attribute.max}
-                </li>
-              ))}
-            </ul>
+            {display.reverse_link_phrase}
+            {rawIconSection}
           </td>
         </tr>
-      ) : null}
 
-      <tr>
-        <th>{addColonText(l('Documentation'))}</th>
-        <td>
-          {nonEmpty(display.documentation)
-            ? (
+        <tr>
+          <th>{l('Long link phrase:')}</th>
+          <td>
+            {longLinkPhrase ? (
               <>
-                {display.documentation}
+                {longLinkPhrase}
                 {rawIconSection}
               </>
-            ) : lp('(none)', 'documentation')}
-        </td>
-      </tr>
-    </table>
+            ) : lp('(none)', 'link_phrase')}
+          </td>
+        </tr>
+
+        {entity0Cardinality == null ? null : (
+          <tr>
+            <th>
+              {addColon(exp.l('Cardinality of {entity_placeholder}', {
+                entity_placeholder: <code>{'{entity0}'}</code>,
+              }))}
+            </th>
+            <td>
+              <Cardinality cardinality={entity0Cardinality} />
+            </td>
+          </tr>
+        )}
+
+        {entity1Cardinality == null ? null : (
+          <tr>
+            <th>
+              {addColon(exp.l('Cardinality of {entity_placeholder}', {
+                entity_placeholder: <code>{'{entity1}'}</code>,
+              }))}
+            </th>
+            <td>
+              <Cardinality cardinality={entity1Cardinality} />
+            </td>
+          </tr>
+        )}
+
+        {orderableDirection == null ? null : (
+          <tr>
+            <th>{l('Orderable direction:')}</th>
+            <td>
+              <OrderableDirection direction={orderableDirection} />
+            </td>
+          </tr>
+        )}
+
+        {display.attributes.length > 0 ? (
+          <tr>
+            <th>{addColonText(l('Attributes'))}</th>
+            <td>
+              <ul>
+                {display.attributes.map((attribute, index) => (
+                  <li key={'attribute-' + index}>
+                    {addColon(l_relationships(attribute.typeName))}
+                    {' '}
+                    {attribute.min}
+                    {'-'}
+                    {attribute.max}
+                  </li>
+                ))}
+              </ul>
+            </td>
+          </tr>
+        ) : null}
+
+        <tr>
+          <th>{addColonText(l('Documentation'))}</th>
+          <td>
+            {nonEmpty(display.documentation)
+              ? (
+                <>
+                  {display.documentation}
+                  {rawIconSection}
+                </>
+              ) : lp('(none)', 'documentation')}
+          </td>
+        </tr>
+      </table>
+    </>
   );
 };
 

--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import Layout from '../../layout';
 import Cardinality from '../../static/scripts/common/components/Cardinality';
+import EntityLink from '../../static/scripts/common/components/EntityLink';
 import OrderableDirection
   from '../../static/scripts/common/components/OrderableDirection';
 import Relationship
@@ -79,15 +80,13 @@ const RelationshipTypeIndex = ({
 
         {isRelationshipEditor($c.user) ? (
           <span className="buttons" style={{float: 'right'}}>
-            <a href={'/relationship/' + relType.gid + '/edit'}>
-              {l('Edit')}
-            </a>
+            <EntityLink content={l('Edit')} entity={relType} subPath="edit" />
             {childrenTypes.length ? null : (
-              <a
-                href={'/relationship/' + relType.gid + '/delete'}
-              >
-                {l('Remove')}
-              </a>
+              <EntityLink
+                content={l('Remove')}
+                entity={relType}
+                subPath="delete"
+              />
             )}
           </span>
         ) : null}

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import Layout from '../../layout';
 import * as manifest from '../../static/manifest';
 import Cardinality from '../../static/scripts/common/components/Cardinality';
+import EntityLink from '../../static/scripts/common/components/EntityLink';
 import expand2react from '../../static/scripts/common/i18n/expand2react';
 import bracketed from '../../static/scripts/common/utility/bracketed';
 import formatEntityTypeName
@@ -115,15 +116,15 @@ const RelationshipTypeDetails = ({
         {'[ '}
         {isRelationshipEditor($c.user) ? (
           <>
-            <a href={'/relationship/' + relType.gid + '/edit'}>
-              {l('Edit')}
-            </a>
+            <EntityLink content={l('Edit')} entity={relType} subPath="edit" />
             {childrenTypes.length ? null : (
               <>
                 {' | '}
-                <a href={'/relationship/' + relType.gid + '/delete'}>
-                  {l('Remove')}
-                </a>
+                <EntityLink
+                  content={l('Remove')}
+                  entity={relType}
+                  subPath="delete"
+                />
               </>
             )}
             {' | '}

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -123,7 +123,7 @@ type EntityLinkProps = {
   +content?: ?Expand2ReactOutput,
   +deletedCaption?: string,
   +disableLink?: boolean,
-  +entity: CoreEntityT | CollectionT,
+  +entity: CoreEntityT | CollectionT | LinkTypeT,
   +hover?: string,
   +nameVariation?: boolean,
   +showCaaPresence?: boolean,
@@ -172,6 +172,8 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     content = content || localizeAreaName(entity);
   } else if (entity.entityType === 'instrument') {
     content = content || localizeInstrumentName(entity);
+  } else if (entity.entityType === 'link_type') {
+    content = content || l_relationships(entity.name);
   }
 
   content = content || ko.unwrap(entity.name);

--- a/root/static/scripts/common/utility/entityHref.js
+++ b/root/static/scripts/common/utility/entityHref.js
@@ -19,7 +19,9 @@ type LinkableEntity =
   | {+entityType: 'editor', +name: string, ...}
   | {+entityType: 'isrc', +isrc: string, ...}
   | {+entityType: 'iswc', +iswc: string, ...}
-  | {+entityType: CoreEntityTypeT | 'collection', +gid: string, ...};
+  | {+entityType: CoreEntityTypeT, +gid: string, ...}
+  | {+entityType: 'collection', +gid: string, ...}
+  | {+entityType: 'link_type', +gid: string, ...};
 
 function generateHref(path, id, subPath, anchorPath) {
   let href = '/' + path + '/';


### PR DESCRIPTION
### Implement MBS-9310

For old enough edits this isn't doable since we do not store entity_id nor entity_gid. Starting 2015 we have that data, so it makes sense to link to the relationship type.

Many changes are indentation - I'd suggest hiding whitespace changes.