### PR TITLE
MBS-11793: Don't fetch Wikipedia abstract when URL is ended

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/WikipediaExtract.pm
@@ -42,8 +42,9 @@ sub _get_extract
             elsif ($_->target->isa('MusicBrainz::Server::Entity::URL::Wikidata')) { 1; }
             else { 0; }
         } grep {
-            $_->target->isa('MusicBrainz::Server::Entity::URL::Wikipedia') ||
-            $_->target->isa('MusicBrainz::Server::Entity::URL::Wikidata')
+            !$_->link->{ended} &&
+            ($_->target->isa('MusicBrainz::Server::Entity::URL::Wikipedia') ||
+             $_->target->isa('MusicBrainz::Server::Entity::URL::Wikidata'))
         } @{ $entity->relationships_by_link_type_names('wikipedia', 'wikidata') };
 
     if (scalar @links) {


### PR DESCRIPTION
### Fix MBS-11793

Obviously, if someone has marked a relationship as ended then we shouldn't be using that relationship to display an abstract - either it will not show anything, or it will show the wrong thing.