### PR TITLE
MBS-11676: Load durations for mediums on /cdtoc

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -42,6 +42,7 @@ sub _load_releases
     my ($self, $c, $cdtoc) = @_;
     my @medium_cdtocs = $c->model('MediumCDTOC')->find_by_discid($cdtoc->discid);
     my @mediums = $c->model('Medium')->load(@medium_cdtocs);
+    $c->model('Medium')->load_track_durations(@mediums);
     $c->model('Track')->load_for_mediums(@mediums);
     my @tracks = map { $_->all_tracks } @mediums;
     $c->model('Recording')->load(@tracks);


### PR DESCRIPTION
### Fix MBS-11676

These are usually only loaded with `load_for_releases`, but they are obviously also needed on the `/cdtoc` page for the `is_perfect_match` comparison to work.
