### PR TITLE
MBS-11569: Limit entity types when creating collection from sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Form/Collection.pm
+++ b/lib/MusicBrainz/Server/Form/Collection.pm
@@ -45,15 +45,22 @@ sub options_type_id {
 
     my $types = select_options_tree($self->ctx, 'CollectionType');
     my $collection = $self->init_object;
+    my $type_filter;
 
     if ($collection && blessed $collection) {
         my $entity_type = $collection->type->item_entity_type;
         unless ($self->ctx->model('Collection')->is_empty($entity_type, $collection->{id})) {
-            my %valid_types =
-                map { $_->id => 1 }
-                    $self->ctx->model('CollectionType')->find_by_entity_type($entity_type);
-            $types = [grep {$valid_types{$_->{value}}} @$types];
+            $type_filter = $entity_type;
         }
+    } elsif ($collection && $collection->{allowed_entity_type}) {
+        $type_filter = $collection->{allowed_entity_type};
+    }
+
+    if (defined $type_filter) {
+        my %valid_types =
+            map { $_->id => 1 }
+                $self->ctx->model('CollectionType')->find_by_entity_type($type_filter);
+        $types = [grep {$valid_types{$_->{value}}} @$types];
     }
 
     return $types;


### PR DESCRIPTION
### Fix MBS-11569

When creating a collection from an entity sidebar, we allowed selecting any collection type for it, even though an entity (of a specific entity type that might not match the collection type) was going to be added to it anyway.
This adds two blocks to that behaviour. First, it loads only the type values that match the entity type passed to the form.
Additionally, it only adds the entity that was seeded if the entity type of the final created collection is the same as the one originally passed to make sure there's no possible case we've missed where an entity would still get added to a collection of the wrong entity type.