### PR TITLE
MBS-7727: Restrict Soundcloud to only "get the music" rels

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3924,7 +3924,45 @@ const CLEANUPS: CleanupEntries = {
   },
   'soundcloud': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?soundcloud\\.com', 'i')],
-    restrict: [LINK_TYPES.soundcloud],
+    restrict: [
+      LINK_TYPES.soundcloud,
+      {
+        recording: LINK_TYPES.downloadfree.recording,
+        release: LINK_TYPES.downloadfree.release,
+      },
+      {
+        recording: LINK_TYPES.downloadpurchase.recording,
+        release: LINK_TYPES.downloadpurchase.release,
+      },
+      {
+        recording: LINK_TYPES.streamingfree.recording,
+        release: LINK_TYPES.streamingfree.release,
+      },
+      {
+        recording: LINK_TYPES.streamingpaid.recording,
+        release: LINK_TYPES.streamingpaid.release,
+      },
+      {
+        recording: [
+          LINK_TYPES.downloadfree.recording,
+          LINK_TYPES.streamingfree.recording,
+        ],
+        release: [
+          LINK_TYPES.downloadfree.release,
+          LINK_TYPES.streamingfree.release,
+        ],
+      },
+      {
+        recording: [
+          LINK_TYPES.downloadpurchase.recording,
+          LINK_TYPES.streamingpaid.recording,
+        ],
+        release: [
+          LINK_TYPES.downloadpurchase.release,
+          LINK_TYPES.streamingpaid.release,
+        ],
+      },
+    ],
     clean: function (url) {
       return url.replace(/^(https?:\/\/)?((www|m)\.)?soundcloud\.com(\/#!)?/, 'https://soundcloud.com');
     },

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3890,6 +3890,30 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'https://soundcloud.com/psuhhoteek/lahemaa-lindude-haali-bird-voices-of-lahemaa',
+             input_entity_type: 'recording',
+limited_link_type_combinations: [
+                                  'downloadfree',
+                                  'downloadpurchase',
+                                  'streamingfree',
+                                  'streamingpaid',
+                                  ['downloadfree', 'streamingfree'],
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+  },
+  {
+                     input_url: 'https://soundcloud.com/bei-ping/sets/bei-ping-mafia-cd-2009',
+             input_entity_type: 'release',
+limited_link_type_combinations: [
+                                  'downloadfree',
+                                  'downloadpurchase',
+                                  'streamingfree',
+                                  'streamingpaid',
+                                  ['downloadfree', 'streamingfree'],
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
+  },
+  {
                      input_url: 'https://soundcloud.com/tags/bug',
        input_relationship_type: 'soundcloud',
        only_valid_entity_types: [],


### PR DESCRIPTION
### Implement MBS-7727

Soundcloud shouldn't be used for license nor crowdfunding relationships (nor, probably, any other that gets added
further down the line). This restricts it to only allow "get the music" relationships (all of them, because apparently some stuff on SoundCloud requires a SoundCloud Go+ subscription, whatever that involves  - not available in my country).

On top of https://github.com/metabrainz/musicbrainz-server/pull/2339 (which used to be part of this PR)