### PR TITLE
MBS-6140: Allow (recording|work)-level-rels for release browse

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -28,7 +28,8 @@ my $ws_defs = Data::OptList::mkopt([
                                           collection) ],
                          inc      => [ qw(aliases artist-credits labels recordings discids
                                           tags user-tags genres user-genres ratings user-ratings
-                                          release-groups media _relations annotation) ],
+                                          release-groups media recording-level-rels
+                                          work-level-rels _relations annotation) ],
                          optional => [ qw(fmt limit offset) ],
      },
      release => {

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/BrowseRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/BrowseRelease.pm
@@ -382,6 +382,102 @@ ws_test 'browse releases via recording',
     </release-list>
 </metadata>';
 
+ws_test 'browse releases via recording, with recording and work rels',
+    '/release?inc=recordings+artist-rels+work-rels+recording-level-rels+work-level-rels&status=official&recording=c43ee188-0049-4eec-ba2e-0385c5edd2db' =>
+    '<?xml version="1.0" ?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <release-list count="1">
+        <release id="ec0d0122-b559-4aa1-a017-7068814aae57">
+            <title>Soup</title>
+            <status id="4e304316-386d-3409-af2e-78857eec5cfe">Official</status>
+            <quality>normal</quality>
+            <text-representation>
+                <language>eng</language>
+                <script>Latn</script>
+            </text-representation>
+            <barcode>0208311348266</barcode>
+            <cover-art-archive>
+                <artwork>false</artwork>
+                <count>0</count>
+                <front>false</front>
+                <back>false</back>
+            </cover-art-archive>
+            <medium-list count="1">
+                <medium>
+                    <position>1</position>
+                    <format id="9712d52a-4509-3d4b-a1a2-67c88c643e31">CD</format>
+                    <pregap id="1a0ba71b-fb23-3931-a426-cd204a82a90e">
+                        <position>0</position>
+                        <number>0</number>
+                        <length>128000</length>
+                        <recording id="c0beb80b-4185-4328-8761-b9e45a5d0ac6">
+                            <title>Hello Goodbye [hidden track]</title>
+                            <length>128000</length>
+                            <relation-list target-type="work">
+                                <relation type="performance" type-id="a3005666-a872-32c3-ad06-98af558e99b0">
+                                    <target>c473ece7-4858-3f4f-9d7a-a1e026400888</target>
+                                    <direction>forward</direction>
+                                    <work id="c473ece7-4858-3f4f-9d7a-a1e026400888">
+                                        <title>Hello Goodbye</title>
+                                        <language>eng</language>
+                                        <language-list>
+                                            <language>eng</language>
+                                        </language-list>
+                                        <relation-list target-type="artist">
+                                            <relation type="composer" type-id="d59d99ea-23d4-4a80-b066-edca32ee158f">
+                                                <target>38c5cdab-5d6d-43d1-85b0-dac41bde186e</target>
+                                                <direction>backward</direction>
+                                                <artist id="38c5cdab-5d6d-43d1-85b0-dac41bde186e" type="Group" type-id="e431f5f6-b5d2-343d-8b36-72607fffb74b">
+                                                    <name>Blind Melon</name>
+                                                    <sort-name>Blind Melon</sort-name>
+                                                </artist>
+                                            </relation>
+                                        </relation-list>
+                                    </work>
+                                </relation>
+                            </relation-list>
+                        </recording>
+                    </pregap>
+                    <track-list count="2" offset="0">
+                    <track id="7b84af2d-96b3-3c50-a667-e7d10e8b000d">
+                        <position>1</position>
+                        <number>1</number>
+                        <title>Galaxie</title>
+                        <length>211133</length>
+                        <recording id="c43ee188-0049-4eec-ba2e-0385c5edd2db">
+                            <title>Hello Goodbye / Galaxie</title>
+                            <length>211133</length>
+                            <relation-list target-type="artist">
+                                <relation type-id="59054b12-01ac-43ee-a618-285fd397e461" type="instrument">
+                                <target>05d83760-08b5-42bb-a8d7-00d80b3bf47c</target>
+                                <direction>backward</direction>
+                                <attribute-list>
+                                    <attribute credited-as="crazy guitar" type-id="63021302-86cd-4aee-80df-2270d54f4978">guitar</attribute>
+                                </attribute-list>
+                                <artist id="05d83760-08b5-42bb-a8d7-00d80b3bf47c" type="Person" type-id="b6e035f4-3ce9-331c-97df-83397230b0df">
+                                    <name>Paul Allgood</name>
+                                    <sort-name>Allgood, Paul</sort-name>
+                                </artist>
+                                </relation>
+                            </relation-list>
+                        </recording>
+                    </track>
+                    <track id="e9f7ca98-ba9d-3276-97a4-26475c9f4527">
+                        <position>2</position>
+                        <number>2</number>
+                        <length>240400</length>
+                        <recording id="c830c239-3f91-4485-9577-4b86f92ad725">
+                            <title>2 X 4</title>
+                            <length>240400</length>
+                        </recording>
+                    </track>
+                    </track-list>
+                </medium>
+            </medium-list>
+        </release>
+    </release-list>
+</metadata>';
+
 ws_test 'browse releases via track artist, including RGs and ratings',
     '/release?track_artist=a16d1433-ba89-4f72-a47b-a370add0bb55&inc=release-groups+ratings' =>
     '<?xml version="1.0"?>

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/BrowseReleases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/BrowseReleases.pm
@@ -259,110 +259,162 @@ test  'browse releases via release group' => sub {
         };
 };
 
