### PR TITLE
MBS-12112: Remove unneeded escape for $

### DIFF
--- a/lib/MusicBrainz/Server/Report/CatNoLooksLikeASIN.pm
+++ b/lib/MusicBrainz/Server/Report/CatNoLooksLikeASIN.pm
@@ -16,7 +16,7 @@ sub query {
             JOIN release r
             ON r.id = rl.release
             JOIN artist_credit ac ON r.artist_credit = ac.id
-        WHERE rl.catalog_number ~ '^B0[0-9A-Z]{8}\$'
+        WHERE rl.catalog_number ~ '^B0[0-9A-Z]{8}$'
     }
 }
 

--- a/lib/MusicBrainz/Server/Report/CatNoLooksLikeISRC.pm
+++ b/lib/MusicBrainz/Server/Report/CatNoLooksLikeISRC.pm
@@ -16,7 +16,7 @@ sub query {
             JOIN release r
             ON r.id = rl.release
             JOIN artist_credit ac ON r.artist_credit = ac.id
-        WHERE rl.catalog_number ~ '^[A-Z]{2}-?[A-Z0-9]{3}-?[0-9]{2}-?[0-9]{5}\$'
+        WHERE rl.catalog_number ~ '^[A-Z]{2}-?[A-Z0-9]{3}-?[0-9]{2}-?[0-9]{5}$'
     }
 }
 

--- a/lib/MusicBrainz/Server/Report/CatNoLooksLikeLabelCode.pm
+++ b/lib/MusicBrainz/Server/Report/CatNoLooksLikeLabelCode.pm
@@ -16,7 +16,7 @@ sub query {
             JOIN release r
             ON r.id = rl.release
             JOIN artist_credit ac ON r.artist_credit = ac.id
-        WHERE rl.catalog_number ~ '^LC[\\s-]*\\d{4,5}\$'
+        WHERE rl.catalog_number ~ '^LC[\\s-]*\\d{4,5}$'
     }
 }
 

--- a/lib/MusicBrainz/Server/Report/DuplicateReleaseGroups.pm
+++ b/lib/MusicBrainz/Server/Report/DuplicateReleaseGroups.pm
@@ -7,9 +7,9 @@ with 'MusicBrainz::Server::Report::ReleaseGroupReport',
 sub query {
     q{
 WITH normalised_names AS (
-    SELECT musicbrainz_unaccent(regexp_replace(lower(rg.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)\$', '')) AS normalised_name, rg.artist_credit
+    SELECT musicbrainz_unaccent(regexp_replace(lower(rg.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)$', '')) AS normalised_name, rg.artist_credit
     FROM release_group rg
-    GROUP BY musicbrainz_unaccent(regexp_replace(lower(rg.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)\$', '')), rg.comment, rg.artist_credit
+    GROUP BY musicbrainz_unaccent(regexp_replace(lower(rg.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)$', '')), rg.comment, rg.artist_credit
     HAVING COUNT(*) > 1
 )
 
@@ -17,7 +17,7 @@ SELECT q.rgid AS release_group_id, q.key, row_number() OVER (ORDER BY ac COLLATE
 
     SELECT release_group.id rgid, artist_credit.name ac, release_group.name rgname, nn.normalised_name||nn.artist_credit AS key
     FROM normalised_names nn
-    JOIN release_group ON nn.normalised_name = musicbrainz_unaccent(regexp_replace(lower(release_group.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)\$', ''))
+    JOIN release_group ON nn.normalised_name = musicbrainz_unaccent(regexp_replace(lower(release_group.name), ' \((disc [0-9]+|bonus disc)(: .*)?\)$', ''))
     AND nn.artist_credit = release_group.artist_credit
     JOIN artist_credit ON artist_credit.id = release_group.artist_credit
     GROUP BY artist_credit.name COLLATE musicbrainz, nn.normalised_name||nn.artist_credit, artist_credit.name, release_group.id, release_group.name


### PR DESCRIPTION
### Fix MBS-12112

Once we changed these to not use double quotes, it seems the escaping slash before $ became unneeded, and it apparently was actually stopping these from returning some results (the catno ones weren't returning any results at all).

Tested by regenerating the reports with sample data and seeing hits appear again (and one extra pair appear for the DuplicateReleaseGroups one which wasn't empty).