### PR TITLE
MBS-11566: Ensure consistent ordering of appearances sections

### DIFF
--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -255,16 +255,20 @@ const RelationshipsTable = ({
     }
   };
 
+  const pagedRelationshipGroups = entity.paged_relationship_groups;
   if (pagedLinkTypeGroup) {
     getRelationshipRows(pagedLinkTypeGroup, tableRows);
-  } else if (entity.paged_relationship_groups) {
-    for (
-      const [targetType, targetTypeGroup] of
-      // $FlowIgnore[incompatible-cast]
-      (Object.entries(entity.paged_relationship_groups):
-        $ReadOnlyArray<[string, PagedTargetTypeGroupT]>)
-    ) {
+  } else if (pagedRelationshipGroups) {
+    const sortedTargetTypes =
+      Object.keys(pagedRelationshipGroups).sort();
+    for (const targetType of sortedTargetTypes) {
       if (!appearanceTypes.includes(targetType)) {
+        continue;
+      }
+
+      const targetTypeGroup: ?PagedTargetTypeGroupT =
+        pagedRelationshipGroups[targetType];
+      if (!targetTypeGroup) {
         continue;
       }
 


### PR DESCRIPTION
### Fix MBS-11566

These need to be sorted by target type, otherwise the different sections jump around the page on every reload.

Tested and it seems to work - Flow hates this though, I need help fixing it. @mwiencek? :)