### PR TITLE
MBS-11922: Show historical (now secondary) types for old Add Release edits

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/AddRelease.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/AddRelease.pm
@@ -10,7 +10,11 @@ use aliased 'MusicBrainz::Server::Entity::Label';
 use aliased 'MusicBrainz::Server::Entity::Recording';
 
 use MusicBrainz::Server::Constants qw( $EDIT_HISTORIC_ADD_RELEASE );
-use MusicBrainz::Server::Edit::Historic::Utils qw( upgrade_date upgrade_id upgrade_type_and_status );
+use MusicBrainz::Server::Edit::Historic::Utils qw(
+    get_historic_type
+    upgrade_date upgrade_id
+    upgrade_type_and_status
+);
 use MusicBrainz::Server::Edit::Types qw( Nullable PartialDateHash );
 use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
@@ -108,8 +112,7 @@ sub build_display_data
         ],
         status         => defined($self->data->{status_id}) &&
                             to_json_object($loaded->{ReleaseStatus}{ $self->data->{status_id} }),
-        type           => defined($self->data->{type_id}) &&
-                            to_json_object($loaded->{ReleaseGroupType}{ $self->data->{type_id} }),
+        type           => get_historic_type($self->data->{type_id}, $loaded),
         language       => defined($self->data->{language_id}) &&
                             to_json_object($loaded->{Language}{ $self->data->{language_id} }),
         script         => defined($self->data->{script_id}) &&

--- a/root/edit/details/historic/AddRelease.js
+++ b/root/edit/details/historic/AddRelease.js
@@ -53,6 +53,7 @@ type Props = {
 const AddRelease = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
   const artist = display.artist;
+  const type = display.type;
 
   return (
     <table className="details add-release">
@@ -73,8 +74,10 @@ const AddRelease = ({edit}: Props): React.Element<'table'> => {
       <tr>
         <th>{addColonText(l('Type'))}</th>
         <td>
-          {display.type
-            ? lp_attributes(display.type.name, 'release_group_primary_type')
+          {type
+            ? type.historic
+              ? lp_attributes(type.name, 'release_group_secondary_type')
+              : lp_attributes(type.name, 'release_group_primary_type')
             : null}
         </td>
       </tr>


### PR DESCRIPTION
### Fix MBS-11922

We already implemented this for AddReleaseGroup, so it makes sense to also make use of it in here, and it seems to work fine.