### PR TITLE
MBS-11680: Group editing URL relationships by external link

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4495,7 +4495,7 @@ Object.values(LINK_TYPES).forEach(function (linkType) {
         }
         return {
           result: RESTRICTED_LINK_TYPES.indexOf(id) === -1,
-          target: ERROR_TARGETS.URL,
+          target: ERROR_TARGETS.RELATIONSHIP,
         };
       };
     }

--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -18,11 +18,18 @@ class HelpIcon extends React.Component {
 
   render() {
     return (
-      <div style={{position: 'relative', display: 'inline-block'}}>
+      <div
+        style={{
+          position: 'relative',
+          display: 'inline-block',
+          marginLeft: '10px',
+        }}
+      >
         <div
           className="img icon help"
           onMouseEnter={() => this.setState({hover: true})}
           onMouseLeave={() => this.setState({hover: false})}
+          style={{verticalAlign: 'text-top'}}
         />
         {this.state.hover &&
           <Tooltip

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -13,6 +13,7 @@ class RemoveButton extends React.Component {
     return (
       <button
         className="nobutton icon remove-item"
+        data-index={this.props['data-index']}
         onClick={this.props.onClick}
         title={this.props.title}
         type="button"

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -29,10 +29,10 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
   }, [props.link]);
 
   const toggle = (open) => {
-    /*
-     * Will be called by ButtonPopover when closed
-     * either by losing focus or click 'Close' button
-     */
+    // Will be called by ButtonPopover when closed by losing focus
+    if (!open) {
+      props.onConfirm(link.rawUrl);
+    }
     setIsOpen(open);
   };
 
@@ -44,6 +44,11 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     });
   };
 
+  const handleConfirm = (closeCallback) => {
+    props.onConfirm(link.rawUrl);
+    closeCallback();
+  };
+
   const buildPopoverChildren = (
     closeAndReturnFocus,
   ) => {
@@ -52,8 +57,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
       <form
         onSubmit={(event) => {
           event.preventDefault();
-          props.onConfirm(link.rawUrl);
-          closeAndReturnFocus();
+          handleConfirm(closeAndReturnFocus);
         }}
       >
         <table>
@@ -102,7 +106,12 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         <div className="buttons" style={{display: 'block', marginTop: '1em'}}>
           <button
             className="negative"
-            onClick={closeAndReturnFocus}
+            onClick={() => {
+              // Reset input field value
+              setLink(props.link);
+              // Avoid calling toggle() otherwise changes will be saved
+              setIsOpen(false);
+            }}
             type="button"
           >
             {l('Cancel')}
@@ -113,10 +122,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
           >
             <button
               className="positive"
-              onClick={() => {
-                props.onConfirm(link.rawUrl);
-                closeAndReturnFocus();
-              }}
+              onClick={() => handleConfirm(closeAndReturnFocus)}
               type="button"
             >
               {l('Done')}

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -91,14 +91,15 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
                   {addColonText(l('Cleaned up to'))}
                 </td>
                 <td>
-                  <a
-                    className="clean-url"
-                    href={link.url}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    {link.url}
-                  </a>
+                  {error ? link.url : (
+                    <a
+                      className="clean-url"
+                      href={link.url}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      {link.url}
+                    </a>)}
                 </td>
               </tr>
             }

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -36,10 +36,6 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     setIsOpen(open);
   };
 
