### PR TITLE
MBS-11761: Properly display ratings on release lists

### DIFF
--- a/root/components/list/ArtistList.js
+++ b/root/components/list/ArtistList.js
@@ -20,8 +20,8 @@ import {
   defineBeginDateColumn,
   defineEndDateColumn,
   defineInstrumentUsageColumn,
+  defineRatingsColumn,
   defineSeriesNumberColumn,
-  ratingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
@@ -116,6 +116,9 @@ const ArtistList = ({
           instrumentCreditsAndRelTypes: instrumentCreditsAndRelTypes,
         })
         : null;
+      const ratingsColumn = defineRatingsColumn<ArtistT>({
+        getEntity: entity => entity,
+      });
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),

--- a/root/components/list/EventList.js
+++ b/root/components/list/EventList.js
@@ -21,10 +21,10 @@ import {
   defineDatePeriodColumn,
   defineLocationColumn,
   defineNameColumn,
+  defineRatingsColumn,
   defineSeriesNumberColumn,
   defineTypeColumn,
   defineTextColumn,
-  ratingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
@@ -109,6 +109,9 @@ const EventList = ({
         getEntity: entity => entity,
         order: order,
         sortable: sortable,
+      });
+      const ratingsColumn = defineRatingsColumn<EventT>({
+        getEntity: entity => entity,
       });
 
       return [

--- a/root/components/list/LabelList.js
+++ b/root/components/list/LabelList.js
@@ -13,14 +13,14 @@ import {CatalystContext} from '../../context';
 import Table from '../Table';
 import formatLabelCode from '../../utility/formatLabelCode';
 import {
+  defineBeginDateColumn,
   defineCheckboxColumn,
+  defineEndDateColumn,
   defineNameColumn,
+  defineEntityColumn,
+  defineRatingsColumn,
   defineTextColumn,
   defineTypeColumn,
-  defineEntityColumn,
-  defineBeginDateColumn,
-  defineEndDateColumn,
-  ratingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
@@ -81,6 +81,9 @@ const LabelList = ({
       const endDateColumn = defineEndDateColumn({
         order: order,
         sortable: sortable,
+      });
+      const ratingsColumn = defineRatingsColumn<LabelT>({
+        getEntity: entity => entity,
       });
 
       return [

--- a/root/components/list/PlaceList.js
+++ b/root/components/list/PlaceList.js
@@ -19,7 +19,7 @@ import {
   defineEntityColumn,
   defineBeginDateColumn,
   defineEndDateColumn,
-  ratingsColumn,
+  defineRatingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
@@ -72,6 +72,9 @@ const PlaceList = ({
       });
       const beginDateColumn = defineBeginDateColumn({});
       const endDateColumn = defineEndDateColumn({});
+      const ratingsColumn = defineRatingsColumn<PlaceT>({
+        getEntity: entity => entity,
+      });
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),

--- a/root/components/list/RecordingList.js
+++ b/root/components/list/RecordingList.js
@@ -21,10 +21,10 @@ import {
   defineCheckboxColumn,
   defineInstrumentUsageColumn,
   defineNameColumn,
+  defineRatingsColumn,
   defineSeriesNumberColumn,
   defineTextColumn,
   isrcsColumn,
-  ratingsColumn,
   removeFromMergeColumn,
   useAcoustIdsColumn,
 } from '../../utility/tableColumns';
@@ -125,6 +125,9 @@ const RecordingList = ({
           instrumentCreditsAndRelTypes: instrumentCreditsAndRelTypes,
         })
         : null;
+      const ratingsColumn = defineRatingsColumn<RecordingT>({
+        getEntity: entity => entity,
+      });
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),

--- a/root/components/list/ReleaseGroupList.js
+++ b/root/components/list/ReleaseGroupList.js
@@ -17,11 +17,11 @@ import parseDate from '../../static/scripts/common/utility/parseDate';
 import {
   defineArtistCreditColumn,
   defineCheckboxColumn,
+  defineCountColumn,
   defineNameColumn,
+  defineRatingsColumn,
   defineSeriesNumberColumn,
   defineTextColumn,
-  defineCountColumn,
-  ratingsColumn,
   removeFromMergeColumn,
 } from '../../utility/tableColumns';
 
@@ -105,6 +105,9 @@ export const ReleaseGroupListTable = ({
         columnName: 'release_count',
         getCount: entity => entity.release_count,
         title: l('Releases'),
+      });
+      const ratingsColumn = defineRatingsColumn<ReleaseGroupT>({
+        getEntity: entity => entity,
       });
 
       return [

--- a/root/components/list/ReleaseList.js
+++ b/root/components/list/ReleaseList.js
@@ -19,13 +19,13 @@ import {
   defineCheckboxColumn,
   defineInstrumentUsageColumn,
   defineNameColumn,
+  defineRatingsColumn,
   defineReleaseCatnosColumn,
   defineReleaseEventsColumn,
   defineReleaseLabelsColumn,
   defineReleaseLanguageColumn,
   defineSeriesNumberColumn,
   defineTextColumn,
-  ratingsColumn,
   taggerColumn,
 } from '../../utility/tableColumns';
 
@@ -153,6 +153,9 @@ const ReleaseList = ({
           title: l('Status'),
         })
         : null;
+      const ratingsColumn = defineRatingsColumn<ReleaseT>({
+        getEntity: entity => entity.releaseGroup ?? null,
+      });
 
       return [
         ...(checkboxColumn ? [checkboxColumn] : []),

--- a/root/components/list/WorkList.js
+++ b/root/components/list/WorkList.js
@@ -15,11 +15,11 @@ import {
   defineArtistRolesColumn,
   defineCheckboxColumn,
   defineNameColumn,
+  defineRatingsColumn,
   defineSeriesNumberColumn,
   defineTypeColumn,
   attributesColumn,
   iswcsColumn,
-  ratingsColumn,
   removeFromMergeColumn,
   workArtistsColumn,
   workLanguagesColumn,
@@ -68,6 +68,9 @@ const WorkList = ({
         order: order,
         sortable: sortable,
         typeContext: 'work_type',
+      });
+      const ratingsColumn = defineRatingsColumn<WorkT>({
+        getEntity: entity => entity,
       });
 
       return [

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -418,6 +418,28 @@ export function defineNameColumn<T: CoreEntityT | CollectionT>(
   };
 }
 
+export function defineRatingsColumn<D>(
+  props: {
+    +getEntity: (D) => RatableT | null,
+  },
+): ColumnOptions<D, number> {
+  return {
+    Cell: ({row: {original}}) => {
+      const ratableEntity = props.getEntity(original);
+      if (ratableEntity == null) {
+        return null;
+      }
+      return (
+        <RatingStars entity={ratableEntity} />
+      );
+    },
+    cellProps: {className: 'c'},
+    Header: N_l('Rating'),
+    headerProps: {className: 'rating c'},
+    id: 'rating',
+  };
+}
+
 export function defineReleaseCatnosColumn<D>(
   props: {
     ...OrderableProps,
@@ -739,15 +761,6 @@ export const iswcsColumn:
     cellProps: {className: 'iswc'},
     Header: N_l('ISWC'),
     id: 'iswcs',
-  };
-
-export const ratingsColumn:
-  ColumnOptions<RatableT, number> = {
-    Cell: ({row: {original}}) => <RatingStars entity={original} />,
-    cellProps: {className: 'c'},
-    Header: N_l('Rating'),
-    headerProps: {className: 'rating c'},
-    id: 'rating',
   };
 
 export const removeFromMergeColumn:

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -369,13 +369,13 @@ export function defineLinkColumn<D>(
   },
 ): ColumnOptions<D, string> {
   return {
+    accessor: row => props.getContent(row) ?? '',
     Cell: ({row: {original}}) => (
       <a href={props.getHref(original)}>
         {props.getContent(original)}
       </a>
     ),
     Header: props.title,
-    accessor: row => props.getContent(row) ?? '',
     id: props.columnName,
   };
 }


### PR DESCRIPTION
### Fix MBS-11761

The ratingsColumn implementation was always expecting ratings to exist on the entity itself, but for release they exist only on the release group. As such, we need to change ratingsColumn into a function that allows passing an accessor to the appropriate entity that has the ratings.


This has probably been broken all the way since ff8bdcdc9a93682d27b49ebc5715f0571362bc80 :(