### PR TITLE
MBS-11811: Do not batch-change track data for collapsed media

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -498,7 +498,7 @@
   <!-- /ko -->
 
   <!-- ko if: mediums() && mediums().length -->
-    <div data-bind="guessCase: $root.guessCaseMediaNames.bind($data)">
+    <div data-bind="guessCase: $root.guessCaseAllMedia.bind($data)">
       [% guesscase(show_icon=1) %]
     </div>
   <!-- /ko -->

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -130,7 +130,9 @@ const actions = {
   guessCaseAllMedia: function () {
     for (const medium of this.mediums.peek()) {
       releaseEditor.guessCaseMediumName(medium);
-      releaseEditor.guessCaseTrackNames(medium);
+      if (!medium.collapsed.peek()) {
+        releaseEditor.guessCaseTrackNames(medium);
+      }
     }
   },
 

--- a/root/static/scripts/release-editor/actions.js
+++ b/root/static/scripts/release-editor/actions.js
@@ -127,7 +127,7 @@ const actions = {
     }
   },
 
-  guessCaseMediaNames: function () {
+  guessCaseAllMedia: function () {
     for (const medium of this.mediums.peek()) {
       releaseEditor.guessCaseMediumName(medium);
       releaseEditor.guessCaseTrackNames(medium);

--- a/root/static/scripts/release-editor/bindingHandlers.js
+++ b/root/static/scripts/release-editor/bindingHandlers.js
@@ -99,6 +99,7 @@ ko.bindingHandlers.artistCreditEditor = {
     const artistCredit = track.artistCredit.peek();
 
     track.medium.release.mediums()
+      .filter(m => !m.collapsed.peek())
       .flatMap(m => m.tracks())
       .forEach(function (t) {
         if (t === track) {


### PR DESCRIPTION
### Implement MBS-11811

Even when a user has closed (collapsed) a certain medium in the release editor, running a batch-change action such as global guess case or changing all matching artist credits still changes the track data for that medium. This can be very confusing, since the editor does not see the changes at all unless they either reopen the medium or pay close attention to the edit previews on the Edit Note tab.

As such, this changes the way those calls work so that they will ignore any medium that is collapsed at the time
the change is made. This was already the case for media which were never expanded in the first place, although that's only because there were no loaded tracks to modify. This only added to the confusion, since there is no good way to see at a glance whether a medium has been loaded and then closed or has never been loaded.

Tested manually with `release/a6ea3af6-e215-4251-81bc-b851665e3658` (`pink` data).