### PR TITLE
MBS-11660: Fix ignoring several periods in admin search by email

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -186,15 +186,9 @@ sub find_by_ip {
 sub search_by_email {
     my ($self, $email) = @_;
 
-    # Remove periods (\.), and anything preceded by a + sign on the user side
-    # for email matching, since both of these are often used as "free aliases"
-    # by email providers
-    $email =~ s/\\\+.*@/@/;
-    $email =~ s/\\\.(.*@)/$1/g;
-
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table .
-        q" WHERE regexp_replace(regexp_replace(email, '(\+.*@)', '@'), '\.(.*@)', '\1', 'g') ~ ?" .
+        q" WHERE (regexp_replace(regexp_replace(email, '[@+].*', ''), '\.', '', 'g') || regexp_replace(email, '.*@', '@')) ~ ?" .
         ' ORDER BY member_since DESC LIMIT 100';
 
     $self->query_to_list($query, [$email]);

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -184,14 +184,14 @@ sub find_by_ip {
 }
 
 sub search_by_email {
-    my ($self, $email) = @_;
+    my ($self, $email_regexp) = @_;
 
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table .
         q" WHERE (regexp_replace(regexp_replace(email, '[@+].*', ''), '\.', '', 'g') || regexp_replace(email, '.*@', '@')) ~ ?" .
         ' ORDER BY member_since DESC LIMIT 100';
 
-    $self->query_to_list($query, [$email]);
+    $self->query_to_list($query, [$email_regexp]);
 }
 
 sub find_by_area {

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -48,16 +48,19 @@ const EmailSearch = ({
             `Since periods (<code>.</code>) and tags preceded with a
              <code>+</code> sign on the user side of the address (that is,
              before the <code>@</code> sign) are often used as “free aliases”
-             by email providers, both of these are ignored by this search
-             to help you find address aliases. This will only get triggered
-             if your query includes <code>@</code> (so, both
-             <code>example@example\\.com</code> and <code>example\\+mb@</code>
-             will match the address <code>exam.ple+mb@example.com</code>,
-             but simply <code>example\\+mb</code> will not).
-             <br/>
-             Don’t forget you still need to escape these symbols
-             (<code>\\.</code> and <code>\\+</code> respectively), otherwise
-             they’ll be understood as special regular expression characters!`,
+             by email providers, both of these are ignored from the registered
+             email addresses by this search to help you find address aliases.
+             Please remove these parts from the user side of the address.
+             Don’t forget you still need to escape periods with a backslash
+             (<code>\\.</code>) in the host side of your search, otherwise
+             they’ll be understood as special regular expression characters!
+             For example, <code>user@host\\.name</code> search will match both
+             <code>user@host.name</code> and
+             <code>us.er+alias@host.name</code>, but neither
+             <code>user@sub.host.name</code> nor <code>user@host-name</code>.
+             Counter-example: <code>us\\.er\\+alias@host\\.name</code> search
+             will match neither <code>us.er+alias@host.name</code> nor
+             <code>user@host.name</code> email addresses.`,
           )}
         </p>
 


### PR DESCRIPTION
# Fix MBS-11660: Periods are not always ignored in admin e-mail searches

Editor search by email (for admin) was failing at removing more than one period `.` from email search and addresses despite the `g` flag because it relied on capture group `()` that would be processed only once. That is why only one period `.` was removed from user info part.

This patch fixes it by splitting email over `@` symbol, for processing user info (removing `+suffix` and periods `.` used for aliases) and host name (not removing anything as these are not for aliases) separately, then contatenating both parts again using `||`.

It also requires admin to not include `+suffix` and periods `.` in user info parts of its regular expression search. This is because it is not possible to programmatically distinguish user info parts in complex regular expression that may include several user info parts such as `^(huey@meb\.o|duey@.+\.meb\.o|.+\.louie\+green\.cap@meb\.o)$` (or it would require a regular expression parser).
    
Add continuous integration tests for the `search_by_email` subroutine.
