### PR TITLE
Revert "When doing a direct database search, also do an exact full text search too"

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -117,7 +117,7 @@ sub search
                          SELECT name              FROM ${type}_alias UNION ALL
                          SELECT sort_name AS name FROM ${type}_alias) names,
                         plainto_tsquery('mb_simple', mb_lower(?)) AS query
-                    WHERE mb_simple_tsvector(name) @@ query OR name = ?
+                    WHERE mb_simple_tsvector(name) @@ query
                     ORDER BY rank DESC
                     LIMIT ?
                 ) AS r
@@ -189,7 +189,7 @@ sub search
                          SELECT name              FROM ${type}_alias UNION ALL
                          SELECT sort_name AS name FROM ${type}_alias) names,
                         plainto_tsquery('mb_simple', mb_lower(?)) AS query
-                    WHERE mb_simple_tsvector(name) @@ query OR name = ?
+                    WHERE mb_simple_tsvector(name) @@ query
                     ORDER BY rank DESC
                     LIMIT ?
                 ) AS r
@@ -251,7 +251,7 @@ sub search
                          SELECT name              FROM ${type}_alias UNION ALL
                          SELECT sort_name AS name FROM ${type}_alias) names,
                         plainto_tsquery('mb_simple', mb_lower(?)) AS query
-                    WHERE mb_simple_tsvector(name) @@ query OR name = ?
+                    WHERE mb_simple_tsvector(name) @@ query
                     ORDER BY rank DESC
                     LIMIT ?
                 ) AS r
@@ -284,7 +284,7 @@ sub search
                     SELECT name, ts_rank_cd(mb_simple_tsvector(name), query, 2) AS rank
                     FROM genre,
                         plainto_tsquery('mb_simple', mb_lower(?)) AS query
-                    WHERE mb_simple_tsvector(name) @@ query OR name = ?
+                    WHERE mb_simple_tsvector(name) @@ query
                     ORDER BY rank DESC
                 ) AS r
                 JOIN genre AS entity ON r.name = entity.name
@@ -304,7 +304,7 @@ sub search
             SELECT tag.id, tag.name, genre.id AS genre_id,
                    ts_rank_cd(mb_simple_tsvector(tag.name), query, 2) AS rank
             FROM tag LEFT JOIN genre USING (name), plainto_tsquery('mb_simple', mb_lower(?)) AS query
-            WHERE mb_simple_tsvector(tag.name) @@ query OR tag.name = ?
+            WHERE mb_simple_tsvector(tag.name) @@ query
             ORDER BY rank DESC, tag.name
             OFFSET ?
         ";
@@ -314,7 +314,7 @@ sub search
         $query = "SELECT id, name, ts_rank_cd(mb_simple_tsvector(name), query, 2) AS rank,
                     email
                   FROM editor, plainto_tsquery('mb_simple', mb_lower(?)) AS query
-                  WHERE mb_simple_tsvector(name) @@ query OR name = ?
+                  WHERE mb_simple_tsvector(name) @@ query
                   ORDER BY rank DESC
                   OFFSET ?";
         $use_hard_search_limit = 0;
@@ -337,7 +337,7 @@ sub search
 
     Sql::run_in_transaction(sub {
         $self->sql->do('SET LOCAL gin_fuzzy_search_limit TO ?', $fuzzy_search_limit);
-        @rows = @{ $self->sql->select_list_of_hashes($query, $query_str, $query_str, @query_args) };
+        @rows = @{ $self->sql->select_list_of_hashes($query, $query_str, @query_args) };
     }, $self->sql);
 
     for my $row (@rows) {


### PR DESCRIPTION
This reverts commit 6a49115d488c6de7c11f454981c5b8a101e0b913.

Rationale: Direct search queries frequently exceed `log_min_duration_statement` and spam our PG logs. I was trying to find out why, and discovered that the `OR name = ?` bits of the query cause a much slower plan to be used. Testing against an artist search, on the order of 2200 ms down to sub-300 ms with the condition removed.

Additionally, a condition like:

```
  mb_simple_tsvector(name) @@
    plainto_tsquery('mb_simple', mb_lower('姫咲ゆずる'))
```

still returns exacts matches for '姫咲ゆずる' or any other name I've tried.

The original commit message didn't provide any reasoning for this change, so since it has a very negative impact on performance, I'm reverting it.