### PR TITLE
MBS-11722: Don't preselect basic as language proficiency

### DIFF
--- a/lib/MusicBrainz/Server/Form/Role/UserProfile.pm
+++ b/lib/MusicBrainz/Server/Form/Role/UserProfile.pm
@@ -3,7 +3,7 @@ package MusicBrainz::Server::Form::Role::UserProfile;
 use HTML::FormHandler::Moose::Role;
 use List::MoreUtils qw( any all );
 use MusicBrainz::Server::Form::Utils qw( language_options select_options_tree validate_username );
-use MusicBrainz::Server::Translation qw( l ln );
+use MusicBrainz::Server::Translation qw( l ln N_l );
 use MusicBrainz::Server::Validation qw( is_valid_url );
 
 has_field 'username' => (
@@ -53,11 +53,13 @@ has_field 'languages' => (
 
 has_field 'languages.language_id' => (
     type => 'Select',
+    messages => { required => N_l('A language is required.') },
     required => 1
 );
 
 has_field 'languages.fluency' => (
     type => 'Select',
+    messages => { required => N_l('A fluency level is required.') },
     required => 1
 );
 

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -280,13 +280,13 @@ class EditProfileForm extends React.Component<Props, State> {
             {field.languages.field.map((languageField, index) => (
               <li className="language" key={index}>
                 <SelectField
-                  allowEmpty={false}
+                  allowEmpty
                   field={languageField.field.language_id}
                   onChange={(e) => this.handleLanguageChange(e, index)}
                   options={this.state.languageOptions}
                 />
                 <SelectField
-                  allowEmpty={false}
+                  allowEmpty
                   field={languageField.field.fluency}
                   onChange={(e) => this.handleFluencyChange(e, index)}
                   options={fluencyOptions}
@@ -300,6 +300,8 @@ class EditProfileForm extends React.Component<Props, State> {
                     {l('Remove')}
                   </button>
                 </span>
+                <FieldErrors field={languageField.field.language_id} />
+                <FieldErrors field={languageField.field.fluency} />
               </li>
             ))}
             <li key="add">


### PR DESCRIPTION
### Implement MBS-11722

Users are apparently often selecting "basic" when it seems incorrect, probably because it is selected by default. "Arabic" is also selected by default, and we seem to have 900+ users with "Arabic (basic)". This might be true, but I find it unlikely.