### PR TITLE
MBS-11664 / MBS-11666: Enable discID tab for releases that wrongly have discids + add report

### DIFF
--- a/lib/MusicBrainz/Server/Report/ShouldNotHaveDiscIDs.pm
+++ b/lib/MusicBrainz/Server/Report/ShouldNotHaveDiscIDs.pm
@@ -1,0 +1,38 @@
+package MusicBrainz::Server::Report::ShouldNotHaveDiscIDs;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub component_name { 'ShouldNotHaveDiscIds' }
+
+sub query {
+    q{
+        SELECT DISTINCT ON (r.id)
+            r.id AS release_id,
+            row_number() OVER (ORDER BY r.artist_credit, r.name)
+        FROM
+        ( SELECT id, artist_credit, name
+          FROM release
+          WHERE id IN (
+              SELECT release FROM medium
+              WHERE (SELECT TRUE FROM medium_format WHERE medium_format.id = medium.format AND has_discids IS FALSE)
+              AND id IN (SELECT medium FROM medium_cdtoc)
+          )
+        ) r
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -91,6 +91,7 @@ use MusicBrainz::Server::PagedReport;
     ReleasesConflictingDiscIDs
     SeparateDiscs
     SetInDifferentRG
+    ShouldNotHaveDiscIDs
     SingleMediumReleasesWithMediumTitles
     SomeFormatsUnset
     SuperfluousDataTracks
@@ -181,6 +182,7 @@ use MusicBrainz::Server::Report::ReleasesMissingDiscIDs;
 use MusicBrainz::Server::Report::ReleasesConflictingDiscIDs;
 use MusicBrainz::Server::Report::SeparateDiscs;
 use MusicBrainz::Server::Report::SetInDifferentRG;
+use MusicBrainz::Server::Report::ShouldNotHaveDiscIDs;
 use MusicBrainz::Server::Report::SingleMediumReleasesWithMediumTitles;
 use MusicBrainz::Server::Report::SomeFormatsUnset;
 use MusicBrainz::Server::Report::SuperfluousDataTracks;

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -94,8 +94,11 @@ function buildLinks(
   }
 
   if (entity.entityType === 'release') {
+    // Drop # + grey out if can't have discIDs unless it has them due to bug
+    const enabledDiscIdTab = entity.may_have_discids /*:: === true */ ||
+      ($c.stash.release_cdtoc_count || 0) > 0;
     links.push(buildLink(
-      entity.may_have_discids /*:: === true */
+      enabledDiscIdTab
         ? texp.l(
           'Disc IDs ({num})',
           {num: $c.stash.release_cdtoc_count || 0},
@@ -104,7 +107,7 @@ function buildLinks(
       entity,
       'discids',
       page,
-      !entity.may_have_discids, /* disable if can't have discids */
+      !enabledDiscIdTab, /* disable tab if irrelevant */
     ));
   }
 

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -405,6 +405,10 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           reportName="ReleasesConflictingDiscIDs"
         />
         <ReportsIndexEntry
+          content={l('Releases that have disc IDs, but shouldn’t')}
+          reportName="ShouldNotHaveDiscIDs"
+        />
+        <ReportsIndexEntry
           content={l(
             'Releases where artist name and label name are the same',
           )}

--- a/root/report/ShouldNotHaveDiscIds.js
+++ b/root/report/ShouldNotHaveDiscIds.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ReleaseList from './components/ReleaseList';
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT, ReportReleaseT} from './types';
+
+const ShouldNotHaveDiscIds = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows releases that have at least one medium with a
+       format that does not support disc IDs, yet have disc IDs attached.
+       Usually this means the disc IDs ended up here because of a bug
+       and should be moved or removed.`,
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases that have disc IDs, but shouldn’t')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} subPath="discids" />
+  </ReportLayout>
+);
+
+export default ShouldNotHaveDiscIds;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -231,6 +231,7 @@ module.exports = {
   'report/ReportsIndex': require('../report/ReportsIndex'),
   'report/SeparateDiscs': require('../report/SeparateDiscs'),
   'report/SetInDifferentRg': require('../report/SetInDifferentRg'),
+  'report/ShouldNotHaveDiscIds': require('../report/ShouldNotHaveDiscIds'),
   'report/SingleMediumReleasesWithMediumTitles': require('../report/SingleMediumReleasesWithMediumTitles'),
   'report/SomeFormatsUnset': require('../report/SomeFormatsUnset'),
   'report/SuperfluousDataTracks': require('../report/SuperfluousDataTracks'),


### PR DESCRIPTION
### Implement MBS-11664 / MBS-11666

Tested locally with sample data by changing hybrid SACD to not allow discids and then checking release/ca9de00b-3934-431b-809c-e07347f99801 and release/e7502670-ca88-4ec3-aa1b-eb5cba687d54