### PR TITLE
MBS-11546: Allow Resident Advisor /exchange URLs for releases 

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2717,7 +2717,7 @@ const CLEANUPS = {
   },
   'residentadvisor': {
     match: [
-      new RegExp('^(https?://)?(www\\.)?ra\\.co/', 'i'),
+      new RegExp('^(https?://)?(www\\.)?ra\\.co/(?!exchange)', 'i'),
       new RegExp('^(https?://)?(www\\.)?residentadvisor\\.net/', 'i'),
     ],
     type: {
@@ -2769,6 +2769,14 @@ const CLEANUPS = {
         }
       }
       return {result: false};
+    },
+  },
+  // TODO: Merge with residentadvisor after MBS-9902 is implemented
+  'residentadvisorexchange': {
+    match: [new RegExp('^(https?://)?(www\\.)?ra\\.co/exchange', 'i')],
+    type: LINK_TYPES.shownotes,
+    clean: function (url) {
+      return url.replace(/^(?:https?:\/\/)?(?:www\.)?ra\.co\/exchange\/([^\/?#]+).*$/, 'https://ra.co/exchange/$1');
     },
   },
   'reverbnation': {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -660,7 +660,7 @@ const CLEANUPS = {
       url = url.replace(/^https?:\/\/(www.)?archive.org\//, 'https://archive.org/');
       // clean up links to files
       url = url.replace(/\?cnt=\d+$/, '');
-      url = url.replace(/^https?:\/\/(.*)\.archive.org\/\d+\/items\/(.*)\/(.*)/, 'https://archive.org/download/$2/$3');
+      url = url.replace(/^https?:\/\/(?:.*)\.archive.org\/\d+\/items\/(.*)\/(.*)/, 'https://archive.org/download/$1/$2');
       // clean up links to items
       return url.replace(/^(https:\/\/archive\.org\/details\/[A-Za-z0-9._-]+)\/$/, '$1');
     },
@@ -910,7 +910,7 @@ const CLEANUPS = {
       'i',
     )],
     clean: function (url) {
-      return url.replace(/(www\.)?([^.\/]+)\.blogspot\.([a-z]{2,3}\.)?[a-z]{2,3}(\/)?/, '$2.blogspot.com/');
+      return url.replace(/(?:www\.)?([^.\/]+)\.blogspot\.(?:[a-z]{2,3}\.)?[a-z]{2,3}(?:\/)?/, '$1.blogspot.com/');
     },
   },
   'bnfcatalogue': {
@@ -1201,7 +1201,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?(deezer\\.com)', 'i')],
     type: LINK_TYPES.streamingfree,
     clean: function (url) {
-      url = url.replace(/^https?:\/\/(www\.)?deezer\.com\/(?:[a-z]{2}\/)?(\w+)\/(\d+).*$/, 'https://www.deezer.com/$2/$3');
+      url = url.replace(/^https?:\/\/(?:www\.)?deezer\.com\/(?:[a-z]{2}\/)?(\w+)\/(\d+).*$/, 'https://www.deezer.com/$1/$2');
       return url;
     },
     validate: function (url, id) {
@@ -1224,7 +1224,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?dhhu\\.dk', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(www\.)?dhhu\.dk\/w\/(.*)+$/, 'http://www.dhhu.dk/w/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?dhhu\.dk\/w\/(.*)+$/, 'http://www.dhhu.dk/w/$1');
       return url;
     },
   },
@@ -1513,7 +1513,7 @@ const CLEANUPS = {
     )],
     type: LINK_TYPES.geonames,
     clean: function (url) {
-      return url.replace(/^https?:\/\/([a-z]+\.)?geonames.org\/([0-9]+)\/.*$/, 'http://sws.geonames.org/$2/');
+      return url.replace(/^https?:\/\/(?:[a-z]+\.)?geonames.org\/([0-9]+)\/.*$/, 'http://sws.geonames.org/$1/');
     },
   },
   'googleplay': {
@@ -1584,7 +1584,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?ibdb\\.com/', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      url = url.replace(/^(https?:\/\/)?(www\.)?ibdb\.com/, 'https://www.ibdb.com');
+      url = url.replace(/^(https?:\/\/)?(?:www\.)?ibdb\.com/, 'https://www.ibdb.com');
       return url;
     },
   },
