### PR TITLE
Fix catalyst warning: don't try to trim/sanitize undef "strings"

### DIFF
--- a/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
@@ -393,7 +393,7 @@ sub _seeded_label
         $result->{label} = { name => trim($name) };
     }
 
-    $result->{catalogNumber} = trim($params->{catalog_number} // '');
+    $result->{catalogNumber} = trim($params->{catalog_number});
     return $result;
 }
 
@@ -542,7 +542,7 @@ sub _seeded_artist_credit_name
     my $result = {};
 
     my $name = _seeded_string($params->{name}, "$field_name.name", $errors);
-    $result->{name} = trim($name // '');
+    $result->{name} = trim($name);
 
     if (my $gid = $params->{mbid}) {
         my $entity = $c->model('Artist')->get_by_gid($gid);
@@ -556,7 +556,7 @@ sub _seeded_artist_credit_name
     }
 
     my $join = _seeded_string($params->{join_phrase}, "$field_name.join_phrase", $errors);
-    $result->{joinPhrase} = sanitize($join // '');
+    $result->{joinPhrase} = sanitize($join);
 
     $result->{artist} //= _seeded_hash($c, \&_seeded_artist, $params->{artist},
         "$field_name.artist", $errors);

--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -162,7 +162,7 @@ sub find_or_insert
     my ($self, $artist_credit) = @_;
 
     for my $name (@{ $artist_credit->{names} }) {
-        $name->{join_phrase} = sanitize($name->{join_phrase} // '');
+        $name->{join_phrase} = sanitize($name->{join_phrase});
     }
 
     my ($id, $name, $positions, $credits, $artists, $join_phrases) =

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -330,6 +330,8 @@ sub collapse_whitespace {
 sub sanitize {
     my $t = shift;
 
+    return '' unless non_empty($t);
+
     $t = NFC($t);
     # Before removing invalid characters, convert space control characters
     # into U+0020 (or else they'll be removed).
@@ -346,6 +348,8 @@ sub sanitize {
 sub trim {
     my $t = shift;
 
+    return '' unless non_empty($t);
+
     $t = sanitize($t);
 
     # Remove leading and trailing space
@@ -357,6 +361,8 @@ sub trim {
 sub trim_comment {
     my $t = shift;
 
+    return '' unless non_empty($t);
+
     $t =~ s/^\s*\(([^()]+)\)\s*$/$1/;
 
     return trim($t);
@@ -364,6 +370,8 @@ sub trim_comment {
 
 sub trim_multiline_text {
     my $t = shift;
+
+    return '' unless non_empty($t);
 
     $t = NFC($t);
     $t = remove_invalid_characters($t);

--- a/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
@@ -56,7 +56,7 @@ sub initialize {
     my $entity_properties = $ENTITIES{model_to_type($self->_edit_model)};
 
     if ($entity_properties->{disambiguation} && exists $opts{comment}) {
-        $opts{comment} = trim($opts{comment} // '');
+        $opts{comment} = trim($opts{comment});
     }
 
     $self->data({


### PR DESCRIPTION
This causes warnings once it gets passed to NFC. If $t is empty, I expect there's no need to do any of the sanitizing / trimming anyway, so we might as well just return it unchanged.

This is triggered at least by _clean_link_attribute with no credit or text value, but looking at logs, I think it's triggered elsewhere too.
