### PR TITLE
MBS-11995: Test error messages in external links editor

### DIFF
--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -44,6 +44,10 @@ const testData = [
              input_entity_type: 'artist',
     expected_relationship_type: 'otherdatabases',
        only_valid_entity_types: [],
+                expected_error: {
+                                  error: undefined,
+                                  target: 'url',
+                                },
   },
   // 45worlds
   {
@@ -4856,6 +4860,10 @@ limited_link_type_combinations: [
     expected_relationship_type: undefined,
        input_relationship_type: 'discographyentry',
        only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'no entries for specific releases',
+                                  target: 'entity',
+                                },
   },
   // Wikisource
   {
@@ -5278,6 +5286,47 @@ testData.forEach(function (subtest, i) {
         );
         tested = true;
       }
+    }
+    if (subtest.expected_error) {
+      const relationshipType = subtest.input_relationship_type ||
+        subtest.expected_relationship_type;
+      if (!relationshipType) {
+        st.fail(
+          'Test is invalid: "expected_error" is specified with neither "expected_relationship_type" nor "input_relationship_type".',
+        );
+        st.end();
+        return;
+      }
+      if (!subtest.input_entity_type) {
+        st.fail(
+          'Test is invalid: "expected error" is specified without "input_entity_type".',
+        );
+        st.end();
+        return;
+      }
+      const cleanUrl = subtest.expected_clean_url || actualCleanUrl;
+      const checker = new Checker(cleanUrl, subtest.input_entity_type);
+      const validationResult = checker.checkRelationship(
+        LINK_TYPES[relationshipType],
+        subtest.input_entity_type,
+      );
+      if (subtest.expected_error.error === undefined) {
+        st.ok(
+          validationResult.error === undefined,
+          'Default error message will be used as expected',
+        );
+      } else {
+        st.ok(
+          validationResult.error.includes(subtest.expected_error.error),
+          'Error message contains expected string',
+        );
+      }
+      st.equal(
+        validationResult.target,
+        subtest.expected_error.target,
+        'Error target matches expected target',
+      );
+      tested = true;
     }
     if (!tested) {
       st.fail('Test is worthless: Nothing has been actually tested.');

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5143,6 +5143,33 @@ function testEntitiesOfType(relationshipType, checker) {
   return {results, testedRules};
 }
 
+// Test whether the error message end target matches what is expected
+function testErrorObject(subtest, relationshipType, st) {
+  const actualCleanUrl = cleanURL(subtest.input_url);
+  const cleanUrl = subtest.expected_clean_url || actualCleanUrl;
+  const checker = new Checker(cleanUrl, subtest.input_entity_type);
+  const validationResult = checker.checkRelationship(
+    LINK_TYPES[relationshipType],
+    subtest.input_entity_type,
+  );
+  if (subtest.expected_error.error === undefined) {
+    st.ok(
+      validationResult.error === undefined,
+      'Default error message will be used as expected',
+    );
+  } else {
+    st.ok(
+      validationResult.error.includes(subtest.expected_error.error),
+      'Error message contains expected string',
+    );
+  }
+  st.equal(
+    validationResult.target,
+    subtest.expected_error.target,
+    'Error target matches expected target',
+  );
+}
+
 testData.forEach(function (subtest, i) {
   test('input URL [' + i + '] = ' + subtest.input_url, {}, function (st) {
     let tested = false;
@@ -5304,28 +5331,7 @@ testData.forEach(function (subtest, i) {
         st.end();
         return;
       }
-      const cleanUrl = subtest.expected_clean_url || actualCleanUrl;
-      const checker = new Checker(cleanUrl, subtest.input_entity_type);
-      const validationResult = checker.checkRelationship(
-        LINK_TYPES[relationshipType],
-        subtest.input_entity_type,
-      );
-      if (subtest.expected_error.error === undefined) {
-        st.ok(
-          validationResult.error === undefined,
-          'Default error message will be used as expected',
-        );
-      } else {
-        st.ok(
-          validationResult.error.includes(subtest.expected_error.error),
-          'Error message contains expected string',
-        );
-      }
-      st.equal(
-        validationResult.target,
-        subtest.expected_error.target,
-        'Error target matches expected target',
-      );
+      testErrorObject(subtest, relationshipType, st);
       tested = true;
     }
     if (!tested) {


### PR DESCRIPTION
### Implement MBS-11995

We should ensure we are returning the expected errors for tests that we expect to fail, including both specific message (when given) and target.
This just uses a substring, rather than the whole error message, because it seems like overkill otherwise and it's easier for oneswe expand with arguments.

Adds a new optional test property `expected_error`. This requires one of `input_relationship_type` or `expected_relationship_type` (since the error might vary depending on the relationship selected) and `input_entity_type` (since the same URL might be allowed for one entity type but not another).

This adds two examples:

One for our block of Wikipedia pages as discography entries for releases, testing a specific error message and `input_relationship_type`.

One for blocking non-specific 45cat pages, testing a generic error message (undefined error) and `expected_relationship_type`.

Further tests to cover other existing blocks and errors will be added in subsequent commits.