### PR TITLE
MBS-12050: Add "edit note does not include" to edit search

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
@@ -6,6 +6,7 @@ with 'MusicBrainz::Server::EditSearch::Predicate';
 sub operator_cardinality_map {
   return (
       'includes' => undef,
+      'not-includes' => undef,
   )
 }
 
@@ -19,12 +20,21 @@ sub combine_with_query {
       '%' . $_ . '%'
     } @{ $self->sql_arguments };
 
+    my $comparison;
+
+    if ($self->operator eq 'not-includes') {
+        $comparison = 'NOT ILIKE';
+    } else {
+        $comparison = 'ILIKE';
+    }
+
     $query->add_where([
-        'EXISTS (
-          SELECT TRUE FROM edit_note
-          WHERE edit_note.text ILIKE ?
-            AND edit_note.edit = edit.id
-        )',
+        "EXISTS (
+          SELECT TRUE
+            FROM edit_note
+           WHERE edit_note.text $comparison ?
+             AND edit_note.edit = edit.id
+        )",
         \@patterns,
     ]);
 };

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -377,6 +377,7 @@
 
 [% MACRO predicate_edit_note_content(field, field_contents) WRAPPER wfield predicate="edit_note_content" %]
   [% operators([ [ 'includes', l('includes') ]
+                 [ 'not-includes', l('does not include') ]
                ], field_contents) %]
   <span class="arg">
     <input type="text" class="name" name="args.0" value="[% html_escape(field_contents.argument(0)) %]" style="width: 170px;" />

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -16,7 +16,8 @@ $(function () {
       '=': 1, '!=': 1,
     },
     edit_note_content: {
-      includes: 1,
+      'includes': 1,
+      'not-includes': 1,
     },
     voter: {
       '=': 1,


### PR DESCRIPTION
### Implement MBS-12050

Tested by filtering the edits by a specific user with "includes" / "does not include": "imported".