### PR TITLE
MBS-11924: Hide useless tabs / subscribers section from deleted profiles

### DIFF
--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -30,7 +30,13 @@ function buildTabs(
 
   const tabs = [buildTab(page, l('Profile'), userPath, 'index')];
 
-  if (viewingOwnProfile || user.preferences.public_subscriptions) {
+  const userDeleted = user.deleted;
+  const hasPublicSubscriptions =
+    !userDeleted && user.preferences.public_subscriptions;
+  const hasPublicTags = !userDeleted && user.preferences.public_tags;
+  const hasPublicRatings = !userDeleted && user.preferences.public_ratings;
+
+  if (viewingOwnProfile || hasPublicSubscriptions) {
     tabs.push(buildTab(
       page,
       l('Subscriptions'),
@@ -39,24 +45,26 @@ function buildTabs(
     ));
   }
 
-  tabs.push(buildTab(
-    page,
-    l('Subscribers'),
-    userPath + '/subscribers',
-    'subscribers',
-  ));
-  tabs.push(buildTab(
-    page,
-    l('Collections'),
-    userPath + '/collections',
-    'collections',
-  ));
+  if (!userDeleted) {
+    tabs.push(buildTab(
+      page,
+      l('Subscribers'),
+      userPath + '/subscribers',
+      'subscribers',
+    ));
+    tabs.push(buildTab(
+      page,
+      l('Collections'),
+      userPath + '/collections',
+      'collections',
+    ));
+  }
 
-  if (viewingOwnProfile || user.preferences.public_tags) {
+  if (viewingOwnProfile || hasPublicTags) {
     tabs.push(buildTab(page, l('Tags'), userPath + '/tags', 'tags'));
   }
 
-  if (viewingOwnProfile || user.preferences.public_ratings) {
+  if (viewingOwnProfile || hasPublicRatings) {
     tabs.push(buildTab(page, l('Ratings'), userPath + '/ratings', 'ratings'));
   }
 

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -295,45 +295,47 @@ const UserProfileInformation = ({
           </UserProfileProperty>
         ) : null}
 
-        <UserProfileProperty name={l('Subscribers:')}>
-          {subscriberCount ? (
-            exp.l(
-              '{count} ({url|view list})',
-              {
-                count: subscriberCount,
-                url: `/user/${encodedName}/subscribers`,
-              },
-            )
-          ) : (
-            l('0')
-          )}
-          {$c.user && !viewingOwnProfile ? (
-            <>
-              {' '}
-              {bracketed(
-                subscribed ? (
-                  <a
-                    href={
-                      `/account/subscriptions/editor/remove?id=${user.id}` +
-                      '&' + returnToCurrentPage($c)
-                    }
-                  >
-                    {l('unsubscribe')}
-                  </a>
-                ) : (
-                  <a
-                    href={
-                      `/account/subscriptions/editor/add?id=${user.id}` +
-                      '&' + returnToCurrentPage($c)
-                    }
-                  >
-                    {l('subscribe')}
-                  </a>
-                ),
-              )}
-            </>
-          ) : null}
-        </UserProfileProperty>
+        {user.deleted ? null : (
+          <UserProfileProperty name={l('Subscribers:')}>
+            {subscriberCount ? (
+              exp.l(
+                '{count} ({url|view list})',
+                {
+                  count: subscriberCount,
+                  url: `/user/${encodedName}/subscribers`,
+                },
+              )
+            ) : (
+              l('0')
+            )}
+            {$c.user && !viewingOwnProfile ? (
+              <>
+                {' '}
+                {bracketed(
+                  subscribed ? (
+                    <a
+                      href={
+                        `/account/subscriptions/editor/remove?id=${user.id}` +
+                        '&' + returnToCurrentPage($c)
+                      }
+                    >
+                      {l('unsubscribe')}
+                    </a>
+                  ) : (
+                    <a
+                      href={
+                        `/account/subscriptions/editor/add?id=${user.id}` +
+                        '&' + returnToCurrentPage($c)
+                      }
+                    >
+                      {l('subscribe')}
+                    </a>
+                  ),
+                )}
+              </>
+            ) : null}
+          </UserProfileProperty>
+        )}
 
         {nonEmpty(biography) ? (
           <UserProfileProperty className="biography" name={l('Bio:')}>


### PR DESCRIPTION
### Implement MBS-11924

We show a lot of general tabs on deleted users' profile pages (Subscribers and Collections always, and Subscriptions, Tags, Ratings unless the editor marked them as private before removal). We also show subscriber info on the profile index.
Deleted profiles should never have any of these things, so there's no reason to show them - they're just a potential source of wasted clicks.