### PR TITLE
MBS-11823: Don't break tags and genres mid-word

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -481,7 +481,7 @@ div.warning img.warning {
         display: flex;
         a {
             display: inline-block;
-            word-break: break-all;
+            overflow-wrap: anywhere;
             padding: 4px;
             flex-grow: 1;
             -webkit-flex-grow: 1;


### PR DESCRIPTION
### Implement MBS-11823

This was set to word-break: break-all to avoid long one-word tags such as weird URLs. That actually means all tags with normal words break weirdly. @mwiencek proposed overflow-wrap: anywhere to cater to both of these issues, and that seems to work - the only worry is that this is not supported in older browsers.