### PR TITLE
MBS-11828 / MBS-9426: UI to find and unlock locked usernames

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -5,6 +5,7 @@ use Try::Tiny;
 BEGIN { extends 'MusicBrainz::Server::Controller' };
 
 use MusicBrainz::Server::Translation qw(l ln );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 
 sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves SecureForm
 {
@@ -198,6 +199,42 @@ sub ip_lookup : Path('/admin/ip-lookup') Args(1) RequireAuth(account_admin) Hidd
         component_props => {
             ipHash => $ip_hash,
             users => [map { $c->unsanitized_editor_json($_) } @users],
+        },
+    );
+}
+
+sub locked_username_search : Path('/admin/locked-usernames/search') Args(0) RequireAuth(account_admin) HiddenOnSlaves {
+    my ($self, $c) = @_;
+
+    my $form = $c->form(form => 'Admin::LockedUsernameSearch');
+    my @results;
+    my $show_results = 0;
+
+    if ($c->form_posted_and_valid($form, $c->req->body_params)) {
+        try {
+            @results = $c->model('Editor')->search_old_editor_names(
+                $form->field('username')->value // '',
+                $form->field('use_regular_expression')->value,
+            );
+            $show_results = 1;
+        } catch {
+            my $error = $_;
+            if ("$error" =~ m/invalid regular expression/) {
+                $form->field('username')->add_error(l('Invalid regular expression.'));
+                $c->response->status(400);
+            } else {
+                die $error;
+            }
+        };
+    }
+
+    $c->stash(
+        current_view => 'Node',
+        component_path => 'admin/LockedUsernameSearch',
+        component_props => {
+            form => $form->TO_JSON,
+            @results ? (results => \@results) : (),
+            showResults => boolean_to_json($show_results),
         },
     );
 }

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -239,6 +239,28 @@ sub locked_username_search : Path('/admin/locked-usernames/search') Args(0) Requ
     );
 }
 
+sub unlock_username : Path('/admin/locked-usernames/unlock') Args(1) RequireAuth(account_admin) HiddenOnSlaves {
+    my ($self, $c, $username) = @_;
+
+    my $form = $c->form(form => 'SecureConfirm');
+
+    if ($c->form_posted_and_valid($form)) {
+        $c->model('MB')->with_transaction(sub {
+            $c->model('Editor')->unlock_old_editor_name($username);
+        });
+        $c->response->redirect($c->uri_for_action('/admin/locked_username_search'));
+    }
+
+    $c->stash(
+        current_view => 'Node',
+        component_path => 'admin/LockedUsernameUnlock',
+        component_props => {
+            form => $form->TO_JSON,
+            username => $username,
+        },
+    );
+}
+
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -274,6 +274,14 @@ sub search_old_editor_names {
     @{ $self->sql->select_single_column_array($query, $name) };
 }
 
+sub unlock_old_editor_name {
+    my ($self, $name) = @_;
+
+    my $query = "DELETE FROM old_editor_name WHERE name = ?";
+
+    $self->sql->do($query, $name);
+}
+
 sub update_email
 {
     my ($self, $editor, $email) = @_;

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -265,6 +265,15 @@ sub insert
     }, $self->sql);
 }
 
