### PR TITLE
MBS-11959: Allow RYM links for music video recordings

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3429,9 +3429,10 @@ const CLEANUPS: CleanupEntries = {
       return url.replace(/^(?:https?:\/\/)?(?:www\.)?rateyourmusic\.com\//, 'https://rateyourmusic.com/');
     },
     validate: function (url, id) {
-      const m = /^https:\/\/rateyourmusic\.com\/(\w+)\//.exec(url);
+      const m = /^https:\/\/rateyourmusic\.com\/(\w+)\/(?:(\w+)\/)?/.exec(url);
       if (m) {
         const prefix = m[1];
+        const subPath = m[2];
         switch (id) {
           case LINK_TYPES.otherdatabases.artist:
             return {
@@ -3451,6 +3452,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'venue',
+              target: ERROR_TARGETS.RELATIONSHIP,
+            };
+          case LINK_TYPES.otherdatabases.recording:
+            return {
+              error: l('Only RYM music videos can be linked to recordings.'),
+              result: prefix === 'release' && subPath === 'musicvideo',
               target: ERROR_TARGETS.RELATIONSHIP,
             };
           case LINK_TYPES.otherdatabases.release:

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3311,6 +3311,13 @@ const testData = [
         only_valid_entity_types: ['place'],
   },
   {
+                     input_url: 'https://rateyourmusic.com/release/musicvideo/metallica/one/',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://rateyourmusic.com/release/musicvideo/metallica/one/',
+        only_valid_entity_types: ['recording', 'release', 'release_group'],
+  },
+  {
                      input_url: 'https://rateyourmusic.com/release/single/tori_amos/a_sorta_fairytale/',
              input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-11959

Since RYM doesn't seem to otherwise have recording level data, this specifically limits recording links to music videos (which have recently been added).