### PR TITLE
MBS-11697: Show historical primary types on old RG edits

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -89,6 +89,7 @@ our @EXPORT_OK = (
         $CONTACT_URL
         $WS_EDIT_RESPONSE_OK $WS_EDIT_RESPONSE_NO_CHANGES
         %ENTITIES_WITH_RELATIONSHIP_CREDITS
+        %HISTORICAL_RELEASE_GROUP_TYPES
         %ENTITIES entities_with @RELATABLE_ENTITIES
         $EDITOR_SANITISED_COLUMNS
         $PASSPHRASE_BCRYPT_COST
@@ -421,6 +422,20 @@ Readonly our %ENTITIES_WITH_RELATIONSHIP_CREDITS => map { $_ => 1 } qw(
     instrument
     label
     place
+);
+
+Readonly our %HISTORICAL_RELEASE_GROUP_TYPES => (
+    1 => 'Album',
+    2 => 'Single',
+    3 => 'EP',
+    4 => 'Compilation',
+    5 => 'Soundtrack',
+    6 => 'Spokenword',
+    7 => 'Interview',
+    8 => 'Audiobook',
+    9 => 'Live',
+    10 => 'Remix',
+    11 => 'Other',
 );
 
 Readonly our %ENTITIES => %{

--- a/lib/MusicBrainz/Server/Edit/Historic/EditReleaseAttrs.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/EditReleaseAttrs.pm
@@ -6,7 +6,7 @@ use List::MoreUtils qw( uniq );
 use MusicBrainz::Server::Constants qw(
     $EDIT_HISTORIC_EDIT_RELEASE_ATTRS
 );
-use MusicBrainz::Server::Edit::Historic::Utils qw( upgrade_type_and_status );
+use MusicBrainz::Server::Edit::Historic::Utils qw( get_historic_type upgrade_type_and_status );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
@@ -66,10 +66,10 @@ sub build_display_data
                 }
             } ],
             status => $_->{old_status_id} && to_json_object($loaded->{ReleaseStatus}{ $_->{old_status_id} }),
-            type   => $_->{old_type_id}   && to_json_object($loaded->{ReleaseGroupType}{ $_->{old_type_id} }),
+            type   => get_historic_type($_->{old_type_id}, $loaded),
         }, $self->_changes ],
         status => $self->data->{new_status_id} && to_json_object($loaded->{ReleaseStatus}{ $self->data->{new_status_id} }),
-        type   => $self->data->{new_type_id}   && to_json_object($loaded->{ReleaseGroupType}{ $self->data->{new_type_id} }),
+        type   => get_historic_type($self->data->{new_type_id}, $loaded),
     };
 }
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
@@ -5,6 +5,7 @@ use MooseX::Types::Moose qw( ArrayRef Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw( $EDIT_RELEASEGROUP_CREATE );
 use MusicBrainz::Server::Edit::Types qw( Nullable ArtistCreditDefinition );
+use MusicBrainz::Server::Edit::Historic::Utils qw( get_historic_type );
 use MusicBrainz::Server::Edit::Utils qw(
     load_artist_credit_definitions
     artist_credit_preview
@@ -59,7 +60,8 @@ sub build_display_data
         artist_credit => to_json_object(artist_credit_preview($loaded, $self->data->{artist_credit})),
         name          => $self->data->{name} || '',
         comment       => $self->data->{comment} || '',
-        type          => $type ? to_json_object($loaded->{ReleaseGroupType}{$type}) : undef,
+        # Older edits store historic (pre-split) "secondary" types
+        type          => get_historic_type($type, $loaded),
         release_group => to_json_object((defined($self->entity_id) &&
                               $loaded->{ReleaseGroup}{ $self->entity_id }) ||
                                   ReleaseGroup->new( name => $self->data->{name} )),

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
@@ -20,6 +20,7 @@ use MusicBrainz::Server::Edit::Utils qw(
     merge_value
     verify_artist_credits
 );
+use MusicBrainz::Server::Edit::Historic::Utils qw( get_historic_type );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
@@ -116,7 +117,6 @@ sub build_display_data
     my %map = (
         name    => 'name',
         comment => 'comment',
-        type    => [ qw( type_id ReleaseGroupType ) ],
     );
 
     my $data = changed_display_data($self->data, $loaded, %map);
@@ -140,9 +140,11 @@ sub build_display_data
         } qw( old new )
     };
 
