### PR TITLE
MBS-11662: Lowercase untitled/unknown if in brackets

### DIFF
--- a/root/static/scripts/guess-case/utils.js
+++ b/root/static/scripts/guess-case/utils.js
@@ -61,6 +61,8 @@ const preBracketSingleWordsList = [
   'takes',
   'techno',
   'trance',
+  'unknown',
+  'untitled',
   'version',
   'video',
   'vocal',

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -358,7 +358,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(26);
+  t.plan(27);
 
   const tests = [
     {
@@ -515,6 +515,12 @@ test('BugFixes', function (t) {
       input: '“quoted stuff”',
       expected: '“Quoted Stuff”',
       bug: 'MBS-8232',
+      mode: 'English',
+    },
+    {
+      input: '[Unknown] / This track is / [Untitled]',
+      expected: '[unknown] / This Track Is / [untitled]',
+      bug: 'MBS-11662',
       mode: 'English',
     },
     /*


### PR DESCRIPTION
### Fix MBS-11662

Rather than fiddle with checkSpecialCase, which currently only works by overriding the entire track title, this just adds 'unknown' and 'untitled' to the list of words lowercased when in brackets (square brackets also count).