-  const handleCancel = () => {
-    toggle(false);
-  };
-
   const handleUrlChange = (event) => {
     setLink({
       ...link,
@@ -106,7 +102,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         <div className="buttons" style={{display: 'block', marginTop: '1em'}}>
           <button
             className="negative"
-            onClick={handleCancel}
+            onClick={closeAndReturnFocus}
             type="button"
           >
             {l('Cancel')}

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -16,19 +16,19 @@ type PropsT = {
   cleanupUrl: (string) => string,
   link: LinkStateT,
   onConfirm: (string) => void,
-  validateLink: (LinkStateT) => ErrorT,
+  validateLink: (LinkStateT) => ErrorT | null,
 };
 
 const URLInputPopover = (props: PropsT): React.MixedElement => {
   const popoverButtonRef = React.useRef(null);
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [link, setLink] = React.useState(props.link);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [link, setLink] = React.useState<LinkStateT>(props.link);
 
   React.useEffect(() => {
     setLink(props.link);
   }, [props.link]);
 
-  const toggle = (open) => {
+  const toggle = (open: boolean) => {
     // Will be called by ButtonPopover when closed by losing focus
     if (!open) {
       props.onConfirm(link.rawUrl);
@@ -36,15 +36,16 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     setIsOpen(open);
   };
 
-  const handleUrlChange = (event) => {
+  const handleUrlChange = (event: SyntheticEvent<HTMLInputElement>) => {
+    const rawUrl = event.currentTarget.value;
     setLink({
       ...link,
-      rawUrl: event.target.value,
-      url: props.cleanupUrl(event.target.value),
+      rawUrl,
+      url: props.cleanupUrl(rawUrl),
     });
   };
 
-  const handleConfirm = (closeCallback) => {
+  const handleConfirm = (closeCallback: () => void) => {
     props.onConfirm(link.rawUrl);
     closeCallback();
   };

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -604,21 +604,11 @@ const ExternalLinkRelationship =
   (props: ExternalLinkRelationshipProps): React.Element<'tr'> => {
     const {link, hasUrlError} = props;
     const linkType = link.type ? linkedEntities.link_type[link.type] : null;
-    let faviconClass: string | void;
     const backward = linkType && linkType.type1 > 'url';
 
     const showTypeSelection = (link.error || hasUrlError)
       ? true
       : !(link.urlMatchesType || isEmpty(link));
-
-    if (!showTypeSelection && link.urlMatchesType) {
-      for (const key of Object.keys(FAVICON_CLASSES)) {
-        if (link.url.indexOf(key) > 0) {
-          faviconClass = FAVICON_CLASSES[key];
-          break;
-        }
-      }
-    }
 
     return (
       <tr className="relationship-item" key={link.relationship}>
@@ -641,10 +631,6 @@ const ExternalLinkRelationship =
                   </LinkTypeSelect>
                 ) : (
                   <label className="relationship-name">
-                    {faviconClass &&
-                    <span
-                      className={'favicon ' + faviconClass + '-favicon'}
-                    />}
                     {linkType ? (
                       backward
                         ? l_relationships(linkType.reverse_link_phrase)
@@ -728,10 +714,22 @@ export class ExternalLink extends React.Component<LinkProps> {
     });
     const firstLink = props.relationships[0];
 
+    let faviconClass: string | void;
+    for (const key of Object.keys(FAVICON_CLASSES)) {
+      if (props.url.indexOf(key) > 0) {
+        faviconClass = FAVICON_CLASSES[key];
+        break;
+      }
+    }
+
     return (
       <React.Fragment>
         <tr className="external-link-item">
           <td>
+            {faviconClass &&
+            <span
+              className={'favicon ' + faviconClass + '-favicon'}
+            />}
             <label>
               {props.isOnlyLink
                 ? addColonText(l('Add link'))

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -671,59 +671,60 @@ const ExternalLinkRelationship =
         <td>
           <div className="relationship-content">
             <label>{addColonText(l('Type'))}</label>
-            {/* If the URL matches its type or is just empty,
-                display either a favicon
-                or a prompt for a new link as appropriate. */
-              showTypeSelection
-                ? (
-                  <LinkTypeSelect
-                    handleTypeBlur={
-                      (event) => props.onTypeBlur(link.index, event)
-                    }
-                    handleTypeChange={
-                      (event) => props.onTypeChange(link.index, event)
-                    }
-                    type={link.type}
-                  >
-                    {props.typeOptions}
-                  </LinkTypeSelect>
-                ) : (
-                  <label className="relationship-name">
-                    {linkType ? (
+            <label className="relationship-name">
+              {/* If the URL matches its type or is just empty,
+                  display either a favicon
+                  or a prompt for a new link as appropriate. */
+                showTypeSelection
+                  ? (
+                    <LinkTypeSelect
+                      handleTypeBlur={
+                        (event) => props.onTypeBlur(link.index, event)
+                      }
+                      handleTypeChange={
+                        (event) => props.onTypeChange(link.index, event)
+                      }
+                      type={link.type}
+                    >
+                      {props.typeOptions}
+                    </LinkTypeSelect>
+                  ) : (
+                    linkType ? (
                       backward
                         ? l_relationships(linkType.reverse_link_phrase)
                         : l_relationships(linkType.link_phrase)
-                    ) : null}
+                    ) : null
+                  )
+              }
+              {linkType &&
+                hasOwnProp(
+                  linkType.attributes,
+                  String(VIDEO_ATTRIBUTE_ID),
+                ) &&
+                <div className="attribute-container">
+                  <label>
+                    <input
+                      checked={link.video}
+                      onChange={
+                        (event) => props.onVideoChange(link.index, event)
+                      }
+                      style={{verticalAlign: 'text-top'}}
+                      type="checkbox"
+                    />
+                    {' '}
+                    {l('video')}
                   </label>
-                )
-            }
-            {linkType &&
-              hasOwnProp(
-                linkType.attributes,
-                String(VIDEO_ATTRIBUTE_ID),
-              ) &&
-              <div className="attribute-container">
-                <label>
-                  <input
-                    checked={link.video}
-                    onChange={
-                      (event) => props.onVideoChange(link.index, event)
-                    }
-                    type="checkbox"
-                  />
-                  {' '}
-                  {l('video')}
-                </label>
-              </div>}
+                </div>}
+              {link.url && !link.error && !hasUrlError &&
+                <TypeDescription type={link.type} url={link.url} />}
+            </label>
           </div>
           {link.error &&
             <div className="error field-error" data-visible="1">
               {link.error.message}
             </div>}
         </td>
-        <td className="link-actions" style={{minWidth: '34px'}}>
-          {link.url && !link.error && !hasUrlError &&
-            <TypeDescription type={link.type} url={link.url} />}
+        <td className="link-actions" style={{minWidth: '17px'}}>
           {!props.isOnlyRelationship &&
             <RemoveButton
               onClick={() => props.onLinkRemove(link.index)}
@@ -844,7 +845,7 @@ export class ExternalLink extends React.Component<LinkProps> {
               </div>
             }
           </td>
-          <td className="link-actions" style={{minWidth: '34px'}}>
+          <td className="link-actions" style={{minWidth: '38px'}}>
             {!isEmpty(props) && firstLink.submitted &&
               <URLInputPopover
                 cleanupUrl={props.cleanupUrl}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -59,6 +59,7 @@ type LinkMapT = Map<string, LinkStateT>;
 type LinkRelationshipT = LinkStateT & {
   error: ErrorT | null,
   index: number,
+  urlIndex: number,
   urlMatchesType?: boolean,
   ...
 };
@@ -513,7 +514,7 @@ export class ExternalLinksEditor
               ? false : linksGroupMap.get(url);
             const duplicateNotice = duplicate
               ? l(`Note: This link already exists 
-                at position #${duplicate[0].index + 1}. 
+                at position #${duplicate[0].urlIndex + 1}. 
                 To merge, press enter or select a type.`)
               : '';
 
@@ -986,8 +987,11 @@ function groupLinksByUrl(
   links: Array<LinkStateT>,
 ): Map<string, Array<LinkRelationshipT>> {
   let map = new Map();
+  let urlIndex = 0;
   links.forEach((link, index) => {
-    const relationship: LinkRelationshipT = {...link, error: null, index};
+    const relationship: LinkRelationshipT = {
+      ...link, error: null, index, urlIndex: index,
+    };
     /*
      * Don't group links that are not submitted,
      * e.g: empty links and the last link(editing)
@@ -995,8 +999,10 @@ function groupLinksByUrl(
     const key = link.submitted ? link.url : String(link.relationship);
     const relationships = map.get(key);
     if (relationships) {
+      relationship.urlIndex = relationships[0].urlIndex;
       relationships.push(relationship);
     } else {
+      relationship.urlIndex = urlIndex++;
       map.set(key, [relationship]);
     }
   });

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -158,6 +158,7 @@ export class ExternalLinksEditor
 
   handleLinkSubmit(
     index: number,
+    urlIndex: number,
     event: SyntheticEvent<HTMLInputElement>,
   ) {
     const link = this.state.links[index];
@@ -172,7 +173,13 @@ export class ExternalLinksEditor
     if (url !== '') {
       link.submitted = true;
     }
-    this.setLinkState(index, link);
+    this.setLinkState(index, link, () => {
+      // Redirect focus to the 'x' icon instead of the link
+      $(this.tableRef.current)
+        .find(`tr.external-link-item:eq(${urlIndex})`)
+        .find('button.remove-item')
+        .focus();
+    });
   }
 
   handleTypeChange(
@@ -492,7 +499,9 @@ export class ExternalLinksEditor
                 error={urlError}
                 handleLinkRemove={(index) => this.removeLink(index)}
                 handleLinkSubmit={
-                  (event) => this.handleLinkSubmit(firstLinkIndex, event)
+                  (event) => this.handleLinkSubmit(
+                    firstLinkIndex, index, event,
+                  )
                 }
                 handleUrlBlur={
                   (event) => this.handleUrlBlur(

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -493,7 +493,7 @@ export class ExternalLink
 
     return (
       <React.Fragment>
-        <tr>
+        <tr className="external-link-item">
           <td>
             <label>
               {props.isOnlyLink
@@ -552,6 +552,7 @@ export class ExternalLink
         <tr className="relationship-item">
           <td />
           <td className="relationship-name">
+            <label>{l('Type:')}</label>
             {/* If the URL matches its type or is just empty, display either a
                 favicon or a prompt for a new link as appropriate. */
               showTypeSelection
@@ -590,6 +591,10 @@ export class ExternalLink
                   {' '}
                   {l('video')}
                 </label>
+              </div>}
+            {props.errorMessage &&
+              <div className="error field-error" data-visible="1">
+                {props.errorMessage}
               </div>}
           </td>
           <td className="link-actions" style={{minWidth: '51px'}}>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -590,7 +590,7 @@ const ExternalLinkRelationship =
               {link.error.message}
             </div>}
         </td>
-        <td>
+        <td className="link-actions" style={{minWidth: '34px'}}>
           {link.url && !link.error && !hasUrlError &&
             <TypeDescription type={link.type} url={link.url} />}
           <RemoveButton
@@ -705,7 +705,7 @@ export class ExternalLink
               </div>
             }
           </td>
-          <td style={{minWidth: '34px'}}>
+          <td className="link-actions" style={{minWidth: '34px'}}>
             {// Use current props to preview changes while editing
               !isEmpty(props) &&
               <URLInputPopover
@@ -740,7 +740,7 @@ export class ExternalLink
         {notEmpty &&
         <tr className="add-relationship">
           <td />
-          <td>
+          <td className="add-item" colSpan="4">
             <button
               className="add-item with-label"
               onClick={props.onAddRelationship.bind(this, props.url)}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -206,16 +206,10 @@ export class ExternalLinksEditor
       const newLinks = prevState.links.concat();
       newLinks.splice(index, 1);
       return {links: newLinks};
-    }, () => {
-      $(this.tableRef.current)
-        .find('tr:gt(' + (index - 1) + ') button.remove:first, ' +
-              'tr:lt(' + (index + 1) + ') button.remove:last')
-        .eq(0)
-        .focus();
     });
   }
 
-  removeLinks(indexes: Array<number>) {
+  removeLinks(indexes: Array<number>, urlIndex: number) {
     this.setState(prevState => {
       const newLinks = [...prevState.links];
       // Iterate from the end to avoid messing up indexes
@@ -223,6 +217,13 @@ export class ExternalLinksEditor
         newLinks.splice(indexes[i], 1);
       }
       return {links: withOneEmptyLink(newLinks, -1)};
+    }, () => {
+      // Return focus to the next item
+      $(this.tableRef.current)
+        .find(`tr.external-link-item:eq(${urlIndex})`)
+        .find('button.edit-item, input')
+        .eq(0)
+        .focus();
     });
   }
 
@@ -512,7 +513,7 @@ export class ExternalLinksEditor
                     index, !!duplicate, event,
                   )
                 }
-                onUrlRemove={() => this.removeLinks(linkIndexes)}
+                onUrlRemove={() => this.removeLinks(linkIndexes, index)}
                 onVideoChange={
                   (index, event) => this.handleVideoChange(index, event)
                 }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -573,8 +573,8 @@ const ExternalLinkRelationship =
     return (
       <tr className="relationship-item" key={link.relationship}>
         <td />
-        <td className="relationship-name">
-          <label>{l('Type:')}</label>
+        <td className="relationship-content">
+          <label>{addColonText(l('Type'))}</label>
           {/* If the URL matches its type or is just empty,
               display either a favicon
               or a prompt for a new link as appropriate. */
@@ -589,7 +589,7 @@ const ExternalLinkRelationship =
                   {props.typeOptions}
                 </LinkTypeSelect>
               ) : (
-                <label>
+                <label className="relationship-name">
                   {faviconClass &&
                   <span
                     className={'favicon ' + faviconClass + '-favicon'}
@@ -680,10 +680,10 @@ export class ExternalLink extends React.Component<LinkProps> {
           <td>
             <label>
               {props.isOnlyLink
-                ? l('Add link:')
+                ? addColonText(l('Add link'))
                 : (
                   props.isLastLink
-                    ? l('Add another link:')
+                    ? addColonText(l('Add another link'))
                     : props.index + 1
                 )}
             </label>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -103,11 +103,12 @@ export class ExternalLinksEditor
 
   handleUrlChange(
     linkIndexes: Array<number>,
+    urlIndex: number,
     rawUrl: string,
   ) {
     let url = rawUrl;
     if (url === '') {
-      this.removeLinks(linkIndexes);
+      this.removeLinks(linkIndexes, urlIndex);
       return;
     }
 
@@ -509,7 +510,7 @@ export class ExternalLinksEditor
                   )
                 }
                 handleUrlChange={
-                  (rawUrl) => this.handleUrlChange(linkIndexes, rawUrl)
+                  (rawUrl) => this.handleUrlChange(linkIndexes, index, rawUrl)
                 }
                 index={index}
                 isLastLink={isLastLink}
@@ -694,7 +695,7 @@ type LinkProps = {
   error: ErrorT | null,
   handleLinkRemove: (number) => void,
   handleLinkSubmit: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
-  handleUrlBlur: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
+  handleUrlBlur: (SyntheticFocusEvent<HTMLInputElement>) => void,
   handleUrlChange: (string) => void,
   index: number,
   isLastLink: boolean,
@@ -901,6 +902,7 @@ export function parseRelationships(
       accum.push({
         relationship: data.id,
         rawUrl: target.name,
+        submitted: true,
         type: data.linkTypeID ?? null,
         url: target.name,
         video: data.attributes

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -758,7 +758,14 @@ export class ExternalLink extends React.Component<LinkProps> {
                 value={props.rawUrl}
               />
             ) : (
-              <a className="url" href={props.url}>{props.url}</a>
+              <a
+                className="url"
+                href={props.url}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {props.url}
+              </a>
             )}
             {props.notice &&
               <div

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -135,7 +135,7 @@ export class ExternalLinksEditor
         }
         newLinks[index] = newLink;
       });
-      return {links: withOneEmptyLink(newLinks, -1)};
+      return {links: withOneEmptyLink(newLinks, linkIndexes[0])};
     });
   }
 
@@ -512,7 +512,7 @@ const ExternalLinkRelationship =
     let faviconClass: string | void;
     const backward = linkType && linkType.type1 > 'url';
 
-    const showTypeSelection = link.error || hasUrlError
+    const showTypeSelection = (link.error || hasUrlError)
       ? true
       : !(link.urlMatchesType || isEmpty(link));
 
@@ -653,6 +653,9 @@ export class ExternalLink
     // Temporarily hide changes while editing
     const props =
       this.state.isPopoverOpen ? this.state.originalProps : this.props;
+    const notEmpty = props.relationships.some(link => {
+      return !isEmpty(link);
+    });
 
     return (
       <React.Fragment>
@@ -704,14 +707,14 @@ export class ExternalLink
                 url={this.props.url}
               />
             }
-            {!isEmpty(props) &&
+            {notEmpty &&
               <RemoveButton
                 onClick={props.onUrlRemove}
                 title={l('Remove Link')}
               />}
           </td>
         </tr>
-        {isEmpty(props) ||
+        {notEmpty &&
           props.relationships.map((link, index) => (
             <ExternalLinkRelationship
               handleTypeChange={props.typeChangeCallback}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -98,19 +98,6 @@ export class ExternalLinksEditor
     this.setState({links: newLinks}, callback);
   }
 
-  handleCancelEdit(links: Array<LinkRelationshipT>) {
-    const newLinks: Array<LinkStateT> = this.state.links.concat();
-    links.forEach((link) => {
-      const {index, type, url, rawUrl} = link;
-      newLinks[index] = Object.assign({}, newLinks[index], {
-        rawUrl,
-        url,
-        type,
-      });
-    });
-    this.setState({links: newLinks});
-  }
-
   appendEmptyLink() {
     this.setState({
       links: this.state.links.concat(

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -204,6 +204,15 @@ export class ExternalLinksEditor
     });
   }
 
+  addRelationship(url: string) {
+    this.setState(prevState => {
+      const newRelationship = newLinkState({
+        url, relationship: uniqueId('new-'),
+      });
+      return {links: prevState.links.concat([newRelationship])};
+    });
+  }
+
   getOldLinksHash(): LinkMapT {
     return keyBy<LinkStateT, string>(
       this.props.initialLinks
@@ -432,6 +441,7 @@ export class ExternalLinksEditor
                 isLastLink={isLastLink}
                 isOnlyLink={linksByUrl.length === 1}
                 key={index}
+                onAddRelationship={this.addRelationship.bind(this)}
                 onCancelEdit={
                   (state) => this.setLinkState(index, state)
                 }
@@ -601,6 +611,7 @@ type LinkProps = {
   index: number,
   isLastLink: boolean,
   isOnlyLink: boolean,
+  onAddRelationship: (string) => void,
   onLinkRemove: (number) => void,
   onUrlRemove: (Array<number>) => void,
   relationships: Array<LinkRelationshipT>,
@@ -726,6 +737,19 @@ export class ExternalLink
               typeOptions={props.typeOptions}
             />
         ))}
+        {notEmpty &&
+        <tr className="add-relationship">
+          <td />
+          <td>
+            <button
+              className="add-item with-label"
+              onClick={props.onAddRelationship.bind(this, props.url)}
+              type="button"
+            >
+              {l('Add another relationship')}
+            </button>
+          </td>
+        </tr>}
       </React.Fragment>
     );
   }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -388,7 +388,7 @@ export class ExternalLinksEditor
         target: URLCleanup.ERROR_TARGETS.RELATIONSHIP,
       };
     } else if (
-      (linksByTypeAndUrl[linkTypeAndUrlString(link)] ||
+      (linksByTypeAndUrl.get(linkTypeAndUrlString(link)) ||
         []).length > 1
     ) {
       error = {
@@ -438,7 +438,7 @@ export class ExternalLinksEditor
             const relationships = item[1];
             /*
              * The first element of tuple `item` is not the URL
-             * when the URL is empty.
+             * when the URL is empty or is the last one.
              */
             const {url, rawUrl} = relationships[0];
             const isLastLink = index === linksByUrl.length - 1;
@@ -863,8 +863,10 @@ function groupLinksByUrl(
   let map = new Map();
   links.forEach((link, index) => {
     const relationship: LinkRelationshipT = {...link, error: null, index};
-    // Treat empty URLs as separate links
-    const key = link.url === '' ? String(link.relationship) : link.url;
+    // Treat empty URLs and the last URL(editing) as separate links
+    const key = (link.url === '' || index === links.length - 1)
+      ? String(link.relationship)
+      : link.url;
     const relationships = map.get(key);
     if (relationships) {
       relationships.push(relationship);

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -226,7 +226,7 @@ export class ExternalLinksEditor
     });
   }
 
-  addRelationship(url: string) {
+  addRelationship(url: string, urlIndex: number) {
     this.setState(prevState => {
       const links = [...prevState.links];
       const linkCount = links.length;
@@ -246,6 +246,13 @@ export class ExternalLinksEditor
         url, relationship: uniqueId('new-'), submitted: true,
       });
       return {links: prevState.links.concat([newRelationship])};
+    }, () => {
+      // Return focus to the new type select
+      $(this.tableRef.current)
+        .find(`tr.add-relationship:eq(${urlIndex})`)
+        .prev()
+        .find('select.link-type')
+        .focus();
     });
   }
 
@@ -499,7 +506,7 @@ export class ExternalLinksEditor
                 isOnlyLink={linksByUrl.length === 1}
                 key={index}
                 notice={duplicateNotice}
-                onAddRelationship={(url) => this.addRelationship(url)}
+                onAddRelationship={(url) => this.addRelationship(url, index)}
                 onTypeChange={
                   (index, event) => this.handleTypeChange(
                     index, !!duplicate, event,

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -548,6 +548,7 @@ export class ExternalLink
               />}
           </td>
         </tr>
+        {isEmpty(props) ||
         <tr className="relationship-item">
           <td />
           <td className="relationship-name">
@@ -601,6 +602,7 @@ export class ExternalLink
               />}
           </td>
         </tr>
+        }
       </React.Fragment>
     );
   }

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -731,13 +731,7 @@ export class ExternalLink extends React.Component<LinkProps> {
               className={'favicon ' + faviconClass + '-favicon'}
             />}
             <label>
-              {props.isOnlyLink
-                ? addColonText(l('Add link'))
-                : (
-                  props.isLastLink
-                    ? addColonText(l('Add another link'))
-                    : props.index + 1
-                )}
+              {props.index + 1}
             </label>
           </td>
           <td>
@@ -752,6 +746,13 @@ export class ExternalLink extends React.Component<LinkProps> {
                   props.handleUrlChange(event.currentTarget.value);
                 }}
                 onKeyDown={(event) => this.handleKeyDown(event)}
+                placeholder={props.isOnlyLink
+                  ? l('Add link')
+                  : (
+                    props.isLastLink
+                      ? l('Add another link')
+                      : ''
+                  )}
                 type="url"
                 // Don't interrupt user input with clean URL
                 value={props.rawUrl}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -747,7 +747,8 @@ export class ExternalLink extends React.Component<LinkProps> {
               typeOptions={props.typeOptions}
             />
         ))}
-        {notEmpty &&
+        {/* Hide the button when link type is auto-selected */}
+        {notEmpty && !props.relationships[0].urlMatchesType &&
         <tr className="add-relationship">
           <td />
           <td className="add-item" colSpan="4">

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -528,7 +528,13 @@ const TypeDescription =
       });
     }
 
-    return <HelpIcon content={typeDescription} />;
+    return (
+      <HelpIcon
+        content={
+          <div style={{textAlign: 'left'}}>{typeDescription}</div>
+        }
+      />
+    );
   };
 
 type ExternalLinkRelationshipProps = {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -527,6 +527,7 @@ const TypeDescription =
 type ExternalLinkRelationshipProps = {
   handleTypeChange: (number, SyntheticEvent<HTMLSelectElement>) => void,
   hasUrlError: boolean,
+  isOnlyRelationship: boolean,
   link: LinkRelationshipT,
   onLinkRemove: (number) => void,
   onVideoChange:
@@ -612,10 +613,11 @@ const ExternalLinkRelationship =
         <td className="link-actions" style={{minWidth: '34px'}}>
           {link.url && !link.error && !hasUrlError &&
             <TypeDescription type={link.type} url={link.url} />}
-          <RemoveButton
-            onClick={props.onLinkRemove.bind(this, link.index)}
-            title={l('Remove Relationship')}
-          />
+          {!props.isOnlyRelationship &&
+            <RemoveButton
+              onClick={props.onLinkRemove.bind(this, link.index)}
+              title={l('Remove Relationship')}
+            />}
         </td>
       </tr>
     );
@@ -749,6 +751,7 @@ export class ExternalLink
             <ExternalLinkRelationship
               handleTypeChange={props.typeChangeCallback}
               hasUrlError={props.error != null}
+              isOnlyRelationship={props.relationships.length === 1}
               key={index}
               link={link}
               onLinkRemove={props.onLinkRemove}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -573,53 +573,55 @@ const ExternalLinkRelationship =
     return (
       <tr className="relationship-item" key={link.relationship}>
         <td />
-        <td className="relationship-content">
-          <label>{addColonText(l('Type'))}</label>
-          {/* If the URL matches its type or is just empty,
-              display either a favicon
-              or a prompt for a new link as appropriate. */
-            showTypeSelection
-              ? (
-                <LinkTypeSelect
-                  handleTypeChange={
-                    (event) => props.onTypeChange(link.index, event)
-                  }
-                  type={link.type}
-                >
-                  {props.typeOptions}
-                </LinkTypeSelect>
-              ) : (
-                <label className="relationship-name">
-                  {faviconClass &&
-                  <span
-                    className={'favicon ' + faviconClass + '-favicon'}
-                  />}
-                  {linkType ? (
-                    backward
-                      ? l_relationships(linkType.reverse_link_phrase)
-                      : l_relationships(linkType.link_phrase)
-                  ) : null}
+        <td>
+          <div className="relationship-content">
+            <label>{addColonText(l('Type'))}</label>
+            {/* If the URL matches its type or is just empty,
+                display either a favicon
+                or a prompt for a new link as appropriate. */
+              showTypeSelection
+                ? (
+                  <LinkTypeSelect
+                    handleTypeChange={
+                      (event) => props.onTypeChange(link.index, event)
+                    }
+                    type={link.type}
+                  >
+                    {props.typeOptions}
+                  </LinkTypeSelect>
+                ) : (
+                  <label className="relationship-name">
+                    {faviconClass &&
+                    <span
+                      className={'favicon ' + faviconClass + '-favicon'}
+                    />}
+                    {linkType ? (
+                      backward
+                        ? l_relationships(linkType.reverse_link_phrase)
+                        : l_relationships(linkType.link_phrase)
+                    ) : null}
+                  </label>
+                )
+            }
+            {linkType &&
+              hasOwnProp(
+                linkType.attributes,
+                String(VIDEO_ATTRIBUTE_ID),
+              ) &&
+              <div className="attribute-container">
+                <label>
+                  <input
+                    checked={link.video}
+                    onChange={
+                      (event) => props.onVideoChange(link.index, event)
+                    }
+                    type="checkbox"
+                  />
+                  {' '}
+                  {l('video')}
                 </label>
-              )
-          }
-          {linkType &&
-            hasOwnProp(
-              linkType.attributes,
-              String(VIDEO_ATTRIBUTE_ID),
-            ) &&
-            <div className="attribute-container">
-              <label>
-                <input
-                  checked={link.video}
-                  onChange={
-                    (event) => props.onVideoChange(link.index, event)
-                  }
-                  type="checkbox"
-                />
-                {' '}
-                {l('video')}
-              </label>
-            </div>}
+              </div>}
+          </div>
           {link.error &&
             <div className="error field-error" data-visible="1">
               {link.error.message}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -112,6 +112,11 @@ export class ExternalLinksEditor
     const rawUrl = event.currentTarget.value;
     let url = rawUrl;
 
+    // Remove empty links
+    if (rawUrl === '') {
+      this.removeLinks(linkIndexes);
+      return;
+    }
     this.setState(prevState => {
       let newLinks = [...prevState.links];
       linkIndexes.forEach(index => {
@@ -206,6 +211,20 @@ export class ExternalLinksEditor
 
   addRelationship(url: string) {
     this.setState(prevState => {
+      const links = [...prevState.links];
+      const linkCount = links.length;
+      const lastLink = links[linkCount - 1];
+      /*
+       * If the last (latest-added) link is empty, then use it
+       * to maintain the order that the empty link should be at the end.
+       */
+      if (lastLink.url === '') {
+        links[linkCount - 1] = Object.assign(
+          {}, lastLink, {url},
+        );
+        return {links: withOneEmptyLink(links)};
+      }
+      // Otherwise create a new link with the given URL
       const newRelationship = newLinkState({
         url, relationship: uniqueId('new-'),
       });

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -647,6 +647,12 @@ table.artist-credit-editor {
             }
         }
 
+        td.link-actions {
+            button.edit-item {
+                margin-right: 4px !important;
+            }
+        }
+
         a.url:focus-visible {
             outline: revert; // reset to UA stylesheet
         }

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -627,10 +627,16 @@ table.artist-credit-editor {
         padding-right: 0;
     }
 
+    .external-link-item {
+        td {
+            padding-bottom: @form-margin / 4;
+        }
+    }
+
     .relationship-item {
         td {
             padding-top: @form-margin / 4;
-            padding-bottom: @form-margin / 2;
+            padding-bottom: @form-margin / 4;
         }
 
         td.relationship-name {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -631,6 +631,16 @@ table.artist-credit-editor {
         td {
             padding-bottom: @form-margin / 4;
         }
+
+        td:first-child {
+            text-align: right;
+
+            label {
+                text-align: center;
+                width: fit-content !important;
+                min-width: 16px;
+            }
+        }
     }
 
     .relationship-item {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -639,9 +639,18 @@ table.artist-credit-editor {
             padding-bottom: @form-margin / 4;
         }
 
-        td.relationship-name {
+        td.relationship-content {
+            display: flex;
+
             label {
                 margin-right: @form-margin / 2;
+                white-space: nowrap;
+            }
+
+            label.relationship-name {
+                flex: 2 5;
+                text-align: left;
+                white-space: inherit;
             }
 
             select {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -620,6 +620,10 @@ table.artist-credit-editor {
     td {
         vertical-align: top;
         padding-top: @form-margin / 2;
+
+        &:first-child {
+            min-width: 75px;
+        }
     }
 
     td.link-actions {
@@ -637,6 +641,7 @@ table.artist-credit-editor {
 
             label {
                 text-align: center;
+                width: -moz-fit-content !important;
                 width: fit-content !important;
                 min-width: 16px;
             }

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -639,7 +639,7 @@ table.artist-credit-editor {
             padding-bottom: @form-margin / 4;
         }
 
-        td.relationship-content {
+        div.relationship-content {
             display: flex;
 
             label {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -646,6 +646,10 @@ table.artist-credit-editor {
                 min-width: 16px;
             }
         }
+
+        a.url:focus-visible {
+            outline: revert; // reset to UA stylesheet
+        }
     }
 
     .relationship-item {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -627,11 +627,24 @@ table.artist-credit-editor {
         padding-right: 0;
     }
 
-    .relationship-item > td.relationship-name {
-        padding-left: 30px;
+    .relationship-item {
+        td {
+            padding-top: @form-margin / 4;
+            padding-bottom: @form-margin / 2;
+        }
 
-        select {
-            width: 100%;
+        td.relationship-name {
+            label {
+                margin-right: @form-margin / 2;
+            }
+
+            select {
+                width: auto;
+            }
+
+            .attribute-container {
+                display: inline-block;
+            }
         }
     }
 }

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -647,6 +647,13 @@ table.artist-credit-editor {
             }
         }
     }
+
+    .add-relationship {
+        td {
+            padding-top: @form-margin / 4;
+            padding-bottom: @form-margin / 2;
+        }
+    }
 }
 
 #external-links-editor, #work-attributes {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -626,6 +626,14 @@ table.artist-credit-editor {
         text-align: right;
         padding-right: 0;
     }
+
+    .relationship-item > td.relationship-name {
+        padding-left: 30px;
+
+        select {
+            width: 100%;
+        }
+    }
 }
 
 #external-links-editor, #work-attributes {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -648,11 +648,13 @@ table.artist-credit-editor {
         }
     }
 
-    .add-relationship {
-        td {
-            padding-top: @form-margin / 4;
-            padding-bottom: @form-margin / 2;
-        }
+    td.link-actions {
+        text-align: right;
+        padding-right: 0;
+    }
+
+    .add-relationship td {
+        padding: 0;
     }
 }
 

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -218,7 +218,7 @@
     // Add relationship by clicking button
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'add-relationship')][2]//button[contains(@class, 'add-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'add-relationship')][1]//button[contains(@class, 'add-item')]",
       value: '',
     },
     {
@@ -251,7 +251,7 @@
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
       // Wikipedia link + current link(3 relationships)
-      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+      value: 'external-link-item\nrelationship-item\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
     },
     // Delete single relationship
     {
@@ -274,7 +274,7 @@
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
       // Wikipedia link + empty input box
-      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+      value: 'external-link-item\nrelationship-item\nexternal-link-item',
     },
     // Automatically delete empty URL
     {
@@ -297,7 +297,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
-      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+      value: 'external-link-item\nrelationship-item\nexternal-link-item',
     },
     // submit the artist
     {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -287,6 +287,7 @@
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '${KEY_TAB}',
     },
+    // Assert not merged
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
@@ -296,13 +297,30 @@
     {
       command: 'assertText',
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][3]//div[contains(@class, 'error')]",
-      value: 'Note: This link already exists at item #2. To merge, press enter or select a type.',
+      value: 'Note: This link already exists at position #2. To merge, press enter or select a type.',
     },
-    // Automatically submitted after selecting a type
+    // Don't merge while using arrow keys to select relationship type
+    {
+      command: 'sendKeys',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][4]//select[contains(@class, 'link-type')]",
+      value: '${KEY_DOWN}',
+    },
+    // Assert not merged
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
+      value: 'https://google.com\n',
+    },
+    // Automatically submitted after selecting a type and moving focus away from the type select
     {
       command: 'select',
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][4]//select[contains(@class, 'link-type')]",
       value: 'label=regexp:\\s*interviews',
+    },
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '',
     },
     {
       command: 'assertEval',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -24,7 +24,12 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//label[1]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//label[1]",
+      value: '1',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][1]//label[2]",
       value: 'Wikipedia',
     },
     // invalid URL detection
@@ -62,13 +67,13 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
     {
-      command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
     },
     // shortened URL detection
     {
@@ -83,13 +88,13 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
       value: 'Please don’t enter bundled/shortened URLs, enter the destination URL(s) instead.',
     },
     {
-      command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
     },
     // deprecated link type detection for new links
     {
@@ -109,12 +114,12 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
       value: 'This relationship type is deprecated and should not be used.',
     },
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
       value: '',
     },
     // URLInputPopover tests
@@ -233,7 +238,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][1]//div[contains(@class, 'error')]",
       value: 'This relationship type is deprecated and should not be used.',
     },
     // relationshipCreate edit for external link is generated for existing release
@@ -378,7 +383,7 @@
     },
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'remove-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'remove-item')]",
       value: '',
     },
     // check that edits are not generated for links that duplicate removed ones
@@ -389,7 +394,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'field-error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'field-error')]",
       value: 'This relationship already exists.',
     },
     {
@@ -410,7 +415,7 @@
     // duplicate the first URL again by editing the other existing URL
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
       value: '',
     },
     // Open popover
@@ -437,7 +442,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//div[contains(@class, 'field-error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][1]//div[contains(@class, 'field-error')]",
       value: 'This relationship already exists.',
     },
     // revert above edit

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -240,11 +240,11 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
-      value: '183\n\n172',
+      value: '183\n172\n',
     },
     {
       command: 'select',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][3]//select[contains(@class, 'link-type')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][4]//select[contains(@class, 'link-type')]",
       value: 'label=regexp:\\s*biographies',
     },
     {
@@ -262,7 +262,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
-      value: '182\n172',
+      value: '172\n182',
     },
     // Delete link with all relationships
     {
@@ -274,6 +274,22 @@
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
       // Wikipedia link + empty input box
+      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+    },
+    // Automatically delete empty URL
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: 'https://en.wikipedia.org/wiki/',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
       value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item',
     },
     // submit the artist
@@ -394,7 +410,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}https://www.gnu.org/licenses/gpl-3.0.en.html',
     },
     // Save URL change
     {
@@ -504,7 +520,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.amazon.co.jp/gp/product/B017VORJK6',
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}https://www.amazon.co.jp/gp/product/B017VORJK6',
     },
     // Save URL change
     {
@@ -532,7 +548,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}https://www.gnu.org/licenses/gpl-3.0.en.html',
     },
     // Save URL change
     {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -199,6 +199,83 @@
       target: "xpath=//table[@id='external-links-editor']//tr[1]//a[contains(@class, 'url')]",
       value: 'https://en.wikipedia.org/wiki/No_Age',
     },
+    // Test grouping links by URL
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: 'https://google.com',
+    },
+    {
+      command: 'select',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//select[contains(@class, 'link-type')]",
+      value: 'label=regexp:\\s*official homepages',
+    },
+    // Add relationship by clicking button
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'add-relationship')][2]//button[contains(@class, 'add-item')]",
+      value: '',
+    },
+    {
+      command: 'assertElementPresent',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][3]//select[contains(@class, 'link-type')]",
+      value: '',
+    },
+    {
+      command: 'select',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][3]//select[contains(@class, 'link-type')]",
+      value: 'label=regexp:\\s*fan pages',
+    },
+    // Add relationship by entering the same URL
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[3]",
+      value: 'https://google.com',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
+      value: '183\n\n172',
+    },
+    {
+      command: 'select',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][3]//select[contains(@class, 'link-type')]",
+      value: 'label=regexp:\\s*biographies',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
+      // Wikipedia link + current link(3 relationships)
+      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+    },
+    // Delete single relationship
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
+      value: '182\n172',
+    },
+    // Delete link with all relationships
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
+      // Wikipedia link + empty input box
+      value: 'external-link-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+    },
     // submit the artist
     {
       command: 'type',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -45,14 +45,14 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
     // clear
     {
-      command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
     },
     // MBS-11688
     {
@@ -67,7 +67,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
     {
@@ -88,7 +88,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: 'Please don’t enter bundled/shortened URLs, enter the destination URL(s) instead.',
     },
     {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -237,6 +237,13 @@
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'https://google.com${KEY_ENTER}',
     },
+    // Pressing enter submits the link
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
+      // Wikipedia link + current link(3 relationships)
+      value: 'external-link-item\nrelationship-item\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+    },
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
@@ -246,12 +253,6 @@
       command: 'select',
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][4]//select[contains(@class, 'link-type')]",
       value: 'label=regexp:\\s*biographies',
-    },
-    {
-      command: 'assertEval',
-      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
-      // Wikipedia link + current link(3 relationships)
-      value: 'external-link-item\nrelationship-item\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
     },
     // Delete single relationship
     {
@@ -263,6 +264,74 @@
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('select.link-type')).map(x => x.value).join('\\n')",
       value: '172\n182',
