### PR TITLE
MBS-8807 / MBS-11538: Collections data missing in some sidebars

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -361,7 +361,7 @@ sub works : Chained('load') {
     );
 }
 
-after [qw( show collections details tags aliases artists labels releases recordings places users works )] => sub {
+after [qw( show collections details tags aliases artists events labels releases recordings places users works )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -541,7 +541,7 @@ sub releases : Chained('load')
     );
 }
 
-after [qw( show collections details tags aliases releases recordings works events relationships )] => sub {
+after [qw( show collections details tags aliases subscribers releases recordings works events relationships )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -52,7 +52,7 @@ after 'load' => sub {
 };
 
 # Stuff that has the side bar and thus needs to display collection information
-after [qw( show aliases collections details tags )] => sub {
+after [qw( show collections details tags aliases )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -168,7 +168,7 @@ sub releases : Chained('load') {
     );
 }
 
-after [qw( show collections details tags aliases recordings releases )] => sub {
+after [qw( show collections details tags aliases artists releases recordings )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -157,7 +157,7 @@ sub relationships : Chained('load') PathPart('relationships') {
     );
 }
 
-after [qw( show collections details tags aliases relationships )] => sub {
+after [qw( show collections details tags aliases subscribers relationships )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -132,8 +132,8 @@ before show => sub {
 };
 
 # Stuff that has the side bar and thus needs to display collection information
-after [qw( cover_art add_cover_art edit_cover_art reorder_cover_art
-           show collections details discids tags )] => sub {
+after [qw( show collections details tags aliases
+           discids cover_art add_cover_art edit_cover_art reorder_cover_art )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -117,7 +117,7 @@ sub show : PathPart('') Chained('load') {
     );
 }
 
-after [qw( show collections details tags aliases )] => sub {
+after [qw( show collections details tags aliases subscribers )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -103,7 +103,7 @@ sub show : PathPart('') Chained('load')
 }
 
 # Stuff that has the side bar and thus needs to display collection information
-after [qw( show collections details tags )] => sub {
+after [qw( show collections details tags aliases )] => sub {
     my ($self, $c) = @_;
     $self->_stash_collections($c);
 };


### PR DESCRIPTION
# Problem

https://tickets.metabrainz.org/browse/MBS-8807
https://tickets.metabrainz.org/browse/MBS-11538

Some tabs/sub-pages that contain sidebars and thus try to display collections have no collections data from the server, therefore display broken collection status (as if no collections, sort of).

- **Artist** missing collection data in **Subscribers** sub-page
- **Area** missing collection data in **Events** tab
- **Instrument** missing collection data in **Artists** tab
- **Label** missing collection data in **Subscribers** sub-page
- **Release** missing collection data in **Aliases** tab
- **Series** missing collection data in **Subscribers** sub-page
- **Work** missing collection data in **Aliases** tab

# Solution

I found how it works, you have to list the tabs/sub-pages that contain sidebar to send them collection data.
So I just added those keywords and also reordered **Release** and **Event** tab list (the latter was missing nothing) that was in unusual order compared to others:

    show collections details tags aliases <subscribers> <other tabs in left to right visual order>

# Misc

I have tested my code on `localhost:5000`.

I had to disable (comment out) this block, to be able to create collections (to allow `POST` forms):
https://github.com/metabrainz/musicbrainz-server/blob/37e4dfab3d9d2d42e2bf844a82e1b8fa6d76e335/lib/MusicBrainz/Server/Controller/Root.pm#L361-L376