### PR TITLE
MBS-11562: Actually randomize when picking rand sort for edit search

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -166,6 +166,8 @@ sub as_string {
     } elsif ($self->order eq 'vote_closing_desc') {
         $order = 'ORDER BY edit.expire_time DESC';
         $extra_conditions = ' AND edit.close_time IS NULL';
+    } elsif ($self->order eq 'rand') {
+        $order = 'ORDER BY RANDOM()';
     }
 
     return 'SELECT edit.*, edit_data.data ' .


### PR DESCRIPTION
### Fix MBS-11562

This was just not selecting any sort when the 'rand' order was selected.
PSQL docs used to say "If sorting is not chosen, the rows will be returned in random order" but that's misleading and has since been corrected to "the rows will be returned in an unspecified order". For at least some queries, the unspecified order is literally "ordered by ID".
This implements an actual ORDER BY RANDOM() when 'rand' is selected. This works fine for smaller queries, but takes forever and is likely to time out in bigger ones. I'd say that keeping it as is is not an option but we might also just decide to drop the random option to avoid the issue entirely. I suspect it's not particularly popular anyway.
