### PR TITLE
MBS-11500: Do not pass GID of removed release to avoid linking

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
@@ -104,7 +104,13 @@ sub foreign_keys {
 sub build_display_data {
     my ($self, $loaded) = @_;
 
-    my $release = $loaded->{Release}{ $self->data->{entity}{id} } ||
+    my $loaded_release = $loaded->{Release}{ $self->data->{entity}{id} };
+    my $release = $loaded_release ||
+        Release->new(
+            id => $self->data->{entity}{id},
+            name => $self->data->{entity}{name},
+        );
+    my $artwork_release = $loaded_release ||
         Release->new(
             gid => $self->data->{entity}{mbid},
             id => $self->data->{entity}{id},
@@ -115,7 +121,7 @@ sub build_display_data {
         ? $self->c->model('CoverArt')->image_type_suffix($self->data->{cover_art_mime_type})
         : "jpg";
 
-    my $artwork = Artwork->new(release => $release,
+    my $artwork = Artwork->new(release => $artwork_release,
                                id => $self->data->{cover_art_id},
                                comment => $self->data->{cover_art_comment},
                                mime_type => $self->data->{cover_art_mime_type},

--- a/root/edit/details/AddCoverArt.js
+++ b/root/edit/details/AddCoverArt.js
@@ -54,8 +54,7 @@ const AddCoverArt = ({edit}: Props): React.Element<'table'> => {
         <th>{l('Filename:')}</th>
         <td>
           <code>
-            {'mbid-' + display.release.gid + '-' +
-              display.artwork.id + '.' + display.artwork.suffix}
+            {display.artwork.filename}
           </code>
         </td>
       </tr>


### PR DESCRIPTION
### Fix MBS-11500

It's probably better not to pass the GID here (even though we have it stored) because the presence of a GID will cause the release to be displayed with a link that goes nowhere (since the release has since been removed).

Taking the GID off from the release passed to Artwork would also break the display of artwork and filename for removed releases. Given that the artwork for a removed release should have been removed itself (CAA-126), this is probably not a big issue, but just in case this passes a separate release entity with a GID to Artwork.

There's also no reason that I can see to form the filename on the edit itself rather than using artwork.filename, so I changed that to no longer depend on the release GID on display_data.