### PR TITLE
MBS-11798: Disallow Instagram internal links

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2138,6 +2138,22 @@ const CLEANUPS = {
               target: ERROR_TARGETS.URL,
             };
           }
+          if ([
+            'accounts',
+            'accounts_center',
+            'direct',
+            'email',
+            'push',
+            'session',
+          ].includes(prefix)) {
+            return {
+              error: l(
+                `This is an internal Instagram page and should not be added.`,
+              ),
+              result: false,
+              target: ERROR_TARGETS.URL,
+            };
+          }
           return {
             result: /^(?!(?:explore|p|stories|tv)$)/.test(prefix) &&
               target === undefined,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2052,6 +2052,13 @@ const testData = [
             expected_clean_url: 'https://www.instagram.com/explore/locations/277133756/pacha-club-ibiza/',
        only_valid_entity_types: [],
   },
+  {
+                     input_url: 'https://www.instagram.com/accounts/edit',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.instagram.com/accounts/',
+       only_valid_entity_types: [],
+  },
   // Irish Traditional Music Tune Index (Alan Ng's Tunography)
   {
                      input_url: 'https://www.irishtune.info/album/MCnnly/#',


### PR DESCRIPTION
### Implement MBS-11798

The ticket specifically asked to disable /accounts which seems to have gotten added a bunch of times. Just in case I'm also disabled a few other internal links that I found with a quick check.