### PR TITLE
MBS-12077: Also block useless edit notes on the release editor

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -47,6 +47,7 @@ use MusicBrainz::Server::Translation qw( comma_list comma_only_list l );
 use MusicBrainz::Server::Validation qw(
     is_database_row_id
     is_guid
+    is_valid_edit_note
     is_valid_url
     is_valid_partial_date
 );
@@ -661,6 +662,11 @@ sub submit_edits {
 
         if ($edit_type == $EDIT_RELEASE_CREATE && !$data->{editNote}) {
             $c->forward('/ws/js/detach_with_error', ['editNote required']);
+        }
+
+        if ($edit_type == $EDIT_RELEASE_CREATE &&
+            !is_valid_edit_note($data->{editNote})) {
+            $c->forward('/ws/js/detach_with_error', ['editNote invalid']);
         }
 
         unless ($edit_type ~~ $ALLOWED_EDIT_TYPES) {

--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -288,6 +288,7 @@ sub is_valid_partial_date
     return 1;
 }
 
+# Keep in sync with invalidEditNote in static/scripts/release-editor/init.js
 sub is_valid_edit_note
 {
     my $edit_note = shift;

--- a/root/release/edit/editnote.tt
+++ b/root/release/edit/editnote.tt
@@ -32,6 +32,10 @@
           [% l('You must provide an edit note when adding a release.') %]
         </p>
 
+        <p class="error field-error" data-bind="showErrorRightAway: invalidEditNote" id="useless-edit-note-error">
+          [% l('Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!') %]
+        </p>
+
         [% make_votable(1) %]
       <!-- /ko -->
     </fieldset>

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -281,6 +281,14 @@ releaseEditor.init = function (options) {
     return self.action === 'add' && !self.rootField.editNote();
   };
 
+  // Keep in sync with is_valid_edit_note in Server::Validation
+  this.rootField.invalidEditNote = function () {
+    return self.action === 'add' && (
+      /^[\p{White_Space}\p{Punctuation}]+$/u.test(self.rootField.editNote()) ||
+      /^\p{ASCII}$/u.test(self.rootField.editNote())
+    );
+  };
+
   this.seed(options.seed);
 
   if (this.action === 'edit') {
@@ -418,7 +426,9 @@ releaseEditor.allowsSubmission = function () {
   return (
     !this.submissionInProgress() &&
     !validation.errorsExist() &&
-    (this.action === 'edit' || this.rootField.editNote()) &&
+    (this.action === 'edit' || !(
+      this.rootField.missingEditNote() || this.rootField.invalidEditNote()
+    )) &&
     this.allEdits().length > 0
   );
 };

--- a/root/static/scripts/tests/release-editor/seeds/useless_edit_note.html
+++ b/root/static/scripts/tests/release-editor/seeds/useless_edit_note.html
@@ -3,15 +3,11 @@
   <body>
     <form action="/release/add" method="POST">
       <input type="hidden" name="artist_credit.names.0.mbid" value="0798d15b-64e2-499f-9969-70167b1d8617" />
-      <input type="hidden" name="edit_note" value="Testing CDTOC attach" />
+      <input type="hidden" name="edit_note" value="." />
       <input type="hidden" name="mediums.0.format" value="CD" />
-      <input type="hidden" name="mediums.0.toc" value="1 3 192512 150 7100 167475" />
       <input type="hidden" name="mediums.0.track.0.name" value="☉" />
-      <input type="hidden" name="mediums.0.track.0.recording" value="19506825-c404-43eb-9b09-86fc152c6780" />
       <input type="hidden" name="mediums.0.track.1.name" value="⧖" />
-      <input type="hidden" name="mediums.0.track.1.recording" value="821f9cce-be76-4278-ab5c-63169792deb1" />
       <input type="hidden" name="mediums.0.track.2.name" value="◌" />
-      <input type="hidden" name="mediums.0.track.2.recording" value="65d62fc9-a9d5-4470-aef1-1b5bff4b9424" />
       <input type="hidden" name="name" value="Vision Creation Newsun" />
       <button type="submit">Submit</button>
     </form>

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -156,6 +156,21 @@ test 'previewing/creating/editing a release group and release' => sub {
     @edits = capture_edits {
         post_json($mech, '/ws/js/edit/create', encode_json({
             edits => $release_edits,
+            editNote => ' .  ',
+            makeVotable => 0,
+        }));
+    } $c;
+
+    is(scalar @edits, 0, 'release not created with invalid note');
+
+    $response = from_json($mech->content);
+
+    is($response->{error}, 'editNote invalid', 'ws response says editNote invalid');
+
+
+    @edits = capture_edits {
+        post_json($mech, '/ws/js/edit/create', encode_json({
+            edits => $release_edits,
             editNote => 'foo',
             makeVotable => 0,
         }));

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -648,6 +648,11 @@ const seleniumTests = [
   {name: 'release-editor/MBS-11114.json5', login: true},
   {name: 'release-editor/MBS-11156.json5', login: true},
   {
+    login: false,
+    name: 'release-editor/MBS-12077.json5',
+    sql: 'vision_creation_newsun.sql',
+  },
+  {
     name: 'Check_Duplicates.json5',
     login: true,
     sql: 'duplicate_checker.sql',

--- a/t/selenium/release-editor/MBS-12077.json5
+++ b/t/selenium/release-editor/MBS-12077.json5
@@ -1,0 +1,60 @@
+{
+  title: 'MBS-12077',
+  commands: [
+    {
+      command: 'open',
+      target: '/static/scripts/tests/release-editor/seeds/useless_edit_note.html',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-username',
+      value: 'editor',
+    },
+    {
+      command: 'type',
+      target: 'id=id-password',
+      value: 'password',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=span.buttons.login > button[type="submit"]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: "xpath=//a[@href='#edit-note']",
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "document.getElementById('useless-edit-note-error').style.display === 'none'",
+      value: 'false',
+    },
+    {
+      command: 'open',
+      target: '/',
+      value: '',
+    },
+    {
+      command: 'handleAlert',
+      target: 'accept',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=span.menu-header',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'link=Log Out',
+      value: '',
+    },
+  ],
+}


### PR DESCRIPTION
### Fix MBS-12077

This does the same for release adds which we already did for all other edits that require edit notes: it enforces not only that there is a note at all, but also that it's not clearly useless.