### PR TITLE
MBS-9375: Restrict Apple Music to paid streaming and/or purchase 

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -799,6 +799,45 @@ const CLEANUPS: CleanupEntries = {
       url = url.replace(/^(https:\/\/music\.apple\.com)\/([a-z-]{3,})\//, '$1/us/$2/');
       return url;
     },
+    validate: function (url, id) {
+      const m = /^https:\/\/music\.apple\.com\/[a-z]{2}\/([a-z-]{3,})\/[0-9]+$/.exec(url);
+      if (m) {
+        const prefix = m[1];
+        switch (id) {
+          case LINK_TYPES.downloadpurchase.artist:
+          case LINK_TYPES.streamingpaid.artist:
+            if (prefix === 'artist') {
+              return {result: true};
+            }
+            return {
+              result: false,
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.label:
+          case LINK_TYPES.streamingpaid.label:
+            if (prefix === 'label') {
+              return {result: true};
+            }
+            return {
+              result: false,
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.recording:
+          case LINK_TYPES.streamingpaid.recording:
+            return {
+              result: prefix === 'music-video',
+              target: ERROR_TARGETS.ENTITY,
+            };
+          case LINK_TYPES.downloadpurchase.release:
+          case LINK_TYPES.streamingpaid.release:
+            return {
+              result: prefix === 'album',
+              target: ERROR_TARGETS.ENTITY,
+            };
+        }
+      }
+      return {result: false, target: ERROR_TARGETS.URL};
+    },
   },
   'archive': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?archive\\.org/', 'i')],

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -788,6 +788,11 @@ const CLEANUPS: CleanupEntries = {
   },
   'applemusic': {
     match: [new RegExp('^(https?://)?([^/]+\\.)?music\\.apple\\.com/', 'i')],
+    restrict: [
+      LINK_TYPES.downloadpurchase,
+      LINK_TYPES.streamingpaid,
+      multiple(LINK_TYPES.downloadpurchase, LINK_TYPES.streamingpaid),
+    ],
     clean: function (url) {
       url = url.replace(/^https?:\/\/(?:(?:beta|geo)\.)?music\.apple\.com\/([a-z]{2}\/)?(artist|album|author|label|music-video)\/(?:[^?#\/]+\/)?(?:id)?([0-9]+)(?:\?.*)?$/, 'https://music.apple.com/$1$2/$3');
       // US page is the default, add its country-code to clarify (MBS-10623)

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -232,6 +232,7 @@ export const LINK_TYPES: LinkTypeMap = {
   },
   streamingpaid: {
     artist: '63cc5d1f-f096-4c94-a43f-ecb32ea94161',
+    label: 'cbe05bdd-a877-4cc6-8060-7ba43a2516ef',
     recording: 'b5f3058a-666c-406f-aafb-f9249fc7b122',
     release: '320adf26-96fa-4183-9045-1f5f32f833cb',
   },

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -751,16 +751,6 @@ const CLEANUPS: CleanupEntries = {
               return {result: true};
             }
             return {
-              error: exp.l(
-                `Only Apple Books “{artist_url_pattern}” pages can be added
-                 directly to artists. Please link audiobooks
-                 to the appropriate release instead.`,
-                {
-                  artist_url_pattern: (
-                    <span className="url-quote">{'/author'}</span>
-                  ),
-                },
-              ),
               result: false,
               target: ERROR_TARGETS.ENTITY,
             };
@@ -2343,16 +2333,6 @@ const CLEANUPS: CleanupEntries = {
               return {result: true};
             }
             return {
-              error: exp.l(
-                `Only iTunes “{artist_url_pattern}” pages can be added
-                 directly to artists. Please link albums, videos, etc.
-                 to the appropriate release or recording instead.`,
-                {
-                  artist_url_pattern: (
-                    <span className="url-quote">{'/artist'}</span>
-                  ),
-                },
-              ),
               result: false,
               target: ERROR_TARGETS.ENTITY,
             };

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -394,23 +394,53 @@ const testData = [
   // Apple Music
   {
                      input_url: 'http://music.apple.com/artist/hangry-angry-f/id444923726',
+             input_entity_type: 'artist',
             expected_clean_url: 'https://music.apple.com/us/artist/444923726',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
   },
   {
                      input_url: 'https://beta.music.apple.com/ca/artist/imposs/205021452',
+             input_entity_type: 'artist',
             expected_clean_url: 'https://music.apple.com/ca/artist/205021452',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
   },
   {
                      input_url: 'https://music.apple.com/us/label/ghostly-international/1543968172',
+             input_entity_type: 'label',
             expected_clean_url: 'https://music.apple.com/us/label/1543968172',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
   },
   {
                      input_url: 'https://music.apple.com/ee/music-video/black-and-yellow/539886832?uo=4&mt=5&app=music',
+             input_entity_type: 'recording',
             expected_clean_url: 'https://music.apple.com/ee/music-video/539886832',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
   },
   {
                      input_url: 'https://music.apple.com/jp/album/uchiagehanabi-single/1263790414',
+             input_entity_type: 'release',
             expected_clean_url: 'https://music.apple.com/jp/album/1263790414',
+limited_link_type_combinations: [
+                                  'downloadpurchase',
+                                  'streamingpaid',
+                                  ['downloadpurchase', 'streamingpaid'],
+                                ],
   },
   // (Internet) Archive
   {


### PR DESCRIPTION
### Implement MBS-9375

This has been wanted forever, but now the restrict tool finally allows us to do it. For now, this just allows paid streaming, paid download or a combination of both for all entities (artist, label, recording, release). If we eventually decide to allow for Apple Music relationships for artists and/or labels, this should be modified accordingly.

I also readded the validation that got dropped with https://github.com/metabrainz/musicbrainz-server/pull/1643

On top of https://github.com/metabrainz/musicbrainz-server/pull/2339 (which allows testing it).