### PR TITLE
MBS-7912: Add edit search option "edit [not] in subscriptions"

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditSubscription.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditSubscription.pm
@@ -1,0 +1,203 @@
+package MusicBrainz::Server::EditSearch::Predicate::EditSubscription;
+use Moose;
+
+with 'MusicBrainz::Server::EditSearch::Predicate';
+
+has user => (
+    is => 'ro',
+    isa => 'MusicBrainz::Server::Authentication::User',
+    required => 1
+);
+
+sub operator_cardinality_map {
+  return (
+    'subscribed' => undef,
+    'not_subscribed' => undef,
+  )
+}
+
+sub combine_with_query {
+    my ($self, $query) = @_;
+
+    $query->add_where([ <<~'SQL', [ ($self->user->id) x 14 ] ]);
+      EXISTS (
+        SELECT TRUE
+          FROM edit_area
+         WHERE edit_area.area IN (
+               SELECT area
+                 FROM editor_collection_area
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_area.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_area.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_artist
+         WHERE edit_artist.artist IN (
+               SELECT artist
+                 FROM editor_subscribe_artist
+                WHERE editor = ?
+                UNION
+               SELECT artist
+                 FROM editor_collection_artist
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_artist.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_artist.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_event
+         WHERE edit_event.event IN (
+               SELECT event
+                 FROM editor_collection_event
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_event.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_event.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_instrument
+         WHERE edit_instrument.instrument IN (
+               SELECT instrument
+                 FROM editor_collection_instrument
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_instrument.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_instrument.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_label
+         WHERE edit_label.label IN (
+               SELECT label
+                 FROM editor_subscribe_label
+                WHERE editor = ?
+                UNION
+               SELECT label
+                 FROM editor_collection_label
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_label.collection
+                         AND editor = ?
+                      )
+               )   
+           AND edit_label.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_place
+         WHERE edit_place.place IN (
+               SELECT place
+                 FROM editor_collection_place
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_place.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_place.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_recording
+         WHERE edit_recording.recording IN (
+               SELECT recording
+                 FROM editor_collection_recording
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_recording.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_recording.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_release
+         WHERE edit_release.release IN (
+               SELECT release
+                 FROM editor_collection_release
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_release.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_release.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_release_group
+         WHERE edit_release_group.release_group IN (
+               SELECT release_group
+                 FROM editor_collection_release_group
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_release_group.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_release_group.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_series
+         WHERE edit_series.series IN (
+               SELECT series
+                 FROM editor_subscribe_series
+                WHERE editor = ?
+                UNION
+               SELECT series
+                 FROM editor_collection_series
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_series.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_series.edit = edit.id
+      ) OR EXISTS (
+        SELECT TRUE
+          FROM edit_work
+         WHERE edit_work.work IN (
+               SELECT work
+                 FROM editor_collection_work
+                WHERE EXISTS (
+                      SELECT TRUE 
+                        FROM editor_subscribe_collection
+                       WHERE collection = editor_collection_work.collection
+                         AND editor = ?
+                      )
+               )
+           AND edit_work.edit = edit.id
+      )
+      SQL
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -23,6 +23,7 @@ use MusicBrainz::Server::EditSearch::Predicate::ReleaseCountry;
 use MusicBrainz::Server::EditSearch::Predicate::RelationshipType;
 use MusicBrainz::Server::EditSearch::Predicate::EditNoteAuthor;
 use MusicBrainz::Server::EditSearch::Predicate::EditNoteContent;
+use MusicBrainz::Server::EditSearch::Predicate::EditSubscription;
 use MusicBrainz::Server::Log qw( log_warning );
 use Try::Tiny;
 
@@ -46,6 +47,7 @@ my %field_map = (
     applied_edits => 'MusicBrainz::Server::EditSearch::Predicate::AppliedEdits',
     edit_note_author => 'MusicBrainz::Server::EditSearch::Predicate::EditNoteAuthor',
     edit_note_content => 'MusicBrainz::Server::EditSearch::Predicate::EditNoteContent',
+    edit_subscription => 'MusicBrainz::Server::EditSearch::Predicate::EditSubscription',
 
     entities_with(['mbid', 'relatable'],
         take => sub {

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -69,6 +69,8 @@
                END;
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditNoteContent';
                predicate_edit_note_content(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::EditSubscription';
+               predicate_edit_subscription(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::ReleaseQuality';
                predicate_set(field.field_name, quality, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::Date';
@@ -384,6 +386,12 @@
   </span>
 [% END %]
 
+[% MACRO predicate_edit_subscription(field, field_contents) WRAPPER wfield predicate="edit_subscription" %]
+  [% operators([ [ 'subscribed', l('is in my subscriptions') ]
+                 [ 'not_subscribed', l('is not in my subscriptions') ]
+               ], field_contents) %]
+[% END %]
+
 [% MACRO predicate_editor_flag(field, field_contents) WRAPPER wfield predicate="set" %]
   [% operators([ [ '=', l('is') ]
                  [ '!=', l('is not') ] ], field_contents) %]
@@ -424,6 +432,7 @@
                    [ 'vote_count', l('Vote tally') ],
                    [ 'edit_note_author', l('Edit Note Authors'), {requires_login => 1} ],
                    [ 'edit_note_content', l('Edit Note Content'), {requires_login => 1} ],
+                   [ 'edit_subscription', l('Edited entity'), {requires_login => 1} ],
                    [ 'area', l('Area') ],
                    [ 'artist', l('Artist') ],
                    [ 'event', l('Event') ],
@@ -464,6 +473,7 @@
     [% predicate_set('release_quality', quality) %]
     [% predicate_vote_count('vote_count') %]
     [% predicate_edit_notes %]
+    [% predicate_edit_subscription('edit_subscription') %]
 
     [% FOR linked_type=[ 'artist', 'label', 'series' ];
          predicate_subscription(linked_type);

--- a/root/static/scripts/common/MB/edit_search.js
+++ b/root/static/scripts/common/MB/edit_search.js
@@ -19,6 +19,10 @@ $(function () {
       'includes': 1,
       'not-includes': 1,
     },
+    edit_subscription: {
+      subscribed: 0,
+      not_subscribed: 0,
+    },
     voter: {
       '=': 1,
       '!=': 1,


### PR DESCRIPTION
### Implement MBS-7912

This is one of the last (the last?) options that has a dedicated page, but cannot be used in edit searches, meaning we can't actually refine the edit lists on the /subscribed page using edit search.

This search checks (AFAICT) every single condition that /subscribed does: artist, label and series subscriptions, and all the possible collection subscriptions. It does *not* check editor subscriptions, which have a separate page (/subscribed_editors), and can already be searched within the edit search separately.

Tested by creating a bunch of collections locally, and by checking my current subscriptions in pink to see the results seemingly match /subscribed (keep in mind that page is ordered with oldest edits from the last two weeks first, newest last).

The query doesn't seem slower than /subscribed itself, but I didn't test quantitatively. If you feel it's needed I can look into that.