### PR TITLE
MBS-9454: Autoremove unused urls with daily.sh

### DIFF
--- a/admin/cron/daily.sh
+++ b/admin/cron/daily.sh
@@ -50,6 +50,9 @@ echo `date`" : Removing unused release groups"
 echo `date`" : Removing unused series"
 ./admin/cleanup/RemoveEmpty series
 
+echo `date`" : Removing unused urls"
+./admin/cleanup/RemoveEmpty url
+
 echo `date`" : Removing unused works"
 ./admin/cleanup/RemoveEmpty work
 

--- a/entities.json
+++ b/entities.json
@@ -719,6 +719,9 @@
         "model": "URL",
         "plural": "urls",
         "plural_url": "urls",
+        "removal": {
+            "automatic": {}
+        },
         "url": "url"
     },
     "work": {

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -250,7 +250,7 @@ sub _merge_impl
     $self->c->model('Edit')->merge_entities('url', $new_id, @old_ids);
     $self->c->model('Relationship')->merge_entities('url', $new_id, \@old_ids);
 
-    $self->_delete(@old_ids);
+    $self->delete(@old_ids);
 
     return 1;
 }
@@ -283,7 +283,7 @@ sub update
     }
 }
 
-sub _delete {
+sub delete {
     my ($self, @ids) = @_;
     $self->sql->do('DELETE FROM url WHERE id = any(?)', \@ids);
 }

--- a/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
+++ b/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
@@ -1,0 +1,40 @@
+package t::MusicBrainz::Script::RemoveEmptyURLs;
+use Test::Routine;
+use Test::More;
+use Test::Fatal;
+
+use MusicBrainz::Script::RemoveEmpty;
+
+with 't::Context';
+
+test 'all' => sub {
+
+my $test = shift;
+my $c = $test->c;
+
+MusicBrainz::Server::Test->prepare_test_database($c, '+url');
+
+my $sql = $c->sql;
+is($sql->select_single_value('SELECT COUNT(*) FROM url'),
+   5,
+   'Five URLs exist before the script is run');
+
+
+my $script = MusicBrainz::Script::RemoveEmpty->new( c => $c );
+ok !exception { $script->run('url') };
+
+is($sql->select_single_value('SELECT COUNT(*) FROM url'),
+   4,
+   'Four URLs exist after the script is run, one has been deleted');
+
+is($sql->select_single_value('SELECT 1 FROM url WHERE id = 2'),
+   1,
+   'Recently updated unused URL has not been deleted');
+
+is($sql->select_single_value('SELECT 1 FROM url WHERE id = 5'),
+   1,
+   'Unused URL with pending edits has not been deleted');
+
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
@@ -109,7 +109,7 @@ cmp_deeply($edits[1]->data, {
     'type1' => 'url',
     'entity1' => {
         'name' => 'http://microsoft.com/',
-        'id' => 5,
+        'id' => 6,
         'gid' => ignore()
     },
     'ended' => 0,

--- a/t/sql/url.sql
+++ b/t/sql/url.sql
@@ -1,10 +1,11 @@
 SET client_min_messages TO 'warning';
 
-INSERT INTO url (id, gid, url)
-    VALUES (1, '9201840b-d810-4e0f-bb75-c791205f5b24', 'http://musicbrainz.org/'),
-           (2, '9b3c5c67-572a-4822-82a3-bdd3f35cf152', 'http://microsoft.com'),
-           (3, '25d6b63a-12dc-41c9-858a-2f42ae610a7d', 'http://zh-yue.wikipedia.org/wiki/%E7%8E%8B%E8%8F%B2'),
-           (4, '7bd45cc7-6189-4712-35e1-cdf3632cf1a9', 'https://www.allmusic.com/artist/faye-wong-mn0000515659');
+INSERT INTO url (id, gid, url, last_updated, edits_pending)
+    VALUES (1, '9201840b-d810-4e0f-bb75-c791205f5b24', 'http://musicbrainz.org/', '2011-01-18 16:23:38+00', 0),
+           (2, '9b3c5c67-572a-4822-82a3-bdd3f35cf152', 'http://microsoft.com', NOW(), 0),
+           (3, '25d6b63a-12dc-41c9-858a-2f42ae610a7d', 'http://zh-yue.wikipedia.org/wiki/%E7%8E%8B%E8%8F%B2', '2011-01-18 16:23:38+00', 0),
+           (4, '7bd45cc7-6189-4712-35e1-cdf3632cf1a9', 'https://www.allmusic.com/artist/faye-wong-mn0000515659', NOW(), 0),
+           (5, '9b3c5c67-572a-4822-82a3-bdd3f35cf153', 'http://microsoft.fr', '2011-01-18 16:23:38+00', 2);
 
 INSERT INTO artist (id, gid, name, sort_name) VALUES (100, 'acd58926-4243-40bb-a2e5-c7464b3ce577', 'Faye Wong', 'Faye Wong');
 INSERT INTO link (id, link_type) VALUES (1, 179);

--- a/t/tests.t
+++ b/t/tests.t
@@ -12,6 +12,7 @@ my @classes = (
     't::Sql',
     't::MusicBrainz::DataStore::Redis',
     't::MusicBrainz::Script::RebuildCoverArt',
+    't::MusicBrainz::Script::RemoveEmptyURLs',
     map {
         Module::Pluggable::Object->new( search_path => $_ )->plugins
     } (


### PR DESCRIPTION
### Fix MBS-9454

While most of these get removed with triggers, in some cases (e.g. having open edits) unused URLs can remain behind as orphans. This ensures the daily cron will remove them like other unused entities. Since we don't usually leave edits when URLs are autoremoved by triggers, we also don't create an edit here.

Tested by running it locally and seeing it did remove one URL (in test data but it might have been one that I accidentally orphaned), at least. It did not remove the URLs I just inserted to test, which makes sense because it does have a "last_updated over a day ago" check...