### PR TITLE
Beta: MBS-12000: Fix error msg for incompatible entity

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -616,27 +616,38 @@ export class ExternalLinksEditor
           switch (checker.entityType) {
             case 'area':
               error.message = l(`This URL is not allowed for areas.`);
+              break;
             case 'artist':
               error.message = l(`This URL is not allowed for artists.`);
+              break;
             case 'event':
               error.message = l(`This URL is not allowed for events.`);
+              break;
             case 'instrument':
               error.message = l(`This URL is not allowed for instruments.`);
+              break;
             case 'label':
               error.message = l(`This URL is not allowed for labels.`);
+              break;
             case 'place':
               error.message = l(`This URL is not allowed for places.`);
+              break;
             case 'recording':
               error.message = l(`This URL is not allowed for recordings.`);
+              break;
             case 'release':
               error.message = l(`This URL is not allowed for releases.`);
+              break;
             case 'release_group':
               error.message = l(`This URL is not allowed for release
                                  groups.`);
+              break;
             case 'series':
               error.message = l(`This URL is not allowed for series.`);
+              break;
             case 'work':
               error.message = l(`This URL is not allowed for works.`);
+              break;
           }
         }
         error.message = check.error || error.message;


### PR DESCRIPTION
# Problem
MBS-12000: "This URL is not allowed for works." when trying to add a Napster (track) URL to a release (single)

Switch case fall-throughs introduced in MBS-11977 (#2280) cause all error message to be 'This URL is not allowed for works.'

# Solution
Add `break`s to all cases.

