### PR TITLE
MBS-12001: Use allowNew for recording links when adding a new track

### DIFF
--- a/root/edit/details/EditMedium.js
+++ b/root/edit/details/EditMedium.js
@@ -156,7 +156,9 @@ const TracklistChangesAdd = ({
             {' '}
           </>
         ) : null}
+        {/* If no recording_id exists, it's creating a recording */}
         <EntityLink
+          allowNew={track && !track.recording.id}
           content={track.name}
           entity={track.recording}
         />


### PR DESCRIPTION
### Fix MBS-12001

For some reason, we did this check for track changes (so, when a new recording is assigned to an existing track) but not for new track adds that create a new recording.