### PR TITLE
MBS-12055: Allow admins to see private editor-editor subscriptions

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -27,7 +27,22 @@ with 'MusicBrainz::Server::Controller::User::SubscriptionsRole' => {
 sub subscriptions : Chained('/user/load') {
     my ($self, $c) = @_;
     my $user = $c->stash->{user};
-    $c->response->redirect($c->uri_for_action('/user/subscriptions/artist', [ $user->name ]));
+    $c->model('Editor')->load_preferences($user);
+
+    my $is_admin_viewing_private = defined $c->user &&
+                                   $c->user->is_account_admin &&
+                                   $c->user->id != $user->id &&
+                                   !$user->preferences->public_subscriptions;
+
+    if ($is_admin_viewing_private) {
+        $c->response->redirect(
+            $c->uri_for_action('/user/subscriptions/editor', [ $user->name ])
+        );
+    } else {
+        $c->response->redirect(
+            $c->uri_for_action('/user/subscriptions/artist', [ $user->name ])
+        );
+    }
 }
 
 1;

--- a/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
+++ b/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
@@ -28,7 +28,10 @@ role {
 
         my $user = $c->stash->{user};
 
-        if (!defined $c->user || $c->user->id != $user->id) {
+        # Admins should have access to editor-editor subscriptions (MBS-12055)
+        if (!defined $c->user || $c->user->id != $user->id && !(
+            $type eq 'editor' && $c->user->is_account_admin
+        )) {
             $c->model('Editor')->load_preferences($user);
             $c->detach('/error_403')
                 unless $user->preferences->public_subscriptions;

--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -36,12 +36,14 @@ function buildTabs(
   const hasPublicTags = !userDeleted && user.preferences.public_tags;
   const hasPublicRatings = !userDeleted && user.preferences.public_ratings;
 
-  if (viewingOwnProfile || hasPublicSubscriptions) {
+  const subsRequireAdminPrivs = showAdmin && !hasPublicSubscriptions;
+  if ((showAdmin || viewingOwnProfile) || hasPublicSubscriptions) {
     tabs.push(buildTab(
       page,
       l('Subscriptions'),
-      userPath + '/subscriptions/artist',
+      userPath + '/subscriptions',
       'subscriptions',
+      subsRequireAdminPrivs ? 'private-tab requires-admin-privileges' : '',
     ));
   }
 

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -383,6 +383,15 @@ div.warning img.warning {
     height: 32px;
 }
 
+.error-tab, .private-tab:not(.sel) {
+    background-color: @negative-light-bg;
+    background-image: data-uri('../images/icons/warning.png');
+    background-repeat: no-repeat;
+    background-position: left 0.5em top 0.5em;
+    background-size: 16px 16px;
+}
+.error-tab a, .private-tab:not(.sel) a { padding-left: 2em !important; }
+
 #content,
 #sidebar {
     display: table-cell;

--- a/root/static/styles/release-editor.less
+++ b/root/static/styles/release-editor.less
@@ -35,14 +35,6 @@ fieldset {
 }
 
 .warning { border-radius: 6px; }
-.error-tab {
-    background-color: @negative-light-bg;
-    background-image: data-uri('../images/icons/warning.png');
-    background-repeat: no-repeat;
-    background-position: left 0.5em top 0.5em;
-    background-size: 16px 16px;
-}
-.error-tab a { padding-left: 2em; }
 .page-error { .error; padding: 1em 0.5em; }
 
 /* __________________________________

--- a/root/user/UserSubscriptions.js
+++ b/root/user/UserSubscriptions.js
@@ -126,12 +126,15 @@ const UserSubscriptions = ({
   user,
   visiblePrivateCollections,
 }: UserSubscriptionsProps): React.Element<typeof UserAccountLayout> => {
+  const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
+  const isAdminViewingPrivate = Boolean(
+    $c.user && !viewingOwnProfile && !user.preferences.public_subscriptions,
+  );
   const action = `/account/subscriptions/${type}/remove`;
   const showSummary = summary.artist > 0 || summary.collection > 0 ||
                       summary.editor > 0 || summary.label > 0 ||
                       summary.series > 0;
   const title = titleByEntityType[type]();
-  const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
   const hasPrivateSubscriptions =
     visiblePrivateCollections?.length ||
     hiddenPrivateCollectionCount != null && hiddenPrivateCollectionCount > 0;
@@ -144,96 +147,100 @@ const UserSubscriptions = ({
     >
       <h2>{title}</h2>
 
-      <p>
-        {'[ '}
-        <a href={`/user/${user.name}/subscriptions/artist`}>
-          {titleByEntityType.artist()}
-        </a>
-        {' | '}
-        <a href={`/user/${user.name}/subscriptions/collection`}>
-          {titleByEntityType.collection()}
-        </a>
-        {' | '}
-        <a href={`/user/${user.name}/subscriptions/label`}>
-          {titleByEntityType.label()}
-        </a>
-        {' | '}
-        <a href={`/user/${user.name}/subscriptions/series`}>
-          {titleByEntityType.series()}
-        </a>
-        {' | '}
-        <a href={`/user/${user.name}/subscriptions/editor`}>
-          {titleByEntityType.editor()}
-        </a>
-        {' ]'}
-      </p>
-
-      {showSummary ? (
+      {isAdminViewingPrivate ? null : (
         <>
           <p>
-            {exp.l(
-              '{editor} is subscribed to:',
-              {editor: <EditorLink editor={user} />},
-            )}
+            {'[ '}
+            <a href={`/user/${user.name}/subscriptions/artist`}>
+              {titleByEntityType.artist()}
+            </a>
+            {' | '}
+            <a href={`/user/${user.name}/subscriptions/collection`}>
+              {titleByEntityType.collection()}
+            </a>
+            {' | '}
+            <a href={`/user/${user.name}/subscriptions/label`}>
+              {titleByEntityType.label()}
+            </a>
+            {' | '}
+            <a href={`/user/${user.name}/subscriptions/series`}>
+              {titleByEntityType.series()}
+            </a>
+            {' | '}
+            <a href={`/user/${user.name}/subscriptions/editor`}>
+              {titleByEntityType.editor()}
+            </a>
+            {' ]'}
           </p>
-          <ul>
-            {summary.artist > 0 ? (
-              <li>
-                {exp.ln(
-                  '{num} artist',
-                  '{num} artists',
-                  summary.artist,
-                  {num: summary.artist},
-                )}
-              </li>
-            ) : null}
 
-            {summary.collection > 0 ? (
-              <li>
-                {exp.ln(
-                  '{num} collection',
-                  '{num} collections',
-                  summary.collection,
-                  {num: summary.collection},
+          {showSummary ? (
+            <>
+              <p>
+                {exp.l(
+                  '{editor} is subscribed to:',
+                  {editor: <EditorLink editor={user} />},
                 )}
-              </li>
-            ) : null}
+              </p>
+              <ul>
+                {summary.artist > 0 ? (
+                  <li>
+                    {exp.ln(
+                      '{num} artist',
+                      '{num} artists',
+                      summary.artist,
+                      {num: summary.artist},
+                    )}
+                  </li>
+                ) : null}
 
-            {summary.editor > 0 ? (
-              <li>
-                {exp.ln(
-                  '{num} editor',
-                  '{num} editors',
-                  summary.editor,
-                  {num: summary.editor},
-                )}
-              </li>
-            ) : null}
+                {summary.collection > 0 ? (
+                  <li>
+                    {exp.ln(
+                      '{num} collection',
+                      '{num} collections',
+                      summary.collection,
+                      {num: summary.collection},
+                    )}
+                  </li>
+                ) : null}
 
-            {summary.label > 0 ? (
-              <li>
-                {exp.ln(
-                  '{num} label',
-                  '{num} labels',
-                  summary.label,
-                  {num: summary.label},
-                )}
-              </li>
-            ) : null}
+                {summary.editor > 0 ? (
+                  <li>
+                    {exp.ln(
+                      '{num} editor',
+                      '{num} editors',
+                      summary.editor,
+                      {num: summary.editor},
+                    )}
+                  </li>
+                ) : null}
 
-            {summary.series > 0 ? (
-              <li>
-                {exp.ln(
-                  '{num} series',
-                  '{num} series',
-                  summary.series,
-                  {num: summary.series},
-                )}
-              </li>
-            ) : null}
-          </ul>
+                {summary.label > 0 ? (
+                  <li>
+                    {exp.ln(
+                      '{num} label',
+                      '{num} labels',
+                      summary.label,
+                      {num: summary.label},
+                    )}
+                  </li>
+                ) : null}
+
+                {summary.series > 0 ? (
+                  <li>
+                    {exp.ln(
+                      '{num} series',
+                      '{num} series',
+                      summary.series,
+                      {num: summary.series},
+                    )}
+                  </li>
+                ) : null}
+              </ul>
+            </>
+          ) : null}
         </>
-      ) : null}
+      )}
 
       {entities.length ? (
         <UserSubscriptionsSection

--- a/root/utility/buildTab.js
+++ b/root/utility/buildTab.js
@@ -14,10 +14,20 @@ const buildTab = (
   title: string,
   path: string,
   tabPage: string,
-): React.Element<'li'> => (
-  <li className={tabPage === page ? 'sel' : null} key={tabPage}>
-    <a href={path}>{title}</a>
-  </li>
-);
+  className?: string,
+): React.Element<'li'> => {
+  const isSelected = tabPage === page;
+  const passedClass = nonEmpty(className) ? className : null;
+  const tabClass = isSelected && nonEmpty(passedClass)
+    ? 'sel ' + passedClass
+    : isSelected
+      ? 'sel'
+      : passedClass;
+  return (
+    <li className={tabClass} key={tabPage}>
+      <a href={path}>{title}</a>
+    </li>
+  );
+};
 
 export default buildTab;

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -1,0 +1,109 @@
+package t::MusicBrainz::Server::Controller::User::Subscriptions;
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Mechanize', 't::Context';
+
+test all => sub {
+
+my $test = shift;
+my $mech = $test->mech;
+my $c    = $test->c;
+
+MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
+MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+    INSERT INTO editor (
+                  id, name, password, privs,
+                  email, website, bio,
+                  member_since, email_confirm_date, last_login_date,
+                  ha1
+                )
+         VALUES (
+                  5, 'adminymcadmin', '{CLEARTEXT}password', 128,
+                  'test@email.com', 'http://test.website', 'biography',
+                  '1989-07-23', '2005-10-20', '2013-04-05',
+                  'aa550c5b01407ef1f3f0d16daf9ec3c8'
+                );
+
+    INSERT INTO artist (
+                  id, gid,
+                  name, sort_name
+                )
+         VALUES (
+                  7, 'b9d99e40-72d7-11de-8a39-0800200c9a66',
+                  'Kate Bush', 'Kate Bush'
+                );
+
+    INSERT INTO edit (id, editor, type, status, expire_time)
+         VALUES (1, 1, 1, 1, now());
+
+    INSERT INTO edit_data (edit, data)
+         VALUES (1, '{}');
+
+    INSERT INTO editor_subscribe_artist (artist, editor, last_edit_sent)
+         VALUES (7, 2, 1);
+    SQL
+
+$mech->get('/user/alice/subscriptions');
+$mech->content_contains(
+  'You need to be logged in to view this page',
+  'viewing subscriptions requires login',
+);
+
+$mech->get('/login');
+$mech->submit_form(
+  with_fields => { username => 'new_editor', password => 'password' }
+);
+
+$mech->get('/user/alice/subscriptions');
+$mech->content_contains(
+  'Artist Subscriptions',
+  'directs to artist subscriptions',
+);
+$mech->content_contains('Kate Bush', 'subscription to Kate Bush is listed');
+
+$mech->get('/user/new_editor/subscriptions/editor');
+$mech->content_contains('new_editor', 'subscription to new_editor is listed');
+
+MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+    INSERT INTO editor_preference (editor, name, value)
+         VALUES (2, 'public_subscriptions', '0')
+    SQL
+
+$mech->get('/user/alice/subscriptions');
+is ($mech->status(), 403, q(alice's subs are now private));
+
+$mech->get('/logout');
+$mech->get('/login');
+$mech->submit_form(
+  with_fields => { username => 'alice', password => 'secret1' }
+);
+
+$mech->get('/user/alice/subscriptions');
+is ($mech->status(), 200, 'alice can still view their own subs');
+$mech->content_contains(
+  'Artist Subscriptions',
+  'directs to artist subscriptions',
+);
+$mech->content_contains('Kate Bush', 'subscription to Kate Bush is listed');
+
+$mech->get('/logout');
+$mech->get('/login');
+$mech->submit_form(
+  with_fields => { username => 'adminymcadmin', password => 'password' }
+);
+
+$mech->get('/user/alice/subscriptions');
+is ($mech->status(), 200, q(account admins can view alice's subs));
+$mech->content_contains(
+  'Editor Subscriptions',
+  'directs to editor subscriptions',
+);
+$mech->content_contains('new_editor', 'subscription to new_editor is listed');
+
+$mech->get('/user/alice/subscriptions/artist');
+is ($mech->status(), 403, q(alice's artist subs are private to admin));
+};
+
+1;


### PR DESCRIPTION
### Implement MBS-12055

@Freso asked for an easier way to see if a sockpuppet editor subscribes to other editors (in order to find more sockpuppets).

They specifically asked for a way to know the tab contains private data and should not be open when streaming so I added a class (to be able to hide it) and a warning / highlight.

![Screenshot from 2021-11-04 14-07-07](https://user-images.githubusercontent.com/1069224/140310775-8b93239f-e1fd-4451-ad1b-fa43ca1812e8.png)

They also specified they did not want to be able to see any other subscriptions, so this hides even the summary
from the user subscription page in this case.

Also, since the /artists page is private, we need to specifically make the tab lead to /editors in this case.