### PR TITLE
MBS-11583: Use sanitized context in hydrated component

### DIFF
--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 
-import {CatalystContext} from '../../context';
+import {SanitizedCatalystContext} from '../../context';
 import Table from '../Table';
 import formatTrackLength
   from '../../static/scripts/common/utility/formatTrackLength';
@@ -56,7 +56,7 @@ const RecordingList = ({
   showRatings = false,
   sortable,
 }: Props): React.Element<typeof Table> => {
-  const $c = React.useContext(CatalystContext);
+  const $c = React.useContext(SanitizedCatalystContext);
 
   const acoustIdsColumn = useAcoustIdsColumn(
     recordings,


### PR DESCRIPTION
### Fix MBS-11583

This is probably using defaultContext since it doesn't have access to CatalystContext. It should only need SanitizedCatalystContext anyway, since that's all it has access to client side, so we just use the SanitizedCatalystContext to begin with.
