### PR TITLE
MBS-11614: Allow merging releases when a medium is empty

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Data/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Release.pm
@@ -626,7 +626,7 @@ test 'find_by_cdtoc' => sub {
     my ($releases, undef) = $c->model('Release')->find_for_cdtoc(1, 1);
     is_deeply(
       [map { $_->id } @$releases],
-      [8, 9, 6, 7, 100]
+      [8, 9, 6, 7, 110]
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -7,7 +7,7 @@ with 't::Context';
 BEGIN { use MusicBrainz::Server::Edit::Release::Merge };
 
 use MusicBrainz::Server::Context;
-use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_MERGE $STATUS_APPLIED );
+use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_MERGE $STATUS_APPLIED $STATUS_ERROR );
 use MusicBrainz::Server::Data::Release;
 use MusicBrainz::Server::Test qw( accept_edit reject_edit );
 
@@ -545,6 +545,62 @@ EOSQL
         ],
         'final recording ids are correct',
     );
+};
+
+test 'Merging release with empty medium (MBS-11614)' => sub {
+
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+release');
+
+    my $wrong_edit = $c->model('Edit')->create(
+        edit_type => $EDIT_RELEASE_MERGE,
+        editor_id => 1,
+        new_entity => {
+            id => 101,
+            name => 'One Empty Medium',
+        },
+        old_entities => [
+            {
+                id => 111,
+                name => 'No Empty Mediums'
+            }
+        ],
+        merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE
+    );
+    ok($wrong_edit->is_open);
+    $c->model('Edit')->accept($wrong_edit);
+    is($wrong_edit->status, $STATUS_ERROR, 'edit is not applied, with an error');
+
+    my $right_edit = $c->model('Edit')->create(
+        edit_type => $EDIT_RELEASE_MERGE,
+        editor_id => 1,
+        new_entity => {
+            id => 111,
+            name => 'No Empty Mediums',
+        },
+        old_entities => [
+            {
+                id => 101,
+                name => 'One Empty Medium'
+            }
+        ],
+        merge_strategy => $MusicBrainz::Server::Data::Release::MERGE_MERGE
+    );
+    
+    ok($right_edit->is_open);
+    $c->model('Edit')->accept($right_edit);
+    is($right_edit->status, $STATUS_APPLIED, 'edit is applied');
+
+    my $release = $c->model('Release')->get_by_id(111);
+    $c->model('Medium')->load_for_releases($release);
+
+    my @mediums = $release->all_mediums;
+    $c->model('Track')->load_for_mediums(@mediums);
+
+    ok($mediums[0]->track_count == 1, 'First medium has one track');
+    ok($mediums[1]->track_count == 1, 'Second medium has one track');
 };
 
 1;

--- a/t/sql/release.sql
+++ b/t/sql/release.sql
@@ -81,7 +81,7 @@ INSERT INTO recording (id, gid, name, artist_credit)
 INSERT INTO medium (id, release, track_count, position)
     VALUES (2, 6, 0, 1), (3, 7, 0, 1),
            (4, 8, 0, 1), (5, 9, 0, 1),
-           (60, 100, 1, 1), (70, 110, 1, 1),
+           (60, 100, 0, 1), (70, 110, 0, 1),
            (80, 101, 0, 1), (81, 101, 0, 2),
            (90, 111, 0, 1), (91, 111, 0, 2);
 INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recording)

