### PR TITLE
MBS-11941: Normalize Worldcat identities URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4515,6 +4515,8 @@ const CLEANUPS: CleanupEntries = {
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?worldcat\.org/, 'https://www.worldcat.org');
       url = url.replace(/^https:\/\/www\.worldcat\.org(?:\/title\/[a-zA-Z0-9_-]+)?\/oclc\/([^&?]+)(?:.*)$/, 'https://www.worldcat.org/oclc/$1');
+      // oclc permalinks have no ending slash but identities ones do
+      url = url.replace(/^https:\/\/www\.worldcat\.org\/(?:wc)?identities\/([^&?/]+)(?:.*)$/, 'https://www.worldcat.org/identities/$1/');
       return url;
     },
   },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4626,6 +4626,24 @@ const testData = [
     expected_relationship_type: 'otherdatabases',
             expected_clean_url: 'https://www.worldcat.org/identities/lccn-no2015052484/',
   },
+  {
+                     input_url: 'http://www.worldcat.org/identities/lccn-n50005018',
+             input_entity_type: 'label',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.worldcat.org/identities/lccn-n50005018/',
+  },
+  {
+                     input_url: 'http://worldcat.org/identities/lccn-n79081635/',
+             input_entity_type: 'place',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.worldcat.org/identities/lccn-n79081635/',
+  },
+  {
+                     input_url: 'https://www.worldcat.org/wcidentities/lccn-n94-9040',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.worldcat.org/identities/lccn-n94-9040/',
+  },
   // YouTube
   {
                      input_url: 'http://youtube.com/user/officialpsy/videos',


### PR DESCRIPTION
### Implement MBS-11941

This ensures the permalinks to Worldcat identities pages include the ending slash, since that's their default.
Additionally, wcidentities pages get converted into identities pages (as far as I can tell they are both the same content with a slightly different design).
