### PR TITLE
MBS-12115: Don't show deleted users' Subscription tab to admins

### DIFF
--- a/root/components/UserAccountTabs.js
+++ b/root/components/UserAccountTabs.js
@@ -23,7 +23,6 @@ function buildTabs(
   page: string,
 ): $ReadOnlyArray<React.Element<'li'>> {
   const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
-  const showAdmin = isAccountAdmin($c.user);
 
   const userName = encodeURIComponent(user.name);
   const userPath = '/user/' + userName;
@@ -31,6 +30,7 @@ function buildTabs(
   const tabs = [buildTab(page, l('Profile'), userPath, 'index')];
 
   const userDeleted = user.deleted;
+  const showAdmin = !userDeleted && isAccountAdmin($c.user);
   const hasPublicSubscriptions =
     !userDeleted && user.preferences.public_subscriptions;
   const hasPublicTags = !userDeleted && user.preferences.public_tags;


### PR DESCRIPTION
### Fix MBS-12115

The recent change to allow admins to see editor subscriptions did not take into account that it's still useless to show "editor subscriptions" once the editor has been deleted. `viewingOwnProfile` shouldn't be a problem, since well, a deleted user isn't going to be viewing anything.