### PR TITLE
MBS-11775: Do not break if relatedArtists is undefined

### DIFF
--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -138,6 +138,9 @@ function cleanCredit(name, isProbablyClassical) {
 }
 
 function bestArtistMatch(artists, name) {
+  if (!artists) {
+    return null;
+  }
   let match = null;
   for (const artist of artists) {
     const similarity = getSimilarity(name, artist.name);

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -463,11 +463,11 @@ test('guessing feat. artists', function (t) {
     },
   ];
 
-  function toJS(track) {
+  function toJS(entity) {
     return {
-      name: track.name(),
+      name: entity.name(),
       artistCredit: {
-        names: track.artistCredit().names.map((name) => {
+        names: entity.artistCredit().names.map((name) => {
           const copy = {...name};
           delete copy.artist;
           delete copy.automaticJoinPhrase;

--- a/root/static/scripts/tests/guessFeat.js
+++ b/root/static/scripts/tests/guessFeat.js
@@ -7,13 +7,14 @@
  */
 
 import test from 'tape';
+import ko from 'knockout';
 
 import guessFeat from '../edit/utility/guessFeat';
 import fields from '../release-editor/fields';
 
 /* eslint-disable sort-keys */
 test('guessing feat. artists', function (t) {
-  t.plan(22);
+  t.plan(24);
 
   const trackTests = [
     {
@@ -425,6 +426,41 @@ test('guessing feat. artists', function (t) {
         },
       },
     },
+    {
+      input: {
+        name: 'Coast To Coast feat. 漢、般若',
+        artistCredit: {names: [{name: 'DJ Baku', joinPhrase: ''}]},
+      },
+      output: {
+        name: 'Coast To Coast',
+        artistCredit: {
+          names: [
+            {name: 'DJ Baku', joinPhrase: ' feat. '},
+            {name: '漢', joinPhrase: '、'},
+            {name: '般若', joinPhrase: ''},
+          ],
+        },
+      },
+    },
+  ];
+
+  const releaseGroupTests = [
+    {
+      input: {
+        name: 'Coast To Coast feat. 漢、般若',
+        artistCredit: {names: [{name: 'DJ Baku', joinPhrase: ''}]},
+      },
+      output: {
+        name: 'Coast To Coast',
+        artistCredit: {
+          names: [
+            {name: 'DJ Baku', joinPhrase: ' feat. '},
+            {name: '漢', joinPhrase: '、'},
+            {name: '般若', joinPhrase: ''},
+          ],
+        },
+      },
+    },
   ];
 
   function toJS(track) {
@@ -448,6 +484,20 @@ test('guessing feat. artists', function (t) {
     );
   }
 
+  function runReleaseGroupTest(x, entity) {
+    /*
+     * This is a hack because RG is in itself hackily implemented
+     * and can be hopefully dropped once all of this uses React
+     */
+    entity.name = ko.observable(entity.name);
+    entity.artistCredit = ko.observable(entity.artistCredit);
+
+    guessFeat(entity);
+    t.deepEqual(
+      toJS(entity), x.output, x.input.name + ' -> ' + x.output.name,
+    );
+  }
+
   for (const test of trackTests) {
     const release = new fields.Release({
       artistCredit: {names: []},
@@ -459,5 +509,9 @@ test('guessing feat. artists', function (t) {
 
   for (const test of releaseTests) {
     runTest(test, new fields.Release(test.input));
+  }
+
+  for (const test of releaseGroupTests) {
+    runReleaseGroupTest(test, new fields.ReleaseGroup(test.input));
   }
 });


### PR DESCRIPTION
### Fix MBS-11775

I could add relatedArtists to ReleaseGroup in entity.js, but none of the artist relationship types seem relevant at all to a featured artist. Given we already have problems with this being overzealous elsewhere (MBS-10477), it seems sensible to be conservative here.