### PR TITLE
MBS-11612: Restore link to genre/delete to genre sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -15,6 +15,15 @@ with 'MusicBrainz::Server::Controller::Role::Details';
 
 sub base : Chained('/') PathPart('genre') CaptureArgs(0) { }
 
+after 'load' => sub {
+    my ($self, $c) = @_;
+    my $entity_name = $self->{entity_name};
+    my $entity = $c->stash->{ $entity_name };
+    $c->stash(
+        can_delete => $c->model('Genre')->can_delete($entity->id)
+    );
+};
+
 sub show : PathPart('') Chained('load') {
     my ($self, $c) = @_;
 

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -47,7 +47,7 @@ sub update {
     $self->sql->update_row('genre', $row, { id => $genre_id });
 }
 
-sub can_delete {1}
+sub can_delete { 1 }
 
 sub delete {
     my ($self, $genre_id) = @_;

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -47,6 +47,8 @@ sub update {
     $self->sql->update_row('genre', $row, { id => $genre_id });
 }
 
+sub can_delete {1}
+
 sub delete {
     my ($self, $genre_id) = @_;
 


### PR DESCRIPTION
### Fix MBS-11612

MBS-10830 stopped showing removal links on the sidebar unless the entity can be deleted, but genres didn't have a can_delete method. I could just hardcode genres to always pass can_delete true or skip the can_delete check for genres, but in case we decide to add blocks to deletion later, maybe it's better to just do this like for other entities.