### PR TITLE
MBS-12057: Show entity type on sidebar "No collections!" message

### DIFF
--- a/root/layout/components/sidebar/CollectionLinks.js
+++ b/root/layout/components/sidebar/CollectionLinks.js
@@ -15,7 +15,21 @@ import EntityLink from '../../../static/scripts/common/components/EntityLink';
 import CollectionList from './CollectionList';
 
 type Props = {
-  +entity: CoreEntityT,
+  +entity: CollectableCoreEntityT,
+};
+
+const noCollectionsStrings = {
+  area: N_l('You have no area collections!'),
+  artist: N_l('You have no artist collections!'),
+  event: N_l('You have no event collections!'),
+  instrument: N_l('You have no instrument collections!'),
+  label: N_l('You have no label collections!'),
+  place: N_l('You have no place collections!'),
+  recording: N_l('You have no recording collections!'),
+  release: N_l('You have no release collections!'),
+  release_group: N_l('You have no release group collections!'),
+  series: N_l('You have no series collections!'),
+  work: N_l('You have no work collections!'),
 };
 
 const CollectionLinks = ({
@@ -35,7 +49,7 @@ const CollectionLinks = ({
       header={l('Collections')}
       ownCollections={$c.stash.own_collections}
       ownCollectionsHeader={l('My collections')}
-      ownCollectionsNoneText={l('You have no collections!')}
+      ownCollectionsNoneText={noCollectionsStrings[entity.entityType]()}
       sectionClass="collections"
       usersLink={
         <EntityLink

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -27,11 +27,10 @@ declare type CoreEntityRoleT<+T> = {
   +relationships?: $ReadOnlyArray<RelationshipT>,
 };
 
-declare type NonUrlCoreEntityT =
+declare type CollectableCoreEntityT =
   | AreaT
   | ArtistT
   | EventT
-  | GenreT
   | InstrumentT
   | LabelT
   | PlaceT
@@ -40,6 +39,10 @@ declare type NonUrlCoreEntityT =
   | ReleaseT
   | SeriesT
   | WorkT;
+
+declare type NonUrlCoreEntityT =
+  | CollectableCoreEntityT
+  | GenreT;
 
 declare type CoreEntityT =
   | NonUrlCoreEntityT


### PR DESCRIPTION
### Implement MBS-12057

This has been confusing to users who do not realize they're on an RG page instead of a release at first
or whatnot. It doesn't seem to have any downside to specify, so we might as well.
