### PR TITLE
MBS-11862: Do not show deprecated relationship types with 0 uses

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -240,7 +240,7 @@ sub search : Path('/search/edits')
         quality => [ [$QUALITY_LOW => N_l('Low')], [$QUALITY_NORMAL => N_l('Normal')], [$QUALITY_HIGH => N_l('High')], [$QUALITY_UNKNOWN => N_l('Default')] ],
         languages => [ grep { $_->frequency > 0 } $c->model('Language')->get_all ],
         countries => [ $c->model('CountryArea')->get_all ],
-        relationship_type => [ $c->model('LinkType')->get_full_tree ]
+        relationship_type => [ $c->model('LinkType')->get_full_tree(get_deprecated_and_empty => 1) ]
     );
     return unless %{ $c->req->query_params };
 

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
@@ -90,7 +90,8 @@ sub tree : Chained('type_specific') PathPart('')
     my ($self, $c) = @_;
 
     my $root = $c->model('LinkType')->get_tree($c->stash->{type0},
-                                                $c->stash->{type1});
+                                                $c->stash->{type1},
+                                                get_deprecated_and_empty => 1);
 
     $c->stash(
         component_path  => 'relationship/linktype/RelationshipTypePairTree',
@@ -127,7 +128,10 @@ sub create : Chained('type_specific') PathPart('create') RequireAuth(relationshi
     my $form = $c->form(
         form => 'Admin::LinkType',
         init_object => { attributes => $attribs },
-        root => $c->model('LinkType')->get_tree($c->stash->{type0}, $c->stash->{type1})
+        root => $c->model('LinkType')->get_tree(
+            $c->stash->{type0},
+            $c->stash->{type1},
+            get_deprecated_and_empty => 1)
     );
     $form->field('parent_id')->_load_options;
 
@@ -172,7 +176,8 @@ sub edit : Chained('load') RequireAuth(relationship_editor)
                     orderable_direction )
         },
         root => $c->model('LinkType')->get_tree($link_type->entity0_type,
-                                                $link_type->entity1_type)
+                                                $link_type->entity1_type,
+                                                get_deprecated_and_empty => 1)
     );
     $form->field('parent_id')->_load_options;
 


### PR DESCRIPTION
### Implement MBS-11862

We've historically just removed link types once we no longer wanted them used and they had 0 uses, but that is a bad idea. It means the historical edits automatically show less info, since there's no type to load anymore, and it's just an unwanted loss of historical data.
As such, this allows us to keep them in the database, but not show them except when there's something to gain from doing so: for type editing / documenting, and for the edit search.
