### PR TITLE
MBS-11757: CD Japan -> CDJapan

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/CDJapan.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/CDJapan.pm
@@ -9,7 +9,7 @@ override href_url => sub {
     shift->url->as_string =~ s{^http:}{https:}r;
 };
 
-sub sidebar_name { 'CD Japan' }
+sub sidebar_name { 'CDJapan' }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
### Fix MBS-11757

They seem to pretty consistently use CDJapan, with a couple exceptions that look like mistakes rather than them not caring, so we should do the same.