-test 'browse releases via recording' => sub {
+test 'browse releases via recording, with recording rels' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
 
-    ws_test_json 'browse releases via recording',
-    '/release?inc=labels&status=official&recording=0c0245df-34f0-416b-8c3f-f20f66e116d0' =>
+    ws_test_json 'browse releases via recording, with recording and work rels',
+    '/release?inc=recordings+artist-rels+work-rels+recording-level-rels+work-level-rels&status=official&recording=c43ee188-0049-4eec-ba2e-0385c5edd2db' =>
         {
-            'release-count' => 2,
+            'release-count' => 1,
             'release-offset' => 0,
-            releases => [
-                {
-                    id => '28fc2337-985b-3da9-ac40-ad6f28ff0d8e',
-                    title => 'LOVE & HONESTY',
-                    status => 'Official',
-                    'status-id' => '4e304316-386d-3409-af2e-78857eec5cfe',
-                    quality => 'normal',
-                    'text-representation' => { language => 'jpn', script => 'Jpan' },
-                    'cover-art-archive' => {
-                        artwork => JSON::false,
-                        count => 0,
-                        front => JSON::false,
-                        back => JSON::false,
-                        darkened => JSON::false,
-                    },
-                    date => '2004-01-15',
-                    country => 'JP',
-                    'release-events' => [{
-                        date => '2004-01-15',
-                        'area' => {
-                            disambiguation => '',
-                            'id' => '2db42837-c832-3c27-b4a3-08198f75693c',
-                            'name' => 'Japan',
-                            'sort-name' => 'Japan',
-                            'iso-3166-1-codes' => ['JP'],
-                            'type' => JSON::null,
-                            'type-id' => JSON::null,
-                        },
-                    }],
-                    barcode => '4988064173891',
-                    asin => 'B0000YGBSG',
-                    'label-info' => [
-                        {
-                            'catalog-number' => 'AVCD-17389',
-                            label => {
-                                id => '168f48c8-057e-4974-9600-aa9956d21e1a',
-                                name => 'avex trax',
-                                'sort-name' => 'avex trax',
-                                'label-code' => JSON::null,
-                                disambiguation => '',
-                                'type' => 'Original Production',
-                                'type-id' => '7aaa37fe-2def-3476-b359-80245850062d',
-                            }
-                        }],
-                    disambiguation => '',
-                    packaging => JSON::null,
-                    'packaging-id' => JSON::null,
+            releases => [{
+                asin => undef,
+                barcode => '0208311348266',
+                'cover-art-archive' => {
+                    artwork => JSON::false,
+                    back => JSON::false,
+                    count => 0,
+                    darkened => JSON::false,
+                    front => JSON::false
                 },
-                {
-                    id => 'cacc586f-c2f2-49db-8534-6f44b55196f2',
-                    title => 'LOVE & HONESTY',
-                    status => 'Official',
-                    'status-id' => '4e304316-386d-3409-af2e-78857eec5cfe',
-                    quality => 'normal',
-                    'text-representation' => { language => 'jpn', script => 'Jpan' },
-                    'cover-art-archive' => {
-                        artwork => JSON::false,
-                        count => 0,
-                        front => JSON::false,
-                        back => JSON::false,
-                        darkened => JSON::false,
-                    },
-                    date => '2004-01-15',
-                    country => 'JP',
-                    'release-events' => [{
-                        date => '2004-01-15',
-                        'area' => {
+                disambiguation => '',
+                id => 'ec0d0122-b559-4aa1-a017-7068814aae57',
+                media => [ {
+                    format => 'CD',
+                    'format-id' => '9712d52a-4509-3d4b-a1a2-67c88c643e31',
+                    title => '',
+                    'track-count' => 2,
+                    'track-offset' => 0,
+                    position => 1,
+                    pregap => {
+                        id => '1a0ba71b-fb23-3931-a426-cd204a82a90e',
+                        title => 'Hello Goodbye [hidden track]',
+                        length => 128000,
+                        position => 0,
+                        number => '0',
+                        recording => {
+                            id => 'c0beb80b-4185-4328-8761-b9e45a5d0ac6',
+                            title => 'Hello Goodbye [hidden track]',
                             disambiguation => '',
-                            'id' => '2db42837-c832-3c27-b4a3-08198f75693c',
-                            'name' => 'Japan',
-                            'sort-name' => 'Japan',
-                            'iso-3166-1-codes' => ['JP'],
-                            'type' => JSON::null,
-                            'type-id' => JSON::null,
-                        },
-                    }],
-                    barcode => '4988064173907',
-                    asin => 'B0000YG9NS',
-                    'label-info' => [
+                            length => 128000,
+                            video => JSON::false,
+                            relations => [{
+                                begin => JSON::null,
+                                attributes => [],
+                                'attribute-ids' => {},
+                                'attribute-values' => {},
+                                type => 'performance',
+                                direction => 'forward',
+                                'type-id' => 'a3005666-a872-32c3-ad06-98af558e99b0',
+                                ended => JSON::false,
+                                'source-credit' => '',
+                                'target-credit' => '',
+                                end => JSON::null,
+                                work => {
+                                    id => 'c473ece7-4858-3f4f-9d7a-a1e026400888',
+                                    attributes => [],
+                                    iswcs => [],
+                                    language => 'eng',
+                                    languages => ['eng'],
+                                    disambiguation => '',
+                                    title => 'Hello Goodbye',
+                                    'type' => JSON::null,
+                                    'type-id' => JSON::null,
+                                    relations => [{
+                                        begin => JSON::null,
+                                        attributes => [],
+                                        'attribute-ids' => {},
+                                        'attribute-values' => {},
+                                        type => 'composer',
+                                        direction => 'backward',
+                                        'type-id' => 'd59d99ea-23d4-4a80-b066-edca32ee158f',
+                                        ended => JSON::false,
+                                        'source-credit' => '',
+                                        'target-credit' => '',
+                                        end => JSON::null,
+                                        artist => {
+                                            id => '38c5cdab-5d6d-43d1-85b0-dac41bde186e',
+                                            'sort-name' => 'Blind Melon',
+                                            disambiguation => '',
+                                            name => 'Blind Melon',
+                                            'type' => 'Group',
+                                            'type-id' => 'e431f5f6-b5d2-343d-8b36-72607fffb74b',
+                                        },
+                                        'target-type' => 'artist',
+                                    }],
+                                },
+                                'target-type' => 'work',
+                            }],
+                        }
+                    },
+                    tracks => [
                         {
-                            'catalog-number' => 'AVCD-17390',
-                            label => {
-                                id => '168f48c8-057e-4974-9600-aa9956d21e1a',
-                                name => 'avex trax',
-                                'sort-name' => 'avex trax',
-                                'label-code' => JSON::null,
+                            id => '7b84af2d-96b3-3c50-a667-e7d10e8b000d',
+                            title => 'Galaxie',
+                            length => 211133,
+                            position => 1,
+                            number => '1',
+                            recording => {
+                                id => 'c43ee188-0049-4eec-ba2e-0385c5edd2db',
+                                title => 'Hello Goodbye / Galaxie',
                                 disambiguation => '',
-                                'type' => 'Original Production',
-                                'type-id' => '7aaa37fe-2def-3476-b359-80245850062d',
+                                length => 211133,
+                                video => JSON::false,
+                                relations => [{
+                                    begin => JSON::null,
+                                    attributes => ['guitar'],
+                                    type => 'instrument',
+                                    direction => 'backward',
+                                    'type-id' => '59054b12-01ac-43ee-a618-285fd397e461',
+                                    ended => JSON::false,
+                                    'attribute-credits' => {'guitar' => 'crazy guitar'},
+                                    'attribute-ids' => {'guitar' => '63021302-86cd-4aee-80df-2270d54f4978'},
+                                    'attribute-values' => {},
+                                    'source-credit' => '',
+                                    'target-credit' => '',
+                                    end => JSON::null,
+                                    artist => {
+                                        id => '05d83760-08b5-42bb-a8d7-00d80b3bf47c',
+                                        'sort-name' => 'Allgood, Paul',
+                                        disambiguation => '',
+                                        name => 'Paul Allgood',
+                                        'type' => 'Person',
+                                        'type-id' => 'b6e035f4-3ce9-331c-97df-83397230b0df',
+                                    },
+                                    'target-type' => 'artist',
+                                }],
                             }
-                        }],
-                    disambiguation => '',
-                    packaging => JSON::null,
-                    'packaging-id' => JSON::null,
-                }]
+                        },
+                        {
+                            id => 'e9f7ca98-ba9d-3276-97a4-26475c9f4527',
+                            title => '2 X 4',
+                            length => 240400,
+                            position => 2,
+                            number => '2',
+                            recording => {
+                                id => 'c830c239-3f91-4485-9577-4b86f92ad725',
+                                title => '2 X 4',
+                                disambiguation => '',
+                                length => 240400,
+                                video => JSON::false,
+                                relations => [],
+                            }
+                        }
+                    ]
+                } ],
+                packaging => JSON::null,
+                'packaging-id' => JSON::null,
+                quality => 'normal',
+                status => 'Official',
+                'status-id' => '4e304316-386d-3409-af2e-78857eec5cfe',
+                'text-representation' => {
+                    language => 'eng',
+                    script => 'Latn'
+                },
+                title => 'Soup',
+                relations => [],
+            }],
         };
 };
 

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -1000,8 +1000,9 @@ INSERT INTO work (comment, edits_pending, gid, id, last_updated, name, type) VAL
 INSERT INTO work (comment, edits_pending, gid, id, last_updated, name, type) VALUES ('', 0, '511f5124-c0ae-3386-bb76-4b6521498a68', 3622832, NULL, 'Milky Way-君の歌-', NULL);
 INSERT INTO work (comment, edits_pending, gid, id, last_updated, name, type) VALUES ('', 0, 'd132b1b7-3432-38e1-9e2d-5e5fa319fe8a', 211564, NULL, 'Let Forever Be', NULL);
 INSERT INTO work (comment, edits_pending, gid, id, last_updated, name, type) VALUES ('', 0, 'c473ece7-4858-3f4f-9d7a-a1e026400887', 2726277, NULL, 'Asleep From Day', NULL);
+INSERT INTO work (comment, edits_pending, gid, id, last_updated, name, type) VALUES ('', 0, 'c473ece7-4858-3f4f-9d7a-a1e026400888', 2726288, NULL, 'Hello Goodbye', NULL);
 
-INSERT INTO work_language (work, language) VALUES (7905446, 198), (4223059, 198);
+INSERT INTO work_language (work, language) VALUES (7905446, 198), (4223059, 198), (2726288, 120);
 
 UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 7905446;
 UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 4223059;
@@ -1052,6 +1053,7 @@ UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 3584196;
 UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 3622832;
 UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 211564;
 UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 2726277;
+UPDATE work_meta SET rating_count = NULL, rating = NULL WHERE id = 2726288;
 
 -- Tags
 INSERT INTO tag (id, name, ref_count) VALUES (1, 'trip-hop', 586);
@@ -1612,6 +1614,7 @@ INSERT INTO l_artist_recording (edits_pending, entity0, entity1, id, last_update
 INSERT INTO l_artist_recording (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 11545, 1542690, 515106, '2011-01-18 15:56:00.408782+00', 12281);
 INSERT INTO l_artist_recording (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 11545, 1542691, 515107, '2011-01-18 15:56:00.408782+00', 12281);
 INSERT INTO l_artist_recording (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 283833, 2726274, 515108, '2011-01-18 15:56:00.408782+00', 12282);
+INSERT INTO l_artist_recording (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 398598, 449989, 515109, '2011-01-18 15:56:00.408782+00', 12282);
 
 INSERT INTO l_artist_release (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 398598, 459740, 79005, '2011-01-18 15:52:02.917556+00', 1956);
 INSERT INTO l_artist_release (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 11545, 24752, 219815, '2011-01-18 15:52:02.917556+00', 34);
@@ -1643,6 +1646,7 @@ INSERT INTO l_artist_url (edits_pending, entity0, entity1, id, last_updated, lin
 INSERT INTO l_artist_url (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 427385, 670180, 36870, '2011-01-18 16:23:37.789736+00', 22998);
 
 INSERT INTO l_artist_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 427385, 7905446, 1117124, '2013-04-02 17:42:38.063723+00', 1123780);
+INSERT INTO l_artist_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 305, 2726288, 1117125, '2013-04-02 17:42:38.063723+00', 1123780);
 
 INSERT INTO l_recording_recording (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 4223059, 4223061, 37160, '2011-01-18 15:56:00.408782+00', 23805);
 
@@ -1697,6 +1701,7 @@ INSERT INTO l_recording_work (edits_pending, entity0, entity1, id, last_updated,
 INSERT INTO l_recording_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 3584196, 3622832, 99903, '2011-01-18 16:15:33.876477+00', 23865);
 INSERT INTO l_recording_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 2726275, 211564, 8120, '2011-01-18 16:15:33.876477+00', 23865);
 INSERT INTO l_recording_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 2726277, 2726277, 230405, '2011-01-18 16:15:33.876477+00', 23865);
+INSERT INTO l_recording_work (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 14488617, 2726288, 230406, '2011-01-18 16:15:33.876477+00', 23865);
 
 INSERT INTO l_release_group_url (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 403214, 615313, 4356, '2011-01-18 16:23:37.789736+00', 6067);
 INSERT INTO l_release_group_url (edits_pending, entity0, entity1, id, last_updated, link) VALUES (0, 403214, 615327, 4613, '2011-01-18 16:23:37.789736+00', 6067);


### PR DESCRIPTION
### Implement MBS-6140

I can see no reason why we would prefer users to make one extra call per release rather than requesting this via browse when they need it. Recording already supports work-level-rels in browse, too, so this adds consistency.

Added tests too.