### PR TITLE
MBS-11682: Fix deadlocks in apply_artist_*_pending_updates

### DIFF
--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1822,9 +1822,13 @@ DECLARE
 BEGIN
     -- DO NOT modify any replicated tables in this function; it's used
     -- by a trigger on slaves.
+    WITH pending AS (
+        DELETE FROM artist_release_pending_update
+        RETURNING release
+    )
     SELECT array_agg(DISTINCT release)
     INTO release_ids
-    FROM artist_release_pending_update;
+    FROM pending;
 
     IF coalesce(array_length(release_ids, 1), 0) > 0 THEN
         -- If the user hasn't generated `artist_release`, then we
@@ -1846,7 +1850,6 @@ BEGIN
         END IF;
     END IF;
 
-    TRUNCATE artist_release_pending_update;
     RETURN NULL;
 END;
 $$ LANGUAGE 'plpgsql';
@@ -1912,9 +1915,13 @@ DECLARE
 BEGIN
     -- DO NOT modify any replicated tables in this function; it's used
     -- by a trigger on slaves.
+    WITH pending AS (
+        DELETE FROM artist_release_group_pending_update
+        RETURNING release_group
+    )
     SELECT array_agg(DISTINCT release_group)
     INTO release_group_ids
-    FROM artist_release_group_pending_update;
+    FROM pending;
 
     IF coalesce(array_length(release_group_ids, 1), 0) > 0 THEN
         -- If the user hasn't generated `artist_release_group`, then we
@@ -1936,7 +1943,6 @@ BEGIN
         END IF;
     END IF;
 
-    TRUNCATE artist_release_group_pending_update;
     RETURN NULL;
 END;
 $$ LANGUAGE 'plpgsql';

--- a/admin/sql/updates/20210606-mbs-11682.sql
+++ b/admin/sql/updates/20210606-mbs-11682.sql
@@ -1,0 +1,85 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION apply_artist_release_pending_updates()
+RETURNS trigger AS $$
+DECLARE
+    release_ids INTEGER[];
+    release_id INTEGER;
+BEGIN
+    -- DO NOT modify any replicated tables in this function; it's used
+    -- by a trigger on slaves.
+    WITH pending AS (
+        DELETE FROM artist_release_pending_update
+        RETURNING release
+    )
+    SELECT array_agg(DISTINCT release)
+    INTO release_ids
+    FROM pending;
+
+    IF coalesce(array_length(release_ids, 1), 0) > 0 THEN
+        -- If the user hasn't generated `artist_release`, then we
+        -- shouldn't update or insert to it. MBS determines whether to
+        -- use this table based on it being non-empty, so a partial
+        -- table would manifest as partial data on the website and
+        -- webservice.
+        PERFORM 1 FROM artist_release LIMIT 1;
+        IF FOUND THEN
+            DELETE FROM artist_release WHERE release = any(release_ids);
+
+            FOREACH release_id IN ARRAY release_ids LOOP
+                -- We handle each release ID separately because the
+                -- `get_artist_release_rows` query can be planned much
+                -- more efficiently that way.
+                INSERT INTO artist_release
+                SELECT * FROM get_artist_release_rows(release_id);
+            END LOOP;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION apply_artist_release_group_pending_updates()
+RETURNS trigger AS $$
+DECLARE
+    release_group_ids INTEGER[];
+    release_group_id INTEGER;
+BEGIN
+    -- DO NOT modify any replicated tables in this function; it's used
+    -- by a trigger on slaves.
+    WITH pending AS (
+        DELETE FROM artist_release_group_pending_update
+        RETURNING release_group
+    )
+    SELECT array_agg(DISTINCT release_group)
+    INTO release_group_ids
+    FROM pending;
+
+    IF coalesce(array_length(release_group_ids, 1), 0) > 0 THEN
+        -- If the user hasn't generated `artist_release_group`, then we
+        -- shouldn't update or insert to it. MBS determines whether to
+        -- use this table based on it being non-empty, so a partial
+        -- table would manifest as partial data on the website and
+        -- webservice.
+        PERFORM 1 FROM artist_release_group LIMIT 1;
+        IF FOUND THEN
+            DELETE FROM artist_release_group WHERE release_group = any(release_group_ids);
+
+            FOREACH release_group_id IN ARRAY release_group_ids LOOP
+                -- We handle each release group ID separately because
+                -- the `get_artist_release_group_rows` query can be
+                -- planned much more efficiently that way.
+                INSERT INTO artist_release_group
+                SELECT * FROM get_artist_release_group_rows(release_group_id);
+            END LOOP;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE 'plpgsql';
+
+COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -100,5 +100,9 @@
                    "20210319-mbs-10647.sql",
                    "20210319-mbs-11451-standalone.sql",
                    "20210507-mbs-11652-artist-series-fks.sql"]
+  },
+
+  "27": {
+    "slave": ["20210606-mbs-11682.sql"]
   }
 }


### PR DESCRIPTION
`TRUNCATE` requires an `ACCESS EXCLUSIVE` lock on the target table. This means it will block on any concurrent operation on the table (which, for the `artist_*_pending_update` tables, means `INSERT` and other `TRUNCATE` statements).

A deadlock may occur as follows:

  1. Txn 1 does `INSERT INTO artist_release_group_pending_update` (e.g. in the `a_del_release` trigger).
  2. Txn 2 does `INSERT INTO artist_release_group_pending_update`.
  3. Txn 2 does `TRUNCATE artist_release_group_pending_update` in the deferred "apply" trigger. This blocks on the `INSERT` from txn 1.
  4. Txn 1 does `TRUNCATE artist_release_group_pending_update` in the deferred "apply" trigger. This blocks on txn 2.
  5. Deadlock.

I'm resolving this by using `DELETE` instead, which I believe works because in this case it only blocks concurrent deletions on the same rows and not concurrent insertions.