### PR TITLE
MBS-11391: Show changes made to external link when editing URL relationship

### DIFF
--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -8,11 +8,12 @@
  */
 
 import * as React from 'react';
+import type {LinkStateT} from '../externalLinks';
 import ButtonPopover from '../../common/components/ButtonPopover';
 
 type PropsT = {
-  errorMessage: React.Node,
-  onCancel: (number, LinkStateT) => void,
+  errorMessage: string,
+  onCancel: ($Shape<LinkStateT>) => void,
   onChange: (number, SyntheticEvent<HTMLInputElement>) => void,
   rawUrl: string,
   url: string,
@@ -60,7 +61,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
             </td>
             <td>
               <input
-                className="value"
+                className="value raw-url"
                 onChange={props.onChange}
                 style={{width: '336px'}}
                 type="url"
@@ -81,7 +82,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
               {l('Cleaned up to:')}
             </td>
             <td>
-              <a href={props.url}>{props.url}</a>
+              <a className="clean-url" href={props.url}>{props.url}</a>
             </td>
           </tr>
         </tbody>

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -60,7 +60,6 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
                 className="value raw-url"
                 onChange={props.onChange}
                 style={{width: '336px'}}
-                type="url"
                 value={props.rawUrl}
               />
               {props.errorMessage &&

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -56,7 +56,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         <tbody>
           <tr>
             <td className="section">
-              {l('Raw URL:')}
+              {l('URL:')}
             </td>
             <td>
               <input
@@ -77,8 +77,8 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
             </td>
           </tr>
           <tr>
-            <td className="section">
-              {l('Clean URL:')}
+            <td className="section" style={{whiteSpace: 'nowrap'}}>
+              {l('Cleaned up to:')}
             </td>
             <td>
               <a href={props.url}>{props.url}</a>

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -1,5 +1,5 @@
 /*
- * @flow strict-local
+ * @flow
  * Copyright (C) 2020 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -9,9 +9,12 @@
 
 import * as React from 'react';
 import ButtonPopover from '../../common/components/ButtonPopover';
+import type {ErrorTarget} from '../externalLinks';
+import {ERROR_TARGETS} from '../URLCleanup';
 
 type PropsT = {
   errorMessage: string,
+  errorTarget: ErrorTarget,
   onCancel: () => void,
   onChange: (SyntheticEvent<HTMLInputElement>) => void,
   onToggle: (boolean) => void,
@@ -66,6 +69,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
                 value={props.rawUrl}
               />
               {props.errorMessage &&
+                props.errorTarget === ERROR_TARGETS.URL &&
                 <div
                   className="error field-error target-url"
                   data-visible="1"

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -13,7 +13,7 @@ import ButtonPopover from '../../common/components/ButtonPopover';
 type PropsT = {
   errorMessage: string,
   onCancel: () => void,
-  onChange: (number, SyntheticEvent<HTMLInputElement>) => void,
+  onChange: (SyntheticEvent<HTMLInputElement>) => void,
   onToggle: (boolean) => void,
   rawUrl: string,
   url: string,

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -57,7 +57,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         <tbody>
           <tr>
             <td className="section">
-              {l('URL:')}
+              {addColonText(l('URL'))}
             </td>
             <td>
               <input
@@ -79,7 +79,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
           </tr>
           <tr>
             <td className="section" style={{whiteSpace: 'nowrap'}}>
-              {l('Cleaned up to:')}
+              {addColonText(l('Cleaned up to'))}
             </td>
             <td>
               <a className="clean-url" href={props.url}>{props.url}</a>

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -1,0 +1,126 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+import ButtonPopover from '../../common/components/ButtonPopover';
+
+type PropsT = {
+  errorMessage: React.Node,
+  onCancel: (number, LinkStateT) => void,
+  onChange: (number, SyntheticEvent<HTMLInputElement>) => void,
+  rawUrl: string,
+  url: string,
+};
+
+const URLInputPopover = (props: PropsT): React.MixedElement => {
+  const popoverButtonRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [
+    originalLinkState,
+    setOriginalLinkState,
+  ] = React.useState({
+    rawUrl: props.rawUrl,
+    url: props.url,
+  });
+
+  const toggle = (open) => {
+    if (open) {
+      // Backup original link state
+      setOriginalLinkState({
+        rawUrl: props.rawUrl,
+        url: props.url,
+      });
+    } else {
+      // Restore original link state when cancelled
+      props.onCancel(originalLinkState);
+    }
+    setIsOpen(open);
+  };
+
+  const buildPopoverChildren = (
+    closeAndReturnFocus,
+  ) => (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setIsOpen(false);
+      }}
+    >
+      <table>
+        <tbody>
+          <tr>
+            <td className="section">
+              {l('Raw URL:')}
+            </td>
+            <td>
+              <input
+                className="value"
+                onChange={props.onChange}
+                style={{width: '336px'}}
+                type="url"
+                value={props.rawUrl}
+              />
+              {props.errorMessage &&
+                <div
+                  className="error field-error target-url"
+                  data-visible="1"
+                >
+                  {props.errorMessage}
+                </div>
+              }
+            </td>
+          </tr>
+          <tr>
+            <td className="section">
+              {l('Clean URL:')}
+            </td>
+            <td>
+              <a href={props.url}>{props.url}</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="buttons" style={{display: 'block', marginTop: '1em'}}>
+        <button
+          className="negative"
+          onClick={closeAndReturnFocus}
+          type="button"
+        >
+          {l('Cancel')}
+        </button>
+        <div
+          className="buttons-right"
+          style={{float: 'right', textAlign: 'right'}}
+        >
+          <button
+            className="positive"
+            onClick={() => setIsOpen(false)}
+            type="button"
+          >
+            {l('Done')}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+
+  return (
+    <ButtonPopover
+      buildChildren={buildPopoverChildren}
+      buttonContent={null}
+      buttonProps={{className: 'icon edit-item'}}
+      buttonRef={popoverButtonRef}
+      id="url-input-popover"
+      isOpen={isOpen}
+      toggle={toggle}
+    />
+  );
+};
+
+export default URLInputPopover;

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -8,13 +8,13 @@
  */
 
 import * as React from 'react';
-import type {LinkStateT} from '../externalLinks';
 import ButtonPopover from '../../common/components/ButtonPopover';
 
 type PropsT = {
   errorMessage: string,
-  onCancel: ($Shape<LinkStateT>) => void,
+  onCancel: () => void,
   onChange: (number, SyntheticEvent<HTMLInputElement>) => void,
+  onToggle: (boolean) => void,
   rawUrl: string,
   url: string,
 };
@@ -22,26 +22,24 @@ type PropsT = {
 const URLInputPopover = (props: PropsT): React.MixedElement => {
   const popoverButtonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
-  const [
-    originalLinkState,
-    setOriginalLinkState,
-  ] = React.useState({
-    rawUrl: props.rawUrl,
-    url: props.url,
-  });
 
   const toggle = (open) => {
-    if (open) {
-      // Backup original link state
-      setOriginalLinkState({
-        rawUrl: props.rawUrl,
-        url: props.url,
-      });
-    } else {
-      // Restore original link state when cancelled
-      props.onCancel(originalLinkState);
+    /*
+     * Will be called by ButtonPopover when closed
+     * either by losing focus or click 'Close' button,
+     * therefore cancel action should be checked here.
+     */
+    if (!open) {
+      props.onCancel();
     }
     setIsOpen(open);
+    props.onToggle(open);
+  };
+
+  const onConfirm = () => {
+    // Bypass 'toggle' to avoid trigering onCancel
+    setIsOpen(false);
+    props.onToggle(false);
   };
 
   const buildPopoverChildren = (
@@ -50,7 +48,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        setIsOpen(false);
+        onConfirm();
       }}
     >
       <table>
@@ -77,14 +75,16 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
               }
             </td>
           </tr>
-          <tr>
-            <td className="section" style={{whiteSpace: 'nowrap'}}>
-              {addColonText(l('Cleaned up to'))}
-            </td>
-            <td>
-              <a className="clean-url" href={props.url}>{props.url}</a>
-            </td>
-          </tr>
+          {props.url &&
+            <tr>
+              <td className="section" style={{whiteSpace: 'nowrap'}}>
+                {addColonText(l('Cleaned up to'))}
+              </td>
+              <td>
+                <a className="clean-url" href={props.url}>{props.url}</a>
+              </td>
+            </tr>
+          }
         </tbody>
       </table>
       <div className="buttons" style={{display: 'block', marginTop: '1em'}}>
@@ -101,7 +101,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         >
           <button
             className="positive"
-            onClick={() => setIsOpen(false)}
+            onClick={onConfirm}
             type="button"
           >
             {l('Done')}

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -79,7 +79,14 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
                 {addColonText(l('Cleaned up to'))}
               </td>
               <td>
-                <a className="clean-url" href={props.url}>{props.url}</a>
+                <a
+                  className="clean-url"
+                  href={props.url}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {props.url}
+                </a>
               </td>
             </tr>
           }

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -29,20 +29,15 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
   const toggle = (open) => {
     /*
      * Will be called by ButtonPopover when closed
-     * either by losing focus or click 'Close' button,
-     * therefore cancel action should be checked here.
+     * either by losing focus or click 'Close' button
      */
-    if (!open) {
-      props.onCancel();
-    }
     setIsOpen(open);
     props.onToggle(open);
   };
 
-  const onConfirm = () => {
-    // Bypass 'toggle' to avoid trigering onCancel
-    setIsOpen(false);
-    props.onToggle(false);
+  const handleCancel = () => {
+    props.onCancel();
+    toggle(false);
   };
 
   const buildPopoverChildren = (
@@ -51,7 +46,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        onConfirm();
+        closeAndReturnFocus();
       }}
     >
       <table>
@@ -94,7 +89,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
       <div className="buttons" style={{display: 'block', marginTop: '1em'}}>
         <button
           className="negative"
-          onClick={closeAndReturnFocus}
+          onClick={handleCancel}
           type="button"
         >
           {l('Cancel')}
@@ -105,7 +100,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
         >
           <button
             className="positive"
-            onClick={onConfirm}
+            onClick={closeAndReturnFocus}
             type="button"
           >
             {l('Done')}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -335,7 +335,9 @@ export class ExternalLinksEditor
               <ExternalLink
                 errorMessage={error || ''}
                 errorTarget={errorTarget}
-                handlePressEnter={this.handlePressEnter.bind(this)}
+                handlePressEnter={
+                  (event) => this.handlePressEnter(event)
+                }
                 handleUrlBlur={
                   (event) => this.handleUrlBlur(index, event)
                 }
@@ -348,7 +350,9 @@ export class ExternalLinksEditor
                 isLastLink={isLastLink}
                 isOnlyLink={this.state.links.length === 1}
                 key={link.relationship}
-                onCancelEdit={this.setLinkState.bind(this, index)}
+                onCancelEdit={
+                  (state) => this.setLinkState(index, state)
+                }
                 onRemove={() => this.removeLink(index)}
                 rawUrl={link.rawUrl}
                 type={link.type}
@@ -406,7 +410,7 @@ type LinkProps = {
   isLastLink: boolean,
   isOnlyLink: boolean,
   onCancelEdit: ($Shape<LinkStateT>) => void,
-  onRemove: (number) => void,
+  onRemove: () => void,
   rawUrl: string,
   type: number | null,
   typeChangeCallback: (SyntheticEvent<HTMLSelectElement>) => void,
@@ -519,7 +523,7 @@ export class ExternalLink
               className="value with-button"
               onBlur={props.handleUrlBlur}
               onChange={props.handleUrlChange}
-              onKeyDown={this.handleKeyDown.bind(this)}
+              onKeyDown={(event) => this.handleKeyDown(event)}
               type="url"
               // Don't interrupt user input with clean URL
               value={props.rawUrl}
@@ -561,9 +565,9 @@ export class ExternalLink
             // Use current props to preview changes while editing
             <URLInputPopover
               errorMessage={this.props.errorMessage}
-              onCancel={this.handleCancelEdit.bind(this)}
+              onCancel={() => this.handleCancelEdit()}
               onChange={this.props.handleUrlChange}
-              onToggle={this.onTogglePopover.bind(this)}
+              onToggle={(open) => this.onTogglePopover(open)}
               rawUrl={this.props.rawUrl}
               url={this.props.url}
             />

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -113,7 +113,6 @@ export class ExternalLinksEditor
 
   handleUrlBlur(
     index: number,
-    error: string,
     event: SyntheticEvent<HTMLInputElement>,
   ) {
     const url = event.currentTarget.value;
@@ -123,19 +122,16 @@ export class ExternalLinksEditor
     if (url !== unicodeUrl) {
       this.setLinkState(index, {url: unicodeUrl});
     }
-    // Don't add link to list if it's empty or has error
-    if (url !== '' && !error) {
+    // Don't add link to list if it's empty
+    if (url !== '') {
       this.appendEmptyLink();
     }
   }
 
-  handlePressEnter(
-    error: string,
-    event: SyntheticKeyboardEvent<HTMLInputElement>,
-  ) {
+  handlePressEnter(event: SyntheticKeyboardEvent<HTMLInputElement>) {
     const url = event.currentTarget.value;
-    // Don't add link to list if it's empty or has error
-    if (url !== '' && !error) {
+    // Don't add link to list if it's empty
+    if (url !== '') {
       this.appendEmptyLink();
     }
   }
@@ -339,9 +335,9 @@ export class ExternalLinksEditor
               <ExternalLink
                 errorMessage={error || ''}
                 errorTarget={errorTarget}
-                handlePressEnter={this.handlePressEnter.bind(this, error)}
+                handlePressEnter={this.handlePressEnter.bind(this)}
                 handleUrlBlur={
-                  (event) => this.handleUrlBlur(index, error, event)
+                  (event) => this.handleUrlBlur(index, event)
                 }
                 handleUrlChange={
                   (event) => this.handleUrlChange(index, event)

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -501,7 +501,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           }
         </td>
         <td>
-          {props.isLastLink ? (
+          {(props.isLastLink || !props.url) ? (
             <input
               className="value with-button"
               onBlur={props.handleUrlBlur}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -113,6 +113,7 @@ export class ExternalLinksEditor
 
   handleUrlBlur(
     index: number,
+    error: string,
     event: SyntheticEvent<HTMLInputElement>,
   ) {
     const url = event.currentTarget.value;
@@ -122,20 +123,32 @@ export class ExternalLinksEditor
     if (url !== unicodeUrl) {
       this.setLinkState(index, {url: unicodeUrl});
     }
-    if (url !== '') {
+    // Don't add link to list if it's empty or has error
+    if (url !== '' && !error) {
       this.appendEmptyLink();
     }
   }
 
-  handlePressEnter(event: SyntheticKeyboardEvent<HTMLInputElement>) {
+  handlePressEnter(
+    error: string,
+    event: SyntheticKeyboardEvent<HTMLInputElement>,
+  ) {
     const url = event.currentTarget.value;
-    if (url !== '') {
+    // Don't add link to list if it's empty or has error
+    if (url !== '' && !error) {
       this.appendEmptyLink();
     }
   }
 
   handleTypeChange(index: number, event: SyntheticEvent<HTMLSelectElement>) {
-    this.setLinkState(index, {type: +event.currentTarget.value || null});
+    const type = +event.currentTarget.value || null;
+    this.setLinkState(index, {type}, () => {
+      const link = this.state.links[index];
+      const isLastLink = index === this.state.links.length - 1;
+      if (isLastLink && link.url && type) {
+        this.appendEmptyLink();
+      }
+    });
   }
 
   handleVideoChange(index: number, event: SyntheticEvent<HTMLInputElement>) {
@@ -326,9 +339,9 @@ export class ExternalLinksEditor
               <ExternalLink
                 errorMessage={error || ''}
                 errorTarget={errorTarget}
-                handlePressEnter={this.handlePressEnter.bind(this)}
+                handlePressEnter={this.handlePressEnter.bind(this, error)}
                 handleUrlBlur={
-                  (event) => this.handleUrlBlur(index, event)
+                  (event) => this.handleUrlBlur(index, error, event)
                 }
                 handleUrlChange={
                   (event) => this.handleUrlChange(index, event)

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -549,8 +549,14 @@ export class ExternalLink
               </label>
             </div>}
         </td>
-        <td style={{minWidth: '51px'}}>
-          {typeDescription && <HelpIcon content={typeDescription} />}
+        <td className="link-actions" style={{minWidth: '51px'}}>
+          {typeDescription &&
+            <HelpIcon
+              content={
+                <div style={{textAlign: 'left'}}>
+                  {typeDescription}
+                </div>}
+            />}
           {!props.isLastLink &&
             // Use current props to preview changes while editing
             <URLInputPopover

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -416,12 +416,18 @@ type LinkProps = {
   video: boolean,
 };
 
-export class ExternalLink extends React.Component<LinkProps> {
-  constructor(props: LinksEditorProps) {
+type ExternalLinkState = {
+  isPopoverOpen: boolean,
+  originalProps: LinkProps,
+};
+
+export class ExternalLink
+  extends React.Component<LinkProps, ExternalLinkState> {
+  constructor(props: LinkProps) {
     super(props);
     this.state = {
-      originalProps: props,
       isPopoverOpen: false,
+      originalProps: props,
     };
   }
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -561,8 +561,8 @@ export class ExternalLink
                   {typeDescription}
                 </div>}
             />}
-          {!props.isLastLink &&
-            // Use current props to preview changes while editing
+          {// Use current props to preview changes while editing
+            !isEmpty(props) &&
             <URLInputPopover
               errorMessage={this.props.errorMessage}
               errorTarget={this.props.errorTarget}
@@ -573,7 +573,7 @@ export class ExternalLink
               url={this.props.url}
             />
           }
-          {!isEmpty(props) && !props.isLastLink &&
+          {!isEmpty(props) &&
             <RemoveButton
               onClick={props.onRemove}
               title={l('Remove Link')}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -466,23 +466,6 @@ export class ExternalLink extends React.Component<LinkProps> {
       });
     }
 
-    if (props.url && !props.errorMessage) {
-      typeDescription = (
-        <>
-          <a
-            href={props.url}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {props.url}
-          </a>
-          <br />
-          <br />
-          {typeDescription}
-        </>
-      );
-    }
-
     const showTypeSelection = props.errorMessage
       ? true
       : !(props.urlMatchesType || isEmpty(props));

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -397,7 +397,7 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
   }
 }
 
-type ErrorTarget = $Values<typeof URLCleanup.ERROR_TARGETS>;
+export type ErrorTarget = $Values<typeof URLCleanup.ERROR_TARGETS>;
 
 type LinkProps = {
   errorMessage: string,
@@ -565,6 +565,7 @@ export class ExternalLink
             // Use current props to preview changes while editing
             <URLInputPopover
               errorMessage={this.props.errorMessage}
+              errorTarget={this.props.errorTarget}
               onCancel={() => this.handleCancelEdit()}
               onChange={this.props.handleUrlChange}
               onToggle={(open) => this.onTogglePopover(open)}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -36,7 +36,7 @@ import {linkTypeOptions} from './forms';
 import * as URLCleanup from './URLCleanup';
 import validation from './validation';
 
-type LinkStateT = {
+export type LinkStateT = {
   rawUrl: string,
   // New relationships will use a unique string ID like "new-1".
   relationship: StrOrNum | null,
@@ -400,7 +400,7 @@ class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
 type ErrorTarget = $Values<typeof URLCleanup.ERROR_TARGETS>;
 
 type LinkProps = {
-  errorMessage: React.Node,
+  errorMessage: string,
   errorTarget: ErrorTarget,
   handlePressEnter: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   handleUrlBlur: (SyntheticEvent<HTMLInputElement>) => void,
@@ -409,7 +409,7 @@ type LinkProps = {
     (SyntheticEvent<HTMLInputElement>) => void,
   isLastLink: boolean,
   isOnlyLink: boolean,
-  onCancelEdit: (number, LinkStateT) => void,
+  onCancelEdit: ($Shape<LinkStateT>) => void,
   onRemove: (number) => void,
   rawUrl: string,
   type: number | null,
@@ -512,7 +512,7 @@ export class ExternalLink extends React.Component<LinkProps> {
               value={props.rawUrl}
             />
           ) : (
-            <a href={props.url}>{props.url}</a>
+            <a className="url" href={props.url}>{props.url}</a>
           )}
           {props.errorMessage &&
             <div

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -621,6 +621,11 @@ table.artist-credit-editor {
         vertical-align: top;
         padding-top: @form-margin / 2;
     }
+
+    td.link-actions {
+        text-align: right;
+        padding-right: 0;
+    }
 }
 
 #external-links-editor, #work-attributes {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -126,7 +126,7 @@
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
       value: '?oldformat=true',
     },
     // assert clean URL is displayed correctly
@@ -161,7 +161,7 @@
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
       value: '?oldformat=true',
     },
     // Test keeping changes when lost focus
@@ -311,7 +311,7 @@
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
     },
     // Save URL change
@@ -421,7 +421,7 @@
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.amazon.co.jp/gp/product/B017VORJK6',
     },
     // Save URL change
@@ -449,7 +449,7 @@
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[contains(@class, 'raw-url')])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
     },
     // Save URL change

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -15,7 +15,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://en.wikipedia.org/wiki/No_Age',
+      value: 'https://en.wikipedia.org/wiki/No_Age${KEY_ENTER}',
     },
     {
       command: 'assertElementPresent',
@@ -30,12 +30,12 @@
     // invalid URL detection
     {
       command: 'click',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'foo',
     },
     {
@@ -43,20 +43,21 @@
       target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
+    // clear
     {
-      command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
-      value: '',
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
     },
     // MBS-11688
     {
       command: 'click',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '//google.com',
     },
     {
@@ -65,19 +66,19 @@
       value: 'Enter a valid url e.g. "http://google.com/"',
     },
     {
-      command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
-      value: '',
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
     },
     // shortened URL detection
     {
       command: 'click',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: '',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'http://goo.gl/example',
     },
     {
@@ -86,14 +87,14 @@
       value: 'Please don’t enter bundled/shortened URLs, enter the destination URL(s) instead.',
     },
     {
-      command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
-      value: '',
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
     },
     // deprecated link type detection for new links
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'http://example.com/',
     },
     {
@@ -115,6 +116,88 @@
       command: 'click',
       target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
       value: '',
+    },
+    // URLInputPopover tests
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      value: '?oldformat=true',
+    },
+    // assert clean URL is displayed correctly
+    {
+      command: 'assertText',
+      target: "xpath=//div[@id='url-input-popover']//a[contains(@class, 'clean-url')]",
+      value: 'https://en.wikipedia.org/wiki/No_Age',
+    },
+    // assert raw URL is preserved
+    {
+      command: 'assertEval',
+      target: "document.getElementsByClassName('raw-url')[0].value.trim()",
+      value: 'https://en.wikipedia.org/wiki/No_Age?oldformat=true',
+    },
+    // Discard URL change by clicking 'Cancel'
+    {
+      command: 'click',
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'negative')]",
+      value: '',
+    },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    // assert URL is unchanged
+    {
+      command: 'assertEval',
+      target: "document.getElementsByClassName('raw-url')[0].value.trim()",
+      value: 'https://en.wikipedia.org/wiki/No_Age',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      value: '?oldformat=true',
+    },
+    // Discard changes when lost focus
+    {
+      command: 'click',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '',
+    },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    // assert URL is unchanged
+    {
+      command: 'assertEval',
+      target: "document.getElementsByClassName('raw-url')[0].value.trim()",
+      value: 'https://en.wikipedia.org/wiki/No_Age',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
+      value: '?oldformat=true',
+    },
+    // Save URL change
+    {
+      command: 'click',
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'positive')]",
+      value: '',
+    },
+    // assert clean URL is used
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//a[contains(@class, 'url')]",
+      value: 'https://en.wikipedia.org/wiki/No_Age',
     },
     // submit the artist
     {
@@ -155,7 +238,7 @@
     },
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[1]//div[contains(@class, 'error')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//div[contains(@class, 'error')]",
       value: 'This relationship type is deprecated and should not be used.',
     },
     // relationshipCreate edit for external link is generated for existing release
@@ -172,12 +255,12 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://www.discogs.com/David-Bowie--Blackstar/release/7949394',
+      value: 'https://www.discogs.com/David-Bowie--Blackstar/release/7949394${KEY_ENTER}',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
-      value: 'https://www.amazon.co.jp/Blackstar-David-Bowie/dp/B017VORJK6/',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://www.amazon.co.jp/Blackstar-David-Bowie/dp/B017VORJK6/${KEY_ENTER}',
     },
     {
       command: 'click',
@@ -225,10 +308,22 @@
       target: '1500',
       value: '',
     },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
+    },
+    // Save URL change
+    {
+      command: 'click',
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'positive')]",
+      value: '',
     },
     {
       command: 'select',
@@ -294,7 +389,7 @@
     // check that edits are not generated for links that duplicate removed ones
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[2]",
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'https://www.amazon.co.jp/gp/product/B017VORJK6',
     },
     {
@@ -319,14 +414,31 @@
     },
     // duplicate the first URL again by editing the other existing URL
     {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
+    },
+    {
+      command: 'select',
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//select[contains(@class, 'link-type')]",
+      value: 'label=regexp:\\B',
+    },
+    // Open popover
+    {
       command: 'click',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.amazon.co.jp/gp/product/B017VORJK6',
+    },
+    // Save URL change
+    {
+      command: 'click',
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'positive')]",
+      value: '',
     },
     {
       command: 'select',
@@ -339,10 +451,22 @@
       value: 'This relationship already exists.',
     },
     // revert above edit
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
     {
       command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
       value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}https://www.gnu.org/licenses/gpl-3.0.en.html',