-    if (exists $data->{type}) {
-        $data->{type}{old} = to_json_object($data->{type}{old});
-        $data->{type}{new} = to_json_object($data->{type}{new});
+    if (exists $self->data->{old}{type_id} || exists $self->data->{new}{type_id}) {
+        $data->{type} = {
+            new => get_historic_type($self->data->{new}{type_id}, $loaded),
+            old => get_historic_type($self->data->{old}{type_id}, $loaded),
+        };
     }
 
     return $data;

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroupType.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroupType.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Entity::ReleaseGroupType;
 
 use Moose;
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Translation::Attributes qw( lp );
 
 extends 'MusicBrainz::Server::Entity';
@@ -9,12 +10,26 @@ with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
     type => 'ReleaseGroupType',
 };
 
+has 'historic' => (
+    is => 'rw',
+    isa => 'Bool',
+    default => 0,
+);
+
 sub entity_type { 'release_group_primary_type' }
 
 sub l_name {
     my $self = shift;
     return lp($self->name, 'release_group_primary_type')
 }
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+    return {
+        %{ $self->$orig },
+        historic => boolean_to_json($self->historic)
+    };
+};
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/root/edit/details/AddReleaseGroup.js
+++ b/root/edit/details/AddReleaseGroup.js
@@ -22,7 +22,7 @@ type AddReleaseGroupEditT = {
     +name: string,
     +release_group: ReleaseGroupT,
     +secondary_types: string,
-    +type: ReleaseGroupTypeT | null,
+    +type: ReleaseGroupTypeT | ReleaseGroupHistoricTypeT | null,
   },
 };
 
@@ -75,9 +75,16 @@ const AddReleaseGroup = ({allowNew, edit}: Props): React.MixedElement => {
 
           {type ? (
             <tr>
-              <th>{l('Primary Type:')}</th>
+              <th>
+                {type.historic
+                  ? addColonText(l('Type'))
+                  : l('Primary Type:')}
+              </th>
               <td>
-                {lp_attributes(type.name, 'release_group_primary_type')}
+                {type.historic
+                  ? lp_attributes(type.name, 'release_group_secondary_type')
+                  : lp_attributes(type.name, 'release_group_primary_type')
+                }
               </td>
             </tr>
           ) : null}

--- a/root/edit/details/EditReleaseGroup.js
+++ b/root/edit/details/EditReleaseGroup.js
@@ -26,7 +26,7 @@ type EditReleaseGroupEditT = {
     +name?: CompT<string>,
     +release_group: ReleaseGroupT,
     +secondary_types: CompT<string>,
-    +type?: CompT<ReleaseGroupTypeT | null>,
+    +type?: CompT<ReleaseGroupTypeT | ReleaseGroupHistoricTypeT | null>,
   },
 };
 
