### PR TITLE
MBS-11843: Add report for "Events with annotations"

### DIFF
--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::PagedReport;
 @all = qw(
     ASINsWithMultipleReleases
     AnnotationsArtists
+    AnnotationsEvents
     AnnotationsLabels
     AnnotationsPlaces
     AnnotationsRecordings

--- a/root/report/AnnotationsEvents.js
+++ b/root/report/AnnotationsEvents.js
@@ -1,0 +1,48 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2018 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import {ANNOTATION_REPORT_TEXT} from './constants';
+import EventList from './components/EventList';
+import ReportLayout from './components/ReportLayout';
+import useAnnotationColumns from './hooks/useAnnotationColumns';
+import type {ReportDataT, ReportEventAnnotationT} from './types';
+
+const AnnotationsEvents = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportEventAnnotationT>):
+React.Element<typeof ReportLayout> => {
+  const annotationColumns = useAnnotationColumns<ReportEventAnnotationT>();
+
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l('This report lists events with annotations.')}
+      entityType="event"
+      extraInfo={ANNOTATION_REPORT_TEXT()}
+      filtered={filtered}
+      generated={generated}
+      title={l('Event annotations')}
+      totalEntries={pager.total_entries}
+    >
+      <EventList
+        columnsAfter={annotationColumns}
+        items={items}
+        pager={pager}
+      />
+    </ReportLayout>
+  );
+};
+
+export default AnnotationsEvents;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -139,6 +139,10 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
 
       <ul>
         <ReportsIndexEntry
+          content={l('Events with annotations')}
+          reportName="AnnotationsEvents"
+        />
+        <ReportsIndexEntry
           content={l('Possibly duplicate events')}
           reportName="DuplicateEvents"
         />

--- a/root/report/components/EventList.js
+++ b/root/report/components/EventList.js
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react';
+import type {ColumnOptionsNoValue} from 'react-table';
 
 import PaginatedResults from '../../components/PaginatedResults';
 import Table from '../../components/Table';
@@ -20,15 +21,19 @@ import {
 } from '../../utility/tableColumns';
 import type {ReportEventT} from '../types';
 
-type Props = {
-  +items: $ReadOnlyArray<ReportEventT>,
+type Props<D: {+event: ?EventT, ...}> = {
+  +columnsAfter?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  +columnsBefore?: $ReadOnlyArray<ColumnOptionsNoValue<D>>,
+  +items: $ReadOnlyArray<D>,
   +pager: PagerT,
 };
 
-const EventList = ({
+const EventList = <D: {+event: ?EventT, ...}>({
+  columnsBefore,
+  columnsAfter,
   items,
   pager,
-}: Props): React.Element<typeof PaginatedResults> => {
+}: Props<D>): React.Element<typeof PaginatedResults> => {
   const existingEventItems = items.reduce((result, item) => {
     if (item.event != null) {
       result.push(item);
@@ -73,15 +78,17 @@ const EventList = ({
       });
 
       return [
+        ...(columnsBefore ? [...columnsBefore] : []),
         nameColumn,
         typeColumn,
         artistsColumn,
         locationColumn,
         dateColumn,
         timeColumn,
+        ...(columnsAfter ? [...columnsAfter] : []),
       ];
     },
-    [],
+    [columnsAfter, columnsBefore],
   );
 
   return (

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -94,6 +94,13 @@ export type ReportEditorT = {
   +row_number: number,
 };
 
+export type ReportEventAnnotationT = {
+  ...ReportAnnotationRoleT,
+  +event: ?EventT,
+  +event_id: number,
+  +row_number: number,
+};
+
 export type ReportEventT = {
   +event: ?EventT,
   +event_id: number,

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -149,6 +149,7 @@ module.exports = {
   'release_group/ReleaseGroupIndex': require('../release_group/ReleaseGroupIndex'),
   'release_group/ReleaseGroupMerge': require('../release_group/ReleaseGroupMerge'),
   'report/AnnotationsArtists': require('../report/AnnotationsArtists'),
+  'report/AnnotationsEvents': require('../report/AnnotationsEvents'),
   'report/AnnotationsLabels': require('../report/AnnotationsLabels'),
   'report/AnnotationsPlaces': require('../report/AnnotationsPlaces'),
   'report/AnnotationsRecordings': require('../report/AnnotationsRecordings'),


### PR DESCRIPTION
### Implement MBS-11843

AnnotationReports already supported this, even, but for some reason we didn't have it yet. Not sure how useful these annotation reports actually are, but we should make them consistent at least.