+    },
+    // Save URL change
+    {
+      command: 'click',
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'positive')]",
+      value: '',
     },
     {
       command: 'select',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -536,8 +536,8 @@
     },
     {
       command: 'assertEval',
-      target: "window.JSON.stringify(window.Array.from(window.document.querySelectorAll('#external-links-editor input[type=url]').values()).map(function (x) { return x.value }))",
-      value: '["https://www.gnu.org/licenses/gpl-3.0.en.html",""]',
+      target: "window.JSON.stringify(window.Array.from(window.document.querySelectorAll('#external-links-editor a[class=url]').values()).map(function (x) { return x.href }))",
+      value: '["https://www.gnu.org/licenses/gpl-3.0.en.html"]',
     },
   ],
 }

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -164,7 +164,7 @@
       target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
       value: '?oldformat=true',
     },
-    // Discard changes when lost focus
+    // Test keeping changes when lost focus
     {
       command: 'click',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
@@ -176,21 +176,16 @@
       target: "xpath=//table[@id='external-links-editor']//tr[1]//button[contains(@class, 'edit-item')]",
       value: '',
     },
-    // assert URL is unchanged
+    // assert changes are kept
     {
       command: 'assertEval',
       target: "document.getElementsByClassName('raw-url')[0].value.trim()",
-      value: 'https://en.wikipedia.org/wiki/No_Age',
+      value: 'https://en.wikipedia.org/wiki/No_Age?oldformat=true',
     },
