### PR TITLE
MBS-11973: Also load edits_pending for appears_on

### DIFF
--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -418,6 +418,7 @@ sub appears_on
             SELECT DISTINCT rg.id, rg.gid, rg.name,
                 rg.type AS primary_type_id,
                 rg.artist_credit AS artist_credit_id,
+                rg.edits_pending,
                 rgm.first_release_date_year,
                 rgm.first_release_date_month,
                 rgm.first_release_date_day


### PR DESCRIPTION
### Fix MBS-11973

This is needed so that RGs with pending edits are actually highlighted as such on the ArtistRecordings page. I can't imagine it will make things particularly slower.

Tested manually by opening edits in one RG in sample data and checking it was highlighted in the relevant artist's recordings tab.