### PR TITLE
MBS-11630: Do not break on empty edits array

### DIFF
--- a/root/static/scripts/release-editor/edits.js
+++ b/root/static/scripts/release-editor/edits.js
@@ -608,7 +608,11 @@ releaseEditor.orderedEditSubmissions = [
     callback: function (release, edits) {
       var edit = edits[0];
 
-      if (edit.edit_type == MB.edit.TYPES.EDIT_RELEASEGROUP_CREATE) {
+      /*
+       * edit can be undef if the only change is RG rename
+       * and the RG has already been renamed to the same name in the meantime
+       */
+      if (edit?.edit_type == MB.edit.TYPES.EDIT_RELEASEGROUP_CREATE) {
         release.releaseGroup(
           new releaseEditor.fields.ReleaseGroup(edits[0].entity),
         );


### PR DESCRIPTION
### Fix MBS-11630

There is at least one case where the edits.releaseGroup array is empty: when the release group has been renamed elsewhere after the editor opened this release editor session to the same name the editor is trying to apply here. As such, we try to access edit_type of an undefined edit. This just uses optional chaining to avoid that attempted call entirely.
