### PR TITLE
MBS-12078: Pass JSON artist to CannotSplit also when empty

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -748,7 +748,7 @@ sub split : Chained('load') Edit {
 
     if ($is_empty) {
         my %props = (
-            artist => $artist,
+            artist => $artist->TO_JSON,
             isEmpty => \1
         );
         $c->stash(


### PR DESCRIPTION
### Fix MBS-12078

This was passing Perl data without converting it to JSON, causing an ISE.