### PR TITLE
MBS-11537: Collapse work attributes when there are too many (but for edits)

### DIFF
--- a/root/cdtoc/attach_list.tt
+++ b/root/cdtoc/attach_list.tt
@@ -4,6 +4,7 @@
     [% END %]
     <td>
       [% React.embed(c, 'static/scripts/common/components/ReleaseEvents', {events => React.to_json_array(release.events)}) %]
+      [% script_manifest('common/components/ReleaseEvents.js', {async => 'async'}) %]
     </td>
     <td>[% release_label_list(release.labels) %]</td>
     <td>[% release_catno_list(release.labels) %]</td>

--- a/root/cdtoc/list.tt
+++ b/root/cdtoc/list.tt
@@ -36,6 +36,7 @@
             <td>[% medium_format_name(medium) %]</td>
             <td>
               [% React.embed(c, 'static/scripts/common/components/ReleaseEvents', {events => React.to_json_array(release.events)}) %]
+              [% script_manifest('common/components/ReleaseEvents.js', {async => 'async'}) %]
             </td>
             <td>[% release_label_list(release.labels) %]</td>
             <td>[% release_catno_list(release.labels) %]</td>

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -815,16 +815,6 @@ END -%]
       l('{variable}:', { variable => variable });
     END -%]
 
-[%~ MACRO work_attributes_list(work) BLOCK # Converted to React at root/static/scripts/common/components/AttributeList.js -%]
-  [%- IF work.attributes %]
-    <ul>
-      [%- FOR attr=work.sorted_attributes %]
-      <li>[% attr.l_value | html %] ([% attr.type.l_name | html %])</li>
-      [%- END %]
-    </ul>
-  [%- END %]
-[%- END -%]
-
 [%~ MACRO link_type_cardinality_name(cardinality) BLOCK ~%] [% # Converted to React at root/static/scripts/common/components/Cardinality.js %]
   [%~ IF cardinality == 0; l('Few relationships');
       ELSIF cardinality == 1; l('Many relationships');

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 import type {ColumnOptions} from 'react-table';
 
 import {SanitizedCatalystContext} from '../../context';
-import manifest from '../../static/manifest';
+import * as manifest from '../../static/manifest';
 import Table from '../Table';
 import ReleaseGroupAppearances
   from '../../static/scripts/common/components/ReleaseGroupAppearances';

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context';
-import manifest from '../../static/manifest';
+import * as manifest from '../../static/manifest';
 import Table from '../Table';
 import filterReleaseLabels
   from '../../static/scripts/common/utility/filterReleaseLabels';

--- a/root/edit/details/AddRelease.js
+++ b/root/edit/details/AddRelease.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import * as manifest from '../../static/manifest';
 import DescriptiveLink from
   '../../static/scripts/common/components/DescriptiveLink';
 import ExpandedArtistCredit from
@@ -139,6 +140,10 @@ const AddRelease = ({allowNew, edit}: Props): React.MixedElement => {
                   abbreviated={false}
                   events={display.events}
                 />
+                {manifest.js(
+                  'common/components/ReleaseEvents',
+                  {async: 'async'},
+                )}
               </td>
             </tr>
           ) : null}

--- a/root/edit/details/EditReleaseLabel.js
+++ b/root/edit/details/EditReleaseLabel.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import * as manifest from '../../static/manifest';
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
@@ -110,6 +111,10 @@ const EditReleaseLabel = ({edit}: Props): React.Element<'table'> => {
           <th>{addColonText(l('Release events'))}</th>
           <td colSpan="2">
             <ReleaseEvents events={releaseEvents} />
+            {manifest.js(
+              'common/components/ReleaseEvents',
+              {async: 'async'},
+            )}
           </td>
         </tr>
       ) : firstDate || firstCountry ? (

--- a/root/edit/details/MergeReleases.js
+++ b/root/edit/details/MergeReleases.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import ReleaseLabelList from '../../components/ReleaseLabelList';
 import ReleaseCatnoList from '../../components/ReleaseCatnoList';
+import * as manifest from '../../static/manifest';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 import DescriptiveLink
@@ -89,6 +90,10 @@ function buildReleaseRow(release, index) {
           </td>
           <td>
             <ReleaseEvents events={release.events} />
+            {manifest.js(
+              'common/components/ReleaseEvents',
+              {async: 'async'},
+            )}
           </td>
           <td>
             <ReleaseLabelList labels={release.labels} />

--- a/root/edit/details/SetCoverArt.js
+++ b/root/edit/details/SetCoverArt.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {Artwork} from '../../components/Artwork';
+import * as manifest from '../../static/manifest';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 import ReleaseEvents
@@ -95,6 +96,7 @@ const SetCoverArt = ({edit}: Props): React.Element<'table'> => {
           ) : l(`We are unable to display this cover art.`)}
         </td>
       </tr>
+      {manifest.js('common/components/ReleaseEvents', {async: 'async'})}
     </table>
   );
 };

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -12,6 +12,7 @@ import * as ReactDOMServer from 'react-dom/server';
 
 import {QUALITY_UNKNOWN} from '../../../constants';
 import {CatalystContext} from '../../../context';
+import * as manifest from '../../../static/manifest';
 import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import ReleaseEvents
   from '../../../static/scripts/common/components/ReleaseEvents';
@@ -242,6 +243,10 @@ const ReleaseSidebar = ({release}: Props): React.Element<'div'> | null => {
         <>
           <h2 className="release-events">{l('Release events')}</h2>
           <ReleaseEvents abbreviated={false} events={releaseEvents} />
+          {manifest.js(
+            'common/components/ReleaseEvents',
+            {async: 'async'},
+          )}
         </>
       ) : null}
 

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -95,13 +95,11 @@ const WorkSidebar = ({work}: Props): React.Element<'div'> => {
           {attributes.length ? (
             <>
               <h2 className="work-attributes">{l('Work attributes')}</h2>
-              <SidebarProperties>
-                <AttributeList attributes={attributes} isSidebar />
-                {manifest.js(
-                  'common/components/AttributeList',
-                  {async: 'async'},
-                )}
-              </SidebarProperties>
+              <AttributeList attributes={attributes} isSidebar />
+              {manifest.js(
+                'common/components/AttributeList',
+                {async: 'async'},
+              )}
             </>
           ) : null}
         </>

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -12,12 +12,13 @@ import * as React from 'react';
 import {CatalystContext} from '../../../context';
 import LinkSearchableLanguage
   from '../../../components/LinkSearchableLanguage';
+import * as manifest from '../../../static/manifest';
 import CodeLink from '../../../static/scripts/common/components/CodeLink';
+import AttributeList
+  from '../../../static/scripts/common/components/AttributeList';
 import commaOnlyList from '../../../static/scripts/common/i18n/commaOnlyList';
 import CommonsImage from
   '../../../static/scripts/common/components/CommonsImage';
-import linkedEntities from '../../../static/scripts/common/linkedEntities';
-import {kebabCase} from '../../../static/scripts/common/utility/strings';
 import ExternalLinks from '../ExternalLinks';
 
 import AnnotationLinks from './AnnotationLinks';
@@ -89,29 +90,20 @@ const WorkSidebar = ({work}: Props): React.Element<'div'> => {
                 </SidebarProperty>
               ))
             ) : null}
