### PR TITLE
Remove redundant style

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -725,7 +725,6 @@ table.tbl {
     /* Striping */
     tr.even td,
     tr.even th {
-        padding: 0.2em 0.4em;
         background: @even-table-row;
     }
     tr:target td { background-color: @highlight-table-row; }


### PR DESCRIPTION
Exact same `padding: 0.2em 0.4em;` is already set on
[`table.tbl td`](https://github.com/metabrainz/musicbrainz-server/blob/ea59e1c57a1d66b57f3f14d4d96df957d666b9b0/root/static/styles/layout.less#L697) and [`table.tbl th`](https://github.com/metabrainz/musicbrainz-server/blob/ea59e1c57a1d66b57f3f14d4d96df957d666b9b0/root/static/styles/layout.less#L668) in this same `layout.less` file.

Remove it from [`table.tbl td.even td, table.tbl td.even th`](https://github.com/metabrainz/musicbrainz-server/blob/ea59e1c57a1d66b57f3f14d4d96df957d666b9b0/root/static/styles/layout.less#L728).

After this removal, as it's a redundant style, nothing changes in the display of odd/even table.tbl (tested on my local docker server).

I thought it would be good to clean this up.