### PR TITLE
MBS-11979: Improve example URL

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -569,6 +569,15 @@ export class ExternalLinksEditor
                        {example_url: <span className="url-quote">{'http://example.com/'}</span>}),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
+    } else if (isNewOrChangedLink && isExample(link.url)) {
+      error = {
+        message: exp.l(
+          `“{example_url}” is just an example.
+          Please enter the actual link you want to add.`,
+          {example_url: <span className="url-quote">{link.url}</span>},
+        ),
+        target: URLCleanup.ERROR_TARGETS.URL,
+      };
     } else if (isNewOrChangedLink && isMusicBrainz(link.url)) {
       error = {
         message: l(`Links to MusicBrainz URLs are not allowed.
@@ -1592,6 +1601,10 @@ function isShortened(url) {
 
 function isGoogleAmp(url) {
   return /^https?:\/\/([^/]+\.)?google\.[^/]+\/amp/.test(url);
+}
+
+function isExample(url) {
+  return /^https?:\/\/(?:[^/]+\.)?example\.(?:com|org|net)(?:\/.*)?$/.test(url);
 }
 
 function isMusicBrainz(url) {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -565,7 +565,8 @@ export class ExternalLinksEditor
       };
     } else if (isNewOrChangedLink && !isValidURL(link.url)) {
       error = {
-        message: l('Enter a valid url e.g. "http://google.com/"'),
+        message: exp.l('Please enter a valid URL, such as “{example_url}”.',
+                       {example_url: <span className="url-quote">{'http://example.com/'}</span>}),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
     } else if (isNewOrChangedLink && isMusicBrainz(link.url)) {

--- a/t/lib/t/MusicBrainz/Server/Controller/RelationshipEditor.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/RelationshipEditor.pm
@@ -331,7 +331,7 @@ test 'Can submit URL relationships using actual URLs, not gids' => sub {
                 'rel-editor.rels.1.link_type' => '183',
                 'rel-editor.rels.1.action' => 'add',
                 'rel-editor.rels.1.entity.0.gid' => '745c079d-374e-4436-9448-da92dedef3ce',
-                'rel-editor.rels.1.entity.1.url' => 'http://example.com/',
+                'rel-editor.rels.1.entity.1.url' => 'http://link.example/',
             }
         );
     } $c;

--- a/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
@@ -21,7 +21,7 @@ test all => sub {
     $mech->get_ok('/url/9201840b-d810-4e0f-bb75-c791205f5b24/edit');
     my $response = $mech->submit_form(
         with_fields => {
-            'edit-url.url' => 'http://google.com',
+            'edit-url.url' => 'http://link.example',
         });
 
     my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
@@ -33,7 +33,7 @@ test all => sub {
             name => 'http://musicbrainz.org/'
         },
         new => {
-            url => 'http://google.com/',
+            url => 'http://link.example/',
         },
         old => {
             url => 'http://musicbrainz.org/',
@@ -44,7 +44,7 @@ test all => sub {
 
     $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
     html_ok($mech->content, '..valid xml');
-    $mech->content_contains('http://google.com', '..has new URI');
+    $mech->content_contains('http://link.example', '..has new URI');
     $mech->content_contains('http://musicbrainz.org/', '..has old URI');
 };
 

--- a/t/lib/t/MusicBrainz/Server/Data/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/CoverArt.pm
@@ -41,7 +41,7 @@ test 'Parses valid cover art relationships' => sub {
 test 'Doesnt parse invalid cover art relationships' => sub {
     my $test = shift;
 
-    my $release = make_release('cover art link', 'http://www.google.com');
+    my $release = make_release('cover art link', 'http://www.link.example');
 
     $test->c->model('CoverArt')->load($release);
     ok(!$release->has_cover_art);

--- a/t/lib/t/MusicBrainz/Server/Data/URL.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/URL.pm
@@ -28,16 +28,16 @@ my $sql = $test->c->sql;
 $sql->begin;
 
 $url_data->update($url->id, {
-    url => 'http://google.com',
+    url => 'http://link.example',
 });
 
 $url = $url_data->get_by_id(1);
 is ( $url->id, 1 );
 is ( $url->gid, '9201840b-d810-4e0f-bb75-c791205f5b24' );
-is ( $url->url, 'http://google.com/', 'URL was updated and normalized to add extra slash at end');
+is ( $url->url, 'http://link.example/', 'URL was updated and normalized to add extra slash at end');
 
 $url_data->update(2, {
-    url => 'http://google.com',
+    url => 'http://link.example',
 });
 
 is($url_data->get_by_gid('9b3c5c67-572a-4822-82a3-bdd3f35cf152')->id,

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -67,7 +67,7 @@
     {
       command: 'assertText',
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
-      value: 'Enter a valid url e.g. "http://google.com/"',
+      value: 'Please enter a valid URL, such as “http://example.com/”.',
     },
     // Don't freeze to link when there's an error
     {
@@ -100,7 +100,7 @@
     {
       command: 'assertText',
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
-      value: 'Enter a valid url e.g. "http://google.com/"',
+      value: 'Please enter a valid URL, such as “http://example.com/”.',
     },
     {
       command: 'click',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -414,12 +414,23 @@
       target: 'css=button.submit.positive',
       value: '',
     },
-    // deprecated link type detection for existing links (MBS-8408)
+    // example link detection (MBS-11979)
     {
       command: 'clickAndWait',
       target: "xpath=//ul[@class='tabs']//a[descendant::text()='Edit']",
       value: '',
     },
+    {
+      command: 'type',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'http://example.com/',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
+      value: '“http://example.com/” is just an example. Please enter the actual link you want to add.',
+    },
+    // deprecated link type detection for existing links (MBS-8408)
     {
       command: 'type',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -423,7 +423,7 @@
     {
       command: 'type',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'http://example.com/',
+      value: 'http://musicmoz.org.example/Composition/Composers/M/Mozart,_Wolfgang_Amadeus/',
     },
     {
       command: 'select',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -95,7 +95,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: '//google.com',
+      value: '//example.com',
     },
     {
       command: 'assertText',
@@ -220,7 +220,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://google.com',
+      value: 'https://link.example',
     },
     {
       command: 'select',
@@ -247,7 +247,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://google.com${KEY_ENTER}',
+      value: 'https://link.example${KEY_ENTER}',
     },
     // Pressing enter submits the link
     {
@@ -286,7 +286,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://google.com',
+      value: 'https://link.example',
     },
     {
       command: 'assertElementPresent',
@@ -303,7 +303,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
-      value: 'https://google.com\n',
+      value: 'https://link.example\n',
     },
     // Duplicate URL notice
     {
@@ -321,7 +321,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll(\"input[type='url']\")).map(x => x.value).join('\\n')",
-      value: 'https://google.com\n',
+      value: 'https://link.example\n',
     },
     // Automatically submitted after selecting a type and moving focus away from the type select
     {
@@ -349,7 +349,7 @@
     {
       command: 'sendKeys',
       target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
-      value: 'https://google.com',
+      value: 'https://link.example',
     },
     {
       command: 'click',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-11979: The previous example `google.com` was a valid URL but search pages are not actually wanted to link to any MB entity.
    

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch replaces it with `example.com` to get rid of this ambiguity in both editing UI and tests. It also tries to improve the phrasing and the formatting.
