### PR TITLE
MBS-11808: Don't show tags in lists where vote count < 1

### DIFF
--- a/lib/MusicBrainz/Server/Data/EntityTag.pm
+++ b/lib/MusicBrainz/Server/Data/EntityTag.pm
@@ -464,6 +464,7 @@ sub find_entities
                  FROM " . $self->parent->_table . "
                      JOIN $tag_table tt ON " . $self->parent->_id_column . " = tt.$type
                  WHERE tag = ?
+                 AND tt.count > 0
                  ORDER BY tt.count DESC, $ordering_condition, " . $self->parent->_id_column;
     $self->query_to_list_limited($query, [$tag_id], $limit, $offset, sub {
         my ($model, $row) = @_;


### PR DESCRIPTION
### Implement MBS-11808

For the general (not user-based) tag lists, there is no reason to show entities where the tag has a global count of 0 or less. That literally means the community *disagrees* that this tag applies to that entity.
