### PR TITLE
MBS-11986 / MBS-12128: New account flag: Spammer

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -346,6 +346,7 @@ Readonly our $LOCATION_EDITOR_FLAG          => 256;
 Readonly our $BANNER_EDITOR_FLAG            => 512;
 Readonly our $EDITING_DISABLED_FLAG         => 1024;
 Readonly our $ADDING_NOTES_DISABLED_FLAG    => 2048;
+Readonly our $SPAMMER_FLAG                  => 4096;
 # If you update this, also update root/utility/sanitizedEditor.js
 Readonly our $PUBLIC_PRIVILEGE_FLAGS        => $AUTO_EDITOR_FLAG &
                                                $BOT_FLAG &

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -37,6 +37,7 @@ sub edit_user : Path('/admin/user/edit') Args(1) RequireAuth HiddenOnSlaves Secu
             account_admin           => $user->is_account_admin,
             editing_disabled        => $user->is_editing_disabled,
             adding_notes_disabled   => $user->is_adding_notes_disabled,
+            spammer                 => $user->is_spammer,
             # user profile
             username                => $user->name,
             email                   => $user->email,

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -75,8 +75,12 @@ sub _perform_login {
         # Bad username / password combo
         $c->stash( bad_login => 1 );
         return 0;
-    }
-    else {
+    } elsif ( $c->user->is_spammer ) {
+        # Automatically log out spammers and notify of why
+        $c->stash( spammy_login => 1 );
+        $c->logout;
+        return 0;
+    } else {
         if ($c->user->requires_password_reset) {
             $c->response->redirect($c->uri_for_action('/account/change_password', {
                 username => $c->user->name,
@@ -171,6 +175,7 @@ sub do_login : Private
             loginForm => $form->TO_JSON,
             isLoginBad => boolean_to_json($c->stash->{bad_login}),
             isLoginRequired => boolean_to_json($c->stash->{required_login} // 1),
+            isSpammer => boolean_to_json($c->stash->{spammy_login}),
             postParameters => ((defined $post_params && scalar(%$post_params)) ? $post_params : undef),
         },
     );

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -355,6 +355,10 @@ sub update_profile
 sub update_privileges {
     my ($self, $editor, $values) = @_;
 
+    # Setting Spammer should also block editing and notes
+    $values->{editing_disabled} ||= $values->{spammer};
+    $values->{adding_notes_disabled} ||= $values->{spammer};
+
     my $privs =   ($values->{auto_editor}           // 0) * $AUTO_EDITOR_FLAG
                 + ($values->{bot}                   // 0) * $BOT_FLAG
                 + ($values->{untrusted}             // 0) * $UNTRUSTED_FLAG
@@ -366,7 +370,8 @@ sub update_privileges {
                 + ($values->{mbid_submitter}        // 0) * $MBID_SUBMITTER_FLAG
                 + ($values->{account_admin}         // 0) * $ACCOUNT_ADMIN_FLAG
                 + ($values->{editing_disabled}      // 0) * $EDITING_DISABLED_FLAG
-                + ($values->{adding_notes_disabled} // 0) * $ADDING_NOTES_DISABLED_FLAG;
+                + ($values->{adding_notes_disabled} // 0) * $ADDING_NOTES_DISABLED_FLAG
+                + ($values->{spammer}               // 0) * $SPAMMER_FLAG;
 
     Sql::run_in_transaction(sub {
         $self->sql->do('UPDATE editor SET privs = ? WHERE id = ?', $privs, $editor->id);

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -109,6 +109,10 @@ sub is_adding_notes_disabled {
     (shift->privileges & $ADDING_NOTES_DISABLED_FLAG) > 0;
 }
 
+sub is_spammer {
+    (shift->privileges & $SPAMMER_FLAG) > 0;
+}
+
 sub public_privileges {
     shift->privileges & $PUBLIC_PRIVILEGE_FLAGS;
 }

--- a/lib/MusicBrainz/Server/Form/Admin/EditUser.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/EditUser.pm
@@ -61,6 +61,10 @@ has_field 'adding_notes_disabled' => (
     type => 'Boolean',
 );
 
+has_field 'spammer' => (
+    type => 'Boolean',
+);
+
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/root/admin/edit_user.tt
+++ b/root/admin/edit_user.tt
@@ -11,6 +11,7 @@
         [% form_row_checkbox(r, 'banner_editor', l('Banner message editor')) %]
         [% form_row_checkbox(r, 'editing_disabled', l('Editing/voting disabled')) %]
         [% form_row_checkbox(r, 'adding_notes_disabled', l('Edit notes disabled')) %]
+        [% form_row_checkbox(r, 'spammer', l('Spammer')) %]
 
         <h2>[%- l('Technical flags') -%]</h2>
         [% form_row_checkbox(r, 'bot', l('Bot')) %]

--- a/root/admin/edit_user.tt
+++ b/root/admin/edit_user.tt
@@ -9,13 +9,15 @@
         [% form_row_checkbox(r, 'link_editor', l('Relationship editor')) %]
         [% form_row_checkbox(r, 'location_editor', l('Location editor')) %]
         [% form_row_checkbox(r, 'banner_editor', l('Banner message editor')) %]
+
+        <h2>[%- l('User sanctions') -%]</h2>
+        [% form_row_checkbox(r, 'spammer', l('Spammer')) %]
         [% form_row_checkbox(r, 'editing_disabled', l('Editing/voting disabled')) %]
         [% form_row_checkbox(r, 'adding_notes_disabled', l('Edit notes disabled')) %]
-        [% form_row_checkbox(r, 'spammer', l('Spammer')) %]
+        [% form_row_checkbox(r, 'untrusted', l('Untrusted')) %]
 
         <h2>[%- l('Technical flags') -%]</h2>
         [% form_row_checkbox(r, 'bot', l('Bot')) %]
-        [% form_row_checkbox(r, 'untrusted', l('Untrusted')) %]
         [% form_row_checkbox(r, 'no_nag', l('No nag')) %]
 
         <h2>[%- l('Administration flags') -%]</h2>

--- a/root/constants.js
+++ b/root/constants.js
@@ -68,6 +68,7 @@ export const LOCATION_EDITOR_FLAG: 256 = 256;
 export const BANNER_EDITOR_FLAG: 512 = 512;
 export const EDITING_DISABLED_FLAG: 1024 = 1024;
 export const ADDING_NOTES_DISABLED_FLAG: 2048 = 2048;
+export const SPAMMER_FLAG: 4096 = 4096;
 export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
                                     BOT_FLAG &
                                     RELATIONSHIP_EDITOR_FLAG &

--- a/root/static/scripts/common/utility/privileges.js
+++ b/root/static/scripts/common/utility/privileges.js
@@ -18,6 +18,7 @@ import {
   LOCATION_EDITOR_FLAG,
   MBID_SUBMITTER_FLAG,
   RELATIONSHIP_EDITOR_FLAG,
+  SPAMMER_FLAG,
   UNTRUSTED_FLAG,
   WIKI_TRANSCLUSION_FLAG,
 } from '../../../../constants';
@@ -113,6 +114,13 @@ export function isAddingNotesDisabled(editor: EditorPropT): boolean {
     return false;
   }
   return (editor.privileges & ADDING_NOTES_DISABLED_FLAG) > 0;
+}
+
+export function isSpammer(editor: EditorPropT): boolean {
+  if (editor == null) {
+    return false;
+  }
+  return (editor.privileges & SPAMMER_FLAG) > 0;
 }
 
 export function isAdmin(editor: EditorPropT): boolean {

--- a/root/user/Login.js
+++ b/root/user/Login.js
@@ -23,6 +23,7 @@ type PropsT = {
   +$c: CatalystContextT,
   +isLoginBad?: boolean,
   +isLoginRequired?: boolean,
+  +isSpammer?: boolean,
   +loginAction: string,
   +loginForm: ReadOnlyFormT<{
     +csrf_token: ReadOnlyFieldT<string>,
@@ -37,6 +38,7 @@ const Login = ({
   $c,
   isLoginBad = false,
   isLoginRequired = false,
+  isSpammer = false,
   loginAction,
   loginForm,
   postParameters,
@@ -64,6 +66,26 @@ const Login = ({
         <div className="row no-label">
           <span className="error">
             <strong>{l('Incorrect username or password')}</strong>
+          </span>
+        </div>
+      ) : null}
+
+      {isSpammer ? (
+        <div className="row no-label">
+          <span className="error">
+            <p>
+              <strong>
+                {l(`You cannot log in because this account
+                    has been marked as a spam account.`)}
+              </strong>
+            </p>
+            <p>
+              {exp.l(
+                `If you think this is a mistake, please contact
+                 <code>support@musicbrainz.org</code>
+                 with the name of your account.`,
+              )}
+            </p>
           </span>
         </div>
       ) : null}

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -30,6 +30,7 @@ import {
   isBot,
   isLocationEditor,
   isRelationshipEditor,
+  isSpammer,
   isWikiTranscluder,
 } from '../static/scripts/common/utility/privileges';
 import commaOnlyList from '../static/scripts/common/i18n/commaOnlyList';
@@ -866,33 +867,47 @@ const UserProfile = ({
       entity={sanitizedAccountLayoutUser(user)}
       page="index"
     >
-      <UserProfileInformation
-        $c={$c}
-        applicationCount={applicationCount}
-        ipHashes={ipHashes}
-        subscribed={subscribed}
-        subscriberCount={subscriberCount}
-        tokenCount={tokenCount}
-        user={user}
-        viewingOwnProfile={viewingOwnProfile}
-      />
+      {isSpammer(user) ? (
+        <>
+          <h2>{l('Blocked Spam Account')}</h2>
+          <p>
+            {l(`This user was blocked and their profile is hidden
+                because they were deemed to be spamming.
+                If you see spam in MusicBrainz, please do let us know
+                by reporting the spammer from their user page.`)}
+          </p>
+        </>
+      ) : (
+        <>
+          <UserProfileInformation
+            $c={$c}
+            applicationCount={applicationCount}
+            ipHashes={ipHashes}
+            subscribed={subscribed}
+            subscriberCount={subscriberCount}
+            tokenCount={tokenCount}
+            user={user}
+            viewingOwnProfile={viewingOwnProfile}
+          />
 
-      <UserProfileStatistics
-        $c={$c}
-        addedEntities={addedEntities}
-        editStats={editStats}
-        secondaryStats={secondaryStats}
-        user={user}
-        votes={votes}
-      />
+          <UserProfileStatistics
+            $c={$c}
+            addedEntities={addedEntities}
+            editStats={editStats}
+            secondaryStats={secondaryStats}
+            user={user}
+            votes={votes}
+          />
 
-      {$c.user && !viewingOwnProfile && !user.deleted ? (
-        <h2 style={{clear: 'both'}}>
-          <a href={`/user/${encodedName}/report`}>
-            {l('Report this user for bad behavior')}
-          </a>
-        </h2>
-      ) : null}
+          {$c.user && !viewingOwnProfile && !user.deleted ? (
+            <h2 style={{clear: 'both'}}>
+              <a href={`/user/${encodedName}/report`}>
+                {l('Report this user for bad behavior')}
+              </a>
+            </h2>
+          ) : null}
+        </>
+      )}
     </UserAccountLayout>
   );
 };


### PR DESCRIPTION
### Implement MBS-11986 / MBS-12128

For now this blocks the user from editing and leaving notes (a combo of editing disabled and notes disabled) and from logging in once logged out.

Future improvements:
* [ ] Automatically log out the editor when marked as spam, so that the login block has a stronger effect. MBS-12129
* [ ] Send user deletion signal to discourse when marked as spam, if desired (but if so, we should figure out a way to restore this if the flag turns out to be added in error). MBS-12130

It was suggested to block profile pages as a 403 but that kinda suggests that there's an issue with the user viewing it - maybe instead detach to a "this user was blocked as spam" template if not account admin? Something like "This user was blocked and their profile is hidden because they were deemed to be spamming. If you see spam in MusicBrainz, please do let us know by reporting the spammer from their user page.".