### PR TITLE
Test loading DBDefs before starting server

### DIFF
--- a/docker/scripts/start_musicbrainz_server.sh
+++ b/docker/scripts/start_musicbrainz_server.sh
@@ -21,6 +21,10 @@ if [ -s "$PID_FILE" ]; then
     fi
 fi
 
+chpst -u musicbrainz:musicbrainz \
+    carton exec -- ./script/dbdefs_exists \
+    || exit $?
+
 exec chpst -u musicbrainz:musicbrainz \
     carton exec -- \
         start_server --port 5000 --pid-file "$PID_FILE" -- \

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -144,6 +144,7 @@ copy_mb(``admin/ admin/'')
 copy_mb(``app.psgi entities.json ./'')
 copy_mb(``bin/ bin/'')
 copy_mb(``lib/ lib/'')
+copy_mb(``script/functions.sh script/dbdefs_exists script/'')
 copy_mb(``script/functions.sh script/git_info script/'')')
 
 m4_define(

--- a/script/dbdefs_exists
+++ b/script/dbdefs_exists
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+
+use utf8;
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use DBDefs;
+
+print "DBDefs exists\n"


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?

:beginner: Reference related tickets with MBS-XXX at least.
-->

Occasionally a server instance would continuously error, we assume it likely did not start with a valid `lib/DBDefs.pm`. In production, this file is generated from `docker/templatesDBDefs.pm.ctmpl` and a JSON config file using git2consul/consul-agent/consul-template.

It is not clear which of these components is the cause of this problem. The content of the `lib/DBDefs.pm` is not known either, but it isn’t missing or empty. (Different error messages would be thrown then.)

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.

:beginner: If you have a lot to say, be more detailed in this section.
-->

This patch just tries loading DBDefs module before running the server. If the module cannot be loaded, consul-template will try starting a new instance automatically, hopefully using a correct configuration provided by consul-agent in the meantime. It assumes to fix a potential bug with consul-template not restarting the server when erroring continuously.

Disclaimer: This does NOT test anything beyond loading DBDefs module such as: validity of configuration values, connection to the database or any other service.

Impl. note: Server won’t reload `lib/DBDefs.pm` if it changed, so there is no need to check DBDefs all the time while running. Consul is in charge of starting/stopping/restarting the server.

This is probably a naive approach but that might save waiting for someone to restart containers when consul-agent misbehaves.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test script works in an existing container
* [x] Build a test image
* [x] Deploy to test instance
* [x] Check it continues to run under normal conditions
* [x] Test deploying invalid configuration through docker server configs

No idea how to reproduce consul-agent not sending proper values in time though.

Note:  Tests helped with identifying that `lib/DBDefs.pm` was neither missing nor empty at least.