### PR TITLE
MBS-11891: Use https when linking to jira

### DIFF
--- a/root/layout.tt
+++ b/root/layout.tt
@@ -112,7 +112,7 @@
                 <a href="//wiki.musicbrainz.org/" class="internal">[% l('Wiki') %]</a>
                 <a href="https://community.metabrainz.org/" class="internal">[% l('Forums') %]</a>
                 <a href="/doc/Communication/IRC" class="internal">[% l('IRC') %]</a>
-                <a href="http://tickets.metabrainz.org/" class="internal">[% l('Bug Tracker') %]</a>
+                <a href="https://tickets.metabrainz.org/" class="internal">[% l('Bug Tracker') %]</a>
                 <a href="https://blog.metabrainz.org/" class="internal">[% l('Blog') %]</a>
                 <a href="https://twitter.com/MusicBrainz" class="internal">[% l('Twitter') %]</a>
                 [%- IF server_details.beta_redirect %]

--- a/root/main/index.js
+++ b/root/main/index.js
@@ -207,7 +207,7 @@ const Homepage = ({
             <a href="/doc/How_to_Contribute">{l('How to Contribute')}</a>
           </li>
           <li>
-            <a href="http://tickets.metabrainz.org/">{l('Bug Tracker')}</a>
+            <a href="https://tickets.metabrainz.org/">{l('Bug Tracker')}</a>
           </li>
           <li>
             <a href="https://community.metabrainz.org/">{l('Forums')}</a>


### PR DESCRIPTION
Convert HTTP link to HTTPS.

Sorry for double commit. Couldn't find a way to edit multiple files into one commit from the GitHub website itself.