+    },
+    // Immediately appends new input box
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://google.com',
+    },
+    {
+      command: 'assertElementPresent',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '',
+    },
+    // Pressing tab does not submit the link when it's a duplicate
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '${KEY_TAB}',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
+      value: 'https://google.com\n',
+    },
+    // Duplicate URL notice
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][3]//div[contains(@class, 'error')]",
+      value: 'Note: This link already exists at item #2. To merge, press enter or select a type.',
+    },
+    // Automatically submitted after selecting a type
+    {
+      command: 'select',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][4]//select[contains(@class, 'link-type')]",
+      value: 'label=regexp:\\s*interviews',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
+      // Wikipedia link + current link(3 relationships)
+      value: 'external-link-item\nrelationship-item\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
+    },
+    // Delete link while entering
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://google.com',
+    },
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][3]//button[contains(@class, 'remove-item')]",
+      value: '',
+    },
+    // Assert link is deleted
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).map(x => x.className).join('\\n')",
+      // Wikipedia link + current link(3 relationships)
+      value: 'external-link-item\nrelationship-item\nexternal-link-item\nrelationship-item\nrelationship-item\nrelationship-item\nadd-relationship\nexternal-link-item',
     },
     // Delete link with all relationships
     {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -126,7 +126,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     {
@@ -155,7 +155,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     // assert URL is unchanged
@@ -178,7 +178,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     // assert changes are kept
@@ -196,18 +196,18 @@
     // assert clean URL is used
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//a[contains(@class, 'url')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//a[contains(@class, 'url')]",
       value: 'https://en.wikipedia.org/wiki/No_Age',
     },
     // Test grouping links by URL
     {
       command: 'click',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'https://google.com',
     },
     {
@@ -234,8 +234,8 @@
     // Add relationship by entering the same URL
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[3]",
-      value: 'https://google.com',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://google.com${KEY_ENTER}',
     },
     {
       command: 'assertEval',
@@ -279,13 +279,20 @@
     // Automatically delete empty URL
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
-      value: 'https://en.wikipedia.org/wiki/',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://en.wikipedia.org/wiki/${KEY_ENTER}',
     },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    // Empty input box and press enter to save
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}${KEY_ENTER}',
     },
     {
       command: 'assertEval',
@@ -331,7 +338,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][1]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//div[contains(@class, 'error')]",
       value: 'This relationship type is deprecated and should not be used.',
     },
     // relationshipCreate edit for external link is generated for existing release
