### PR TITLE
MBS-11619: Ignore periods and +tags in e-mail admin searches

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -195,7 +195,7 @@ sub search_by_email {
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table .
         q" WHERE regexp_replace(regexp_replace(email, '(\+.*@)', '@'), '\.(.*@)', '\1', 'g') ~ ?" .
-        ' ORDER BY member_since LIMIT 100';
+        ' ORDER BY member_since DESC LIMIT 100';
 
     $self->query_to_list($query, [$email]);
 }

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -186,8 +186,15 @@ sub find_by_ip {
 sub search_by_email {
     my ($self, $email) = @_;
 
+    # Remove periods (\.), and anything preceded by a + sign on the user side
+    # for email matching, since both of these are often used as "free aliases"
+    # by email providers
+    $email =~ s/\\\+.*@/@/;
+    $email =~ s/\\\.(.*@)/$1/g;
+
     my $query = 'SELECT ' . $self->_columns .
-        ' FROM ' . $self->_table . ' WHERE email ~ ?' .
+        ' FROM ' . $self->_table .
+        q" WHERE regexp_replace(regexp_replace(email, '(\+.*@)', '@'), '\.(.*@)', '\1', 'g') ~ ?" .
         ' ORDER BY member_since LIMIT 100';
 
     $self->query_to_list($query, [$email]);

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import FormRowText from '../components/FormRowText';
 import FormSubmit from '../components/FormSubmit';
 import Layout from '../layout';
+import expand2react from '../static/scripts/common/i18n/expand2react';
 
 import UserList from './components/UserList';
 
@@ -40,6 +41,23 @@ const EmailSearch = ({
               link: 'https://www.postgresql.org/docs/12/' +
                 'functions-matching.html#FUNCTIONS-POSIX-REGEXP',
             },
+          )}
+        </p>
+        <p>
+          {expand2react(
+            `Since periods (<code>.</code>) and tags preceded with a
+             <code>+</code> sign on the user side of the address (that is,
+             before the <code>@</code> sign) are often used as “free aliases”
+             by email providers, both of these are ignored by this search
+             to help you find address aliases. This will only get triggered
+             if your query includes <code>@</code> (so, both
+             <code>example@example\\.com</code> and <code>example\\+mb@</code>
+             will match the address <code>exam.ple+mb@example.com</code>,
+             but simply <code>example\\+mb</code> will not).
+             <br/>
+             Don’t forget you still need to escape these symbols
+             (<code>\\.</code> and <code>\\+</code> respectively), otherwise
+             they’ll be understood as special regular expression characters!`,
           )}
         </p>
 


### PR DESCRIPTION
### Implement MBS-11619 / MBS-11620

These are often used by spammers to get "new" emails for more accounts, since many providers (such as Gmail) allow to add periods and/or +tags to the address to create aliases for the same account. We don't want to fully block this (many people use email+musicbrainz@provider to receive their MB emails, for example) but it should be easy to find people using it for nefarious purposes.

Also made the results show up to the *newest* 100 editors that match, rather than the oldest.