### PR TITLE
MBS-12060: Block google.com/search URLs on URL relationships

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -603,6 +603,13 @@ export class ExternalLinksEditor
                     Enter the destination URL instead.`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
+    } else if (isNewOrChangedLink && isGoogleSearch(link.url)) {
+      error = {
+        message: l(`Please don’t enter links to search results.
+                    If you’ve found any links through your search
+                    that seem useful, do enter those instead.`),
+        target: URLCleanup.ERROR_TARGETS.URL,
+      };
     } else if (!link.type) {
       error = {
         message: l(`Please select a link type for the URL
@@ -1601,6 +1608,10 @@ function isShortened(url) {
 
 function isGoogleAmp(url) {
   return /^https?:\/\/([^/]+\.)?google\.[^/]+\/amp/.test(url);
+}
+
+function isGoogleSearch(url) {
+  return /^https?:\/\/(?:[^/?#]+\.)?google\.[^/?#]+\/search/.test(url);
 }
 
 function isExample(url) {

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -430,6 +430,17 @@
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: '“http://example.com/” is just an example. Please enter the actual link you want to add.',
     },
+    // Google search link detection (MBS-12060)
+    {
+      command: 'type',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://www.google.com/search?q=good+music&oq=good+music&aqs=chrome..69i57j46i512j0i512l2j46i512j69i60l3.1930j0j7&sourceid=chrome&ie=UTF-8',
+    },
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
+      value: 'Please don’t enter links to search results. If you’ve found any links through your search that seem useful, do enter those instead.',
+    },
     // deprecated link type detection for existing links (MBS-8408)
     {
       command: 'type',


### PR DESCRIPTION
### Implement MBS-12060

We currently have 32 of these for google.com, but I'm pretty sure that's because a lot of them get removed soon after they're added - I've certainly seen this happen.