### PR TITLE
MBS-11773: Make "featuring in title" reports case insensitive

### DIFF
--- a/lib/MusicBrainz/Server/Report/FeaturingRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingRecordings.pm
@@ -12,7 +12,7 @@ sub query {
         FROM recording r
             JOIN artist_credit ac ON r.artist_credit = ac.id
         WHERE
-            r.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
+            r.name ~* E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
     ";
 }
 

--- a/lib/MusicBrainz/Server/Report/FeaturingReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingReleaseGroups.pm
@@ -14,7 +14,7 @@ sub query {
             JOIN artist_credit ac ON rg.artist_credit = ac.id
             JOIN release_group_meta rm ON rg.id = rm.id
         WHERE
-            rg.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
+            rg.name ~* E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
     ";
 }
 

--- a/lib/MusicBrainz/Server/Report/FeaturingReleases.pm
+++ b/lib/MusicBrainz/Server/Report/FeaturingReleases.pm
@@ -14,7 +14,7 @@ sub query {
             JOIN artist_credit ac ON r.artist_credit = ac.id
             JOIN release_meta rm ON r.id = rm.id
         WHERE
-            r.name ~ E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
+            r.name ~* E' \\\\((duet with|(f|w)/|(f|feat|ft)\\\\.|featuring) '
     ";
 }
 


### PR DESCRIPTION
### Implement MBS-11773

These are currently skipping stuff like "Feat." and "Duet With". There seems to be no good reason for that - the guessFeat function, for example, is case insensitive.