### PR TITLE
MBS-11776: Readd "loading-message" class to the medium loading message

### DIFF
--- a/root/static/scripts/release/components/MediumTable.js
+++ b/root/static/scripts/release/components/MediumTable.js
@@ -311,7 +311,11 @@ const MediumTable = (React.memo<PropsT>(({
 
         {loadingMessage ? (
           <tr>
-            <td colSpan={columnCount} style={{padding: '1em'}}>
+            <td
+              className="loading-message"
+              colSpan={columnCount}
+              style={{padding: '1em'}}
+            >
               {loadingMessage}
             </td>
           </tr>


### PR DESCRIPTION
### Fix MBS-11776

We used to have this before the React conversion, and it is used by some userscripts which don't really have a great substitute. This used to be in a div inside the td, but that div didn't seem to have any use other than it being easy to append with JQuery. Hopefully just having it on the td itself works as well.