### PR TITLE
MBS-12105: Block editors from sending messages if they are blocked from adding notes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -317,6 +317,22 @@ sub contact : Chained('load') RequireAuth HiddenOnSlaves SecureForm
     my ($self, $c) = @_;
 
     my $editor = $c->stash->{user};
+
+    if ($c->user->is_adding_notes_disabled) {
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Send Email'),
+                message  => l(
+                    'You are not allowed to send messages to editors.',
+                ),
+            },
+            current_view    => 'Node',
+        );
+        $c->detach;
+
+    }
+
     unless ($editor->email) {
         $c->stash(
             component_path  => 'user/UserMessage',

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -25,6 +25,7 @@ import escapeRegExp from '../static/scripts/common/utility/escapeRegExp';
 import nonEmpty from '../static/scripts/common/utility/nonEmpty';
 import {
   isAccountAdmin,
+  isAddingNotesDisabled,
   isAutoEditor,
   isBot,
   isLocationEditor,
@@ -203,7 +204,7 @@ const UserProfileInformation = ({
                   </a>,
                 )
               ) : (
-                $c.user ? (
+                $c.user && !isAddingNotesDisabled($c.user) ? (
                   <>
                     {bracketed(
                       <a href={`/user/${encodedName}/contact`}>


### PR DESCRIPTION
### Implement MBS-12105

The whole point of blocking notes is to block abusive communication, which obviously also includes possible abusive emails.