--- a/t/sql/release.sql
+++ b/t/sql/release.sql
@@ -62,14 +62,17 @@ INSERT INTO release (id, gid, name, artist_credit, release_group) VALUES (5, '53
 
 -- test merge strategies
 INSERT INTO release_group (id, gid, name, artist_credit)
-    VALUES (100, '7a14d050-759c-41c0-b7a0-71424d1b177a', 'Pregap?', 1);
+    VALUES (100, '7a14d050-759c-41c0-b7a0-71424d1b177a', 'Pregap?', 1),
+           (101, '3a14d050-759c-41c0-b7a0-71424d1b177a', 'Empty Medium Merge', 2);
 INSERT INTO release (id, gid, name, release_group, artist_credit)
     VALUES (6, '7a906020-72db-11de-8a39-0800200c9a70', 'The Prologue (disc 1)', 1, 1),
            (7, '7a906020-72db-11de-8a39-0800200c9a71', 'The Prologue (disc 2)', 1, 1),
            (8, '7a906020-72db-11de-8a39-0800200c9a72', 'Subversion EP (disc 1)', 1, 1),
            (9, '7a906020-72db-11de-8a39-0800200c9a73', 'Subversion EP (disc 2)', 1, 1),
            (100, '6b89a7f7-ac01-4b57-ab0a-381b10523b34', 'Pregap', 100, 1),
-           (110, '94a44113-f3e7-4bf1-8d68-0d71922ac346', 'No pregap', 100, 1);
+           (110, '94a44113-f3e7-4bf1-8d68-0d71922ac346', 'No pregap', 100, 1),
+           (101, '3b89a7f7-ac01-4b57-ab0a-381b10523b34', 'One Empty Medium', 101, 2),
+           (111, '34a44113-f3e7-4bf1-8d68-0d71922ac346', 'No Empty Mediums', 101, 2);
 INSERT INTO recording (id, gid, name, artist_credit)
     VALUES (2, '50a772b0-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
            (3, '5d9cb570-f0cc-11df-98cf-0800200c9a66', 'Track on recording', 1),
@@ -78,14 +81,19 @@ INSERT INTO recording (id, gid, name, artist_credit)
 INSERT INTO medium (id, release, track_count, position)
     VALUES (2, 6, 0, 1), (3, 7, 0, 1),
            (4, 8, 0, 1), (5, 9, 0, 1),
-           (60, 100, 1, 1), (70, 110, 1, 1);
+           (60, 100, 1, 1), (70, 110, 1, 1),
+           (80, 101, 0, 1), (81, 101, 0, 2),
+           (90, 111, 0, 1), (91, 111, 0, 2);
 INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recording)
     VALUES (2, 'd6de1f70-4a29-4cce-a35b-aa2b56265583', 'Track on recording', 1, 2, 1, 1, 2),
            (3, '929e5fb9-cfe7-4764-b3f6-80e056f0c1da', 'Track on recording', 1, 3, 1, 1, 3),
            (4, '7e489434-e293-44e9-9254-8dec56a0c0c6', 'Track on recording', 1, 4, 1, 1, 4),
            (5, 'a833f5c7-dd13-40ba-bb5b-dc4e35d2bb90', 'Track on recording', 1, 5, 1, 1, 5),
            (60, 'fb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'Pregap', 1, 60, 0, '', 2),
-           (70, '0f4846f2-f96b-4fc3-b979-5fce32f193e5', 'Not pregap', 1, 70, 1, '1', 2);
+           (70, '0f4846f2-f96b-4fc3-b979-5fce32f193e5', 'Not pregap', 1, 70, 1, '1', 2),
+           (81, 'ab6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'A Track', 2, 81, 1, '1', 2),
+           (90, 'bb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'A Track', 2, 90, 1, '1', 2),
+           (91, 'cb6e4cd4-fa17-434f-b6ce-d1622e6f3b82', 'Another Track', 2, 91, 1, '1', 2);
 
 -- Test for searching by track artist
 INSERT INTO artist_credit (id, name, artist_count) VALUES (3, 'Various Artists', 2);


### PR DESCRIPTION
### Implement MBS-11614

If a release has two mediums, each with 1 track, and another has two mediums, one empty and one with 1 track, we should allow merging the empty one into the non-empty one. After all, that data doesn't mean the medium actually has 0 tracks, just that we don't have enough info about the tracks on that medium.
Merging the other way around (into the release with the 0-track medium) should still fail, but with a more explanatory error message.