### PR TITLE
Replace direction prop with backward

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -290,7 +290,7 @@ sub load_paged {
                 my $lt_group = RelationshipLinkTypeGroup->new(
                     link_type => $link_types->{$link_type_id},
                     link_type_id => $link_type_id,
-                    direction => $direction,
+                    backward => ($direction == $DIRECTION_BACKWARD),
                     total_relationships => $total_relationships,
                     limit => $limit,
                     offset => $offset,
@@ -361,7 +361,7 @@ sub load_paged {
                 $link_type_groups->{$group_key} = RelationshipLinkTypeGroup->new(
                     link_type => $link_types->{$link_type_filter},
                     link_type_id => $link_type_filter,
-                    direction => $direction,
+                    backward => ($direction == $DIRECTION_BACKWARD),
                     total_relationships => 0,
                     limit => $limit,
                     offset => $offset,

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -291,7 +291,7 @@ around TO_JSON => sub {
 
     $json->{begin_date} = $link->begin_date->is_empty ? undef : partial_date_to_hash($link->begin_date);
     $json->{end_date} = $link->end_date->is_empty ? undef : partial_date_to_hash($link->end_date);
-    $json->{direction} = 'backward' if $self->direction == $DIRECTION_BACKWARD;
+    $json->{backward} = boolean_to_json($self->direction == $DIRECTION_BACKWARD);
 
     my $source = $self->source;
     $self->link_entity($source->entity_type, $source->id, $source);

--- a/lib/MusicBrainz/Server/Entity/RelationshipLinkTypeGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/RelationshipLinkTypeGroup.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Entity::RelationshipLinkTypeGroup;
 
 use Moose;
-use MusicBrainz::Server::Constants qw( :direction );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( add_linked_entity );
@@ -16,9 +15,9 @@ has 'link_type' => (
     isa => 'Maybe[LinkType]',
 );
 
-has 'direction' => (
+has 'backward' => (
     is => 'ro',
-    isa => 'Int',
+    isa => 'Bool',
 );
 
 has 'relationships' => (
@@ -61,7 +60,6 @@ sub TO_JSON {
     my ($self) = @_;
 
     my $link_type_id = $self->link_type_id + 0;
-    my $direction = $self->direction == $DIRECTION_BACKWARD ? 'backward' : 'forward';
     my $is_loaded = boolean_to_json($self->is_loaded);
     my $total_relationships = $self->total_relationships + 0;
     my $limit = $self->limit + 0;
@@ -72,7 +70,7 @@ sub TO_JSON {
 
     return {
         link_type_id => $link_type_id,
-        direction => $direction,
+        backward => boolean_to_json($self->backward),
         relationships => [map { $_->TO_JSON } $self->all_relationships],
         is_loaded => $is_loaded,
         total_relationships => $total_relationships,

--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -42,10 +42,9 @@ const renderPhraseGroup = (phraseGroup: RelationshipPhraseGroupT) => (
 
 const renderWorkRelationship = (relationship: RelationshipT) => {
   const work = relationship.target;
-  const backward = relationship.direction === 'backward';
   const phrase = interpolate(
     relationship,
-    backward ? 'reverse_link_phrase' : 'link_phrase',
+    relationship.backward ? 'reverse_link_phrase' : 'link_phrase',
     /*
      * Work relationships are not grouped together on a single line,
      * because we have to output the relationships of the work under
@@ -59,7 +58,7 @@ const renderWorkRelationship = (relationship: RelationshipT) => {
     ? <span className="mp">{phrase}</span>
     : phrase;
 
-  const targetCredit = backward
+  const targetCredit = relationship.backward
     ? relationship.entity0_credit
     : relationship.entity1_credit;
 
@@ -92,7 +91,7 @@ const irrelevantLinkTypes = new Map([
 
 function isIrrelevantLinkType(relationship) {
   return irrelevantLinkTypes.get(relationship.linkTypeID) ===
-    (relationship.direction === 'backward');
+    relationship.backward;
 }
 
 const GroupedTrackRelationships = ({

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -57,22 +57,19 @@ const pickAppearancesTypes = (entityType) => {
 const getLinkPhraseForGroup = (linkTypeGroup) => (
   interpolateText(
     {linkTypeID: linkTypeGroup.link_type_id},
-    linkTypeGroup.direction === 'backward'
+    linkTypeGroup.backward
       ? 'reverse_link_phrase'
       : 'link_phrase',
     true, /* forGrouping */
   )
 );
 
-const getDirectionFromName = (direction) => {
-  switch (direction) {
-    case 'forward':
-      return 1;
-    case 'backward':
-      return 2;
-    default:
-      return 0;
-  }
+/*
+ * Matches $DIRECTION_FORWARD and $DIRECTION_BACKWARD from
+ * lib/MusicBrainz/Server/Constants.pm.
+ */
+const getDirectionInteger = (backward) => {
+  return backward ? 2 : 1;
 };
 
 const RelationshipsTable = ({
@@ -121,7 +118,7 @@ const RelationshipsTable = ({
               <a
                 href={uriWith(
                   $c.req.uri, {
-                    direction: getDirectionFromName(group.direction),
+                    direction: getDirectionInteger(group.backward),
                     link_type_id: group.link_type_id,
                     page: 1,
                   },
@@ -210,7 +207,7 @@ const RelationshipsTable = ({
     for (const relationship of linkTypeGroup.relationships) {
       let sourceCredit = '';
       let targetCredit = '';
-      if (relationship.direction === 'backward') {
+      if (relationship.backward) {
         targetCredit = relationship.entity0_credit;
         sourceCredit = relationship.entity1_credit;
       } else {
@@ -290,7 +287,8 @@ const RelationshipsTable = ({
         tableRows.push(
           <RelationshipsTableGroup
             group={linkTypeGroup}
-            key={linkTypeGroup.link_type_id + '-' + linkTypeGroup.direction}
+            key={linkTypeGroup.link_type_id + '-' +
+              String(linkTypeGroup.backward)}
             relationshipRows={relationshipRows}
           />,
         );

--- a/root/static/scripts/common/components/Relationship.js
+++ b/root/static/scripts/common/components/Relationship.js
@@ -67,20 +67,20 @@ const RelationshipContent = ({
   allowNewEntity1,
   relationship,
 }: Props) => {
-  const direction = relationship.direction;
+  const backward = relationship.backward;
   const linkType = linkedEntities.link_type[relationship.linkTypeID];
   let entity0 = relationship.entity0;
   let entity1 = relationship.entity1;
   const type0 = linkType.type0 ||
-    (direction === 'backward'
+    (backward
       ? relationship.target_type
       : relationship.source_type);
   const type1 = linkType.type1 ||
-    (direction === 'backward'
+    (backward
       ? relationship.source_type
       : relationship.target_type);
   if (!entity0 || !entity1) {
-    if (direction === 'backward') {
+    if (backward) {
       entity0 = relationship.target;
       entity1 = linkedEntities[type1][relationship.entity1_id] ||
         {entityType: type1, id: relationship.entity1_id};

--- a/root/static/scripts/edit/ExampleRelationships.js
+++ b/root/static/scripts/edit/ExampleRelationships.js
@@ -143,7 +143,7 @@ MB.ExampleRelationshipsEditor = (function (ERE) {
               let source = data;
               let target = rel.target;
 
-              if (rel.direction == 'backward') {
+              if (rel.backward) {
                 source = rel.target;
                 target = data;
               }

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -191,7 +191,7 @@ class Dialog {
       target = options.relationship.target(source);
     } else {
       options.relationship = this.viewModel.getRelationship({
-        target: target, direction: options.direction,
+        target: target, backward: !!options.backward,
       }, source);
 
       const linkTypeChildren =
@@ -793,7 +793,7 @@ export class BatchRelationshipDialog extends Dialog {
     delete model.entities;
 
     model.target = this.relationship().target(this.source);
-    model.direction = this.backward() ? 'backward' : 'forward';
+    model.backward = !!this.backward();
 
     for (const source of this.sources) {
       model = {...model};

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -219,7 +219,7 @@ MB.getRelationship = function (data, source) {
   let backward = source.entityType > target.entityType;
 
   if (source.entityType === target.entityType) {
-    backward = (data.direction === 'backward');
+    backward = !!data.backward;
   }
 
   data.entities = backward ? [target, source] : [source, target];
@@ -340,7 +340,7 @@ function addRelationshipsFromQueryString(source) {
       begin_date: parseDate(rel.begin_date || ''),
       end_date: parseDate(rel.end_date || ''),
       ended: !!Number(rel.ended),
-      direction: rel.direction,
+      backward: !!rel.backward,
       linkOrder: Number(rel.link_order) || 0,
     };
 

--- a/root/static/scripts/relationship-editor/generic.js
+++ b/root/static/scripts/relationship-editor/generic.js
@@ -263,7 +263,7 @@ export function prepareSubmission(formName) {
         data.removed = relationship.removed();
 
         if (data.entities[1].gid === source.gid) {
-          data.direction = 'backward';
+          data.backward = true;
         }
 
         return data;

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -238,7 +238,7 @@ test('guessing feat. artists', function (t) {
                 gid: 'd50548a0-3cfd-4d7a-964b-0aef6545d819',
                 entityType: 'artist',
               },
-              direction: 'backward',
+              backward: true,
               linkTypeID: 156,
             },
           ],
@@ -346,7 +346,7 @@ test('guessing feat. artists', function (t) {
         relationships: [
           {
             target: {name: 'London Symphony Orchestra', entityType: 'artist'},
-            direction: 'backward',
+            backward: true,
             linkTypeID: 45,
           },
         ],
@@ -373,7 +373,7 @@ test('guessing feat. artists', function (t) {
         relationships: [
           {
             target: {name: 'Roberto Cascio', entityType: 'artist'},
-            direction: 'backward',
+            backward: true,
             linkTypeID: 46,
           },
         ],
@@ -403,7 +403,7 @@ test('guessing feat. artists', function (t) {
               name: 'The Drottningholm Court Theatre Orchestra & Chorus',
               entityType: 'artist',
             },
-            direction: 'backward',
+            backward: true,
             linkTypeID: 45,
           },
         ],

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -486,7 +486,7 @@ relationshipEditorTest('dialog backwardness', function (t) {
       input: {
         source: recording1,
         target: recording0,
-        direction: 'backward',
+        backward: true,
       },
       expected: {
         backward: true,
@@ -711,7 +711,7 @@ relationshipEditorTest((
       linkTypeID: 234,
       target: target,
       entities: [target, source],
-      direction: 'backward',
+      backward: true,
     },
   ]));
 
@@ -827,7 +827,7 @@ relationshipEditorTest((
       relationships: [
         {
           linkTypeID: 103,
-          direction: 'backward',
+          backward: true,
           ended: true,
           target: {
             entityType: 'artist',
@@ -843,7 +843,7 @@ relationshipEditorTest((
         },
         {
           linkTypeID: 103,
-          direction: 'backward',
+          backward: true,
           ended: true,
           target: {
             entityType: 'artist',
@@ -863,7 +863,7 @@ relationshipEditorTest((
 
   var newRelationship = vm.getRelationship({
     linkTypeID: 103,
-    direction: 'backward',
+    backward: true,
     ended: true,
     target: {
       entityType: 'artist',
@@ -947,7 +947,7 @@ relationshipEditorTest((
 
   var newRelationship1 = vm.getRelationship({
     linkTypeID: 742,
-    direction: 'backward',
+    backward: true,
     target: {
       entityType: 'release_group',
       name: '「神のみぞ知るセカイ」キャラクターCD.0',
@@ -960,7 +960,7 @@ relationshipEditorTest((
 
   var newRelationship2 = vm.getRelationship({
     linkTypeID: 742,
-    direction: 'backward',
+    backward: true,
     target: {
       entityType: 'release_group',
       name: '「神のみぞ知るセカイ」キャラクターCD.1',
@@ -973,7 +973,7 @@ relationshipEditorTest((
 
   var newRelationship3 = vm.getRelationship({
     linkTypeID: 742,
-    direction: 'backward',
+    backward: true,
     target: {
       entityType: 'release_group',
       name: '「神のみぞ知るセカイ」キャラクターCD.2',
@@ -1065,7 +1065,7 @@ var loveMeDo = {
   relationships: [
     {
       linkTypeID: 44,
-      direction: 'backward',
+      backward: true,
       target: {
         entityType: 'artist',
         name: 'Ringo Starr',
@@ -1181,7 +1181,7 @@ relationshipEditorTest((
   var compositionData = {
     id: 666,
     linkTypeID: 168,
-    direction: 'backward',
+    backward: true,
     target: beethoven,
     linkOrder: 0,
     attributes: [],
@@ -1273,7 +1273,7 @@ relationshipEditorTest((
   var relData = [
     {
       attributes:  [],
-      direction: 'backward',
+      backward: true,
       id: 55536,
       linkOrder: 15,
       linkTypeID: 281,

--- a/root/types/relationship.js
+++ b/root/types/relationship.js
@@ -66,7 +66,7 @@ declare type LinkTypeT = {
 };
 
 declare type PagedLinkTypeGroupT = {
-  +direction: 'backward' | 'forward',
+  +backward: boolean,
   +is_loaded: boolean,
   +limit: number,
   +link_type_id: number,
@@ -83,7 +83,7 @@ declare type RelationshipT = $ReadOnly<{
   ...DatePeriodRoleT,
   ...EditableRoleT,
   +attributes: $ReadOnlyArray<LinkAttrT>,
-  +direction?: 'backward',
+  +backward: boolean,
   +entity0?: CoreEntityT,
   +entity0_credit: string,
   +entity0_id: number,

--- a/root/utility/groupRelationships.js
+++ b/root/utility/groupRelationships.js
@@ -224,7 +224,7 @@ const getSortName = x => x.entityType === 'artist' ? x.sort_name : x.name;
 
 function targetIsOrderable(relationship: RelationshipT) {
   const linkType = linkedEntities.link_type[relationship.linkTypeID];
-  const backward = relationship.direction === 'backward';
+  const backward = relationship.backward;
   // `backward` indicates that the relationship target is entity0
   return (linkType.orderable_direction === 1 && !backward) ||
           (linkType.orderable_direction === 2 && backward);
@@ -272,7 +272,7 @@ export default function groupRelationships(
       }
     }
 
-    const backward = relationship.direction === 'backward';
+    const backward = relationship.backward;
     const linkType = linkedEntities.link_type[relationship.linkTypeID];
 
     /*
@@ -369,7 +369,7 @@ export default function groupRelationships(
       }
     }
 
-    const targetCredit = relationship.direction === 'backward'
+    const targetCredit = relationship.backward
       ? relationship.entity0_credit
       : relationship.entity1_credit;
     const isOrderable = targetIsOrderable(relationship);

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Release.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Release.pm
@@ -30,7 +30,7 @@ test all => sub {
 
     cmp_deeply($vocal_performance, {
         linkTypeID => 149,
-        direction => 'backward',
+        backward => JSON::true,
         ended => JSON::false,
         target => {
             area => undef,


### PR DESCRIPTION
We often need to know whether a relationship is backward (meaning: its target is entity0), and have a lot of `direction === "backward"` checks throughout the code. It would be much simpler to replace these with a boolean, as we don't support more than two directions anyway.