### PR TITLE
MBS-11581: Don't try to display / offer darkened art as RG cover art

### DIFF
--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -169,9 +169,11 @@ sub set_cover_art : Chained('load') PathPart('set-cover-art') Args(0) Edit
     my ($releases, $hits) = $c->model('Release')->find_by_release_group(
         $entity->id);
     $c->model('Release')->load_related_info(@$releases);
+    $c->model('Release')->load_meta(@$releases);
     $c->model('ArtistCredit')->load(@$releases);
 
-    my $artwork = $c->model('Artwork')->find_front_cover_by_release(@$releases);
+    my @non_darkened_releases = grep { $_->may_have_cover_art } @$releases;
+    my $artwork = $c->model('Artwork')->find_front_cover_by_release(@non_darkened_releases);
     $c->model('CoverArtType')->load_for(@$artwork);
     my %artwork_map = map { $_->release->id => $_ } @$artwork;
 

--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -181,6 +181,8 @@ sub load_for_release_groups
         FROM cover_art_archive.index_listing
         JOIN musicbrainz.release
           ON musicbrainz.release.id = cover_art_archive.index_listing.release
+        JOIN musicbrainz.release_meta
+          ON musicbrainz.release_meta.id = musicbrainz.release.id
         LEFT JOIN (
           SELECT release, date_year, date_month, date_day
           FROM release_country
@@ -194,6 +196,7 @@ sub load_for_release_groups
         ON cover_art_archive.index_listing.mime_type = cover_art_archive.image_type.mime_type
         WHERE release.release_group IN (" . placeholders(@ids) . ")
         AND is_front = true
+        AND cover_art_presence != 'darkened'
         ORDER BY release.release_group, release_group_cover_art.release,
           release_event.date_year, release_event.date_month,
           release_event.date_day";


### PR DESCRIPTION
### Fix MBS-11581

Tested with /release-group/2139ac67-3b29-4e1b-9568-2968f3ef38d6 - darkened status there is incorrect, as it was when we looked into https://github.com/metabrainz/musicbrainz-server/pull/1914, but it works for testing. We really need to also fix MBS-6567 soonish though.