### PR TITLE
MBS-7859: Hide irrelevant recording rels from release view

### DIFF
--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -146,15 +146,21 @@ function getCombinedTrackRelationships(
     const recordingRelationships = recording.relationships;
     if (recordingRelationships) {
       for (const relationship of recordingRelationships) {
-        pushRelationship(relationship, track);
-
         const target = relationship.target;
+
+        if (!isIrrelevantLinkType(
+          relationship, target.entityType,
+        )) {
+          pushRelationship(relationship, track);
+        }
 
         if (target.entityType === 'work') {
           const workRelationships = target.relationships;
           if (workRelationships) {
             for (const workRelationship of workRelationships) {
-              if (!isIrrelevantLinkType(workRelationship)) {
+              if (!isIrrelevantLinkType(
+                workRelationship, target.entityType,
+              )) {
                 pushRelationship(workRelationship, track);
               }
             }


### PR DESCRIPTION
### Implement MBS-7859

Similar to what MBS-9419 did for works, there's a lot of recording relationships that do not really have any relevance to a release display. For example, there's very little use to seeing every recording that mashes up the one on the release (potentially a huge list).

Tested with `release/dcb09143-f938-3381-bd4e-94034cc40d34` and `release/6c3cf9d8-88a8-43ed-850b-55813f01e451` as suggested on the ticket - I think I got all the relationship directions right, but feel free to double/triple check! :) 