### PR TITLE
MBS-12114: Account for the "Disk" alternative spelling to "Disc"

### DIFF
--- a/lib/MusicBrainz/Server/Report/MediumsWithOrderInTitle.pm
+++ b/lib/MusicBrainz/Server/Report/MediumsWithOrderInTitle.pm
@@ -13,7 +13,7 @@ sub query {
     FROM release
     JOIN artist_credit ac ON release.artist_credit = ac.id
     JOIN medium ON medium.release = release.id
-    WHERE medium.name ~* concat('^(Cassette|CD|Disc|DVD|SACD|Vinyl)\s*', medium.position)
+    WHERE medium.name ~* concat('^(Cassette|CD|Dis[ck]|DVD|SACD|Vinyl)\s*', medium.position)
     SQL
 }
 

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -448,7 +448,7 @@ class Medium {
     });
     this.confirmedEarlyFormat = ko.observable(this.hasTooEarlyFormat());
     this.hasUselessMediumTitle = ko.computed(function () {
-      return /^(Cassette|CD|Disc|DVD|SACD|Vinyl)\s*\d+/i.test(self.name());
+      return /^(Cassette|CD|Dis[ck]|DVD|SACD|Vinyl)\s*\d+/i.test(self.name());
     });
     this.confirmedMediumTitle = ko.observable(this.hasUselessMediumTitle());
     this.needsTrackInfo = ko.computed(function () {


### PR DESCRIPTION
### Implement MBS-12114

This is a reasonably common use, even if it's not as common as "Disc", so it makes sense to check for it too in the release editor and for the report.

Tested by hand (using it and seeing it was detected in the RE, then detected by the report).