### PR TITLE
MBS-11550: Move PostParameters to static/scripts for translation

### DIFF
--- a/root/main/ConfirmSeed.js
+++ b/root/main/ConfirmSeed.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import PostParameters, {
   type PostParametersT,
-} from '../components/PostParameters';
+} from '../static/scripts/common/components/PostParameters';
 import Layout from '../layout';
 import * as manifest from '../static/manifest';
 

--- a/root/static/scripts/common/components/PostParameters.js
+++ b/root/static/scripts/common/components/PostParameters.js
@@ -9,8 +9,8 @@
 
 import * as React from 'react';
 
-import {compareStrings} from '../static/scripts/common/utility/compare';
-import hydrate from '../utility/hydrate';
+import {compareStrings} from '../utility/compare';
+import hydrate from '../../../../utility/hydrate';
 
 export type PostParametersT = {
   +[param: string]: string | $ReadOnlyArray<string>,

--- a/root/static/scripts/confirm-seed.js
+++ b/root/static/scripts/confirm-seed.js
@@ -7,5 +7,5 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../components/PostParameters';
+import './common/components/PostParameters';
 import '../../main/components/ConfirmSeedButtons';

--- a/root/static/scripts/user/login.js
+++ b/root/static/scripts/user/login.js
@@ -7,4 +7,4 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-import '../../../components/PostParameters';
+import '../common/components/PostParameters';

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -826,7 +826,7 @@ button.guess-timezone {
     }
 }
 
-/* root/components/PostParameters.js */
+/* root/static/scripts/common/components/PostParameters.js */
 
 .post-parameters {
     a.expand-link {

--- a/root/user/Login.js
+++ b/root/user/Login.js
@@ -13,7 +13,7 @@ import FormRowText from '../components/FormRowText';
 import FormSubmit from '../components/FormSubmit';
 import PostParameters, {
   type PostParametersT,
-} from '../components/PostParameters';
+} from '../static/scripts/common/components/PostParameters';
 import Layout from '../layout';
 import * as manifest from '../static/manifest';
 import DBDefs from '../static/scripts/common/DBDefs';


### PR DESCRIPTION
### Fix MBS-11550

Hydrated components don't get translated unless they are under static/scripts, apparently.

.pot files also need to be regenerated.