### PR TITLE
MBS-11582: Add a sortname method for instrument guess case

### DIFF
--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -123,11 +123,14 @@ MB.GuessCase.work = {
 MB.GuessCase.series = MB.GuessCase.work;
 MB.GuessCase.event = MB.GuessCase.work;
 
-// lol
+// For instruments, all we need to do is lowercase the string
+function lowercaseInstrumentName(name) {
+  return name.toLowerCase();
+}
+
 MB.GuessCase.instrument = {
-  guess: function (string) {
-    return string.toLowerCase();
-  },
+  guess: lowercaseInstrumentName,
+  sortname: lowercaseInstrumentName,
 };
 
 export default self;


### PR DESCRIPTION
### Fix MBS-11582

This is needed for alias sortname guessing, which just breaks completely otherwise. Also replacing the comment with something a bit more useful.