### PR TITLE
MBS-11767: Show track-level artists on loaded mediums

### DIFF
--- a/root/static/scripts/release/components/MediumTable.js
+++ b/root/static/scripts/release/components/MediumTable.js
@@ -85,8 +85,8 @@ const MediumTable = (React.memo<PropsT>(({
     React.useState(false);
 
   const showArtists = React.useMemo(
-    () => mediumHasMultipleArtists(release, medium),
-    [release, medium],
+    () => mediumHasMultipleArtists(release, tracks),
+    [release, tracks],
   );
 
   const loadedTrackCount = (tracks?.length) ?? 0;

--- a/root/utility/mediumHasMultipleArtists.js
+++ b/root/utility/mediumHasMultipleArtists.js
@@ -9,9 +9,8 @@
 
 export default function mediumHasMultipleArtists(
   release: ReleaseT,
-  medium: MediumT,
+  tracks: ?$ReadOnlyArray<TrackT>,
 ): boolean {
-  const tracks = medium.tracks;
   if (!tracks || !tracks.length) {
     return false;
   }


### PR DESCRIPTION
It's intended that we don't store or modify the medium itself in state, as this would lead to a lot of unnecessary updates due to how `React.memo` works.  We try to keep object references the same at all costs and only store the bits of information that actually change in state.

We weren't following this correctly with the `mediumHasMultipleArtists` call.  It was memoized based on the medium, but that reference doesn't change.  The tracks do, so modify the function to accept tracks and memoize based on that reference instead.