### PR TITLE
Fix Catalyst warning: ensure parent format id is not undef

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Release.pm
@@ -100,9 +100,10 @@ sub medium_format {
     # case of it not being one of these few formats. I'm not sure of the
     # best mitigation for either problem.
     my $name;
+    my $parent_format_id = $format->parent ? $format->parent->id : $format->parent_id;
     if ($name = $map{$format->id}) {
         return "http://schema.org/${name}Format";
-    } elsif ($name = $map{$format->parent ? $format->parent->id : $format->parent_id}) {
+    } elsif ($parent_format_id && ($name = $map{$parent_format_id})) {
         return "http://schema.org/${name}Format";
     }
 }


### PR DESCRIPTION
Some top level formats (like SACD) have no parent format, yet don't appear on the medium format map since they aren't supported by the schema.org enum (https://schema.org/MusicReleaseFormatType). As such, we were trying to access the map with an undef parent format id.
