### PR TITLE
MBS-11744: Make it easier to mouse-select release dates in tables

### DIFF
--- a/root/static/styles/entity.less
+++ b/root/static/styles/entity.less
@@ -120,9 +120,11 @@ div.release-events-container {
             min-width: 10em;
 
             li.release-event {
+                display: table-row;
+
                 .release-country {
                     box-sizing: border-box;
-                    display: inline-block;
+                    display: table-cell;
                     width: 4em;
                     /*
                      * Cancel 3px padding of the flag to keep country/date texts
@@ -132,7 +134,7 @@ div.release-events-container {
                 }
 
                 .release-date {
-                    display: inline-block;
+                    display: table-cell;
                     margin-left: 4em;
                 }
 


### PR DESCRIPTION
### Improve MBS-11744

By using table-row / table-cell here, we allow the full dates to be selected easily by triple-clicking and we stop double-clicking on the year from also selecting the country code.

Solution suggested by @mwiencek.
