### PR TITLE
MBS-11711: Show informative error if no relationships in group

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::Data::Utils 'model_to_type';
 use MusicBrainz::Server::Validation qw( is_guid is_positive_integer );
 use MusicBrainz::Server::Constants qw( :direction %ENTITIES );
 use Readonly;
+use aliased 'MusicBrainz::Server::Entity::RelationshipLinkTypeGroup';
 
 no if $] >= 5.018, warnings => "experimental::smartmatch";
 
@@ -116,13 +117,19 @@ role
                 );
 
                 if (defined $pager) {
-                    if (!scalar @$lt_groups) {
-                        $c->detach('/error_400');
-                    }
                     if (scalar @$lt_groups > 1) {
                         die 'Expected only one link type group';
                     }
-                    my $lt_group = $lt_groups->[0];
+
+                    my $lt_group;
+                    if (!scalar @$lt_groups) {
+                        $lt_group = RelationshipLinkTypeGroup->new(
+                            link_type_id => $link_type_id,
+                        );
+                    } else {
+                        $lt_group = $lt_groups->[0];
+                    }                    
+                     
                     $pager->total_entries($lt_group->total_relationships);
                     $c->stash->{pager} = $pager;
                     $c->stash->{paged_link_type_group} = $lt_group;

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -296,7 +296,7 @@ const RelationshipsTable = ({
     }
   }
 
-  if (totalRelationships === 0) {
+  if (totalRelationships === 0 && !pagedLinkTypeGroup) {
     return nonEmpty(fallbackMessage) ? (
       <>
         <h2>{heading}</h2>
@@ -326,15 +326,26 @@ const RelationshipsTable = ({
   let finalHeading = heading;
 
   if (pagedLinkTypeGroup /*:: && pager */) {
-    finalHeading = exp.l(
+    const linkPhrase = getLinkPhraseForGroup(pagedLinkTypeGroup);
+    finalHeading = linkPhrase ? exp.l(
       '“{link_phrase}” relationships',
       {link_phrase: getLinkPhraseForGroup(pagedLinkTypeGroup)},
-    );
-    pageContent = (
-      <PaginatedResults pager={pager}>
-        {tableElement}
-      </PaginatedResults>
-    );
+    ) : l('Invalid relationship type');
+    if (pagedLinkTypeGroup.total_relationships > 0) {
+      pageContent = (
+        <PaginatedResults pager={pager}>
+          {tableElement}
+        </PaginatedResults>
+      );
+    } else {
+      pageContent = (
+        <p>
+          {linkPhrase
+            ? l('No relationships of the selected type were found.')
+            : l('The provided relationship type ID is not valid.')}
+        </p>
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
### Fix MBS-11711

Sometimes a link to a specific relationship type group page might become outdated, if all relationships have been moved away from it. Right now, we just detach 400, which seems unfair - the request is not bad, there's just nothing to show.
