### PR TITLE
Increase the default relationship page limit sizes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -35,7 +35,7 @@ parameter 'allow_integer_ids' => (
     default => sub { 1 },
 );
 
-Readonly our $RELATIONSHIP_PAGE_SIZE => 100;
+Readonly our $RELATIONSHIP_PAGE_SIZE => 250;
 
 role
 {

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -233,12 +233,14 @@ sub _load_related_info {
     $self->load_entities(@rels);
 }
 
+Readonly our $DEFAULT_LOAD_PAGED_LIMIT => 100;
+
 sub load_paged {
     my ($self, $source, $target_types, %opts) = @_;
 
     my $source_type = $source->entity_type;
     my $source_id = $source->id;
-    my $limit = $opts{limit} // 25;
+    my $limit = $opts{limit} // $DEFAULT_LOAD_PAGED_LIMIT;
     my $offset = $opts{offset} // 0;
     my $link_type_filter = $opts{link_type_id};
     my $direction_filter = $opts{direction};

--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -215,9 +215,8 @@ sub fill_temporary_tables {
 
     # Recordings linked to works via performance / "recording of"
     # relationships, but only where the number of recordings per work
-    # exceeds 25. We already output the first such 25 recordings on the
-    # work index page. ("25" is simply the default limit of
-    # Data::Relationship::load_paged.)
+    # exceeds 100 (`DEFAULT_LOAD_PAGED_LIMIT`). We already output the
+    # first such 100 recordings on the work index page.
     log('Filling tmp_sitemaps_work_recordings_count');
     $sql->do("INSERT INTO tmp_sitemaps_work_recordings_count (work, recordings_count)
                 SELECT DISTINCT q.work, q.recordings_count FROM
@@ -226,7 +225,8 @@ sub fill_temporary_tables {
                        FROM l_recording_work lrw
                        JOIN link l ON l.id = lrw.link
                       WHERE l.link_type = 278) q
-                 WHERE q.recordings_count > 25");
+                 WHERE q.recordings_count > ?",
+             $MusicBrainz::Server::Data::Relationship::DEFAULT_LOAD_PAGED_LIMIT);
 
     log('Analyzing tmp_sitemaps_work_recordings_count');
     $sql->do("ANALYZE tmp_sitemaps_work_recordings_count");


### PR DESCRIPTION
Amends 12b43e8330b0feda64c636665735c7c3c931b7b5

Based on feedback, this increases the initial table size for each link type group from 25 to 100. Testing this against London Symphony Orchestra shows a ~1.67x slowdown from 2.193s to 3.664s.

The page size of the paged pages has been increased from 100 to 250. Testing against /artist/38712b4c-0fd4-4c65-8c7a-45676fecc973/relationships?direction=1&link_type_id=150&page=3 shows a slowdown of ~2.06x from 1.145s to 2.361s.