### PR TITLE
MBS-11756: Collapse artist roles when there are too many

### DIFF
--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {CatalystContext} from '../../context';
 import Table from '../Table';
+import * as manifest from '../../static/manifest';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList';
 import localizeArtistRoles
@@ -56,7 +57,7 @@ const EventList = ({
   showRatings = false,
   showType = false,
   sortable,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<typeof React.Fragment> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -145,7 +146,12 @@ const EventList = ({
     ],
   );
 
-  return <Table columns={columns} data={events} />;
+  return (
+    <>
+      <Table columns={columns} data={events} />
+      {manifest.js('common/components/ArtistRoles', {async: 'async'})}
+    </>
+  );
 };
 
 export default EventList;

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -197,6 +197,7 @@ const ReleaseList = ({
   return (
     <>
       <Table columns={columns} data={releases} />
+      {manifest.js('common/components/ReleaseEvents', {async: 'async'})}
       {manifest.js('common/components/TaggerIcon', {async: 'async'})}
     </>
   );

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../../context';
+import * as manifest from '../../static/manifest';
 import Table from '../Table';
 import {
   defineArtistRolesColumn,
@@ -43,7 +44,7 @@ const WorkList = ({
   showRatings = false,
   sortable,
   works,
-}: Props): React.Element<typeof Table> => {
+}: Props): React.Element<typeof React.Fragment> => {
   const $c = React.useContext(CatalystContext);
 
   const columns = React.useMemo(
@@ -99,7 +100,14 @@ const WorkList = ({
     ],
   );
 
-  return <Table columns={columns} data={works} />;
+  return (
+    <>
+      <Table columns={columns} data={works} />
+      {manifest.js('common/components/ArtistRoles', {async: 'async'})}
+      {manifest.js('common/components/AttributeList', {async: 'async'})}
+      {manifest.js('common/components/WorkArtists', {async: 'async'})}
+    </>
+  );
 };
 
 export default WorkList;

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -12,6 +12,7 @@ import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import Table from '../../components/Table';
+import * as manifest from '../../static/manifest';
 import {
   defineArtistRolesColumn,
   defineDatePeriodColumn,
@@ -94,6 +95,7 @@ const EventList = <D: {+event: ?EventT, ...}>({
   return (
     <PaginatedResults pager={pager}>
       <Table columns={columns} data={existingEventItems} />
+      {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );
 };

--- a/root/report/components/WorkList.js
+++ b/root/report/components/WorkList.js
@@ -12,6 +12,7 @@ import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import Table from '../../components/Table';
+import * as manifest from '../../static/manifest';
 import {
   defineArtistRolesColumn,
   defineEntityColumn,
@@ -76,6 +77,7 @@ const WorkList = <D: {+work: ?WorkT, ...}>({
   return (
     <PaginatedResults pager={pager}>
       <Table columns={columns} data={existingWorkItems} />
+      {manifest.js('common/components/ArtistRoles', {async: 'async'})}
     </PaginatedResults>
   );
 };

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import * as manifest from '../../static/manifest';
 import ArtistRoles from '../../static/scripts/common/components/ArtistRoles';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import EventLocations
@@ -41,6 +42,10 @@ function buildResult(result, index) {
       </td>
       <td>
         <ArtistRoles relations={event.performers} />
+        {manifest.js(
+          'common/components/ArtistRoles',
+          {async: 'async'},
+        )}
       </td>
       <td>
         <EventLocations event={event} />

--- a/root/static/scripts/common/components/ArtistRoles.js
+++ b/root/static/scripts/common/components/ArtistRoles.js
@@ -12,27 +12,51 @@ import * as React from 'react';
 import commaOnlyList from '../i18n/commaOnlyList';
 import localizeArtistRoles from '../i18n/localizeArtistRoles';
 
+import CollapsibleList from './CollapsibleList';
 import EntityLink from './EntityLink';
 
-type Props = {
-  +relations: $ReadOnlyArray<{
-    +credit: string,
-    +entity: ArtistT,
-    +roles: $ReadOnlyArray<string>,
-  }>,
+type RelationT = {
+  +credit: string,
+  +entity: ArtistT,
+  +roles: $ReadOnlyArray<string>,
 };
 
-const ArtistRoles = ({relations}: Props): React.Element<'ul'> => (
-  <ul>
-    {relations.map(r => (
-      <li key={r.entity.id}>
-        {exp.l('{artist} ({roles})', {
-          artist: <EntityLink content={r.credit} entity={r.entity} />,
-          roles: commaOnlyList(localizeArtistRoles(r.roles)),
-        })}
-      </li>
-    ))}
-  </ul>
+type ArtistRolesProps = {
+  +relations: $ReadOnlyArray<RelationT>,
+};
+
+const buildArtistRoleRow = (relation: RelationT) => {
+  return (
+    <li key={relation.entity.id + '-' + relation.credit}>
+      {exp.l('{artist} ({roles})', {
+        artist: (
+          <EntityLink
+            content={relation.credit}
+            entity={relation.entity}
+          />
+        ),
+        roles: commaOnlyList(localizeArtistRoles(relation.roles)),
+      })}
+    </li>
+  );
+};
+
+const ArtistRoles = ({
+  relations,
+}: ArtistRolesProps): React.Element<typeof CollapsibleList> => (
+  <CollapsibleList
+    ariaLabel={l('Artist Roles')}
+    buildRow={buildArtistRoleRow}
+    className="artist-roles"
+    rows={relations}
+    showAllTitle={l('Show all artists')}
+    showLessTitle={l('Show less artists')}
+    toShowAfter={0}
+    toShowBefore={4}
+  />
 );
 
-export default ArtistRoles;
+export default (hydrate<ArtistRolesProps>(
+  'div.artist-roles-container',
+  ArtistRoles,
+): React.AbstractComponent<ArtistRolesProps, void>);

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -70,6 +70,10 @@ export const WorkListRow = ({
       <td><EntityLink entity={work} /></td>
       <td>
         <ArtistRoles relations={work.writers} />
+        {manifest.js(
+          'common/components/ArtistRoles',
+          {async: 'async'},
+        )}
       </td>
       <td>
         <WorkArtists artists={work.artists} />

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -134,7 +134,13 @@ export function defineArtistRolesColumn<D>(
 }>> {
   return {
     Cell: ({row: {original}}) => (
-      <ArtistRoles relations={props.getRoles(original)} />
+      <>
+        <ArtistRoles relations={props.getRoles(original)} />
+        {manifest.js(
+          'common/components/ArtistRoles',
+          {async: 'async'},
+        )}
+      </>
     ),
     Header: props.title,
     id: props.columnName,

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -18,7 +18,6 @@ import ReleaseCatnoList from '../components/ReleaseCatnoList';
 import ReleaseLabelList from '../components/ReleaseLabelList';
 import ReleaseLanguageScript from '../components/ReleaseLanguageScript';
 import SortableTableHeader from '../components/SortableTableHeader';
-import * as manifest from '../static/manifest';
 import linkedEntities from '../static/scripts/common/linkedEntities';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink';
@@ -134,13 +133,7 @@ export function defineArtistRolesColumn<D>(
 }>> {
   return {
     Cell: ({row: {original}}) => (
-      <>
-        <ArtistRoles relations={props.getRoles(original)} />
-        {manifest.js(
-          'common/components/ArtistRoles',
-          {async: 'async'},
-        )}
-      </>
+      <ArtistRoles relations={props.getRoles(original)} />
     ),
     Header: props.title,
     id: props.columnName,
@@ -477,15 +470,7 @@ export function defineReleaseEventsColumn(
 ): ColumnOptions<ReleaseT, ?$ReadOnlyArray<ReleaseEventT>> {
   return {
     accessor: x => x.events,
-    Cell: ({cell: {value}}) => (
-      <>
-        <ReleaseEvents events={value} />
-        {manifest.js(
-          'common/components/ReleaseEvents',
-          {async: 'async'},
-        )}
-      </>
-    ),
+    Cell: ({cell: {value}}) => <ReleaseEvents events={value} />,
     Header: (props.sortable
       ? (
         <>
@@ -643,10 +628,6 @@ export const attributesColumn:
       original.attributes ? (
         <ul>
           <AttributeList attributes={original.attributes} />
-          {manifest.js(
-            'common/components/AttributeList',
-            {async: 'async'},
-          )}
         </ul>
       ) : null
     ),
@@ -792,15 +773,7 @@ export const trackColumn:
 export const workArtistsColumn:
   ColumnOptions<WorkT, $ReadOnlyArray<ArtistCreditT>> = {
     accessor: x => x.artists,
-    Cell: ({cell: {value}}) => (
-      <>
-        <WorkArtists artists={value} />
-        {manifest.js(
-          'common/components/WorkArtists',
-          {async: 'async'},
-        )}
-      </>
-    ),
+    Cell: ({cell: {value}}) => <WorkArtists artists={value} />,
     Header: N_l('Artists'),
     id: 'work-artists',
   };

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -45,6 +45,7 @@ const entries = [
   'collection/edit',
   'common',
   'common/components/AcoustIdCell',
+  'common/components/ArtistRoles',
   'common/components/AttributeList',
   'common/components/ReleaseEvents',
   'common/components/TaggerIcon',


### PR DESCRIPTION
### Implement MBS-11756

This applies to artists for events and to writers for works.

On top of https://github.com/metabrainz/musicbrainz-server/pull/2024

For a works example, see artist/164f0d73-1234-4e2c-8743-d77bf2191051/works and for an events example, area/525d4e18-3d00-31b9-a58b-a146a916de8f/events