### PR TITLE
Fix Catalyst warning: id is missing in edit previews

### DIFF
--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -337,7 +337,7 @@ sub TO_JSON {
         editor_id => $self->editor_id + 0,
         expires_time => datetime_to_iso8601($self->expires_time),
         historic_type => $self->can('historic_type') ? $self->historic_type + 0 : undef,
-        id => $self->id + 0,
+        id => $self->id ? $self->id + 0 : undef,
         is_loaded => boolean_to_json($self->is_loaded),
         is_open => boolean_to_json($self->is_open),
         $can_preview ? (preview => boolean_to_json($self->preview)) : (),

--- a/root/edit/CannotApproveEdit.js
+++ b/root/edit/CannotApproveEdit.js
@@ -15,7 +15,7 @@ import {EDIT_STATUS_DELETED} from '../constants';
 
 type Props = {
   +$c: CatalystContextT,
-  +edit: EditT,
+  +edit: {...EditT, +id: number},
 };
 
 const CannotApproveEdit = (

--- a/root/edit/CannotCancelEdit.js
+++ b/root/edit/CannotCancelEdit.js
@@ -14,7 +14,7 @@ import EditLink from '../static/scripts/common/components/EditLink';
 
 type Props = {
   +$c: CatalystContextT,
-  +edit: EditT,
+  +edit: {...EditT, +id: number},
 };
 
 const CannotCancelEdit = (

--- a/root/edit/NoteIsRequired.js
+++ b/root/edit/NoteIsRequired.js
@@ -14,7 +14,7 @@ import EditLink from '../static/scripts/common/components/EditLink';
 
 type Props = {
   +$c: CatalystContextT,
-  +edit: EditT,
+  +edit: {...EditT, +id: number},
 };
 
 const NoteIsRequired = (

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -24,7 +24,7 @@ import formatUserDate from '../../utility/formatUserDate';
 
 type Props = {
   +$c: CatalystContextT,
-  +edit: EditT,
+  +edit: {...EditT, +id: number},
 };
 
 const EditSidebar = ({

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -26,7 +26,7 @@ import Vote from './Vote';
 
 type Props = {
   +$c: CatalystContextT,
-  +edit: EditT,
+  +edit: {...EditT, +id: number},
   +index: number,
 };
 

--- a/root/main/error/Error500.js
+++ b/root/main/error/Error500.js
@@ -19,7 +19,7 @@ import ErrorInfo from './components/ErrorInfo';
 
 type Props = {
   +$c: CatalystContextT,
-  +edits?: $ReadOnlyArray<EditT>,
+  +edits?: $ReadOnlyArray<{...EditT, +id: number}>,
   +formattedErrors?: $ReadOnlyArray<string>,
   +hostname?: string,
   +useLanguages: boolean,

--- a/root/static/scripts/common/utility/entityHref.js
+++ b/root/static/scripts/common/utility/entityHref.js
@@ -48,6 +48,10 @@ export function editHref(
   edit: EditT,
   subPath?: string,
 ): string {
+  if (edit.id == null) {
+    throw new Error(`An edit missing an ID was passed.
+                     Ensure you are not using this on a preview.`);
+  }
   return generateHref('edit', edit.id.toString(), subPath);
 }
 

--- a/root/types.js
+++ b/root/types.js
@@ -524,7 +524,7 @@ declare type EditT = {
   +editor_id: number,
   +expires_time: string,
   +historic_type: number | null,
-  +id: number,
+  +id: number | null, // id is missing in previews
   +is_loaded: boolean,
   +is_open: boolean,
   +preview?: boolean,


### PR DESCRIPTION
We were always expecting an ID, but edit previews don't yet have an edit ID. Since having separate types for edits and previews would probably be too complicated (many places use ...EditT and whatnot) we just make id possibly null and ensure we specify it is being passed where we use it and know for sure we are passing it.

Warning: 
`[warning] POST https://musicbrainz.org/ws/js/edit/preview caused a warning: Use of uninitialized value in addition (+) at lib/MusicBrainz/Server/Edit.pm line 330, <$fh> line 1.`