-
-            {attributes.length ? (
-              attributes.map((attr) => {
-                const type = linkedEntities.work_attribute_type[attr.typeID];
-                return (
-                  <SidebarProperty
-                    className={'work-attribute work-attribute-' +
-                      kebabCase(type.name)}
-                    key={attr.id}
-                    label={addColonText(
-                      lp_attributes(type.name, 'work_attribute_type'),
-                    )}
-                  >
-                    {attr.value_id == null
-                      ? attr.value
-                      : lp_attributes(
-                        attr.value, 'work_attribute_type_allowed_value',
-                      )}
-                  </SidebarProperty>
-                );
-              })
-            ) : null}
           </SidebarProperties>
+
+          {attributes.length ? (
+            <>
+              <h2 className="work-attributes">{l('Work attributes')}</h2>
+              <SidebarProperties>
+                <AttributeList attributes={attributes} isSidebar />
+                {manifest.js(
+                  'common/components/AttributeList',
+                  {async: 'async'},
+                )}
+              </SidebarProperties>
+            </>
+          ) : null}
         </>
       ) : null}
 

--- a/root/recording/RecordingHeader.js
+++ b/root/recording/RecordingHeader.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
-import manifest from '../static/manifest';
+import * as manifest from '../static/manifest';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink';
 import TaggerIcon from '../static/scripts/common/components/TaggerIcon';

--- a/root/recording/RecordingIndex.js
+++ b/root/recording/RecordingIndex.js
@@ -13,6 +13,7 @@ import PaginatedResults from '../components/PaginatedResults';
 import Relationships from '../components/Relationships';
 import ReleaseLabelList from '../components/ReleaseLabelList';
 import ReleaseCatnoList from '../components/ReleaseCatnoList';
