### PR TITLE
Fix double JSON dump gpg-signing

### DIFF
--- a/admin/ExportAllTables
+++ b/admin/ExportAllTables
@@ -296,7 +296,10 @@ if ($fCompress and $fDoFullExport)
     $mbdump->make_tar("mbdump-wikidocs.tar.bz2", @WIKIDOCS_TABLE_LIST);
     $mbdump->make_tar("mbdump-documentation.tar.bz2", @DOCUMENTATION_TABLE_LIST);
 
-    $mbdump->write_checksum_files;
+    MusicBrainz::Script::MBDump::write_checksum_files(
+        $mbdump->compression,
+        $mbdump->output_dir,
+    );
 
     my $encrypt_for = DBDefs->GPG_ENCRYPT_KEY;
     if ($encrypt_for) {

--- a/lib/MusicBrainz/Script/JSONDump.pm
+++ b/lib/MusicBrainz/Script/JSONDump.pm
@@ -116,7 +116,6 @@ EOF
             "mbdump/$dump_fname",
             'JSON_DUMPS_SCHEMA_NUMBER',
         );
-        $mbdump->write_checksum_files;
     } else {
         move($mbdump->export_dir,
              catdir($mbdump->output_dir, $dump_fname)) or die $!;

--- a/lib/MusicBrainz/Script/JSONDump/Full.pm
+++ b/lib/MusicBrainz/Script/JSONDump/Full.pm
@@ -170,6 +170,11 @@ sub run_impl {
         );
     }
 
+    if ($self->compression_enabled) {
+        log('Writing checksum files');
+        MusicBrainz::Script::MBDump::write_checksum_files('xz', $self->output_dir);
+    }
+
     log('Updating full_json_dump_replication_sequence to ' .
         $dump_replication_sequence);
     $c->sql->auto_commit(1);

--- a/lib/MusicBrainz/Script/JSONDump/Incremental.pm
+++ b/lib/MusicBrainz/Script/JSONDump/Incremental.pm
@@ -221,17 +221,22 @@ sub run_impl {
         });
 
         if ($did_update_anything) {
-            for my $entity_type (@{ $self->dumped_entity_types }) {
-                # Output each replication sequence in its own dir.
-                my $output_dir = catdir(
-                    $self->output_dir, "json-dump-$start_sequence");
+            # Output each replication sequence in its own dir.
+            my $output_dir = catdir(
+                $self->output_dir, "json-dump-$start_sequence");
 
+            for my $entity_type (@{ $self->dumped_entity_types }) {
                 $self->create_json_dump(
                     $c,
                     $entity_type,
                     output_dir => $output_dir,
                     replication_sequence => $start_sequence,
                 );
+            }
+
+            if ($self->compression_enabled) {
+                log('Writing checksum files');
+                MusicBrainz::Script::MBDump::write_checksum_files('xz', $output_dir);
             }
         } else {
             last;

--- a/lib/MusicBrainz/Script/MBDump.pm
+++ b/lib/MusicBrainz/Script/MBDump.pm
@@ -127,6 +127,8 @@ sub gpg_sign {
            '--default-key', $sign_with,
            '--detach-sign',
            '--armor',
+           '--batch',
+           '--yes',
            $file_to_be_signed;
 
     if ($? != 0) {
@@ -197,16 +199,15 @@ sub write_file {
 }
 
 sub write_checksum_files {
-    my ($self) = @_;
+    my ($compression, $output_dir) = @_;
 
-    my $compression = $self->compression;
     return unless $compression;
 
     my $tar_ext = $compression eq 'bzip2'
         ? 'bz2'
         : $compression;
 
-    my $output_dir = shell_quote($self->output_dir);
+    $output_dir = shell_quote($output_dir);
     for my $hash_program ('md5sum', 'sha256sum') {
         my $hash_output_file = uc($hash_program . 's');
         chomp (my $hash_bin = `which g$hash_program` || `which $hash_program`);


### PR DESCRIPTION
The production JSON dumps deployment currently hangs indefinitely with the following type of message:

> File '/tmp/mbscript-xxx/json-dump-xxx/MD5SUMS.asc' exists.
> Overwrite? (y/N)

This may be due to a gpg upgrade in the recent switch to Ubuntu 20.04.

To resolve this, for one, I'm adding `--batch --yes` to the gpg command to always overwrite existing .asc files.

Secondly, I'm fixing the code to not run `write_checksum_files` multiple times per dump.