### PR TITLE
MBS-11571: Warn about e-mail as a username

### DIFF
--- a/root/account/register.tt
+++ b/root/account/register.tt
@@ -1,4 +1,5 @@
 [% WRAPPER "layout.tt" title=l("Create an Account") full_width=1 %]
+[% script_manifest('register.js') %]
 <div id="content">
 
      [%- IF invalid_captcha_response -%]
@@ -29,6 +30,9 @@
         [% form_row_text(r, 'username', l('Username:')) %]
         <div class="row no-label">
             <span class="input-note">[% l('Your username will be publicly visible.') %]</span>
+        </div>
+        <div class="row no-label" id="email-username-warning">
+            [% warning(l('The username you have entered looks like an email address. This is allowed, but please keep in mind that everyone will be able to see it. Only use an email address as your username if you are completely sure you are happy with that.')) %]
         </div>
         [% form_row_password(r, 'password', l('Password:')) %]
         [% form_row_password(r, 'confirm_password', l('Confirm password:')) %]

--- a/root/static/scripts/register.js
+++ b/root/static/scripts/register.js
@@ -1,0 +1,27 @@
+/*
+ * @flow
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import $ from 'jquery';
+
+import debounce from './common/utility/debounce';
+
+$(function () {
+  function warnAboutEmailAsUsername() {
+    const username =
+    $('#id-register\\\.username').val();
+    const isPossibleEmail = /\w+@\w+\.\w+/.test(username);
+    $('#email-username-warning').toggle(isPossibleEmail);
+  }
+
+  $('#id-register\\\.username')
+    .keyup(debounce(warnAboutEmailAsUsername, 500))
+    .change(debounce(warnAboutEmailAsUsername, 500));
+
+  warnAboutEmailAsUsername();
+});

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -842,3 +842,7 @@ button.guess-timezone {
         width: 50ch;
     }
 }
+
+/* root/account/register.tt */
+
+#email-username-warning {display: none}

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -55,6 +55,7 @@ const entries = [
   'place/map',
   'recording/form',
   'recording/merge',
+  'register',
   'release/coverart',
   'release/index',
   'release-editor',


### PR DESCRIPTION
### Implement MBS-11571

While a user should be able to use an email address string as their username if they so desire, they should only do it if they are sure it's ok with them for it to be public.
This adds a warning for that scenario.
