### PR TITLE
MBS-2221: Add date docs to relationship editor

### DIFF
--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -128,6 +128,9 @@
       <!-- ko if: isBeginDate -->
         <button class="icon copy-date" type="button" title="[% l('Copy to end date') | html %]" data-bind="click: $parent.copyDate"></button>
       <!-- /ko -->
+      <!-- ko if: !isBeginDate -->
+        (<a href="#" data-bind="click: $parent.toggleDatesHelp.bind($parent)">[% l('help') | html %]</a>)
+      <!-- /ko -->
       <div class="error" data-bind="text: $parent.dateError(date)"></div>
       <div class="error" data-bind="text: isBeginDate ? $parent.tooShortBeginYearError() : $parent.tooShortEndYearError()"></div>
     </td>
@@ -172,6 +175,14 @@
           <input type="checkbox" data-bind="checked: relationship().ended, disable: relationship().disableEndedCheckBox" />
           [% l('This relationship has ended.') %]
         </label>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <div class="ar-descr" data-bind="visible: showDatesHelp()">
+          <p>[% l('If you want to set the relationship as happening on one specific date, just set the same end date and start date. You can use the arrow button to copy the begin date to the end date.') %]</p>
+          <p>[% l('If you do not know the end date, but you know the relationship has ended and this seems like useful information to store (for example, if someone is no longer a member of a band), you can indicate it with the checkbox above.') %]</p>
+        </div>
       </td>
     </tr>
   <!-- /ko -->

--- a/root/static/scripts/relationship-editor/common/dialog.js
+++ b/root/static/scripts/relationship-editor/common/dialog.js
@@ -375,6 +375,10 @@ class Dialog {
     relationship.entities(relationship.entities().slice(0).reverse());
   }
 
+  toggleDatesHelp() {
+    this.showDatesHelp(!this.showDatesHelp.peek());
+  }
+
   copyDate(data, event) {
     const dialog = ko.contextFor(event.target).$parent;
     dialog.relationship().end_date.year(data.date.year());
@@ -660,6 +664,7 @@ let _uiSetupDone = false;
 Object.assign(Dialog.prototype, {
   loading: ko.observable(false),
   showAttributesHelp: ko.observable(false),
+  showDatesHelp: ko.observable(false),
   showLinkTypeHelp: ko.observable(false),
 
   uiOptions: {


### PR DESCRIPTION
### Implement MBS-2221

This adds a bit of documentation about how to indicate a relationship happened in one day (or month/year) only and about the ended checkbox.

Only adding it to the relationship editor and not DateRangeFieldset since it seems mostly relationship specific (does not apply much to aliases, for example).

![Screenshot from 2021-08-09 21-28-21](https://user-images.githubusercontent.com/1069224/128755666-8a0ed681-84e7-488a-a500-6b2c9137c7c8.png)
