### PR TITLE
Allow disabling the template renderer

### DIFF
--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -407,6 +407,11 @@ sub HTML_VALIDATOR { 'http://validator.w3.org/nu/?out=json' }
 # We use a small Node.js server (root/server.js) to render React.js
 # templates. RENDERER_SOCKET configures the local (UNIX) socket path it
 # listens on.
+#
+# If this is set to '' or undef, MBS will not try to communicate with the
+# template-renderer. This can be useful if you only make web service requests
+# and don't have the renderer running, as any attempts to communicate with it
+# will just result in socket timeouts.
 sub RENDERER_SOCKET {
     catfile(tmpdir, 'musicbrainz-template-renderer.socket')
 }

--- a/lib/MusicBrainz/Server/Renderer.pm
+++ b/lib/MusicBrainz/Server/Renderer.pm
@@ -19,12 +19,14 @@ our @EXPORT_OK = qw(
 sub send_to_renderer {
     my ($c, $message, $expect_response) = @_;
 
+    my $socket = $c->stash->{renderer_socket};
+    return unless defined $socket;
+
     require bytes;
 
     state $body_json = JSON->new->utf8->allow_unknown(0)->allow_blessed(0);
     my $encoded_body = encode_with_linked_entities($body_json, $message);
 
-    my $socket = $c->stash->{renderer_socket};
     $socket->send(pack('V', bytes::length($encoded_body)));
     $socket->send($encoded_body);
 

--- a/lib/MusicBrainz/Server/View/Node.pm
+++ b/lib/MusicBrainz/Server/View/Node.pm
@@ -18,11 +18,17 @@ sub process {
     my $component_path = $c->stash->{component_path} // $c->req->path;
     my $component_props = $c->stash->{component_props} // {};
     my $response = render_component($c, $component_path, $component_props);
-    my ($content_type, $status, $body) =
-        @$response{qw(content_type status body)};
+    my ($content_type, $status, $body);
 
-    if ($content_type eq 'text/html') {
-        $body = $DOCTYPE . $body;
+    if (defined $response) {
+        ($content_type, $status, $body) =
+            @$response{qw(content_type status body)};
+
+        if ($content_type eq 'text/html') {
+            $body = $DOCTYPE . $body;
+        }
+    } else {
+        $content_type = 'text/plain';
     }
 
     $c->res->content_type($content_type . '; charset=utf-8');


### PR DESCRIPTION
If `RENDERER_SOCKET` is empty, MBS will now avoid communicating with the template renderer at all. This will prevent socket timeouts ("Couldn't connect to the renderer") from occurring if certain non-WS requests leak into our WS containers in production (as these containers don't have any renderer process).

A blank response is returned if this happens, because it's not an error that's even intended to be /allowed/ to be triggered normally (and I don't suspect anyone will use this flag outside of us), but I improved the logging to include the URL that triggered it. (You can already find which URLs are causing this in Sentry.)