### PR TITLE
MBS-11644: Allow specifying a release MBID when moving a CD TOC

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -413,10 +413,32 @@ sub move : Local Edit
         $c->stash( template => 'cdtoc/move_search.tt' );
 
         if ($c->form_submitted_and_valid($search_release, $c->req->query_params)) {
+            my $query = $search_release->field('query')->value;
+            my ($mbid) = $query =~ m/(
+                [\da-f]{8} -
+                [\da-f]{4} -
+                [\da-f]{4} -
+                [\da-f]{4} -
+                [\da-f]{12}
+            )/ax;
+
             my $releases = $self->_load_paged($c, sub {
-                $c->model('Search')->search('release', $search_release->field('query')->value, shift, shift,
+                if (defined $mbid) {
+                    $c->stash->{was_mbid_search} = 1;
+                    my $release = $c->model('Release')->get_by_gid($mbid);
+                    return [] unless defined $release;
+                    return [
+                        MusicBrainz::Server::Entity::SearchResult->new(
+                            position => 1,
+                            score => 100,
+                            entity => $release,
+                        ),
+                    ];
+                }
+                $c->model('Search')->search('release', $query, shift, shift,
                                             { track_count => $cdtoc->track_count });
             });
+
             my @releases = map { $_->entity } @$releases;
             $c->model('ArtistCredit')->load(@releases);
             $c->model('Release')->load_related_info(@releases);

--- a/root/cdtoc/move_search.tt
+++ b/root/cdtoc/move_search.tt
@@ -12,7 +12,7 @@
     [% USE r = FormRenderer(query_release) %]
     <input type="hidden" name="toc" value="[% medium_cdtoc.id %]" />
     [% WRAPPER form_row %]
-      [% r.label('query', l('Release title:')) %]
+      [% r.label('query', add_colon(l('Release title or MBID'))) %]
       [% r.text('query') %]
       [% form_submit(l('Search'), 'inline') %]
     [% END %]


### PR DESCRIPTION
### Implement MBS-11644

MBS-7473 / https://github.com/metabrainz/musicbrainz-server/pull/1387, but for moving rather than attaching a new CD TOC.
