### PR TITLE
MBS-11806: Don't group relationships for different track sets

### DIFF
--- a/root/utility/groupRelationships.js
+++ b/root/utility/groupRelationships.js
@@ -114,14 +114,25 @@ const areDatedExtraAttributesEqual = (a, b) => (
   arraysEqual(a.attributes, b.attributes, areLinkAttrsEqual)
 );
 
-const areRelationshipTargetGroupsEqual = (a, b) => (
-  a.key === b.key &&
-  arraysEqual(
-    a.datedExtraAttributesList,
-    b.datedExtraAttributesList,
-    areDatedExtraAttributesEqual,
-  )
-);
+const areRelationshipTargetGroupsEqual = (a, b) => {
+  const aTracks = a.tracks;
+  const bTracks = b.tracks;
+
+  return (
+    a.key === b.key &&
+    arraysEqual(
+      a.datedExtraAttributesList,
+      b.datedExtraAttributesList,
+      areDatedExtraAttributesEqual,
+    ) &&
+    (aTracks && bTracks)
+      ? arraysEqual(
+        Array.from(aTracks),
+        Array.from(bTracks),
+        (a, b) => a === b,
+      ) : true
+  );
+};
 
 function displayLinkPhrase(linkTypeInfo) {
   const phrase = linkTypeInfo.phrase;


### PR DESCRIPTION
### Fix MBS-11806

As far as I can tell, this code was written for relationships that apply to one entity only (one recording, one release...). As such, there was never a need to check for more than "are the rels related, and are the attributes the same".
But this now also used for grouped display of medium relationships under a release, and that involves relationships from different tracks. Nothing in the code checked whether the tracks actually matched before they got combined - one of the sets of tracks
would just get dropped when combining the two relationship groups. This now makes sure that the tracks also match, if they exist, before allowing a merged display of the relationship.
