### PR TITLE
MBS-11531: Pass $c to _load in load_filtered

### DIFF
--- a/lib/MusicBrainz/Server/Report/FilterForEditor.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor.pm
@@ -4,9 +4,9 @@ use Moose::Role;
 requires 'filter_sql';
 
 sub load_filtered {
-    my ($self, $editor_id, $limit, $offset) = @_;
+    my ($self, $c, $editor_id, $limit, $offset) = @_;
     my ($query, @params) = $self->filter_sql($editor_id);
-    return $self->_load($query, $limit, $offset, @params);
+    return $self->_load($c, $query, $limit, $offset, @params);
 }
 
 1;


### PR DESCRIPTION
### Fix MBS-11531

_load was changed in 7984bf28dd29b2095b96d2263eacff29f5781d37 to take $c, but the load_filtered call wasn't updated and is ISEing.
