### PR TITLE
Try to eradicate 5xx errors during deployment

### DIFF
--- a/script/update_containers.sh
+++ b/script/update_containers.sh
@@ -103,21 +103,14 @@ do
   for service in $SERVICES
   do
     container="$service-$DEPLOY_ENV"
-    http_status=0
-    while [[ $http_status -ne 200 ]]
+    while [[ $(
+      ssh "$host" \
+        docker exec "$container" \
+          curl -I -s -o /dev/null -w "%{http_code}" 'http://localhost:5000'
+    ) -ne 200 ]]
     do
-      http_status=$(
-        ssh "$host" \
-          docker exec "$container" \
-            curl -I -s -o /dev/null -w "%{http_code}" 'http://localhost:5000'
-      )
-      if [[ $http_status -eq 200 ]]
-      then
-        break
-      else
-        echo "$host: Waiting for $container to come back up..."
-        sleep 1
-      fi
+      echo "$host: Waiting for $container to come back up..."
+      sleep 1
     done
 
     echo "$host: Bringing $container out of maintenance mode..."

--- a/script/update_containers.sh
+++ b/script/update_containers.sh
@@ -76,26 +76,58 @@ else
   HOSTS="$*"
 fi
 
-if [[ $DEPLOY_ENV == beta ]]
-then
-  pause=90
-else
-  pause=30
-fi
-
-last_host=${HOSTS/* }
-
 for host in $HOSTS
 do
+  for service in $SERVICES
+  do
+    container="$service-$DEPLOY_ENV"
+    echo "$host: Putting $container into maintenance mode..."
+
+    ssh "$host" \
+      sudo -H -S -- \
+        /root/docker-server-configs/scripts/set_service_maintenance.sh \
+          enable \
+          "$container" \
+          5000
+  done
+
+  # Production value of DETERMINE_MAX_REQUEST_TIME
+  sleep 60
+
   echo "$host: Updating containers..."
   ssh "$host" \
     sudo -H -S -- \
       /root/docker-server-configs/scripts/update_services.sh \
         $DEPLOY_ENV $SERVICES
-  if [[ $host != "$last_host" ]]
-  then
-    sleep $pause
-  fi
+
+  for service in $SERVICES
+  do
+    container="$service-$DEPLOY_ENV"
+    http_status=0
+    while [[ $http_status -ne 200 ]]
+    do
+      http_status=$(
+        ssh "$host" \
+          docker exec "$container" \
+            curl -I -s -o /dev/null -w "%{http_code}" 'http://localhost:5000'
+      )
+      if [[ $http_status -eq 200 ]]
+      then
+        break
+      else
+        echo "$host: Waiting for $container to come back up..."
+        sleep 1
+      fi
+    done
+
+    echo "$host: Bringing $container out of maintenance mode..."
+    ssh "$host" \
+      sudo -H -S -- \
+        /root/docker-server-configs/scripts/set_service_maintenance.sh \
+          disable \
+          "$container" \
+          5000
+  done
 done
 
 # vi: set et sts=2 sw=2 ts=2 :


### PR DESCRIPTION
Depends on https://github.com/metabrainz/docker-server-configs/pull/190

If we put a service into maintenance mode, the gateway will stop forwarding requests to it. If we then wait the full duration of the configured max request time, any request that hit the container before going into maintenance mode will be fully handled and we can stop the container.

There's no need to have separate timeouts configured for prod and beta because `DETERMINE_MAX_REQUEST_TIME` is the same for both.

After restarting a container, we run `curl` against the service until it comes back up before disabling maintenance mode.