### PR TITLE
MBS-11753: Fix selectors for RangeSelect in ArtistEdit

### DIFF
--- a/root/static/scripts/edit/MB/Control/ArtistEdit.js
+++ b/root/static/scripts/edit/MB/Control/ArtistEdit.js
@@ -98,7 +98,7 @@ MB.Control.ArtistEdit = function () {
   self.$type.bind('change.mb', self.typeChanged);
 
   MB.Control.RangeSelect(
-    '#artist-credit-renamer span.rename-artist-credit input[type="checkbox"]',
+    '#artist-credit-renamer input[type="checkbox"]',
   );
 
   MB.Control.initializeGuessCase('artist', 'id-edit-artist');


### PR DESCRIPTION
### Fix MBS-11753

It seems this broke during the conversion to React (MBS-11195), since the selectors changed. Tested, and this change seems to work both for collapsible and non-collapsible editor sections.
