### PR TITLE
MBS-11563: Invalidate entity_link_type_counts on relationship inserts

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -804,6 +804,13 @@ sub insert
         $self->c->model('Series')->automatically_reorder($values->{entity1_id});
     }
 
+    $self->delete_entity_link_type_counts(
+        $type0,
+        $type1,
+        $row->{entity0},
+        $row->{entity1},
+    );
+
     return $self->_entity_class->new( id => $id );
 }
 


### PR DESCRIPTION
12b43e8330b0feda64c636665735c7c3c931b7b5 added some caching for the number of relationships for a given entity & link type, so that we don't have to recount them on every page load. While that commit made sure to invalidate the cached entries on relationship updates and deletions, it forgot to do so for insertions. This commit does that.