### PR TITLE
MBS-1588: Better errors for invalid CD TOC

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -158,7 +158,11 @@ sub attach : Local DenyWhenReadonly Edit
     my $cdtoc = MusicBrainz::Server::Entity::CDTOC->new_from_toc($toc)
         or $self->error(
             $c, status => HTTP_BAD_REQUEST,
-            message => l('The provided CD TOC is not valid')
+            message => l(
+                'The provided CD TOC is not valid. This is probably an issue
+                 with the software you used to generate it. Try again
+                 and please report the error to your software maker if it persists,
+                 including the technical information below.')
         );
 
     $c->stash( cdtoc => $cdtoc );
@@ -351,7 +355,7 @@ sub move : Local Edit
     my $medium_cdtoc = $c->model('MediumCDTOC')->get_by_id($medium_cdtoc_id)
         or $self->error(
             $c, status => HTTP_BAD_REQUEST,
-            message => l('The provided CD TOC is not valid')
+            message => l('The provided CD TOC ID doesn’t exist.')
         );
 
     $c->model('CDTOC')->load($medium_cdtoc);


### PR DESCRIPTION
### Implement MBS-1588

When a user tries to attach an invalid CD TOC, just telling them that it is invalid isn't very useful. They probably didn't generate it themselves and have no idea what to do with this info. If they even report it then they're likely to report it to MBS, but it's most likely an issue with the software they used to generate the CD TOC in the first place. This makes the error message hopefully more useful.
Also, the /move action also had the same error message, but no CD TOC is provided to the action to begin with, just a (Medium) CD TOC id. Changed the error message to specify that the id is what is invalid.
