### PR TITLE
MBS-11622: Clean up Apple Music label URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -648,7 +648,7 @@ const CLEANUPS = {
   'applemusic': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i')],
     clean: function (url) {
-      url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
+      url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|label|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
       // US page is the default, add its country-code to clarify (MBS-10623)
       url = url.replace(/^(https:\/\/music\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
       return url;

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -401,6 +401,10 @@ const testData = [
             expected_clean_url: 'https://music.apple.com/ca/artist/205021452',
   },
   {
+                     input_url: 'https://music.apple.com/us/label/ghostly-international/1543968172',
+            expected_clean_url: 'https://music.apple.com/us/label/1543968172',
+  },
+  {
                      input_url: 'https://music.apple.com/ee/music-video/black-and-yellow/539886832?uo=4&mt=5&app=music',
             expected_clean_url: 'https://music.apple.com/ee/music-video/539886832',
   },


### PR DESCRIPTION
### Implement MBS-11622

We shouldn't really autoselect-validate these; while we still don't have a streaming page for labels, this seems like a good indication we could use one. But this adds cleanup for now.