@@ -404,7 +411,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     {
@@ -514,7 +521,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     {
@@ -542,7 +549,7 @@
     // Open popover
     {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -48,6 +48,17 @@
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
+    // Don't freeze to link when there's an error
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
+      value: 'foo\n',
+    },
     // clear
     {
       command: 'click',

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -288,8 +288,13 @@
     },
     {
       command: 'assertEval',
-      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('a.url') ? x.querySelector('a.url').href : x.querySelector('input').value, x.querySelector('.error').textContent].join('\\t')).join('\\n')",
-      value: '\thttp://foo.bar.baz/\tPlease select a link type for the URL you’ve entered.\n77\t\tRequired field.\n76\thttp://foo.bar.baz/foo/\tThis URL is not allowed for the selected link type, or is incorrectly formatted.',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"external-link-item\"]')).slice(0,3).map(x => x.querySelector('a.url') ? x.querySelector('a.url').href : x.querySelector('input').value).join('\\n')",
+      value: 'http://foo.bar.baz/\n\nhttp://foo.bar.baz/foo/',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"relationship-item\"]')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('.error').textContent].join('\\t')).join('\\n')",
+      value: '\tPlease select a link type for the URL you’ve entered.\n77\tRequired field.\n76\tThis URL is not allowed for the selected link type, or is incorrectly formatted.',
     },
     // MBS-7250: seeding empty date parts gives an ISE
     {

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -294,12 +294,12 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"external-link-item\"]')).slice(0, 3).map(x => x.querySelector('.error') ? x.querySelector('.error').textContent : '').join('\\n')",
-      value: '\nRequired field.\nThis URL is not allowed for the selected link type, or is incorrectly formatted.',
+      value: '\nRequired field.\n',
     },
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"relationship-item\"]')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('.error') ? x.querySelector('.error').textContent : ''].join('\\t')).join('\\n')",
-      value: '\tPlease select a link type for the URL you’ve entered.\n77\t\n76\t',
+      value: '\tPlease select a link type for the URL you’ve entered.\n77\t\n76\tThis URL is not allowed for the selected link type.',
     },
     // MBS-7250: seeding empty date parts gives an ISE
     {

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -293,8 +293,13 @@
     },
     {
       command: 'assertEval',
-      target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"relationship-item\"]')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('.error').textContent].join('\\t')).join('\\n')",
-      value: '\tPlease select a link type for the URL you’ve entered.\n77\tRequired field.\n76\tThis URL is not allowed for the selected link type, or is incorrectly formatted.',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"external-link-item\"]')).slice(0, 3).map(x => x.querySelector('.error') ? x.querySelector('.error').textContent : '').join('\\n')",
+      value: '\nRequired field.\nThis URL is not allowed for the selected link type, or is incorrectly formatted.',
+    },
+    {
+      command: 'assertEval',
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr[class=\"relationship-item\"]')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('.error') ? x.querySelector('.error').textContent : ''].join('\\t')).join('\\n')",
+      value: '\tPlease select a link type for the URL you’ve entered.\n77\t\n76\t',
     },
     // MBS-7250: seeding empty date parts gives an ISE
     {


### PR DESCRIPTION
# Problem

The current external links editor has the following drawbacks:

* It does not make obvious a URL can be pasted a second time to add another relationship type
* It is not easy to find if a URL has been pasted already (except when using the same relationship type)
* It requires double editing to change a URL having two relationships
* Error’s position is the same for both relationship type and URL, it isn’t always obvious which field must be edited to fix the error.

# Solution

MBS-11680: Group editing URL relationships by external link

Implement a new UI for external links editor, where links with the same URL are grouped together, relationship types are shown under the URL as a list, and URLs are numbered for reference in error messages.

## Details

* Additional relationship can be added in two different ways:
  * Either by pasting the same URL a second time (as before);
  * Or by clicking the 'Add another relationship' button.


* Additional input elements are shown only when needed:
  * 'Add another relationship' button only if permitted, (auto-selected relationship types currently don’t allow for a second relationship);
  * 'Remove relationship' button is displayed only if there are several relationships as at least one relationship is required per URL.

* Linked URL is highlighted when focused to ease keyboard navigation.

* Reference the position of the original URL through a notice when the pasted URL is a duplicate.  Users can then press enter or select a different type to confirm merging with the existing one.

* Improve layout to prevent relationship type description `?` button to hide other controls and to be unintentionally triggered.

* Improve workflow with links that have error by instantly appending new input boxes and not freezing them.

* Enable validating URLs in URL editing popover and display URL-related errors only (without re-rendering the whole list).

* Fix opening links in a new tab (to prevent editing data loss)

* Fix error target of restricted link types (to `RELATIONSHIP`)