### PR TITLE
MBS-11650: Add tag and rating statistics to profile page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -447,6 +447,7 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     my $edit_stats = $c->model('Editor')->various_edit_counts($user->id);
     $edit_stats->{last_day_count} = $c->model('Editor')->last_24h_edit_count($user->id);
     my $added_entities = $c->model('Editor')->added_entities_counts($user->id);
+    my $secondary_stats = $c->model('Editor')->secondary_counts($user->id, $c->stash->{viewing_own_profile});
 
     my @ip_hashes;
     if ($c->user_exists && $c->user->is_account_admin && !(
@@ -465,6 +466,7 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
         user            => $c->unsanitized_editor_json($user),
         votes           => $c->stash->{votes},
         addedEntities   => $added_entities,
+        secondaryStats  => $secondary_stats,
     );
 
     $c->stash(

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -679,7 +679,7 @@ const UserProfileStatistics = ({
               <abbr title={l('Newly applied edits may ' +
                              'need 24 hours to appear')}
               >
-                {exp.l('Added entities')}
+                {l('Added entities')}
               </abbr>
             </th>
           </tr>

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -446,6 +446,12 @@ type EditStatsT = {
   +rejected_count: number,
 };
 
+type SecondaryStatsT = {
+  +downvoted_tag_count?: number,
+  +rating_count?: number,
+  +upvoted_tag_count?: number,
+};
+
 type VoteStatsT = Array<{
   +all: {
     +count: number,
@@ -477,6 +483,7 @@ type UserProfileStatisticsProps = {
   +$c: CatalystContextT,
   +addedEntities: EntitiesStatsT,
   +editStats: EditStatsT,
+  +secondaryStats: SecondaryStatsT,
   +user: UnsanitizedEditorT,
   +votes: VoteStatsT,
 };
@@ -486,6 +493,7 @@ const UserProfileStatistics = ({
   editStats,
   user,
   votes,
+  secondaryStats,
   addedEntities,
 }: UserProfileStatisticsProps) => {
   const voteTotals = votes.pop();
@@ -494,6 +502,11 @@ const UserProfileStatistics = ({
                           editStats.accepted_auto_count;
   const hasAddedEntities =
     Object.values(addedEntities).some((number) => number !== 0);
+  const hasPublicRatings = secondaryStats.rating_count != null;
+  const hasPublicTags = secondaryStats.upvoted_tag_count != null;
+  const ratingCount = secondaryStats.rating_count ?? 0;
+  const upvotedTagCount = secondaryStats.upvoted_tag_count ?? 0;
+  const downvotedTagCount = secondaryStats.downvoted_tag_count ?? 0;
 
   return (
     <>
@@ -709,6 +722,58 @@ const UserProfileStatistics = ({
           )}
         </tbody>
       </table>
+
+      {hasPublicTags || hasPublicRatings ? (
+        <table
+          className="statistics"
+          title={l('This table shows a summary ' +
+                  'of secondary data added by this editor.')}
+        >
+          <thead>
+            <tr>
+              <th colSpan="2">
+                {l('Tags and ratings')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {hasPublicTags ? (
+              <>
+                <UserProfileProperty name={l('Tags upvoted')}>
+                  {$c.user && upvotedTagCount > 0 ? exp.l(
+                    '{count} ({view_url|view})',
+                    {
+                      count: formatCount($c, upvotedTagCount),
+                      view_url: `/user/${encodedName}/tags`,
+                    },
+                  ) : formatCount($c, upvotedTagCount)}
+                </UserProfileProperty>
+
+                <UserProfileProperty name={l('Tags downvoted')}>
+                  {$c.user && downvotedTagCount > 0 ? exp.l(
+                    '{count} ({view_url|view})',
+                    {
+                      count: formatCount($c, downvotedTagCount),
+                      view_url: `/user/${encodedName}/tags?show_downvoted=1`,
+                    },
+                  ) : formatCount($c, downvotedTagCount)}
+                </UserProfileProperty>
+              </>
+            ) : null}
+            {hasPublicRatings ? (
+              <UserProfileProperty name={l('Ratings')}>
+                {$c.user && ratingCount > 0 ? exp.l(
+                  '{count} ({view_url|view})',
+                  {
+                    count: formatCount($c, ratingCount),
+                    view_url: `/user/${encodedName}/ratings`,
+                  },
+                ) : formatCount($c, ratingCount)}
+              </UserProfileProperty>
+            ) : null}
+          </tbody>
+        </table>
+      ) : null}
     </>
   );
 };
@@ -718,6 +783,7 @@ type UserProfileProps = {
   +addedEntities: EntitiesStatsT,
   +editStats: EditStatsT,
   +ipHashes: $ReadOnlyArray<string>,
+  +secondaryStats: SecondaryStatsT,
   +subscribed: boolean,
   +subscriberCount: number,
   +user: UnsanitizedEditorT,
@@ -728,6 +794,7 @@ const UserProfile = ({
   $c,
   editStats,
   ipHashes,
+  secondaryStats,
   subscribed,
   subscriberCount,
   user,
@@ -755,6 +822,7 @@ const UserProfile = ({
         $c={$c}
         addedEntities={addedEntities}
         editStats={editStats}
+        secondaryStats={secondaryStats}
         user={user}
         votes={votes}
       />


### PR DESCRIPTION
### Implement MBS-11650

It seems interesting to see a sum of tags (up- and downvoted) and ratings for each user, if they are public (or the user's own). Ideally this could also show a count of CB reviews (MBS-11653).

![Screenshot from 2021-05-10 14-44-21](https://user-images.githubusercontent.com/1069224/117654819-f4815d80-b19e-11eb-8043-879afb1a606d.png)

Tested with `pink` data, logged in vs out, modifying preferences to make sure that works as it should. I can't guarantee this doesn't cause a slowdown though.