### PR TITLE
MBS-11531 (II): Pass $c to load_filtered call

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Report.pm
+++ b/lib/MusicBrainz/Server/Controller/Report.pm
@@ -42,7 +42,7 @@ sub show : Path Args(1)
         if ($filtered) {
             if ($can_be_filtered) {
                 if ($c->user_exists) {
-                    return $report->load_filtered($c->user->id, shift, shift);
+                    return $report->load_filtered($c, $c->user->id, shift, shift);
                 }
                 else {
                     $c->forward('/user/login')


### PR DESCRIPTION
### Fix MBS-11531 (for real now)

The previous patch for this (https://github.com/metabrainz/musicbrainz-server/pull/2021) stopped it ISEing, but was still passing the wrong args. Now everything should work.