@@ -2459,7 +2459,7 @@ const CLEANUPS = {
     match: [new RegExp('^(https?://)?(www\\.)?openlibrary\\.org', 'i')],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, 'https://openlibrary.org/$2/$3');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?openlibrary\.org\/(authors|books|works)\/(OL[0-9]+[AMW]\/)(.*)*$/, 'https://openlibrary.org/$1/$2');
       return url;
     },
   },
@@ -2726,12 +2726,12 @@ const CLEANUPS = {
       ...LINK_TYPES.discographyentry,
     },
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(www\.)?ra\.co\//, 'https://ra.co/');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ra\.co\//, 'https://ra.co/');
       url = url.replace(/^https:\/\/ra\.co\/(clubs|dj|events|labels|podcast|reviews|tracks)\/([^\/?#]+).*$/, 'https://ra.co/$1/$2');
       return url;
     },
     validate: function (url, id) {
-      if (/^https?:\/\/(www\.)?residentadvisor\.net\//.test(url)) {
+      if (/^https?:\/\/(?:www\.)?residentadvisor\.net\//.test(url)) {
         return {
           error: exp.l(
             `This is a link to the old Resident Advisor domain. Please
@@ -2850,7 +2850,7 @@ const CLEANUPS = {
     )],
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(wiki|www)\.rockinchina\.com\/w\/(.*)+$/, 'http://www.rockinchina.com/w/$2');
+      url = url.replace(/^(?:https?:\/\/)?(?:wiki|www)\.rockinchina\.com\/w\/(.*)+$/, 'http://www.rockinchina.com/w/$1');
       return url;
     },
   },
@@ -3455,7 +3455,7 @@ const CLEANUPS = {
     type: {...LINK_TYPES.score, ...LINK_TYPES.image},
     clean: function (url) {
       url = url.replace(/\/wiki\/[^#]+#(?:mediaviewer|\/media)\/(.*)/, '\/wiki\/$1');
-      url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, 'https://commons.wikimedia.org/wiki/File:$2');
+      url = url.replace(/^https?:\/\/upload\.wikimedia\.org\/wikipedia\/commons\/(?:thumb\/)?[0-9a-z]\/[0-9a-z]{2}\/([^\/]+)(\/[^\/]+)?$/, 'https://commons.wikimedia.org/wiki/File:$1');
       url = url.replace(/\?uselang=[a-z-]+$/, '');
       url = url.replace(/#.*$/, '');
       url = reencodeMediawikiLocalPart(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3172,6 +3172,13 @@ const testData = [
             expected_clean_url: 'https://ra.co/podcast/491',
        only_valid_entity_types: ['release'],
   },
+  {
+                     input_url: 'http://www.ra.co/exchange/552',
+             input_entity_type: 'release',
+    expected_relationship_type: 'shownotes',
+            expected_clean_url: 'https://ra.co/exchange/552',
+       only_valid_entity_types: ['release'],
+  },
   // ReverbNation
   {
                      input_url: 'https://reverbnation.com/negator',


### PR DESCRIPTION
### Implement MBS-11546

RA has over 500 entries on their RA Exchange podcast series, under /exchange (we have three of them in the DB right now). These shouldn't be blocked, and should autoselect to show notes.

Since we don't support autoselecting to two different types for the same entity, this excludes them from the main RA cleanup and adds a separate cleanup entry for them, to be merged with MBS-9902.

Additionally, made some more capturing groups non-capturing (noticed the issue because it caught me when originally adapting the RA cleanup).