### PR TITLE
MBS-11942: Deleted users can still use pending verification links

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -126,6 +126,10 @@ sub verify_email : Path('/verify-email') ForbiddenOnSlaves DenyWhenReadonly
         $c->detach;
     }
 
+    if ($editor->deleted) {
+        $c->detach('/user/not_found');
+    }
+
     $c->model('Editor')->update_email($editor, $email);
 
     if ($c->user_exists) {


### PR DESCRIPTION
### Fix MBS-11942

If a user gets deleted after they get send a verification link, but before they click on it, the email is added to the now-deleted user. This is certainly not intended, so this checks the user is not deleted before actually updating anything.

This isn't tested because I can't actually send verification emails from my local system, but I don't see why it wouldn't work. Scream if I did a dumb.