### PR TITLE
MBS-11737: Return different error if IA metadata is empty

### DIFF
--- a/root/static/scripts/edit/MB/CoverArt.js
+++ b/root/static/scripts/edit/MB/CoverArt.js
@@ -198,9 +198,7 @@ MB.CoverArt.sign_upload = function (fileUpload, gid, mimeType) {
     const errorInfo = jqxhr.responseJSON?.error;
     if (errorInfo && typeof errorInfo === 'object') {
       fileUpload.signErrorMessage(errorInfo.message);
-      if (errorInfo.error_details) {
-        fileUpload.signErrorDetails(errorInfo.error_details);
-      }
+      fileUpload.signErrorDetails(errorInfo.error_details ?? '');
     }
     deferred.reject('error obtaining signature: ' + status + ' ' + error);
   });


### PR DESCRIPTION
Recently the "we don't own the associated item" message has been triggering for users when it's not true. This error can erroneously occur if the IA metadata API returns an empty response, which just means we need to wait for it to populate.  We can return a different message in this case asking the user to retry later, rather than the current, incorrect message.

While I was trying to debug this, I added some logging to Sentry which I've kept in case it's useful in the future.