### PR TITLE
Standardize (uppercase) caps on SQL strings

### DIFF
--- a/admin/nagios/reports-running
+++ b/admin/nagios/reports-running
@@ -14,7 +14,7 @@ use Pod::Usage;
 my $c = MusicBrainz::Server::Context->create_script_context;
 my $res = $c->sql->select_single_row_array(
     "
-SELECT extract(day from date_trunc('day', now() - min(generated_at))) as days_old
+SELECT extract(day FROM date_trunc('day', now() - min(generated_at))) AS days_old
 FROM report.index
      ")
     or critical('Failed to determine when reports last ran');

--- a/admin/nagios/statistics-collected
+++ b/admin/nagios/statistics-collected
@@ -15,9 +15,9 @@ my $c = MusicBrainz::Server::Context->create_script_context;
 my $res = $c->sql->select_single_row_array(
     "
 SELECT date_collected,
-        date_trunc('day', now())::date - date_collected as days_old
+        date_trunc('day', now())::date - date_collected AS days_old
 FROM statistics.statistic
-order by id desc limit 1
+ORDER BY id desc LIMIT 1
      ")
     or critical('Failed to collect statistics');
 

--- a/lib/MusicBrainz/Server/Data/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Alias.pm
@@ -197,7 +197,7 @@ sub merge
     # preferring primary_for_locale and the target entity
     # therefore, partition by everything except primary_by_locale
     $self->sql->do(
-        "DELETE FROM $table WHERE id in (
+        "DELETE FROM $table WHERE id IN (
              SELECT a.id FROM (
                  SELECT id, rank() OVER (PARTITION BY $type, name, locale, type, sort_name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day
                                          ORDER BY primary_for_locale DESC, ($type = ?) DESC) > 1 AS redundant

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -220,7 +220,7 @@ sub _merge_impl
          SELECT DISTINCT ?::int
          FROM country_area
          WHERE area = any(?) AND NOT EXISTS (
-           SELECT TRUE from country_area WHERE area = ?
+           SELECT TRUE FROM country_area WHERE area = ?
          )',
          $new_id, \@old_ids, $new_id
     );

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -192,7 +192,7 @@ sub find_by_release
                      FROM artist
                      JOIN artist_credit_name acn ON acn.artist = artist.id
                      JOIN release ON release.artist_credit = acn.artist_credit
-                     wHERE release.id = ?)
+                     WHERE release.id = ?)
                  ORDER BY artist.name COLLATE musicbrainz, artist.id";
     $self->query_to_list_limited($query, [($release_id) x 2], $limit, $offset);
 }

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -139,7 +139,7 @@ sub merge {
         "UPDATE editor_collection_$type ec
          SET added = x.added, comment = x.comment
          FROM (
-            SELECT $type, min(added) AS added, string_agg(comment, '\n\n-------\n\n') as comment
+            SELECT $type, min(added) AS added, string_agg(comment, '\n\n-------\n\n') AS comment
             FROM editor_collection_$type
             WHERE collection = any(?)
             GROUP BY $type

--- a/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
+++ b/lib/MusicBrainz/Server/Data/EditorOAuthToken.pm
@@ -103,7 +103,7 @@ sub delete_editor
     my ($self, $editor_id) = @_;
     $self->sql->do("DELETE FROM editor_oauth_token WHERE editor = ?", $editor_id);
     $self->sql->do("DELETE FROM editor_oauth_token WHERE application IN ".
-        "(SELECT id from application WHERE owner = ?)", $editor_id);
+        "(SELECT id FROM application WHERE owner = ?)", $editor_id);
 }
 
 sub create_authorization_code

--- a/lib/MusicBrainz/Server/Data/Link.pm
+++ b/lib/MusicBrainz/Server/Data/Link.pm
@@ -63,9 +63,9 @@ sub _load_attributes
                 root_attr.gid AS root_gid,
                 root_attr.name AS root_name,
                 COALESCE(text_value, '') AS text_value,
