### PR TITLE
MBS-11696: Disallow Twitter documentation links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3305,9 +3305,18 @@ const CLEANUPS = {
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/twitter\.com\/[^\/?#]+(\/status\/\d+)?$/.exec(url);
+      const m = /^https:\/\/twitter\.com\/([^\/?#]+)(\/status\/\d+)?$/.exec(url);
       if (m) {
-        const isATweet = !!m[1];
+        const username = m[1];
+        if (['privacy', 'rules', 'tos'].includes(username)) {
+          return {
+            error: l(
+              'This is not a profile, but a Twitter documentation page.',
+            ),
+            result: false,
+          };
+        }
+        const isATweet = !!m[2];
         if (Object.values(LINK_TYPES.streamingfree).includes(id)) {
           return {
             result: isATweet &&

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4127,6 +4127,13 @@ const testData = [
             expected_clean_url: 'https://twitter.com/mountain_goats/status/1062342708470132738',
        only_valid_entity_types: ['recording'],
   },
+  {
+                     input_url: 'https://twitter.com/privacy',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'socialnetwork',
+       only_valid_entity_types: [],
+  },
   // Universal Music
   {
                      input_url: 'http://www.universal-music.co.jp/sweety/products/umca-59007/',


### PR DESCRIPTION
### Implement MBS-11696

These three at least have the same format as standard Twitter usernames, but redirect to documentation pages. There might be more, these are the three I found right now.