### PR TITLE
Fix Catalyst warning: don't pass undef review text to markdown

### DIFF
--- a/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
+++ b/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
@@ -7,6 +7,7 @@ use JSON;
 use Text::Markdown qw( markdown );
 use Text::Trim qw( trim );
 use URI;
+use MusicBrainz::Server::Data::Utils qw( non_empty );
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( encode_entities );
 use aliased 'MusicBrainz::Server::Entity::CritiqueBrainz::Review';
@@ -63,7 +64,7 @@ sub _parse_review {
     return Review->new(
         id => $data->{id},
         created => DateTime->from_epoch(epoch => str2time($data->{created})),
-        body => markdown($data->{text}),
+        body => non_empty($data->{text}) ? markdown($data->{text}) : '',
         author => User->new(id => $data->{user}{id}, name => $data->{user}{display_name})
     );
 }


### PR DESCRIPTION
CB supports rating-only reviews (without a review text). Those have an undef body, but we're still passing that through `markdown()`, causing warnings.

Warnings:
```
[warning] GET http://localhost:5000/release-group/cc053745-c447-3566-8f27-bed5438c9133 caused a warning: Use of uninitialized value $self in string ne at /home/reosarevok/perl5/lib/perl5/Text/Markdown.pm line 190.
[warning] GET http://localhost:5000/release-group/cc053745-c447-3566-8f27-bed5438c9133 caused a warning: Use of uninitialized value $text in substitution (s///) at /home/reosarevok/perl5/lib/perl5/Text/Markdown.pm line 270.
[warning] GET http://localhost:5000/release-group/cc053745-c447-3566-8f27-bed5438c9133 caused a warning: Use of uninitialized value $text in substitution (s///) at /home/reosarevok/perl5/lib/perl5/Text/Markdown.pm line 271.
```