### PR TITLE
MBS-11564: Don't block Niconi Commons links with Nicovideo cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2364,7 +2364,10 @@ const CLEANUPS = {
     type: LINK_TYPES.score,
   },
   'niconicovideo': {
-    match: [new RegExp('^(https?://)?([^/]+\\.)?(nicovideo\\.jp/)', 'i')],
+    match: [new RegExp(
+      '^(https?://)?((?!commons)[^/]+\\.)?(nicovideo\\.jp/)',
+      'i',
+    )],
     type: {...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel},
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?ch\.nicovideo\.jp\/([^\/]+).*$/, 'https://ch.nicovideo.jp/$1');

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2718,6 +2718,12 @@ const testData = [
             expected_clean_url: 'https://ch.nicovideo.jp/maverickdci',
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
+  // Niconi Commons (excluded from Niconico autoselect)
+  {
+                     input_url: 'https://commons.nicovideo.jp/material/nc216831',
+             input_entity_type: 'recording',
+    expected_relationship_type: undefined,
+  },
   // NLA (National Library of Australia)
   {
                      input_url: 'http://nla.gov.au/nla.party-548358/',


### PR DESCRIPTION
### Fix MBS-11564

commons.nicovideo links are separate from the general nicovideo system and should not be autoselected as streamingfree (if they should be autoselected at all then probably as downloadfree, but that is an issue for a future PR). They also shouldn't be blocked, which is what the cleanup code was currently doing.
For now, this patch just makes the system ignore them so that they can be entered as needed.