### PR TITLE
MBS-11702: Group results also for release/recording/RG search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -172,15 +172,16 @@ sub search
                 push @where_args, "%".$where->{artist}."%";
             }
         }
+        my $extra_groupby_columns = $extra_columns =~ s/[^ ,]+ AS //gr;
 
         $query = "
-            SELECT DISTINCT
+            SELECT
                 entity.id,
                 entity.gid,
                 entity.name,
                 entity.comment,
                 $extra_columns
-                r.rank
+                MAX(rank) AS rank
             FROM
                 (
                     SELECT name, ts_rank_cd(mb_simple_tsvector(name), query, 2) AS rank
@@ -195,8 +196,10 @@ sub search
                 ) AS r
                 $join_sql
                 $where_sql
+            GROUP BY
+                $extra_groupby_columns entity.id, entity.gid, entity.name, entity.comment
             ORDER BY
-                r.rank DESC, entity.name
+                rank DESC, entity.name
                 ${extra_ordering}, entity.gid
             OFFSET
                 ?


### PR DESCRIPTION
### Fix MBS-11702

For some reason, while the other searches grouped to get the max rank, the release/recording/RG search did not - it selected distinct on all values, including rank. This leads to releases being returned several times if they appear on multiple rows with different ranks, messing up (for example) some cdtoc release search results.

Do let me know if there's a reason I'm missing why this *should* work differently - it seems it has worked like this since the start of direct search, so maybe there is a reason.