### PR TITLE
MBS-11915: Don't show area icon if there's already a flag icon

### DIFF
--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -278,6 +278,8 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
           {content}
         </span>
       );
+      // Avoid having the icon *and* the flag
+      showIcon = false;
     }
   }
 


### PR DESCRIPTION
### Implement MBS-11915

A flag icon already implies this is an area, so having the globe icon followed by the flag just seems over the top and weird.

Tested by checking /area/0a65a727-7465-4e6c-8b15-ed4d09e021ee and /recording/5e75d044-4afc-4d1e-b23f-c17ab7d824d7 (pink data)