### PR TITLE
MBS-11981: Don't break Ko-fi shop URLs get in URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2421,7 +2421,7 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'kofi': {
-    match: [new RegExp('^(https?://)?(www\\.)?ko-fi.com/[^/?#]', 'i')],
+    match: [new RegExp('^(https?://)?(www\\.)?ko-fi\\.com/(?!s/)', 'i')],
     restrict: [LINK_TYPES.patronage],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:www\.)?ko-fi\.com\/([^\/?#]+)(?:.*)?$/, 'https://ko-fi.com/$1');

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -7,8 +7,8 @@
  */
 
 import test from 'tape';
-import {arraysEqual} from '../../common/utility/arrays';
 
+import {arraysEqual} from '../../common/utility/arrays';
 import {
   LINK_TYPES,
   cleanURL,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2314,6 +2314,13 @@ const testData = [
     expected_relationship_type: 'patronage',
             expected_clean_url: 'https://ko-fi.com/35MJZ8OL4IO',
   },
+  // Ko-fi shop (not to autoselect because they could be different purchase options)
+  {
+                     input_url: 'https://ko-fi.com/s/e953259fd9',
+             input_entity_type: 'artist',
+            expected_clean_url: 'https://ko-fi.com/s/e953259fd9', // uncleaned
+    expected_relationship_type: undefined,
+  },
   // laboiteauxparoles
   {
                      input_url: 'https://laboiteauxparoles.com/interprete/269/loco-locass',


### PR DESCRIPTION
### Fix MBS-11981

It's not fully clear to me whether these can only be purchase for mail order, can also be a download, or maybe even more options, so for now this just avoids cleaning them up / selecting any specific type for them