### PR TITLE
MBS-12087: Fix TT TaggerIcon call

### DIFF
--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -522,7 +522,7 @@ END -%]
 END -%]
 
 [%~ MACRO tagger_icon(entity) BLOCK -%]
-    [%- React.embed(c, 'static/scripts/common/components/TaggerIcon', {entity => React.to_json_object(entity)}) -%]
+    [%- React.embed(c, 'static/scripts/common/components/TaggerIcon', {entityType => entity.entity_type, gid => entity.gid}) -%]
 [%- END -%]
 
 [%~ MACRO release_label_list(labels) BLOCK; # Converted to React at root/components/ReleaseLabelList.js

--- a/t/selenium.js
+++ b/t/selenium.js
@@ -652,6 +652,7 @@ const seleniumTests = [
     login: true,
     sql: 'duplicate_checker.sql',
   },
+  {name: 'CD_Lookup.json5', login: true},
 ];
 
 const testPath = name => path.resolve(__dirname, 'selenium', name);

--- a/t/selenium/CD_Lookup.json5
+++ b/t/selenium/CD_Lookup.json5
@@ -1,0 +1,82 @@
+{
+  title: 'CD Lookup',
+  commands: [
+    {
+      command: 'open',
+      target: '/cdtoc/attach?tracks=1&toc=1+1+15104+150&tport=8000',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-filter-release.query',
+      value: '★',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'xpath=//h2[contains(text(), "Search by release")]/following-sibling::form//button[@type="submit"]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "window.document.querySelector('table.tbl').innerText",
+      value: 'Release\tArtist\tCountry/Date\tLabel\tCatalog#\tBarcode\tTagger\nRelease Group: ★ (Blackstar)\n★\tDavid Bowie\t\n\t\t\t888751738621\t\n\n\t CD 1 (show tracklist)\t',
+    },
+    {
+      command: 'assertEval',
+      target: "window.document.querySelector('a.tagger-icon').href",
+      value: 'http://127.0.0.1:8000/openalbum?id=24d4159a-99d9-425d-a7b8-1b9ec0261a33',
+    },
+    {
+      command: 'click',
+      target: 'css=input[name="medium"][value="1690850"]',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: "xpath=//button[contains(text(), 'Attach CD TOC')]",
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: "xpath=//button[contains(text(), 'Enter edit')]",
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 55,
+        status: 2,
+        data: {
+          cdtoc: '1 1 15104 150',
+          release: {
+            id: 1693299,
+            name: '★',
+          },
+          entity_id: 1,
+          medium_id: '1690850',
+        }
+      },
+    },
+    {
+      command: 'open',
+      target: '/cdtoc/attach?tracks=1&toc=1+1+15104+150&tport=8000',
+      value: '',
+    },
+    {
+      command: 'assertTextMatches',
+      target: 'css=h2 + p',
+      value: 'We found discs matching the information you requested',
+    },
+    {
+      command: 'assertEval',
+      target: "window.document.querySelector('table.tbl').innerText",
+      value: 'Position\tTitle\tArtist\tFormat\tCountry/Date\tLabel\tCatalog#\tBarcode\tTagger\n1/1 (show tracklist)\t★\tDavid Bowie\tCD\t\n\t\t\t888751738621\t',
+    },
+    {
+      command: 'assertTextMatches',
+      target: 'css=table.tbl + p',
+      value: 'We used DiscID JlNvZmrMXulXHkVZC6JtM1AShZg- to look up this information.',
+    },
+  ],
+}

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -146,7 +146,7 @@ INSERT INTO release (id, gid, name, artist_credit, release_group, status, packag
     (2154808, '1bda2f85-0576-4077-b3fa-0fc939079b61', 'Weapons of Mass Seduction', 2196047, 1954919, 1, NULL, 120, 28, NULL, '', -1);
 
 INSERT INTO medium (id, release, position, format, name, edits_pending, last_updated, track_count) VALUES
-    (1690850, 1693299, 1, 1, '', 0, '2015-05-18 20:20:39.009738+00', 14);
+    (1690850, 1693299, 1, 1, '', 0, '2015-05-18 20:20:39.009738+00', 0);
 
 INSERT INTO release_gid_redirect (gid, new_id, created) VALUES
     ('190542dd-e12b-3a84-a95b-9640a8de8b9f', 26, '2012-04-09 20:07:05.161415+00');


### PR DESCRIPTION
### Fix MBS-12087

`TaggerIcon` was updated to take entity type and MBID instead of an entity, but the TT `tagger_icon` macro wasn't updated for it, so it was linking to `?id=undefined`

Tested on the URL mentioned on the ticket.