### PR TITLE
MBS-10902: Stop changing zxx language name at the Perl level

### DIFF
--- a/lib/MusicBrainz/Server/Data/Language.pm
+++ b/lib/MusicBrainz/Server/Data/Language.pm
@@ -57,14 +57,6 @@ sub load_for_works {
 
     load_subobjects($self, 'language', map { $_->all_languages } @objs);
 
-    for my $work (@objs) {
-        for my $wl ($work->all_languages) {
-            if ($wl->language && $wl->language->iso_code_3 eq 'zxx') {
-                $wl->language->name(l('[No lyrics]'));
-            }
-        }
-    }
-
     return;
 }
 

--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -5,7 +5,7 @@ use MooseX::Types::Moose qw( ArrayRef Int Maybe Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw( $EDIT_WORK_CREATE );
 use MusicBrainz::Server::Edit::Types qw( Nullable );
-use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( l N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
@@ -71,22 +71,13 @@ sub build_display_data
 
     if (defined $data->{language_id}) {
         my $language = $loaded->{Language}{$data->{language_id}};
-        if ($language->iso_code_3 eq 'zxx') {
-            $language->name(l('[No lyrics]'));
-        }
         $display->{language} = to_json_object($language);
     }
 
     if (defined $data->{languages}) {
-        $display->{languages} = [
-            map {
-                my $language = $loaded->{Language}{$_};
-                if ($language && $language->iso_code_3 eq 'zxx') {
-                    $language->name(l('[No lyrics]'));
-                }
-                $language ? $language->name : l('[removed]')
-            } @{ $data->{languages} }
-        ];
+        $display->{languages} = to_json_array([
+            map { $loaded->{Language}{$_} } @{ $data->{languages} }
+        ]);
     }
 
     return $display;

--- a/lib/MusicBrainz/Server/Edit/Work/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Edit.pm
@@ -16,7 +16,7 @@ use MusicBrainz::Server::Edit::Utils qw(
     changed_display_data
 );
 use MusicBrainz::Server::Edit::Exceptions;
-use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( l N_l );
 use Set::Scalar;
 
@@ -177,14 +177,8 @@ sub build_display_data
 
     if (exists $data->{new}{languages}) {
         for my $side (qw( old new )) {
-            $display->{languages}{$side} = [
-                map {
-                    my $language = $loaded->{Language}{$_};
-                    if ($language && $language->iso_code_3 eq 'zxx') {
-                        $language->name(l('[No lyrics]'));
-                    }
-                    $language ? $language->name : l('[removed]');
-                } @{ $data->{$side}{languages} // [] }
+            $display->{languages}{$side} = to_json_array[
+                map { $loaded->{Language}{$_} } @{ $data->{$side}{languages} // [] }
             ];
         }
     }

--- a/root/edit/details/AddWork.js
+++ b/root/edit/details/AddWork.js
@@ -12,6 +12,8 @@ import * as React from 'react';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
 import {commaOnlyListText} from
   '../../static/scripts/common/i18n/commaOnlyList';
+import localizeLanguageName
+  from '../../static/scripts/common/i18n/localizeLanguageName';
 
 type AddWorkEditT = {
   ...EditT,
@@ -22,7 +24,7 @@ type AddWorkEditT = {
     +comment: string,
     +iswc: string,
     +language?: LanguageT,
-    +languages?: $ReadOnlyArray<string>,
+    +languages?: $ReadOnlyArray<LanguageT>,
     +name: string,
     +type: WorkTypeT | null,
     +work: WorkT,
@@ -73,7 +75,7 @@ const AddWork = ({edit}: Props): React.MixedElement => {
         {language ? (
           <tr>
             <th>{addColonText(l('Language'))}</th>
-            <td>{l_languages(language.name)}</td>
+            <td>{localizeLanguageName(language, true)}</td>
           </tr>
         ) : null}
         {languages && languages.length ? (
@@ -81,7 +83,7 @@ const AddWork = ({edit}: Props): React.MixedElement => {
             <th>{addColonText(l('Lyrics Languages'))}</th>
             <td>
               {commaOnlyListText(languages.map(
-                language => l_languages(language),
+                language => localizeLanguageName(language, true),
               ))}
             </td>
           </tr>

--- a/root/edit/details/EditWork.js
+++ b/root/edit/details/EditWork.js
@@ -13,6 +13,8 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 import {commaOnlyListText}
   from '../../static/scripts/common/i18n/commaOnlyList';
+import localizeLanguageName
+  from '../../static/scripts/common/i18n/localizeLanguageName';
 import Diff from '../../static/scripts/edit/components/edit/Diff';
 import DiffSide from '../../static/scripts/edit/components/edit/DiffSide';
 import FullChangeDiff
@@ -28,7 +30,7 @@ type EditWorkEditT = {
     },
     +comment?: CompT<string | null>,
     +iswc?: CompT<string | null>,
-    +languages?: CompT<$ReadOnlyArray<string>>,
+    +languages?: CompT<$ReadOnlyArray<LanguageT>>,
     +name?: CompT<string>,
     +type?: CompT<WorkTypeT | null>,
     +work: WorkT,
@@ -39,7 +41,7 @@ type Props = {
   +edit: EditWorkEditT,
 };
 
-const localizeLanguageName = name => l_languages(name);
+const localizeLanguage = language => localizeLanguageName(language, true);
 
 const EditWork = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
@@ -97,10 +99,10 @@ const EditWork = ({edit}: Props): React.Element<'table'> => {
         <Diff
           label={addColonText(l('Lyrics Languages'))}
           newText={commaOnlyListText(
-            languages.new.map(localizeLanguageName),
+            languages.new.map(localizeLanguage),
           )}
           oldText={commaOnlyListText(
-            languages.old.map(localizeLanguageName),
+            languages.old.map(localizeLanguage),
           )}
           split=", "
         />

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -17,6 +17,7 @@ import AddEntityDialog, {
 import {ENTITIES, MAX_RECENT_ENTITIES} from '../../constants';
 import mbEntity from '../../entity';
 import commaOnlyList from '../../i18n/commaOnlyList';
+import localizeLanguageName from '../../i18n/localizeLanguageName';
 import {reduceArtistCredit} from '../../immutable-entities';
 import MB from '../../MB';
 import {compactMap, first, groupBy, last} from '../../utility/arrays';
@@ -850,7 +851,7 @@ MB.Control.autocomplete_formatters = {
       a.prepend(
         '<span class="autocomplete-language">' +
         he.escape(commaOnlyList(
-          item.languages.map(wl => l_languages(wl.language.name)),
+          item.languages.map(wl => localizeLanguageName(wl.language, true)),
         )) + '</span>',
       );
     }

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -18,6 +18,7 @@ import localizeLinkAttributeTypeDescription
   from '../../i18n/localizeLinkAttributeTypeDescription';
 import localizeLinkAttributeTypeName
   from '../../i18n/localizeLinkAttributeTypeName';
+import localizeLanguageName from '../../i18n/localizeLanguageName';
 import {reduceArtistCredit} from '../../immutable-entities';
 import bracketed, {bracketedText} from '../../utility/bracketed';
 import formatDate from '../../utility/formatDate';
@@ -434,7 +435,7 @@ function formatWork(work: WorkT) {
       {languages && languages.length ? (
         showExtraInfo(
           commaOnlyListText(
-            languages.map(wl => l_languages(wl.language.name)),
+            languages.map(wl => localizeLanguageName(wl.language, true)),
           ),
           'language',
         )

--- a/root/static/scripts/common/components/WorkListEntry.js
+++ b/root/static/scripts/common/components/WorkListEntry.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import localizeLanguageName from '../i18n/localizeLanguageName';
 import {CatalystContext} from '../../../../context';
 import RatingStars from '../../../../components/RatingStars';
 import loopParity from '../../../../utility/loopParity';
@@ -95,7 +96,7 @@ export const WorkListRow = ({
               data-iso-639-3={language.language.iso_code_3}
               key={language.language.id}
             >
-              {l_languages(language.language.name)}
+              {localizeLanguageName(language.language, true)}
             </li>
           ))}
         </ul>

--- a/root/static/scripts/common/i18n/localizeLanguageName.js
+++ b/root/static/scripts/common/i18n/localizeLanguageName.js
@@ -1,0 +1,24 @@
+/*
+ * @flow strict
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+function localizeLanguageName(
+  language: LanguageT | null,
+  isWork?: boolean = false,
+): string {
+  if (!language) {
+    return l('[removed]');
+  }
+  // For works, "No linguistic content" is meant as "No lyrics"
+  if (isWork && language.iso_code_3 === 'zxx') {
+    return l('[No lyrics]');
+  }
+  return l_languages(language.name);
+}
+
+export default localizeLanguageName;

--- a/root/utility/tableColumns.js
+++ b/root/utility/tableColumns.js
@@ -46,6 +46,8 @@ import formatEndDate from '../static/scripts/common/utility/formatEndDate';
 import renderMergeCheckboxElement
   from '../static/scripts/common/utility/renderMergeCheckboxElement';
 import expand2react from '../static/scripts/common/i18n/expand2react';
+import localizeLanguageName
+  from '../static/scripts/common/i18n/localizeLanguageName';
 import yesNo from '../static/scripts/common/utility/yesNo';
 import type {ReportRelationshipRoleT} from '../report/types';
 
@@ -865,7 +867,7 @@ export const workLanguagesColumn:
             data-iso-639-3={language.language.iso_code_3}
             key={language.language.id}
           >
-            {l_languages(language.language.name)}
+            {localizeLanguageName(language.language, true)}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
### Fix MBS-10902

This was causing issues when both work and release edits were being loaded, in that releases would appear with the language
[No lyrics]. Now that all relevant edits are React anyway, there's no need to massage the work on the Perl level at all. Instead, this just passes the languages (rather than their names) to JS and lets localizeLanguageName change the displayed name only.

Tested this by visiting add work / edit work edits, work searches, artists' work pages.

I didn't change the calls for l_languages for release/stats stuff right now, although I guess we could if that seems more consistent / better :) 