### PR TITLE
MBS-11970: Add recaptcha.net to script-src CSP

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -692,8 +692,12 @@ sub set_csp_headers {
             push @csp_script_src, qw(
                 https://www.google.com/recaptcha/
                 https://www.gstatic.com/recaptcha/
+                https://www.recaptcha.net/recaptcha/
             );
-            push @csp_frame_src, 'https://www.google.com/recaptcha/';
+            push @csp_frame_src, qw(
+                https://www.google.com/recaptcha/
+                https://www.recaptcha.net/recaptcha/
+            );
         }
     }
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-11970

While we are currently following what https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha says to use, at least one person couldn't register an account because https://www.recaptcha.net/recaptcha/ isn't whitelisted, and the FAQ says in a separate answer to "please use 'www.recaptcha.net' in your code in circumstances when 'www.google.com' is not accessible."