### PR TITLE
MBS-11890: Beta: Fix alias "guess sort name" for persons

### DIFF
--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -36,6 +36,8 @@ export const VOCAL_ROOT_ID = 3;
 
 export const AREA_TYPE_COUNTRY = 1;
 
+export const ARTIST_TYPE_PERSON = 1;
+
 export const CONTACT_URL = 'https://metabrainz.org/contact';
 
 export const DARTIST_ID = 2;

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import FormRowText from '../../../../components/FormRowText';
 import GuessCase from '../../guess-case/MB/GuessCase/Main';
+import {ARTIST_TYPE_PERSON} from '../../common/constants';
 
 type SortNamedEntityT = {
   +entityType: CoreEntityTypeT,
@@ -55,10 +56,12 @@ export function runReducer(
     }
     case 'guess-case-sortname': {
       const {entityType, typeID} = action.entity;
+      const isPerson =
+        entityType === 'artist' && typeID === ARTIST_TYPE_PERSON;
       newState.sortNameField.value =
         GuessCase.entities[entityType].sortname(
           newState.nameField.value ?? '',
-          typeID,
+          isPerson,
         );
       break;
     }

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -14,6 +14,7 @@ import GuessCase from '../../guess-case/MB/GuessCase/Main';
 
 type SortNamedEntityT = {
   +entityType: CoreEntityTypeT,
+  +typeID?: number | null,
   ...
 };
 
@@ -53,10 +54,11 @@ export function runReducer(
       break;
     }
     case 'guess-case-sortname': {
-      const {entityType} = action.entity;
+      const {entityType, typeID} = action.entity;
       newState.sortNameField.value =
         GuessCase.entities[entityType].sortname(
           newState.nameField.value ?? '',
+          typeID,
         );
       break;
     }

--- a/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
+++ b/root/static/scripts/edit/components/FormRowSortNameWithGuessCase.js
@@ -105,10 +105,10 @@ export const FormRowSortNameWithGuessCase = ({
       required={required}
     >
       <button
-        className="guesscase-title icon"
+        className="guesscase-sortname icon"
         disabled={disabled}
         onClick={handleGuessCase}
-        title={l('Guess case')}
+        title={l('Guess sort name')}
         type="button"
       />
       <button

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -28,7 +28,7 @@ class GuessCase {
   entities: {
     [entityType: string]: {
       guess: (string) => string,
-      sortname: (string, typeId?: ?number) => string,
+      sortname: (string, isPerson: boolean) => string,
     },
   };
 

--- a/root/static/scripts/guess-case/MB/GuessCase/Main.js
+++ b/root/static/scripts/guess-case/MB/GuessCase/Main.js
@@ -28,7 +28,7 @@ class GuessCase {
   entities: {
     [entityType: string]: {
       guess: (string) => string,
-      sortname: (string) => string,
+      sortname: (string, typeId?: ?number) => string,
     },
   };
 


### PR DESCRIPTION
Reverts the parts of 5f1b33c that removed the typeID, which is needed for person sort names to be guessed correctly.