### PR TITLE
MBS-8098: Allow release-group-level-rels in release lookup

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -29,7 +29,8 @@ my $ws_defs = Data::OptList::mkopt([
                          inc      => [ qw(aliases artist-credits labels recordings discids
                                           tags user-tags genres user-genres ratings user-ratings
                                           release-groups media recording-level-rels
-                                          work-level-rels _relations annotation) ],
+                                          release-group-level-rels work-level-rels
+                                          _relations annotation) ],
                          optional => [ qw(fmt limit offset) ],
      },
      release => {
@@ -38,7 +39,8 @@ my $ws_defs = Data::OptList::mkopt([
                          inc      => [ qw(artists labels recordings release-groups aliases
                                           tags user-tags genres user-genres ratings user-ratings collections user-collections
                                           artist-credits discids media recording-level-rels
-                                          work-level-rels _relations annotation) ],
+                                          release-group-level-rels work-level-rels
+                                          _relations annotation) ],
                          optional => [ qw(fmt) ],
      },
      release => {
@@ -117,6 +119,10 @@ sub release_toplevel {
 
          my @release_groups = map { $_->release_group } @releases;
          $c->model('ReleaseGroup')->load_meta(@release_groups);
+
+        if ($inc->release_group_level_rels) {
+            push @rels_entities, @release_groups;
+        }
 
          $self->linked_release_groups($c, $stash, \@release_groups);
     }

--- a/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
+++ b/lib/MusicBrainz/Server/WebService/WebServiceInc.pm
@@ -13,7 +13,7 @@ has $_ => (
           aliases discids isrcs media puids various_artists artist_credits
           artists labels recordings releases release_groups works
           tags genres ratings user_tags user_genres user_ratings collections user_collections
-          recording_level_rels work_level_rels rels annotation release_events
+          recording_level_rels release_group_level_rels work_level_rels rels annotation release_events
 ), map { $_ . '_rels' } @RELATABLE_ENTITIES);
 
 has has_rels => (

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/LookupRelease.pm
@@ -711,6 +711,81 @@ test 'release lookup with release-group and ratings' => sub {
     { username => 'the-anti-kuno', password => 'wrong' };
 };
 
+test 'release lookup with release-group-level-rels and series-rels' => sub {
+
+    MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');
+
+    ws2_test_json 'release lookup with release-group-level-rels and series-rels',
+    '/release/aff4a693-5970-4e2e-bd46-e2ee49c22de7?inc=release-groups+release-group-level-rels+series-rels' =>
+        {
+            id => 'aff4a693-5970-4e2e-bd46-e2ee49c22de7',
+            title => 'the Love Bug',
+            status => 'Official',
+            'status-id' => '4e304316-386d-3409-af2e-78857eec5cfe',
+            quality => 'normal',
+            disambiguation => '',
+            packaging => JSON::null,
+            'packaging-id' => JSON::null,
+            'text-representation' => { language => 'eng', script => 'Latn' },
+            'cover-art-archive' => {
+                artwork => JSON::true,
+                count => 1,
+                front => JSON::true,
+                back => JSON::false,
+                darkened => JSON::false,
+            },
+            date => '2004-03-17',
+            country => 'JP',
+            'release-events' => [{
+                date => '2004-03-17',
+                'area' => {
+                    disambiguation => '',
+                    'id' => '2db42837-c832-3c27-b4a3-08198f75693c',
+                    'name' => 'Japan',
+                    'sort-name' => 'Japan',
+                    'iso-3166-1-codes' => ['JP'],
+                    'type' => JSON::null,
+                    'type-id' => JSON::null,
+                },
+            }],
+            barcode => '4988064451180',
+            asin => 'B0001FAD2O',
+            relations => [ ],
+            'release-group' => {
+                id => '153f0a09-fead-3370-9b17-379ebd09446b',
+                title => 'the Love Bug',
+                disambiguation => '',
+                'first-release-date' => '2004-03-17',
+                'primary-type' => 'Single',
+                'primary-type-id' => 'd6038452-8ee0-3f68-affc-2de9a1ede0b9',
+                'secondary-types' => [],
+                'secondary-type-ids' => [],
+                relations => [{
+                    'target-type' => 'series',
+                    begin => JSON::null,
+                    'source-credit' => '',
+                    end => JSON::null,
+                    'type-id' => '01018437-91d8-36b9-bf89-3f885d53b5bd',
+                    'attribute-ids' => {'number' => 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a'},
+                    direction => 'forward',
+                    attributes => ['number'],
+                    ended => JSON::false,
+                    'target-credit' => '',
+                    type => 'part of',
+                    'attribute-values' => {'number' => '1'},
+                    'ordering-key' => 1,
+                    series => {
+                        name => 'A Release Group Series',
+                        type => 'Release group',
+                        id => 'd977f7fd-96c9-4e3e-83b5-eb484a9e6581',
+                        'type-id' => '4c1c4949-7b6c-3a2d-9d54-a50a27e4fa77',
+                        disambiguation => '',
+                    },
+                }],
+            },
+        };
+};
+
 test 'release lookup with discids' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database(shift->c, '+webservice');

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/LookupRelease.pm
@@ -471,6 +471,61 @@ ws_test 'release lookup with release-groups and ratings',
     </release>
 </metadata>';
 
+ws_test 'release lookup with release-group-level-rels and series-rels',
+    '/release/aff4a693-5970-4e2e-bd46-e2ee49c22de7?inc=release-groups+release-group-level-rels+series-rels' =>
+    '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <release id="aff4a693-5970-4e2e-bd46-e2ee49c22de7">
+        <title>the Love Bug</title>
+        <status id="4e304316-386d-3409-af2e-78857eec5cfe">Official</status>
+        <quality>normal</quality>
+        <text-representation>
+            <language>eng</language>
+            <script>Latn</script>
+        </text-representation>
+        <release-group type="Single" type-id="d6038452-8ee0-3f68-affc-2de9a1ede0b9" id="153f0a09-fead-3370-9b17-379ebd09446b">
+            <title>the Love Bug</title>
+            <first-release-date>2004-03-17</first-release-date>
+            <primary-type id="d6038452-8ee0-3f68-affc-2de9a1ede0b9">Single</primary-type>
+            <relation-list target-type="series">
+                <relation type="part of" type-id="01018437-91d8-36b9-bf89-3f885d53b5bd">
+                    <target>d977f7fd-96c9-4e3e-83b5-eb484a9e6581</target>
+                    <ordering-key>1</ordering-key>
+                    <direction>forward</direction>
+                    <attribute-list>
+                        <attribute type-id="a59c5830-5ec7-38fe-9a21-c7ea54f6650a" value="1">number</attribute>
+                    </attribute-list>
+                    <series id="d977f7fd-96c9-4e3e-83b5-eb484a9e6581" type="Release group" type-id="4c1c4949-7b6c-3a2d-9d54-a50a27e4fa77">
+                        <name>A Release Group Series</name>
+                    </series>
+                </relation>
+            </relation-list>
+        </release-group>
+        <date>2004-03-17</date>
+        <country>JP</country>
+        <release-event-list count="1">
+            <release-event>
+                <date>2004-03-17</date>
+                <area id="2db42837-c832-3c27-b4a3-08198f75693c">
+                    <name>Japan</name>
+                    <sort-name>Japan</sort-name>
+                    <iso-3166-1-code-list>
+                        <iso-3166-1-code>JP</iso-3166-1-code>
+                    </iso-3166-1-code-list>
+                </area>
+            </release-event>
+        </release-event-list>
+        <barcode>4988064451180</barcode>
+        <asin>B0001FAD2O</asin>
+        <cover-art-archive>
+            <artwork>true</artwork>
+            <count>1</count>
+            <front>true</front>
+            <back>false</back>
+        </cover-art-archive>
+    </release>
+</metadata>';
+
 ws_test 'release lookup with discids and recordings',
     '/release/b3b7e934-445b-4c68-a097-730c6a6d47e6?inc=discids+recordings' =>
     '<?xml version="1.0" encoding="UTF-8"?>

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -915,7 +915,8 @@ INSERT INTO place_alias (id, place, name, locale, edits_pending, last_updated, t
 -- Series
 
 INSERT INTO series (id, gid, name, type, ordering_attribute, ordering_type) VALUES
-    (25, 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582', 'Bach-Werke-Verzeichnis', 5, 788, 1);
+    (25, 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582', 'Bach-Werke-Verzeichnis', 5, 788, 1),
+    (30, 'd977f7fd-96c9-4e3e-83b5-eb484a9e6581', 'A Release Group Series', 1, 788, 1);
 
 INSERT INTO series_alias (id, series, name, sort_name) VALUES
     (7, 25, 'BWV', 'BWV');
@@ -932,18 +933,24 @@ INSERT INTO work_language (work, language) VALUES
 
 INSERT INTO link (attribute_count, begin_date_day, begin_date_month, begin_date_year, created, end_date_day, end_date_month, end_date_year, ended, id, link_type) VALUES
     (1, NULL, NULL, NULL, '2014-07-09 15:10:16.494155-05', NULL, NULL, NULL, '0', 180865, 743),
+    (1, NULL, NULL, NULL, '2014-07-09 15:10:16.494155-05', NULL, NULL, NULL, '0', 180875, 742),
     (1, NULL, NULL, NULL, '2014-07-03 15:25:50.050958-05', NULL, NULL, NULL, '0', 180086, 743),
     (1, NULL, NULL, NULL, '2014-06-24 07:16:41.33395-05', NULL, NULL, NULL, '0', 178448, 743);
 
 INSERT INTO link_attribute (attribute_type, created, link) VALUES
     (788, '2014-07-09 15:10:16.494155-05', 180865),
+    (788, '2014-07-09 15:10:16.494155-05', 180875),
     (788, '2014-07-03 15:25:50.050958-05', 180086),
     (788, '2014-06-24 07:16:41.33395-05', 178448);
 
 INSERT INTO link_attribute_text_value (attribute_type, link, text_value) VALUES
     (788, 180865, 'BWV 1'),
     (788, 180086, 'BWV 2'),
-    (788, 178448, 'BWV 3');
+    (788, 178448, 'BWV 3'),
+    (788, 180875, '1');
+
+INSERT INTO l_release_group_series (edits_pending, entity0, entity0_credit, entity1, entity1_credit, id, last_updated, link, link_order) VALUES
+    (0, 403214, '', 30, '', 7765, '2014-07-09 15:10:16.494155-05', 180875, 1);
 
 INSERT INTO l_series_work (edits_pending, entity0, entity0_credit, entity1, entity1_credit, id, last_updated, link, link_order) VALUES
     (0, 25, '', 12488154, '', 7760, '2014-07-09 15:10:16.494155-05', 180865, 1),


### PR DESCRIPTION
### Implement MBS-8098

This is particularly useful to know if a release's release group is part of a release group series.

On top of https://github.com/metabrainz/musicbrainz-server/pull/2173