### PR TITLE
MBS-11961: Rename "random" in edit search since it's not random

### DIFF
--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -30,7 +30,7 @@
       <option value="vote_closing_asc"' _ selected_if_matches('vote_closing_asc', query.order) _ '>' _ l('voting closing sooner first')     _ '</option>
       <option value="vote_closing_desc"' _ selected_if_matches('vote_closing_desc', query.order) _ '>' _ l('voting closing later first')     _ '</option>
       <option value="latest_note"' _ selected_if_matches('latest_note', query.order) _ '>' _ l('with recent edit notes first')     _ '</option>
-      <option value="rand"' _ selected_if_matches('rand', query.order) _ '>' _ l('randomly')     _ '</option>
+      <option value="rand"' _ selected_if_matches('rand', query.order) _ '>' _ l('in an unspecified order (possibly faster)')     _ '</option>
     </select>' -%]
     [%- match_or_negation_block = '<select name="negation">
       <option value="0"' _ selected_if_matches('0', query.negate, 1) _ '>' _ l('match')        _ '</option>


### PR DESCRIPTION
### Implement MBS-11961

This just does not select any sort when the 'rand' order is selected.

PSQL docs used to say "If sorting is not chosen, the rows will be returned in random order" but that's misleading and has since been corrected to "the rows will be returned in an unspecified order". For at least some queries, the unspecified order is literally "ordered by ID", which means people will be confused about the clear non-randomness.

Actually making this random seems to have little use, and makes things very slow (see https://github.com/metabrainz/musicbrainz-server/pull/2043). Since the most useful thing about the current option is that skipping sorting sometimes makes things quite a bit faster, this just renames the option to be less misleading.