### PR TITLE
MBS-9376: Indicate that edit searches can be bookmarked + link docs

### DIFF
--- a/root/edit/search.tt
+++ b/root/edit/search.tt
@@ -1,7 +1,7 @@
 [%- PROCESS 'edit/search_macros.tt' -%]
 [% WRAPPER 'layout.tt' title=l('Search for Edits') full_width=1 %]
   <div id="content">
-    <h1>[% l('Search for Edits') %]</h1>
+    [% PROCESS search_heading %]
     [%- IF timed_out -%]
       <div class="warning">
         <p>[% l('Your search took too long and was cancelled. It may help to be more specific, or to try again.') %]</p>

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -183,7 +183,7 @@
   </span>
 
   <span>
-    (<a href="[% c.uri_for('/doc/How_to_Search_for_Edits#Date_format') %]" target="_blank">[% l('help') %]</a>)
+    (<a href="[% c.uri_for('/doc/How_to_Use_the_Edit_Search#Dates') %]" target="_blank">[% l('help') %]</a>)
   </span>
 [% END %]
 

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -4,6 +4,12 @@
 </span>
 [% END %]
 
+[% BLOCK search_heading %]
+  <h1>[% l('Search for Edits') %]</h1>
+  <p>[% l('The filters below allow you to find only edits fulfilling specific criteria. See the {doc_link|documentation} for more info about using the filters.', {doc_link => doc_link('How to Use the Edit Search')}) %]</p>
+  <p>[% l('If you want to save an edit search for future use, you can just bookmark it!') %]</p>
+[% END %]
+
 [% BLOCK search_form %]
 <form action="[% c.req.uri.path %]" method="get" id="edit-search">
   <p>

--- a/root/edit/search_results.tt
+++ b/root/edit/search_results.tt
@@ -2,7 +2,7 @@
 [% PROCESS 'edit/search_macros.tt' %]
 [% WRAPPER 'layout.tt' title=l('Search for Edits') full_width=1 %]
     <div id="content">
-        <h1>[% l('Search for Edits') %]</h1>
+        [% PROCESS search_heading %]
 
         [% WRAPPER search_form %]
 


### PR DESCRIPTION
### Implement MBS-9376

This adds some help text to the top of edit searches that directs users to a how to page for using the search (in the works) and informs them that the searches can be bookmarked to save them.