### PR TITLE
MBS-3774: Add URL with begin and end dates

### DIFF
--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -36,7 +36,9 @@ import {
   type StateT as GuessCaseOptionsStateT,
   type WritableStateT as WritableGuessCaseOptionsStateT,
 } from '../edit/components/GuessCaseOptions';
-import copyFieldData, {copyFieldErrors} from '../edit/utility/copyFieldData';
+import copyFieldData, {
+  copyDatePeriodField,
+} from '../edit/utility/copyFieldData';
 import {
   createCompoundField,
   createField,
@@ -101,36 +103,6 @@ const blankDatePeriod = {
   id: 0,
   type: 'compound_field',
 };
-
-function copyPartialDateField(
-  sourceField: PartialDateFieldT,
-  targetField: WritablePartialDateFieldT,
-) {
-  const sourceSubfields = sourceField.field;
-  const targetSubfields = targetField.field;
-  copyFieldData(sourceSubfields.year, targetSubfields.year);
-  copyFieldData(sourceSubfields.month, targetSubfields.month);
-  copyFieldData(sourceSubfields.day, targetSubfields.day);
-  copyFieldErrors(sourceField, targetField);
-}
-
-function copyDatePeriodField(
-  sourceField: DatePeriodFieldT,
-  targetField: WritableDatePeriodFieldT,
-) {
-  const sourceSubfields = sourceField.field;
-  const targetSubfields = targetField.field;
-  copyPartialDateField(
-    sourceSubfields.begin_date,
-    targetSubfields.begin_date,
-  );
-  copyPartialDateField(
-    sourceSubfields.end_date,
-    targetSubfields.end_date,
-  );
-  copyFieldData(sourceSubfields.ended, targetSubfields.ended);
-  copyFieldErrors(sourceField, targetField);
-}
 
 function createInitialState(form, searchHintType) {
   return {

--- a/root/static/scripts/edit/MB/edit.js
+++ b/root/static/scripts/edit/MB/edit.js
@@ -108,6 +108,16 @@ import request from '../../common/utility/request';
         editData.attributes = [{type: {gid: VIDEO_ATTRIBUTE_GID}}];
       }
 
+      editData.begin_date = fields.partialDate(link.begin_date);
+      editData.end_date = fields.partialDate(link.end_date);
+
+      if (editData.end_date
+        && Object.values(editData.end_date).some(nonEmpty)) {
+        editData.ended = true;
+      } else {
+        editData.ended = Boolean(value(link.ended));
+      }
+
       return editData;
     },
 

--- a/root/static/scripts/edit/components/DateRangeFieldset.js
+++ b/root/static/scripts/edit/components/DateRangeFieldset.js
@@ -16,6 +16,7 @@ import FormRowPartialDate, {
 } from '../../../../components/FormRowPartialDate';
 import FormRowCheckbox from '../../../../components/FormRowCheckbox';
 import {applyAllPendingErrors} from '../../../../utility/subfieldErrors';
+import parseIntegerOrNull from '../../common/utility/parseIntegerOrNull';
 import {isDatePeriodValid} from '../utility/dates';
 
 /* eslint-disable flowtype/sort-keys */
@@ -37,14 +38,14 @@ export type StateT = DatePeriodFieldT;
 
 export type WritableStateT = WritableDatePeriodFieldT;
 
-function partialDateFromField(
+export function partialDateFromField(
   compoundField: PartialDateFieldT,
-) {
+): PartialDateT {
   const fields = compoundField.field;
   return {
-    day: fields.day.value,
-    month: fields.month.value,
-    year: fields.year.value,
+    day: parseIntegerOrNull(fields.day.value),
+    month: parseIntegerOrNull(fields.month.value),
+    year: parseIntegerOrNull(fields.year.value),
   };
 }
 

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -1,0 +1,222 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+import mutate from 'mutate-cow';
+import ButtonPopover from '../../common/components/ButtonPopover';
+import type {LinkRelationshipT} from '../externalLinks';
+import DateRangeFieldset, {
+  partialDateFromField,
+  runReducer as runDateRangeFieldsetReducer,
+  type ActionT as DateRangeFieldsetActionT,
+} from './DateRangeFieldset';
+import {
+  createCompoundField,
+  createField,
+} from '../../edit/utility/createField';
+import {l} from '../../common/i18n';
+import {
+  applyAllPendingErrors,
+  hasSubfieldErrors,
+} from '../../../../utility/subfieldErrors';
+import {copyDatePeriodField} from '../utility/copyFieldData';
+
+type PropsT = {
+  onConfirm: (DatePeriodRoleT) => void,
+  relationship: LinkRelationshipT,
+};
+
+type StateT = {
+  +datePeriodField: DatePeriodFieldT,
+};
+
+type WritableStateT = {
+  ...StateT,
+  datePeriodField: WritableDatePeriodFieldT,
+};
+
+type ActionT =
+| {
+  +action: DateRangeFieldsetActionT,
+  +type: 'update-date-period',
+  }
+| {+type: 'reset'}
+| {+type: 'show-all-pending-errors'};
+
+const createInitialState = (props: PropsT): StateT => {
+  const relationship = props.relationship;
+  const beginDate = relationship.begin_date;
+  const endDate = relationship.end_date;
+
+  return {
+    datePeriodField: {
+      errors: [],
+      has_errors: false,
+      field: {
+        begin_date: createCompoundField(
+          'period.begin_date',
+          {
+            day: beginDate?.day ?? null,
+            month: beginDate?.month ?? null,
+            year: beginDate?.year ?? null,
+          },
+        ),
+        end_date: createCompoundField(
+          'period.end_date',
+          {
+            day: endDate?.day ?? null,
+            month: endDate?.month ?? null,
+            year: endDate?.year ?? null,
+          },
+        ),
+        ended: createField('period.ended', relationship.ended),
+      },
+      html_name: '',
+      id: 0,
+      type: 'compound_field',
+    },
+  };
+};
+
+const ExternalLinkAttributeDialog = (props: PropsT): React.MixedElement => {
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = React.useState(false);
+  const initialState = createInitialState(props);
+
+  const resetReducer = (state: WritableStateT): void => {
+    copyDatePeriodField(initialState.datePeriodField, state.datePeriodField);
+  };
+
+  const reducer = (state: StateT, action: ActionT): StateT => {
+    return mutate<WritableStateT, StateT>(
+      state, (newState) => {
+        switch (action.type) {
+          case 'update-date-period':
+            runDateRangeFieldsetReducer(
+              newState.datePeriodField,
+              action.action,
+            );
+            break;
+          case 'reset':
+            resetReducer(newState);
+            break;
+          case 'show-all-pending-errors':
+            applyAllPendingErrors(newState.datePeriodField);
+            break;
+          default:
+            throw new Error('Unknown action: ' + action.type);
+        }
+      },
+    );
+  };
+
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    props,
+    createInitialState,
+  );
+  const hasErrors = hasSubfieldErrors(state.datePeriodField);
+
+  const dateDispatch = React.useCallback((action) => {
+    dispatch({action, type: 'update-date-period'});
+  }, [dispatch]);
+
+  const onToggle = (open) => {
+    if (open) {
+      dispatch({type: 'reset'});
+    }
+    setOpen(open);
+  };
+
+  const handleConfirm = (closeAndReturnFocus) => {
+    if (hasErrors) {
+      return;
+    }
+    const field = state.datePeriodField.field;
+    props.onConfirm({
+      begin_date: partialDateFromField(field.begin_date),
+      end_date: partialDateFromField(field.end_date),
+      ended: field.ended.value,
+    });
+    closeAndReturnFocus();
+  };
+
+  // Ensure errors are shown if the user tries to submit with Enter
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' && hasErrors) {
+      dispatch({type: 'show-all-pending-errors'});
+      event.preventDefault();
+    }
+  };
+
+  const handleSubmit = (event) => {
+    if (hasErrors) {
+      dispatch({type: 'show-all-pending-errors'});
+      event.preventDefault();
+    }
+  };
+
+  const buildPopoverChildren =
+    (closeAndReturnFocus): React.Element<'form'> => {
+      return (
+        <form
+          className="external-link-attribute-dialog"
+          onKeyDown={handleKeyDown}
+          onSubmit={handleSubmit}
+        >
+          <DateRangeFieldset
+            dispatch={dateDispatch}
+            endedLabel={l('This relationship has ended.')}
+            field={state.datePeriodField}
+          />
+          <div
+            className="buttons"
+            style={{display: 'block', marginTop: '1em'}}
+          >
+            <button
+              className="negative"
+              onClick={closeAndReturnFocus}
+              type="button"
+            >
+              {l('Cancel')}
+            </button>
+            <div
+              className="buttons-right"
+              style={{float: 'right', textAlign: 'right'}}
+            >
+              <button
+                className="positive"
+                disabled={hasErrors}
+                onClick={() => handleConfirm(closeAndReturnFocus)}
+                type="submit"
+              >
+                {l('Done')}
+              </button>
+            </div>
+          </div>
+        </form>
+      );
+    };
+
+  return (
+    <ButtonPopover
+      buildChildren={buildPopoverChildren}
+      buttonContent={null}
+      buttonProps={{
+        className: 'icon edit-item',
+      }}
+      buttonRef={buttonRef}
+      id="external-link-attribute-dialog"
+      isOpen={open}
+      toggle={onToggle}
+    />
+  );
+};
+
+export default ExternalLinkAttributeDialog;

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -773,7 +773,8 @@ const ExternalLinkRelationship =
                 <TypeDescription type={link.type} url={link.url} />}
               {(
                 !isDateEmpty(link.begin_date) ||
-                !isDateEmpty(link.end_date)
+                !isDateEmpty(link.end_date) ||
+                link.ended
               ) &&
                 <span className="date-period">
                   {` (${formatDatePeriod(link)})`}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -769,15 +769,19 @@ const ExternalLinkRelationship =
                     {l('video')}
                   </label>
                 </div>}
