### PR TITLE
MBS-11848: Add report for releases with Amazon cover art without CAA cover

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithAmazonCoverArt.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithAmazonCoverArt.pm
@@ -1,0 +1,39 @@
+package MusicBrainz::Server::Report::ReleasesWithAmazonCoverArt;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {
+    q(
+        SELECT 
+            r.id AS release_id,
+            row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+        FROM (
+            SELECT release_coverart.id
+            FROM release_coverart
+            WHERE cover_art_url ~ '^https?://.*.images-amazon.com'
+            AND NOT EXISTS (
+                SELECT TRUE FROM cover_art_archive.cover_art ca
+                JOIN cover_art_archive.cover_art_type cat ON ca.id = cat.id
+                WHERE ca.release = release_coverart.id AND cat.type_id = 1
+            )
+          ) rca
+        JOIN release r ON rca.id = r.id 
+        JOIN artist_credit ac ON r.artist_credit = ac.id
+    );
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -80,6 +80,7 @@ use MusicBrainz::Server::PagedReport;
     ReleaseRGDifferentName
     ReleasesSameBarcode
     ReleasesToConvert
+    ReleasesWithAmazonCoverArt
     ReleasesWithCAANoTypes
     ReleasesWithDownloadRelationships
     ReleasesWithEmptyMediums
@@ -173,6 +174,7 @@ use MusicBrainz::Server::Report::ReleaseLabelSameArtist;
 use MusicBrainz::Server::Report::ReleaseRGDifferentName;
 use MusicBrainz::Server::Report::ReleasesToConvert;
 use MusicBrainz::Server::Report::ReleasesSameBarcode;
+use MusicBrainz::Server::Report::ReleasesWithAmazonCoverArt;
 use MusicBrainz::Server::Report::ReleasesWithCAANoTypes;
 use MusicBrainz::Server::Report::ReleasesWithDownloadRelationships;
 use MusicBrainz::Server::Report::ReleasesWithEmptyMediums;

--- a/root/report/ReleasesWithAmazonCoverArt.js
+++ b/root/report/ReleasesWithAmazonCoverArt.js
@@ -1,0 +1,44 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ReleaseList from './components/ReleaseList';
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT, ReportReleaseT} from './types';
+
+const ReleasesWithAmazonCoverArt = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows releases which have cover art from Amazon, but have
+       no front cover in the Cover Art Archive. The use of Amazon art
+       is going to be discontinued eventually, so these releases will lose
+       their front cover unless one is added to the Cover Art Archive.`,
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l(
+      `Releases that have Amazon cover art
+       but no Cover Art Archive front cover`,
+    )}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default ReleasesWithAmazonCoverArt;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -334,6 +334,13 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
         />
         <ReportsIndexEntry
           content={l(
+            `Releases that have Amazon cover art
+             but no Cover Art Archive front cover`,
+          )}
+          reportName="ReleasesWithAmazonCoverArt"
+        />
+        <ReportsIndexEntry
+          content={l(
             `Releases in the Cover Art Archive
              where no cover art piece has types`,
           )}

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -227,6 +227,7 @@ module.exports = {
   'report/ReleasesConflictingDiscIds': require('../report/ReleasesConflictingDiscIds'),
   'report/ReleasesSameBarcode': require('../report/ReleasesSameBarcode'),
   'report/ReleasesToConvert': require('../report/ReleasesToConvert'),
+  'report/ReleasesWithAmazonCoverArt': require('../report/ReleasesWithAmazonCoverArt'),
   'report/ReleasesWithCaaNoTypes': require('../report/ReleasesWithCaaNoTypes'),
   'report/ReleasesWithDownloadRelationships': require('../report/ReleasesWithDownloadRelationships'),
   'report/ReleasesWithEmptyMediums': require('../report/ReleasesWithEmptyMediums'),


### PR DESCRIPTION
### Implement MBS-11848

Since we want to drop Amazon cover art, this will help users ensure the albums they care about keep a front cover.