+import * as manifest from '../static/manifest';
 import Annotation from '../static/scripts/common/components/Annotation';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink';
@@ -125,6 +126,10 @@ const RecordingAppearancesTable = ({
                   </td>
                   <td>
                     <ReleaseEvents events={release.events} />
+                    {manifest.js(
+                      'common/components/ReleaseEvents',
+                      {async: 'async'},
+                    )}
                   </td>
                   <td>
                     <ReleaseLabelList labels={release.labels} />

--- a/root/release/ReleaseHeader.js
+++ b/root/release/ReleaseHeader.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import EntityHeader from '../components/EntityHeader';
-import manifest from '../static/manifest';
+import * as manifest from '../static/manifest';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink';
 import EntityLink from '../static/scripts/common/components/EntityLink';

--- a/root/release/ReleaseIndex.js
+++ b/root/release/ReleaseIndex.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 
-import manifest from '../static/manifest';
+import * as manifest from '../static/manifest';
 import Annotation from '../static/scripts/common/components/Annotation';
 import linkedEntities from '../static/scripts/common/linkedEntities';
 import TracklistAndCredits

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -90,6 +90,10 @@ function buildReleaseStatusTable(
           <td>{release.combined_track_count || lp('-', 'missing data')}</td>
           <td>
             <ReleaseEvents events={release.events} />
+            {manifest.js(
+              'common/components/ReleaseEvents',
+              {async: 'async'},
+            )}
           </td>
           <td>
             <ReleaseLabelList labels={release.labels} />

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context';
-import manifest from '../../static/manifest';
+import * as manifest from '../../static/manifest';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import TaggerIcon from '../../static/scripts/common/components/TaggerIcon';
 import formatTrackLength

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context';
-import manifest from '../../static/manifest';
+import * as manifest from '../../static/manifest';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
@@ -57,6 +57,10 @@ function buildResult($c, result, index) {
       </td>
       <td>
         <ReleaseEvents events={release.events} />
+        {manifest.js(
+          'common/components/ReleaseEvents',
+          {async: 'async'},
+        )}
       </td>
       <td>
         <ReleaseLabelList labels={release.labels} />

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -471,7 +471,6 @@ module.exports = {
   'static/scripts/common/components/TaggerIcon': require('../static/scripts/common/components/TaggerIcon'),
   'static/scripts/common/components/WarningIcon': require('../static/scripts/common/components/WarningIcon'),
   'static/scripts/common/components/WikipediaExtract': require('../static/scripts/common/components/WikipediaExtract'),
-  'static/scripts/common/components/WorkArtists': require('../static/scripts/common/components/WorkArtists'),
   'static/scripts/edit/components/AddIcon': require('../static/scripts/edit/components/AddIcon'),
   'static/scripts/edit/components/FormRowNameWithGuessCase': require('../static/scripts/edit/components/FormRowNameWithGuessCase'),
   'static/scripts/edit/components/GuessCaseIcon': require('../static/scripts/edit/components/GuessCaseIcon'),

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -40,7 +40,6 @@ require('./common/components/FingerprintTable');
 require('./common/components/WikipediaExtract');
 require('./common/MB/Control/Autocomplete');
 require('./common/components/ReleaseEvents');
-require('./common/components/WorkArtists');
 require('./common/MB/Control/SelectAll');
 require('./common/components/TagEditor');
 require('./common/components/sidebar/AcousticBrainz');

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -39,7 +39,6 @@ require('./common/components/CommonsImage');
 require('./common/components/FingerprintTable');
 require('./common/components/WikipediaExtract');
 require('./common/MB/Control/Autocomplete');
-require('./common/components/ReleaseEvents');
 require('./common/MB/Control/SelectAll');
 require('./common/components/TagEditor');
 require('./common/components/sidebar/AcousticBrainz');

--- a/root/static/scripts/common/components/AttributeList.js
+++ b/root/static/scripts/common/components/AttributeList.js
@@ -10,29 +10,128 @@
 import * as React from 'react';
 
 import {bracketedText} from '../utility/bracketed';
+import {kebabCase} from '../utility/strings';
+import {SidebarProperty}
+  from '../../../../layout/components/sidebar/SidebarProperties';
 
-type Props = {
-  +entity: WorkT,
-};
+const TO_SHOW_BEFORE = 2;
+const TO_SHOW_AFTER = 1;
+const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + TO_SHOW_AFTER + 2;
 
-const AttributeList = ({entity}: Props): React.Element<'ul'> | null => (
-  entity.attributes ? (
-    <ul>
-      {entity.attributes.map(attribute => (
-        <li key={attribute.id}>
-          {lp_attributes(
-            attribute.value,
-            'work_attribute_type_allowed_value',
-          )}
-          {' '}
-          {bracketedText(lp_attributes(
-            attribute.typeName,
-            'work_attribute_type',
-          ))}
-        </li>
-      ))}
-    </ul>
-  ) : null
+const buildAttributeListRow = (attribute) => (
+  <li
+    className={'work-attribute work-attribute-' +
+      kebabCase(attribute.typeName)}
+    key={attribute.id}
+  >
+    {attribute.value_id == null
+      ? attribute.value
+      : lp_attributes(
+        attribute.value, 'work_attribute_type_allowed_value',
+      )}
+    {' '}
+    {bracketedText(lp_attributes(
+      attribute.typeName,
+      'work_attribute_type',
+    ))}
+  </li>
 );
 
-export default AttributeList;
+const buildAttributeSidebarRow = (attribute) => (
+  <SidebarProperty
+    className={'work-attribute work-attribute-' +
+      kebabCase(attribute.typeName)}
+    key={attribute.id}
+    label={addColonText(
+      lp_attributes(attribute.typeName, 'work_attribute_type'),
+    )}
+  >
+    {attribute.value_id == null
+      ? attribute.value
+      : lp_attributes(
+        attribute.value, 'work_attribute_type_allowed_value',
+      )}
+  </SidebarProperty>
+);
+
+type AttributeListProps = {|
+  +attributes: ?$ReadOnlyArray<WorkAttributeT>,
+  +isSidebar?: boolean,
+|};
+
+const AttributeList = ({
+  attributes,
+  isSidebar = false,
+}: AttributeListProps) => {
+  const [expanded, setExpanded] = React.useState<boolean>(false);
+
+  const expand = React.useCallback(event => {
+    event.preventDefault();
+    setExpanded(true);
+  });
+
+  const collapse = React.useCallback(event => {
+    event.preventDefault();
+    setExpanded(false);
+  });
+
+  const tooManyEvents = attributes
+    ? attributes.length >= TO_TRIGGER_COLLAPSE
+    : false;
+
+  return (
+    (attributes?.length) ? (
+      <>
+        {(tooManyEvents && !expanded) ? (
+          <>
+            {attributes.slice(0, TO_SHOW_BEFORE).map(
+              attribute => isSidebar
+                ? buildAttributeSidebarRow(attribute)
+                : buildAttributeListRow(attribute),
+            )}
+            <p className="show-all" key="show-all">
+              <a
+                href="#"
+                onClick={expand}
+                role="button"
+                title={l('Show all attributes')}
+              >
+                {bracketedText(texp.l('show {n} more', {
+                  n: attributes.length - (TO_SHOW_BEFORE + TO_SHOW_AFTER),
+                }))}
+              </a>
+            </p>
+            {attributes.slice(-TO_SHOW_AFTER).map(
+              attribute => isSidebar
+                ? buildAttributeSidebarRow(attribute)
+                : buildAttributeListRow(attribute),
+            )}
+          </>
+        ) : (
+          <>
+            {attributes.map(attribute => isSidebar
+              ? buildAttributeSidebarRow(attribute)
+              : buildAttributeListRow(attribute))}
+            {tooManyEvents && expanded ? (
+              <p className="show-less" key="show-less">
+                <a
+                  href="#"
+                  onClick={collapse}
+                  role="button"
+                  title={l('Show less attributes')}
+                >
+                  {bracketedText(l('show less'))}
+                </a>
+              </p>
+            ) : null}
+          </>
+        )}
+      </>
+    ) : null
+  );
+};
+
+export default (hydrate<AttributeListProps>(
+  'div.entity-attributes-container',
+  AttributeList,
+): React.AbstractComponent<AttributeListProps, void>);

--- a/root/static/scripts/common/components/AttributeList.js
+++ b/root/static/scripts/common/components/AttributeList.js
@@ -14,9 +14,7 @@ import {kebabCase} from '../utility/strings';
 import {SidebarProperty}
   from '../../../../layout/components/sidebar/SidebarProperties';
 
-const TO_SHOW_BEFORE = 2;
-const TO_SHOW_AFTER = 1;
-const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + TO_SHOW_AFTER + 2;
+import CollapsibleList from './CollapsibleList';
 
 const buildAttributeListRow = (attribute) => (
   <li
@@ -62,74 +60,20 @@ type AttributeListProps = {|
 const AttributeList = ({
   attributes,
   isSidebar = false,
-}: AttributeListProps) => {
-  const [expanded, setExpanded] = React.useState<boolean>(false);
-
-  const expand = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(true);
-  });
-
-  const collapse = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(false);
-  });
-
-  const tooManyEvents = attributes
-    ? attributes.length >= TO_TRIGGER_COLLAPSE
-    : false;
-
-  return (
-    (attributes?.length) ? (
-      <>
-        {(tooManyEvents && !expanded) ? (
-          <>
-            {attributes.slice(0, TO_SHOW_BEFORE).map(
-              attribute => isSidebar
-                ? buildAttributeSidebarRow(attribute)
-                : buildAttributeListRow(attribute),
-            )}
-            <p className="show-all" key="show-all">
-              <a
-                href="#"
-                onClick={expand}
-                role="button"
-                title={l('Show all attributes')}
-              >
-                {bracketedText(texp.l('show {n} more', {
-                  n: attributes.length - (TO_SHOW_BEFORE + TO_SHOW_AFTER),
-                }))}
-              </a>
-            </p>
-            {attributes.slice(-TO_SHOW_AFTER).map(
-              attribute => isSidebar
-                ? buildAttributeSidebarRow(attribute)
-                : buildAttributeListRow(attribute),
-            )}
-          </>
-        ) : (
-          <>
-            {attributes.map(attribute => isSidebar
-              ? buildAttributeSidebarRow(attribute)
-              : buildAttributeListRow(attribute))}
-            {tooManyEvents && expanded ? (
-              <p className="show-less" key="show-less">
-                <a
-                  href="#"
-                  onClick={collapse}
-                  role="button"
-                  title={l('Show less attributes')}
-                >
-                  {bracketedText(l('show less'))}
-                </a>
-              </p>
-            ) : null}
-          </>
-        )}
-      </>
-    ) : null
-  );
-};
+}: AttributeListProps) => (
+  <CollapsibleList
+    ContainerElement={isSidebar ? 'dl' : 'ul'}
+    InnerElement={isSidebar ? 'p' : 'li'}
+    ariaLabel={l('Work Attributes')}
+    buildRow={isSidebar ? buildAttributeSidebarRow : buildAttributeListRow}
+    className={isSidebar ? 'properties work-attributes' : 'work-attributes'}
+    rows={attributes}
+    showAllTitle={l('Show all attributes')}
+    showLessTitle={l('Show less attributes')}
+    toShowAfter={1}
+    toShowBefore={2}
+  />
+);
 
 export default (hydrate<AttributeListProps>(
   'div.entity-attributes-container',

--- a/root/static/scripts/common/components/CollapsibleList.js
+++ b/root/static/scripts/common/components/CollapsibleList.js
@@ -1,0 +1,119 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {SidebarProperty}
+  from '../../../../layout/components/sidebar/SidebarProperties';
+import {bracketedText} from '../utility/bracketed';
+
+type BuildRowPropsT = {
+  abbreviated?: boolean,
+};
+
+type Props<T> = {
+  +ariaLabel: string,
+  +buildRow:
+    (T, ?BuildRowPropsT) => React.Element<'li' | typeof SidebarProperty>,
+  +buildRowProps?: BuildRowPropsT,
+  +className: string,
+  +ContainerElement?: 'dl' | 'ul',
+  +InnerElement?: 'p' | 'li',
+  +rows: ?$ReadOnlyArray<T>,
+  +showAllTitle: string,
+  +showLessTitle: string,
+  +toShowAfter: number,
+  +toShowBefore: number,
+};
+
+const CollapsibleList = <T>({
+  ariaLabel,
+  buildRow,
+  buildRowProps,
+  className,
+  ContainerElement = 'ul',
+  InnerElement = 'li',
+  rows,
+  showAllTitle,
+  showLessTitle,
+  toShowAfter,
+  toShowBefore,
+}: Props<T>): React.MixedElement | null => {
+  const [expanded, setExpanded] = React.useState<boolean>(false);
+
+  const expand = React.useCallback(event => {
+    event.preventDefault();
+    setExpanded(true);
+  });
+
+  const collapse = React.useCallback(event => {
+    event.preventDefault();
+    setExpanded(false);
+  });
+
+  const containerProps = {
+    'aria-label': ariaLabel,
+    'className': className,
+  };
+
+  const TO_TRIGGER_COLLAPSE = toShowBefore + toShowAfter + 2;
+
+  const tooManyRows = rows
+    ? rows.length >= TO_TRIGGER_COLLAPSE
+    : false;
+
+  return (
+    (rows && rows.length) ? (
+      (tooManyRows && !expanded) ? (
+        <ContainerElement {...containerProps}>
+          {toShowBefore > 0 ? (
+            rows.slice(0, toShowBefore).map(
+              row => buildRow(row, buildRowProps),
+            )
+          ) : null}
+          <InnerElement className="show-all" key="show-all">
+            <a
+              href="#"
+              onClick={expand}
+              role="button"
+              title={showAllTitle}
+            >
+              {bracketedText(texp.l('show {n} more', {
+                n: rows.length - (toShowBefore + toShowAfter),
+              }))}
+            </a>
+          </InnerElement>
+          {toShowAfter > 0 ? (
+            rows.slice(-toShowAfter).map(
+              row => buildRow(row, buildRowProps),
+            )
+          ) : null}
+        </ContainerElement>
+      ) : (
+        <ContainerElement {...containerProps}>
+          {rows.map(row => buildRow(row, buildRowProps))}
+          {tooManyRows && expanded ? (
+            <InnerElement className="show-less" key="show-less">
+              <a
+                href="#"
+                onClick={collapse}
+                role="button"
+                title={showLessTitle}
+              >
+                {bracketedText(l('show less'))}
+              </a>
+            </InnerElement>
+          ) : null}
+        </ContainerElement>
+      )
+    ) : null
+  );
+};
+
+export default CollapsibleList;

--- a/root/static/scripts/common/components/ReleaseEvents.js
+++ b/root/static/scripts/common/components/ReleaseEvents.js
@@ -10,22 +10,19 @@
 import * as React from 'react';
 
 import CountryAbbr from '../../../../components/CountryAbbr';
-import {bracketedText} from '../utility/bracketed';
 import formatDate from '../utility/formatDate';
 import isDateEmpty from '../utility/isDateEmpty';
 
+import CollapsibleList from './CollapsibleList';
 import EntityLink from './EntityLink';
-
-const TO_SHOW_BEFORE = 2;
-const TO_SHOW_AFTER = 1;
-const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + TO_SHOW_AFTER + 2;
 
 const releaseEventKey = event => (
   String(event.country ? event.country.id : '') + '\0' +
   formatDate(event.date)
 );
 
-const buildReleaseEventRow = (event, abbreviated) => {
+const buildReleaseEventRow = (event, props) => {
+  const abbreviated = !!(props?.abbreviated);
   const country = event.country;
   const hasDate = !isDateEmpty(event.date);
 
@@ -84,76 +81,19 @@ type ReleaseEventsProps = {|
 const ReleaseEvents = ({
   abbreviated = true,
   events,
-}: ReleaseEventsProps) => {
-  const [expanded, setExpanded] = React.useState<boolean>(false);
-
-  const expand = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(true);
-  });
-
-  const collapse = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(false);
-  });
-
-  const containerProps = {
-    'aria-label': l('Release events'),
-    'className': 'release-events' +
-      (abbreviated ? ' abbreviated' : ' links'),
-  };
-
-  const tooManyEvents = events
-    ? events.length >= TO_TRIGGER_COLLAPSE
-    : false;
-
-  return (
-    (events && events.length) ? (
-      <>
-        {(tooManyEvents && !expanded) ? (
-          <>
-            <ul {...containerProps}>
-              {events.slice(0, TO_SHOW_BEFORE).map(
-                event => buildReleaseEventRow(event, abbreviated),
-              )}
-              <li className="show-all" key="show-all">
-                <a
-                  href="#"
-                  onClick={expand}
-                  role="button"
-                  title={l('Show all release events')}
-                >
-                  {bracketedText(texp.l('show {n} more', {
-                    n: events.length - (TO_SHOW_BEFORE + TO_SHOW_AFTER),
-                  }))}
-                </a>
-              </li>
-              {events.slice(-TO_SHOW_AFTER).map(
-                event => buildReleaseEventRow(event, abbreviated),
-              )}
-            </ul>
-          </>
-        ) : (
-          <ul {...containerProps}>
-            {events.map(event => buildReleaseEventRow(event, abbreviated))}
-            {tooManyEvents && expanded ? (
-              <li className="show-less" key="show-less">
-                <a
-                  href="#"
-                  onClick={collapse}
-                  role="button"
-                  title={l('Show less release events')}
-                >
-                  {bracketedText(l('show less'))}
-                </a>
-              </li>
-            ) : null}
-          </ul>
-        )}
-      </>
-    ) : null
-  );
-};
+}: ReleaseEventsProps) => (
+  <CollapsibleList
+    ariaLabel={l('Release events')}
+    buildRow={buildReleaseEventRow}
+    buildRowProps={{abbreviated: abbreviated}}
+    className={'release-events' + (abbreviated ? ' abbreviated' : ' links')}
+    rows={events}
+    showAllTitle={l('Show all release events')}
+    showLessTitle={l('Show less release events')}
+    toShowAfter={1}
+    toShowBefore={2}
+  />
+);
 
 export default (hydrate<ReleaseEventsProps>(
   'div.release-events-container',

--- a/root/static/scripts/common/components/WorkArtists.js
+++ b/root/static/scripts/common/components/WorkArtists.js
@@ -9,12 +9,8 @@
 
 import * as React from 'react';
 
-import {bracketedText} from '../utility/bracketed';
-
 import ArtistCreditLink from './ArtistCreditLink';
-
-const TO_SHOW_BEFORE = 4;
-const TO_TRIGGER_COLLAPSE = TO_SHOW_BEFORE + 2;
+import CollapsibleList from './CollapsibleList';
 
 const buildWorkArtistRow = (artistCredit: ArtistCreditT) => {
   return (
@@ -28,72 +24,18 @@ type WorkArtistsProps = {
   +artists: ?$ReadOnlyArray<ArtistCreditT>,
 };
 
-const WorkArtists = ({artists}: WorkArtistsProps) => {
-  const [expanded, setExpanded] = React.useState<boolean>(false);
-
-  const expand = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(true);
-  });
-
-  const collapse = React.useCallback(event => {
-    event.preventDefault();
-    setExpanded(false);
-  });
-
-  const containerProps = {
-    'aria-label': l('Work Artists'),
-    'className': 'work-artists',
-  };
-
-  const tooManyArtists = artists
-    ? artists.length >= TO_TRIGGER_COLLAPSE
-    : false;
-
-  return (
-    (artists && artists.length) ? (
-      <>
-        {(tooManyArtists && !expanded) ? (
-          <>
-            <ul {...containerProps}>
-              {artists.slice(0, TO_SHOW_BEFORE).map(
-                artist => buildWorkArtistRow(artist),
-              )}
-              <li className="show-all" key="show-all">
-                <a
-                  href="#"
-                  onClick={expand}
-                  role="button"
-                  title={l('Show all artists')}
-                >
-                  {bracketedText(texp.l('show {n} more', {
-                    n: artists.length - TO_SHOW_BEFORE,
-                  }))}
-                </a>
-              </li>
-            </ul>
-          </>
-        ) : (
-          <ul {...containerProps}>
-            {artists.map(artist => buildWorkArtistRow(artist))}
-            {tooManyArtists && expanded ? (
-              <li className="show-less" key="show-less">
-                <a
-                  href="#"
-                  onClick={collapse}
-                  role="button"
-                  title={l('Show less artists')}
-                >
-                  {bracketedText(l('show less'))}
-                </a>
-              </li>
-            ) : null}
-          </ul>
-        )}
-      </>
-    ) : null
-  );
-};
+const WorkArtists = ({artists}: WorkArtistsProps) => (
+  <CollapsibleList
+    ariaLabel={l('Work Artists')}
+    buildRow={buildWorkArtistRow}
+    className="work-artists"
+    rows={artists}
+    showAllTitle={l('Show all artists')}
+    showLessTitle={l('Show less artists')}
+    toShowAfter={0}
+    toShowBefore={4}
+  />
+);
 
 export default (hydrate<WorkArtistsProps>(
   'div.work-artists-container',

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -73,6 +73,10 @@ export const WorkListRow = ({
       </td>
       <td>
         <WorkArtists artists={work.artists} />
+        {manifest.js(
+          'common/components/WorkArtists',
+          {async: 'async'},
+        )}
       </td>
       {showIswcs ? (
         <td>

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -11,12 +11,13 @@ import * as React from 'react';
 
 import localizeLanguageName from '../i18n/localizeLanguageName';
 import {CatalystContext} from '../../../../context';
+import * as manifest from '../../../manifest';
 import RatingStars from '../../../../components/RatingStars';
 import loopParity from '../../../../utility/loopParity';
 
 import ArtistRoles from './ArtistRoles';
-import CodeLink from './CodeLink';
 import AttributeList from './AttributeList';
+import CodeLink from './CodeLink';
 import EntityLink from './EntityLink';
 import WorkArtists from './WorkArtists';
 
@@ -103,7 +104,15 @@ export const WorkListRow = ({
       </td>
       {showAttributes ? (
         <td>
-          <AttributeList entity={work} />
+          {work.attributes ? (
+            <ul>
+              <AttributeList attributes={work.attributes} />
+              {manifest.js(
+                'common/components/AttributeList',
+                {async: 'async'},
+              )}
+            </ul>
+          ) : null}
         </td>
       ) : null}
       {showRatings ? (

--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -114,6 +114,10 @@ p.subheader {
     list-style: none;
 }
 
+div.entity-attributes-container p {
+    margin: 0;
+}
+
 div.release-events-container {
     ul.release-events {
         &.abbreviated {

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 
-import manifest from '../static/manifest';
+import * as manifest from '../static/manifest';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 import EntityLink from '../static/scripts/common/components/EntityLink';
 import loopParity from '../utility/loopParity';

--- a/root/statistics/LanguagesScripts.js
+++ b/root/statistics/LanguagesScripts.js
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 
-import manifest from '../static/manifest';
+import * as manifest from '../static/manifest';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 import loopParity from '../utility/loopParity';
 import LinkSearchableProperty from '../components/LinkSearchableProperty';

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -778,7 +778,15 @@ export const trackColumn:
 export const workArtistsColumn:
   ColumnOptions<WorkT, $ReadOnlyArray<ArtistCreditT>> = {
     accessor: x => x.artists,
-    Cell: ({cell: {value}}) => <WorkArtists artists={value} />,
+    Cell: ({cell: {value}}) => (
+      <>
+        <WorkArtists artists={value} />
+        {manifest.js(
+          'common/components/WorkArtists',
+          {async: 'async'},
+        )}
+      </>
+    ),
     Header: N_l('Artists'),
     id: 'work-artists',
   };

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -471,7 +471,15 @@ export function defineReleaseEventsColumn(
 ): ColumnOptions<ReleaseT, ?$ReadOnlyArray<ReleaseEventT>> {
   return {
     accessor: x => x.events,
-    Cell: ({cell: {value}}) => <ReleaseEvents events={value} />,
+    Cell: ({cell: {value}}) => (
+      <>
+        <ReleaseEvents events={value} />
+        {manifest.js(
+          'common/components/ReleaseEvents',
+          {async: 'async'},
+        )}
+      </>
+    ),
     Header: (props.sortable
       ? (
         <>

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -18,6 +18,7 @@ import ReleaseCatnoList from '../components/ReleaseCatnoList';
 import ReleaseLabelList from '../components/ReleaseLabelList';
 import ReleaseLanguageScript from '../components/ReleaseLanguageScript';
 import SortableTableHeader from '../components/SortableTableHeader';
+import * as manifest from '../static/manifest';
 import linkedEntities from '../static/scripts/common/linkedEntities';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink';
@@ -624,7 +625,17 @@ export function defineTypeColumn(
 
 export const attributesColumn:
   ColumnOptions<WorkT, $ReadOnlyArray<WorkAttributeT>> = {
-    Cell: ({row: {original}}) => <AttributeList entity={original} />,
+    Cell: ({row: {original}}) => (
+      original.attributes ? (
+        <ul>
+          <AttributeList attributes={original.attributes} />
+          {manifest.js(
+            'common/components/AttributeList',
+            {async: 'async'},
+          )}
+        </ul>
+      ) : null
+    ),
     Header: N_l('Attributes'),
     id: 'attributes',
   };

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -46,6 +46,7 @@ const entries = [
   'common',
   'common/components/AcoustIdCell',
   'common/components/AttributeList',
+  'common/components/ReleaseEvents',
   'common/components/TaggerIcon',
   'common/components/WorkArtists',
   'confirm-seed',

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -47,6 +47,7 @@ const entries = [
   'common/components/AcoustIdCell',
   'common/components/AttributeList',
   'common/components/TaggerIcon',
+  'common/components/WorkArtists',
   'confirm-seed',
   'edit',
   'edit/notes-received',

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -45,6 +45,7 @@ const entries = [
   'collection/edit',
   'common',
   'common/components/AcoustIdCell',
+  'common/components/AttributeList',
   'common/components/TaggerIcon',
   'confirm-seed',
   'edit',


### PR DESCRIPTION
### Implement MBS-11537

Since users have started adding codes for every PRO under the sun, some of these lists have gotten quite unwieldy, with 30+ entries. It makes sense to collapse them, in the same way we do for work artists and release events.

Tested with the entities mentioned on the ticket, work/be15e96f-b967-3d39-bed6-194a9e836338 / artist/4853b4f9-bcd6-4663-86bd-36d1270c6a3b/works

Not changing it for edits because there we should see all new added codes IMO.