+              {link.url && !link.error && !hasUrlError &&
+                <TypeDescription type={link.type} url={link.url} />}
               {(
                 !isDateEmpty(link.begin_date) ||
                 !isDateEmpty(link.end_date)
               ) &&
-                <span className={link.ended ? 'deleted' : undefined}>
+                <span
+                  className={link.ended
+                    ? 'date-period deleted'
+                    : 'date-period'}
+                >
                   {` (${formatDatePeriod(link)})`}
                 </span>}
-              {link.url && !link.error && !hasUrlError &&
-                <TypeDescription type={link.type} url={link.url} />}
             </label>
           </div>
           {link.error &&

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -775,11 +775,7 @@ const ExternalLinkRelationship =
                 !isDateEmpty(link.begin_date) ||
                 !isDateEmpty(link.end_date)
               ) &&
-                <span
-                  className={link.ended
-                    ? 'date-period deleted'
-                    : 'date-period'}
-                >
+                <span className="date-period">
                   {` (${formatDatePeriod(link)})`}
                 </span>}
             </label>

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -26,6 +26,7 @@ import MB from '../common/MB';
 import {groupBy, keyBy, uniqBy} from '../common/utility/arrays';
 import {hasSessionStorage} from '../common/utility/storage';
 import {uniqueId} from '../common/utility/strings';
