### PR TITLE
MBS-11825: Use same order for art types when editing vs adding

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CoverArtType.pm
+++ b/lib/MusicBrainz/Server/Entity/CoverArtType.pm
@@ -7,6 +7,7 @@ extends 'MusicBrainz::Server::Entity';
 
 with 'MusicBrainz::Server::Entity::Role::OptionsTree' => {
     type => 'CoverArtType',
+    sort_criterion => 'id',
 };
 
 sub entity_type { 'cover_art_type' }


### PR DESCRIPTION
### Implement MBS-11825

The Add Cover Art page currently uses a knockout form that is sorted by ID (notice CoverArtFields is display: none). The Edit Cover Art page uses the CoverArtFields display that is sorted by l_name. This is actually one of the rare cases where an ID sort seems preferable, since that ensures Front, Back and Booklet (the most relevant and common types) are sorted first whatever the language. As such, this forces sort by ID for the CoverArtType OptionsTree.