### PR TITLE
Upgrade Flow to 0.162.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.161.0",
+    "flow-bin": "0.162.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -132,6 +132,8 @@ type InitialStateT<T: EntityItemT> = {
   +width?: string,
 };
 
+const EMPTY_ITEMS: $ReadOnlyArray<ItemT<empty>> = Object.freeze([]);
+
 export function createInitialState<+T: EntityItemT>(
   initialState: InitialStateT<T>,
 ): {...StateT<T>} {
@@ -156,7 +158,7 @@ export function createInitialState<+T: EntityItemT>(
     );
   }
 
-  const state: $Shape<{...StateT<T>}> = {
+  const state: {...StateT<T>} = {
     activeUser: null,
     entityType,
     error: 0,
@@ -164,6 +166,7 @@ export function createInitialState<+T: EntityItemT>(
     indexedSearch: true,
     inputValue,
     isOpen: false,
+    items: EMPTY_ITEMS,
     page: 1,
     pendingSearch: null,
     recentItems: null,

--- a/root/static/scripts/common/linkedEntities.js
+++ b/root/static/scripts/common/linkedEntities.js
@@ -50,7 +50,9 @@ export type LinkedEntitiesT = {
   link_type_tree: {
     [entityTypes: string]: $ReadOnlyArray<LinkTypeT>,
   },
-  mergeLinkedEntities: (update: ?$Shape<LinkedEntitiesT>) => void,
+  mergeLinkedEntities: (
+    update: ?$ReadOnly<$Partial<LinkedEntitiesT>>,
+  ) => void,
   place: {
     [placeId: number]: PlaceT,
   },
@@ -125,7 +127,7 @@ const linkedEntities/*: LinkedEntitiesT */ = Object.create(Object.seal({
   work:                           EMPTY_OBJECT,
   work_attribute_type:            EMPTY_OBJECT,
 
-  mergeLinkedEntities(update/*: ?$Shape<LinkedEntitiesT> */) {
+  mergeLinkedEntities(update/*: ?$ReadOnly<$Partial<LinkedEntitiesT>> */) {
     if (update) {
       for (const [type, entities] of Object.entries(update)) {
         if (hasOwnProperty.call(linkedEntities, type)) {

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -10,7 +10,10 @@
 import * as React from 'react';
 import mutate from 'mutate-cow';
 import ButtonPopover from '../../common/components/ButtonPopover';
-import type {LinkRelationshipT} from '../externalLinks';
+import type {
+  LinkRelationshipT,
+  LinkStateT,
+} from '../externalLinks';
 import DateRangeFieldset, {
   partialDateFromField,
   runReducer as runDateRangeFieldsetReducer,
@@ -27,7 +30,7 @@ import {
 import {copyDatePeriodField} from '../utility/copyFieldData';
 
 type PropsT = {
-  onConfirm: (DatePeriodRoleT) => void,
+  onConfirm: ($ReadOnly<$Partial<LinkStateT>>) => void,
   relationship: LinkRelationshipT,
 };
 

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -123,7 +123,7 @@ export class ExternalLinksEditor
 
   setLinkState(
     index: number,
-    state: $Shape<LinkStateT>,
+    state: $ReadOnly<$Partial<LinkStateT>>,
     callback?: () => void,
   ) {
     const newLinks: Array<LinkStateT> = this.state.links.concat();
@@ -193,7 +193,7 @@ export class ExternalLinksEditor
     urlIndex: number,
     canMerge: boolean,
   ) {
-    const link = {...this.state.links[index]};
+    const link: {...LinkStateT} = {...this.state.links[index]};
     const url = event.currentTarget.value;
     const trimmed = url.trim();
     const unicodeUrl = getUnicodeUrl(trimmed);
@@ -279,7 +279,7 @@ export class ExternalLinksEditor
     event: SyntheticEvent<HTMLInputElement>,
     canMerge: boolean,
   ) {
-    const link = {...this.state.links[index]};
+    const link: {...LinkStateT} = {...this.state.links[index]};
     const url = event.currentTarget.value;
     const trimmed = url.trim();
     const unicodeUrl = getUnicodeUrl(trimmed);
@@ -346,7 +346,7 @@ export class ExternalLinksEditor
       return;
     }
 
-    const link = {...this.state.links[index]};
+    const link: {...LinkStateT} = {...this.state.links[index]};
     if (link.url && link.type) {
       link.submitted = true;
     }
@@ -981,7 +981,7 @@ type ExternalLinkRelationshipProps = {
   +highlight: HighlightT,
   +isOnlyRelationship: boolean,
   +link: LinkRelationshipT,
-  +onAttributesChange: (number, DatePeriodRoleT) => void,
+  +onAttributesChange: (number, $ReadOnly<$Partial<LinkStateT>>) => void,
   +onLinkRemove: (number) => void,
   +onTypeBlur: (number, SyntheticFocusEvent<HTMLSelectElement>) => void,
   +onTypeChange: (number, SyntheticEvent<HTMLSelectElement>) => void,
@@ -1104,7 +1104,7 @@ type LinkProps = {
   +duplicate: number | null,
   +error: ErrorT | null,
   +getRelationshipHighlightType: (LinkRelationshipT) => HighlightT,
-  +handleAttributesChange: (number, DatePeriodRoleT) => void,
+  +handleAttributesChange: (number, $ReadOnly<$Partial<LinkStateT>>) => void,
   +handleLinkRemove: (number) => void,
   +handleLinkSubmit: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   +handleUrlBlur: (SyntheticFocusEvent<HTMLInputElement>) => void,
@@ -1346,7 +1346,7 @@ const defaultLinkState: LinkStateT = {
   video: false,
 };
 
-function newLinkState(state: $Shape<LinkStateT>) {
+function newLinkState(state: $ReadOnly<$Partial<LinkStateT>>) {
   return {...defaultLinkState, ...state};
 }
 

--- a/root/static/scripts/release/types.js
+++ b/root/static/scripts/release/types.js
@@ -42,7 +42,7 @@ export type ActionT =
 
 export type PropsT = {
   +initialCreditsMode: CreditsModeT,
-  +initialLinkedEntities: $Shape<LinkedEntitiesT>,
+  +initialLinkedEntities: $ReadOnly<$Partial<LinkedEntitiesT>>,
   +noScript: boolean,
   +release: ReleaseWithMediumsT,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,10 +2945,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.161.0:
-  version "0.161.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.161.0.tgz#1c03ea4a9e3036a8bc639f050bd8dc6f5288e8bb"
-  integrity sha512-5BKQi+sjOXz67Kbc1teiBwd5e0Da6suW7S5oUCm9VclnzSZ3nlfNZUdrkvgJ5S4w5KDBDToEL7rREpn8rKF1zg==
+flow-bin@0.162.1:
+  version "0.162.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.162.1.tgz#5aaac790dab8664ce363fd0f09764fb9f0daed20"
+  integrity sha512-gFNWkEzBuQ9YzQcPKcVL16V5MZixbiQ+Kn867iwaCfs1TAFuhQQcng4vX3Rtyd7JI3O+g8jToEX7pEDhdzG80Q==
 
 follow-redirects@^1.0.0:
   version "1.11.0"


### PR DESCRIPTION
The code changes aren't necessary to upgrade, but this release introduces a new utility type, `$Partial<T>` (which returns `T` with all properties marked as optional). This can replace `$Shape<T>` for us, which is unsound: https://flow.org/en/docs/types/utilities/#toc-shape