### PR TITLE
MBS-12017 / MBS-12018: Correctly capitalize YouTube on guess case and set /g

### DIFF
--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -82,19 +82,19 @@ const POSTPROCESS_FIXLIST = [
    * "fe" is considered a lowercase word, but "Santa Fe" is very common in
    * song titles, so change that "fe" back into "Fe".
    */
-  [/(\b|^)Santa fe(\b|$)/g,        'Santa Fe'],
-  [/(\b|^)R\s*&\s*B(\b)/i,         'R&B'],
-  [/(\b|^)\[live\](\b)/i,          '(live)'],
-  [/(\b|^)Djs(\b)/i,               'DJs'],
-  [/(\b|^)imac(\b)/i,              'iMac'], // Apple products
-  [/(\b|^)ipad(\b)/i,              'iPad'],
-  [/(\b|^)iphone(\b)/i,            'iPhone'],
-  [/(\b|^)ipod(\b)/i,              'iPod'],
-  [/(\b|^)itunes(\b)/i,            'iTunes'],
-  [/(\b|^)youtube(\b)/ig,          'YouTube'],
-  [/(\s|^)Rock '?n'? Roll(\s|$)/i, "Rock 'n' Roll"],
-  [/(\b)w([/／])o(\b)/i,           'w$2o'], // w/o should be lowercase
-  [/(\b)f([.．/／])(\b)/i,         'f$2'], // f. and f/ should be lowercase
+  [/(\b|^)Santa fe(\b|$)/g,         'Santa Fe'],
+  [/(\b|^)R\s*&\s*B(\b)/ig,         'R&B'],
+  [/(\b|^)\[live\](\b)/i,           '(live)'],
+  [/(\b|^)Djs(\b)/ig,               'DJs'],
+  [/(\b|^)imac(\b)/ig,              'iMac'], // Apple products
+  [/(\b|^)ipad(\b)/ig,              'iPad'],
+  [/(\b|^)iphone(\b)/ig,            'iPhone'],
+  [/(\b|^)ipod(\b)/ig,              'iPod'],
+  [/(\b|^)itunes(\b)/ig,            'iTunes'],
+  [/(\b|^)youtube(\b)/ig,           'YouTube'],
+  [/(\s|^)Rock '?n'? Roll(\s|$)/ig, "Rock 'n' Roll"],
+  [/(\b)w([/／])o(\b)/i,            'w$2o'], // w/o should be lowercase
+  [/(\b)f([.．/／])(\b)/i,          'f$2'], // f. and f/ should be lowercase
 ];
 /* eslint-enable no-multi-spaces */
 

--- a/root/static/scripts/guess-case/modes.js
+++ b/root/static/scripts/guess-case/modes.js
@@ -91,6 +91,7 @@ const POSTPROCESS_FIXLIST = [
   [/(\b|^)iphone(\b)/i,            'iPhone'],
   [/(\b|^)ipod(\b)/i,              'iPod'],
   [/(\b|^)itunes(\b)/i,            'iTunes'],
+  [/(\b|^)youtube(\b)/ig,          'YouTube'],
   [/(\s|^)Rock '?n'? Roll(\s|$)/i, "Rock 'n' Roll"],
   [/(\b)w([/／])o(\b)/i,           'w$2o'], // w/o should be lowercase
   [/(\b)f([.．/／])(\b)/i,         'f$2'], // f. and f/ should be lowercase

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -413,7 +413,7 @@ test('Work', function (t) {
 });
 
 test('BugFixes', function (t) {
-  t.plan(29);
+  t.plan(30);
 
   const tests = [
     {
@@ -552,6 +552,12 @@ test('BugFixes', function (t) {
       input: 'I Love My iPad, My IPod and My Iphone!',
       expected: 'I Love My iPad, My iPod and My iPhone!',
       bug: 'MBS-7421',
+      mode: 'English',
+    },
+    {
+      input: 'A story of YouTube (youtube edit)',
+      expected: 'A Story of YouTube (YouTube edit)',
+      bug: 'MBS-12017',
       mode: 'English',
     },
     {

--- a/root/static/scripts/tests/GuessCase.js
+++ b/root/static/scripts/tests/GuessCase.js
@@ -549,8 +549,8 @@ test('BugFixes', function (t) {
       mode: 'Turkish',
     },
     {
-      input: 'I Love My iPad, My IPod and My Iphone!',
-      expected: 'I Love My iPad, My iPod and My iPhone!',
+      input: 'I Love My iPad, My IPod and My Iphone, my iphone!',
+      expected: 'I Love My iPad, My iPod and My iPhone, My iPhone!',
       bug: 'MBS-7421',
       mode: 'English',
     },


### PR DESCRIPTION
### Implement MBS-12017 and fix MBS-12018

We do this for stuff like iPad, so we might as well do it for YouTube.

When adding a test I used "youtube" twice, and was confused when it didn't pass; then I noticed that all of these words should be marked `/g` or they will only be corrected the first time they appear on a title, so I amended the rest of the ones that seemed relevant with the second commit here.