### PR TITLE
Fix deprecated link type tests

### DIFF
--- a/lib/MusicBrainz/Server/Data/LinkType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkType.pm
@@ -126,7 +126,7 @@ sub get_tree
                 is_deprecated = FALSE
                 OR
                 EXISTS (
-                    SELECT 1 FROM link WHERE link.link_type = id
+                    SELECT 1 FROM link WHERE link.link_type = lt.id
                 )
             )
             EOSQL
@@ -134,7 +134,7 @@ sub get_tree
 
     for my $row (@{
         $self->sql->select_list_of_hashes(
-            'SELECT ' . $self->_columns . ' FROM ' . $self->_table . '
+            'SELECT ' . $self->_columns . ' FROM ' . $self->_table . ' lt
              WHERE entity_type0=? AND entity_type1=? ' . $extra_condition . '
              ORDER BY child_order, id', $type0, $type1)
     }) {
@@ -171,7 +171,7 @@ sub get_full_tree
                 is_deprecated = FALSE
                 OR
                 EXISTS (
-                    SELECT 1 FROM link WHERE link.link_type = id
+                    SELECT 1 FROM link WHERE link.link_type = lt.id
                 )
             )
             EOSQL
@@ -179,8 +179,8 @@ sub get_full_tree
 
     for my $row (@{
         $self->sql->select_list_of_hashes(
-            'SELECT '  .$self->_columns . ' FROM ' . $self->_table .
-            ' ' . $extra_condition . '
+            'SELECT '  .$self->_columns . ' FROM ' . $self->_table . ' lt ' .
+             $extra_condition . '
              ORDER BY entity_type0, entity_type1, child_order, id')
     }) {
         my $obj = $self->_new_from_row($row);

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -98,11 +98,6 @@
       value: 'http://example.com/',
     },
     {
-      command: 'runScript',
-      target: 'document.querySelector(\'option[value="666"]\').disabled = false;',
-      value: '',
-    },
-    {
       command: 'select',
       target: 'css=select.link-type',
       value: 'label=regexp:\\s*MusicMoz',
@@ -116,6 +111,12 @@
       command: 'click',
       target: "xpath=//table[@id='external-links-editor']//tr[2]//button[contains(@class, 'remove-item')]",
       value: '',
+    },
+    // deprecated and empty links do not appear at all
+    {
+      command: 'assertEval',
+      target: 'document.querySelector(\'option[value="667"]\')',
+      value: 'null',
     },
     // URLInputPopover tests
     // Open popover
@@ -220,11 +221,6 @@
       command: 'type',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
       value: 'http://example.com/',
-    },
-    {
-      command: 'runScript',
-      target: 'document.querySelector(\'option[value="666"]\').disabled = false;',
-      value: '',
     },
     {
       command: 'select',

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -105,11 +105,18 @@ INSERT INTO label_gid_redirect (gid, new_id, created) VALUES
 INSERT INTO link_type (id, parent, child_order, gid, entity_type0, entity_type1, name, description, link_phrase, reverse_link_phrase, long_link_phrase, priority, last_updated, is_deprecated, has_dates, entity0_cardinality, entity1_cardinality) VALUES
 --    (74, 73, 1, '98e08c20-8402-4163-8970-53504bb6a1e4', 'release', 'url', 'purchase for download', 'This is used to link to a page where the release can be purchased for download.', 'purchase for download', 'download purchase page for', 'can be purchased for download at', 0, '2013-12-10 13:51:19.794106+00', false, true, 0, 0),
 --    (85, 73, 3, '08445ccf-7b99-4438-9f9a-fb9ac18099ee', 'release', 'url', 'streaming music', 'This relationship type is used to link a release to a site where the tracks can be legally streamed for free, e.g. Spotify.', 'stream {video} for free', 'free music {video} streaming page for', '{video} can be streamed for free at', 0, '2014-01-19 02:56:04.116246+00', false, true, 0, 0),
-    (666, 188, 0, 'baf4b924-088c-41b3-8b49-7a4d1d5f3be9', 'artist', 'url', 'musicmoz', '', 'MusicMoz', 'MusicMoz page for', 'has a MusicMoz page at', 0, '2017-09-11 04:00:09.052103+00', true, false, 0, 0);
+    -- We want this to be deprecated but need to change that later, since we cannot insert any usages otherwise
+    (666, 188, 0, 'baf4b924-088c-41b3-8b49-7a4d1d5f3be9', 'artist', 'url', 'musicmoz', 'This links an artist to its MusicMoz page', 'MusicMoz', 'MusicMoz page for', 'has a MusicMoz page at', 0, '2017-09-11 04:00:09.052103+00', false, false, 0, 0),
+    -- We want this to be deprecated and have zero uses
+    (667, 188, 0, 'baf4b924-088c-41b3-8b49-7a4d1d5f3be8', 'artist', 'url', 'deleted', 'This relationship type has been deprecated and has zero uses', 'deleted', 'deleted', 'deleted', 0, '2017-09-11 04:00:09.052103+00', true, false, 0, 0);
 
 INSERT INTO link (id, link_type, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, attribute_count, created, ended) VALUES
     (6313, 74, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2011-05-16 15:03:23.368437+00', false),
-    (6330, 85, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2011-05-16 15:03:23.368437+00', false);
+    (6330, 85, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2011-05-16 15:03:23.368437+00', false),
+    -- 666 needs one usage in order to be displayed at all, since it will be deprecated
+    (63100, 666, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2011-05-16 15:03:23.368437+00', false);
+
+UPDATE link_type SET is_deprecated = TRUE WHERE id = 666;
 
 INSERT INTO place (id, gid, name, type, address, area, coordinates, comment, edits_pending, last_updated, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, ended) VALUES
     (1161, '88f4fdcb-c7a7-4df3-bd7d-9b02a8cb2a32', 'Many Rooms Music', 1, 'Agoura, California', NULL, NULL, '', 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'f');


### PR DESCRIPTION
This test broke with ec722a87b939d4d113e8b44ee1c5bb17c981f39c because MusicMoz, having zero uses, is now not shown for selection.
This adds one use for that to make sure it can still be found, and a description so that we don't need to artificially enable
the selector like we were doing.
It also adds one new link type which is deprecated and has zero uses, to test it doesn't show up at all.
