### PR TITLE
MBS-11802: Add mock LinkType for examples

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
@@ -181,7 +181,11 @@ sub build_display_data {
                                             end_date => MusicBrainz::Server::Entity::PartialDate->new(
                                                 $rel->{link}{end_date}
                                             ),
-                                            type => $loaded->{LinkType}{ $self->data->{link_id} },
+                                            type => $display_data->{link_type} //
+                                                    LinkType->new(
+                                                        id => $self->data->{link_id},
+                                                        name => $self->data->{new}{name}
+                                                    ),
                                         )
                                 )
                         )


### PR DESCRIPTION
### Fix MBS-11802

While the edit itself does not require a LinkType to exist (in the case of removed link types), the examples do. This adds a mock LinkType for that purpose.