+sub search_old_editor_names {
+    my ($self, $name, $use_regular_expression) = @_;
+
+    my $condition = $use_regular_expression ? "name ~* ?" : "LOWER(name) = LOWER(?)";
+    my $query = "SELECT name FROM old_editor_name WHERE $condition LIMIT 100";
+
+    @{ $self->sql->select_single_column_array($query, $name) };
+}
+
 sub update_email
 {
     my ($self, $editor, $email) = @_;

--- a/lib/MusicBrainz/Server/Form/Admin/LockedUsernameSearch.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/LockedUsernameSearch.pm
@@ -1,0 +1,23 @@
+package MusicBrainz::Server::Form::Admin::LockedUsernameSearch;
+
+use HTML::FormHandler::Moose;
+
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => (default => 'lockedusernamesearch');
+
+has_field 'username' => (type => 'Text');
+has_field 'use_regular_expression' => (type => 'Boolean');
+has_field 'submit' => (type => 'Submit');
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/admin/LockedUsernameSearch.js
+++ b/root/admin/LockedUsernameSearch.js
@@ -14,6 +14,7 @@ import FormRowText from '../components/FormRowText';
 import FormSubmit from '../components/FormSubmit';
 import Layout from '../layout';
 import expand2react from '../static/scripts/common/i18n/expand2react';
+import bracketed from '../static/scripts/common/utility/bracketed';
 
 type Props = {
   +form: FormT<{
@@ -71,7 +72,15 @@ const LockedUsernameSearch = ({
             {results?.length ? (
               <ul>
                 {results.map(result => (
-                  <li key={result}>{result}</li>
+                  <li key={result}>
+                    {result}
+                    {' '}
+                    {bracketed(
+                      <a href={`/admin/locked-usernames/unlock/${result}`}>
+                        {'unlock'}
+                      </a>,
+                    )}
+                  </li>
                 ))}
               </ul>
             ) : (

--- a/root/admin/LockedUsernameSearch.js
+++ b/root/admin/LockedUsernameSearch.js
@@ -1,0 +1,89 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import FormRowCheckbox from '../components/FormRowCheckbox';
+import FormRowText from '../components/FormRowText';
+import FormSubmit from '../components/FormSubmit';
+import Layout from '../layout';
+import expand2react from '../static/scripts/common/i18n/expand2react';
+
+type Props = {
+  +form: FormT<{
+    +use_regular_expression: ReadOnlyFieldT<boolean>,
+    +username: ReadOnlyFieldT<string>,
+  }>,
+  +results?: $ReadOnlyArray<string>,
+  +showResults: boolean,
+};
+
+const LockedUsernameSearch = ({
+  form,
+  results,
+  showResults,
+}: Props): React.Element<typeof Layout> => (
+  <Layout fullWidth title="Search locked usernames">
+    <div id="content">
+      <h1>{'Search locked usernames'}</h1>
+
+      <form action="/admin/locked-usernames/search" method="post">
+        <p>
+          {expand2react(
+            'Enter a username or a {link|POSIX regular expression}.',
+            {
+              link: 'https://www.postgresql.org/docs/12/' +
+                'functions-matching.html#FUNCTIONS-POSIX-REGEXP',
+            },
+          )}
+        </p>
+
+        <FormRowText
+          field={form.field.username}
+          label="Username:"
+          size={50}
+          uncontrolled
+        />
+
+        <FormRowCheckbox
+          field={form.field.use_regular_expression}
+          label="Search using regular expression"
+          uncontrolled
+        />
+
+        <div className="row no-label">
+          <FormSubmit
+            label="Search"
+            name="lockedusernamesearch.submit"
+            value="1"
+          />
+        </div>
+
+        {showResults ? (
+          <>
+            <h3>{'Matching locked names:'}</h3>
+            {results?.length ? (
+              <ul>
+                {results.map(result => (
+                  <li key={result}>{result}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>
+                {'No locked usernames matched your search.'}
+              </p>
+            )}
+          </>
+        ) : null}
+      </form>
+    </div>
+  </Layout>
+);
+
+export default LockedUsernameSearch;

--- a/root/admin/LockedUsernameUnlock.js
+++ b/root/admin/LockedUsernameUnlock.js
@@ -1,0 +1,50 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import FormCsrfToken from '../components/FormCsrfToken';
+import FormSubmit from '../components/FormSubmit';
+import Layout from '../layout';
+import expand2text from '../static/scripts/common/i18n/expand2text';
+
+type Props = {
+  +$c: CatalystContextT,
+  +form: SecureConfirmFormT,
+  +username: string,
+};
+
+const LockedUsernameUnlock = ({
+  $c,
+  form,
+  username,
+}: Props): React.Element<typeof Layout> => (
+  <Layout fullWidth title="Unlock username">
+    <div id="content">
+      <h1>{'Unlock username'}</h1>
+      <p>
+        {expand2text(
+          `Are you sure you wish to unlock
+           the username “{username}” for reuse?`,
+          {username: username},
+        )}
+      </p>
+      <form action={$c.req.uri} method="post" name="confirm">
+        <FormCsrfToken form={form} />
+        <FormSubmit
+          label="Yes, I’m sure"
+          name="confirm.submit"
+          value="1"
+        />
+      </form>
+    </div>
+  </Layout>
+);
+
+export default LockedUsernameUnlock;

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -167,6 +167,11 @@ const AdminMenu = ({user}: UserProp) => (
           <li>
             <a href="/admin/email-search">{l('Email Search')}</a>
           </li>
+          <li>
+            <a href="/admin/locked-usernames/search">
+              {l('Locked Username Search')}
+            </a>
+          </li>
         </>
       ) : null}
     </ul>

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -38,6 +38,7 @@ module.exports = {
   'admin/EditBanner': require('../admin/EditBanner'),
   'admin/EmailSearch': require('../admin/EmailSearch'),
   'admin/IpLookup': require('../admin/IpLookup'),
+  'admin/LockedUsernameSearch': require('../admin/LockedUsernameSearch'),
   'admin/attributes/Attribute': require('../admin/attributes/Attribute'),
   'admin/attributes/CannotRemoveAttribute': require('../admin/attributes/CannotRemoveAttribute'),
   'admin/attributes/Index': require('../admin/attributes/Index'),

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -39,6 +39,7 @@ module.exports = {
   'admin/EmailSearch': require('../admin/EmailSearch'),
   'admin/IpLookup': require('../admin/IpLookup'),
   'admin/LockedUsernameSearch': require('../admin/LockedUsernameSearch'),
+  'admin/LockedUsernameUnlock': require('../admin/LockedUsernameUnlock'),
   'admin/attributes/Attribute': require('../admin/attributes/Attribute'),
   'admin/attributes/CannotRemoveAttribute': require('../admin/attributes/CannotRemoveAttribute'),
   'admin/attributes/Index': require('../admin/attributes/Index'),

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -91,6 +91,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Admin::email_search',
   'Controller::Admin::ip_lookup',
   'Controller::Admin::locked_username_search',
+  'Controller::Admin::unlock_username',
   'Controller::Ajax::filter_artist_recordings_form',
   'Controller::Ajax::filter_artist_release_groups_form',
   'Controller::Ajax::filter_artist_releases_form',

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -90,6 +90,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Admin::edit_user',
   'Controller::Admin::email_search',
   'Controller::Admin::ip_lookup',
+  'Controller::Admin::locked_username_search',
   'Controller::Ajax::filter_artist_recordings_form',
   'Controller::Ajax::filter_artist_release_groups_form',
   'Controller::Ajax::filter_artist_releases_form',


### PR DESCRIPTION
### Implement MBS-11828 / MBS-9426

Tested locally by adding and deleting some accounts, then searching for / unlocking the appropriate usernames.

Search page:
![Screenshot from 2021-08-02 15-43-55](https://user-images.githubusercontent.com/1069224/127863979-3c8afb31-541e-4647-b999-2800647b4eff.png)

Unlock page:
![Screenshot from 2021-08-02 15-44-30](https://user-images.githubusercontent.com/1069224/127864029-e70dc85a-5902-410e-b546-7e9712d2ca5f.png)
