### PR TITLE
MBS-12019: Do not list downvoted tags on sidebar when logged out

### DIFF
--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -30,7 +30,8 @@ const TagList = ({
   isGenreList = false,
   tags,
 }: TagListProps) => {
-  const links = tags ? tags.reduce((accum, t) => {
+  const upvotedTags = tags ? tags.filter(tag => tag.count > 0) : null;
+  const links = upvotedTags ? upvotedTags.reduce((accum, t) => {
     if (Boolean(t.tag.genre) === isGenreList) {
       accum.push(<TagLink key={'tag-' + t.tag.name} tag={t.tag.name} />);
     }


### PR DESCRIPTION
### Fix MBS-12019

We already hid these when logged in, but we were not filtering them out at all when the user is logged out and we simply use `TagList`.

Tested by hand with Ed Sheeran, which has some tags with 0 votes such as 'ed sheeran does not make sillyname tracks ಠ_ಠ'' which were still showing on the sidebar.