### PR TITLE
Beta: Allow submitting form from empty URL input

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -202,15 +202,22 @@ export class ExternalLinksEditor
     if (url !== '' && !error) {
       link.submitted = true;
       this.setLinkState(index, link, () => {
-        /*
-         * Redirect focus to the next item (either input or link)
-         * instead of staying on the current link.
-         */
-        $(this.tableRef.current)
-          .find(`tr.external-link-item:eq(${urlIndex + 1})`)
-          .find('a,input')
-          .eq(0)
-          .focus();
+        // Redirect focus instead of staying on the current link
+        if (link.type) {
+          // If type is selected, jump to the next item(either input or link)
+          $(this.tableRef.current)
+            .find(`tr.external-link-item:eq(${urlIndex + 1})`)
+            .find('a,input')
+            .eq(0)
+            .focus();
+        } else {
+          // If type is not selected, jump to type selector
+          $(this.tableRef.current)
+            .find(`tr.external-link-item:eq(${urlIndex})
+                  + tr.relationship-item`)
+            .find('select.link-type')
+            .focus();
+        }
       });
     } else {
       this.setLinkState(index, link);

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -898,8 +898,11 @@ export class ExternalLink extends React.Component<LinkProps> {
               typeOptions={props.typeOptions}
             />
         ))}
-        {/* Hide the button when link type is auto-selected */}
-        {notEmpty && !firstLink.urlMatchesType &&
+        {/*
+          * Hide the button when link is not submitted
+          * or link type is auto-selected.
+          */}
+        {notEmpty && firstLink.submitted && !firstLink.urlMatchesType &&
         <tr className="add-relationship">
           <td />
           <td className="add-item" colSpan="4">

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -202,10 +202,14 @@ export class ExternalLinksEditor
     if (url !== '' && !error) {
       link.submitted = true;
       this.setLinkState(index, link, () => {
-        // Redirect focus to the 'x' icon instead of the link
+        /*
+         * Redirect focus to the next item (either input or link)
+         * instead of staying on the current link.
+         */
         $(this.tableRef.current)
-          .find(`tr.external-link-item:eq(${urlIndex})`)
-          .find('button.remove-item')
+          .find(`tr.external-link-item:eq(${urlIndex + 1})`)
+          .find('a,input')
+          .eq(0)
           .focus();
       });
     } else {
@@ -771,7 +775,11 @@ type LinkProps = {
 
 export class ExternalLink extends React.Component<LinkProps> {
   handleKeyDown(event: SyntheticKeyboardEvent<HTMLInputElement>) {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && this.props.url) {
+      /*
+       * If there's a link, prevent default and submit it,
+       * otherwise allow submitting the form from empty field.
+       */
       event.preventDefault();
       this.props.handleLinkSubmit(event);
     }


### PR DESCRIPTION
# Problem
After MBS-11680, Enter key is used for submitting links in URL input box, hence users can no longer submit the form from external links editor when they only want to add a single link.

# Solution
Redirect focus to the next item in external links list (either link or input), and prevent default onKeyDown handler only when the field is not empty, therefore users can follow the following steps to submit the form:
1. Paste a URL
2. Press Enter, this submits the link and jumps to the next empty input box
3. Press Enter again, the form is submitted
