### PR TITLE
MBS-11688: The external link section will disappear once any link starts with //

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -556,7 +556,7 @@ export function getUnicodeUrl(url: string): string {
   return unicodeUrl;
 }
 
-function isValidURL(url) {
+function isValidURL(url: string) {
   const a = document.createElement('a');
   a.href = url;
 
@@ -576,7 +576,12 @@ function isValidURL(url) {
     return false;
   }
 
-  if (!protocolRegex.test(a.protocol)) {
+  /*
+   * Check if protocol string is in URL and is valid
+   * Protocol of URL like "//google.com" is inferred as "https:"
+   * but the URL is invalid
+   */
+  if (!url.startsWith(a.protocol) || !protocolRegex.test(a.protocol)) {
     return false;
   }
 

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -48,6 +48,27 @@
       target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
       value: '',
     },
+    // MBS-11688
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      value: '//google.com',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
+      value: 'Enter a valid url e.g. "http://google.com/"',
+    },
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
+      value: '',
+    },
     // shortened URL detection
     {
       command: 'click',


### PR DESCRIPTION
# Problem

MBS-11688: The external link section will disappear once any link starts with //


# Solution

Fix `isValidURL` to correctly validate links starting with "//"

