### PR TITLE
MBS-12083: Add caching to get_types_for_timeline

### DIFF
--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -525,21 +525,11 @@ sub get_types_for_timeline
 
     for my $t ($self->all_pairs) {
         my $table = join('_', 'l', @$t);
-        my $data = $self->sql->select_list_of_hashes(<<~"SQL", @$t);
-                SELECT link_type_filtered.id,
-                       link_type_filtered.name,
-                       link_type_filtered.parent,
-                       count(l_table.id)
-                  FROM $table l_table
-            RIGHT JOIN link ON l_table.link = link.id
-            RIGHT JOIN (SELECT *
-                          FROM link_type
-                         WHERE entity_type0 = ?
-                           AND entity_type1 = ?) link_type_filtered
-                    ON link.link_type = link_type_filtered.id
-              GROUP BY link_type_filtered.name,
-                       link_type_filtered.id,
-                       link_type_filtered.parent
+        my $data = $self->sql->select_list_of_hashes(<<~'SQL', @$t);
+                SELECT link_type.name
+                  FROM link_type
+                 WHERE entity_type0 = ?
+                   AND entity_type1 = ?
             SQL
 
         for (@$data) {

--- a/lib/MusicBrainz/Server/Data/Relationship.pm
+++ b/lib/MusicBrainz/Server/Data/Relationship.pm
@@ -521,6 +521,11 @@ sub get_types_for_timeline
 {
     my $self = shift;
 
+    my $cache = $self->c->cache('statistics');
+    my $cached_types = $cache->get('types_for_timeline');
+
+    return %$cached_types if $cached_types;
+
     my %rel_types;
 
     for my $t ($self->all_pairs) {
@@ -541,6 +546,7 @@ sub get_types_for_timeline
         }
     }
 
+    $cache->set('types_for_timeline', \%rel_types, 60 * 60 * 24);
     return %rel_types;
 }
 


### PR DESCRIPTION
### Fix MBS-12083

This takes forever unless cached, so we should cache it and avoid everyone suffering that pain every time.

@mwiencek: I haven't used cache much before, so I tried to copy the way `get_all` responses get cached. Please do let me know if I (probably) did a dumb.