### PR TITLE
MBS-11991: Add links for uses of artist credits in entity editor

### DIFF
--- a/root/static/scripts/artist/components/ArtistCreditRenamer.js
+++ b/root/static/scripts/artist/components/ArtistCreditRenamer.js
@@ -12,9 +12,11 @@ import * as React from 'react';
 
 import hydrate from '../../../../utility/hydrate';
 import ArtistCreditLink from '../../common/components/ArtistCreditLink';
+import ArtistCreditUsageLink
+  from '../../common/components/ArtistCreditUsageLink';
 import {compare} from '../../common/i18n';
 import {reduceArtistCredit} from '../../common/immutable-entities';
-import {bracketedText} from '../../common/utility/bracketed';
+import bracketed, {bracketedText} from '../../common/utility/bracketed';
 import {sortedIndexWith} from '../../common/utility/arrays';
 import diffArtistCredits from '../../edit/utility/diffArtistCredits';
 
@@ -127,6 +129,15 @@ const ArtistCreditRow = ({
         value={artistCredit.id}
       />
       <ArtistCreditLink artistCredit={artistCredit} />
+      {' '}
+      <span className="small">
+        {bracketed(
+          <ArtistCreditUsageLink
+            artistCredit={artistCredit}
+            content={l('see uses')}
+          />,
+        )}
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
### Implement MBS-11991

Tested manually.

This is now used in exactly the same way in two places (here and in ArtistCreditList). We could turn it into its own component but I'm not sure if it makes sense yet. Let me know what you think! :) 