### PR TITLE
MBS-11530: Avoid common/MB/release code running on these

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -285,7 +285,7 @@
     <table class="advanced-format">
       <tr>
         <td class="icon">
-          <button type="button" class="icon collapse-medium" data-click="toggleMedium" data-bind="css: { 'expand-medium': collapsed, 'collapse-medium': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand medium') %]' : '[% l('Collapse medium') %]' }"></button>
+          <button type="button" class="icon collapse-medium" data-click="toggleMedium" data-bind="css: { 'expand-re-medium': collapsed, 'collapse-re-medium': !collapsed() }, attr: { title: collapsed() ? '[% l('Expand medium') %]' : '[% l('Collapse medium') %]' }"></button>
         </td>
 
         <td class="format">

--- a/root/release/index.tt
+++ b/root/release/index.tt
@@ -61,4 +61,6 @@
         [%- END -%]
       </div>
     [% END %]
+
+    [% script_manifest('release/index.js', {async => 'async'}) %]
 [%- END -%]

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -54,7 +54,6 @@ import(/* webpackChunkName: "common-menu" */ './common/MB/Control/Menu');
 import(
   /* webpackChunkName: "common-edit-search" */ './common/MB/edit_search'
 );
-import(/* webpackChunkName: "common-release" */ './common/MB/release');
 import(/* webpackChunkName: "common-ratings" */ './common/ratings');
 import(/* webpackChunkName: "common-tagger" */ './common/tagger');
 import(/* webpackChunkName: "common-cover-art" */ './common/coverart');

--- a/root/static/scripts/release/index.js
+++ b/root/static/scripts/release/index.js
@@ -8,9 +8,9 @@
 
 import $ from 'jquery';
 
-import request from '../utility/request';
-import getBooleanCookie from '../utility/getBooleanCookie';
-import setCookie from '../utility/setCookie';
+import request from '../common/utility/request';
+import getBooleanCookie from '../common/utility/getBooleanCookie';
+import setCookie from '../common/utility/setCookie';
 
 $(function () {
   var $bottomCredits = $('#bottom-credits');

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -77,11 +77,11 @@ fieldset.advanced-medium {
     &.expanded div.icon { display: block; }
 
     button {
-        &.collapse-medium {
+        &.collapse-re-medium {
             background-image: data-uri('../images/icons/collapse.png');
         }
 
-        &.expand-medium {
+        &.expand-re-medium {
             background-image: data-uri('../images/icons/expand.png');
         }
 

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -55,6 +55,7 @@ const entries = [
   'place/map',
   'recording/form',
   'recording/merge',
+  'release/index',
   'release-editor',
   'release-group/index',
   'series',


### PR DESCRIPTION
### Fix MBS-11530

Using `.collapse-medium` here broke because `common/MB/release` actually has code that runs on clicking a `.collapse-medium`.
For now, using `collapse-re-medium` / `expand-re-medium` to ensure a quick fix, but we shouldn't be running that code inside the release editor anyway, it's only relevant to a release's display page.
