### PR TITLE
Improvements to Edit Release Label edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -118,6 +118,19 @@ sub build_display_data {
             exists $data->{new}{catalog_number} ? (new => $data->{new}{catalog_number}) : (),
             old => $data->{old}{catalog_number},
         },
+        label => {
+            exists $data->{new}{label}
+                ? (
+                    new => defined $data->{new}{label} ? to_json_object(
+                        $loaded->{Label}{gid_or_id($data->{new}{label})} //
+                        Label->new(name => $data->{new}{label}{name})
+                    ) : undef
+                ) : (),
+            old => defined $data->{old}{label} ? to_json_object(
+                $loaded->{Label}{gid_or_id($data->{old}{label})} //
+                Label->new(name => $data->{old}{label}{name})
+            ) : undef,
+        },
         barcode => $data->{release}{barcode}
     };
 
@@ -149,16 +162,6 @@ sub build_display_data {
             $event_display;
         } @{ $data->{release}{events} // [] }
     ];
-
-    for (qw( new old )) {
-        if (my $label = $data->{$_}{label}) {
-            next unless %$label;
-            $display_data->{label}{$_} = to_json_object(
-                $loaded->{Label}{gid_or_id($label)} //
-                Label->new(name => $label->{name})
-            );
-        }
-    }
 
     return $display_data;
 }

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -141,9 +141,11 @@ sub build_display_data {
                 );
             }
 
-            $event_display->{date} = to_json_object(
-                MusicBrainz::Server::Entity::PartialDate->new($_->{date})
-            );
+            if ($_->{date}) {
+                $event_display->{date} = to_json_object(
+                    MusicBrainz::Server::Entity::PartialDate->new($_->{date})
+                );
+            }
             $event_display;
         } @{ $data->{release}{events} // [] }
     ];

--- a/root/edit/details/EditReleaseLabel.js
+++ b/root/edit/details/EditReleaseLabel.js
@@ -22,13 +22,13 @@ type EditReleaseLabelEditT = {
   ...EditT,
   +display_data: {
     +barcode: string | null,
-    +catalog_number?: {
+    +catalog_number: {
       +new?: string | null,
       +old: string | null,
     },
     +combined_format?: string,
     +events: $ReadOnlyArray<ReleaseEventT>,
-    +label?: {
+    +label: {
       +new?: LabelT | null,
       +old: LabelT | null,
     },
@@ -44,7 +44,9 @@ const EditReleaseLabel = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
   const barcode = display.barcode;
   const catNo = display.catalog_number;
+  const showCatNo = nonEmpty(catNo.old) || nonEmpty(catNo.new);
   const label = display.label;
+  const showLabel = label.old || label.new;
   const releaseEvents = display.events;
   const hasMultipleEvents = display.events?.length > 1;
   const firstEvent = display.events[0];
@@ -62,10 +64,16 @@ const EditReleaseLabel = ({edit}: Props): React.Element<'table'> => {
         </tr>
       )}
 
-      {label ? (
+      {showLabel ? (
         <tr>
           <th>{addColonText(l('Label'))}</th>
-          {label.new ? (
+          {label.new === undefined ? (
+            <td colSpan="2">
+              {label.old ? (
+                <EntityLink entity={label.old} />
+              ) : null}
+            </td>
+          ) : (
             <>
               <td className="old">
                 {label.old ? (
@@ -73,20 +81,16 @@ const EditReleaseLabel = ({edit}: Props): React.Element<'table'> => {
                 ) : null}
               </td>
               <td className="new">
-                <EntityLink entity={label.new} />
+                {label.new ? (
+                  <EntityLink entity={label.new} />
+                ) : null}
               </td>
             </>
-          ) : (
-            <td colSpan="2">
-              {label.old ? (
-                <EntityLink entity={label.old} />
-              ) : null}
-            </td>
           )}
         </tr>
       ) : null}
 
-      {catNo ? (
+      {showCatNo ? (
         catNo.new === undefined ? (
           <tr>
             <th>{addColonText(l('Catalog number'))}</th>


### PR DESCRIPTION
This hides "Date:" if there's no date at all to show (which was meant to happen already, but we were passing an empty string as the date in that situation), fixes a regression where we wouldn't show the label diff if the label was being removed (because it was detecting a new label being missing as the label just not changing), and fixes hiding the label and catno sections when they are empty, rather than just unchanged.