+import {bracketedText} from '../common/utility/bracketed';
 import {isMalware} from '../../../url/utility/isGreyedOut';
 
 import isPositiveInteger from './utility/isPositiveInteger';
@@ -37,8 +38,8 @@ import * as URLCleanup from './URLCleanup';
 import validation from './validation';
 import isDateEmpty from '../common/utility/isDateEmpty';
 import formatDatePeriod from '../common/utility/formatDatePeriod';
-import
-ExternalLinkAttributeDialog from './components/ExternalLinkAttributeDialog';
+import ExternalLinkAttributeDialog
+  from './components/ExternalLinkAttributeDialog';
 
 type ErrorTarget = $Values<typeof URLCleanup.ERROR_TARGETS>;
 
@@ -777,7 +778,8 @@ const ExternalLinkRelationship =
                 link.ended
               ) &&
                 <span className="date-period">
-                  {` (${formatDatePeriod(link)})`}
+                  {' '}
+                  {bracketedText(formatDatePeriod(link))}
                 </span>}
             </label>
           </div>

--- a/root/static/scripts/edit/utility/copyFieldData.js
+++ b/root/static/scripts/edit/utility/copyFieldData.js
@@ -33,11 +33,10 @@ export default function copyFieldData<T>(
   copyFieldErrors(sourceField, targetField);
 }
 
