### PR TITLE
MBS-11875: Don't consider Braille an unlikely script

### DIFF
--- a/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithUnlikelyLanguageScript.pm
@@ -22,7 +22,7 @@ sub query {
             JOIN script ON r.script = script.id
             JOIN language ON r.language = language.id
         WHERE (
-            script.iso_code NOT IN ('Kana', 'Latn', 'Qaaa') AND 
+            script.iso_code NOT IN ('Brai', 'Kana', 'Latn', 'Qaaa') AND 
             language.iso_code_3 IN (
               'eng', 'spa', 'deu', 'fra', 'por', 'ita', 'swe', 'nor', 'fin',
               'est', 'lav', 'lit', 'pol', 'nld', 'cat', 'hun', 'ces', 'slk',
@@ -30,7 +30,7 @@ sub query {
             )
         ) OR (
             language.iso_code_3 = 'jpn' AND 
-            script.iso_code NOT IN ('Hira', 'Hrkt', 'Kana', 'Jpan', 'Latn', 'Qaaa') 
+            script.iso_code NOT IN ('Brai', 'Hira', 'Hrkt', 'Kana', 'Jpan', 'Latn', 'Qaaa') 
         ) 
     ";
 }


### PR DESCRIPTION
### Implement MBS-11875

Braille is specifically meant to be used as a script for many languages and as such it shouldn't be considered as unlikely in combination with them.