### PR TITLE
MBS-11693: Give useful message when rejecting Musixmatch /album links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2779,11 +2779,11 @@ const CLEANUPS = {
     type: LINK_TYPES.lyrics,
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?musixmatch\.com\/(artist)\/([^\/?#]+).*$/, 'https://www.musixmatch.com/$1/$2');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?musixmatch\.com\/(lyrics)\/([^\/?#]+)\/([^\/?#]+).*$/, 'https://www.musixmatch.com/$1/$2/$3');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?musixmatch\.com\/(album|lyrics)\/([^\/?#]+)\/([^\/?#]+).*$/, 'https://www.musixmatch.com/$1/$2/$3');
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www.musixmatch\.com\/(artist|lyrics)\/[^?#]+$/.exec(url);
+      const m = /^https:\/\/www.musixmatch\.com\/(album|artist|lyrics)\/[^?#]+$/.exec(url);
       if (m) {
         const prefix = m[1];
         switch (id) {
@@ -2792,6 +2792,25 @@ const CLEANUPS = {
               result: prefix === 'artist',
               target: ERROR_TARGETS.RELATIONSHIP,
             };
+          case LINK_TYPES.lyrics.release_group:
+            if (prefix === 'album') {
+              return {
+                error: exp.l(
+                  `Musixmatch “{album_url_pattern}” pages are a bad match
+                   for MusicBrainz release groups, and linking to them
+                   is currently disallowed. Please consider adding Musixmatch
+                   links to the relevant artists and works instead.`,
+                  {
+                    album_url_pattern: (
+                      <span className="url-quote">{'/album'}</span>
+                    ),
+                  },
+                ),
+                result: false,
+                target: ERROR_TARGETS.ENTITY,
+              };
+            }
+            return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'lyrics',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2750,10 +2750,11 @@ const testData = [
        only_valid_entity_types: ['artist'],
   },
   {
-                     input_url: 'https://www.musixmatch.com/album/Bruno-Mars/This-Is-My-Love-Remixes-3',
+                     input_url: 'http://www.musixmatch.com/album/Bruno-Mars/This-Is-My-Love-Remixes-3#',
              input_entity_type: 'album',
     expected_relationship_type: undefined,
        input_relationship_type: 'lyrics',
+            expected_clean_url: 'https://www.musixmatch.com/album/Bruno-Mars/This-Is-My-Love-Remixes-3',
        only_valid_entity_types: [],
   },
   {


### PR DESCRIPTION
### Implement MBS-11693

When we decided to block these we didn't yet have a way to indicate why we were blocking it in the error message, but we specifically suggested in the forums we should add that info once it was possible. Then... we forgot about it. This adds that info.
I checked in case the situation got better in the meantime and we should allow the links instead, but it doesn't seem to be the case.