### PR TITLE
MBS-11643: Don't disable links that haven't ended yet

### DIFF
--- a/root/layout/components/ExternalLinks.js
+++ b/root/layout/components/ExternalLinks.js
@@ -16,6 +16,7 @@ import {FAVICON_CLASSES} from '../../static/scripts/common/constants';
 import {compare, l} from '../../static/scripts/common/i18n';
 import linkedEntities from '../../static/scripts/common/linkedEntities';
 import {uniqBy} from '../../static/scripts/common/utility/arrays';
+import isDisabledLink from '../../utility/isDisabledLink';
 
 function faviconClass(urlEntity) {
   let matchingClass;
@@ -94,7 +95,7 @@ const ExternalLinks = ({
     const relationship = relationships[i];
     const target = relationship.target;
 
-    if (relationship.ended || target.entityType !== 'url') {
+    if (target.entityType !== 'url' || isDisabledLink(relationship, target)) {
       continue;
     }
 

--- a/root/utility/isDisabledLink.js
+++ b/root/utility/isDisabledLink.js
@@ -8,12 +8,20 @@
  */
 
 import isGreyedOut from '../url/utility/isGreyedOut';
+import isFutureDate from '../utility/isFutureDate';
 
 export default function isDisabledLink(
-  relationshipOrLinkDatePeriod: {+ended: boolean, ...},
+  relationshipOrLinkDatePeriod: {
+    +end_date: PartialDateT | null,
+    +ended: boolean,
+    ...
+  },
   entity: CoreEntityT,
 ): boolean {
+  const isEnded = relationshipOrLinkDatePeriod.ended &&
+                  !isFutureDate(relationshipOrLinkDatePeriod.end_date);
+
   return entity.entityType === 'url' && (
-    relationshipOrLinkDatePeriod.ended || isGreyedOut(entity.href_url)
+    isEnded || isGreyedOut(entity.href_url)
   );
 }


### PR DESCRIPTION
### Fix MBS-11643

We used to disable any link marked as ended, even if the end date was in the future. This doesn't make much sense, so I made it so isDisabledLink actually checks for the end date too.
This also uses isDisabledLink, rather than just ended, to decide whether to display a link on the sidebar. I think it makes sense that we would also explicitly stop showing any links marked with isGreyedOut on the sidebar, so it seems like a win-win.
