### PR TITLE
MBS-11590: Standardize display of empty fields in cover art edits

### DIFF
--- a/root/edit/details/AddCoverArt.js
+++ b/root/edit/details/AddCoverArt.js
@@ -39,16 +39,16 @@ const AddCoverArt = ({edit}: Props): React.Element<'table'> => {
         </td>
       </tr>
 
-      {display.artwork.types?.length ? (
-        <tr>
-          <th>{l('Types:')}</th>
-          <td>
-            {commaOnlyList(display.artwork.types.map(
+      <tr>
+        <th>{l('Types:')}</th>
+        <td>
+          {display.artwork.types?.length ? (
+            commaOnlyList(display.artwork.types.map(
               type => lp_attributes(type, 'cover_art_type'),
-            ))}
-          </td>
-        </tr>
-      ) : null}
+            ))
+          ) : lp('(none)', 'type')}
+        </td>
+      </tr>
 
       <tr>
         <th>{l('Filename:')}</th>

--- a/root/edit/details/RemoveCoverArt.js
+++ b/root/edit/details/RemoveCoverArt.js
@@ -60,14 +60,12 @@ const RemoveCoverArt = ({edit}: Props): React.Element<'table'> => {
         </tr>
       ) : null}
 
-      <tr>
-        <th>{l('Comment:')}</th>
-        <td>
-          {nonEmpty(display.artwork.comment)
-            ? display.artwork.comment
-            : lp('(none)', 'comment')}
-        </td>
-      </tr>
+      {display.artwork.comment ? (
+        <tr>
+          <th>{l('Comment:')}</th>
+          <td>{display.artwork.comment}</td>
+        </tr>
+      ) : null}
 
       <EditArtwork artwork={display.artwork} release={display.release} />
     </table>


### PR DESCRIPTION
### Implement MBS-11590

RemoveCoverArt used to show '(none)' when either types or comment were blank. AddCoverArt used to show nothing for either case.
Arguably every cover art piece should have types, so them being missing is quite relevant to an AddCoverArt edit too. Having no comment is not really strange nor problematic. As such, this standardizes the display by not showing empty comments in either edit, and showing empty types on both.