### PR TITLE
Beta: Fix text overflow caused by long URL

### DIFF
--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -96,6 +96,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
                       className="clean-url"
                       href={link.url}
                       rel="noreferrer"
+                      style={{overflowWrap: 'anywhere'}}
                       target="_blank"
                     >
                       {link.url}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -848,6 +848,7 @@ export class ExternalLink extends React.Component<LinkProps> {
                 className="url"
                 href={props.url}
                 rel="noreferrer"
+                style={{overflowWrap: 'anywhere'}}
                 target="_blank"
               >
                 {props.url}


### PR DESCRIPTION
# Problem
Long URLs in ExternalLinks and URLInputPopover cause text overflow and width change.

# Solution
Update `overflow-wrap` to `anywhere` instead of `break-word`.
