### PR TITLE
MBS-11960: Also assign seeded URL to rawURL

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1466,6 +1466,16 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
   const entityTypes = [sourceType, 'url'].sort().join('-');
   let initialLinks = parseRelationships(sourceData.relationships);
 
+  initialLinks.sort(function (a, b) {
+    const typeA = a.type && linkedEntities.link_type[a.type];
+    const typeB = b.type && linkedEntities.link_type[b.type];
+
+    return compare(
+      typeA ? l_relationships(typeA.link_phrase).toLowerCase() : '',
+      typeB ? l_relationships(typeB.link_phrase).toLowerCase() : '',
+    );
+  });
+
   // Terribly get seeded URLs
   if (MB.formWasPosted) {
     if (hasSessionStorage) {
@@ -1501,16 +1511,6 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
       }));
     }
   }
-
-  initialLinks.sort(function (a, b) {
-    const typeA = a.type && linkedEntities.link_type[a.type];
-    const typeB = b.type && linkedEntities.link_type[b.type];
-
-    return compare(
-      typeA ? l_relationships(typeA.link_phrase).toLowerCase() : '',
-      typeB ? l_relationships(typeB.link_phrase).toLowerCase() : '',
-    );
-  });
 
   initialLinks = initialLinks.map(function (link) {
     /*

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1494,6 +1494,7 @@ MB.createExternalLinksEditor = function (options: InitialOptionsT) {
       ((Object.values(urls): any): $ReadOnlyArray<SeededUrlShape>)
     ) {
       initialLinks.push(newLinkState({
+        rawUrl: data.text || '',
         relationship: uniqueId('new-'),
         type: parseInt(data.link_type_id, 10) || null,
         url: data.text || '',


### PR DESCRIPTION
### Fix MBS-11960

Without this, the seeded URL is stored and can be submitted, but it does not get displayed to the user, which seems less than ideal.

On a second commit, I make it so seeded links always come after existing ones.

Tested with the seeding options suggested on the ticket, plus with a couple extra links (just the URL, just the type) to make sure multi-seeding works.