### PR TITLE
MBS-11598: Do not generate image link if we don't have a suffix

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Artwork.pm
+++ b/lib/MusicBrainz/Server/Entity/Artwork.pm
@@ -98,7 +98,16 @@ sub filename
     return sprintf("mbid-%s-%d.%s", $self->release->gid, $self->id, $self->suffix);
 }
 
-sub image { my $self = shift; return $self->_url_prefix . "." . $self->suffix; }
+sub image {
+    my $self = shift;
+    
+    # If the file has been removed from CAA the suffix will not exist,
+    # but we still call this for edit display 
+    return undef unless $self->suffix;
+    
+    return $self->_url_prefix . "." . $self->suffix;
+}
+
 sub small_thumbnail { my $self = shift; return $self->_url_prefix . "-250.jpg"; }
 sub large_thumbnail { my $self = shift; return $self->_url_prefix . "-500.jpg"; }
 sub huge_thumbnail { my $self = shift; return $self->_url_prefix . "-1200.jpg"; }

--- a/root/types.js
+++ b/root/types.js
@@ -150,7 +150,7 @@ declare type ArtworkT = {
   +huge_ia_thumbnail: string,
   +huge_thumbnail: string,
   +id: number,
-  +image: string,
+  +image: string | null,
   +large_ia_thumbnail: string,
   +large_thumbnail: string,
   +mime_type: string,


### PR DESCRIPTION
### Fix MBS-11598

AFAICT this happens if the file has been removed from CAA. The thumbnails still work, at the moment, but I think that's just because of a bug where deleted images won't get purged from the IA.
This also removes a concatenation-with-undef Catalyst warning.