-                COALESCE((SELECT true FROM link_text_attribute_type ltat
+                COALESCE((SELECT TRUE FROM link_text_attribute_type ltat
                           WHERE ltat.attribute_type = attr.id), false) AS free_text,
-                COALESCE((SELECT true FROM link_creditable_attribute_type lcat
+                COALESCE((SELECT TRUE FROM link_creditable_attribute_type lcat
                           WHERE lcat.attribute_type = attr.id), false) AS creditable,
                 COALESCE((SELECT comment FROM instrument
                           WHERE instrument.gid = attr.gid), '') AS instrument_comment

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -33,12 +33,12 @@ sub _columns
            '(SELECT r.name FROM link_attribute_type r WHERE r.id = link_attribute_type.root) root_name, ' .
            '(SELECT r.gid FROM link_attribute_type r WHERE r.id = link_attribute_type.root) root_gid, ' .
            'COALESCE(
-                (SELECT true FROM link_text_attribute_type
+                (SELECT TRUE FROM link_text_attribute_type
                  WHERE attribute_type = link_attribute_type.id),
                 false
             ) AS free_text, ' .
            'COALESCE(
-                (SELECT true FROM link_creditable_attribute_type
+                (SELECT TRUE FROM link_creditable_attribute_type
                  WHERE attribute_type = link_attribute_type.id),
                 false
             ) AS creditable, ' .
@@ -201,7 +201,7 @@ sub merge_instrument_attributes {
           LEFT JOIN link_attribute_credit lac ON (lac.link = la.link AND lac.attribute_type = la.attribute_type)
           JOIN link_type ON link.link_type = link_type.id
           WHERE link.id IN (
-              SELECT link from link_attribute where attribute_type = any(?)
+              SELECT link FROM link_attribute WHERE attribute_type = any(?)
           )
       GROUP BY link.id, link_type,
                begin_date_year, begin_date_month, begin_date_day,

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -25,7 +25,7 @@ sub _columns
 {
     return 'medium.id, release, position, format, medium.name,
             medium.edits_pending, track_count,
-            COALESCE((SELECT true FROM track WHERE medium = medium.id AND position = 0), false) AS has_pregap,
+            COALESCE((SELECT TRUE FROM track WHERE medium = medium.id AND position = 0), false) AS has_pregap,
             (SELECT count(*) FROM track WHERE medium = medium.id AND position > 0 AND is_data_track = false) AS cdtoc_track_count';
 }
 

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -976,7 +976,7 @@ sub get_entity_link_type_counts {
     return $data if defined $data;
 
     my $rows = $self->sql->select_list_of_hashes(
-        'SELECT link.link_type, count(*) as l_count ' .
+        'SELECT link.link_type, count(*) AS l_count ' .
         "FROM l_${type0}_${type1} r " .
         'JOIN link ON r.link = link.id ' .
         "WHERE r.$side = ? " .

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -772,7 +772,7 @@ sub _order_by {
         },
         "catno" => sub {
             $extra_join = "LEFT OUTER JOIN
-                (SELECT release, array_agg(catalog_number) AS catnos from release_label
+                (SELECT release, array_agg(catalog_number) AS catnos FROM release_label
                   WHERE catalog_number IS NOT NULL GROUP BY release) rl
                 ON rl.release = release.id";
             $also_select = "catnos";
@@ -1007,7 +1007,7 @@ sub can_merge {
                  FROM changes
                  JOIN medium changed_m ON changed_m.id = changes.id
                  JOIN medium all_m ON all_m.release = changed_m.release
-                 WHERE all_m.id not in (select id from changes)
+                 WHERE all_m.id NOT IN (SELECT id FROM changes)
                )
              ) s
              GROUP BY position

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -246,8 +246,8 @@ sub _find_by_artist_slow
     push @$conditions, "acn.artist = ?";
     # Show only RGs with official releases by default, plus all-status-less ones so people fix the status
     unless ($show_all) {
-        push @$conditions, "(EXISTS (SELECT 1 FROM release where release.release_group = rg.id AND release.status = '1') OR
-                            NOT EXISTS (SELECT 1 FROM release where release.release_group = rg.id AND release.status IS NOT NULL))";
+        push @$conditions, "(EXISTS (SELECT 1 FROM release WHERE release.release_group = rg.id AND release.status = '1') OR
+                            NOT EXISTS (SELECT 1 FROM release WHERE release.release_group = rg.id AND release.status IS NOT NULL))";
        }
     push @$params, $artist_id;
 
@@ -416,8 +416,8 @@ sub _find_by_track_artist_slow
     my $extra_conditions = '';
     # Show only RGs with official releases by default, plus all-status-less ones so people fix the status
     unless ($show_all) {
-        $extra_conditions = " AND (EXISTS (SELECT 1 FROM release where release.release_group = rg.id AND release.status = '1') OR
-                            NOT EXISTS (SELECT 1 FROM release where release.release_group = rg.id AND release.status IS NOT NULL)) ";
+        $extra_conditions = " AND (EXISTS (SELECT 1 FROM release WHERE release.release_group = rg.id AND release.status = '1') OR
+                            NOT EXISTS (SELECT 1 FROM release WHERE release.release_group = rg.id AND release.status IS NOT NULL)) ";
        }
 
     my $query = "SELECT DISTINCT " . $self->_columns . ",

--- a/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
+++ b/lib/MusicBrainz/Server/Data/Role/QueryToList.pm
@@ -59,7 +59,7 @@ sub query_to_list_limited {
         $query = qq{
             WITH x AS ($query)
             SELECT x.*, c.count AS total_row_count
-            FROM x, (SELECT count(*) from x) c
+            FROM x, (SELECT count(*) FROM x) c
         };
     }
 

--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -183,7 +183,7 @@ sub search
                 r.rank
             FROM
                 (
-                    SELECT name, ts_rank_cd(mb_simple_tsvector(name), query, 2) as rank
+                    SELECT name, ts_rank_cd(mb_simple_tsvector(name), query, 2) AS rank
                     FROM
                         (SELECT name              FROM ${type}       UNION ALL
                          SELECT name              FROM ${type}_alias UNION ALL
@@ -301,7 +301,7 @@ sub search
 
     elsif ($type eq "tag") {
         $query = "
-            SELECT tag.id, tag.name, genre.id as genre_id,
+            SELECT tag.id, tag.name, genre.id AS genre_id,
                    ts_rank_cd(mb_simple_tsvector(tag.name), query, 2) AS rank
             FROM tag LEFT JOIN genre USING (name), plainto_tsquery('mb_simple', mb_lower(?)) AS query
             WHERE mb_simple_tsvector(tag.name) @@ query OR tag.name = ?

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -240,7 +240,7 @@ sub automatically_reorder {
     my ($self, $series_id) = @_;
 
     return unless $self->c->sql->select_single_value(
-        'SELECT true FROM series WHERE id = ? AND ordering_type = ?',
+        'SELECT TRUE FROM series WHERE id = ? AND ordering_type = ?',
         $series_id, $SERIES_ORDERING_TYPE_AUTOMATIC
     );
 

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -1141,7 +1141,7 @@ my %stats = (
             my $data = $sql->select_list_of_lists(
                 "SELECT type.id, COUNT(rg.id) AS count
                  FROM release_group_primary_type type
-                 LEFT JOIN release_group rg on rg.type = type.id
+                 LEFT JOIN release_group rg ON rg.type = type.id
                  GROUP BY type.id",
             );
 
@@ -1164,7 +1164,7 @@ my %stats = (
                  FROM release_group_secondary_type type
                  LEFT JOIN release_group_secondary_type_join type_join
                      ON type.id = type_join.secondary_type
-                 JOIN release_group rg on rg.id = type_join.release_group
+                 JOIN release_group rg ON rg.id = type_join.release_group
                  GROUP BY type.id",
             );
 
@@ -1835,11 +1835,11 @@ my %stats = (
             my $data = $sql->select_list_of_lists(
                 "SELECT c, COUNT(*) AS freq
                 FROM (
-                    SELECT r.id, count(distinct release.id) as c
+                    SELECT r.id, count(distinct release.id) AS c
                         FROM recording r
                         LEFT JOIN track t ON t.recording = r.id
                         LEFT JOIN medium m ON t.medium = m.id
-                        LEFT JOIN release on m.release = release.id
+                        LEFT JOIN release ON m.release = release.id
                     GROUP BY r.id
                 ) AS t
                 GROUP BY c

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -398,7 +398,7 @@ sub _find_recording_artists
         SELECT lrw.entity1 AS work, r.artist_credit
         FROM l_recording_work lrw
         JOIN recording r ON lrw.entity0 = r.id
-        LEFT JOIN track t on r.id = t.recording
+        LEFT JOIN track t ON r.id = t.recording
         WHERE lrw.entity1 IN (" . placeholders(@$ids) . ")
         GROUP BY lrw.entity1, r.artist_credit
         ORDER BY count(*) DESC, artist_credit

--- a/lib/MusicBrainz/Server/Report/AnnotationReport.pm
+++ b/lib/MusicBrainz/Server/Report/AnnotationReport.pm
@@ -10,17 +10,17 @@ sub query {
     my ($self) = @_;
     my $entity_type = $self->entity_type;
 
-    my $query = "SELECT s.text, substr(s.created::text, 0, 17) AS created, e.id AS ${entity_type}_id, row_number() OVER (order by s.created DESC, e.name COLLATE musicbrainz)
+    my $query = "SELECT s.text, substr(s.created::text, 0, 17) AS created, e.id AS ${entity_type}_id, row_number() OVER (ORDER BY s.created DESC, e.name COLLATE musicbrainz)
                     FROM (
-                        select *, row_number() over (partition by $entity_type order by created desc)
-                        from ${entity_type}_annotation ea
-                        join annotation an on ea.annotation = an.id
-                        join $entity_type e on e.id = ea.$entity_type
+                        SELECT *, row_number() OVER (PARTITION BY $entity_type ORDER BY created desc)
+                        FROM ${entity_type}_annotation ea
+                        JOIN annotation an ON ea.annotation = an.id
+                        JOIN $entity_type e ON e.id = ea.$entity_type
                     ) s
-                    join $entity_type e on e.gid = s.gid
-                    where row_number = 1
-                    and s.text != ''
-                    order by s.created DESC, s.text";
+                    JOIN $entity_type e ON e.gid = s.gid
+                    WHERE row_number = 1
+                    AND s.text != ''
+                    ORDER BY s.created DESC, s.text";
 
     return $query;
 }

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -10,33 +10,33 @@ WITH groups AS (
          SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
-         JOIN link on link.id = laa.link
-         JOIN link_type on link_type.id = link.link_type
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
          AND link_type.name IN ('member of band', 'collaboration', 'conductor position')),
      persons_entity0 AS (
          SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
-         JOIN link on link.id = laa.link
-         JOIN link_type on link_type.id = link.link_type
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
          AND link_type.name IN ('member of band', 'collaboration', 'voice actor', 'conductor position', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      persons_entity1 AS (
          SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
-         JOIN link on link.id = laa.link
-         JOIN link_type on link_type.id = link.link_type
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
          AND link_type.name IN ('catalogued', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      artists AS (
          SELECT DISTINCT ON (id) id, name FROM
              (SELECT * FROM persons_entity0
                   UNION
-              SELECT * from persons_entity1) AS persons
+              SELECT * FROM persons_entity1) AS persons
           EXCEPT
-              SELECT * from groups)
+              SELECT * FROM groups)
 SELECT DISTINCT ON (artists.id) artists.id AS artist_id, row_number() OVER (ORDER BY artists.name COLLATE musicbrainz, artists.id)
     FROM artists
     ";

--- a/lib/MusicBrainz/Server/Report/CoverArtRelationships.pm
+++ b/lib/MusicBrainz/Server/Report/CoverArtRelationships.pm
@@ -13,7 +13,7 @@ sub query {
         FROM release r
             JOIN l_release_url l_ru ON r.id = l_ru.entity0
             JOIN link l ON l_ru.link = l.id
-            JOIN artist_credit ac on ac.id = r.artist_credit
+            JOIN artist_credit ac ON ac.id = r.artist_credit
         WHERE l.link_type = 78 AND l_ru.edits_pending = 0
     ";
 }

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsArtists.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsArtists.pm
@@ -35,7 +35,7 @@ SELECT q.entity AS artist_id, row_number() OVER (ORDER BY artist.name COLLATE mu
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN artist on q.entity = artist.id
+JOIN artist ON q.entity = artist.id
 GROUP BY q.entity, artist.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsLabels.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsLabels.pm
@@ -64,7 +64,7 @@ SELECT q.entity AS label_id, row_number() OVER (ORDER BY label.name COLLATE musi
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN label on q.entity = label.id
+JOIN label ON q.entity = label.id
 GROUP BY q.entity, label.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsRecordings.pm
@@ -65,7 +65,7 @@ SELECT q.entity AS recording_id, row_number() OVER (ORDER BY recording.name COLL
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN recording on q.entity = recording.id
+JOIN recording ON q.entity = recording.id
 GROUP BY q.entity, recording.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsReleaseGroups.pm
@@ -64,7 +64,7 @@ SELECT q.entity AS release_group_id, row_number() OVER (ORDER BY release_group.n
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN release_group on q.entity = release_group.id
+JOIN release_group ON q.entity = release_group.id
 GROUP BY q.entity, release_group.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsReleases.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsReleases.pm
@@ -64,7 +64,7 @@ SELECT q.entity AS release_id, row_number() OVER (ORDER BY release.name COLLATE 
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN release on q.entity = release.id
+JOIN release ON q.entity = release.id
 GROUP BY q.entity, release.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/DuplicateRelationshipsWorks.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateRelationshipsWorks.pm
@@ -57,7 +57,7 @@ SELECT q.entity AS work_id, row_number() OVER (ORDER BY work.name COLLATE musicb
     GROUP BY link.link_type, lxx.entity0, lxx.entity1 HAVING COUNT(*) > 1
 
 ) AS q
-JOIN work on q.entity = work.id
+JOIN work ON q.entity = work.id
 GROUP BY q.entity, work.name
 
     ";

--- a/lib/MusicBrainz/Server/Report/ISRCsWithManyRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/ISRCsWithManyRecordings.pm
@@ -9,7 +9,7 @@ sub component_name { 'IsrcsWithManyRecordings' }
 
 sub query {
     "
-        SELECT i.isrc, recordingcount, r.id as recording_id, r.name, r.length,
+        SELECT i.isrc, recordingcount, r.id AS recording_id, r.name, r.length,
           row_number() OVER (ORDER BY i.isrc)
         FROM isrc i
           JOIN recording r ON (r.id = i.recording)

--- a/lib/MusicBrainz/Server/Report/ISWCsWithManyWorks.pm
+++ b/lib/MusicBrainz/Server/Report/ISWCsWithManyWorks.pm
@@ -18,7 +18,7 @@ sub component_name { 'IswcsWithManyWorks' }
 
 sub query {
     "
-        SELECT i.iswc, workcount, w.id as work_id,
+        SELECT i.iswc, workcount, w.id AS work_id,
           row_number() OVER (ORDER BY i.iswc)
         FROM iswc i
           JOIN work w ON (w.id = i.work)

--- a/lib/MusicBrainz/Server/Report/RecordingsWithoutVACredit.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingsWithoutVACredit.pm
@@ -12,7 +12,7 @@ sub query {
             r.id AS recording_id,
             row_number() OVER (ORDER BY r.artist_credit, r.name)
         FROM recording r
-        JOIN artist_credit_name acn on acn.artist_credit = r.artist_credit
+        JOIN artist_credit_name acn ON acn.artist_credit = r.artist_credit
         WHERE acn.artist = $VARTIST_ID AND acn.name != 'Various Artists'
     ";
 }

--- a/lib/MusicBrainz/Server/Report/RecordingsWithoutVALink.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingsWithoutVALink.pm
@@ -12,8 +12,8 @@ sub query {
             r.id AS recording_id,
             row_number() OVER (ORDER BY r.artist_credit, r.name)
         FROM recording r
-        JOIN artist_credit_name acn on acn.artist_credit = r.artist_credit
-        JOIN artist a on a.id = acn.artist
+        JOIN artist_credit_name acn ON acn.artist_credit = r.artist_credit
+        JOIN artist a ON a.id = acn.artist
         WHERE acn.name = 'Various Artists'
           AND a.name != 'Various Artists'
     ";

--- a/lib/MusicBrainz/Server/Report/ReleaseGroupsWithoutVACredit.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseGroupsWithoutVACredit.pm
@@ -12,7 +12,7 @@ sub query {
             rg.id AS release_group_id,
             row_number() OVER (ORDER BY rg.artist_credit, rg.name)
         FROM release_group rg
-        JOIN artist_credit_name acn on acn.artist_credit = rg.artist_credit
+        JOIN artist_credit_name acn ON acn.artist_credit = rg.artist_credit
         WHERE acn.artist = $VARTIST_ID AND acn.name != 'Various Artists'
     ";
 }

--- a/lib/MusicBrainz/Server/Report/ReleaseGroupsWithoutVALink.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseGroupsWithoutVALink.pm
@@ -12,8 +12,8 @@ sub query {
             rg.id AS release_group_id,
             row_number() OVER (ORDER BY rg.artist_credit, rg.name)
         FROM release_group rg
-        JOIN artist_credit_name acn on acn.artist_credit = rg.artist_credit
-        JOIN artist a on a.id = acn.artist
+        JOIN artist_credit_name acn ON acn.artist_credit = rg.artist_credit
+        JOIN artist a ON a.id = acn.artist
         WHERE acn.name = 'Various Artists'
           AND a.name != 'Various Artists'
     ";

--- a/lib/MusicBrainz/Server/Report/ReleasedTooEarly.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasedTooEarly.pm
@@ -21,9 +21,9 @@ sub query {
             ) events ON (events.release = r.id)
             JOIN medium m ON m.release = r.id
             LEFT JOIN medium_format mf ON mf.id = m.format
-            LEFT JOIN medium_cdtoc mcd on mcd.medium = m.id
+            LEFT JOIN medium_cdtoc mcd ON mcd.medium = m.id
             WHERE
-              (mcd.id IS NOT NULL AND date_year < (select min(year) from medium_format where has_discids = 't')) OR
+              (mcd.id IS NOT NULL AND date_year < (SELECT min(year) FROM medium_format WHERE has_discids = 't')) OR
               (mcd.id IS NOT NULL AND mf.year IS NOT NULL AND mf.has_discids = 'f') OR
               (mf.year IS NOT NULL AND date_year < mf.year)
           ) r

--- a/lib/MusicBrainz/Server/Report/ReleasesWithoutVACredit.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithoutVACredit.pm
@@ -14,16 +14,16 @@ sub query {
         FROM (
             SELECT r.id, r.artist_credit, r.name
             FROM release r
-            JOIN artist_credit_name acn on acn.artist_credit = r.artist_credit
+            JOIN artist_credit_name acn ON acn.artist_credit = r.artist_credit
             WHERE acn.artist = $VARTIST_ID AND acn.name != 'Various Artists'
 
             UNION
 
             SELECT r.id, r.artist_credit, r.name
             FROM track
-            JOIN artist_credit_name acn on acn.artist_credit = track.artist_credit
-            JOIN medium on medium.id = track.medium
-            JOIN release r on r.id = medium.release
+            JOIN artist_credit_name acn ON acn.artist_credit = track.artist_credit
+            JOIN medium PN medium.id = track.medium
+            JOIN release r ON r.id = medium.release
             WHERE acn.artist = $VARTIST_ID AND acn.name != 'Various Artists'
         ) r
     ";

--- a/lib/MusicBrainz/Server/Report/ReleasesWithoutVALink.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithoutVALink.pm
@@ -14,8 +14,8 @@ sub query {
         FROM (
             SELECT r.id, r.artist_credit, r.name
             FROM release r
-            JOIN artist_credit_name acn on acn.artist_credit = r.artist_credit
-            JOIN artist a on a.id = acn.artist
+            JOIN artist_credit_name acn ON acn.artist_credit = r.artist_credit
+            JOIN artist a ON a.id = acn.artist
             WHERE acn.name = 'Various Artists'
               AND a.name != 'Various Artists'
 
@@ -23,10 +23,10 @@ sub query {
 
             SELECT r.id, r.artist_credit, r.name
             FROM track
-            JOIN artist_credit_name acn on acn.artist_credit = track.artist_credit
-            JOIN artist a on a.id = acn.artist
-            JOIN medium on medium.id = track.medium
-            JOIN release r on r.id = medium.release
+            JOIN artist_credit_name acn ON acn.artist_credit = track.artist_credit
+            JOIN artist a ON a.id = acn.artist
+            JOIN medium ON medium.id = track.medium
+            JOIN release r ON r.id = medium.release
             WHERE acn.name = 'Various Artists'
               AND a.name != 'Various Artists'
         ) r

--- a/lib/MusicBrainz/Server/Report/SeparateDiscs.pm
+++ b/lib/MusicBrainz/Server/Report/SeparateDiscs.pm
@@ -12,7 +12,7 @@ sub query {
         FROM
             release r
             JOIN artist_credit ac ON r.artist_credit = ac.id
-            JOIN release_group rg on rg.id = r.release_group
+            JOIN release_group rg ON rg.id = r.release_group
             LEFT JOIN release_country ON r.id = release_country.release
         WHERE
             r.name ~ E'\\\\((disc [0-9]+|bonus disc)(: .*)?\\\\)'

--- a/lib/MusicBrainz/Server/Report/SetInDifferentRG.pm
+++ b/lib/MusicBrainz/Server/Report/SetInDifferentRG.pm
@@ -21,7 +21,7 @@ sub query {
                 JOIN release r1 ON l.entity1 = r1.id
                 JOIN link ON l.link = link.id
                 JOIN link_type ON link.link_type = link_type.id
-            WHERE link_type.gid in ('6d08ec1e-a292-4dac-90f3-c398a39defd5', 'fc399d47-23a7-4c28-bfcf-0607a562b644')
+            WHERE link_type.gid IN ('6d08ec1e-a292-4dac-90f3-c398a39defd5', 'fc399d47-23a7-4c28-bfcf-0607a562b644')
                 AND r0.release_group <> r1.release_group
             UNION
             SELECT r1.id
@@ -30,7 +30,7 @@ sub query {
                 JOIN release r1 ON l.entity1 = r1.id
                 JOIN link ON l.link = link.id
                 JOIN link_type ON link.link_type = link_type.id
-            WHERE link_type.gid in ('6d08ec1e-a292-4dac-90f3-c398a39defd5', 'fc399d47-23a7-4c28-bfcf-0607a562b644')
+            WHERE link_type.gid IN ('6d08ec1e-a292-4dac-90f3-c398a39defd5', 'fc399d47-23a7-4c28-bfcf-0607a562b644')
                 AND r0.release_group <> r1.release_group
         )
     ";

--- a/lib/MusicBrainz/Server/Sitemap/Constants.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Constants.pm
@@ -218,7 +218,7 @@ our Readonly %SITEMAP_SUFFIX_INFO = map {
                 return $SECONDARY_PAGE_PRIORITY if $opts{has_aliases};
                 return $EMPTY_PAGE_PRIORITY;
             },
-            extra_sql => {columns => "EXISTS (SELECT true FROM ${entity_type}_alias a WHERE a.$entity_type = ${entity_type}.id) AS has_aliases"},
+            extra_sql => {columns => "EXISTS (SELECT TRUE FROM ${entity_type}_alias a WHERE a.$entity_type = ${entity_type}.id) AS has_aliases"},
             jsonld_markup => ($entity_properties->{sitemaps_lastmod_table} ? 1 : 0),
         };
     }

--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -109,7 +109,7 @@ sub create_temporary_tables {
 sub fill_temporary_tables {
     my ($self, $sql) = @_;
 
-    my $is_official = "(EXISTS (SELECT TRUE FROM release where release.release_group = q.rg AND release.status = '1')
+    my $is_official = "(EXISTS (SELECT TRUE FROM release WHERE release.release_group = q.rg AND release.status = '1')
                         OR NOT EXISTS (SELECT 1 FROM release WHERE release.release_group = q.rg AND release.status IS NOT NULL))";
 
     # Release groups that will appear on the non-VA listings, per artist
@@ -266,7 +266,7 @@ sub build_one_entity {
 
     # Find the counts in each potential batch of 50,000
     my $raw_batches = $sql->select_list_of_hashes(
-        "SELECT batch, count(id) from (SELECT id, ceil(id / ?::float) AS batch FROM $entity_type) q GROUP BY batch ORDER BY batch ASC",
+        "SELECT batch, count(id) FROM (SELECT id, ceil(id / ?::float) AS batch FROM $entity_type) q GROUP BY batch ORDER BY batch ASC",
         $MAX_SITEMAP_SIZE
     );
 

--- a/po/extract_pot_db
+++ b/po/extract_pot_db
@@ -44,7 +44,7 @@ my $domain = $domain[0];
 # and ctx, which specifies a column to use for a msgctxt entry (unused at present).
 my @DBDEFS = (
               {'domain' => 'statistics', 'table' => 'statistics.statistic_event', 'columns' => ['title', 'description'], 'id' => 'date'},
-              {'domain' => 'countries', 'table' => 'area JOIN iso_3166_1 iso on iso.area = area.id', 'columns' => ['area.name'], 'comment' => ['iso.code']},
+              {'domain' => 'countries', 'table' => 'area JOIN iso_3166_1 iso ON iso.area = area.id', 'columns' => ['area.name'], 'comment' => ['iso.code']},
               {'domain' => 'languages', 'table' => 'language', 'columns' => ['name'], 'comment' => ['frequency', 'iso_code_3'], 'where' => 'iso_code_2t IS NOT NULL OR frequency > 0'},
               {'domain' => 'languages_notrim', 'table' => 'language', 'columns' => ['name'], 'comment' => ['frequency', 'iso_code_3']},
               {'domain' => 'scripts', 'table' => 'script', 'columns' => ['name'], 'comment' => ['frequency', 'iso_code']},
@@ -125,7 +125,7 @@ sub parse_db {
                 $select_cols .= ", COALESCE(" . $col . "::text, 'null')";
             }
         }
-        my $query = "SELECT $select_cols from $table";
+        my $query = "SELECT $select_cols FROM $table";
         if ($where) {
             $query .= " WHERE $where";
         }

--- a/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -74,10 +74,10 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phra
            (2, 1, 3, 'David Bowie', '');
 EOSQL
 
-    is($c->sql->select_single_value('SELECT count(*) from artist_credit'), 2, 'Two artist credits before merge');
+    is($c->sql->select_single_value('SELECT count(*) FROM artist_credit'), 2, 'Two artist credits before merge');
     $c->model('ArtistCredit')->merge_artists(2, [ 3 ]);
-    is($c->sql->select_single_value('SELECT count(*) from artist_credit'), 1, 'One artist credit after merge');
-    is($c->sql->select_single_value('SELECT count(*) from artist_credit_name'), 2, 'AC after merge has two artists');
+    is($c->sql->select_single_value('SELECT count(*) FROM artist_credit'), 1, 'One artist credit after merge');
+    is($c->sql->select_single_value('SELECT count(*) FROM artist_credit_name'), 2, 'AC after merge has two artists');
 };
 
 test 'Merging updates matching names' => sub {

--- a/t/lib/t/MusicBrainz/Server/Data/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Edit.pm
@@ -333,8 +333,8 @@ test 'Open edits expire in 7 days (MBS-8681)' => sub {
     is($edit->edit_conditions->{duration}, 7);
 
     my ($expire_time) = @{ $c->sql->select_list_of_hashes(<<'EOSQL', $edit->id) };
-SELECT expire_time as got,
-       (open_time + interval '@ 7 days') as expected
+SELECT expire_time AS got,
+       (open_time + interval '@ 7 days') AS expected
   FROM edit WHERE id = ?
 EOSQL
 

--- a/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
@@ -67,7 +67,7 @@ test 'Create, update, delete instruments' => sub {
     is($instrument->comment, 'Instrument comment', 'newly-created instrument is correct');
     is($instrument->description, '', 'newly-created instrument is correct');
     ok(defined $instrument->gid, 'newly-created instrument has an MBID');
-    ok($test->c->sql->select_single_value('SELECT true from link_attribute_type where gid = ?', $instrument->gid),
+    ok($test->c->sql->select_single_value('SELECT TRUE FROM link_attribute_type WHERE gid = ?', $instrument->gid),
        'link_attribute_type row was inserted too');
 
     # ---
@@ -85,7 +85,7 @@ test 'Create, update, delete instruments' => sub {
     is($instrument->type_id, undef, 'updated instrument data is correct');
     is($instrument->comment, 'Updated comment', 'updated instrument data is correct');
     is($instrument->description, 'Newly-created description', 'updated instrument data is correct');
-    is($test->c->sql->select_single_value('SELECT description from link_attribute_type where gid = ?', $instrument->gid),
+    is($test->c->sql->select_single_value('SELECT description FROM link_attribute_type WHERE gid = ?', $instrument->gid),
        'Newly-created description',
        'link_attribute_type row was updated');
 
@@ -93,7 +93,7 @@ test 'Create, update, delete instruments' => sub {
     $instrument_data->delete($instrument->id);
     $instrument = $instrument_data->get_by_id($instrument->id);
     ok(!defined $instrument, 'instrument was deleted');
-    ok(!defined $test->c->sql->select_single_value('SELECT true from link_attribute_type where gid = ?', $gid),
+    ok(!defined $test->c->sql->select_single_value('SELECT TRUE FROM link_attribute_type WHERE gid = ?', $gid),
        'link_attribute_type row was deleted too');
 };
 
@@ -108,13 +108,13 @@ test 'Merge instruments' => sub {
 
     my $instrument = $instrument_data->get_by_id(4);
     ok(!defined $instrument);
-    is($c->sql->select_single_value('SELECT id from link_attribute_type where gid = ?', "945c079d-374e-4436-9448-da92dedef3cf"),
+    is($c->sql->select_single_value('SELECT id FROM link_attribute_type WHERE gid = ?', "945c079d-374e-4436-9448-da92dedef3cf"),
        undef, "No link_attribute_type exists for merged-away instrument");
 
     $instrument = $instrument_data->get_by_id(3);
     ok(defined $instrument);
     is($instrument->name, 'Test Instrument');
-    ok($c->sql->select_single_value('SELECT id from link_attribute_type where gid = ?', $instrument->gid),
+    ok($c->sql->select_single_value('SELECT id FROM link_attribute_type WHERE gid = ?', $instrument->gid),
        "Still have a link_attribute_type row for merged-into instrument");
 
     my $recording = $c->model('Recording')->get_by_id(1);

--- a/t/lib/t/MusicBrainz/Server/Data/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Release.pm
@@ -290,7 +290,7 @@ test 'preserve track MBIDs on merge' => sub {
         old_ids => [ 9 ]
     );
 
-    my $redirects = $c->sql->select_list_of_hashes('SELECT gid, new_id from track_gid_redirect');
+    my $redirects = $c->sql->select_list_of_hashes('SELECT gid, new_id FROM track_gid_redirect');
 
     cmp_deeply($redirects, [{'gid'=> 'a833f5c7-dd13-40ba-bb5b-dc4e35d2bb90', 'new_id' => 4}], 'gid redirect for deleted track exists');
 };

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -55,7 +55,7 @@ is($rel->link->end_date->year, 1995);
 subtest 'creating cover art relationships should update the releases coverart' => sub {
     my $url = 'http://web.archive.org/web/20100820183338/wiki.jpopstop.com/images/8/8d/alan_-_Kaze_ni_Mukau_Hana_CDDVD_mu-mo.jpg';
 
-    $c->sql->do('UPDATE link_type SET is_deprecated = FALSE where id = 78');
+    $c->sql->do('UPDATE link_type SET is_deprecated = FALSE WHERE id = 78');
 
     my $edit = $c->model('Edit')->create(
         edit_type => $EDIT_RELATIONSHIP_CREATE,
@@ -68,7 +68,7 @@ subtest 'creating cover art relationships should update the releases coverart' =
         ended => 0,
     );
 
-    $c->sql->do('UPDATE link_type SET is_deprecated = TRUE where id = 78');
+    $c->sql->do('UPDATE link_type SET is_deprecated = TRUE WHERE id = 78');
 
     my $release = $c->model('Release')->get_by_id(1);
     $c->model('Release')->load_meta($release);

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -218,9 +218,9 @@ UPDATE release_coverart
 INSERT INTO url (id, gid, url)
   VALUES (1, '24332737-b876-4d5e-9c30-e414b4570bda', 'http://www.archive.org/download/CoverArtsForVariousAlbum/karenkong-mulakan.jpg');
 
-UPDATE link_type SET is_deprecated = FALSE where id = 78;
+UPDATE link_type SET is_deprecated = FALSE WHERE id = 78;
 INSERT INTO link (id, link_type) VALUES (1, 78);
-UPDATE link_type SET is_deprecated = TRUE where id = 78;
+UPDATE link_type SET is_deprecated = TRUE WHERE id = 78;
 INSERT INTO l_release_url (id, entity0, entity1, link) VALUES (1, 1, 1, 1);
 EOSQL
 

--- a/t/lib/t/Sql.pm
+++ b/t/lib/t/Sql.pm
@@ -88,16 +88,16 @@ test 'All tests' => sub {
 
     {
         # Do with autocommit
-        like(exception { $sql->do('SELECT 1 from tag') },
+        like(exception { $sql->do('SELECT 1 FROM tag') },
            qr/do called while not in transaction, or marked to auto commit/,
            'must be in some sort of transaction');
 
         $sql->auto_commit(1);
-        ok !exception { $sql->do('SELECT 1 from tag') }, 'can do queries with auto commit';
+        ok !exception { $sql->do('SELECT 1 FROM tag') }, 'can do queries with auto commit';
         is($sql->_auto_commit, 0, 'do should invalidate autocommit');
 
         $sql->auto_commit(1);
-        ok !exception { $sql->do('SELECT 1 from tag WHERE id = ?', 1) }, 'can do queries with binds';
+        ok !exception { $sql->do('SELECT 1 FROM tag WHERE id = ?', 1) }, 'can do queries with binds';
 
         $sql->auto_commit(1);
         ok exception { $sql->do('Absolute nonsense') }, 'do throws on an SQL exception';

--- a/t/sql/release.sql
+++ b/t/sql/release.sql
@@ -106,5 +106,5 @@ INSERT INTO track (id, gid, name, artist_credit, medium, position, number, recor
            (7, 'b98ad21e-b1fb-4036-912e-3737636d270c', 'Track on recording', 3, 7, 1, 1, 2);
 
 -- release_meta
-UPDATE release_meta SET cover_art_presence = 'present' WHERE id in (7, 8);
+UPDATE release_meta SET cover_art_presence = 'present' WHERE id IN (7, 8);
 UPDATE release_meta SET cover_art_presence = 'darkened' WHERE id = 9;


### PR DESCRIPTION
This fixes as many lowercase 'from', 'select', 'on', 'as', etc. as I could find. I'm sure I missed some. I also intentionally skipped issues in old SQL upgrade packages, since those probably shouldn't be changed.
