### PR TITLE
Remove useless arrows on add_cover_art images

### DIFF
--- a/root/release/add_cover_art.tt
+++ b/root/release/add_cover_art.tt
@@ -132,12 +132,10 @@
           <div class="thumb-position">
             [%- display_artwork(image) -%]
             <div style="display: flex; justify-content: space-around;">
-              <button type="button" class="left">&larr;</button>
               [% React.embed(c, 'static/scripts/edit/components/InformationIcon', {
                 style => {'align-self' => 'flex-start'},
                 title => l('Types:') _ ' ' _ (comma_only_list(image.l_types) || '-') _ 
                         (image.comment ? (' / ' _ l('Comment:') _ ' ' _ image.comment) : '')}) %]
-              <button type="button" class="right" style="float: right;">&rarr;</button>
             </div>
           </div>
         [%- END -%]


### PR DESCRIPTION
I accidentally added these with 1b625f2903f2f82e680fd10cc6f636df07893aa8 but it doesn't do anything here.