### PR TITLE
Allow limiting compression threads from config

### DIFF
--- a/admin/BundleSearchIndexesDump
+++ b/admin/BundleSearchIndexesDump
@@ -79,6 +79,7 @@ sub _error { warn "[error] ", (sprintf shift, @_), "\n"; }
 
 my $BACKUP_STAMP = $ENV{BACKUP_STAMP};
 my $COMPRESSION_LEVEL = DBDefs->SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL;
+my $COMPRESSION_THREADS = DBDefs->DUMP_COMPRESSION_THREADS;
 
 my @backup_dirs;
 my @extraneous_files;
@@ -170,7 +171,7 @@ EOF
             ' --verbose' .
             ' -- ' .
             shell_quote($dump_dir) .
-            " | zstd -T0 -$COMPRESSION_LEVEL" .
+            " | zstd -T$COMPRESSION_THREADS -$COMPRESSION_LEVEL" .
             ' > ' . shell_quote("$working_dir/$tar_file");
     if ($? != 0)
     {

--- a/admin/RunJSONDump
+++ b/admin/RunJSONDump
@@ -38,7 +38,7 @@ echo `date`" : Making a full JSON dump"
     --worker-count 4 \
     || exit $?
 
-# Copy the full export to the FTP directory.
+echo `date`" : Copying the full export to the local FTP directory"
 chown "$JSON_DUMP_USER:$JSON_DUMP_GROUP" "$TEMP_DIR"/*
 chmod "$JSON_DUMP_FILE_MODE" "$TEMP_DIR"/*
 mv "$TEMP_DIR"/* "$DUMP_DIR"/"$DUMP_STAMP"/
@@ -55,8 +55,10 @@ echo "$DUMP_STAMP" > "$DUMP_DIR"/LATEST
 chmod "$JSON_DUMP_FILE_MODE" "$DUMP_DIR"/LATEST
 chown "$JSON_DUMP_USER:$JSON_DUMP_GROUP" "$DUMP_DIR"/LATEST
 
+echo `date`" : Deleting old full exports from the local FTP directory"
 ./bin/delete-old-fullexports -k -r "$DUMP_DIR"
 
+echo `date`" : Syncing the local FTP directory with the FTP server"
 MBS_ADMIN_CONFIG=config.json-dump.sh ./bin/rsync-fullexport-files
 
 # eof

--- a/admin/RunSearchIndexesDump
+++ b/admin/RunSearchIndexesDump
@@ -43,7 +43,7 @@ BACKUP_STAMP="$DUMP_STAMP" \
     --working-dir "$TEMP_DIR" \
     || exit $?
 
-# Copy the dump to the FTP directory.
+echo `date`" : Copying the dump to the local FTP directory"
 chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" "$TEMP_DIR"/*
 chmod "$SEARCH_INDEXES_DUMP_FILE_MODE" "$TEMP_DIR"/*
 mv "$TEMP_DIR"/* "$DUMP_DIR"/"$DUMP_STAMP"/
@@ -60,6 +60,8 @@ echo "$DUMP_STAMP" > "$DUMP_DIR"/LATEST
 chmod "$SEARCH_INDEXES_DUMP_FILE_MODE" "$DUMP_DIR"/LATEST
 chown "$SEARCH_INDEXES_DUMP_USER:$SEARCH_INDEXES_DUMP_GROUP" "$DUMP_DIR"/LATEST
 
+echo `date`" : Deleting old full exports from the local FTP directory"
 ./bin/delete-old-fullexports -k -r "$DUMP_DIR"
 
+echo `date`" : Syncing the local FTP directory with the FTP server"
 MBS_ADMIN_CONFIG=config.search-indexes-dump.sh ./bin/rsync-fullexport-files

--- a/lib/DBDefs/Default.pm
+++ b/lib/DBDefs/Default.pm
@@ -472,6 +472,10 @@ sub SOLRCLOUD_RSYNC_BANDWIDTH { undef }
 sub SOLRCLOUD_SSH_CIPHER_SPEC { undef }
 sub SEARCH_INDEXES_DUMP_COMPRESSION_LEVEL { undef }
 
+# Controls the number of threads to use when compressing JSON dumps or search
+# index dumps. Passed as `-T` or `--threads` to xz and zstd.
+sub DUMP_COMPRESSION_THREADS { 0 }
+
 sub WIKIMEDIA_COMMONS_IMAGES_ENABLED { 1 }
 
 # On release browse endpoints in the webservice, we limit the number of

--- a/lib/MusicBrainz/Script/MBDump.pm
+++ b/lib/MusicBrainz/Script/MBDump.pm
@@ -59,6 +59,12 @@ has compression_level => (
     isa => 'Maybe[Str]',
 );
 
+has compression_threads => (
+    is => 'rw',
+    isa => 'Maybe[Int]',
+    default => DBDefs->DUMP_COMPRESSION_THREADS,
+);
+
 has replication_sequence => (
     is => 'ro',
     isa => 'Maybe[Int]',
@@ -153,11 +159,12 @@ sub make_tar {
     my $output_dir = $self->output_dir;
     my $compression = $self->compression;
     my $compression_level = $self->compression_level;
+    my $compression_threads = $self->compression_threads;
 
     my $compress_command;
     if ($compression) {
         $compress_command = "$compression";
-        $compress_command .= ' --threads=0' if $compression eq 'xz';
+        $compress_command .= " --threads=$compression_threads" if $compression eq 'xz';
         $compress_command .= " -$compression_level" if defined $compression_level;
     }
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

To compress JSON dumps (using `xz`) and search index dumps (using `zstd`), the number of threads is currently not limited so dumps can be made available faster. However, it now has detrimental impacts to the server’s availability when dumps are built.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch adds the key `DUMP_COMPRESSION_THREADS` to the configuration so it can be changed at deployment time. It doesn’t change the default though.

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Set the value for `DUMP_COMPRESSION_THREADS` key to `4` in docker server configs for both `musicbrainz-json-dump` and `musicbrainz-search-indexes-dump`.