@@ -39,6 +39,8 @@ const EditReleaseGroup = ({edit}: Props): React.Element<'table'> => {
   const name = display.name;
   const comment = display.comment;
   const type = display.type;
+  const oldType = type?.old;
+  const newType = type?.new;
   const secondaryTypes = display.secondary_types;
   const artistCredit = display.artist_credit;
 
@@ -66,12 +68,23 @@ const EditReleaseGroup = ({edit}: Props): React.Element<'table'> => {
       ) : null}
       {type ? (
         <FullChangeDiff
-          label={l('Primary Type:')}
-          newContent={type.new?.name
-            ? lp_attributes(type.new.name, 'release_group_primary_type')
+          label={
+            (newType?.historic || oldType?.historic)
+              ? addColonText(l('Type'))
+              : l('Primary Type:')}
+          newContent={newType?.name
+            ? (
+              newType?.historic
+                ? lp_attributes(newType.name, 'release_group_secondary_type')
+                : lp_attributes(newType.name, 'release_group_primary_type')
+            )
             : ''}
-          oldContent={type.old?.name
-            ? lp_attributes(type.old.name, 'release_group_primary_type')
+          oldContent={oldType?.name
+            ? (
+              oldType?.historic
+                ? lp_attributes(oldType.name, 'release_group_secondary_type')
+                : lp_attributes(oldType.name, 'release_group_primary_type')
+            )
             : ''}
         />
       ) : null}

--- a/root/edit/details/historic/EditReleaseAttributes.js
+++ b/root/edit/details/historic/EditReleaseAttributes.js
@@ -18,16 +18,28 @@ type EditReleaseAttributesEditT = {
     +changes: $ReadOnlyArray<{
       +releases: $ReadOnlyArray<ReleaseT | null>,
       +status: ReleaseStatusT | null,
-      +type: ReleaseGroupTypeT | null,
+      +type: ReleaseGroupTypeT | ReleaseGroupHistoricTypeT | null,
     }>,
     +status: ReleaseStatusT | null,
-    +type: ReleaseGroupTypeT | null,
+    +type: ReleaseGroupTypeT | ReleaseGroupHistoricTypeT | null,
   },
 };
 
 type Props = {
   +edit: EditReleaseAttributesEditT,
 };
+
+function getTypeName(type) {
+  return type ? (
+    type.historic ? lp_attributes(
+      type.name,
+      'release_group_secondary_type',
+    ) : lp_attributes(
+      type.name,
+      'release_group_primary_type',
+    )
+  ) : '?';
+}
 
 const EditReleaseAttributes = ({edit}: Props): React.Element<'table'> => (
   <table className="details edit-release">
@@ -44,11 +56,7 @@ const EditReleaseAttributes = ({edit}: Props): React.Element<'table'> => (
                     status: change.status
                       ? lp_attributes(change.status.name, 'release_status')
                       : '?',
-                    type: change.type
-                      ? lp_attributes(
-                        change.type.name,
-                        'release_group_primary_type',
-                      ) : '?',
+                    type: getTypeName(change.type),
                   },
                 )}
               </td>
@@ -64,11 +72,7 @@ const EditReleaseAttributes = ({edit}: Props): React.Element<'table'> => (
     <tr>
       <th>{l('New Type:')}</th>
       <td className="new" colSpan="2">
-        {edit.display_data.type
-          ? lp_attributes(
-            edit.display_data.type.name,
-            'release_group_primary_type',
-          ) : '?'}
+        {getTypeName(edit.display_data.type)}
       </td>
     </tr>
 

--- a/root/types/releasegroup.js
+++ b/root/types/releasegroup.js
@@ -30,4 +30,13 @@ declare type ReleaseGroupT = $ReadOnly<{
   +typeName: string | null,
 }>;
 
-declare type ReleaseGroupTypeT = OptionTreeT<'release_group_type'>;
+declare type ReleaseGroupTypeT = {
+  ...OptionTreeT<'release_group_type'>,
+  +historic: false,
+};
+
+declare type ReleaseGroupHistoricTypeT = {
+  +historic: true,
+  +id: number,
+  +name: string,
+};


### PR DESCRIPTION
### Implement MBS-11697

Old release group (and even older release) edits that involved one of the primary types that became secondary types with the NGS change were not showing the types, or even the change at all in some cases.
Luckily, we had a perfectly good map of type ids to names in the seemingly unused Server/Release.pm file, so I could use that to restore the information enough to actually display something useful.
I added the list to Server/Constants.pm since we might want to remove Server/Release.pm anyway, unless I'm missing something.
Just the types not having a gid seemed like a perfectly valid way of distinguishing these "mocked up" old types, so I haven't bothered trying to figure out any other option.

Testing edits, with pink data: edit/11088448 - edit/16294643/ - edit/8137486