### PR TITLE
MBS-11850: Make footer links more visible 

### DIFF
--- a/root/layout.tt
+++ b/root/layout.tt
@@ -107,17 +107,25 @@
            IF c.try_get_session('merger') AND !hide_merge_helper -%]
 
         <div id="footer">
-            <p class="left">
-                <a href="https://metabrainz.org/donate" class="internal">[% l('Donate') %]</a> |
-                <a href="//wiki.musicbrainz.org/" class="internal">[% l('Wiki') %]</a> |
-                <a href="https://community.metabrainz.org/" class="internal">[% l('Forums') %]</a> |
-                <a href="/doc/Communication/IRC" class="internal">[% l('IRC') %]</a> |
-                <a href="http://tickets.metabrainz.org/" class="internal">[% l('Bug Tracker') %]</a> |
-                <a href="https://blog.metabrainz.org/" class="internal">[% l('Blog') %]</a> |
+            <p class="left" id="footer-menu">
+                <a href="https://metabrainz.org/donate" class="internal">[% l('Donate') %]</a>
+                <a href="//wiki.musicbrainz.org/" class="internal">[% l('Wiki') %]</a>
+                <a href="https://community.metabrainz.org/" class="internal">[% l('Forums') %]</a>
+                <a href="/doc/Communication/IRC" class="internal">[% l('IRC') %]</a>
+                <a href="http://tickets.metabrainz.org/" class="internal">[% l('Bug Tracker') %]</a>
+                <a href="https://blog.metabrainz.org/" class="internal">[% l('Blog') %]</a>
                 <a href="https://twitter.com/MusicBrainz" class="internal">[% l('Twitter') %]</a>
-                [%- IF server_details.beta_redirect %] |
+                [%- IF server_details.beta_redirect %]
                 <a href="[% c.uri_for('/set-beta-preference', {returnto => c.relative_uri}) %]" class="internal">[% server_details.is_beta ? l('Stop using beta site') : l('Use beta site') %]</a>
                 [%- END -%]
+            </p>
+
+            <p class="right">
+                [% l('Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and {supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}.',
+                    { MeB  => 'https://metabrainz.org/',
+                      spon => 'https://metabrainz.org/sponsors',
+                      supp => 'https://metabrainz.org/supporters',
+                      caa  => '//coverartarchive.org/' }) %]
                 [% IF server_details.git.branch ~%]
                 <br/>
                     [%~ l('Running: <span class="tooltip" title="{msg}">{branch} ({sha})</span>',
@@ -130,14 +138,6 @@
                 [% l('Last replication packet received at {datetime}',
                      { datetime => UserDate.format(last_replication_date) }) %]
                 [%- END -%]
-            </p>
-
-            <p class="right">
-                [% l('Brought to you by {MeB|MetaBrainz Foundation} and our {spon|sponsors} and {supp|supporters}. Cover Art provided by the {caa|Cover Art Archive}.',
-                    { MeB  => 'https://metabrainz.org/',
-                      spon => 'https://metabrainz.org/sponsors',
-                      supp => 'https://metabrainz.org/supporters',
-                      caa  => '//coverartarchive.org/' }) %]
             </p>
         </div>
     </body>

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -52,8 +52,8 @@ const Footer = (): React.Element<'div'> => {
            {spon|sponsors} and {supp|supporters}. Cover Art provided
            by the {caa|Cover Art Archive}.`,
           {
-            MeB: 'https://metabrainz.org/',
             caa: '//coverartarchive.org/',
+            MeB: 'https://metabrainz.org/',
             spon: 'https://metabrainz.org/sponsors',
             supp: 'https://metabrainz.org/supporters',
           },

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -21,38 +21,43 @@ const Footer = (): React.Element<'div'> => {
   const stash = $c.stash;
   return (
     <div id="footer">
-      <p className="left">
+      <p className="left" id="footer-menu">
         <a className="internal" href={DONATE_URL}>{l('Donate')}</a>
-        {' | '}
         <a className="internal" href="//wiki.musicbrainz.org/">{l('Wiki')}</a>
-        {' | '}
         <a className="internal" href="https://community.metabrainz.org/">{l('Forums')}</a>
-        {' | '}
         <a className="internal" href="/doc/Communication/IRC">
           {l('Chat (IRC)')}
         </a>
-        {' | '}
         <a className="internal" href="http://tickets.metabrainz.org/">{l('Bug Tracker')}</a>
-        {' | '}
         <a className="internal" href="https://blog.metabrainz.org/">{l('Blog')}</a>
-        {' | '}
         <a className="internal" href="https://twitter.com/MusicBrainz">{l('Twitter')}</a>
 
         {DBDefs.BETA_REDIRECT_HOSTNAME ? (
-          <>
-            {' | '}
-            <a
-              className="internal"
-              href={
-                '/set-beta-preference?' + returnToCurrentPage($c)
-              }
-            >
-              {DBDefs.IS_BETA
-                ? l('Stop using beta site')
-                : l('Use beta site')}
-            </a>
-          </>
+          <a
+            className="internal"
+            href={
+              '/set-beta-preference?' + returnToCurrentPage($c)
+            }
+          >
+            {DBDefs.IS_BETA
+              ? l('Stop using beta site')
+              : l('Use beta site')}
+          </a>
         ) : null}
+      </p>
+
+      <p className="right">
+        {exp.l(
+          `Brought to you by {MeB|MetaBrainz Foundation} and our
+           {spon|sponsors} and {supp|supporters}. Cover Art provided
+           by the {caa|Cover Art Archive}.`,
+          {
+            MeB: 'https://metabrainz.org/',
+            caa: '//coverartarchive.org/',
+            spon: 'https://metabrainz.org/sponsors',
+            supp: 'https://metabrainz.org/supporters',
+          },
+        )}
 
         {DBDefs.DB_STAGING_SERVER && DBDefs.GIT_BRANCH ? (
           <>
@@ -83,20 +88,6 @@ const Footer = (): React.Element<'div'> => {
             })}
           </>
         ) : null}
-      </p>
-
-      <p className="right">
-        {exp.l(
-          `Brought to you by {MeB|MetaBrainz Foundation} and our
-           {spon|sponsors} and {supp|supporters}. Cover Art provided
-           by the {caa|Cover Art Archive}.`,
-          {
-            MeB: 'https://metabrainz.org/',
-            caa: '//coverartarchive.org/',
-            spon: 'https://metabrainz.org/sponsors',
-            supp: 'https://metabrainz.org/supporters',
-          },
-        )}
       </p>
     </div>
   );

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -531,15 +531,22 @@ div.warning img.warning {
 ** Footer
 */
 #footer {
-    height: 1em;
-    margin: 1em 0;
     padding: 0 1em;
     font-size: @small-text;
     color: @very-dark-text;
 }
 
 #footer a { color: @link-default; }
-#footer a:hover { color: @text-orange; }
+
+#footer #footer-menu a {
+    color: @musicbrainz-purple;
+    padding: 10px 8px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+#footer a:hover,
+#footer #footer-menu a:hover { color: @text-orange; }
 
 #footer p {
     display: inline-block;


### PR DESCRIPTION
### Implement MBS-11850

By following the same general style as in the header menu, adding color, making them bold and adding a bit more space between them, these links will hopefully stand out a bit more.
This also moves all the explanatory text for slaves/staging servers to the right paragraph to let the links stand alone on the left, although that shouldn't be a problem in production anyway.

![screencapture-localhost-5000-2021-08-05-14_17_09](https://user-images.githubusercontent.com/1069224/128342656-2060c12f-0cd7-47be-bcd3-0631d9e305bc.png)

