### PR TITLE
MBS-11553: Move from passing $c to React.useContext in layout pages

### DIFF
--- a/root/account/EditProfile.js
+++ b/root/account/EditProfile.js
@@ -33,7 +33,6 @@ const EditProfile = ({
   }
   return (
     <UserAccountLayout
-      $c={$c}
       entity={sanitizedAccountLayoutUser(user)}
       page="edit_profile"
       title={l('Edit Profile')}

--- a/root/account/LostPassword.js
+++ b/root/account/LostPassword.js
@@ -22,12 +22,11 @@ type LostPasswordFormT = FormT<{
 }>;
 
 type Props = {
-  +$c: CatalystContextT,
   +form: LostPasswordFormT,
 };
 
 const LostPassword = (props: Props): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Lost Password')}>
+  <Layout fullWidth title={l('Lost Password')}>
     <h1>{l('Lost Password')}</h1>
     <p>
       {exp.l(

--- a/root/account/LostUsername.js
+++ b/root/account/LostUsername.js
@@ -21,12 +21,11 @@ type LostUsernameFormT = FormT<{
 }>;
 
 type Props = {
-  +$c: CatalystContextT,
   +form: LostUsernameFormT,
 };
 
 const LostUsername = (props: Props): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Lost Username')}>
+  <Layout fullWidth title={l('Lost Username')}>
     <h1>{l('Lost Username')}</h1>
     <p>
       {l(`Enter your email address below and we will send you an email with

--- a/root/account/Preferences.js
+++ b/root/account/Preferences.js
@@ -28,7 +28,6 @@ const Preferences = ({
   ...props
 }: Props): React.Element<typeof UserAccountLayout> => (
   <UserAccountLayout
-    $c={$c}
     entity={sanitizedAccountLayoutUser($c.user)}
     page="preferences"
     title={l('Preferences')}

--- a/root/account/applications/Edit.js
+++ b/root/account/applications/Edit.js
@@ -16,12 +16,11 @@ import type {ApplicationFormT}
   from '../../static/scripts/account/components/ApplicationForm';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: ApplicationFormT,
 };
 
 const EditApplication = (props: Props): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Edit Application')}>
+  <Layout fullWidth title={l('Edit Application')}>
     <h1>{l('Edit Application')}</h1>
     <ApplicationForm
       action="edit"

--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -17,7 +17,6 @@ import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
 import loopParity from '../../utility/loopParity';
 
 type Props = {
-  +$c: CatalystContextT,
   +applications: $ReadOnlyArray<ApplicationT>,
   +appsPager: PagerT,
   +tokens: $ReadOnlyArray<EditorOAuthTokenT>,
@@ -76,13 +75,12 @@ function formatScopes(token: EditorOAuthTokenT) {
 }
 
 const Index = ({
-  $c,
   applications,
   appsPager,
   tokens,
   tokensPager,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Applications')}>
+  <Layout fullWidth title={l('Applications')}>
     <h1>{l('Applications')}</h1>
 
     <h2>{l('Authorized Applications')}</h2>

--- a/root/account/applications/Register.js
+++ b/root/account/applications/Register.js
@@ -17,12 +17,11 @@ import type {ApplicationFormT}
   from '../../static/scripts/account/components/ApplicationForm';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: ApplicationFormT,
 };
 
 const RegisterApplication = (props: Props): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Register Application')}>
+  <Layout fullWidth title={l('Register Application')}>
     <h1>{l('Register Application')}</h1>
     <ApplicationForm
       action="register"

--- a/root/account/applications/Remove.js
+++ b/root/account/applications/Remove.js
@@ -12,16 +12,13 @@ import * as React from 'react';
 import ConfirmLayout from '../../components/ConfirmLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: SecureConfirmFormT,
 };
 
 const RemoveApplication = ({
-  $c,
   form,
 }: Props): React.Element<typeof ConfirmLayout> => (
   <ConfirmLayout
-    $c={$c}
     form={form}
     question={l('Are you sure you want to remove this application?')}
     title={l('Remove Application')}

--- a/root/account/applications/RevokeAccess.js
+++ b/root/account/applications/RevokeAccess.js
@@ -12,16 +12,13 @@ import * as React from 'react';
 import ConfirmLayout from '../../components/ConfirmLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: SecureConfirmFormT,
 };
 
 const RevokeApplicationAccess = ({
-  $c,
   form,
 }: Props): React.Element<typeof ConfirmLayout> => (
   <ConfirmLayout
-    $c={$c}
     form={form}
     question={l(
       `Are you sure you want to revoke this application's access?`,

--- a/root/account/sso/DiscourseRegistered.js
+++ b/root/account/sso/DiscourseRegistered.js
@@ -12,15 +12,13 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +emailAddress: string,
 };
 
 const DiscourseRegistered = ({
-  $c,
   emailAddress,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Account Created')}>
+  <Layout fullWidth title={l('Account Created')}>
     <h2>{l('Account Created')}</h2>
     <p style={{fontSize: '1.2em'}}>
       {exp.l(

--- a/root/account/sso/DiscourseUnconfirmedEmailAddress.js
+++ b/root/account/sso/DiscourseUnconfirmedEmailAddress.js
@@ -11,14 +11,8 @@ import * as React from 'react';
 
 import Layout from '../../layout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const DiscourseUnconfirmedEmailAddress = ({
-  $c,
-}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Unverified Email Address')}>
+const DiscourseUnconfirmedEmailAddress = (): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Unverified Email Address')}>
     <h2>{l('Unverified Email Address')}</h2>
     <p>
       {exp.l(

--- a/root/admin/EditBanner.js
+++ b/root/admin/EditBanner.js
@@ -15,15 +15,14 @@ import FormSubmit from '../components/FormSubmit';
 import Layout from '../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: ReadOnlyFormT<{
     +csrf_token: ReadOnlyFieldT<string>,
     +message: ReadOnlyFieldT<string>,
   }>,
 };
 
-const EditBanner = ({$c, form}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Edit Banner Message')}>
+const EditBanner = ({form}: Props): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Edit Banner Message')}>
     <div id="content">
       <h1>{l('Edit banner message')}</h1>
       <p>

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -17,7 +17,6 @@ import expand2react from '../static/scripts/common/i18n/expand2react';
 import UserList from './components/UserList';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: FormT<{
     +email: ReadOnlyFieldT<string>,
   }>,
@@ -25,11 +24,10 @@ type Props = {
 };
 
 const EmailSearch = ({
-  $c,
   form,
   results,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Search users by email')}>
+  <Layout fullWidth title={l('Search users by email')}>
     <div id="content">
       <h1>{l('Search users by email')}</h1>
 

--- a/root/admin/IpLookup.js
+++ b/root/admin/IpLookup.js
@@ -14,17 +14,15 @@ import Layout from '../layout';
 import UserList from './components/UserList';
 
 type Props = {
-  +$c: CatalystContextT,
   +ipHash: string,
   +users: $ReadOnlyArray<UnsanitizedEditorT>,
 };
 
 const IpLookup = ({
-  $c,
   ipHash,
   users,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('IP lookup')}>
+  <Layout fullWidth title={l('IP lookup')}>
     <div id="content">
       <h1>{l('IP lookup')}</h1>
       <p>

--- a/root/admin/attributes/Attribute.js
+++ b/root/admin/attributes/Attribute.js
@@ -36,7 +36,6 @@ type AttributeT =
   | WorkTypeT;
 
 type Props = {
-  +$c: CatalystContextT,
   +attributes: Array<AttributeT>,
   +model: string,
 };
@@ -84,11 +83,10 @@ const renderAttributes = (attribute) => {
 };
 
 const Attribute = ({
-  $c,
   attributes,
   model,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={model}>
+  <Layout fullWidth title={model}>
     <h1>
       <a href="/admin/attributes">{l('Attributes')}</a>
       {' / ' + model}

--- a/root/admin/attributes/CannotRemoveAttribute.js
+++ b/root/admin/attributes/CannotRemoveAttribute.js
@@ -12,15 +12,13 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +message: string,
 };
 
 const CannotRemoveAttribute = ({
-  $c,
   message,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Cannot Remove Attribute')}>
+  <Layout fullWidth title={l('Cannot Remove Attribute')}>
     <h1>{l('Cannot Remove Attribute')}</h1>
     <p>
       {message}

--- a/root/admin/attributes/Index.js
+++ b/root/admin/attributes/Index.js
@@ -13,12 +13,11 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +models: Array<string>,
 };
 
-const Attributes = ({$c, models}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Attributes')}>
+const Attributes = ({models}: Props): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Attributes')}>
     <h1>{l('Attributes')}</h1>
     <ul>
       {models.sort().map((item) => (

--- a/root/admin/attributes/Language.js
+++ b/root/admin/attributes/Language.js
@@ -21,18 +21,16 @@ const frequencyLabels = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +attributes: Array<LanguageT>,
   +model: string,
 };
 
 const Language = ({
-  $c,
   model,
   attributes,
 }: Props): React.Element<typeof Layout> => {
   return (
-    <Layout $c={$c} fullWidth title={model || l('Language')}>
+    <Layout fullWidth title={model || l('Language')}>
       <h1>
         <a href="/admin/attributes">{l('Attributes')}</a>
         {' / ' + l('Language')}

--- a/root/admin/attributes/Script.js
+++ b/root/admin/attributes/Script.js
@@ -23,17 +23,15 @@ const frequencyLabels = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +attributes: Array<ScriptT>,
   +model: string,
 };
 
 const Script = ({
-  $c,
   model,
   attributes,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={model || l('Script')}>
+  <Layout fullWidth title={model || l('Script')}>
     <h1>
       <a href="/admin/attributes">{l('Attributes')}</a>
       {' / ' + l('Script')}

--- a/root/admin/wikidoc/CreateWikiDoc.js
+++ b/root/admin/wikidoc/CreateWikiDoc.js
@@ -28,7 +28,7 @@ const CreateWikiDoc = ({
   $c,
   form,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Add Page')}>
+  <Layout fullWidth title={l('Add Page')}>
     <div id="content">
       <h1>{l('Add Page')}</h1>
       <form action={$c.req.uri} method="post">

--- a/root/admin/wikidoc/DeleteWikiDoc.js
+++ b/root/admin/wikidoc/DeleteWikiDoc.js
@@ -24,7 +24,7 @@ const DeleteWikiDoc = ({
   form,
   page,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Remove Page')}>
+  <Layout fullWidth title={l('Remove Page')}>
     <div id="content">
       <h1>{l('Remove Page')}</h1>
       <p>

--- a/root/admin/wikidoc/EditWikiDoc.js
+++ b/root/admin/wikidoc/EditWikiDoc.js
@@ -30,7 +30,7 @@ const EditWikiDoc = ({
   form,
   page,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Update Page')}>
+  <Layout fullWidth title={l('Update Page')}>
     <div id="content">
       <h1>{l('Update Page')}</h1>
       <form action={$c.req.uri} method="post">

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -145,7 +145,7 @@ const WikiDocTable = ({
 };
 
 const WikiDocIndex = (props: PropsT): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Transclusion Table')}>
+  <Layout fullWidth title={l('Transclusion Table')}>
     <div className="content">
       <h1>{l('Transclusion Table')}</h1>
       <p>

--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -28,7 +28,7 @@ const AreaArtists = ({
   artists,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="artists" title={l('Artists')}>
+  <AreaLayout entity={area} page="artists" title={l('Artists')}>
     <h2>{l('Artists')}</h2>
 
     {artists?.length ? (

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -28,7 +28,7 @@ const AreaEvents = ({
   events,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="events" title={l('Events')}>
+  <AreaLayout entity={area} page="events" title={l('Events')}>
     <h2>{l('Events')}</h2>
 
     {events.length > 0 ? (

--- a/root/area/AreaIndex.js
+++ b/root/area/AreaIndex.js
@@ -18,19 +18,17 @@ import * as manifest from '../static/manifest';
 import AreaLayout from './AreaLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +numberOfRevisions: number,
   +wikipediaExtract: WikipediaExtractT | null,
 };
 
 const AreaIndex = ({
-  $c,
   area,
   numberOfRevisions,
   wikipediaExtract,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="index">
+  <AreaLayout entity={area} page="index">
     <Annotation
       annotation={area.latest_annotation}
       collapse

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -28,7 +28,7 @@ const AreaLabels = ({
   labels,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="labels" title={l('Labels')}>
+  <AreaLayout entity={area} page="labels" title={l('Labels')}>
     <h2>{l('Labels')}</h2>
 
     {labels.length > 0 ? (

--- a/root/area/AreaLayout.js
+++ b/root/area/AreaLayout.js
@@ -16,7 +16,6 @@ import localizeAreaName from '../static/scripts/common/i18n/localizeAreaName';
 import AreaHeader from './AreaHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: AreaT,
   +fullWidth?: boolean,
@@ -25,7 +24,6 @@ type Props = {
 };
 
 const AreaLayout = ({
-  $c,
   children,
   entity: area,
   fullWidth = false,
@@ -33,7 +31,6 @@ const AreaLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title)
       ? hyphenateTitle(localizeAreaName(area), title)
       : localizeAreaName(area)}

--- a/root/area/AreaMerge.js
+++ b/root/area/AreaMerge.js
@@ -28,7 +28,7 @@ const AreaMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge areas')}>
+  <Layout fullWidth title={l('Merge areas')}>
     <div id="content">
       <h1>{l('Merge areas')}</h1>
       <p>

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -32,7 +32,7 @@ const AreaPlaces = ({
   pager,
   places,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="places" title={l('Places')}>
+  <AreaLayout entity={area} page="places" title={l('Places')}>
     <h2>{l('Places')}</h2>
 
     {places?.length ? (

--- a/root/area/AreaRecordings.js
+++ b/root/area/AreaRecordings.js
@@ -26,7 +26,7 @@ const AreaRecordings = ({
   pagedLinkTypeGroup,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="recordings" title={l('Recordings')}>
+  <AreaLayout entity={area} page="recordings" title={l('Recordings')}>
     <RelationshipsTable
       $c={$c}
       entity={area}

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -31,7 +31,7 @@ const AreaReleases = ({
   pager,
   releases,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="releases" title={l('Releases')}>
+  <AreaLayout entity={area} page="releases" title={l('Releases')}>
     {pagedLinkTypeGroup ? null : (
       <>
         <h2>{l('Releases')}</h2>

--- a/root/area/AreaUsers.js
+++ b/root/area/AreaUsers.js
@@ -15,19 +15,17 @@ import EditorLink from '../static/scripts/common/components/EditorLink';
 import AreaLayout from './AreaLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +editors: $ReadOnlyArray<EditorT>,
   +pager: PagerT,
 };
 
 const AreaUsers = ({
-  $c,
   area,
   editors,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="users" title={l('Users')}>
+  <AreaLayout entity={area} page="users" title={l('Users')}>
     <h2>{l('Users')}</h2>
 
     {pager.total_entries ? (

--- a/root/area/AreaWorks.js
+++ b/root/area/AreaWorks.js
@@ -26,7 +26,7 @@ const AreaWorks = ({
   pagedLinkTypeGroup,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout $c={$c} entity={area} page="works" title={l('Works')}>
+  <AreaLayout entity={area} page="works" title={l('Works')}>
     <RelationshipsTable
       $c={$c}
       entity={area}

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -28,7 +28,7 @@ const ArtistEvents = ({
   events,
   pager,
 }: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout $c={$c} entity={artist} page="events" title={l('Events')}>
+  <ArtistLayout entity={artist} page="events" title={l('Events')}>
     <h2>{l('Events')}</h2>
 
     {events.length > 0 ? (

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -226,7 +226,7 @@ const ArtistIndex = ({
   const existingReleaseGroups = releaseGroups?.length ? releaseGroups : null;
 
   return (
-    <ArtistLayout $c={$c} entity={artist} page="index">
+    <ArtistLayout entity={artist} page="index">
       {eligibleForCleanup ? (
         <p className="cleanup">
           {l(`This artist has no relationships, recordings, releases or

--- a/root/artist/ArtistLayout.js
+++ b/root/artist/ArtistLayout.js
@@ -15,7 +15,6 @@ import ArtistSidebar from '../layout/components/sidebar/ArtistSidebar';
 import ArtistHeader from './ArtistHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: ArtistT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const ArtistLayout = ({
-  $c,
   children,
   entity: artist,
   fullWidth = false,
@@ -32,7 +30,6 @@ const ArtistLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(artist.name, title) : artist.name}
   >
     <div id="content">

--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -29,7 +29,7 @@ const ArtistMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge artists')}>
+  <Layout fullWidth title={l('Merge artists')}>
     <div id="content">
       <h1>{l('Merge artists')}</h1>
       <p>

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -136,7 +136,6 @@ const ArtistRecordings = ({
   videoOnly,
 }: Props): React.Element<typeof ArtistLayout> => (
   <ArtistLayout
-    $c={$c}
     entity={artist}
     page="recordings"
     title={l('Recordings')}

--- a/root/artist/ArtistRelationships.js
+++ b/root/artist/ArtistRelationships.js
@@ -29,7 +29,6 @@ const ArtistRelationships = ({
   pager,
 }: Props): React.Element<typeof ArtistLayout> => (
   <ArtistLayout
-    $c={$c}
     entity={artist}
     page="relationships"
     title={l('Relationships')}

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -42,7 +42,7 @@ const ArtistReleases = ({
   showingVariousArtistsOnly,
   wantVariousArtistsOnly,
 }: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout $c={$c} entity={artist} page="releases" title={l('Releases')}>
+  <ArtistLayout entity={artist} page="releases" title={l('Releases')}>
     <h2>{l('Releases')}</h2>
 
     <Filter

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -28,7 +28,7 @@ const ArtistWorks = ({
   pager,
   works,
 }: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout $c={$c} entity={artist} page="works" title={l('Works')}>
+  <ArtistLayout entity={artist} page="works" title={l('Works')}>
     <h2>{l('Works')}</h2>
 
     {works?.length ? (

--- a/root/artist/CannotSplit.js
+++ b/root/artist/CannotSplit.js
@@ -12,15 +12,13 @@ import * as React from 'react';
 import ArtistLayout from './ArtistLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +artist: ArtistT,
 };
 
 const CannotSplit = ({
-  $c,
   artist,
 }: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout $c={$c} entity={artist} page="cannot_split">
+  <ArtistLayout entity={artist} page="cannot_split">
     <h2>{l('Split Into Separate Artists')}</h2>
     <p>
       {exp.l(

--- a/root/artist/SpecialPurpose.js
+++ b/root/artist/SpecialPurpose.js
@@ -12,16 +12,13 @@ import * as React from 'react';
 import ArtistLayout from './ArtistLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +artist: ArtistT,
 };
 
 const SpecialPurpose = ({
-  $c,
   artist,
 }: Props): React.Element<typeof ArtistLayout> => (
   <ArtistLayout
-    $c={$c}
     entity={artist}
     fullWidth
     page="special_purpose"

--- a/root/artist_credit/ArtistCreditIndex.js
+++ b/root/artist_credit/ArtistCreditIndex.js
@@ -82,7 +82,6 @@ const ArtistCreditIndex = (
   props: Props,
 ): React.Element<typeof ArtistCreditLayout> => (
   <ArtistCreditLayout
-    $c={props.$c}
     artistCredit={props.artistCredit}
     page=""
   >

--- a/root/artist_credit/ArtistCreditLayout.js
+++ b/root/artist_credit/ArtistCreditLayout.js
@@ -17,7 +17,6 @@ import {reduceArtistCredit}
   from '../static/scripts/common/immutable-entities';
 
 type Props = {
-  +$c: CatalystContextT,
   +artistCredit: $ReadOnly<{...ArtistCreditT, +id: number}>,
   +children: React.Node,
   +page: string,
@@ -33,14 +32,12 @@ const tabLinks: $ReadOnlyArray<[string, () => string]> = [
 ];
 
 const ArtistCreditLayout = ({
-  $c,
   artistCredit,
   children,
   page,
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     fullWidth
     title={
       nonEmpty(title)

--- a/root/artist_credit/EntityList.js
+++ b/root/artist_credit/EntityList.js
@@ -51,7 +51,7 @@ const EntityList = ({
   page,
   pager,
 }: Props): React.Element<typeof ArtistCreditLayout> => (
-  <ArtistCreditLayout $c={$c} artistCredit={artistCredit} page={page}>
+  <ArtistCreditLayout artistCredit={artistCredit} page={page}>
     <h2>
       {expand2text(
         headingsText[entityType](pager.total_entries),

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -173,7 +173,7 @@ React.Element<typeof CollectionLayout> => {
       collection.collaborators.some(x => x.id === user.id));
 
   return (
-    <CollectionLayout $c={$c} entity={collection} page="index">
+    <CollectionLayout entity={collection} page="index">
       <div className="description">
         {collection.description_html ? (
           <>

--- a/root/collection/CollectionLayout.js
+++ b/root/collection/CollectionLayout.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context';
 import Layout from '../layout';
 import CollectionSidebar
   from '../layout/components/sidebar/CollectionSidebar';
@@ -16,7 +17,6 @@ import CollectionSidebar
 import CollectionHeader from './CollectionHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: CollectionT,
   +fullWidth?: boolean,
@@ -25,13 +25,13 @@ type Props = {
 };
 
 const CollectionLayout = ({
-  $c,
   children,
   entity: collection,
   fullWidth = false,
   page,
   title,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
   const mainTitle = texp.l(
     'Collection “{collection}”',
     {collection: collection.name},
@@ -39,7 +39,6 @@ const CollectionLayout = ({
 
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title) ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/collection/CollectionMerge.js
+++ b/root/collection/CollectionMerge.js
@@ -107,7 +107,7 @@ const CollectionMerge = ({
   );
 
   return (
-    <Layout $c={$c} fullWidth title={l('Merge collections')}>
+    <Layout fullWidth title={l('Merge collections')}>
       <div id="content">
         <h1>{l('Merge collections')}</h1>
         <p>

--- a/root/collection/CreateCollection.js
+++ b/root/collection/CreateCollection.js
@@ -17,18 +17,15 @@ import CollectionEditForm
 import type {CollectionEditFormT} from './types';
 
 type Props = {
-  +$c: CatalystContextT,
   +collectionTypes: SelectOptionsT,
   +form: CollectionEditFormT,
 };
 
 const CreateCollection = ({
-  $c,
   collectionTypes,
   form,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     fullWidth
     title={l('Create a new collection')}
   >

--- a/root/collection/DeleteCollection.js
+++ b/root/collection/DeleteCollection.js
@@ -24,7 +24,6 @@ const DeleteCollection = ({
   collection,
 }: Props): React.Element<typeof CollectionLayout> => (
   <CollectionLayout
-    $c={$c}
     entity={collection}
     fullWidth
     page="delete"

--- a/root/collection/EditCollection.js
+++ b/root/collection/EditCollection.js
@@ -17,20 +17,17 @@ import CollectionLayout from './CollectionLayout';
 import type {CollectionEditFormT} from './types';
 
 type Props = {
-  +$c: CatalystContextT,
   +collection: CollectionT,
   +collectionTypes: SelectOptionsT,
   +form: CollectionEditFormT,
 };
 
 const EditCollection = ({
-  $c,
   collection,
   collectionTypes,
   form,
 }: Props): React.Element<typeof CollectionLayout> => (
   <CollectionLayout
-    $c={$c}
     entity={collection}
     fullWidth
     page="edit"

--- a/root/components/ConfirmLayout.js
+++ b/root/components/ConfirmLayout.js
@@ -14,7 +14,6 @@ import Layout from '../layout';
 import FormCsrfToken from './FormCsrfToken';
 
 type Props = {
-  +$c: CatalystContextT,
   +action?: string,
   +form: ConfirmFormT | SecureConfirmFormT,
   +question: Expand2ReactOutput,
@@ -22,13 +21,12 @@ type Props = {
 };
 
 const ConfirmLayout = ({
-  $c,
   action,
   form,
   question,
   title,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={title}>
+  <Layout fullWidth title={title}>
     <h1>{title}</h1>
     <p>{question}</p>
     <form action={action} method="post">

--- a/root/components/StatusPage.js
+++ b/root/components/StatusPage.js
@@ -9,7 +9,6 @@
 
 import * as React from 'react';
 
-import {CatalystContext} from '../context';
 import Layout from '../layout';
 
 type Props = {
@@ -18,14 +17,10 @@ type Props = {
 };
 
 const StatusPage = ({title, children}: Props): React.MixedElement => (
-  <CatalystContext.Consumer>
-    {$c => (
-      <Layout $c={$c} fullWidth title={title}>
-        <h1>{title}</h1>
-        {children}
-      </Layout>
-    )}
-  </CatalystContext.Consumer>
+  <Layout fullWidth title={title}>
+    <h1>{title}</h1>
+    {children}
+  </Layout>
 );
 
 export default StatusPage;

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -30,7 +30,6 @@ export type AccountLayoutUserT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: AccountLayoutUserT,
   +page: string,
@@ -52,7 +51,6 @@ export function sanitizedAccountLayoutUser(
 }
 
 const UserAccountLayout = ({
-  $c,
   children,
   entity: user,
   page,
@@ -60,7 +58,6 @@ const UserAccountLayout = ({
   ...layoutProps
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     fullWidth
     title={nonEmpty(title)
       ? hyphenateTitle(texp.l('Editor “{user}”', {user: user.name}), title)

--- a/root/doc/DocError.js
+++ b/root/doc/DocError.js
@@ -28,7 +28,7 @@ const DocError = ({
   const useGoogleCustomSearch = !!DBDefs.GOOGLE_CUSTOM_SEARCH;
 
   return (
-    <Layout $c={$c} fullWidth title={l('Page Not Found')}>
+    <Layout fullWidth title={l('Page Not Found')}>
       <div className="wikicontent" id="content">
         {useGoogleCustomSearch ? <DocSearchBox /> : null}
 

--- a/root/doc/DocPage.js
+++ b/root/doc/DocPage.js
@@ -22,13 +22,11 @@ type DocPageT = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +id: string,
   +page: DocPageT,
 };
 
 const DocPage = ({
-  $c,
   id,
   page,
 }: Props): React.Element<typeof Layout> => {
@@ -54,7 +52,7 @@ const DocPage = ({
     </a>
   );
   return (
-    <Layout $c={$c} fullWidth noIcons title={page.title}>
+    <Layout fullWidth noIcons title={page.title}>
       <div className="wikicontent" id="content">
         {useGoogleCustomSearch ? <DocSearchBox /> : null}
 

--- a/root/edit/CannotApproveEdit.js
+++ b/root/edit/CannotApproveEdit.js
@@ -14,13 +14,10 @@ import EditLink from '../static/scripts/common/components/EditLink';
 import {EDIT_STATUS_DELETED} from '../constants';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: {...EditT, +id: number},
 };
 
-const CannotApproveEdit = (
-  {$c, edit}: Props,
-): React.Element<typeof Layout> => {
+const CannotApproveEdit = ({edit}: Props): React.Element<typeof Layout> => {
   const editDisplay = 'edit #' + edit.id;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
   const editIsClosed = !edit.is_open;
@@ -36,7 +33,7 @@ const CannotApproveEdit = (
     )
   );
   return (
-    <Layout $c={$c} fullWidth title={l('Error Approving Edit')}>
+    <Layout fullWidth title={l('Error Approving Edit')}>
       <h1>{l('Error Approving Edit')}</h1>
       <p>
         {exp.l(

--- a/root/edit/CannotCancelEdit.js
+++ b/root/edit/CannotCancelEdit.js
@@ -13,18 +13,15 @@ import Layout from '../layout';
 import EditLink from '../static/scripts/common/components/EditLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: {...EditT, +id: number},
 };
 
-const CannotCancelEdit = (
-  {$c, edit}: Props,
-): React.Element<typeof Layout> => {
+const CannotCancelEdit = ({edit}: Props): React.Element<typeof Layout> => {
   const editDisplay = 'edit #' + edit.id;
   const editIsClosed = !edit.is_open;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
   return (
-    <Layout $c={$c} fullWidth title={l('Error Cancelling Edit')}>
+    <Layout fullWidth title={l('Error Cancelling Edit')}>
       <h1>{l('Error Cancelling Edit')}</h1>
       <p>
         {exp.l(

--- a/root/edit/CannotVote.js
+++ b/root/edit/CannotVote.js
@@ -1,5 +1,5 @@
 /*
- * @flow
+ * @flow strict-local
  * Copyright (C) 2020 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -11,12 +11,8 @@ import * as React from 'react';
 
 import Layout from '../layout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const CannotVote = ({$c}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Error Voting on Edits')}>
+const CannotVote = (): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Error Voting on Edits')}>
     <h1>{l('Error Voting on Edits')}</h1>
     <p>
       {l('You’re not currently allowed to vote, please read the banner.')}

--- a/root/edit/NoteIsRequired.js
+++ b/root/edit/NoteIsRequired.js
@@ -1,5 +1,5 @@
 /*
- * @flow
+ * @flow strict-local
  * Copyright (C) 2020 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -13,17 +13,14 @@ import Layout from '../layout';
 import EditLink from '../static/scripts/common/components/EditLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: {...EditT, +id: number},
 };
 
-const NoteIsRequired = (
-  {$c, edit}: Props,
-): React.Element<typeof Layout> => {
+const NoteIsRequired = ({edit}: Props): React.Element<typeof Layout> => {
   const editDisplay = 'edit #' + edit.id;
   const editLink = <EditLink content={editDisplay} edit={edit} />;
   return (
-    <Layout $c={$c} fullWidth title={l('Error Approving Edit')}>
+    <Layout fullWidth title={l('Error Approving Edit')}>
       <h1>{l('Error Approving Edit')}</h1>
       <p>
         {exp.l(

--- a/root/elections/Index.js
+++ b/root/elections/Index.js
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const Index = ({$c, elections}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Auto-editor elections')}>
+  <Layout fullWidth title={l('Auto-editor elections')}>
     <h1>{l('Auto-editor elections')}</h1>
     {elections.length
       ? <ElectionTable $c={$c} elections={elections} />

--- a/root/elections/Nominate.js
+++ b/root/elections/Nominate.js
@@ -13,18 +13,15 @@ import ConfirmLayout from '../components/ConfirmLayout';
 import EditorLink from '../static/scripts/common/components/EditorLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +candidate: EditorT,
   +form: SecureConfirmFormT,
 };
 
 const Nominate = ({
-  $c,
   candidate,
   form,
 }: Props): React.Element<typeof ConfirmLayout> => (
   <ConfirmLayout
-    $c={$c}
     form={form}
     question={exp.l(
       `Are you sure you want to nominate the editor {editor}

--- a/root/elections/Show.js
+++ b/root/elections/Show.js
@@ -26,7 +26,7 @@ const Show = ({$c, election}: Props): React.Element<typeof Layout> | null => {
   }
   const title = texp.l('Auto-editor election #{no}', {no: election.id});
   return (
-    <Layout $c={$c} fullWidth title={title}>
+    <Layout fullWidth title={title}>
       <h1>{title}</h1>
       <p>
         <a href="/elections">{l('Back to elections')}</a>

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -31,7 +31,6 @@ const Aliases = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       page="aliases"
       title={l('Aliases')}

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -70,7 +70,6 @@ const Details = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       page="details"
       title={l('Details')}

--- a/root/entity/Ratings.js
+++ b/root/entity/Ratings.js
@@ -15,14 +15,12 @@ import EditorLink from '../static/scripts/common/components/EditorLink';
 import EntityLink from '../static/scripts/common/components/EntityLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: RatableT,
   +privateRatingCount: number,
   +publicRatings: $ReadOnlyArray<RatingT>,
 };
 
 const Ratings = ({
-  $c,
   entity,
   privateRatingCount,
   publicRatings,
@@ -33,7 +31,6 @@ const Ratings = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       page="ratings"
       title={l('Ratings')}

--- a/root/entity/Subscribers.js
+++ b/root/entity/Subscribers.js
@@ -43,7 +43,6 @@ const Subscribers = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       page="subscribers"
       title={l('Subscribers')}

--- a/root/entity/Tags.js
+++ b/root/entity/Tags.js
@@ -31,7 +31,7 @@ const Tags = ({
   const LayoutComponent = chooseLayoutComponent(entityType);
 
   return (
-    <LayoutComponent $c={$c} entity={entity} page="tags" title={l('Tags')}>
+    <LayoutComponent entity={entity} page="tags" title={l('Tags')}>
       <MainTagEditor
         $c={$c}
         aggregatedTags={allTags}

--- a/root/entity/alias/AddOrEditAlias.js
+++ b/root/entity/alias/AddOrEditAlias.js
@@ -45,7 +45,6 @@ const AddOrEditAlias = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       fullWidth
       title={header}

--- a/root/entity/alias/DeleteAlias.js
+++ b/root/entity/alias/DeleteAlias.js
@@ -35,7 +35,6 @@ const DeleteAlias = ({
 
   return (
     <LayoutComponent
-      $c={$c}
       entity={entity}
       fullWidth
       title={header}

--- a/root/event/EventIndex.js
+++ b/root/event/EventIndex.js
@@ -20,7 +20,6 @@ import * as manifest from '../static/manifest';
 import EventLayout from './EventLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +event: EventT,
   +numberOfRevisions: number,
@@ -28,7 +27,6 @@ type Props = {
 };
 
 const EventIndex = ({
-  $c,
   eligibleForCleanup,
   event,
   numberOfRevisions,
@@ -37,7 +35,7 @@ const EventIndex = ({
   const setlist = event.setlist;
 
   return (
-    <EventLayout $c={$c} entity={event} page="index">
+    <EventLayout entity={event} page="index">
       {eligibleForCleanup ? (
         <CleanupBanner entityType="event" />
       ) : null}

--- a/root/event/EventLayout.js
+++ b/root/event/EventLayout.js
@@ -15,7 +15,6 @@ import EventSidebar from '../layout/components/sidebar/EventSidebar';
 import EventHeader from './EventHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: EventT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const EventLayout = ({
-  $c,
   children,
   entity: event,
   fullWidth = false,
@@ -32,7 +30,6 @@ const EventLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(event.name, title) : event.name}
   >
     <div id="content">

--- a/root/event/EventMerge.js
+++ b/root/event/EventMerge.js
@@ -28,7 +28,7 @@ const EventMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge events')}>
+  <Layout fullWidth title={l('Merge events')}>
     <div id="content">
       <h1>{l('Merge events')}</h1>
       <p>

--- a/root/genre/CreateGenre.js
+++ b/root/genre/CreateGenre.js
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const CreateGenre = ({$c, form}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Add a new genre')}>
+  <Layout fullWidth title={l('Add a new genre')}>
     <div id="content">
       <h1>{l('Add a new genre')}</h1>
       <GenreEditForm $c={$c} form={form} />

--- a/root/genre/DeleteGenre.js
+++ b/root/genre/DeleteGenre.js
@@ -24,7 +24,6 @@ const DeleteGenre = ({
   genre,
 }: Props): React.Element<typeof GenreLayout> => (
   <GenreLayout
-    $c={$c}
     entity={genre}
     fullWidth
     page="delete"

--- a/root/genre/EditGenre.js
+++ b/root/genre/EditGenre.js
@@ -25,7 +25,6 @@ const EditGenre = ({
   genre,
 }: Props): React.Element<typeof GenreLayout> => (
   <GenreLayout
-    $c={$c}
     entity={genre}
     fullWidth
     page="edit"

--- a/root/genre/GenreIndex.js
+++ b/root/genre/GenreIndex.js
@@ -14,16 +14,13 @@ import TagLink from '../static/scripts/common/components/TagLink';
 import GenreLayout from './GenreLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +genre: GenreT,
 };
 
 const GenreIndex = ({
-  $c,
   genre,
 }: Props): React.Element<typeof GenreLayout> => (
   <GenreLayout
-    $c={$c}
     entity={genre}
     page="index"
     title={l('Genre information')}

--- a/root/genre/GenreLayout.js
+++ b/root/genre/GenreLayout.js
@@ -15,7 +15,6 @@ import GenreSidebar from '../layout/components/sidebar/GenreSidebar';
 import GenreHeader from './GenreHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: GenreT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const GenreLayout = ({
-  $c,
   children,
   entity: genre,
   fullWidth = false,
@@ -32,7 +30,6 @@ const GenreLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(genre.name, title) : genre.name}
   >
     <div id="content">

--- a/root/genre/GenreListPage.js
+++ b/root/genre/GenreListPage.js
@@ -13,15 +13,13 @@ import Layout from '../layout';
 import EntityLink from '../static/scripts/common/components/EntityLink';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +genres: $ReadOnlyArray<GenreT>,
 };
 
 const GenreListPage = ({
-  $c,
   genres,
 }: PropsT): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Genre List')}>
+  <Layout fullWidth title={l('Genre List')}>
     <div id="content">
       <h1>{l('Genre List')}</h1>
       <p>

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -31,7 +31,6 @@ const InstrumentArtists = ({
   pager,
 }: Props): React.Element<typeof InstrumentLayout> => (
   <InstrumentLayout
-    $c={$c}
     entity={instrument}
     page="artists"
     title={l('Artists')}

--- a/root/instrument/InstrumentIndex.js
+++ b/root/instrument/InstrumentIndex.js
@@ -19,19 +19,17 @@ import * as manifest from '../static/manifest';
 import InstrumentLayout from './InstrumentLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +instrument: InstrumentT,
   +numberOfRevisions: number,
   +wikipediaExtract: WikipediaExtractT | null,
 };
 
 const InstrumentIndex = ({
-  $c,
   instrument,
   numberOfRevisions,
   wikipediaExtract,
 }: Props): React.Element<typeof InstrumentLayout> => (
-  <InstrumentLayout $c={$c} entity={instrument} page="index">
+  <InstrumentLayout entity={instrument} page="index">
     {instrument.description ? (
       <>
         <h2>{l('Description')}</h2>

--- a/root/instrument/InstrumentLayout.js
+++ b/root/instrument/InstrumentLayout.js
@@ -18,7 +18,6 @@ import localizeInstrumentName
 import InstrumentHeader from './InstrumentHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: InstrumentT,
   +fullWidth?: boolean,
@@ -27,7 +26,6 @@ type Props = {
 };
 
 const InstrumentLayout = ({
-  $c,
   children,
   entity: instrument,
   fullWidth = false,
@@ -42,7 +40,6 @@ const InstrumentLayout = ({
   });
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title)
         ? hyphenateTitle(nameWithType, title)
         : nameWithType}

--- a/root/instrument/InstrumentMerge.js
+++ b/root/instrument/InstrumentMerge.js
@@ -28,7 +28,7 @@ const InstrumentMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge instruments')}>
+  <Layout fullWidth title={l('Merge instruments')}>
     <div id="content">
       <h1>{l('Merge instruments')}</h1>
       <p>

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -31,7 +31,6 @@ const InstrumentRecordings = ({
   recordings,
 }: Props): React.Element<typeof InstrumentLayout> => (
   <InstrumentLayout
-    $c={$c}
     entity={instrument}
     page="recordings"
     title={l('Recordings')}

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -31,7 +31,6 @@ const InstrumentReleases = ({
   releases,
 }: Props): React.Element<typeof InstrumentLayout> => (
   <InstrumentLayout
-    $c={$c}
     entity={instrument}
     page="releases"
     title={l('Releases')}

--- a/root/instrument/List.js
+++ b/root/instrument/List.js
@@ -14,7 +14,6 @@ import EntityLink from '../static/scripts/common/components/EntityLink';
 import expand2react from '../static/scripts/common/i18n/expand2react';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +instrument_types: $ReadOnlyArray<InstrumentTypeT>,
   +instruments_by_type: {
     +[typeId: number]: $ReadOnlyArray<InstrumentT>,
@@ -37,14 +36,13 @@ const Instrument = ({instrument}) => (
 );
 
 const InstrumentList = ({
-  $c,
   instrument_types: instrumentTypes,
   instruments_by_type: instrumentsByType,
 }: PropsT): React.Element<typeof Layout> => {
   const unknown = instrumentsByType.unknown;
 
   return (
-    <Layout $c={$c} fullWidth title={l('Instrument List')}>
+    <Layout fullWidth title={l('Instrument List')}>
       <div id="content">
         <h1>{l('Instrument List')}</h1>
         {instrumentTypes.map(type => (

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -34,7 +34,6 @@ const Index = ({
   const isrc = isrcs[0];
   return (
     <Layout
-      $c={$c}
       fullWidth
       title={texp.l('ISRC “{isrc}”', {isrc: isrc.isrc})}
     >

--- a/root/iswc/Index.js
+++ b/root/iswc/Index.js
@@ -25,7 +25,6 @@ const Index = ({$c, iswcs, works}: Props): React.Element<typeof Layout> => {
   const iswc = iswcs[0];
   return (
     <Layout
-      $c={$c}
       fullWidth
       title={texp.l('ISWC “{iswc}”', {iswc: iswc.iswc})}
     >

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -41,7 +41,7 @@ const LabelIndex = ({
   releases,
   wikipediaExtract,
 }: Props): React.Element<typeof LabelLayout> => (
-  <LabelLayout $c={$c} entity={label} page="index">
+  <LabelLayout entity={label} page="index">
     {eligibleForCleanup ? (
       <CleanupBanner entityType="label" />
     ) : null}

--- a/root/label/LabelLayout.js
+++ b/root/label/LabelLayout.js
@@ -15,7 +15,6 @@ import LabelSidebar from '../layout/components/sidebar/LabelSidebar';
 import LabelHeader from './LabelHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: LabelT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const LabelLayout = ({
-  $c,
   children,
   entity: label,
   fullWidth = false,
@@ -32,7 +30,6 @@ const LabelLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(label.name, title) : label.name}
   >
     <div id="content">

--- a/root/label/LabelMerge.js
+++ b/root/label/LabelMerge.js
@@ -28,7 +28,7 @@ const LabelMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge labels')}>
+  <Layout fullWidth title={l('Merge labels')}>
     <div id="content">
       <h1>{l('Merge labels')}</h1>
       <p>

--- a/root/label/LabelRelationships.js
+++ b/root/label/LabelRelationships.js
@@ -29,7 +29,6 @@ const LabelRelationships = ({
   pager,
 }: Props): React.Element<typeof LabelLayout> => (
   <LabelLayout
-    $c={$c}
     entity={label}
     page="relationships"
     title={l('Relationships')}

--- a/root/label/SpecialPurpose.js
+++ b/root/label/SpecialPurpose.js
@@ -12,16 +12,13 @@ import * as React from 'react';
 import LabelLayout from './LabelLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +label: LabelT,
 };
 
 const SpecialPurpose = ({
-  $c,
   label,
 }: Props): React.Element<typeof LabelLayout> => (
   <LabelLayout
-    $c={$c}
     entity={label}
     fullWidth
     page="special_purpose"

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context';
 import {formatUserDateObject} from '../utility/formatUserDate';
 import getRequestCookie from '../utility/getRequestCookie';
 import {RT_SLAVE} from '../static/scripts/common/constants';
@@ -105,143 +106,149 @@ const ServerDetailsBanner = () => {
 
 export type Props = $ReadOnly<{
   ...HeadProps,
-  +$c: CatalystContextT,
   children: React$Node,
   fullWidth?: boolean,
 }>;
 
 const Layout = ({
-  $c,
   children,
   fullWidth = false,
   homepage = false,
   noIcons,
   pager,
   title,
-}: Props): React.Element<'html'> => (
-  <html lang={$c.stash.current_language_html}>
-    <Head
-      homepage={homepage}
-      noIcons={noIcons}
-      pager={pager}
-      title={title}
-    />
+}: Props): React.Element<'html'> => {
+  const $c = React.useContext(CatalystContext);
 
-    <body>
-      <Header />
+  return (
+    <html lang={$c.stash.current_language_html}>
+      <Head
+        homepage={homepage}
+        noIcons={noIcons}
+        pager={pager}
+        title={title}
+      />
 
-      {isEditingDisabled($c.user) || isAddingNotesDisabled($c.user) ? (
-        <div className="banner editing-disabled">
-          <p>
-            {isEditingDisabled($c.user) ? (
-              isAddingNotesDisabled($c.user) ? (
-                exp.l(
-                  `You’re currently not allowed to edit, vote or leave edit
-                   notes because an admin has revoked your privileges.
-                   If you haven’t already been contacted
-                   about why, please {uri|send us a message}.`,
-                  {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
+      <body>
+        <Header />
+
+        {isEditingDisabled($c.user) || isAddingNotesDisabled($c.user) ? (
+          <div className="banner editing-disabled">
+            <p>
+              {isEditingDisabled($c.user) ? (
+                isAddingNotesDisabled($c.user) ? (
+                  exp.l(
+                    `You’re currently not allowed to edit, vote or leave edit
+                     notes because an admin has revoked your privileges.
+                     If you haven’t already been contacted
+                     about why, please {uri|send us a message}.`,
+                    {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
+                  )
+                ) : (
+                  exp.l(
+                    `You’re currently not allowed to edit or vote because an
+                     admin has revoked your privileges. If you haven’t already
+                     been contacted about why,
+                     please {uri|send us a message}.`,
+                    {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
+                  )
                 )
               ) : (
                 exp.l(
-                  `You’re currently not allowed to edit or vote because an
-                   admin has revoked your privileges. If you haven’t already
-                   been contacted about why, please {uri|send us a message}.`,
+                  `You’re currently not allowed to leave edit notes because
+                   an admin has revoked your privileges. If you haven’t
+                   already been contacted about why,
+                   please {uri|send us a message}.`,
                   {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
                 )
-              )
-            ) : (
-              exp.l(
-                `You’re currently not allowed to leave edit notes because
-                 an admin has revoked your privileges. If you haven’t already
-                 been contacted about why, please {uri|send us a message}.`,
-                {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
-              )
-            )}
-          </p>
-        </div>
-      ) : null}
-
-      {!getRequestCookie($c.req, 'server_details_dismissed_mtime') &&
-        <ServerDetailsBanner />}
-
-      {!!(nonEmpty($c.stash.alert) && ($c.stash.alert_mtime ?? Infinity) >
-        Number(getRequestCookie($c.req, 'alert_dismissed_mtime', '0'))) &&
-        <div className="banner warning-header">
-          <p dangerouslySetInnerHTML={{__html: $c.stash.alert}} />
-          <DismissBannerButton bannerName="alert" />
-        </div>}
-
-      {!!DBDefs.DB_READ_ONLY &&
-        <div className="banner server-details">
-          <p>
-            {l(
-              `The server is temporarily in read-only mode
-               for database maintenance.`,
-            )}
-          </p>
-        </div>}
-
-      {showBirthdayBanner($c) &&
-        <div className="banner birthday-message">
-          <p>
-            <BirthdayCakes />
-            {' '}
-            {l('Happy birthday, and thanks for contributing to MusicBrainz!')}
-            {' '}
-            <BirthdayCakes />
-          </p>
-          <DismissBannerButton bannerName="birthday_message" />
-        </div>}
-
-      {!!($c.stash.new_edit_notes /*:: === true */ &&
-          ($c.stash.new_edit_notes_mtime ?? Infinity) >
-          Number(
-            getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', '0'),
-          ) &&
-          ($c.user?.is_limited ||
-          getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !==
-          'false')) &&
-          <div className="banner new-edit-notes">
-            <p>
-              {exp.l(
-                `{link|New notes} have been left on some of your edits.
-                 Please make sure to read them and respond if necessary.`,
-                {link: '/edit/notes-received'},
               )}
             </p>
-            <DismissBannerButton bannerName="new_edit_notes" />
+          </div>
+        ) : null}
+
+        {!getRequestCookie($c.req, 'server_details_dismissed_mtime') &&
+          <ServerDetailsBanner />}
+
+        {!!(nonEmpty($c.stash.alert) && ($c.stash.alert_mtime ?? Infinity) >
+          Number(getRequestCookie($c.req, 'alert_dismissed_mtime', '0'))) &&
+          <div className="banner warning-header">
+            <p dangerouslySetInnerHTML={{__html: $c.stash.alert}} />
+            <DismissBannerButton bannerName="alert" />
           </div>}
 
-      {!!$c.stash.makes_no_changes /*:: === true */ &&
-        <div className="banner warning-header">
-          <p>
-            {l(
-              `The data you have submitted does not make any changes
-               to the data already present.`,
-            )}
-          </p>
-        </div>}
+        {!!DBDefs.DB_READ_ONLY &&
+          <div className="banner server-details">
+            <p>
+              {l(
+                `The server is temporarily in read-only mode
+                 for database maintenance.`,
+              )}
+            </p>
+          </div>}
 
-      {!!(nonEmpty($c.sessionid) && nonEmpty($c.flash.message)) &&
-        <div className="banner flash">
-          <p dangerouslySetInnerHTML={{__html: $c.flash.message}} />
-        </div>}
+        {showBirthdayBanner($c) &&
+          <div className="banner birthday-message">
+            <p>
+              <BirthdayCakes />
+              {' '}
+              {l(`Happy birthday, and thanks
+                  for contributing to MusicBrainz!`)}
+              {' '}
+              <BirthdayCakes />
+            </p>
+            <DismissBannerButton bannerName="birthday_message" />
+          </div>}
 
-      <div
-        className={(fullWidth ? 'fullwidth ' : '') +
-          (homepage ? 'homepage' : '')}
-        id="page"
-      >
-        {children}
-      </div>
+        {!!($c.stash.new_edit_notes /*:: === true */ &&
+            ($c.stash.new_edit_notes_mtime ?? Infinity) >
+            Number(
+              getRequestCookie($c.req, 'new_edit_notes_dismissed_mtime', '0'),
+            ) &&
+            ($c.user?.is_limited ||
+            getRequestCookie($c.req, 'alert_new_edit_notes', 'true') !==
+            'false')) &&
+            <div className="banner new-edit-notes">
+              <p>
+                {exp.l(
+                  `{link|New notes} have been left on some of your edits.
+                   Please make sure to read them and respond if necessary.`,
+                  {link: '/edit/notes-received'},
+                )}
+              </p>
+              <DismissBannerButton bannerName="new_edit_notes" />
+            </div>}
 
-      {($c.session?.merger && !$c.stash.hide_merge_helper /*:: === true */) &&
-        <MergeHelper merger={$c.session.merger} />}
+        {!!$c.stash.makes_no_changes /*:: === true */ &&
+          <div className="banner warning-header">
+            <p>
+              {l(
+                `The data you have submitted does not make any changes
+                 to the data already present.`,
+              )}
+            </p>
+          </div>}
 
-      <Footer />
-    </body>
-  </html>
-);
+        {!!(nonEmpty($c.sessionid) && nonEmpty($c.flash.message)) &&
+          <div className="banner flash">
+            <p dangerouslySetInnerHTML={{__html: $c.flash.message}} />
+          </div>}
+
+        <div
+          className={(fullWidth ? 'fullwidth ' : '') +
+            (homepage ? 'homepage' : '')}
+          id="page"
+        >
+          {children}
+        </div>
+
+        {($c.session?.merger &&
+          !$c.stash.hide_merge_helper /*:: === true */) &&
+          <MergeHelper merger={$c.session.merger} />}
+
+        <Footer />
+      </body>
+    </html>
+  );
+};
 
 export default Layout;

--- a/root/main/ConfirmSeed.js
+++ b/root/main/ConfirmSeed.js
@@ -30,7 +30,7 @@ const ConfirmSeed = ({
 }: Props): React.Element<typeof Layout> => {
   const title = l('Confirm Form Submission');
   return (
-    <Layout $c={$c} fullWidth title={title}>
+    <Layout fullWidth title={title}>
       <h1>{title}</h1>
       <p>
         {exp.l(

--- a/root/main/error/Error400.js
+++ b/root/main/error/Error400.js
@@ -26,7 +26,7 @@ const Error400 = ({
   message,
   useLanguages,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Bad Request')}>
+  <ErrorLayout title={l('Bad Request')}>
     <p>
       <strong>
         {l('Sorry, there was a problem with your request.')}

--- a/root/main/error/Error401.js
+++ b/root/main/error/Error401.js
@@ -18,7 +18,7 @@ type Props = {
 const Error401 = ({
   $c,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Unauthorized Request')}>
+  <ErrorLayout title={l('Unauthorized Request')}>
     <p>
       <strong>
         {l('Sorry, you are not authorized to view this page.')}

--- a/root/main/error/Error403.js
+++ b/root/main/error/Error403.js
@@ -20,7 +20,7 @@ type Props = {
 const Error403 = ({
   $c,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Forbidden Request')}>
+  <ErrorLayout title={l('Forbidden Request')}>
     <p>
       <strong>
         {l('The page you requested is private.')}

--- a/root/main/error/Error404.js
+++ b/root/main/error/Error404.js
@@ -27,7 +27,7 @@ const Error404 = ({
   $c,
   message,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Page Not Found')}>
+  <ErrorLayout title={l('Page Not Found')}>
     <p>
       <strong>
         {l(`Sorry, the page you're looking for does not exist.`)}

--- a/root/main/error/Error500.js
+++ b/root/main/error/Error500.js
@@ -32,7 +32,7 @@ const Error500 = ({
   hostname,
   useLanguages,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Internal Server Error')}>
+  <ErrorLayout title={l('Internal Server Error')}>
     <p>
       <strong>
         {l('Oops, something went wrong!')}

--- a/root/main/error/Error503.js
+++ b/root/main/error/Error503.js
@@ -11,14 +11,8 @@ import * as React from 'react';
 
 import ErrorLayout from './ErrorLayout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const Error503 = ({
-  $c,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('System Busy')}>
+const Error503 = (): React.Element<typeof ErrorLayout> => (
+  <ErrorLayout title={l('System Busy')}>
     <p>
       <strong>
         {l('The system is overloaded or you are making requests too fast.')}

--- a/root/main/error/ErrorLayout.js
+++ b/root/main/error/ErrorLayout.js
@@ -12,17 +12,15 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +title: string,
 };
 
 const ErrorLayout = ({
-  $c,
   children,
   title,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={title}>
+  <Layout fullWidth title={title}>
     <div id="content">
       <h1>{title}</h1>
       {children}

--- a/root/main/error/MirrorError403.js
+++ b/root/main/error/MirrorError403.js
@@ -11,14 +11,8 @@ import * as React from 'react';
 
 import ErrorLayout from './ErrorLayout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const MirrorError403 = ({
-  $c,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Forbidden Request')}>
+const MirrorError403 = (): React.Element<typeof ErrorLayout> => (
+  <ErrorLayout title={l('Forbidden Request')}>
     <p>
       <strong>
         {l(`Sorry, you are unable to perform that action

--- a/root/main/error/MirrorError404.js
+++ b/root/main/error/MirrorError404.js
@@ -11,15 +11,8 @@ import * as React from 'react';
 
 import ErrorLayout from './ErrorLayout';
 
-type Props = {
-  +$c: CatalystContextT,
-  +message?: string,
-};
-
-const MirrorError404 = ({
-  $c,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Page Not Found')}>
+const MirrorError404 = (): React.Element<typeof ErrorLayout> => (
+  <ErrorLayout title={l('Page Not Found')}>
     <p>
       <strong>
         {l(`Sorry, the page you're looking for

--- a/root/main/error/TimeoutError.js
+++ b/root/main/error/TimeoutError.js
@@ -26,7 +26,7 @@ const TimeoutError = ({
   hostname,
   useLanguages,
 }: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout $c={$c} title={l('Request Timed Out')}>
+  <ErrorLayout title={l('Request Timed Out')}>
     <p>
       <strong>
         {l('Processing your request took too long and timed out.')}

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -18,18 +18,15 @@ import {reduceArtistCredit}
 import entityHref from '../static/scripts/common/utility/entityHref';
 
 type Props = {
-  +$c: CatalystContextT,
   +blogEntries: $ReadOnlyArray<BlogEntryT> | null,
   +newestReleases: $ReadOnlyArray<ArtworkT>,
 };
 
 const Homepage = ({
-  $c,
   blogEntries,
   newestReleases,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     fullWidth
     homepage
     title={l('MusicBrainz - The Open Music Encyclopedia')}

--- a/root/oauth2/OAuth2Authorize.js
+++ b/root/oauth2/OAuth2Authorize.js
@@ -28,7 +28,7 @@ const OAuth2Authorize = ({
   offline,
   permissions,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('OAuth Authorization')}>
+  <Layout fullWidth title={l('OAuth Authorization')}>
     <h1>{l('Authorization')}</h1>
 
     <p>

--- a/root/oauth2/OAuth2Error.js
+++ b/root/oauth2/OAuth2Error.js
@@ -12,17 +12,15 @@ import * as React from 'react';
 import Layout from '../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +errorDescription: string,
   +errorMessage: string,
 };
 
 const OAuth2Error = ({
-  $c,
   errorDescription,
   errorMessage,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('OAuth Authorization Error')}>
+  <Layout fullWidth title={l('OAuth Authorization Error')}>
     <h1>{texp.l('Error: {error}', {error: errorMessage})}</h1>
     <p>{errorDescription}</p>
     <p>{exp.l('{doc|Learn more}', {doc: '/doc/Development/OAuth2'})}</p>

--- a/root/oauth2/OAuth2Oob.js
+++ b/root/oauth2/OAuth2Oob.js
@@ -12,17 +12,15 @@ import * as React from 'react';
 import Layout from '../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +application: ApplicationT,
   +code: string,
 };
 
 const OAuth2Oob = ({
-  $c,
   application,
   code,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('OAuth Authorization')}>
+  <Layout fullWidth title={l('OAuth Authorization')}>
     <h1>{l('Success!')}</h1>
     <p>
       {texp.l(

--- a/root/otherlookup/OtherLookupIndex.js
+++ b/root/otherlookup/OtherLookupIndex.js
@@ -15,15 +15,13 @@ import OtherLookupForm from './OtherLookupForm';
 import type {OtherLookupFormT} from './types';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: OtherLookupFormT,
 };
 
 const OtherLookupIndex = ({
-  $c,
   form,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Other Lookups')}>
+  <Layout fullWidth title={l('Other Lookups')}>
     <div className="content">
       <h1>{l('Other Lookups')}</h1>
       <OtherLookupForm form={form} />

--- a/root/otherlookup/OtherLookupReleaseResults.js
+++ b/root/otherlookup/OtherLookupReleaseResults.js
@@ -13,17 +13,15 @@ import Layout from '../layout';
 import ReleaseList from '../components/list/ReleaseList';
 
 type Props = {
-  +$c: CatalystContextT,
   +pager: PagerT,
   +query: string,
   +results: $ReadOnlyArray<ReleaseT>,
 };
 
 const OtherLookupReleaseResults = ({
-  $c,
   results,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Search Results')}>
+  <Layout fullWidth title={l('Search Results')}>
     <h1>{l('Search Results')}</h1>
     {results.length ? (
       <ReleaseList

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -28,7 +28,7 @@ const PlaceEvents = ({
   pager,
   place,
 }: Props): React.Element<typeof PlaceLayout> => (
-  <PlaceLayout $c={$c} entity={place} page="events" title={l('Events')}>
+  <PlaceLayout entity={place} page="events" title={l('Events')}>
     <h2>{l('Events')}</h2>
 
     {events.length > 0 ? (

--- a/root/place/PlaceIndex.js
+++ b/root/place/PlaceIndex.js
@@ -19,7 +19,6 @@ import * as manifest from '../static/manifest';
 import PlaceLayout from './PlaceLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +numberOfRevisions: number,
   +place: PlaceT,
@@ -27,13 +26,12 @@ type Props = {
 };
 
 const PlaceIndex = ({
-  $c,
   eligibleForCleanup,
   numberOfRevisions,
   place,
   wikipediaExtract,
 }: Props): React.Element<typeof PlaceLayout> => (
-  <PlaceLayout $c={$c} entity={place} page="index">
+  <PlaceLayout entity={place} page="index">
     {eligibleForCleanup ? (
       <CleanupBanner entityType="place" />
     ) : null}

--- a/root/place/PlaceLayout.js
+++ b/root/place/PlaceLayout.js
@@ -15,7 +15,6 @@ import PlaceSidebar from '../layout/components/sidebar/PlaceSidebar';
 import PlaceHeader from './PlaceHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: PlaceT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const PlaceLayout = ({
-  $c,
   children,
   entity: place,
   fullWidth = false,
@@ -32,7 +30,6 @@ const PlaceLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(place.name, title) : place.name}
   >
     <div id="content">

--- a/root/place/PlaceMap.js
+++ b/root/place/PlaceMap.js
@@ -15,7 +15,6 @@ import DBDefs from '../static/scripts/common/DBDefs-client';
 import PlaceLayout from './PlaceLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +mapDataArgs: {
     +draggable: boolean,
     +place: {
@@ -27,11 +26,10 @@ type Props = {
 };
 
 const PlaceMap = ({
-  $c,
   mapDataArgs,
   place,
 }: Props): React.Element<typeof PlaceLayout> => (
-  <PlaceLayout $c={$c} entity={place} page="map" title={l('Map')}>
+  <PlaceLayout entity={place} page="map" title={l('Map')}>
     {place.coordinates ? (
       DBDefs.MAPBOX_ACCESS_TOKEN ? (
         <>

--- a/root/place/PlaceMerge.js
+++ b/root/place/PlaceMerge.js
@@ -28,7 +28,7 @@ const PlaceMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge places')}>
+  <Layout fullWidth title={l('Merge places')}>
     <div id="content">
       <h1>{l('Merge places')}</h1>
       <p>

--- a/root/place/PlacePerformances.js
+++ b/root/place/PlacePerformances.js
@@ -27,7 +27,6 @@ const PlacePerformances = ({
   place,
 }: Props): React.Element<typeof PlaceLayout> => (
   <PlaceLayout
-    $c={$c}
     entity={place}
     page="performances"
     title={l('Performances')}

--- a/root/recording/RecordingFingerprints.js
+++ b/root/recording/RecordingFingerprints.js
@@ -15,16 +15,13 @@ import FingerprintTable
 import RecordingLayout from './RecordingLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +recording: RecordingWithArtistCreditT,
 };
 
 const RecordingFingerprints = ({
-  $c,
   recording,
 }: Props): React.Element<typeof RecordingLayout> => (
   <RecordingLayout
-    $c={$c}
     entity={recording}
     page="fingerprints"
     title={l('Fingerprints')}

--- a/root/recording/RecordingIndex.js
+++ b/root/recording/RecordingIndex.js
@@ -152,7 +152,7 @@ const RecordingIndex = ({
   recording,
   tracks,
 }: Props): React.Element<typeof RecordingLayout> => (
-  <RecordingLayout $c={$c} entity={recording} page="index">
+  <RecordingLayout entity={recording} page="index">
     <Annotation
       annotation={recording.latest_annotation}
       collapse

--- a/root/recording/RecordingLayout.js
+++ b/root/recording/RecordingLayout.js
@@ -18,7 +18,6 @@ import {
 import RecordingHeader from './RecordingHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: RecordingWithArtistCreditT,
   +fullWidth?: boolean,
@@ -27,7 +26,6 @@ type Props = {
 };
 
 const RecordingLayout = ({
-  $c,
   children,
   entity: recording,
   fullWidth = false,
@@ -43,7 +41,6 @@ const RecordingLayout = ({
     : texp.l('Recording “{name}” by {artist}', titleArgs);
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title) ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -31,7 +31,7 @@ const RecordingMerge = ({
   isrcsDiffer = false,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge recordings')}>
+  <Layout fullWidth title={l('Merge recordings')}>
     <div id="content">
       <h1>{l('Merge recordings')}</h1>
       <p>

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
@@ -12,15 +12,13 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +type: LinkAttrTypeT,
 };
 
 const RelationshipAttributeTypeInUse = ({
-  $c,
   type,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Relationship attribute in use')}>
+  <Layout fullWidth title={l('Relationship attribute in use')}>
     <div className="content">
       <h1>{l('Relationship attribute in use')}</h1>
       <p>

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -77,7 +77,7 @@ const RelationshipAttributeTypeIndex = ({
     : linkedEntities.link_attribute_type[attribute.parent_id];
 
   return (
-    <Layout $c={$c} fullWidth noIcons title={title}>
+    <Layout fullWidth noIcons title={title}>
       <div id="content">
         <h1 className="hierarchy-links">
           <a href="/relationship-attributes">

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -169,7 +169,7 @@ const RelationshipAttributeTypesList = ({
   $c,
   root,
 }: AttributesListProps): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth noIcons title={l('Relationship Attributes')}>
+  <Layout fullWidth noIcons title={l('Relationship Attributes')}>
     <div id="content">
       <RelationshipsHeader page="attributes" />
       {isRelationshipEditor($c.user) ? (

--- a/root/relationship/linktype/RelationshipTypeInUse.js
+++ b/root/relationship/linktype/RelationshipTypeInUse.js
@@ -12,15 +12,13 @@ import * as React from 'react';
 import Layout from '../../layout';
 
 type Props = {
-  +$c: CatalystContextT,
   +type: LinkTypeT,
 };
 
 const RelationshipTypeInUse = ({
-  $c,
   type,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Relationship Type In Use')}>
+  <Layout fullWidth title={l('Relationship Type In Use')}>
     <div className="content">
       <h1>{l('Relationship Type In Use')}</h1>
       <p>

--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -54,7 +54,7 @@ const RelationshipTypeIndex = ({
   let lastExampleName = '';
 
   return (
-    <Layout $c={$c} fullWidth noIcons title={title}>
+    <Layout fullWidth noIcons title={title}>
       <div id="content">
         <h1 className="hierarchy-links">
           <a href="/relationships">

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -167,7 +167,6 @@ const RelationshipTypePairTree = ({
 
   return (
     <Layout
-      $c={$c}
       fullWidth
       noIcons
       title={texp.l(

--- a/root/relationship/linktype/RelationshipTypesList.js
+++ b/root/relationship/linktype/RelationshipTypesList.js
@@ -15,7 +15,6 @@ import formatEntityTypeName
 import RelationshipsHeader from '../RelationshipsHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +table: $ReadOnlyArray<$ReadOnlyArray<$ReadOnlyArray<string>>>,
   +types: $ReadOnlyArray<string>,
 };
@@ -57,14 +56,13 @@ const TypesTable = ({table, types}: Props) => (
 );
 
 const RelationshipTypesList = ({
-  $c,
   table,
   types,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth noIcons title={l('Relationship Types')}>
+  <Layout fullWidth noIcons title={l('Relationship Types')}>
     <div className="wikicontent" id="content">
       <RelationshipsHeader page="relationships" />
-      <TypesTable $c={$c} table={table} types={types} />
+      <TypesTable table={table} types={types} />
     </div>
   </Layout>
 );

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -57,7 +57,7 @@ const CoverArt = ({
   const title = l('Cover Art');
 
   return (
-    <ReleaseLayout $c={$c} entity={release} page="cover-art" title={title}>
+    <ReleaseLayout entity={release} page="cover-art" title={title}>
       <h2>
         {release.cover_art_presence === 'darkened'
           ? l('Cannot show cover art')

--- a/root/release/CoverArtDarkened.js
+++ b/root/release/CoverArtDarkened.js
@@ -12,18 +12,16 @@ import * as React from 'react';
 import ReleaseLayout from './ReleaseLayout';
 
 type Props = {
-  +$c: CatalystContextT,
   +release: ReleaseT,
 };
 
 const CoverArtDarkened = ({
-  $c,
   release,
 }: Props): React.Element<typeof ReleaseLayout> => {
   const title = l('Cannot Add Cover Art');
 
   return (
-    <ReleaseLayout $c={$c} entity={release} page="cover-art" title={title}>
+    <ReleaseLayout entity={release} page="cover-art" title={title}>
       <h2>{title}</h2>
       <p>
         {l(`The Cover Art Archive has had a takedown request in the past

--- a/root/release/ReleaseLayout.js
+++ b/root/release/ReleaseLayout.js
@@ -17,7 +17,6 @@ import {reduceArtistCredit}
 import ReleaseHeader from './ReleaseHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: ReleaseT,
   +fullWidth?: boolean,
@@ -26,7 +25,6 @@ type Props = {
 };
 
 const ReleaseLayout = ({
-  $c,
   children,
   entity: release,
   fullWidth = false,
@@ -39,7 +37,6 @@ const ReleaseLayout = ({
   });
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title) ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/release/RemoveCoverArt.js
+++ b/root/release/RemoveCoverArt.js
@@ -34,7 +34,7 @@ const RemoveCoverArt = ({
   const title = l('Remove Cover Art');
 
   return (
-    <ReleaseLayout $c={$c} entity={release} fullWidth title={title}>
+    <ReleaseLayout entity={release} fullWidth title={title}>
       <h2>{title}</h2>
       <p>
         {exp.l(

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -27,7 +27,6 @@ type Props = {
 };
 
 const ReleaseGroupLayout = ({
-  $c,
   children,
   entity: releaseGroup,
   fullWidth = false,
@@ -40,7 +39,6 @@ const ReleaseGroupLayout = ({
   });
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title) ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/release_group/ReleaseGroupMerge.js
+++ b/root/release_group/ReleaseGroupMerge.js
@@ -28,7 +28,7 @@ const ReleaseGroupMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge release groups')}>
+  <Layout fullWidth title={l('Merge release groups')}>
     <div id="content">
       <h1>{l('Merge release groups')}</h1>
       <p>

--- a/root/report/ReportNotAvailable.js
+++ b/root/report/ReportNotAvailable.js
@@ -11,14 +11,8 @@ import * as React from 'react';
 
 import Layout from '../layout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const ReportNotAvailable = ({
-  $c,
-}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Error')}>
+const ReportNotAvailable = (): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Error')}>
     <div id="content">
       <h1>{l('Error')}</h1>
 

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -37,7 +37,7 @@ const ReportsIndexEntry = ({
 );
 
 const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Reports')}>
+  <Layout fullWidth title={l('Reports')}>
     <div id="content">
       <h1>{l('Reports')}</h1>
 

--- a/root/report/components/ReportLayout.js
+++ b/root/report/components/ReportLayout.js
@@ -63,7 +63,7 @@ const ReportLayout = ({
   const $c = React.useContext(CatalystContext);
 
   return (
-    <Layout $c={$c} fullWidth title={title}>
+    <Layout fullWidth title={title}>
       <h1>{title}</h1>
 
       <ul>

--- a/root/search/SearchIndex.js
+++ b/root/search/SearchIndex.js
@@ -18,19 +18,17 @@ import type {TagLookupFormT} from '../taglookup/types';
 import SearchForm from './components/SearchForm';
 
 type Props = {
-  +$c: CatalystContextT,
   +otherLookupForm: OtherLookupFormT,
   +searchForm: SearchFormT,
   +tagLookupForm: TagLookupFormT,
 };
 
 const SearchIndex = ({
-  $c,
   otherLookupForm,
   searchForm,
   tagLookupForm,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Search')}>
+  <Layout fullWidth title={l('Search')}>
     <div id="content">
       <h1>{l('Search')}</h1>
       <SearchForm form={searchForm} />

--- a/root/search/components/AnnotationResults.js
+++ b/root/search/components/AnnotationResults.js
@@ -13,7 +13,7 @@ import EntityLink from '../../static/scripts/common/components/EntityLink';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
 import loopParity from '../../utility/loopParity';
-import type {ResultsPropsWithContextT} from '../types';
+import type {ResultsPropsT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
@@ -42,15 +42,14 @@ function buildResult(result, index) {
 }
 
 const AnnotationResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<AnnotationT>):
+}: ResultsPropsT<AnnotationT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -53,7 +53,7 @@ const AreaResults = ({
   results,
 }: ResultsPropsWithContextT<AreaT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -73,7 +73,7 @@ const ArtistResults = ({
   results,
 }: ResultsPropsWithContextT<ArtistT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <ArtistResultsInline
       pager={pager}
       query={query}

--- a/root/search/components/CDStubResults.js
+++ b/root/search/components/CDStubResults.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import CDStubLink from '../../static/scripts/common/components/CDStubLink';
 import loopParity from '../../utility/loopParity';
-import type {ResultsPropsWithContextT} from '../types';
+import type {ResultsPropsT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
@@ -32,15 +32,14 @@ function buildResult(result, index) {
 }
 
 const CDStubResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<CDStubT>):
+}: ResultsPropsT<CDStubT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/DocResults.js
+++ b/root/search/components/DocResults.js
@@ -12,12 +12,8 @@ import * as React from 'react';
 import Layout from '../../layout';
 import {GOOGLE_CUSTOM_SEARCH} from '../../static/scripts/common/DBDefs';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const DocResults = ({$c}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Documentation Search')}>
+const DocResults = (): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Documentation Search')}>
     <div className="wikicontent" id="content">
       <h1>{l('Documentation Search')}</h1>
       <script

--- a/root/search/components/EditorResults.js
+++ b/root/search/components/EditorResults.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import EditorLink from '../../static/scripts/common/components/EditorLink';
 import loopParity from '../../utility/loopParity';
-import type {ResultsPropsWithContextT} from '../types';
+import type {ResultsPropsT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
@@ -30,15 +30,14 @@ function buildResult(result, index) {
 }
 
 const EditorResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<EditorT>):
+}: ResultsPropsT<EditorT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -58,7 +58,7 @@ const EventResults = ({
   results,
 }: ResultsPropsWithContextT<EventT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -42,7 +42,7 @@ const InstrumentResults = ({
   results,
 }: ResultsPropsWithContextT<InstrumentT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={(result, index) => buildResult($c, result, index)}
       columns={

--- a/root/search/components/LabelResults.js
+++ b/root/search/components/LabelResults.js
@@ -56,7 +56,7 @@ const LabelResults = ({
   results,
 }: ResultsPropsWithContextT<LabelT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -53,7 +53,7 @@ const PlaceResults = ({
   results,
 }: ResultsPropsWithContextT<PlaceT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -155,7 +155,7 @@ const RecordingResults = ({
 React.Element<typeof ResultsLayout> => {
   linenum = 0;
   return (
-    <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
       <RecordingResultsInline
         pager={pager}
         query={query}

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -54,7 +54,7 @@ const ReleaseGroupResults = ({
   results,
 }: ResultsPropsWithContextT<ReleaseGroupT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -128,7 +128,7 @@ const ReleaseResults = ({
   results,
 }: ResultsPropsWithContextT<ReleaseT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <ReleaseResultsInline
       pager={pager}
       query={query}

--- a/root/search/components/ResultsLayout.js
+++ b/root/search/components/ResultsLayout.js
@@ -9,39 +9,42 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context';
 import Layout from '../../layout';
 import formatUserDate from '../../utility/formatUserDate';
 
 import SearchForm from './SearchForm';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +form: SearchFormT,
   +lastUpdated?: string,
 };
 
 const ResultsLayout = ({
-  $c,
   children,
   form,
   lastUpdated,
-}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Search Results')}>
-    <div id="content">
-      <h1>{l('Search Results')}</h1>
-      {nonEmpty(lastUpdated) ? (
-        <p>
-          {exp.l(
-            'Last updated: {date}',
-            {date: formatUserDate($c, lastUpdated)},
-          )}
-        </p>
-      ) : null}
-      {children}
-      <SearchForm form={form} />
-    </div>
-  </Layout>
-);
+}: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
+
+  return (
+    <Layout fullWidth title={l('Search Results')}>
+      <div id="content">
+        <h1>{l('Search Results')}</h1>
+        {nonEmpty(lastUpdated) ? (
+          <p>
+            {exp.l(
+              'Last updated: {date}',
+              {date: formatUserDate($c, lastUpdated)},
+            )}
+          </p>
+        ) : null}
+        {children}
+        <SearchForm form={form} />
+      </div>
+    </Layout>
+  );
+};
 
 export default ResultsLayout;

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -45,7 +45,7 @@ const SeriesResults = ({
   results,
 }: ResultsPropsWithContextT<SeriesT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/TagResults.js
+++ b/root/search/components/TagResults.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import TagLink from '../../static/scripts/common/components/TagLink';
 import loopParity from '../../utility/loopParity';
-import type {ResultsPropsWithContextT} from '../types';
+import type {ResultsPropsT} from '../types';
 
 import PaginatedSearchResults from './PaginatedSearchResults';
 import ResultsLayout from './ResultsLayout';
@@ -36,15 +36,14 @@ function buildResult(result, index) {
 }
 
 const TagResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<TagT>):
+}: ResultsPropsT<TagT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}
       columns={

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -42,7 +42,7 @@ const WorkResults = ({
   results,
 }: ResultsPropsWithContextT<WorkT>):
 React.Element<typeof ResultsLayout> => (
-  <ResultsLayout $c={$c} form={form} lastUpdated={lastUpdated}>
+  <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={(result, index) => buildResult(result, index)}
       columns={

--- a/root/series/SeriesIndex.js
+++ b/root/series/SeriesIndex.js
@@ -101,7 +101,6 @@ const listPicker = ({
 
 type SeriesIndexProps = {
   ...SeriesItemNumbersRoleT,
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +entities: ?$ReadOnlyArray<CoreEntityT>,
   +numberOfRevisions: number,
@@ -111,7 +110,6 @@ type SeriesIndexProps = {
 };
 
 const SeriesIndex = ({
-  $c,
   eligibleForCleanup,
   entities,
   numberOfRevisions,
@@ -123,7 +121,7 @@ const SeriesIndex = ({
   const seriesEntityType = series.type.item_entity_type;
   const existingEntities = entities?.length ? entities : null;
   return (
-    <SeriesLayout $c={$c} entity={series} page="index">
+    <SeriesLayout entity={series} page="index">
       {eligibleForCleanup ? (
         <CleanupBanner entityType="series" />
       ) : null}

--- a/root/series/SeriesLayout.js
+++ b/root/series/SeriesLayout.js
@@ -15,7 +15,6 @@ import SeriesSidebar from '../layout/components/sidebar/SeriesSidebar';
 import SeriesHeader from './SeriesHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: SeriesT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const SeriesLayout = ({
-  $c,
   children,
   entity: series,
   fullWidth = false,
@@ -32,7 +30,6 @@ const SeriesLayout = ({
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     title={nonEmpty(title) ? hyphenateTitle(series.name, title) : series.name}
   >
     <div id="content">

--- a/root/series/SeriesMerge.js
+++ b/root/series/SeriesMerge.js
@@ -28,7 +28,7 @@ const SeriesMerge = ({
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge series')}>
+  <Layout fullWidth title={l('Merge series')}>
     <div id="content">
       <h1>{l('Merge series')}</h1>
       <p>

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -36,7 +36,7 @@ const Countries = ({
   countryStats,
   dateCollected,
 }: CountriesStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout $c={$c} fullWidth page="countries" title={l('Countries')}>
+  <StatisticsLayout fullWidth page="countries" title={l('Countries')}>
     <p>
       {texp.l('Last updated: {date}',
               {date: dateCollected})}

--- a/root/statistics/CoverArt.js
+++ b/root/statistics/CoverArt.js
@@ -63,7 +63,7 @@ const CoverArt = ({
   stats,
   typeStats,
 }: CoverArtStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout $c={$c} fullWidth page="coverart" title={l('Cover Art')}>
+  <StatisticsLayout fullWidth page="coverart" title={l('Cover Art')}>
     <p>
       {texp.l('Last updated: {date}', {date: dateCollected})}
     </p>

--- a/root/statistics/Editors.js
+++ b/root/statistics/Editors.js
@@ -95,7 +95,7 @@ const Editors = ({
   topRecentlyActiveVoters,
   topVoters,
 }: EditorsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout $c={$c} fullWidth page="editors" title={l('Editors')}>
+  <StatisticsLayout fullWidth page="editors" title={l('Editors')}>
     <p>
       {texp.l('Last updated: {date}', {date: dateCollected})}
     </p>

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -33,7 +33,7 @@ const Edits = ({
   stats,
   statsByCategory,
 }: EditsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout $c={$c} fullWidth page="edits" title={l('Edits')}>
+  <StatisticsLayout fullWidth page="edits" title={l('Edits')}>
     <p>
       {texp.l('Last updated: {date}', {date: dateCollected})}
     </p>

--- a/root/statistics/Formats.js
+++ b/root/statistics/Formats.js
@@ -39,7 +39,6 @@ const Formats = ({
   stats,
 }: FormatsStatsT): React.Element<typeof StatisticsLayout> => (
   <StatisticsLayout
-    $c={$c}
     fullWidth
     page="formats"
     title={l('Release/Medium Formats')}

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -78,7 +78,7 @@ const Index = ({
   const _formatPercentage = (a, b) => formatPercentage($c, a / b, 1);
 
   return (
-    <StatisticsLayout $c={$c} fullWidth page="index" title={l('Overview')}>
+    <StatisticsLayout fullWidth page="index" title={l('Overview')}>
       <p>
         {texp.l('Last updated: {date}', {date: dateCollected})}
       </p>

--- a/root/statistics/LanguagesScripts.js
+++ b/root/statistics/LanguagesScripts.js
@@ -44,7 +44,6 @@ const LanguagesScripts = ({
   scriptStats,
 }: LanguagesScriptsStatsT): React.Element<typeof StatisticsLayout> => (
   <StatisticsLayout
-    $c={$c}
     fullWidth
     page="languages-scripts"
     title={l('Languages and Scripts')}

--- a/root/statistics/NoStatistics.js
+++ b/root/statistics/NoStatistics.js
@@ -13,14 +13,8 @@ import {l_statistics as l} from '../static/scripts/common/i18n/statistics';
 
 import StatisticsLayout from './StatisticsLayout';
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const NoStatistics = ({
-  $c,
-}: Props): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout $c={$c} fullWidth page="index" title={l('No Statistics')}>
+const NoStatistics = (): React.Element<typeof StatisticsLayout> => (
+  <StatisticsLayout fullWidth page="index" title={l('No Statistics')}>
     <h2>{l('No Statistics')}</h2>
     <p>
       {exp.l(

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -92,7 +92,6 @@ const Relationships = ({
   types,
 }: RelationshipsStatsT): React.Element<typeof StatisticsLayout> => (
   <StatisticsLayout
-    $c={$c}
     fullWidth
     page="relationships"
     title={l('Relationships')}

--- a/root/statistics/StatisticsLayout.js
+++ b/root/statistics/StatisticsLayout.js
@@ -17,7 +17,6 @@ import {l_statistics as l, N_l_statistics as N_l}
   from '../static/scripts/common/i18n/statistics';
 
 type StatisticsLayoutPropsT = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +fullWidth: boolean,
   +page: string,
@@ -89,7 +88,6 @@ const infoLinks = [
 ];
 
 const StatisticsLayout = ({
-  $c,
   children,
   fullWidth = false,
   page,
@@ -99,7 +97,6 @@ const StatisticsLayout = ({
   const htmlTitle = hyphenateTitle(l('Database Statistics'), title);
   return (
     <Layout
-      $c={$c}
       fullWidth={fullWidth}
       title={htmlTitle}
     >

--- a/root/tag/EntityList.js
+++ b/root/tag/EntityList.js
@@ -175,7 +175,7 @@ const EntityList = ({
   pager,
   tag,
 }: EntityListProps): React.Element<typeof TagLayout> => (
-  <TagLayout $c={$c} page={page} tag={tag}>
+  <TagLayout page={page} tag={tag}>
     <EntityListContent
       $c={$c}
       entityTags={entityTags}

--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -13,7 +13,6 @@ import Layout from '../layout';
 import TagLink from '../static/scripts/common/components/TagLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +tagMaxCount: number,
   +tags: $ReadOnlyArray<AggregatedTagT>,
 };
@@ -42,11 +41,10 @@ function getTagSize(count: number, tagMaxCount: number) {
 }
 
 const TagCloud = ({
-  $c,
   tagMaxCount,
   tags,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Tags')}>
+  <Layout fullWidth title={l('Tags')}>
     <div id="content">
       <h1>{l('Tags')}</h1>
       <p>

--- a/root/tag/TagIndex.js
+++ b/root/tag/TagIndex.js
@@ -33,7 +33,7 @@ type Props = {
 const TagIndex = (props: Props): React.Element<typeof TagLayout> => {
   const genre = props.tag.genre;
   return (
-    <TagLayout $c={props.$c} page="" tag={props.tag}>
+    <TagLayout page="" tag={props.tag}>
       {genre ? (
         <>
           <h2>{l('Genre')}</h2>

--- a/root/tag/TagLayout.js
+++ b/root/tag/TagLayout.js
@@ -14,7 +14,6 @@ import Layout from '../layout';
 import TagLink from '../static/scripts/common/components/TagLink';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +page: string,
   +tag: TagT,
@@ -37,14 +36,12 @@ const tabLinks: $ReadOnlyArray<[string, () => string]> = [
 ];
 
 const TagLayout = ({
-  $c,
   children,
   page,
   tag,
   title,
 }: Props): React.Element<typeof Layout> => (
   <Layout
-    $c={$c}
     fullWidth
     title={
       nonEmpty(title)

--- a/root/taglookup/Index.js
+++ b/root/taglookup/Index.js
@@ -16,7 +16,7 @@ import type {TagLookupPropsT} from './types';
 import TagLookupNagSection from './Nag';
 
 const TagLookup = (props: TagLookupPropsT): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Tag Lookup')}>
+  <Layout fullWidth title={l('Tag Lookup')}>
     <div className="content">
       <h1>{l('Tag Lookup')}</h1>
       {props.nag ? <TagLookupNagSection /> : null}

--- a/root/taglookup/Results.js
+++ b/root/taglookup/Results.js
@@ -18,7 +18,7 @@ import type {TagLookupResultsPropsT} from './types';
 const TagLookupResults = <T>(
   props: TagLookupResultsPropsT<T>,
 ): React.Element<typeof Layout> => (
-  <Layout $c={props.$c} fullWidth title={l('Tag Lookup Results')}>
+  <Layout fullWidth title={l('Tag Lookup Results')}>
     <div className="content">
       <h1>{l('Tag Lookup Results')}</h1>
       {props.nag ? <TagLookupNagSection /> : null}

--- a/root/taglookup/types.js
+++ b/root/taglookup/types.js
@@ -17,13 +17,11 @@ export type TagLookupFormT = FormT<{
 }>;
 
 export type TagLookupPropsT = {
-  +$c: CatalystContextT,
   +form: TagLookupFormT,
   +nag: boolean,
 };
 
 export type TagLookupResultsPropsT<T> = {
-  +$c: CatalystContextT,
   +children: React$Node,
   +form: TagLookupFormT,
   +nag: boolean,

--- a/root/url/UrlIndex.js
+++ b/root/url/UrlIndex.js
@@ -15,12 +15,11 @@ import UrlLayout from './UrlLayout';
 import isGreyedOut from './utility/isGreyedOut';
 
 type Props = {
-  +$c: CatalystContextT,
   +url: UrlT,
 };
 
-const UrlIndex = ({$c, url}: Props): React.Element<typeof UrlLayout> => (
-  <UrlLayout $c={$c} entity={url} page="index" title={l('URL Information')}>
+const UrlIndex = ({url}: Props): React.Element<typeof UrlLayout> => (
+  <UrlLayout entity={url} page="index" title={l('URL Information')}>
     <h2 className="url-details">{l('URL Details')}</h2>
     <table className="details">
       <tr>

--- a/root/url/UrlLayout.js
+++ b/root/url/UrlLayout.js
@@ -15,7 +15,6 @@ import UrlSidebar from '../layout/components/sidebar/UrlSidebar';
 import UrlHeader from './UrlHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: UrlT,
   +fullWidth?: boolean,
@@ -24,14 +23,13 @@ type Props = {
 };
 
 const UrlLayout = ({
-  $c,
   children,
   entity: url,
   fullWidth = false,
   page,
   title,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} title={title}>
+  <Layout title={title}>
     <div id="content">
       <UrlHeader page={page} url={url} />
       {children}

--- a/root/user/Login.js
+++ b/root/user/Login.js
@@ -41,7 +41,7 @@ const Login = ({
   loginForm,
   postParameters,
 }: PropsT): React$Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Log In')}>
+  <Layout fullWidth title={l('Log In')}>
     <h1>{l('Log In')}</h1>
 
     {isLoginRequired ? (

--- a/root/user/PrivilegedUsers.js
+++ b/root/user/PrivilegedUsers.js
@@ -14,7 +14,6 @@ import Layout from '../layout';
 import UserInlineList from './components/UserInlineList';
 
 type Props = {
-  +$c: CatalystContextT,
   +accountAdmins: $ReadOnlyArray<EditorT>,
   +autoEditors: $ReadOnlyArray<EditorT>,
   +bannerEditors: $ReadOnlyArray<EditorT>,
@@ -25,7 +24,6 @@ type Props = {
 };
 
 const PrivilegedUsers = ({
-  $c,
   accountAdmins,
   autoEditors,
   bannerEditors,
@@ -34,7 +32,7 @@ const PrivilegedUsers = ({
   relationshipEditors,
   transclusionEditors,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Privileged user accounts')}>
+  <Layout fullWidth title={l('Privileged user accounts')}>
     <div id="content">
       <h1>{l('Privileged user accounts')}</h1>
 

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -77,7 +77,6 @@ const ReportUser = ({
   user,
 }: Props): React.Element<typeof UserAccountLayout> => (
   <UserAccountLayout
-    $c={$c}
     entity={user}
     page="report"
     title={l('Report User')}

--- a/root/user/UserCollections.js
+++ b/root/user/UserCollections.js
@@ -160,7 +160,6 @@ const UserCollections = ({
 
   return (
     <UserAccountLayout
-      $c={$c}
       entity={user}
       page="collections"
       title={l('Collections')}

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -739,7 +739,6 @@ const UserProfile = ({
 
   return (
     <UserAccountLayout
-      $c={$c}
       entity={sanitizedAccountLayoutUser(user)}
       page="index"
     >

--- a/root/user/UserSubscriptions.js
+++ b/root/user/UserSubscriptions.js
@@ -97,7 +97,6 @@ const UserSubscriptions = ({
 
   return (
     <UserAccountLayout
-      $c={$c}
       entity={user}
       page="subscriptions"
       title={title}

--- a/root/user/UserTag.js
+++ b/root/user/UserTag.js
@@ -39,7 +39,7 @@ const UserTag = ({
   taggedEntities,
   user,
 }: Props): React.Element<typeof UserAccountLayout> => (
-  <UserAccountLayout $c={$c} entity={user} page="tags">
+  <UserAccountLayout entity={user} page="tags">
     <nav className="breadcrumb">
       <ol>
         <li>

--- a/root/user/UserTagEntity.js
+++ b/root/user/UserTagEntity.js
@@ -52,7 +52,7 @@ const UserTagEntity = ({
   tag,
   user,
 }: UserTagEntityProps): React.Element<typeof UserAccountLayout> => (
-  <UserAccountLayout $c={$c} entity={user} page="tags">
+  <UserAccountLayout entity={user} page="tags">
     <nav className="breadcrumb">
       <ol>
         <li>

--- a/root/user/UserTagList.js
+++ b/root/user/UserTagList.js
@@ -60,7 +60,7 @@ const UserTagList = ({
   tags,
   user,
 }: Props): React.Element<typeof UserAccountLayout> => (
-  <UserAccountLayout $c={$c} entity={user} page="tags" title={l('Tags')}>
+  <UserAccountLayout entity={user} page="tags" title={l('Tags')}>
     <h2>
       {getTagListHeading(user.name, showDownvoted)}
     </h2>

--- a/root/utility/chooseLayoutComponent.js
+++ b/root/utility/chooseLayoutComponent.js
@@ -42,7 +42,6 @@ const layoutPicker = {
 export default function chooseLayoutComponent(
   typeName: string,
 ): React$ComponentType<{
-  +$c: CatalystContextT,
   +children: React$Node,
   +entity: CoreEntityT | EditorT | CollectionT,
   +fullWidth?: boolean,

--- a/root/vote/VotingIndex.js
+++ b/root/vote/VotingIndex.js
@@ -42,12 +42,8 @@ const VotingGuideRow = ({
   );
 };
 
-type Props = {
-  +$c: CatalystContextT,
-};
-
-const VotingIndex = ({$c}: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Voting suggestions')}>
+const VotingIndex = (): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Voting suggestions')}>
     <div id="content">
       <h1>{l('Voting suggestions')}</h1>
 

--- a/root/work/WorkIndex.js
+++ b/root/work/WorkIndex.js
@@ -38,7 +38,7 @@ const WorkIndex = ({
   wikipediaExtract,
   work,
 }: Props): React.Element<typeof WorkLayout> => (
-  <WorkLayout $c={$c} entity={work} page="index">
+  <WorkLayout entity={work} page="index">
     {eligibleForCleanup ? (
       <CleanupBanner entityType="work" />
     ) : null}

--- a/root/work/WorkLayout.js
+++ b/root/work/WorkLayout.js
@@ -15,7 +15,6 @@ import WorkSidebar from '../layout/components/sidebar/WorkSidebar';
 import WorkHeader from './WorkHeader';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: WorkT,
   +fullWidth?: boolean,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const WorkLayout = ({
-  $c,
   children,
   entity: work,
   fullWidth = false,
@@ -39,7 +37,6 @@ const WorkLayout = ({
   });
   return (
     <Layout
-      $c={$c}
       title={nonEmpty(title) ? hyphenateTitle(mainTitle, title) : mainTitle}
     >
       <div id="content">

--- a/root/work/WorkMerge.js
+++ b/root/work/WorkMerge.js
@@ -30,7 +30,7 @@ const WorkMerge = ({
   iswcsDiffer = false,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
-  <Layout $c={$c} fullWidth title={l('Merge works')}>
+  <Layout fullWidth title={l('Merge works')}>
     <div id="content">
       <h1>{l('Merge works')}</h1>
       <p>


### PR DESCRIPTION
### Implement MBS-11553

Only for layout pages and related bits here (there's more to do, but this is pretty big).

On top of https://github.com/metabrainz/musicbrainz-server/pull/1850