### PR TITLE
Remove now unneeded old RA checks

### DIFF
--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -141,8 +141,7 @@ my %URL_SPECIALIZATIONS = (
     'QuebecInfoMusique'   => qr{^https?://(?:www\.)?qim\.com/}i,
     'Rateyourmusic'       => qr{^https?://(?:www\.)?rateyourmusic\.com/}i,
     'Recochoku'           => qr{^https?://(?:www\.)?recochoku\.jp/}i,
-    # Remove residentadvisor.net once MBBE-31 is done
-    'ResidentAdvisor'     => qr{^https?://(?:www\.)?(ra\.co|residentadvisor\.net)/}i,
+    'ResidentAdvisor'     => qr{^https?://(?:www\.)?ra\.co/}i,
     'ReverbNation'        => qr{^https?://(?:www\.)?reverbnation\.com/}i,
     'RockComAr'           => qr{^https?://(?:www\.)?rock\.com\.ar/}i,
     'RockensDanmarkskort' => qr{^https?://(?:www\.)?rockensdanmarkskort\.dk/}i,

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -146,8 +146,6 @@ export const FAVICON_CLASSES = {
   'ra.co': 'residentadvisor',
   'rateyourmusic.com': 'rateyourmusic',
   'recochoku.jp': 'recochoku',
-  // Remove once MBBE-31 is done
-  'residentadvisor.net': 'residentadvisor',
   'reverbnation.com': 'reverbnation',
   'rock.com.ar': 'rockcomar',
   'rockensdanmarkskort.dk': 'rockensdanmarkskort',


### PR DESCRIPTION
### Follows completion of MBBE-31

There's only one residentadvisor.net URL left, and it is an ended biography page (so it won't be on the sidebar anyway). Everything else is now ra.co.