### PR TITLE
MBS-11819: Show to admins whether account has oAuth uses

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -441,6 +441,10 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     $c->stash->{subscriber_count} = $subscr_model->get_subscribed_editor_count($user->id);
     $c->stash->{votes}            = $c->model('Vote')->editor_statistics($user);
 
+    my ($tokens, $token_count) = $c->model('EditorOAuthToken')->find_granted_by_editor($user->id);
+
+    my ($applications, $application_count) = $c->model('Application')->find_by_owner($user->id);
+
     $c->model('Gender')->load($user);
     $c->model('EditorLanguage')->load_for_editor($user);
 
@@ -459,14 +463,16 @@ sub profile : Chained('load') PathPart('') HiddenOnSlaves
     }
 
     my %props = (
-        editStats       => $edit_stats,
-        ipHashes        => \@ip_hashes,
-        subscribed      => $c->stash->{subscribed},
-        subscriberCount => $c->stash->{subscriber_count},
-        user            => $c->unsanitized_editor_json($user),
-        votes           => $c->stash->{votes},
-        addedEntities   => $added_entities,
-        secondaryStats  => $secondary_stats,
+        applicationCount    => $application_count,
+        editStats           => $edit_stats,
+        ipHashes            => \@ip_hashes,
+        subscribed          => $c->stash->{subscribed},
+        subscriberCount     => $c->stash->{subscriber_count},
+        tokenCount          => $token_count,
+        user                => $c->unsanitized_editor_json($user),
+        votes               => $c->stash->{votes},
+        addedEntities       => $added_entities,
+        secondaryStats      => $secondary_stats,
     );
 
     $c->stash(

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -125,18 +125,22 @@ const UserProfileProperty = ({
 
 type UserProfileInformationProps = {
   +$c: CatalystContextT,
+  +applicationCount: number,
   +ipHashes: $ReadOnlyArray<string>,
   +subscribed: boolean,
   +subscriberCount: number,
+  +tokenCount: number,
   +user: UnsanitizedEditorT,
   +viewingOwnProfile: boolean,
 };
 
 const UserProfileInformation = ({
   $c,
+  applicationCount,
   ipHashes,
   subscribed,
   subscriberCount,
+  tokenCount,
   user,
   viewingOwnProfile,
 }: UserProfileInformationProps) => {
@@ -270,11 +274,45 @@ const UserProfileInformation = ({
         </UserProfileProperty>
 
         {(viewingOwnProfile || isAccountAdmin(viewingUser)) ? (
-          <UserProfileProperty name={l('Last login:')}>
-            {nonEmpty(user.last_login_date)
-              ? formatUserDate($c, user.last_login_date)
-              : l("Hasn't logged in yet")}
-          </UserProfileProperty>
+          <>
+            <UserProfileProperty name={l('Last login:')}>
+              {nonEmpty(user.last_login_date)
+                ? formatUserDate($c, user.last_login_date)
+                : l("Hasn't logged in yet")}
+            </UserProfileProperty>
+
+            {tokenCount ? (
+              <UserProfileProperty
+                name={addColonText(l('Authorized applications'))}
+              >
+                {tokenCount}
+                {viewingOwnProfile ? (
+                  <>
+                    {' '}
+                    <a href="/account/applications" rel="nofollow">
+                      {bracketedText(l('see list'))}
+                    </a>
+                  </>
+                ) : null}
+              </UserProfileProperty>
+            ) : null}
+
+            {applicationCount ? (
+              <UserProfileProperty
+                name={addColonText(l('Developer applications'))}
+              >
+                {applicationCount}
+                {viewingOwnProfile ? (
+                  <>
+                    {' '}
+                    <a href="/account/applications" rel="nofollow">
+                      {bracketedText(l('see list'))}
+                    </a>
+                  </>
+                ) : null}
+              </UserProfileProperty>
+            ) : null}
+          </>
         ) : null}
 
         {nonEmpty(user.website) ? (
@@ -783,22 +821,26 @@ const UserProfileStatistics = ({
 type UserProfileProps = {
   +$c: CatalystContextT,
   +addedEntities: EntitiesStatsT,
+  +applicationCount: number,
   +editStats: EditStatsT,
   +ipHashes: $ReadOnlyArray<string>,
   +secondaryStats: SecondaryStatsT,
   +subscribed: boolean,
   +subscriberCount: number,
+  +tokenCount: number,
   +user: UnsanitizedEditorT,
   +votes: VoteStatsT,
 };
 
 const UserProfile = ({
   $c,
+  applicationCount,
   editStats,
   ipHashes,
   secondaryStats,
   subscribed,
   subscriberCount,
+  tokenCount,
   user,
   votes,
   addedEntities,
@@ -813,9 +855,11 @@ const UserProfile = ({
     >
       <UserProfileInformation
         $c={$c}
+        applicationCount={applicationCount}
         ipHashes={ipHashes}
         subscribed={subscribed}
         subscriberCount={subscriberCount}
+        tokenCount={tokenCount}
         user={user}
         viewingOwnProfile={viewingOwnProfile}
       />


### PR DESCRIPTION
### Implement MBS-11819

As an admin, it's useful to know how an account has been used before deleting it. If no oAuth authorizations nor applications exist, then there's no worries that deleting it might cause issues elsewhere nor that there's spam somewhere else we have not yet seen.

Ideally we would also link to the user's BB, LB and CB profiles, at least, but right now that's not trivial at all since for example BB does not currently allow finding users by MB username nor MB user id.