### PR TITLE
MBS-11559: Specify tracklist is empty in Remove medium edits

### DIFF
--- a/root/edit/details/AddMedium.js
+++ b/root/edit/details/AddMedium.js
@@ -154,7 +154,7 @@ const AddMedium = ({allowNew, edit}: Props): React.MixedElement => {
       ) : null}
 
       <tr>
-        <th>{l('Tracklist:')}</th>
+        <th>{addColonText(l('Tracklist'))}</th>
         <td>
           <table className="tbl">
             <tbody>

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -40,7 +40,7 @@ const RemoveMedium = ({edit}: Props): React.Element<'table'> => {
       </tr>
 
       <tr>
-        <th>{l('Tracklist:')}</th>
+        <th>{addColonText(l('Tracklist'))}</th>
         <td>
           <table className="tbl">
             <tbody>

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -39,21 +39,22 @@ const RemoveMedium = ({edit}: Props): React.Element<'table'> => {
         </td>
       </tr>
 
-      {display.tracks ? (
-        <tr>
-          <th>{addColon(l('Tracklist'))}</th>
-          <td>
-            <table className="tbl">
-              <tbody>
+      <tr>
+        <th>{l('Tracklist:')}</th>
+        <td>
+          <table className="tbl">
+            <tbody>
+              {display.tracks?.length ? (
                 <MediumTracklist
                   showArtists
                   tracks={display.tracks}
                 />
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      ) : null}
+              ) : l('The tracklist for this medium is unknown.')}
+            </tbody>
+          </table>
+        </td>
+      </tr>
+
     </table>
   );
 };


### PR DESCRIPTION
### Implement MBS-11559

There seems to be no reason not to display exactly the same on removal edits as we do in add edits.
