### PR TITLE
MBS-11367 (II): Restore turning autocomplete on at the start

### DIFF
--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -477,6 +477,13 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
         response(filteredTerms);
       },
     });
+
+    /*
+     * MBS-9862: jQuery UI disables the browser's builtin autocomplete
+     * history in a non-configurable way, but we want it to show here
+     * if the user hasn't typed anything yet, so flip it back on.
+     */
+    input.setAttribute('autocomplete', 'on');
   }
 }
 


### PR DESCRIPTION
### Fixes up MBS-11367

The previous patch (https://github.com/metabrainz/musicbrainz-server/pull/2000) removed this section and replaced it with an onChange, but both are needed. This ensures the autocomplete is still set to on on page load.