### PR TITLE
MBS-11989: Also correct rg to release_group for delete_alias

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -119,11 +119,12 @@ sub delete_alias : Chained('alias') PathPart('delete') Edit
     my $type = $self->{entity_name};
     my $entity = $c->stash->{ $type };
     my $edit = $c->model('Edit')->find_creation_edit($model_to_edit_type{add}->{ $self->{model} }, $alias->id, id_field => 'alias_id');
+    my $entity_type = $type eq 'rg' ? 'release_group' : $type;
 
     my %props = (
         alias => $alias->TO_JSON,
         entity => $entity->TO_JSON,
-        type => $type,
+        type => $entity_type,
     );
 
     $c->stash(


### PR DESCRIPTION
### Fix MBS-11989

We already do this for add_alias and edit_alias, but I guess we forgot to do it for delete_alias, and that is causing an error when loading the layout on React.
Why we use "rg" I don't know, but in any case it seems sensible to have all of these work until we maybe decide to change it.
