### PR TITLE
MBS-11673: Block smart links to myurls.bio

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -630,6 +630,7 @@ const URL_SHORTENERS = [
   'music.indiefy.net',
   'musics.link',
   'mylink.page',
+  'myurls.bio',
   'odesli.co',
   'orcd.co',
   'owl.ly',


### PR DESCRIPTION
### Implement MBS-11673

As the domain suggests, this seems to be just a link aggregator.
