### PR TITLE
Fix Catalyst warning: don't try using undef to access hash

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -174,12 +174,16 @@ sub build_display_data
     my $type1 = $self->data->{type1};
     my $model0 = type_to_model($type0);
     my $model1 = type_to_model($type1);
-    my $entity0 = $loaded->{$model0}{gid_or_id($self->data->{entity0})} ||
+    my $entity0_gid_or_id = gid_or_id($self->data->{entity0});
+    my $loaded_entity_0 = $loaded->{$model0}{$entity0_gid_or_id} if $entity0_gid_or_id;
+    my $entity0 = $loaded_entity_0 ||
         $self->c->model($model0)->_entity_class->new(
             id => 0,
             name => $self->data->{entity0}{name}
         );
-    my $entity1 = $loaded->{$model1}{gid_or_id($self->data->{entity1})} ||
+    my $entity1_gid_or_id = gid_or_id($self->data->{entity1});
+    my $loaded_entity_1 = $loaded->{$model1}{$entity1_gid_or_id} if $entity1_gid_or_id;
+    my $entity1 = $loaded_entity_1 ||
         $self->c->model($model1)->_entity_class->new(
             id => 0,
             name => $self->data->{entity1}{name}


### PR DESCRIPTION
Entities that haven't been created yet and are only being previewed lack both gid and id, but we were trying to use the result of gid_or_id to access a $loaded entry. That will never work and results in a warning, so this just makes sure to only do that if gid_or_id has a result.

Warning:
```
[warning] POST http://localhost:5000/ws/js/edit/preview caused a warning: Use of uninitialized value in hash element at lib/MusicBrainz/Server/Edit/Relationship/Create.pm line 184, <$fh> line 1.
[warning] POST http://localhost:5000/ws/js/edit/preview caused a warning: Use of uninitialized value in hash element at lib/MusicBrainz/Server/Edit/Relationship/Create.pm line 189, <$fh> line 1.
```