### PR TITLE
MBS-11747: Hide release details on edit preview

### DIFF
--- a/root/edit/details/RemoveReleaseLabel.js
+++ b/root/edit/details/RemoveReleaseLabel.js
@@ -32,10 +32,12 @@ const RemoveReleaseLabel = ({edit}: Props): React.Element<'table'> => {
 
   return (
     <table className="details remove-release-label">
-      <tr>
-        <th>{l('Release:')}</th>
-        <td><DescriptiveLink entity={display.release} /></td>
-      </tr>
+      {edit.preview /*:: === true */ ? null : (
+        <tr>
+          <th>{l('Release:')}</th>
+          <td><DescriptiveLink entity={display.release} /></td>
+        </tr>
+      )}
       <tr>
         <th>{l('Label:')}</th>
         <td>

--- a/root/edit/details/edit_release.tt
+++ b/root/edit/details/edit_release.tt
@@ -1,10 +1,12 @@
 [%- PROCESS 'edit/details/macros.tt' -%]
 
 <table class="details edit-release">
-  <tr>
-    <th>[% l('Release:') %]</th>
-    <td colspan="2">[% descriptive_link(edit.display_data.release) %]</td>
-  </tr>
+  [% UNLESS edit.preview %]
+    <tr>
+      <th>[% l('Release:') %]</th>
+      <td colspan="2">[% descriptive_link(edit.display_data.release) %]</td>
+    </tr>
+  [% END %]
 
   [%- display_word_diff(l('Name:'),
                         html_escape(edit.display_data.name.old),

--- a/root/edit/details/edit_release_label.tt
+++ b/root/edit/details/edit_release_label.tt
@@ -1,10 +1,12 @@
 [%- PROCESS 'edit/details/macros.tt' -%]
 
 <table class="details edit-release-label">
-    <tr>
-        <th>[% l('Release:') %]</th>
-        <td colspan="2">[% descriptive_link(edit.display_data.release) %]</td>
-    </tr>
+    [% UNLESS edit.preview %]
+      <tr>
+          <th>[% l('Release:') %]</th>
+          <td colspan="2">[% descriptive_link(edit.display_data.release) %]</td>
+      </tr>
+   [% END %]
 
     [% IF edit.data.new.exists('label') || edit.data.old.defined('label') %]
     <tr>


### PR DESCRIPTION
### Implement MBS-11747

These will always apply to the release currently being edited if seen as a preview. Changing these to show only if the edit is not a preview, matching what AddReleaseLabel already does.