### PR TITLE
MBS-12102: Fix cover art check on RG TO_JSON

### DIFF
--- a/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
@@ -131,7 +131,7 @@ around TO_JSON => sub {
 
     return {
         %{ $self->$orig },
-        $self->has_cover_art ? (cover_art => to_json_object($self->cover_art)) : (),
+        $self->has_loaded_cover_art ? (cover_art => to_json_object($self->cover_art)) : (),
         firstReleaseDate    => $self->first_release_date ? $self->first_release_date->format : undef,
         hasCoverArt         => boolean_to_json($self->has_cover_art),
         # TODO: remove this once Autocomplete.js can use $c and releaseGroupType.js


### PR DESCRIPTION
### Fix MBS-12102

This broke in 7d28f5c7efb224b670ee3853c1336ad3e1c53abc (https://github.com/metabrainz/musicbrainz-server/pull/1868) since I changed the meaning of has_cover_art but did not change this check to still use the original variable.

Tested manually.