### PR TITLE
MBS-11977: Fix targeting ENTITY for URL relationship error

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -445,17 +445,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'record',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -477,27 +477,27 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: /^(artist|composer|conductor|orchestra|soloist)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'listing',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'venue',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: /^(album|cd|media|music|record)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -519,12 +519,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.allmusic.artist:
             return {
               result: prefix === 'artist/mn',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.allmusic.recording:
             return {
               result: prefix === 'performance/mq',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.allmusic.release:
             if (prefix === 'album/mw') {
@@ -551,18 +551,18 @@ const CLEANUPS: CleanupEntries = {
             }
             return {
               result: prefix === 'album/release/mr',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.allmusic.release_group:
             return {
               result: prefix === 'album/mw',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.allmusic.work:
             return {
               result: prefix === 'composition/mc' ||
                 prefix === 'song/mt',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -661,12 +661,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.streamingpaid.artist:
             return {
               result: prefix === 'artists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingpaid.release:
             return {
               result: prefix === 'albums',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -712,17 +712,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'person',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'source',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
             return {
               result: prefix === 'song',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -823,7 +823,7 @@ const CLEANUPS: CleanupEntries = {
               result: /^view\/[1-9][0-9]*\.htm$/.test(path) ||
                 /^subview(\/[1-9][0-9]*){2}\.htm$/.test(path) ||
                 /^item\/[^\/]+(?:\/[1-9][0-9]*)?$/.test(path),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -857,7 +857,7 @@ const CLEANUPS: CleanupEntries = {
                  not to a specific album or track.`,
               ),
               result: false,
-              target: ERROR_TARGETS.URL,
+              target: ERROR_TARGETS.ENTITY,
             };
           }
           return {result: /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url)};
@@ -869,22 +869,22 @@ const CLEANUPS: CleanupEntries = {
                  not to a specific album or track.`,
               ),
               result: false,
-              target: ERROR_TARGETS.URL,
+              target: ERROR_TARGETS.ENTITY,
             };
           }
           return {
             result: /^https:\/\/[^\/]+\.bandcamp\.com\/$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.review.release_group:
           return {
             result: /^https:\/\/daily\.bandcamp\.com\/\d+\/\d+\/\d+\/[\w-]+-review\/$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.lyrics.work:
           return {
             result: /^https:\/\/[^\/]+\.bandcamp\.com\/track\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
       }
       return {result: false, target: ERROR_TARGETS.URL};
@@ -918,17 +918,17 @@ const CLEANUPS: CleanupEntries = {
             return {
               result: prefix === undefined && target !== undefined ||
                 prefix === 'a' && /^[1-9][0-9]*$/.test(target),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.bandsintown.event:
             return {
               result: prefix === 'e' && /^[1-9][0-9]*$/.test(target),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.bandsintown.place:
             return {
               result: prefix === 'v' && /^[1-9][0-9]*$/.test(target),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -995,24 +995,24 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.recording:
             return {
               result: prefix === 'track' || prefix === 'stem',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.release:
             return {
               result: prefix === 'release' ||
                 prefix === 'chart' ||
                 prefix === 'stem-pack',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1054,12 +1054,12 @@ const CLEANUPS: CleanupEntries = {
                   : l(`Please link to the main page for the label,
                        not a specific product.`),
                 result: false,
-                target: ERROR_TARGETS.URL,
+                target: ERROR_TARGETS.ENTITY,
               };
             case LINK_TYPES.mailorder.release:
               return {
                 result: product !== undefined,
-                target: ERROR_TARGETS.RELATIONSHIP,
+                target: ERROR_TARGETS.ENTITY,
               };
           }
         }
@@ -1129,13 +1129,13 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.work:
             return {
               result: digit === '1' || digit === '2',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
           case LINK_TYPES.otherdatabases.release:
             return {
               result: digit === '3' || digit === '4',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.series:
             return {result: true};
@@ -1172,12 +1172,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'works/work',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix !== 'works/work',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1201,7 +1201,7 @@ const CLEANUPS: CleanupEntries = {
             id === LINK_TYPES.otherdatabases.work) {
           return {result: true};
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -1220,12 +1220,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'rec/r',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'tune/t',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1248,12 +1248,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'people',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
             return {
               result: prefix === 'files',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1358,17 +1358,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: ['artist', 'composer', 'ensemble'].includes(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'album' || prefix === 'Album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'work',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1401,17 +1401,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'talent',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
             return {
               result: prefix === 'matrix',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'objects',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1487,17 +1487,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.streamingfree.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.release:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:
             return {
               result: prefix === 'track' || prefix === 'episode',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1572,23 +1572,23 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.discogs.artist:
             return {
               result: prefix === 'artist' || prefix === 'user',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.label:
           case LINK_TYPES.discogs.series:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.place:
             return {
               result: prefix === 'artist' || prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.release_group:
             return {
               result: prefix === 'master',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.release:
             if (prefix === 'master') {
@@ -1609,12 +1609,12 @@ const CLEANUPS: CleanupEntries = {
             }
             return {
               result: prefix === 'release',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.discogs.work:
             return {
               result: prefix === 'composition',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1641,17 +1641,17 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.otherdatabases.work:
           return {
             result: /^http:\/\/d-nb\.info\/(?:gnd\/)?(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.otherdatabases.label:
           return {
             result: /^http:\/\/d-nb\.info\/(?:(?:dnbn|gnd)\/)?(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.otherdatabases.release:
           return {
             result: /^http:\/\/d-nb\.info\/(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
       }
       return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1711,22 +1711,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.streamingfree.artist:
             return {
               result: path === 'artists' && query === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.label:
             return {
               result: path === 'labels' && query === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.release:
             return {
               result: path === 'albums' && query === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:
             return {
               result: path === 'song' && query === 'song_id',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1759,22 +1759,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: /^(composers|ensembles|performers)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'albums',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'labels',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.instrument:
             return {
               result: /^instruments\/[a-z-]+$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -1803,7 +1803,7 @@ const CLEANUPS: CleanupEntries = {
     validate: function (url, id) {
       return {
         result: id === LINK_TYPES.otherdatabases.release,
-        target: ERROR_TARGETS.RELATIONSHIP,
+        target: ERROR_TARGETS.ENTITY,
       };
     },
   },
@@ -1894,7 +1894,7 @@ const CLEANUPS: CleanupEntries = {
     validate: function (url, id) {
       return {
         result: id === LINK_TYPES.otherdatabases.instrument,
-        target: ERROR_TARGETS.RELATIONSHIP,
+        target: ERROR_TARGETS.ENTITY,
       };
     },
   },
@@ -1910,7 +1910,7 @@ const CLEANUPS: CleanupEntries = {
           id === LINK_TYPES.otherdatabases.label ||
           id === LINK_TYPES.otherdatabases.release_group ||
           id === LINK_TYPES.otherdatabases.work,
-        target: ERROR_TARGETS.RELATIONSHIP,
+        target: ERROR_TARGETS.ENTITY,
       };
     },
   },
@@ -1925,17 +1925,17 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.lyrics.artist:
           return {
             result: /^https:\/\/genius\.com\/artists\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.lyrics.release_group:
           return {
             result: /^https:\/\/genius\.com\/albums\/[\w-]+\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.lyrics.work:
           return {
             result: /^https:\/\/genius\.com\/(?!(?:artists|albums)\/)[\w-]+-lyrics$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
       }
       return {result: false, target: ERROR_TARGETS.URL};
@@ -1977,7 +1977,7 @@ const CLEANUPS: CleanupEntries = {
             id === LINK_TYPES.otherdatabases.work) {
           return {result: true};
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -2000,21 +2000,21 @@ const CLEANUPS: CleanupEntries = {
               result: db === 'mdb' &&
                 type === 'author' &&
                 slashRef === undefined,
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.mailorder.release:
             return {
               result: db === 'products' &&
                 type === 'detail' &&
                 slashRef !== undefined,
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: db === 'mdb' &&
                 type === 'detail' &&
                 slashRef !== undefined,
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2046,13 +2046,13 @@ const CLEANUPS: CleanupEntries = {
               result: prefix === 'name/nm' ||
                 prefix === 'character/ch' ||
                 prefix === 'company/co',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.imdb.label:
           case LINK_TYPES.imdb.place:
             return {
               result: prefix === 'company/co',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.imdb.recording:
           case LINK_TYPES.imdb.release:
@@ -2060,7 +2060,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.imdb.work:
             return {
               result: prefix === 'title/tt',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2230,12 +2230,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'tune',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2290,12 +2290,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.recording:
             return {
               result: prefix === 'music-video',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.release:
             return {
               result: /^(album|audiobook|podcast|preorder)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2327,12 +2327,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'song',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2361,12 +2361,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: /^kashu\.php\?artist=\d+$/.test(tail),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: /^song_view\.html\?\d+$/.test(tail),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2395,12 +2395,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'search/index',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'lyric',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2445,17 +2445,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: /^(?:auteur|interprete)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.label:
             return {
               result: prefix === 'editeur',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'titre',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2502,7 +2502,7 @@ const CLEANUPS: CleanupEntries = {
             id === LINK_TYPES.otherdatabases.work) {
           return {result: true};
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -2553,22 +2553,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'events',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.series:
             return {
               result: prefix === 'groups',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'venues',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2598,12 +2598,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'a',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'l',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2671,13 +2671,13 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'records',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'songs',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2699,12 +2699,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2729,22 +2729,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: /^(?:artists?|bands?)$/.test(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'labels',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'albums',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.review.release_group:
             return {
               result: prefix === 'reviews',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2771,17 +2771,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.streamingfree.artist:
             return {
               result: prefix === 'music/artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:
             return {
               result: ['live', 'music/song', 'video/mv'].includes(prefix),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.release:
             return {
               result: prefix === 'music/album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2817,12 +2817,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artista' || prefix === 'grupo',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'disco',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2847,17 +2847,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: prefix === 'release',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2881,7 +2881,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.release_group:
             if (prefix === 'album') {
@@ -2901,11 +2901,11 @@ const CLEANUPS: CleanupEntries = {
                 target: ERROR_TARGETS.ENTITY,
               };
             }
-            return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+            return {result: false, target: ERROR_TARGETS.ENTITY};
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'lyrics',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -2940,22 +2940,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: /^M\d{11}\/(CLASSICAL(?:\/COMPOSER)?|POPULAR)$/.test(subpath),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: /^L\d{11}$/.test(subpath),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
             return {
               result: /^[A-Z]{2,3}\d{4,6}$/.test(subpath),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: /^U\d{11}\/(CLASSICAL|POPULAR)$/.test(subpath),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3008,17 +3008,17 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.streamingpaid.artist:
           return {
             result: /^https:\/\/[a-z]{2}\.napster\.com\/artist\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.streamingpaid.recording:
           return {
             result: /^https:\/\/[a-z]{2}\.napster\.com\/artist\/[\w-]+\/album\/[\w-]+\/track\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.streamingpaid.release:
           return {
             result: /^https:\/\/[a-z]{2}\.napster\.com\/artist\/[\w-]+\/album\/[\w-]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
       }
       return {result: false, target: ERROR_TARGETS.URL};
@@ -3115,12 +3115,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.recording:
             return {
               result: prefix === 'titel',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3139,7 +3139,7 @@ const CLEANUPS: CleanupEntries = {
         if (id === LINK_TYPES.lyrics.work) {
           return {result: true};
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3179,17 +3179,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'venues',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'works',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3252,20 +3252,20 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'performance',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'expression',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3314,20 +3314,20 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'lyrics/artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.release_group:
             return {
               result: prefix === 'lyrics/album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'lyrics',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3356,15 +3356,15 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: type === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: type === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3400,24 +3400,24 @@ const CLEANUPS: CleanupEntries = {
               result: type === 'artistes' &&
                 page === 'biographie' &&
                 /^artistid=\d+$/.test(query),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: type === 'albums' &&
                 page === 'description' &&
                 /^albumid=\d+$/.test(query),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: type === 'oeuvres' &&
                 page === 'oeuvre' &&
                 /^oeuvreid=\d+&albumid=\d+$/.test(query),
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3436,41 +3436,41 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'concert',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'venue',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release:
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'release',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.series:
             return {
               result: prefix === 'classifiers',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'work',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3523,37 +3523,37 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.discographyentry.release:
             return {
               result: prefix === 'podcast',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'dj',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'events',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'labels',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'clubs',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
             return {
               result: prefix === 'tracks',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.review.release_group:
             return {
               result: prefix === 'reviews',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3601,20 +3601,20 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: !subsection,
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: subsection === 'discos',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: subsection === 'letras',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       // Keep validating URLs from before Rock.com.ar 2017 relaunch
       m = /^http:\/\/rock\.com\.ar\/(?:(bios|discos|letras)(?:\/[0-9]+){2}\.shtml|(artistas)\/.+)$/.exec(url);
@@ -3624,20 +3624,20 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'artistas' || prefix === 'bios',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'discos',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'letras',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3683,7 +3683,7 @@ const CLEANUPS: CleanupEntries = {
         if (id === LINK_TYPES.lyrics.work) {
           return {result: true};
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3707,27 +3707,27 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.secondhandsongs.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.secondhandsongs.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.secondhandsongs.recording:
             return {
               result: prefix === 'performance',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.secondhandsongs.release:
             return {
               result: prefix === 'release',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.secondhandsongs.work:
             return {
               result: prefix === 'work',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3749,22 +3749,22 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.setlistfm.artist:
             return {
               result: prefix === 'setlists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.setlistfm.event:
             return {
               result: prefix === 'setlist' || prefix === 'festival',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.setlistfm.place:
             return {
               result: prefix === 'venue',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.setlistfm.series:
             return {
               result: prefix === 'festivals',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3790,10 +3790,10 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.otherdatabases.label:
           return {
             result: /^http:\/\/snaccooperative\.org\/ark:\/99166\/[a-z0-9]+$/.test(url),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.URL,
           };
       }
-      return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+      return {result: false, target: ERROR_TARGETS.ENTITY};
     },
   },
   'songfacts': {
@@ -3819,17 +3819,17 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.songkick.artist:
             return {
               result: prefix === 'artists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.songkick.event:
             return {
               result: prefix === 'concerts' || prefix === 'festivals',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.songkick.place:
             return {
               result: prefix === 'venues',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -3870,15 +3870,15 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'composer',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'title',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3902,20 +3902,20 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.streamingfree.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.release:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.streamingfree.recording:
             return {
               result: prefix === 'track' || prefix === 'episode',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3948,30 +3948,30 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.artist:
             return {
               result: prefix === 'recordings/artists',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'events',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.place:
             return {
               result: prefix === 'sessions',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'recordings',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'tunes',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -3999,25 +3999,25 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.label:
             return {
               result: prefix === 'label',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.recording:
             return {
               result: prefix === 'track',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.downloadpurchase.release:
             return {
               result: prefix === 'title',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
-        return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
+        return {result: false, target: ERROR_TARGETS.ENTITY};
       }
       return {result: false, target: ERROR_TARGETS.URL};
     },
@@ -4099,13 +4099,13 @@ const CLEANUPS: CleanupEntries = {
           return {
             result: isATweet &&
               (id === LINK_TYPES.streamingfree.recording),
-            target: ERROR_TARGETS.RELATIONSHIP,
+            target: ERROR_TARGETS.ENTITY,
           };
         } else if (isATweet) {
           return {
             error: l('Please link to Twitter profiles, not tweets.'),
             result: false,
-            target: ERROR_TARGETS.URL,
+            target: ERROR_TARGETS.ENTITY,
           };
         }
         return {result: true};
@@ -4150,28 +4150,28 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.otherdatabases.label:
             return {
               result: prefix === 'Ar',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.event:
             return {
               result: prefix === 'E',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.recording:
           case LINK_TYPES.otherdatabases.work:
             return {
               result: prefix === 'S',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.release_group:
             return {
               result: prefix === 'Al',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.otherdatabases.series:
             return {
               result: prefix === 'Es',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -4193,12 +4193,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'song',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -4220,12 +4220,12 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.lyrics.artist:
             return {
               result: prefix === 'artist',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.lyrics.work:
             return {
               result: prefix === 'lyric',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};
@@ -4247,27 +4247,27 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.vgmdb.artist:
             return {
               result: prefix === 'artist' || prefix === 'org',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.vgmdb.release:
             return {
               result: prefix === 'album',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.vgmdb.label:
             return {
               result: prefix === 'org',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.vgmdb.event:
             return {
               result: prefix === 'event',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
           case LINK_TYPES.vgmdb.work:
             return {
               result: prefix === 'product',
-              target: ERROR_TARGETS.RELATIONSHIP,
+              target: ERROR_TARGETS.ENTITY,
             };
         }
         return {result: false, target: ERROR_TARGETS.RELATIONSHIP};

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -551,32 +551,32 @@ export class ExternalLinksEditor
     } else if (isNewOrChangedLink && isMusicBrainz(link.url)) {
       error = {
         message: l(`Links to MusicBrainz URLs are not allowed.
-                Did you mean to paste something else?`),
+                    Did you mean to paste something else?`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
     } else if (isNewOrChangedLink && isMalware(link.url)) {
       error = {
         message: l(`Links to this website are not allowed
-                because it is known to host malware.`),
+                    because it is known to host malware.`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
     } else if (isNewOrChangedLink && isShortened(link.url)) {
       error = {
         message: l(`Please don’t enter bundled/shortened URLs,
-                enter the destination URL(s) instead.`),
+                    enter the destination URL(s) instead.`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
     } else if (isNewOrChangedLink && isGoogleAmp(link.url)) {
       error = {
         message: l(`Please don’t enter Google AMP links,
-                since they are effectively an extra redirect.
-                Enter the destination URL instead.`),
+                    since they are effectively an extra redirect.
+                    Enter the destination URL instead.`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
     } else if (!link.type) {
       error = {
         message: l(`Please select a link type for the URL
-                you’ve entered.`),
+                    you’ve entered.`),
         target: URLCleanup.ERROR_TARGETS.RELATIONSHIP,
       };
     } else if (
@@ -584,7 +584,7 @@ export class ExternalLinksEditor
     ) {
       error = {
         message: l(`This relationship type is deprecated 
-                and should not be used.`),
+                    and should not be used.`),
         target: URLCleanup.ERROR_TARGETS.RELATIONSHIP,
       };
     } else if (
@@ -602,18 +602,15 @@ export class ExternalLinksEditor
           message: '',
           target: URLCleanup.ERROR_TARGETS.NONE,
         };
-        error.target = check.target ||
-          URLCleanup.ERROR_TARGETS.NONE;
+        error.target = check.target || URLCleanup.ERROR_TARGETS.NONE;
         if (error.target === URLCleanup.ERROR_TARGETS.URL) {
-          error.message = l(
-            `This URL is not allowed for the selected link type,
-            or is incorrectly formatted.`,
-          );
+          error.message = l(`This URL is not allowed
+                             for the selected link type,
+                             or is incorrectly formatted.`);
         }
-        if (error.target ===
-          URLCleanup.ERROR_TARGETS.RELATIONSHIP) {
+        if (error.target === URLCleanup.ERROR_TARGETS.RELATIONSHIP) {
           error.message = l(`This URL is not allowed 
-                    for the selected link type.`);
+                             for the selected link type.`);
         }
         if (error.target === URLCleanup.ERROR_TARGETS.ENTITY) {
           switch (checker.entityType) {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -615,6 +615,33 @@ export class ExternalLinksEditor
           error.message = l(`This URL is not allowed 
                     for the selected link type.`);
         }
+        if (error.target === URLCleanup.ERROR_TARGETS.ENTITY) {
+          switch (checker.entityType) {
+            case 'area':
+              error.message = l(`This URL is not allowed for areas.`);
+            case 'artist':
+              error.message = l(`This URL is not allowed for artists.`);
+            case 'event':
+              error.message = l(`This URL is not allowed for events.`);
+            case 'instrument':
+              error.message = l(`This URL is not allowed for instruments.`);
+            case 'label':
+              error.message = l(`This URL is not allowed for labels.`);
+            case 'place':
+              error.message = l(`This URL is not allowed for places.`);
+            case 'recording':
+              error.message = l(`This URL is not allowed for recordings.`);
+            case 'release':
+              error.message = l(`This URL is not allowed for releases.`);
+            case 'release_group':
+              error.message = l(`This URL is not allowed for release
+                                 groups.`);
+            case 'series':
+              error.message = l(`This URL is not allowed for series.`);
+            case 'work':
+              error.message = l(`This URL is not allowed for works.`);
+          }
+        }
         error.message = check.error || error.message;
       }
     }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-11977: Mismatched entity type in external links editor doesn't trigger the appropriate error message

(see the ticket for details)

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Fix targeting `ENTITY` for URL relationship error.

It also required adding a generic error message for `ENTITY` error target (which was associated to custom error message only so far).

# Notes

Further improvement would be to specify which entity type should be linked to the entered URL, and which URL pattern would be suitable for the current entity, as proposed in “Implementation notes” of the ticket. Actually, it is probably worth a separate ticket.

# Checklist for author

* [ ] Rebase on `master` if #2263 is merged first
