### PR TITLE
MBS-11917: New report: Releases with "Disc n" medium titles

### DIFF
--- a/lib/MusicBrainz/Server/Report/MediumsWithOrderInTitle.pm
+++ b/lib/MusicBrainz/Server/Report/MediumsWithOrderInTitle.pm
@@ -1,0 +1,30 @@
+package MusicBrainz::Server::Report::MediumsWithOrderInTitle;
+use Moose;
+use namespace::autoclean;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {
+    <<~'SQL'
+    SELECT DISTINCT ON (release.id)
+        release.id AS release_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, release.name COLLATE musicbrainz)
+    FROM release
+    JOIN artist_credit ac ON release.artist_credit = ac.id
+    JOIN medium ON medium.release = release.id
+    WHERE medium.name ~* concat('^(Cassette|CD|Disc|DVD|SACD|Vinyl)\s*', medium.position)
+    SQL
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -60,6 +60,7 @@ use MusicBrainz::Server::PagedReport;
     LabelsDisambiguationSameName
     LimitedEditors
     LinksWithMultipleEntities
+    MediumsWithOrderInTitle
     MediumsWithSequenceIssues
     MislinkedPseudoReleases
     MultipleASINs
@@ -154,6 +155,7 @@ use MusicBrainz::Server::Report::ISWCsWithManyWorks;
 use MusicBrainz::Server::Report::LabelsDisambiguationSameName;
 use MusicBrainz::Server::Report::LimitedEditors;
 use MusicBrainz::Server::Report::LinksWithMultipleEntities;
+use MusicBrainz::Server::Report::MediumsWithOrderInTitle;
 use MusicBrainz::Server::Report::MediumsWithSequenceIssues;
 use MusicBrainz::Server::Report::MislinkedPseudoReleases;
 use MusicBrainz::Server::Report::MultipleASINs;

--- a/root/report/MediumsWithOrderInTitle.js
+++ b/root/report/MediumsWithOrderInTitle.js
@@ -1,0 +1,42 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ReleaseList from './components/ReleaseList';
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT, ReportReleaseT} from './types';
+
+const MediumsWithOrderInTitle = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={exp.l(
+      `This report lists releases where at least one medium has a title
+       that seems to just be indicating its position (such a first medium
+       with the title “Disc 1”). These should usually be removed, as per
+       {release_style|the release guidelines}.`,
+      {release_style: '/doc/Style/Release#Medium_title'},
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases with mediums named after their position')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default MediumsWithOrderInTitle;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -358,6 +358,10 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           reportName="ReleasesWithCAANoTypes"
         />
         <ReportsIndexEntry
+          content={l('Releases with mediums named after their position')}
+          reportName="MediumsWithOrderInTitle"
+        />
+        <ReportsIndexEntry
           content={l('Releases with non-sequential mediums')}
           reportName="MediumsWithSequenceIssues"
         />

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -207,6 +207,7 @@ module.exports = {
   'report/LabelsDisambiguationSameName': require('../report/LabelsDisambiguationSameName'),
   'report/LimitedEditors': require('../report/LimitedEditors'),
   'report/LinksWithMultipleEntities': require('../report/LinksWithMultipleEntities'),
+  'report/MediumsWithOrderInTitle': require('../report/MediumsWithOrderInTitle'),
   'report/MediumsWithSequenceIssues': require('../report/MediumsWithSequenceIssues'),
   'report/MislinkedPseudoReleases': require('../report/MislinkedPseudoReleases'),
   'report/MultipleAsins': require('../report/MultipleAsins'),


### PR DESCRIPTION
### Implement MBS-11917

This checks for any releases that have mediums where the name is "CD n", "Disc n" or similar, with n being
the medium position. These should only very, very rarely be correct, and only if they can be proven to really be intended as a disc *title*.