-
 export function copyPartialDateField(
   sourceField: PartialDateFieldT,
   targetField: WritablePartialDateFieldT,
-) {
+): void {
   const sourceSubfields = sourceField.field;
   const targetSubfields = targetField.field;
   copyFieldData(sourceSubfields.year, targetSubfields.year);
@@ -49,7 +48,7 @@ export function copyPartialDateField(
 export function copyDatePeriodField(
   sourceField: DatePeriodFieldT,
   targetField: WritableDatePeriodFieldT,
-) {
+): void {
   const sourceSubfields = sourceField.field;
   const targetSubfields = targetField.field;
   copyPartialDateField(

--- a/root/static/scripts/edit/utility/copyFieldData.js
+++ b/root/static/scripts/edit/utility/copyFieldData.js
@@ -32,3 +32,34 @@ export default function copyFieldData<T>(
   targetField.value = sourceField.value;
   copyFieldErrors(sourceField, targetField);
 }
+
+
+export function copyPartialDateField(
+  sourceField: PartialDateFieldT,
+  targetField: WritablePartialDateFieldT,
+) {
+  const sourceSubfields = sourceField.field;
+  const targetSubfields = targetField.field;
+  copyFieldData(sourceSubfields.year, targetSubfields.year);
+  copyFieldData(sourceSubfields.month, targetSubfields.month);
+  copyFieldData(sourceSubfields.day, targetSubfields.day);
+  copyFieldErrors(sourceField, targetField);
+}
+
+export function copyDatePeriodField(
+  sourceField: DatePeriodFieldT,
+  targetField: WritableDatePeriodFieldT,
+) {
+  const sourceSubfields = sourceField.field;
+  const targetSubfields = targetField.field;
+  copyPartialDateField(
+    sourceSubfields.begin_date,
+    targetSubfields.begin_date,
+  );
+  copyPartialDateField(
+    sourceSubfields.end_date,
+    targetSubfields.end_date,
+  );
+  copyFieldData(sourceSubfields.ended, targetSubfields.ended);
+  copyFieldErrors(sourceField, targetField);
+}

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -698,6 +698,14 @@ table.artist-credit-editor {
     }
 }
 
+.external-link-attribute-dialog {
+    span.partial-date {
+        input {
+            width: 4em;
+        }
+    }
+}
+
 #external-links-editor, #work-attributes {
     width: 100%;
     padding: (@form-margin / 2);

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -676,6 +676,10 @@ table.artist-credit-editor {
                 flex: 2 5;
                 text-align: left;
                 white-space: inherit;
+
+                span.date-period {
+                    white-space: nowrap;
+                }
             }
 
             select {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -728,5 +728,94 @@
       target: "window.JSON.stringify(window.Array.from(window.document.querySelectorAll('#external-links-editor a[class=url]').values()).map(function (x) { return x.href }))",
       value: '["https://www.gnu.org/licenses/gpl-3.0.en.html"]',
     },
+    // Set begin date & end date
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://www.amazon.co.jp/gp/product/B017VORJK6${KEY_ENTER}',
+    },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    // begin date: ????-01-01
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.begin_date.month']",
+      value: '1',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.begin_date.day']",
+      value: '1',
+    },
+    // end date: 2021-01-01
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.end_date.year']",
+      value: '2021',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.end_date.month']",
+      value: '1',
+    },
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.end_date.day']",
+      value: '1',
+    },
+    // Mark as ended
+    {
+      command: 'click',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-period.ended']",
+      value: '',
+    },
+    // Save
+    {
+      command: 'click',
+      target: "xpath=(//div[@id='external-link-attribute-dialog']//button[contains(@class, 'positive')])[1]",
+      value: '',
+    },
+    // Assert date period is correctly displayed
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//span[contains(@class, 'deleted')][1]",
+      value: ' (????-01-01 – 2021-01-01)',
+    },
+    // Check edit preview
+    {
+      command: 'click',
+      target: 'css=a[href="#edit-note"]',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '1500',
+      value: '',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=(//div[contains(@class, 'edit-list')]//h2)[1]",
+      value: 'Add relationship',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=(//div[contains(@class, 'edit-details')])[1]",
+      value: 'Relationship: ★ by David Bowie has Amazon ASIN https://www.amazon.co.jp/gp/product/B017VORJK6 [info] from ????-01-01 until 2021-01-01',
+    },
+    // Revert changes
+    {
+      command: 'click',
+      target: 'css=a[href="#information"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//button[contains(@class, 'remove-item')]",
+      value: '',
+    },
   ],
 }

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -782,7 +782,7 @@
     // Assert date period is correctly displayed
     {
       command: 'assertText',
-      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//span[contains(@class, 'deleted')][1]",
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//span[contains(@class, 'date-period')][1]",
       value: ' (????-01-01 – 2021-01-01)',
     },
     // Check edit preview


### PR DESCRIPTION
### Implement MBS-3774

Display date period next to relationship name, add a popover for setting begin and end dates of URL, enabling date period editing for entity edit pages other than URL.

<img width="803" alt="Screenshot" src="https://user-images.githubusercontent.com/17172063/129680951-5145badc-6c3a-4a09-a86d-0c90150fd3e1.png">
