### PR TITLE
MBS-11971: Always load URL rels when loading paged subsets

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -138,7 +138,10 @@ role
                 $loaded = 1;
             }
 
-            unless (defined $c->stash->{paged_link_type_group}) {
+            if (defined $c->stash->{paged_link_type_group}) {
+                # Still load URL rels since we want them for the sidebar
+                $c->model('Relationship')->load_subset(['url'], $entity);
+            } else {
                 my $types = $relationships->{subset}{$action};
                 if (!defined $types && !$loaded) {
                     $types = $relationships->{default};


### PR DESCRIPTION
### Fix MBS-11971

This is needed in order for them to still show on the sidebar for pages like /artist/mbid/relationships?link_type_id=168
that would otherwise only load that specific link type. The issue was introduced by https://github.com/metabrainz/musicbrainz-server/pull/1953/commits/12b43e8330b0feda64c636665735c7c3c931b7b5

Tested manually on the page listed on the ticket.