### PR TITLE
MBS-11957: Clean up twitch.com to twitch.tv

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4036,10 +4036,10 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'twitch': {
-    match: [new RegExp('^(https?://)?([^/]+\\.)?(twitch\\.tv/)', 'i')],
+    match: [new RegExp('^(https?://)?([^/]+\\.)?twitch\\.(?:com|tv)/', 'i')],
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel}],
     clean: function (url) {
-      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?twitch\.tv\/((?:videos\/)?[^\/?#]+)(?:.*)?$/, 'https://www.twitch.tv/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:www\.)?twitch\.(?:com|tv)\/((?:videos\/)?[^\/?#]+)(?:.*)?$/, 'https://www.twitch.tv/$1');
       return url;
     },
     validate: function (url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4097,6 +4097,13 @@ const testData = [
             expected_clean_url: 'https://www.twitch.tv/videos/1234567890',
        only_valid_entity_types: ['recording', 'release'],
   },
+  {
+                     input_url: 'http://twitch.com/pisceze',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'videochannel',
+            expected_clean_url: 'https://www.twitch.tv/pisceze',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
   // Twitter
   {
                      input_url: 'http://twitter.com/miguelgrimaldo',


### PR DESCRIPTION
### Implement MBS-11957

Twitch allows both but automatically redirects. We had 5 of these in the DB right now, which I fixed by hand (including the test example).
