### PR TITLE
MBS-11671: force hourCycle: 'h23' for %H in formatUserDate

### DIFF
--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -10,6 +10,7 @@ import test from 'tape';
 
 import formatDate from '../common/utility/formatDate';
 import * as age from '../../../utility/age';
+import formatUserDate from '../../../utility/formatUserDate';
 import compareDates, {
   compareDatePeriods,
 } from '../common/utility/compareDates';
@@ -539,5 +540,26 @@ test('fullwidthLatin', function (t) {
     fullwidthLatin.toFullwidthLatin(' feat. '),
     '　ｆｅａｔ．　',
     'fully converted toFullwidthLatin',
+  );
+});
+
+test('formatUserDate', function (t) {
+  t.plan(1);
+
+  t.equal(
+    formatUserDate(
+      {
+        stash: {current_language: 'en'},
+        user: {
+          preferences: {
+            datetime_format: '%Y-%m-%d %H:%M %Z',
+            timezone: 'Africa/Cairo',
+          },
+        },
+      },
+      '2021-05-12T22:05:05.640Z',
+    ),
+    '2021-05-13 00:05 GMT+2',
+    '%H ranges from 00-23',
   );
 });

--- a/root/utility/formatUserDate.js
+++ b/root/utility/formatUserDate.js
@@ -32,7 +32,7 @@ const formatterCache = new Map();
 const patterns = {
   '%A': ['weekday', {weekday: 'long'}],
   '%B': ['month', {month: 'long'}],
-  '%H': ['hour', {hour: '2-digit', hour12: false}],
+  '%H': ['hour', {hour: '2-digit', hourCycle: 'h23'}],
   '%M': ['minute', {minute: '2-digit', hour: '2-digit'}],
   '%S': ['second', {second: '2-digit', minute: '2-digit'}],
   '%X': [null, {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle

This seems to have broken with the upgrade to Node v16.

(I've honestly never seen 1-24 before so don't know why that's a default for en.)