### PR TITLE
MBS-11782: Hide more irrelevant work rels from release's bottom credits

### DIFF
--- a/root/components/GroupedTrackRelationships.js
+++ b/root/components/GroupedTrackRelationships.js
@@ -91,7 +91,9 @@ const irrelevantLinkTypes = new Map([
   [350, false], // arrangements
 ]);
 
-function isIrrelevantLinkType(relationship) {
+export function isIrrelevantLinkType(
+  relationship: RelationshipT,
+): boolean {
   return irrelevantLinkTypes.get(relationship.linkTypeID) ===
     relationship.backward;
 }

--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -9,6 +9,8 @@
 
 import * as React from 'react';
 
+import {isIrrelevantLinkType}
+  from '../../../../components/GroupedTrackRelationships';
 import Relationships from '../../../../components/Relationships';
 import StaticRelationshipsDisplay
   from '../../../../components/StaticRelationshipsDisplay';
@@ -152,7 +154,9 @@ function getCombinedTrackRelationships(
           const workRelationships = target.relationships;
           if (workRelationships) {
             for (const workRelationship of workRelationships) {
-              pushRelationship(workRelationship, track);
+              if (!isIrrelevantLinkType(workRelationship)) {
+                pushRelationship(workRelationship, track);
+              }
             }
           }
         }


### PR DESCRIPTION
### Implement MBS-11782

Expands MBS-9419 to also work with a release's bottom credits. Worth keeping in mind that there is another big difference this doesn't yet deal with - bottom credits display URL rels, while inline ones do not. Not sure whether those are desired or should also be dropped.