### PR TITLE
MBS-11852: Only call TO_JSON on editor if it exists

### DIFF
--- a/lib/MusicBrainz/Server/Entity/EditNote.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNote.pm
@@ -9,6 +9,7 @@ use namespace::autoclean;
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
 use MusicBrainz::Server::Data::Utils qw( datetime_to_iso8601 );
 use MusicBrainz::Server::Entity::Types;
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Filters qw( format_editnote );
 use MusicBrainz::Server::Types qw( DateTime );
 
@@ -125,7 +126,7 @@ around TO_JSON => sub {
 
     my $json = $self->$orig;
     $json->{editor_id} = $self->editor_id + 0;
-    $json->{editor} = $self->editor->TO_JSON;
+    $json->{editor} = to_json_object($self->editor);
     $json->{post_time} = datetime_to_iso8601($self->post_time);
     $json->{formatted_text} = $self->editor_id == $EDITOR_MODBOT
         ? $self->localize : format_editnote($self->text);

--- a/root/edit/components/EditorTypeInfo.js
+++ b/root/edit/components/EditorTypeInfo.js
@@ -13,35 +13,37 @@ import bracketed from '../../static/scripts/common/utility/bracketed';
 import {isBot} from '../../static/scripts/common/utility/privileges';
 
 type Props = {
-  +editor: EditorT,
+  +editor: EditorT | null,
 };
 
 const EditorTypeInfo = ({
   editor,
-}: Props): React.Element<typeof React.Fragment> => (
-  <>
-    {editor.is_limited ? (
-      <span className="editor-class">
-        {bracketed(
-          <span
-            className="tooltip"
-            title={l('This user is new to MusicBrainz.')}
-          >
-            {l('beginner')}
-          </span>,
-        )}
-      </span>
-    ) : null}
-    {isBot(editor) ? (
-      <span className="editor-class">
-        {bracketed(
-          <span className="tooltip" title={l('This user is automated.')}>
-            {l('bot')}
-          </span>,
-        )}
-      </span>
-    ) : null}
-  </>
+}: Props): React.Element<typeof React.Fragment> | null => (
+  editor == null ? null : (
+    <>
+      {editor.is_limited ? (
+        <span className="editor-class">
+          {bracketed(
+            <span
+              className="tooltip"
+              title={l('This user is new to MusicBrainz.')}
+            >
+              {l('beginner')}
+            </span>,
+          )}
+        </span>
+      ) : null}
+      {isBot(editor) ? (
+        <span className="editor-class">
+          {bracketed(
+            <span className="tooltip" title={l('This user is automated.')}>
+              {l('bot')}
+            </span>,
+          )}
+        </span>
+      ) : null}
+    </>
+  )
 );
 
 export default EditorTypeInfo;

--- a/root/types/edit.js
+++ b/root/types/edit.js
@@ -57,7 +57,7 @@ declare type EditT = {
 
 // MusicBrainz::Server::Entity::EditNote::TO_JSON
 declare type EditNoteT = {
-  +editor: EditorT,
+  +editor: EditorT | null,
   +editor_id: number,
   +formatted_text: string,
   +post_time: string | null,


### PR DESCRIPTION
### Fix MBS-11852

When trying to approve an edit with a No vote + note, we load edit notes for the edit (to see if one of the editor_ids matches the approver's) but we do not load the actual editors themselves.
On doing TO_JSON for edit when passing it to NoteIsRequired, we were (correctly) running to_json_array on the edit notes, and this was running TO_JSON directly on the note's editor, which, of course, had not been loaded. This changes it to run to_json_object, which is smarter and actually ensures TO_JSON can be called before calling it.

To test, create an open edit with one editor, vote No and leave a note with a second editor, and then try and approve the edit with a third editor. Of course, editor 2 will need to be allowed to vote/leave notes (so, not a beginner) which can be annoying to trigger with sample data, but certainly doable (worst case, just do what I did and enter 10 open edits, then accept them).