### PR TITLE
MBS-11910: Allow editing rel credits in the external links editor

### DIFF
--- a/root/artist_credit/ArtistCreditIndex.js
+++ b/root/artist_credit/ArtistCreditIndex.js
@@ -99,8 +99,9 @@ const ArtistCreditIndex = (
             {name.artist.name === name.name ? null : (
               <>
                 {' '}
-                {texp.l(
+                {texp.lp(
                   'credited as “{credit}”',
+                  'artist credit',
                   {credit: name.name},
                 )}
               </>

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -193,10 +193,16 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
     }
   };
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = (
+    event: SyntheticEvent<HTMLFormElement>,
+    closeAndReturnFocus: () => void,
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
     if (hasErrors) {
       dispatch({type: 'show-all-pending-errors'});
-      event.preventDefault();
+    } else {
+      handleConfirm(closeAndReturnFocus);
     }
   };
 
@@ -206,7 +212,7 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
         <form
           className="external-link-attribute-dialog"
           onKeyDown={handleKeyDown}
-          onSubmit={handleSubmit}
+          onSubmit={(event) => handleSubmit(event, closeAndReturnFocus)}
         >
           <DateRangeFieldset
             dispatch={dateDispatch}
@@ -234,7 +240,6 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
               <button
                 className="positive"
                 disabled={hasErrors}
-                onClick={() => handleConfirm(closeAndReturnFocus)}
                 type="submit"
               >
                 {l('Done')}

--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -30,13 +30,17 @@ import DateRangeFieldset, {
   partialDateFromField,
   runReducer as runDateRangeFieldsetReducer,
 } from './DateRangeFieldset.js';
+import UrlRelationshipCreditFieldset
+  from './UrlRelationshipCreditFieldset.js';
 
 type PropsT = {
+  creditableEntityProp: 'entity0_credit' | 'entity1_credit' | null,
   onConfirm: ($ReadOnly<Partial<LinkStateT>>) => void,
   relationship: LinkRelationshipT,
 };
 
 type StateT = {
+  +credit: FieldT<string | null>,
   +datePeriodField: DatePeriodFieldT,
   +initialDatePeriodField: DatePeriodFieldT,
 };
@@ -50,6 +54,7 @@ type ActionT =
       +props: PropsT,
       +type: 'update-initial-date-period',
     }
+  | {+credit: string, +type: 'update-relationship-credit'}
   | {+type: 'reset'}
   | {+type: 'show-all-pending-errors'};
 
@@ -57,6 +62,13 @@ const createInitialState = (props: PropsT): StateT => {
   const relationship = props.relationship;
   const beginDate = relationship.begin_date;
   const endDate = relationship.end_date;
+
+  const credit = createField(
+    'credit',
+    props.creditableEntityProp
+      ? relationship[props.creditableEntityProp]
+      : null,
+  );
 
   const datePeriodField = {
     errors: [],
@@ -86,6 +98,7 @@ const createInitialState = (props: PropsT): StateT => {
   };
 
   return {
+    credit,
     datePeriodField,
     initialDatePeriodField: datePeriodField,
   };
@@ -115,6 +128,9 @@ const reducer = (state: StateT, action: ActionT): StateT => {
       break;
     case 'show-all-pending-errors':
       applyAllPendingErrors(ctx.get('datePeriodField'));
+      break;
+    case 'update-relationship-credit':
+      ctx.set('credit', 'value', action.credit);
       break;
     default:
       throw new Error('Unknown action: ' + action.type);
@@ -155,12 +171,17 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
     if (hasErrors) {
       return;
     }
-    const field = state.datePeriodField.field;
-    props.onConfirm({
-      begin_date: partialDateFromField(field.begin_date),
-      end_date: partialDateFromField(field.end_date),
-      ended: field.ended.value,
-    });
+    const dateFields = state.datePeriodField.field;
+    const confirmedProps = {
+      begin_date: partialDateFromField(dateFields.begin_date),
+      end_date: partialDateFromField(dateFields.end_date),
+      ended: dateFields.ended.value,
+    };
+    if (props.creditableEntityProp) {
+      // $FlowIgnore[prop-missing]
+      confirmedProps[props.creditableEntityProp] = state.credit.value;
+    }
+    props.onConfirm(confirmedProps);
     closeAndReturnFocus();
   };
 
@@ -192,6 +213,12 @@ const ExternalLinkAttributeDialog = (props: PropsT): React$MixedElement => {
             endedLabel={l('This relationship has ended.')}
             field={state.datePeriodField}
           />
+          {props.creditableEntityProp ? (
+            <UrlRelationshipCreditFieldset
+              dispatch={dispatch}
+              field={state.credit}
+            />
+          ) : null}
           <div
             className="buttons"
             style={{display: 'block', marginTop: '1em'}}

--- a/root/static/scripts/edit/components/UrlRelationshipCreditFieldset.js
+++ b/root/static/scripts/edit/components/UrlRelationshipCreditFieldset.js
@@ -1,0 +1,51 @@
+/*
+ * @flow strict
+ * Copyright (C) 2020 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import FieldErrors from './FieldErrors.js';
+import FormRowText from './FormRowText.js';
+
+export type ActionT = {+credit: string, +type: 'update-relationship-credit'};
+
+type PropsT = {
+  +dispatch: (ActionT) => void,
+  +field: FieldT<string | null>,
+};
+
+export type StateT = DatePeriodFieldT;
+
+const UrlRelationshipCreditFieldset = ({
+  dispatch,
+  field,
+}: PropsT): React$Element<'fieldset'> => {
+  function handleCreditChange(
+    event: SyntheticKeyboardEvent<HTMLInputElement>,
+  ) {
+    dispatch({
+      credit: event.currentTarget.value,
+      type: 'update-relationship-credit',
+    });
+  }
+
+  return (
+    <fieldset>
+      <legend>{l('Credit')}</legend>
+      <FormRowText
+        field={field}
+        label={addColonText(l('Credited to'))}
+        onChange={handleCreditChange}
+      />
+      <FieldErrors
+        field={field}
+        includeSubFields={false}
+      />
+    </fieldset>
+  );
+};
+
+export default UrlRelationshipCreditFieldset;

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -452,6 +452,36 @@
       target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'external-link-item')][2]//div[contains(@class, 'error')]",
       value: 'Please don’t enter links to search results. If you’ve found any links through your search that seem useful, do enter those instead.',
     },
+    // Set relationship credit
+    {
+      command: 'sendKeys',
+      target: "xpath=(//table[@id='external-links-editor']//input[@type='url'])[1]",
+      value: 'https://soundcloud.com/psuhhoteek${KEY_ENTER}',
+    },
+    // Open popover
+    {
+      command: 'click',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//button[contains(@class, 'edit-item')]",
+      value: '',
+    },
+    // Set credit: Testy
+    {
+      command: 'sendKeys',
+      target: "xpath=//div[@id='external-link-attribute-dialog']//input[@id='id-credit']",
+      value: 'Testy',
+    },
+    // Save
+    {
+      command: 'click',
+      target: "xpath=(//div[@id='external-link-attribute-dialog']//button[contains(@class, 'positive')])[1]",
+      value: '',
+    },
+    // Assert credit is correctly displayed
+    {
+      command: 'assertText',
+      target: "xpath=//table[@id='external-links-editor']//tr[contains(@class, 'relationship-item')][2]//span[contains(@class, 'entity-credit')][1]",
+      value: ' (credited as “Testy”)',
+    },
     // deprecated link type detection for existing links (MBS-8408)
     {
       command: 'type',


### PR DESCRIPTION
### Implement MBS-11910

# Problem
URL relationships can have credits for the non-URL entity, if it is of a creditable type, but there is no way currently to change the credit from the entity page (only from the URL `/edit` page). This is confusing, and we really should allow editing this data from the page URL rels are most commonly edited, same as we now do for relationship dates.

# Solution
This makes it possible to change the credited entity in the same popup where we currently change the dates.
Note that this doesn't implement any changes in the release editor since release-url rels are not currently creditable - if that changes then [we should] make relevant changes to `externalLinkRelationship` in `root/static/scripts/edit/MB/edit.js`

# Testing
Tested manually by adding, editing and removing a credit for the artist for a URL relationship in an `/artist/edit` page (you can do this with any Artist-URL relationship from the artist edit page), including that the row for the relationship is highlighted when the credit changes.

Tested that work edit pages do not crash and that the dialog still allows editing dates for their URLs (works are not creditable so the credit bit is missing there). Same for release pages. Also added one selenium test for display of the credited info (but that doesn't test it being submitted).

# Known issues
Submitting the popup leaves a console warning: "Form submission canceled because the form is not connected". This already happens in production.