-    {
-      command: 'sendKeys',
-      target: "xpath=(//div[@id='url-input-popover']//input[@type='url'])[1]",
-      value: '?oldformat=true',
-    },
-    // Save URL change
+    // Close popover
     {
       command: 'click',
-      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'positive')]",
+      target: "xpath=//div[@id='url-input-popover']//button[contains(@class, 'negative')]",
       value: '',
     },
     // assert clean URL is used

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -414,14 +414,9 @@
     },
     // duplicate the first URL again by editing the other existing URL
     {
-      command: 'sendKeys',
-      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: '${KEY_HOME}${KEY_SHIFT}${KEY_END}${KEY_SHIFT}${KEY_BKSP}',
-    },
-    {
-      command: 'select',
-      target: "xpath=//table[@id='external-links-editor']//tr[2]//select[contains(@class, 'link-type')]",
-      value: 'label=regexp:\\B',
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
+      value: '',
     },
     // Open popover
     {

--- a/t/selenium/release-editor/Seeding.json5
+++ b/t/selenium/release-editor/Seeding.json5
@@ -288,7 +288,7 @@
     },
     {
       command: 'assertEval',
-      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('input').value, x.querySelector('.error').textContent].join('\\t')).join('\\n')",
+      target: "Array.from(document.querySelectorAll('#external-links-editor tr')).slice(0, 3).map(x => [x.querySelector('select').value, x.querySelector('a.url') ? x.querySelector('a.url').href : x.querySelector('input').value, x.querySelector('.error').textContent].join('\\t')).join('\\n')",
       value: '\thttp://foo.bar.baz/\tPlease select a link type for the URL you’ve entered.\n77\t\tRequired field.\n76\thttp://foo.bar.baz/foo/\tThis URL is not allowed for the selected link type, or is incorrectly formatted.',
     },
     // MBS-7250: seeding empty date parts gives an ISE


### PR DESCRIPTION
# Problem

MBS-11391: Show changes made to external link when editing URL relationship

# Solution

Implemented a popover for URL editing, which contains two fields - raw URL and clean URL.

Links aren't added to list automatically, users will have to press enter or let the input box blurred.
