### PR TITLE
MBS-10205: Readd link to the Data Removal Policy to the menu

### DIFF
--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -132,6 +132,9 @@ const AboutMenu = () => (
       <li>
         <a href="https://metabrainz.org/gdpr">{l('GDPR Compliance')}</a>
       </li>
+      <li>
+        <a href="/doc/Data_Removal_Policy">{l('Data Removal Policy')}</a>
+      </li>
       <li className="separator">
         <a href="/elections">{l('Auto-editor Elections')}</a>
       </li>


### PR DESCRIPTION
### Implement MBS-10205

This was removed in ad98fdd6f9e3f11b524ef077a83a1b52ec9ed9d0 but neither commit, ticket nor PR have any explanation about why.
It makes sense to re-add it IMO as a clear pointer to what we do remove (birth dates, sometimes legal names) and what we do not remove (pretty much anything else). I reworded the linked page a bit to clarify that, see MBS-11657.