### PR TITLE
MBS-11558: Show current tracklist data on removal edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -51,7 +51,7 @@ sub foreign_keys
     my %fk;
 
     $fk{Medium} = { $self->medium_id => [ 'MediumFormat', 'Release ArtistCredit' ] };
-    $fk{MediumFormat} = { $self->data->{format_id} => [] };
+    $fk{MediumFormat} = { $self->data->{format_id} => [] } if $self->data->{format_id};
     $fk{Release} = { $self->data->{release_id} => [qw( ArtistCredit )] };
 
     tracklist_foreign_keys(\%fk, $self->data->{tracklist});
@@ -63,9 +63,11 @@ sub build_display_data
 {
     my ($self, $loaded) = @_;
 
+    my $format = $self->data->{format_id};
+
     my $medium = $loaded->{Medium}{ $self->medium_id } //
                  Medium->new(
-                     format => $loaded->{MediumFormat}{ $self->data->{format_id} },
+                     format => $format ? $loaded->{MediumFormat}{$format} : undef,
                      name => $self->data->{name},
                      position => $self->data->{position},
                      release_id => $self->data->{release_id},

--- a/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -65,7 +65,15 @@ sub build_display_data
 
     my $format = $self->data->{format_id};
 
-    my $medium = $loaded->{Medium}{ $self->medium_id } //
+    my $loaded_medium = $loaded->{Medium}{ $self->medium_id };
+    if ($loaded_medium && $self->is_open) {
+        $self->c->model('Track')->load_for_mediums($loaded_medium);
+        my @tracks = $loaded_medium->all_tracks;
+        $self->c->model('ArtistCredit')->load(@tracks);
+        $self->c->model('Recording')->load(@tracks);
+    }
+
+    my $medium = $loaded_medium //
                  Medium->new(
                      format => $format ? $loaded->{MediumFormat}{$format} : undef,
                      name => $self->data->{name},

--- a/t/lib/t/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -3,13 +3,14 @@ use Test::Routine;
 use Test::More;
 
 with 't::Edit';
-with 't::Context';
+with 't::Context', 't::Mechanize';
 
 BEGIN { use MusicBrainz::Server::Edit::Medium::Delete }
 
 use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Constants qw( $EDIT_MEDIUM_DELETE );
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
+use MusicBrainz::Server::Track qw( format_track_length );
 
 test all => sub {
 
@@ -62,6 +63,54 @@ test 'Deleting a medium will also delete its tracks' => sub {
 
     is($c->model('Track')->get_by_id(1), undef, 'Track with row id 1 has been deleted');
     is($c->model('Track')->get_by_id(2), undef, 'Track with row id 1 has been deleted');
+};
+
+test 'Warning is shown if data has changed (MBS-11558)' => sub {
+    my $test = shift;
+    my $c = $test->c;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+edit_medium');
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+        INSERT INTO track (id, gid, name, medium, recording, artist_credit, position, number, length)
+            VALUES (1, '15d6a884-0274-486c-81fe-94ff57b8cf36', 1, 1, 1, 1, 1, 'A1', null),
+                   (2, '03d0854f-6053-416c-a67f-8c79a796ed39', 1, 1, 1, 1, 2, 'A2', null);
+        SQL
+
+    my $edit = _create_edit($c);
+    $mech->get_ok(
+        '/edit/' . $edit->id,
+        'Fetched the edit page before medium changes',
+    );
+    $mech->text_lacks('Warning:', 'No warning present');
+    $mech->text_contains('Tracklist:', 'Old tracklist shown');
+
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+        UPDATE track
+           SET length = 12345
+         WHERE id = 1
+        SQL
+
+    $mech->get_ok(
+        '/edit/' . $edit->id,
+        'Fetched the edit page after adding track duration',
+    );
+    $mech->text_contains('Warning:', 'Warning is present');
+    $mech->text_contains('Original tracklist:', 'Old tracklist shown');
+    $mech->text_contains('Current tracklist:', 'New tracklist shown');
+    $mech->text_contains(
+        format_track_length(12345),
+        'New track length shown',
+    );
+
+    accept_edit($c, $edit);
+
+    $mech->get_ok(
+        '/edit/' . $edit->id,
+        'Fetched the edit page after accepting the edit',
+    );
+    $mech->text_lacks('Warning:', 'No warning present anymore');
+    $mech->text_contains('Tracklist:', 'Only old tracklist shown again');
 };
 
 sub _create_edit {


### PR DESCRIPTION
### Implement MBS-11558

This shows the current tracklist (and a warning) if there are significant changes between the current tracklist for the medium being removed and the tracklist that got stored when entering the removal edit. These are only shown if the edit is open, since otherwise there's probably no real use to them.

Tested with https://musicbrainz.org/edit/78642529 and https://musicbrainz.org/edit/78629796 + a search of open removal edits (but those edits might no longer be open depending on when the testing happens). For testing with local data, just try to enter remove medium edits and then add / remove tracks from the tracklist, add/remove the tracklist completely, and change the tracklist titles or whatnot.

![Screenshot from 2021-12-09 15-41-17](https://user-images.githubusercontent.com/1069224/145407167-ecc606d9-7aca-4d61-a4d0-e6840a0de2f0.png)
