### PR TITLE
MBS-11709: Beta: Edit notes with { show raw HTML

### DIFF
--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -16,7 +16,6 @@ import {
 } from '../../constants';
 import {CatalystContext} from '../../context';
 import EditorLink from '../../static/scripts/common/components/EditorLink';
-import expand2react from '../../static/scripts/common/i18n/expand2react';
 import getVoteName from '../../static/scripts/edit/utility/getVoteName';
 import formatUserDate from '../../utility/formatUserDate';
 
@@ -83,9 +82,10 @@ const EditNote = ({
             : l('[time missing]')}
         </a>
       </h3>
-      <div className={'edit-note-text' + (isModBot ? ' modbot' : '')}>
-        {expand2react(editNote.formatted_text)}
-      </div>
+      <div
+        className={'edit-note-text' + (isModBot ? ' modbot' : '')}
+        dangerouslySetInnerHTML={{__html: editNote.formatted_text}}
+      />
     </div>
   );
 };


### PR DESCRIPTION
`expand2react` is intended to expand our i18n syntax, so if it encounters a `{`, it expects it to be the start of a variable substitution. Edit notes are not translated strings; the HTML we're given from the server should be displayed as-is, so we should be using `dangerouslySetInnerHTML` here.