### PR TITLE
MBS-11342: Add message about track durations and recording reusing

### DIFF
--- a/root/release/edit/recordings.tt
+++ b/root/release/edit/recordings.tt
@@ -2,11 +2,19 @@
   <div class="warning field-error" data-bind="showErrorRightAway: needsRecordings">
     <p><strong>[% l('Note:') %]</strong> [%- l('All tracks require an associated recording. Click “Edit” to select a recording for each track. Choose “Add a new recording” if an appropriate one doesn’t exist yet.') -%]</p>
 
-    <p data-bind="if: tracksWithUnsetPreviousRecordings().length">
-      <button type="button" class="styled-button" data-click="reuseUnsetPreviousRecordings">
-        [%~ l('Reuse previous recordings') | html ~%]
-      </button>
-    </p>
+    <div data-bind="if: tracksWithUnsetPreviousRecordings().length">
+      <p>
+        [% l(
+          'Keep in mind that recording durations are {doc_link|recalculated from tracks} once the duration of a track changes. As such, if you correct the duration of a track whose recording is only used in this release, just reuse the old recording, don’t create a new one. If the recording is also used elsewhere and the durations are significantly different, consider creating a new recording instead.',
+          { doc_link => doc_link('Recording') }
+        ) %]
+      </p>
+      <p>
+        <button type="button" class="styled-button" data-click="reuseUnsetPreviousRecordings">
+          [%~ l('Reuse previous recordings') | html ~%]
+        </button>
+      </p>
+    </div>
   </div>
 
   <div class="half-width" data-bind="affectsBubble: $root.recordingBubble">


### PR DESCRIPTION
### Implement MBS-11342

Apparently it's fairly common for editors to just create a new recording rather than reusing the existing one whenever the system unsets the previous recording for a duration change, since they do not realize that the listed (old) duration for the recording will get changed once their edit passes.

![Screenshot from 2021-06-16 16-56-40](https://user-images.githubusercontent.com/1069224/122233047-68acd080-cec4-11eb-94e6-b1e525eb0968.png)

If you feel this is too TL;DR, I'd be happy to get better ideas - I'm not super happy with it but also not sure how to explain it more shortly.