### PR TITLE
MBS-11717: Also show edits pending in ArtistCreditUsageLink

### DIFF
--- a/root/artist_credit/ArtistCreditLayout.js
+++ b/root/artist_credit/ArtistCreditLayout.js
@@ -59,6 +59,7 @@ const ArtistCreditLayout = ({
             'Artist credit “{artist_credit}”',
             {artist_credit: reduceArtistCredit(artistCredit)},
           )}
+          showEditsPending
         />
       </h1>
       <Tabs>

--- a/root/report/components/ArtistCreditList.js
+++ b/root/report/components/ArtistCreditList.js
@@ -37,7 +37,10 @@ const ArtistCreditList = ({
             {item.artist_credit ? (
               <>
                 <td>
-                  <ArtistCreditUsageLink artistCredit={item.artist_credit} />
+                  <ArtistCreditUsageLink
+                    artistCredit={item.artist_credit}
+                    showEditsPending
+                  />
                 </td>
               </>
             ) : (

--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -25,9 +25,9 @@ type MpIconProps = {
   +artistCredit: ArtistCreditT,
 };
 
-const MpIcon = hydrate<MpIconProps>('span.ac-mp', (
+export const MpIcon = (hydrate<MpIconProps>('span.ac-mp', (
   {artistCredit}: MpIconProps,
-) => {
+): React.Element<typeof React.Fragment> => {
   const [hover, setHover] = React.useState(false);
 
   let editSearch =
@@ -65,7 +65,7 @@ const MpIcon = hydrate<MpIconProps>('span.ac-mp', (
       ) : null}
     </>
   );
-});
+}): React.AbstractComponent<MpIconProps, void>);
 
 const ArtistCreditLink = ({
   artistCredit,

--- a/root/static/scripts/common/components/ArtistCreditUsageLink.js
+++ b/root/static/scripts/common/components/ArtistCreditUsageLink.js
@@ -11,9 +11,12 @@ import * as React from 'react';
 
 import {reduceArtistCredit} from '../immutable-entities';
 
+import {MpIcon} from './ArtistCreditLink';
+
 type Props = {
   +artistCredit: ArtistCreditT,
   +content?: string,
+  +showEditsPending?: boolean,
   +subPath?: string,
   +target?: '_blank',
 };
@@ -21,9 +24,10 @@ type Props = {
 const ArtistCreditUsageLink = ({
   artistCredit,
   content,
+  showEditsPending = false,
   subPath,
   ...props
-}: Props): React.Element<'a'> | null => {
+}: Props): React.Element<'a' | 'span'> | null => {
   const id = artistCredit.id;
   if (id == null) {
     return null;
@@ -32,10 +36,20 @@ const ArtistCreditUsageLink = ({
   if (nonEmpty(subPath)) {
     href += '/' + subPath;
   }
-  return (
+
+  const artistCreditLink = (
     <a href={href} {...props}>
       {nonEmpty(content) ? content : reduceArtistCredit(artistCredit)}
     </a>
+  );
+
+  return (
+    artistCredit.editsPending /*:: === true */ && showEditsPending ? (
+      <span className="mp">
+        {artistCreditLink}
+        <MpIcon artistCredit={artistCredit} />
+      </span>
+    ) : artistCreditLink
   );
 };
 

--- a/root/static/styles/tooltip.less
+++ b/root/static/styles/tooltip.less
@@ -41,7 +41,13 @@
         background: @text-white;
         border: 1px solid @medium-border;
         box-shadow: 0 2px 5px @medium-border;
+        font-size: @default-text-size;
+        font-weight: normal;
         padding: 5px 10px;
         width: 240px;
+    }
+
+    .tooltip-content a {
+        color: @link-default !important;
     }
 }


### PR DESCRIPTION
### Fix MBS-11717

This only shows it when requested, since it doesn't make sense everywhere `ArtistCreditUsageLink` is used (such as on every tab of `ArtistCreditLayout`.

@mwiencek: there's an issue here where `Tooltip` is inside the `h1` for the `ArtistCreditLayout` header, meaning the text in the tooltip is also at h1 size and doesn't really work well. This seems like a more widespread issue with `Tooltip`, in that it probably doesn't make sense that it takes on the style of its container. What do you suggest for this? A `tooltip` class that overrides it?

Specifically added to `artist-credit/$id` (on the header) and `report/ArtistCreditsWithDubiousTrailingPhrases` (and any other AC reports)