### PR TITLE
Wrap all localized_note strings in N_l or N_ln

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -74,10 +74,10 @@ sub do_merge
             $self->id => {
                 editor_id => $EDITOR_MODBOT,
                 text => localized_note(
-                    'The “{artist_type}” type has not been added to the ' .
-                    'destination artist because it conflicted with the ' .
-                    'gender setting of one of the artists here. Group ' .
-                    'artists cannot have a gender.',
+                    N_l('The “{artist_type}” type has not been added to the ' .
+                        'destination artist because it conflicted with the ' .
+                        'gender setting of one of the artists here. Group ' .
+                        'artists cannot have a gender.'),
                     vars => {
                         artist_type => localized_note(
                             $dropped_type->name,
@@ -99,10 +99,10 @@ sub do_merge
             $self->id => {
                 editor_id => $EDITOR_MODBOT,
                 text => localized_note(
-                    'The “{gender}” gender has not been added to the ' .
-                    'destination artist because it conflicted with the ' .
-                    'group type of one of the artists here. Group artists ' .
-                    'cannot have a gender.',
+                    N_l('The “{gender}” gender has not been added to the ' .
+                        'destination artist because it conflicted with the ' .
+                        'group type of one of the artists here. Group artists ' .
+                        'cannot have a gender.'),
                     vars => {
                         gender => localized_note(
                             $dropped_gender->name,

--- a/lib/MusicBrainz/Server/Edit/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/IPI.pm
@@ -5,7 +5,7 @@ use utf8;
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
 use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
-use MusicBrainz::Server::Translation qw( N_l );
+use MusicBrainz::Server::Translation qw( N_ln );
 use Set::Scalar;
 
 has 'reused_ipis' => (
@@ -32,6 +32,21 @@ after initialize => sub {
     my @added_ipis = $added_ipis_set->members;
     $self->reused_ipis($self->c->model($self->_edit_model)->find_reused_ipis(@added_ipis));
 };
+
+# Strings used in post_insert, wrapped in N_ln so that they can be
+# properly extracted.
+N_ln(
+    'The IPI {ipi} is already in use on {artist_count} artist. ' .
+        'Please check {artist_search|all uses of this IPI}.',
+    'The IPI {ipi} is already in use on {artist_count} artists. ' .
+        'Please check {artist_search|all uses of this IPI}.',
+);
+N_ln(
+    'The IPI {ipi} is already in use on {label_count} label. ' .
+        'Please check {label_search|all uses of this IPI}.',
+    'The IPI {ipi} is already in use on {label_count} labels. ' .
+        'Please check {label_search|all uses of this IPI}.',
+);
 
 after post_insert => sub {
     my $self = shift;

--- a/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
@@ -5,7 +5,7 @@ use utf8;
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
 use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
-use MusicBrainz::Server::Translation qw( N_l );
+use MusicBrainz::Server::Translation qw( N_ln );
 use Set::Scalar;
 
 has 'reused_isnis' => (
@@ -32,6 +32,21 @@ after initialize => sub {
     my @added_isnis = $added_isnis_set->members;
     $self->reused_isnis($self->c->model($self->_edit_model)->find_reused_isnis(@added_isnis));
 };
+
+# Strings used in post_insert, wrapped in N_ln so that they can be
+# properly extracted.
+N_ln(
+    'The ISNI {isni} is already in use on {artist_count} artist. ' .
+        'Please check {artist_search|all uses of this ISNI}.',
+    'The ISNI {isni} is already in use on {artist_count} artists. ' .
+        'Please check {artist_search|all uses of this ISNI}.',
+);
+N_ln(
+    'The ISNI {isni} is already in use on {label_count} label. ' .
+        'Please check {label_search|all uses of this ISNI}.',
+    'The ISNI {isni} is already in use on {label_count} labels. ' .
+        'Please check {label_search|all uses of this ISNI}.',
+);
 
 after post_insert => sub {
     my $self = shift;

--- a/po/mb_server.pot
+++ b/po/mb_server.pot
@@ -10,7 +10,7 @@ msgstr ""
 "#-#-#-#-#  mb_server.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-09 00:37+0300\n"
+"POT-Creation-Date: 2021-06-09 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6398,6 +6398,22 @@ msgstr ""
 msgid "Merge artists"
 msgstr ""
 
+#: ../lib/MusicBrainz/Server/Edit/Artist/Merge.pm:77
+#, perl-brace-format
+msgid ""
+"The “{artist_type}” type has not been added to the destination artist "
+"because it conflicted with the gender setting of one of the artists here. "
+"Group artists cannot have a gender."
+msgstr ""
+
+#: ../lib/MusicBrainz/Server/Edit/Artist/Merge.pm:102
+#, perl-brace-format
+msgid ""
+"The “{gender}” gender has not been added to the destination artist because "
+"it conflicted with the group type of one of the artists here. Group artists "
+"cannot have a gender."
+msgstr ""
+
 #: ../lib/MusicBrainz/Server/Edit/Event/AddAlias.pm:11
 msgid "Add event alias"
 msgstr ""
@@ -6843,6 +6859,50 @@ msgstr ""
 #: ../root/release_group/ReleaseGroupMerge.js:33
 msgid "Merge release groups"
 msgstr ""
+
+#: ../lib/MusicBrainz/Server/Edit/Role/IPI.pm:39
+#, perl-brace-format
+msgid ""
+"The IPI {ipi} is already in use on {artist_count} artist. Please check "
+"{artist_search|all uses of this IPI}."
+msgid_plural ""
+"The IPI {ipi} is already in use on {artist_count} artists. Please check "
+"{artist_search|all uses of this IPI}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../lib/MusicBrainz/Server/Edit/Role/IPI.pm:45
+#, perl-brace-format
+msgid ""
+"The IPI {ipi} is already in use on {label_count} label. Please check "
+"{label_search|all uses of this IPI}."
+msgid_plural ""
+"The IPI {ipi} is already in use on {label_count} labels. Please check "
+"{label_search|all uses of this IPI}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../lib/MusicBrainz/Server/Edit/Role/ISNI.pm:39
+#, perl-brace-format
+msgid ""
+"The ISNI {isni} is already in use on {artist_count} artist. Please check "
+"{artist_search|all uses of this ISNI}."
+msgid_plural ""
+"The ISNI {isni} is already in use on {artist_count} artists. Please check "
+"{artist_search|all uses of this ISNI}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../lib/MusicBrainz/Server/Edit/Role/ISNI.pm:45
+#, perl-brace-format
+msgid ""
+"The ISNI {isni} is already in use on {label_count} label. Please check "
+"{label_search|all uses of this ISNI}."
+msgid_plural ""
+"The ISNI {isni} is already in use on {label_count} labels. Please check "
+"{label_search|all uses of this ISNI}."
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../lib/MusicBrainz/Server/Edit/Series/AddAlias.pm:11
 msgid "Add series alias"
@@ -9212,7 +9272,7 @@ msgid ""
 "before you can approve it."
 msgstr ""
 
-#: ../root/edit/components/EditNote.js:83
+#: ../root/edit/components/EditNote.js:82
 msgid "[time missing]"
 msgstr ""
 


### PR DESCRIPTION
We were missing the appropriate no-op functions on some of these, so they were never extracted into the POT files.

The IPI/ISNI ones have to be done outside of the localized_note call because the way the plural string is passed doesn't match the function signature of N_ln.

I've regenerated the POT files so that you can see the changes.