### PR TITLE
[WIP] MBS-12012: Allow "dupe" URL rels with diff dates

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -8138,11 +8138,23 @@ export class Checker {
       }
       return {result: true};
     }
-    // Multiple types are selected
+    /*
+     * Multiple types are selected
+     * We make sure that the types match one of the sets
+     * of allowed types, allowing for multiple uses of a type
+     * (to support dated relationships)
+     */
+    const selectedTypesSet = new Set(selectedTypes);
     const result = allowedTypes.some(
-      (allowedType) => Array.isArray(allowedType) &&
-        selectedTypes.length === allowedType.length &&
-        (new Set(selectedTypes)).isSubsetOf(new Set(allowedType)),
+      (allowedType) => {
+        const allowedTypeSet = new Set(Array.isArray(allowedType)
+          ? allowedType
+          : [allowedType]);
+        return (
+          selectedTypesSet.size === allowedTypeSet.size &&
+          selectedTypesSet.isSubsetOf(allowedTypeSet)
+        );
+      },
     );
     if (!result) {
       return {

--- a/root/static/scripts/external-links-editor/components/ExternalLink.js
+++ b/root/static/scripts/external-links-editor/components/ExternalLink.js
@@ -177,12 +177,18 @@ component _ExternalLink(
   const addRelationshipButton = React.useMemo(() => {
     /*
      * Hide the button when the link is not submitted,
-     * or the link does not match only a single type.
+     * or the link matches only a single type and the
+     * existing rel has no dates set.
      */
     if (
       isEmpty ||
       !isSubmitted ||
-      doesUrlMatchOnlyOnePossibleType(source.entityType, link)
+      (
+        doesUrlMatchOnlyOnePossibleType(source.entityType, link) &&
+        link.relationships[0].beginDate == null &&
+        link.relationships[0].endDate == null &&
+        !link.relationships[0].ended
+      )
     ) {
       return null;
     }

--- a/root/static/scripts/external-links-editor/components/ExternalLinkRelationship.js
+++ b/root/static/scripts/external-links-editor/components/ExternalLinkRelationship.js
@@ -218,9 +218,20 @@ component _ExternalLinkRelationship(
       <td className="link-actions">
         {(
           link.relationships.length > 1 &&
+          /*
+           * If there is more than one rel for the link, we allow removing
+           * ones with dates or newly added ones, even if they are of the
+           * autoselected type.
+           */
           (
             relationshipError != null ||
-            !doesUrlMatchOnlyOnePossibleType(source.entityType, link)
+            !doesUrlMatchOnlyOnePossibleType(source.entityType, link) ||
+            (
+              relationship.beginDate != null ||
+              relationship.endDate != null ||
+              relationship.ended
+            ) ||
+            status.isNew
           )
         ) ? (
           <RemoveButton

--- a/root/static/scripts/external-links-editor/state.js
+++ b/root/static/scripts/external-links-editor/state.js
@@ -27,7 +27,6 @@ import {
 import {compareStrings} from '../common/utility/compare.mjs';
 import deepFreezeInDevelopment
   from '../common/utility/deepFreezeInDevelopment.js';
-import formatDatePeriod from '../common/utility/formatDatePeriod.js';
 import isDatabaseRowId from '../common/utility/isDatabaseRowId.js';
 import {
   advanceUniqueId,
@@ -477,16 +476,6 @@ function moveFocusToNextLink(
   ctx.set('focus', nextLink ? `#external-link-${nextLink.key}` : 'empty');
 }
 
-function stringifyTypeAndDate(relationship: LinkRelationshipStateT): string {
-  const dateContainer = {
-    begin_date: relationship.beginDate,
-    end_date: relationship.endDate,
-    ended: relationship.ended,
-  };
-  const dateString = formatDatePeriod(dateContainer);
-  return (relationship.linkTypeID ?? '') + dateString;
-}
-
 function updateRemovedOnMatchingRelationships(
   relationshipsCtx: CowContext<$ReadOnlyArray<LinkRelationshipStateT>>,
   matchCallback: (LinkRelationshipStateT) => boolean,
@@ -637,12 +626,7 @@ export function reducer(
       let relationshipsToMerge;
       updateLink(ctx, duplicateOf.link, existingLinkCtx => {
         const existingRelationships = existingLinkCtx.read().relationships;
-        const existingRelationshipTypeIdsAndDates =
-          new Set(existingRelationships.map(r => stringifyTypeAndDate(r)));
-        relationshipsToMerge = duplicate.relationships.filter(
-          r => r.linkTypeID == null ||
-            !existingRelationshipTypeIdsAndDates.has(stringifyTypeAndDate(r)),
-        );
+        relationshipsToMerge = duplicate.relationships;
         existingLinkCtx.set(
           'relationships',
           existingRelationships.concat(relationshipsToMerge),

--- a/root/static/scripts/external-links-editor/state.js
+++ b/root/static/scripts/external-links-editor/state.js
@@ -27,6 +27,7 @@ import {
 import {compareStrings} from '../common/utility/compare.mjs';
 import deepFreezeInDevelopment
   from '../common/utility/deepFreezeInDevelopment.js';
+import formatDatePeriod from '../common/utility/formatDatePeriod.js';
 import isDatabaseRowId from '../common/utility/isDatabaseRowId.js';
 import {
   advanceUniqueId,
@@ -476,6 +477,16 @@ function moveFocusToNextLink(
   ctx.set('focus', nextLink ? `#external-link-${nextLink.key}` : 'empty');
 }
 
+function stringifyTypeAndDate(relationship: LinkRelationshipStateT): string {
+  const dateContainer = {
+    begin_date: relationship.beginDate,
+    end_date: relationship.endDate,
+    ended: relationship.ended,
+  };
+  const dateString = formatDatePeriod(dateContainer);
+  return (relationship.linkTypeID ?? '') + dateString;
+}
+
 function updateRemovedOnMatchingRelationships(
   relationshipsCtx: CowContext<$ReadOnlyArray<LinkRelationshipStateT>>,
   matchCallback: (LinkRelationshipStateT) => boolean,
@@ -626,11 +637,11 @@ export function reducer(
       let relationshipsToMerge;
       updateLink(ctx, duplicateOf.link, existingLinkCtx => {
         const existingRelationships = existingLinkCtx.read().relationships;
-        const existingRelationshipTypeIds =
-          new Set(existingRelationships.map(r => r.linkTypeID));
+        const existingRelationshipTypeIdsAndDates =
+          new Set(existingRelationships.map(r => stringifyTypeAndDate(r)));
         relationshipsToMerge = duplicate.relationships.filter(
           r => r.linkTypeID == null ||
-            !existingRelationshipTypeIds.has(r.linkTypeID),
+            !existingRelationshipTypeIdsAndDates.has(stringifyTypeAndDate(r)),
         );
         existingLinkCtx.set(
           'relationships',

--- a/root/static/scripts/external-links-editor/validation.js
+++ b/root/static/scripts/external-links-editor/validation.js
@@ -10,6 +10,7 @@
 import type {CowContext} from 'mutate-cow';
 import * as tree from 'weight-balanced-tree';
 
+import areDatesEqual from '../common/utility/areDatesEqual.js';
 import isObjectEmpty from '../common/utility/isObjectEmpty.js';
 import * as URLCleanup from '../edit/URLCleanup.js';
 import isShortenedUrl from '../edit/utility/isShortenedUrl.js';
@@ -331,7 +332,10 @@ function getRelationshipError(
     }
     return (
       relationship.id !== other.id &&
-      relationship.linkTypeID === other.linkTypeID
+      relationship.linkTypeID === other.linkTypeID &&
+      areDatesEqual(relationship.beginDate, other.beginDate) &&
+      areDatesEqual(relationship.endDate, other.endDate) &&
+      relationship.ended === other.ended
     );
   };
 


### PR DESCRIPTION
### Fix MBS-12012 / Implement MBS-12013

2026: Updating this for the new external link code.

# Problem
We have no way to indicate that a link stopped working, then came back. See MBS-13605 for a real life example.

# Solution
This changes link validation to only consider links duplicates if they have the same date period.

It also allows adding (and removing) additional relationships even for autoselected links, as long as the first one has dates or ended set (MBS-12013).

# AI usage
None

# Testing
Manually:
* Add two "official homepage" links, one with dates and one without, and see they can be submitted and edited.
* Check that the "Add another relationship" button appears for autoselected links but only after adding dates to them (MBS-12013)
* Check that validation accepts multiple relationships of the same type for a link, even for autoselected ones, as long as they are not duplicates.
* Check that complete duplicates (same dates) are still detected as such.
* Check that different relationships with different dates but the same type are no longer dropped when merging links.