### PR TITLE
MBS-9631: Add 1200px to available image sizes

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Artwork.pm
+++ b/lib/MusicBrainz/Server/Entity/Artwork.pm
@@ -101,15 +101,17 @@ sub filename
 sub image { my $self = shift; return $self->_url_prefix . "." . $self->suffix; }
 sub small_thumbnail { my $self = shift; return $self->_url_prefix . "-250.jpg"; }
 sub large_thumbnail { my $self = shift; return $self->_url_prefix . "-500.jpg"; }
+sub huge_thumbnail { my $self = shift; return $self->_url_prefix . "-1200.jpg"; }
 
 # These accessors allow for requesting thumbnails directly from the IA,
 # bypassing our artwork redirect service. These are suitable for any <img>
 # tags in our templates, avoiding a pointless 307 redirect and preventing
-# our redirect service from becoming overloaded. The "250px"/"500px"/
+# our redirect service from becoming overloaded. The "250px"/"500px"/"1200px"
 # "original" links still point to the public API at coverartarchive.org via
 # small_thumbnail, large_thumbnail, etc.
 sub small_ia_thumbnail { shift->_ia_url_prefix . '_thumb250.jpg' }
 sub large_ia_thumbnail { shift->_ia_url_prefix . '_thumb500.jpg' }
+sub huge_ia_thumbnail { shift->_ia_url_prefix . '_thumb1200.jpg' }
 
 sub TO_JSON {
     my ($self) = @_;
@@ -117,6 +119,8 @@ sub TO_JSON {
     my $json = {
         comment => $self->comment,
         filename => $self->filename,
+        huge_ia_thumbnail => $self->huge_ia_thumbnail,
+        huge_thumbnail => $self->huge_thumbnail,
         image => $self->image,
         id => $self->id,
         large_ia_thumbnail => $self->large_ia_thumbnail,

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Utils.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Utils.pm
@@ -87,7 +87,8 @@ sub artwork {
              ($artwork->is_front ? (representativeOfPage => 'True') : ()),
              thumbnail => [
                  {'@type' => 'ImageObject', contentUrl => $artwork->small_thumbnail, encodingFormat => 'jpg'},
-                 {'@type' => 'ImageObject', contentUrl => $artwork->large_thumbnail, encodingFormat => 'jpg'}
+                 {'@type' => 'ImageObject', contentUrl => $artwork->large_thumbnail, encodingFormat => 'jpg'},
+                 {'@type' => 'ImageObject', contentUrl => $artwork->huge_thumbnail, encodingFormat => 'jpg'}
              ]
            };
 }

--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -45,6 +45,7 @@ export const ArtworkImage = ({
     <span
       className="cover-art-image"
       data-fallback={fallback || ''}
+      data-huge-thumbnail={artwork.huge_ia_thumbnail}
       data-large-thumbnail={artwork.large_ia_thumbnail}
       data-message={nonEmpty(message)
         ? message

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -39,6 +39,12 @@ const CoverArtLinks = ({
         {' | '}
       </>
     ) : null}
+    {artwork.huge_thumbnail ? (
+      <>
+        <a href={artwork.huge_thumbnail}>{l('1200px')}</a>
+        {' | '}
+      </>
+    ) : null}
     <a href={artwork.image}>{l('original')}</a>
   </>
 );

--- a/root/types.js
+++ b/root/types.js
@@ -147,6 +147,8 @@ declare type ArtworkT = {
   ...EditableRoleT,
   +comment: string,
   +filename: string | null,
+  +huge_ia_thumbnail: string,
+  +huge_thumbnail: string,
   +id: number,
   +image: string,
   +large_ia_thumbnail: string,

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
@@ -49,6 +49,11 @@ test all => sub {
                     'encodingFormat' => 'jpg',
                     'contentUrl' => DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . '/release/14b9d183-7dab-42ba-94a3-7388a66604b8/12345-500.jpg',
                     '@type' => 'ImageObject'
+                },
+                {
+                    'encodingFormat' => 'jpg',
+                    'contentUrl' => DBDefs->COVER_ART_ARCHIVE_DOWNLOAD_PREFIX . '/release/14b9d183-7dab-42ba-94a3-7388a66604b8/12345-1200.jpg',
+                    '@type' => 'ImageObject'
                 }
             ]
         }


### PR DESCRIPTION
### Implement MBS-9631

Seems the IA has triggered a reindex to get all 1200px thumbnails generated (see CAA-88), so it seems like a good time to add this.
I expect we still want large-thumbnail, not huge-thumbnail, in root/static/scripts/common/coverart.js for the thumbnail URL, but added it everywhere else we have thumbnails - including to data as huge-thumbnail in case userscripts or whatnot want to use it.
