### PR TITLE
MBS-11611: Do not keep/add trailing slash in OC ReMix URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2465,7 +2465,7 @@ const CLEANUPS = {
     type: LINK_TYPES.otherdatabases,
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ocremix\.org\//, 'https://ocremix.org/');
-      url = url.replace(/^https:\/\/ocremix\.org\/(album|artist|game|org|remix|song)\/([^\/?#]+).*$/, 'https://ocremix.org/$1/$2/');
+      url = url.replace(/^https:\/\/ocremix\.org\/(album|artist|game|org|remix|song)\/([^\/?#]+).*$/, 'https://ocremix.org/$1/$2');
       return url;
     },
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2851,37 +2851,37 @@ const testData = [
                      input_url: 'http://www.ocremix.org/artist/4792/oneup',
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/artist/4792/',
+            expected_clean_url: 'https://ocremix.org/artist/4792',
   },
   {
                      input_url: 'https://ocremix.org/org/2/nintendo',
              input_entity_type: 'label',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/org/2/',
+            expected_clean_url: 'https://ocremix.org/org/2',
   },
   {
                      input_url: 'https://ocremix.org/album/46/final-fantasy-vi-balance-and-ruin',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/album/46/',
+            expected_clean_url: 'https://ocremix.org/album/46',
   },
   {
                      input_url: 'https://ocremix.org/remix/OCR00002#tab-details',
              input_entity_type: 'release',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/remix/OCR00002/',
+            expected_clean_url: 'https://ocremix.org/remix/OCR00002',
   },
   {
                      input_url: 'http://ocremix.org/game/512/jade-cocoon-story-of-the-tamamayu-ps1',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/game/512/',
+            expected_clean_url: 'https://ocremix.org/game/512',
   },
   {
                      input_url: 'http://ocremix.org/song/1033',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',
-            expected_clean_url: 'https://ocremix.org/song/1033/',
+            expected_clean_url: 'https://ocremix.org/song/1033',
   },
   // Offizielle Deutsche Charts
   {


### PR DESCRIPTION
### Implement MBS-11611

They don't have trailing slashes in cases where they don't append names to the URLs (e.g. https://ocremix.org/remix/OCR00002) so it might be sensible to do the same.


This would probably cause the risk of duplicate links though, so we might want to do a MBBE cleanup if we merge this? :) 