### PR TITLE
Pass public editor privs when converting editor to JSON

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -37,7 +37,7 @@ our %EXPORT_TAGS = (
     vote               => _get(qr/^VOTE_/),
     edit_status        => _get(qr/^STATUS_/),
     access_scope       => _get(qr/^ACCESS_SCOPE_/),
-    privileges         => _get(qr/_FLAG$/),
+    privileges         => _get(qr/_FLAGS?$/),
     language_frequency => _get(qr/^LANGUAGE_FREQUENCY/),
     script_frequency   => _get(qr/^SCRIPT_FREQUENCY/),
     election_status => [
@@ -345,6 +345,14 @@ Readonly our $LOCATION_EDITOR_FLAG          => 256;
 Readonly our $BANNER_EDITOR_FLAG            => 512;
 Readonly our $EDITING_DISABLED_FLAG         => 1024;
 Readonly our $ADDING_NOTES_DISABLED_FLAG    => 2048;
+# If you update this, also update root/utility/sanitizedEditor.js
+Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG &
+                                               $BOT_FLAG &
+                                               $RELATIONSHIP_EDITOR_FLAG &
+                                               $WIKI_TRANSCLUSION_FLAG &
+                                               $ACCOUNT_ADMIN_FLAG &
+                                               $LOCATION_EDITOR_FLAG &
+                                               $BANNER_EDITOR_FLAG;
 
 Readonly our $ELECTION_VOTE_NO      => -1;
 Readonly our $ELECTION_VOTE_ABSTAIN => 0;

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -109,6 +109,10 @@ sub is_adding_notes_disabled {
     (shift->privileges & $ADDING_NOTES_DISABLED_FLAG) > 0;
 }
 
+sub public_privileges {
+    shift->privileges & $PUBLIC_PRIVILEGE_FLAGS;
+}
+
 has 'email' => (
     is        => 'rw',
     isa       => 'Str',
@@ -324,6 +328,7 @@ sub TO_JSON {
         gravatar => $self->gravatar,
         id => $self->id,
         name => $self->name,
+        privileges => $self->public_privileges,
     };
 }
 

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -306,7 +306,7 @@ sub _unsanitized_json {
         languages                   => to_json_array($self->languages),
         last_login_date             => datetime_to_iso8601($self->last_login_date),
         preferences                 => $self->preferences->TO_JSON,
-        privileges                  => $self->privileges,
+        privileges                  => 0 + $self->privileges,
         registration_date           => datetime_to_iso8601($self->registration_date),
         website                     => $self->website,
     };
@@ -328,7 +328,7 @@ sub TO_JSON {
         gravatar => $self->gravatar,
         id => $self->id,
         name => $self->name,
-        privileges => $self->public_privileges,
+        privileges => 0 + $self->public_privileges,
     };
 }
 

--- a/root/utility/sanitizedEditor.js
+++ b/root/utility/sanitizedEditor.js
@@ -10,6 +10,7 @@
 // NOTE: Don't convert to an ES module; this is used by root/server.js.
 /* eslint-disable import/no-commonjs */
 
+// If you update this, also update $PUBLIC_PRIVILEGE_FLAGS in Constants.pm
 const publicFlags = 1 & // AUTO_EDITOR_FLAG
                     2 & // BOT_FLAG
                     8 & // RELATIONSHIP_EDITOR_FLAG


### PR DESCRIPTION
EditorT expects privileges to be passed, and there's no real reason why we shouldn't do this anyway.
