### PR TITLE
MBS-4685 / MBS-13084: Allow modifying and removing edit notes

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -437,6 +437,7 @@ sub notes_received : Path('/edit/notes-received') RequireAuth {
     });
 
     $c->model('Editor')->load(@$edit_notes);
+    $c->model('EditNoteChange')->load_latest(@$edit_notes);
     $c->model('Edit')->load_for_edit_notes(@$edit_notes);
     $c->model('Vote')->load_for_edits(map { $_->edit } @$edit_notes);
 

--- a/lib/MusicBrainz/Server/Controller/EditNote.pm
+++ b/lib/MusicBrainz/Server/Controller/EditNote.pm
@@ -45,6 +45,21 @@ sub detach_if_cannot_change {
         $c->detach;
     }
 
+    if ($is_own_note && $c->user->is_adding_notes_disabled) {
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Can’t change edit note'),
+                message  => l(
+                    'You’re currently not allowed to leave or change edit notes because an admin has revoked your privileges. If you haven’t already been contacted about why, please {uri|send us a message}.',
+                    { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } },
+                ),
+            },
+            current_view    => 'Node',
+        );
+        $c->detach;
+    }
+
     my $is_note_deleted = $edit_note->{latest_change} &&
                           $edit_note->{latest_change}->{status} eq 'deleted';
 

--- a/lib/MusicBrainz/Server/Controller/EditNote.pm
+++ b/lib/MusicBrainz/Server/Controller/EditNote.pm
@@ -4,7 +4,7 @@ use MooseX::MethodAttributes;
 use namespace::autoclean;
 
 use List::AllUtils qw( first_index );
-use MusicBrainz::Server::Constants qw( $CONTACT_URL );
+use MusicBrainz::Server::Constants qw( $CONTACT_URL $EDITOR_MODBOT );
 use MusicBrainz::Server::Data::Utils qw( load_everything_for_edits );
 use MusicBrainz::Server::Validation qw( is_database_row_id );
 use MusicBrainz::Server::Translation qw( l );
@@ -81,7 +81,9 @@ sub detach_if_cannot_change {
     } @$all_edit_notes;
     my $has_reply = 0;
     for (my $i = $note_index + 1; $i < @$all_edit_notes; $i++) {
-        if ($all_edit_notes->[$i]->editor_id != $edit_note->editor_id) {
+        my $reply_editor = $all_edit_notes->[$i]->editor_id;
+        if (($reply_editor != $edit_note->editor_id) &&
+            ($reply_editor != $EDITOR_MODBOT)) {
             $has_reply = 1;
             last;
         }

--- a/lib/MusicBrainz/Server/Controller/EditNote.pm
+++ b/lib/MusicBrainz/Server/Controller/EditNote.pm
@@ -1,0 +1,152 @@
+package MusicBrainz::Server::Controller::EditNote;
+use Moose;
+use MooseX::MethodAttributes;
+use namespace::autoclean;
+
+use List::AllUtils qw( first_index );
+use MusicBrainz::Server::Constants qw( $CONTACT_URL );
+use MusicBrainz::Server::Data::Utils qw( load_everything_for_edits );
+use MusicBrainz::Server::Validation qw( is_database_row_id );
+use MusicBrainz::Server::Translation qw( l );
+
+extends 'MusicBrainz::Server::Controller';
+with 'MusicBrainz::Server::Controller::Role::Load' => {
+    model => 'EditNote',
+    entity_name => 'edit_note',
+};
+
+sub base : Chained('/') PathPart('edit-note') CaptureArgs(0) { }
+
+sub _load
+{
+    my ($self, $c, $edit_note_id) = @_;
+    return unless is_database_row_id($edit_note_id);
+    my $edit_note = $c->model('EditNote')->get_by_id($edit_note_id);
+    $c->model('Editor')->load($edit_note);
+    $c->model('EditNoteChange')->load_latest($edit_note);
+    return $edit_note;
+}
+
+sub delete : PathPart('delete') Chained('load') {
+    my ($self, $c) = @_;
+
+    my $form = $c->form( form => 'EditNoteDelete' );
+    my $edit_note = $c->stash->{edit_note};
+    my $edit_id = $edit_note->{edit_id};
+    my $edit = $c->model('Edit')->get_by_id($edit_id);
+    load_everything_for_edits($c, [ $edit ]);
+
+    my $is_own_note = $c->user && $c->user->id == $edit_note->{editor_id};
+    my $is_admin = $c->user && $c->user->is_account_admin;
+
+    unless ($is_own_note || $is_admin) {
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Can’t change edit note'),
+                message  => l('You can’t change other users’ edit notes.'),
+            },
+            current_view    => 'Node',
+        );
+        $c->detach;
+    }
+
+    my $is_note_deleted = $edit_note->{latest_change} &&
+                          $edit_note->{latest_change}->{status} eq 'deleted';
+
+    if ($is_note_deleted && !$is_admin) {
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Can’t change edit note'),
+                message  => l('This note has already been removed.'),
+            },
+            current_view    => 'Node',
+        );
+        $c->detach;
+    }
+
+    my $all_edit_notes = $edit->{edit_notes};
+    my $note_index = first_index {
+        $_->id == $edit_note->id,
+    } @$all_edit_notes;
+    my $has_reply = 0;
+    for (my $i = $note_index + 1; $i < @$all_edit_notes; $i++) {
+        if ($all_edit_notes->[$i]->editor_id != $edit_note->editor_id) {
+            $has_reply = 1;
+            last;
+        }
+    }
+
+    if ($has_reply && !$is_admin) {
+        $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Can’t change edit note'),
+                message  => l(
+                    'You can’t change this note, since somebody else has already replied to it. If there’s an important reason why it should be changed (for example, it contains private data), please {contact_url|contact us}.',
+                    {contact_url => $CONTACT_URL},
+                ),
+            },
+            current_view    => 'Node',
+        );
+        $c->detach;
+    }
+
+    my $now = DateTime->now( time_zone => $edit_note->post_time->time_zone );
+    my $note_age = $now - $edit_note->post_time;
+    my $is_note_too_old = $note_age->{days} > 0;
+
+    if ($is_note_too_old && !$is_admin) {
+      $c->stash(
+            component_path  => 'user/UserMessage',
+            component_props => {
+                title    => l('Can’t change edit note'),
+                message  => l(
+                    'You can’t change this note, since it was entered too long ago. If there’s an important reason why it should be changed (for example, it contains private data), please {contact_url|contact us}.',
+                    {contact_url => $CONTACT_URL},
+                ),
+            },
+            current_view    => 'Node',
+      );
+      $c->detach;
+    }
+
+    if ($c->form_posted_and_valid($form)) {
+        if (!$form->field('cancel')->input) {
+            $c->model('MB')->with_transaction(sub {
+                $c->model('EditNote')->delete_content(
+                    $edit_note->id,
+                    $c->user->id,
+                    $form->field('reason')->value,
+                );
+            });
+        }
+        $c->response->redirect(
+            $c->uri_for_action('/edit/show', [ $edit_id ])
+        );
+        $c->detach;
+    } else {
+        $c->stash(
+            component_path => 'edit/DeleteNote',
+            component_props => {
+                edit => $edit->TO_JSON,
+                editNote => $edit_note->TO_JSON,
+                form => $form->TO_JSON,
+            },
+            current_view => 'Node',
+        );
+    }
+}
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -132,6 +132,33 @@ sub find_by_recipient {
     );
 }
 
+sub delete_content {
+    my ($self, $edit_note_id, $change_editor_id, $reason) = @_;
+
+    my @args = (
+        $edit_note_id,
+        $change_editor_id,
+        $edit_note_id,
+        $reason,
+        $edit_note_id
+    );
+
+    $self->sql->do(<<~"SQL", @args);
+        INSERT INTO edit_note_change (
+                        status, edit_note, change_editor,
+                        old_note, new_note, reason
+                    )
+             VALUES (
+                        'deleted', ?, ?,
+                        (SELECT text FROM edit_note WHERE id = ?), '', ?
+                    );
+
+        UPDATE edit_note
+           SET text = ''
+         WHERE id = ?;
+        SQL
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MusicBrainz/Server/Data/EditNote.pm
+++ b/lib/MusicBrainz/Server/Data/EditNote.pm
@@ -159,6 +159,35 @@ sub delete_content {
         SQL
 }
 
+sub modify_content {
+    my ($self, $edit_note_id, $change_editor_id, $new_content, $reason) = @_;
+
+    my @args = (
+        $edit_note_id,
+        $change_editor_id,
+        $edit_note_id,
+        $new_content,
+        $reason,
+        $new_content,
+        $edit_note_id
+    );
+
+    $self->sql->do(<<~"SQL", @args);
+        INSERT INTO edit_note_change (
+                        status, edit_note, change_editor,
+                        old_note, new_note, reason
+                    )
+             VALUES (
+                        'edited', ?, ?,
+                        (SELECT text FROM edit_note WHERE id = ?), ?, ?
+                    );
+
+        UPDATE edit_note
+           SET text = ?
+         WHERE id = ?;
+        SQL
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/MusicBrainz/Server/Data/EditNoteChange.pm
+++ b/lib/MusicBrainz/Server/Data/EditNoteChange.pm
@@ -1,0 +1,58 @@
+package MusicBrainz::Server::Data::EditNoteChange;
+use Moose;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Entity::EditNoteChange;
+
+extends 'MusicBrainz::Server::Data::Entity';
+
+sub _table
+{
+    return 'edit_note_change';
+}
+
+sub _columns
+{
+    return 'id, change_editor AS editor_id, change_time, status, reason';
+}
+
+sub _entity_class
+{
+    return 'MusicBrainz::Server::Entity::EditNoteChange';
+}
+
+sub get_latest
+{
+    my ($self, $id) = @_;
+    my $query = 'SELECT ' . $self->_columns .
+                ' FROM ' . $self->_table .
+                ' WHERE edit_note = ?' .
+                ' ORDER BY change_time DESC, id DESC LIMIT 1';
+    my $row = $self->sql->select_single_row_hash($query, $id)
+        or return undef;
+    return $self->_new_from_row($row);
+}
+
+sub load_latest
+{
+    my ($self, @edit_notes) = @_;
+    for my $edit_note (@edit_notes) {
+        my $edit_note_change = $self->get_latest($edit_note->id) or next;
+        $edit_note->latest_change($edit_note_change);
+    }
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut
+

--- a/lib/MusicBrainz/Server/Data/Utils.pm
+++ b/lib/MusicBrainz/Server/Data/Utils.pm
@@ -221,6 +221,7 @@ sub load_everything_for_edits
         $c->model('Vote')->load_for_edits(@$edits);
         $c->model('EditNote')->load_for_edits(@$edits);
         $c->model('Editor')->load(map { ($_, @{ $_->votes }, @{ $_->edit_notes }) } @$edits);
+        $c->model('EditNoteChange')->load_latest(map { @{ $_->edit_notes } } @$edits);
     } catch {
         use Data::Dumper;
         croak 'Failed loading edits (' . (join q(, ), map { $_->id } @$edits) . ")\n" .

--- a/lib/MusicBrainz/Server/Entity/EditNote.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNote.pm
@@ -47,6 +47,11 @@ has 'post_time' => (
     coerce => 1
 );
 
+has 'latest_change' => (
+    isa => 'EditNoteChange',
+    is  => 'rw',
+);
+
 my %domain_classes = (
     'attributes' => 'Attributes',
     'countries' => 'Countries',
@@ -129,12 +134,16 @@ around TO_JSON => sub {
     }
 
     my $json = $self->$orig;
+    $json->{id} = $self->id + 0;
     $json->{edit_id} = $self->edit_id + 0;
     $json->{editor_id} = $self->editor_id + 0;
     $json->{editor} = to_json_object($self->editor);
     $json->{post_time} = datetime_to_iso8601($self->post_time);
     $json->{formatted_text} = $self->editor_id == $EDITOR_MODBOT
         ? $self->localize : format_editnote($self->text);
+    $json->{latest_change} = $self->latest_change
+        ? $self->latest_change->TO_JSON
+        : undef;
 
     return $json;
 };

--- a/lib/MusicBrainz/Server/Entity/EditNoteChange.pm
+++ b/lib/MusicBrainz/Server/Entity/EditNoteChange.pm
@@ -1,0 +1,75 @@
+package MusicBrainz::Server::Entity::EditNoteChange;
+
+use 5.18.2;
+
+use Moose;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Data::Utils qw( datetime_to_iso8601 );
+use MusicBrainz::Server::Entity::Types;
+use MusicBrainz::Server::Types qw( DateTime );
+
+extends 'MusicBrainz::Server::Entity';
+
+has 'editor_id' => (
+    isa => 'Int',
+    is => 'rw',
+);
+
+has 'editor' => (
+    isa => 'Editor',
+    is => 'rw'
+);
+
+has 'edit_note_id' => (
+    isa => 'Int',
+    is => 'rw',
+);
+
+has 'edit_note' => (
+    isa => 'EditNote',
+    is => 'rw',
+    weak_ref => 1
+);
+
+has 'reason' => (
+    isa => 'Str',
+    is => 'rw',
+);
+
+has 'change_time' => (
+    isa => DateTime,
+    is => 'rw',
+    coerce => 1
+);
+
+has 'status' => (
+    isa => 'Str',
+    is  => 'rw',
+);
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{change_editor_id} = $self->editor_id + 0;
+    $json->{change_time} = datetime_to_iso8601($self->change_time);
+    $json->{reason} = $self->reason;
+    $json->{status} = $self->status;
+
+    return $json;
+};
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Entity/Types.pm
+++ b/lib/MusicBrainz/Server/Entity/Types.pm
@@ -9,6 +9,7 @@ for my $cls (qw(AggregatedTag AggregatedGenre Annotation Application
                 Barcode CDTOC CDStub Collection CollectionType Coordinates
                 CoverArtType
                 CritiqueBrainz::Review CritiqueBrainz::User
+                EditNoteChange
                 Editor EditorOAuthToken
                 Event EventAlias EventAliasType EventType
                 Gender Genre GenreAlias GenreAliasType

--- a/lib/MusicBrainz/Server/Form/EditNoteDelete.pm
+++ b/lib/MusicBrainz/Server/Form/EditNoteDelete.pm
@@ -1,0 +1,27 @@
+package MusicBrainz::Server::Form::EditNoteDelete;
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => ( default => 'edit-note-delete' );
+
+has_field 'cancel' => ( type => 'Submit' );
+has_field 'submit' => ( type => 'Submit' );
+has_field 'reason' => (
+    type => '+MusicBrainz::Server::Form::Field::Text',
+    not_nullable => 1,
+);
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Form/EditNoteModify.pm
+++ b/lib/MusicBrainz/Server/Form/EditNoteModify.pm
@@ -1,0 +1,32 @@
+package MusicBrainz::Server::Form::EditNoteModify;
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => ( default => 'edit-note-modify' );
+
+has_field 'cancel' => ( type => 'Submit' );
+has_field 'submit' => ( type => 'Submit' );
+has_field 'reason' => (
+    type => '+MusicBrainz::Server::Form::Field::Text',
+    not_nullable => 1,
+);
+has_field 'text' => (
+    type => 'Text',
+    required => 1,
+    input_without_param => '',
+);
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Form/EditNoteModify.pm
+++ b/lib/MusicBrainz/Server/Form/EditNoteModify.pm
@@ -5,6 +5,9 @@ use warnings;
 use HTML::FormHandler::Moose;
 extends 'MusicBrainz::Server::Form';
 
+use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Validation qw( is_valid_edit_note );
+
 has '+name' => ( default => 'edit-note-modify' );
 
 has_field 'cancel' => ( type => 'Submit' );
@@ -15,9 +18,21 @@ has_field 'reason' => (
 );
 has_field 'text' => (
     type => 'Text',
-    required => 1,
     input_without_param => '',
 );
+
+sub validate
+{
+    my ($self) = @_;
+
+    unless ($self->field('cancel')->input) {
+        if (!defined $self->field('text')->value) {
+            $self->field('text')->add_error(l('You must provide an edit note. If you want to blank the note, please remove it instead.'));
+        } elsif (!is_valid_edit_note($self->field('text')->value)) {
+            $self->field('text')->add_error(l('Your edit note seems to have no actual content. Please provide a note that will be helpful to your fellow editors!'));
+        }
+    }
+}
 
 1;
 

--- a/root/constants.js
+++ b/root/constants.js
@@ -76,3 +76,5 @@ export const PUBLIC_FLAGS: number = AUTO_EDITOR_FLAG &
                                     ACCOUNT_ADMIN_FLAG &
                                     LOCATION_EDITOR_FLAG &
                                     BANNER_EDITOR_FLAG;
+
+export const EDITOR_MODBOT = 4;

--- a/root/edit/DeleteNote.js
+++ b/root/edit/DeleteNote.js
@@ -1,0 +1,79 @@
+/*
+ * @flow strict
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import Layout from '../layout/index.js';
+import FormRowText from '../static/scripts/edit/components/FormRowText.js';
+
+import EditNoteListEntry from './components/EditNoteListEntry.js';
+
+type DeleteNoteFormT = FormT<{
+  +cancel: ReadOnlyFieldT<string>,
+  +reason: ReadOnlyFieldT<string>,
+  +submit: ReadOnlyFieldT<string>,
+}>;
+
+type Props = {
+  +edit: GenericEditWithIdT,
+  +editNote: EditNoteT,
+  +form: DeleteNoteFormT,
+};
+
+const DeleteNote = ({
+  edit,
+  editNote,
+  form,
+}: Props): React$Element<typeof Layout> => (
+  <Layout fullWidth title={l('Remove edit note')}>
+    <h1>{l('Remove edit note')}</h1>
+    <p>
+      {l('Are you sure you want to remove the following edit note?')}
+    </p>
+    <div className="edit-notes">
+      <EditNoteListEntry
+        edit={edit}
+        editNote={editNote}
+        showEditControls={false}
+      />
+    </div>
+    <form method="post">
+      <p>
+        {l(
+          `Providing a reason for the removal is recommended if you feel
+           it will make things clearer for other editors checking
+           the editing history in the future. Otherwise it can be omitted.`,
+        )}
+      </p>
+      <FormRowText
+        field={form.field.reason}
+        label={addColonText(l('Reason'))}
+        size={50}
+        uncontrolled
+      />
+      <span className="buttons">
+        <button
+          name="edit-note-delete.submit"
+          type="submit"
+          value="1"
+        >
+          {l('Yes, I am sure')}
+        </button>
+        <button
+          className="negative"
+          name="edit-note-delete.cancel"
+          type="submit"
+          value="1"
+        >
+          {l('Cancel')}
+        </button>
+      </span>
+    </form>
+  </Layout>
+);
+
+export default DeleteNote;

--- a/root/edit/ModifyNote.js
+++ b/root/edit/ModifyNote.js
@@ -1,0 +1,97 @@
+/*
+ * @flow strict
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import Layout from '../layout/index.js';
+import FormRowText from '../static/scripts/edit/components/FormRowText.js';
+import FormRowTextArea
+  from '../static/scripts/edit/components/FormRowTextArea.js';
+
+import EditNoteListEntry from './components/EditNoteListEntry.js';
+import EditNoteHelp from './components/EditNoteHelp.js';
+
+type ModifyEditNoteFormT = FormT<{
+  +cancel: ReadOnlyFieldT<string>,
+  +reason: ReadOnlyFieldT<string>,
+  +submit: ReadOnlyFieldT<string>,
+  +text: ReadOnlyFieldT<string>,
+}>;
+
+type Props = {
+  +edit: GenericEditWithIdT,
+  +editNote: EditNoteT,
+  +form: ModifyEditNoteFormT,
+};
+
+const ModifyNote = ({
+  edit,
+  editNote,
+  form,
+}: Props): React$Element<typeof Layout> => (
+  <Layout fullWidth title={l('Modify edit note')}>
+    <h1>{l('Modify edit note')}</h1>
+    <p>
+      {l('You are modifying the following edit note:')}
+    </p>
+    <div className="edit-notes">
+      <EditNoteListEntry
+        edit={edit}
+        editNote={editNote}
+        showEditControls={false}
+      />
+    </div>
+    <form method="post">
+      <FormRowTextArea
+        cols={50}
+        field={form.field.text}
+        label={addColonText(l('New edit note'))}
+        required
+        rows={10}
+      />
+      <EditNoteHelp>
+        <p>
+          {l(
+            `Keep in mind modification of edit notes is mostly intended
+             to correct small mistakes. Editors won’t be notified
+             of your changes via email.`,
+          )}
+        </p>
+      </EditNoteHelp>
+      <p>
+        {l(`Providing a reason is optional but can make things more clear
+            for editors checking this edit in the future. Keep in mind
+            the reason will be displayed to other editors.`)}
+      </p>
+      <FormRowText
+        field={form.field.reason}
+        label={addColonText(l('Reason'))}
+        size={50}
+        uncontrolled
+      />
+      <span className="buttons">
+        <button
+          name="edit-note-modify.submit"
+          type="submit"
+          value="1"
+        >
+          {l('Submit')}
+        </button>
+        <button
+          className="negative"
+          name="edit-note-modify.cancel"
+          type="submit"
+          value="1"
+        >
+          {l('Cancel')}
+        </button>
+      </span>
+    </form>
+  </Layout>
+);
+
+export default ModifyNote;

--- a/root/edit/ModifyNote.js
+++ b/root/edit/ModifyNote.js
@@ -12,8 +12,8 @@ import FormRowText from '../static/scripts/edit/components/FormRowText.js';
 import FormRowTextArea
   from '../static/scripts/edit/components/FormRowTextArea.js';
 
-import EditNoteListEntry from './components/EditNoteListEntry.js';
 import EditNoteHelp from './components/EditNoteHelp.js';
+import EditNoteListEntry from './components/EditNoteListEntry.js';
 
 type ModifyEditNoteFormT = FormT<{
   +cancel: ReadOnlyFieldT<string>,

--- a/root/edit/ModifyNote.js
+++ b/root/edit/ModifyNote.js
@@ -50,7 +50,6 @@ const ModifyNote = ({
         cols={50}
         field={form.field.text}
         label={addColonText(l('New edit note'))}
-        required
         rows={10}
       />
       <EditNoteHelp>

--- a/root/edit/NotesReceived.js
+++ b/root/edit/NotesReceived.js
@@ -56,6 +56,7 @@ const NotesReceived = ({
                     edit={edit}
                     editNote={editNote}
                     key={index}
+                    showEditControls
                   />
                 );
               })}

--- a/root/edit/NotesReceived.js
+++ b/root/edit/NotesReceived.js
@@ -13,14 +13,12 @@ import PaginatedResults from '../components/PaginatedResults.js';
 import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import * as manifest from '../static/manifest.mjs';
-import EditLink from '../static/scripts/common/components/EditLink.js';
 import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
 import NewNotesAlertCheckbox
   from '../static/scripts/edit/components/NewNotesAlertCheckbox.js';
-import {getEditHeaderClass} from '../utility/edit.js';
 import getRequestCookie from '../utility/getRequestCookie.mjs';
 
-import EditNote from './components/EditNote.js';
+import EditNoteListEntry from './components/EditNoteListEntry.js';
 
 type Props = {
   +editNotes: $ReadOnlyArray<EditNoteT>,
@@ -53,19 +51,12 @@ const NotesReceived = ({
             <PaginatedResults pager={pager}>
               {editNotes.map((editNote, index) => {
                 const edit = linkedEntities.edit[editNote.edit_id];
-                const editLinkText = texp.l(
-                  'Edit #{id} - {name}',
-                  {id: edit.id, name: l(edit.edit_name)},
-                );
                 return (
-                  <div className="edit-list" key={index}>
-                    <div className={getEditHeaderClass(edit)}>
-                      <h2>
-                        <EditLink content={editLinkText} edit={edit} />
-                      </h2>
-                    </div>
-                    <EditNote edit={edit} editNote={editNote} index={0} />
-                  </div>
+                  <EditNoteListEntry
+                    edit={edit}
+                    editNote={editNote}
+                    key={index}
+                  />
                 );
               })}
             </PaginatedResults>

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -13,6 +13,7 @@ import {
   EDIT_VOTE_APPROVE,
   EDIT_VOTE_NO,
   EDIT_VOTE_YES,
+  EDITOR_MODBOT,
 } from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
@@ -63,7 +64,7 @@ const EditNote = ({
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const allEditNotes = edit.edit_notes;
-  const isModBot = editNote.editor_id === 4;
+  const isModBot = editNote.editor_id === EDITOR_MODBOT;
   const anchor = returnNoteAnchor(edit, index);
   const isOwner = edit.editor_id === editNote.editor_id;
   const isCurrentEditor = Boolean(user && user.id === editNote.editor_id);
@@ -90,8 +91,8 @@ const EditNote = ({
   /*
    * We only want to show the controls for modifying/removing a note
    * to a normal user in the case where the note is their own, nobody else
-   * has posted in response (the same user can have other notes), the note
-   * is not older than 24 hours, and it hasn't already been removed.
+   * has posted in response (the same user or ModBot can have other notes),
+   * the note is not older than 24 hours, and it hasn't already been removed.
    * For admins, we can show it all the time.
    */
   let hasReply = true;
@@ -104,7 +105,8 @@ const EditNote = ({
     const noteIndex = allEditNotes.findIndex(note => note.id === editNote.id);
     const noteAndAfter = allEditNotes.slice(noteIndex);
     hasReply = (noteAndAfter.some(
-      note => note.editor_id !== editNote.editor_id,
+      note => note.editor_id !== editNote.editor_id &&
+              note.editor_id !== EDITOR_MODBOT,
     ));
   }
   const noteDate = nonEmpty(editNote.post_time)

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -16,8 +16,11 @@ import {
 } from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
+import {isAccountAdmin}
+  from '../../static/scripts/common/utility/privileges.js';
 import getVoteName from '../../static/scripts/edit/utility/getVoteName.js';
 import formatUserDate from '../../utility/formatUserDate.js';
+import parseIsoDate from '../../utility/parseIsoDate.js';
 
 import EditorTypeInfo from './EditorTypeInfo.js';
 
@@ -26,6 +29,7 @@ type PropsT = {
   +editNote: EditNoteT,
   +index: number,
   +isOnEditPage?: boolean,
+  +showEditControls?: boolean,
 };
 
 function returnNoteAnchor(edit: GenericEditWithIdT, index: number) {
@@ -54,11 +58,15 @@ const EditNote = ({
   editNote,
   index,
   isOnEditPage = false,
+  showEditControls = true,
 }: PropsT): React$Element<'div'> => {
   const $c = React.useContext(CatalystContext);
+  const user = $c.user;
+  const allEditNotes = edit.edit_notes;
   const isModBot = editNote.editor_id === 4;
   const anchor = returnNoteAnchor(edit, index);
   const isOwner = edit.editor_id === editNote.editor_id;
+  const isCurrentEditor = Boolean(user && user.id === editNote.editor_id);
   const lastRelevantVote = edit.votes.find(vote => (
     vote.editor_id === editNote.editor_id &&
     !vote.superseded
@@ -69,6 +77,44 @@ const EditNote = ({
     lastRelevantVote.vote === EDIT_VOTE_YES
   );
 
+  // To display the appropriate message if the note has been removed
+  const isDeleted = editNote.latest_change?.status === 'deleted';
+  const deletedBySelf =
+    editNote.latest_change?.change_editor_id === editNote.editor_id;
+  const changeReason = editNote.latest_change?.reason;
+
+  /*
+   * We only want to show the controls for modifying/removing a note
+   * to a normal user in the case where the note is their own, nobody else
+   * has posted in response (the same user can have other notes), the note
+   * is not older than 24 hours, and it hasn't already been removed.
+   * For admins, we can show it all the time.
+   */
+  let hasReply = true;
+  /*
+   * If we haven't loaded the edit notes, we're probably
+   * on the notes received page, so they won't be the editor's own notes
+   * anyway and there's nothing to modify or remove for non-admins.
+   */
+  if (allEditNotes.length) {
+    const noteIndex = allEditNotes.findIndex(note => note.id === editNote.id);
+    const noteAndAfter = allEditNotes.slice(noteIndex);
+    hasReply = (noteAndAfter.some(
+      note => note.editor_id !== editNote.editor_id,
+    ));
+  }
+  const noteDate = nonEmpty(editNote.post_time)
+    ? parseIsoDate(editNote.post_time)
+    : null;
+  const twentyFourHours = 86400000;
+  const isRecent = Boolean(
+    noteDate && (new Date().getTime() - noteDate.getTime()) < twentyFourHours,
+  );
+  const canBeChangedByOwner = isCurrentEditor && !hasReply &&
+                              isRecent && !isDeleted;
+  const canShowEditControls = showEditControls &&
+                              (canBeChangedByOwner || isAccountAdmin(user));
+
   return (
     <div className="edit-note" id={anchor}>
       <h3 className={returnVoteClass(lastRelevantVote, isOwner)}>
@@ -78,6 +124,16 @@ const EditNote = ({
           : null}
         {' '}
         <EditorTypeInfo editor={editNote.editor} />
+        {canShowEditControls ? (
+          <span className="change-note-controls">
+            {' '}
+            <a
+              className="remove-item icon"
+              href={`/edit-note/${editNote.id}/delete`}
+              title={l('Remove edit note')}
+            />
+          </span>
+        ) : null}
         <a
           className="date"
           href={(isOnEditPage ? '' : `/edit/${edit.id}`) + `#${anchor}`}
@@ -89,10 +145,38 @@ const EditNote = ({
             : l('[time missing]')}
         </a>
       </h3>
-      <div
-        className={'edit-note-text' + (isModBot ? ' modbot' : '')}
-        dangerouslySetInnerHTML={{__html: editNote.formatted_text}}
-      />
+      {isDeleted ? (
+        <div className="edit-note-text deleted-note">
+          {deletedBySelf ? (
+            nonEmpty(changeReason) ? (
+              texp.l(
+                `This edit note was removed by its author.
+                 Reason given: “{reason}”.`,
+                {reason: changeReason},
+              )
+            ) : (
+              l(`This edit note was removed by its author.
+                 No reason was provided.`)
+            )
+          ) : (
+            nonEmpty(changeReason) ? (
+              texp.l(
+                `This edit note was removed by an admin.
+                 Reason given: “{reason}”.`,
+                {reason: changeReason},
+              )
+            ) : (
+              l(`This edit note was removed by an admin.
+                 No reason was provided.`)
+            )
+          )}
+        </div>
+      ) : (
+        <div
+          className={'edit-note-text' + (isModBot ? ' modbot' : '')}
+          dangerouslySetInnerHTML={{__html: editNote.formatted_text}}
+        />
+      )}
     </div>
   );
 };

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -16,7 +16,7 @@ import {
 } from '../../constants.js';
 import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
-import {isAccountAdmin}
+import {isAccountAdmin, isAddingNotesDisabled}
   from '../../static/scripts/common/utility/privileges.js';
 import getVoteName from '../../static/scripts/edit/utility/getVoteName.js';
 import formatUserDate from '../../utility/formatUserDate.js';
@@ -115,7 +115,8 @@ const EditNote = ({
     noteDate && (new Date().getTime() - noteDate.getTime()) < twentyFourHours,
   );
   const canBeChangedByOwner = isCurrentEditor && !hasReply &&
-                              isRecent && !isDeleted;
+                              isRecent && !isDeleted &&
+                              !isAddingNotesDisabled(user);
   const canShowEditControls = showEditControls &&
                               (canBeChangedByOwner || isAccountAdmin(user));
 

--- a/root/edit/components/EditNote.js
+++ b/root/edit/components/EditNote.js
@@ -77,11 +77,15 @@ const EditNote = ({
     lastRelevantVote.vote === EDIT_VOTE_YES
   );
 
-  // To display the appropriate message if the note has been removed
+  // To display the appropriate message if the edit note has been changed
   const isDeleted = editNote.latest_change?.status === 'deleted';
-  const deletedBySelf =
+  const isModified = editNote.latest_change?.status === 'edited';
+  const changedBySelf =
     editNote.latest_change?.change_editor_id === editNote.editor_id;
   const changeReason = editNote.latest_change?.reason;
+  const changeTime = editNote.latest_change?.change_time
+    ? formatUserDate($c, editNote.latest_change.change_time)
+    : null;
 
   /*
    * We only want to show the controls for modifying/removing a note
@@ -128,6 +132,11 @@ const EditNote = ({
           <span className="change-note-controls">
             {' '}
             <a
+              className="edit-item icon"
+              href={`/edit-note/${editNote.id}/modify`}
+              title={l('Modify edit note')}
+            />
+            <a
               className="remove-item icon"
               href={`/edit-note/${editNote.id}/delete`}
               title={l('Remove edit note')}
@@ -147,7 +156,7 @@ const EditNote = ({
       </h3>
       {isDeleted ? (
         <div className="edit-note-text deleted-note">
-          {deletedBySelf ? (
+          {changedBySelf ? (
             nonEmpty(changeReason) ? (
               texp.l(
                 `This edit note was removed by its author.
@@ -172,10 +181,53 @@ const EditNote = ({
           )}
         </div>
       ) : (
-        <div
-          className={'edit-note-text' + (isModBot ? ' modbot' : '')}
-          dangerouslySetInnerHTML={{__html: editNote.formatted_text}}
-        />
+        <>
+          <div
+            className={'edit-note-text' + (isModBot ? ' modbot' : '')}
+            dangerouslySetInnerHTML={{__html: editNote.formatted_text}}
+          />
+          {isModified ? (
+            <div className="edit-note-modified-text small">
+              {changedBySelf ? (
+                nonEmpty(changeReason) ? (
+                  texp.l(
+                    `Last modified by the note author ({time}).
+                     Reason given: “{reason}”.`,
+                    {
+                      reason: changeReason,
+                      // $FlowIgnore[incompatible-call]
+                      time: changeTime,
+                    },
+                  )
+                ) : (
+                  texp.l(
+                    'Last modified by the note author ({time}).',
+                    // $FlowIgnore[incompatible-call]
+                    {time: changeTime},
+                  )
+                )
+              ) : (
+                nonEmpty(changeReason) ? (
+                  texp.l(
+                    `Last modified by an admin ({time}).
+                     Reason given: “{reason}”.`,
+                    {
+                      reason: changeReason,
+                      // $FlowIgnore[incompatible-call]
+                      time: changeTime,
+                    },
+                  )
+                ) : (
+                  texp.l(
+                    'Last modified by an admin ({time}).',
+                    // $FlowIgnore[incompatible-call]
+                    {time: changeTime},
+                  )
+                )
+              )}
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/root/edit/components/EditNoteHelp.js
+++ b/root/edit/components/EditNoteHelp.js
@@ -1,0 +1,34 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+type Props = {
+  +children?: React$Node,
+};
+
+const EditNoteHelp = ({
+  children,
+}: Props): React$Element<'div'> => (
+  <div className="edit-note-help">
+    <p>
+      {exp.l(
+        `Edit notes support
+        {doc_formatting|a limited set of wiki formatting options}.
+        Please do always keep the {doc_coc|Code of Conduct} in mind
+        when writing edit notes!`,
+        {
+          doc_coc: {href: '/doc/Code_of_Conduct', target: '_blank'},
+          doc_formatting: {href: '/doc/Edit_Note', target: '_blank'},
+        },
+      )}
+    </p>
+    {children}
+  </div>
+);
+
+export default EditNoteHelp;

--- a/root/edit/components/EditNoteListEntry.js
+++ b/root/edit/components/EditNoteListEntry.js
@@ -21,6 +21,7 @@ type PropsT = {
 const EditNoteListEntry = ({
   edit,
   editNote,
+  showEditControls,
 }: PropsT): React$Element<'div'> => {
   const editTitle = texp.l(
     'Edit #{id} - {name}',
@@ -38,6 +39,7 @@ const EditNoteListEntry = ({
         edit={edit}
         editNote={editNote}
         index={0}
+        showEditControls={showEditControls}
       />
     </div>
   );

--- a/root/edit/components/EditNoteListEntry.js
+++ b/root/edit/components/EditNoteListEntry.js
@@ -1,0 +1,46 @@
+/*
+ * @flow strict
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import EditLink from '../../static/scripts/common/components/EditLink.js';
+import {getEditHeaderClass} from '../../utility/edit.js';
+
+import EditNote from './EditNote.js';
+
+type PropsT = {
+  +edit: GenericEditWithIdT,
+  +editNote: EditNoteT,
+  +showEditControls?: boolean,
+};
+
+const EditNoteListEntry = ({
+  edit,
+  editNote,
+}: PropsT): React$Element<'div'> => {
+  const editTitle = texp.l(
+    'Edit #{id} - {name}',
+    {id: edit.id, name: l(edit.edit_name)},
+  );
+
+  return (
+    <div className="edit-list">
+      <div className={getEditHeaderClass(edit)}>
+        <h2>
+          <EditLink content={editTitle} edit={edit} />
+        </h2>
+      </div>
+      <EditNote
+        edit={edit}
+        editNote={editNote}
+        index={0}
+      />
+    </div>
+  );
+};
+
+export default EditNoteListEntry;

--- a/root/edit/components/EditNotes.js
+++ b/root/edit/components/EditNotes.js
@@ -16,6 +16,7 @@ import {
 } from '../../utility/edit.js';
 
 import EditNote from './EditNote.js';
+import EditNoteHelp from './EditNoteHelp.js';
 
 type Props = {
   +edit: GenericEditWithIdT,
@@ -61,18 +62,7 @@ const EditNotes = ({
             className="add-edit-note edit-note"
             style={hide ? {display: 'none'} : {}}
           >
-            <p className="edit-note-help">
-              {exp.l(
-                `Edit notes support
-                 {doc_formatting|a limited set of wiki formatting options}.
-                 Please do always keep the {doc_coc|Code of Conduct} in mind
-                 when writing edit notes!`,
-                {
-                  doc_coc: {href: '/doc/Code_of_Conduct', target: '_blank'},
-                  doc_formatting: {href: '/doc/Edit_Note', target: '_blank'},
-                },
-              )}
-            </p>
+            <EditNoteHelp />
             <div className="edit-note-text">
               <textarea
                 className="edit-note"

--- a/root/layout.tt
+++ b/root/layout.tt
@@ -22,7 +22,7 @@
                             If you haven’t already been contacted about why, please {uri|send us a message}.',
                             { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
                     [%- ELSE -%]
-                        [% l('You’re currently not allowed to leave edit notes because an admin has revoked your privileges.
+                        [% l('You’re currently not allowed to leave or change edit notes because an admin has revoked your privileges.
                             If you haven’t already been contacted about why, please {uri|send us a message}.',
                             { uri => { href => 'https://metabrainz.org/contact', target => '_blank' } }) %]
                     [%- END -%]

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -215,9 +215,9 @@ const Layout = ({
                 )
               ) : (
                 exp.l(
-                  `You’re currently not allowed to leave edit notes because
-                   an admin has revoked your privileges. If you haven’t
-                   already been contacted about why,
+                  `You’re currently not allowed to leave or change edit notes
+                   because an admin has revoked your privileges.
+                   If you haven’t already been contacted about why,
                    please {uri|send us a message}.`,
                   {uri: {href: 'https://metabrainz.org/contact', target: '_blank'}},
                 )

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -106,6 +106,7 @@ export default {
   'edit/DeleteNote': (): Promise<mixed> => import('../edit/DeleteNote.js'),
   'edit/EditData': (): Promise<mixed> => import('../edit/EditData.js'),
   'edit/EditIndex': (): Promise<mixed> => import('../edit/EditIndex.js'),
+  'edit/ModifyNote': (): Promise<mixed> => import('../edit/ModifyNote.js'),
   'edit/NoteIsRequired': (): Promise<mixed> => import('../edit/NoteIsRequired.js'),
   'edit/NotesReceived': (): Promise<mixed> => import('../edit/NotesReceived.js'),
   'edit/OpenEdits': (): Promise<mixed> => import('../edit/OpenEdits.js'),

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -103,6 +103,7 @@ export default {
   'edit/CannotApproveEdit': (): Promise<mixed> => import('../edit/CannotApproveEdit.js'),
   'edit/CannotCancelEdit': (): Promise<mixed> => import('../edit/CannotCancelEdit.js'),
   'edit/CannotVote': (): Promise<mixed> => import('../edit/CannotVote.js'),
+  'edit/DeleteNote': (): Promise<mixed> => import('../edit/DeleteNote.js'),
   'edit/EditData': (): Promise<mixed> => import('../edit/EditData.js'),
   'edit/EditIndex': (): Promise<mixed> => import('../edit/EditIndex.js'),
   'edit/NoteIsRequired': (): Promise<mixed> => import('../edit/NoteIsRequired.js'),

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -111,6 +111,11 @@ table.vote-tally {
         overflow-wrap: anywhere;
     }
 
+    .edit-note-modified-text {
+        padding-left: 1.5em;
+        padding-top: 0.5em;
+    }
+
     .modbot, .deleted-note {
         color: @very-dark-text;
 
@@ -209,11 +214,11 @@ table.vote-tally {
         display: none;
         margin-top: 5px;
     }
+}
 
-    .edit-note-help {
-        .help-box();
-        margin-left: 1em;
-    }
+.edit-note-help {
+    .help-box();
+    margin-left: 1em;
 }
 
 /*

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -111,7 +111,7 @@ table.vote-tally {
         overflow-wrap: anywhere;
     }
 
-    .modbot {
+    .modbot, .deleted-note {
         color: @very-dark-text;
 
         a {

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -521,7 +521,7 @@ ul.conditions button.remove img {
     }
 }
 
-input.icon, div.icon.img, span.icon.img, button.icon {
+input.icon, div.icon.img, span.icon.img, button.icon, a.icon {
     min-width: @form-icon-size;
     min-height: @form-icon-size;
     border: 0 !important;
@@ -531,7 +531,7 @@ input.icon, div.icon.img, span.icon.img, button.icon {
     cursor: pointer;
 }
 
-div.img, button.icon { display: inline-block; }
+div.img, button.icon, a.icon { display: inline-block; }
 
 button.with-label {
     border: none;
@@ -551,6 +551,7 @@ button.add-item {
 }
 
 .remove-artist-credit,
+a.remove-item,
 button.remove-item,
 button.close-dialog {
     /* The !important overrides .nobutton:hover. */

--- a/root/types/edit.js
+++ b/root/types/edit.js
@@ -31,15 +31,23 @@ declare type EditT = CurrentEditT | HistoricEditT;
 
 declare type EditWithIdT = $ReadOnly<{...EditT, +id: number}>;
 
+declare type EditNoteChangeT = {
+  +change_editor_id: number,
+  +change_time: string,
+  +reason: string,
+  +status: 'edited' | 'deleted',
+};
+
 // MusicBrainz::Server::Entity::EditNote::TO_JSON
 declare type EditNoteT = {
   +edit_id: number,
   +editor: EditorT | null,
   +editor_id: number,
   +formatted_text: string,
+  +id: number,
+  +latest_change?: EditNoteChangeT,
   +post_time: string | null,
 };
-
 
 // Reused by all other edit types
 declare type GenericEditT = {

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
@@ -105,7 +105,33 @@ test all => sub {
         'Can modify note again after recovering edit note privileges',
     );
 
-    # Actually modify edit note 4
+    note('We try to modify the note by blanking it');
+    $mech->submit_form(
+        with_fields => {
+        'edit-note-modify.text' => '',
+        'edit-note-modify.reason' => 'Fixing typo',
+        }
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'You must provide an edit note',
+        'Can’t submit blank edit note when modifying it',
+    );
+
+    note('We try to modify the note and make it just the letter "a"');
+    $mech->submit_form(
+        with_fields => {
+        'edit-note-modify.text' => 'a',
+        'edit-note-modify.reason' => 'Fixing typo',
+        }
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'no actual content',
+        'Can’t submit content-free edit note when modifying it',
+    );
+
+    note('We actually modify the note with a proper text');
     $mech->submit_form(
         with_fields => {
         'edit-note-modify.text' => 'Editor 1 leaves another note years later',

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
@@ -1,0 +1,169 @@
+package t::MusicBrainz::Server::Controller::Edit::ChangeNote;
+use strict;
+use warnings;
+
+use Test::Routine;
+use Test::More;
+use utf8;
+
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Context', 't::Mechanize';
+
+=head1 DESCRIPTION
+
+This checks that edit notes can be deleted, and the restrictions on who
+and when can do so.
+
+=cut
+
+test all => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $change_note_classname = 'change-note-controls';
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+change_edit_note',
+    );
+
+    # Test as normal editor
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'editor1', password => 'pass'}
+    );
+
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Editor 1 leaves an extra comment',
+        'Edit note is present',
+    );
+
+    # We only expect 2 edits to be editable by editor 1
+    my @change_class_matches = $mech->content =~ /$change_note_classname/g;
+    is(
+        scalar @change_class_matches,
+        2,
+        '2 sets of change note controls shown to normal user',
+    );
+
+    $mech->get_ok('/edit-note/1/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'since somebody else has already replied',
+        'Can’t remove note with replies',
+    );
+
+    $mech->get_ok('/edit-note/2/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'can’t change other users',
+        'Can’t remove note by other user',
+    );
+
+    $mech->get_ok('/edit-note/3/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'it was entered too long ago',
+        'Can’t remove too old note',
+    );
+
+    $mech->get_ok('/edit-note/4/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Are you sure you want to remove the following edit note',
+        'Can remove note followed by own notes only',
+    );
+
+    $mech->get_ok('/edit-note/5/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Are you sure you want to remove the following edit note',
+        'Can remove last note',
+    );
+
+    # Actually remove edit note 5
+    $mech->submit_form(
+        with_fields => {'edit-note-delete.reason' => 'I did a dumb'}
+    );
+
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'This edit note was removed by its author. Reason given: “I did a dumb”.',
+        'Removal message (with reason) is present',
+    );
+    $mech->content_lacks(
+        'Editor 1 leaves an extra comment',
+        'Edit note is no longer present',
+    );
+
+    $mech->get_ok('/edit-note/5/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'This note has already been removed',
+        'Can’t remove already removed note',
+    );
+
+    $mech->get_ok('/edit/1');
+    @change_class_matches = $mech->content =~ /$change_note_classname/g;
+    is(
+        scalar @change_class_matches,
+        1,
+        'Only 1 set of change edit note controls shown to normal user after removing one note',
+    );
+
+    $mech->get('/logout');
+
+    # Test as admin
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'admin3', password => 'pass'}
+    );
+
+    $mech->get_ok('/edit/1');
+    @change_class_matches = $mech->content =~ /$change_note_classname/g;
+    is(
+        scalar @change_class_matches,
+        5,
+        '5 sets of change note controls shown to admin',
+    );
+
+    $mech->get_ok('/edit-note/1/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Are you sure you want to remove the following edit note',
+        'Admin can remove older notes',
+    );
+    # Delete edit note 1 without a reason
+    $mech->submit_form(
+        with_fields => {'edit-note-delete.reason' => ''}
+    );
+
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'This edit note was removed by an admin. No reason was provided.',
+        'Removal message (without reason) is present',
+    );
+
+    $mech->get_ok('/edit-note/5/delete');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Are you sure you want to remove the following edit note',
+        'Admin can "remove" again an already removed note to change reason',
+    );
+    # "Delete" edit note 5 again to change the reason
+    $mech->submit_form(
+        with_fields => {'edit-note-delete.reason' => 'Editor made a mistake'}
+    );
+    $mech->get_ok('/edit/1');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'This edit note was removed by an admin. Reason given: “Editor made a mistake”.',
+        'Removal message (with new reason) is present',
+    );
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/ChangeNote.pm
@@ -45,7 +45,7 @@ test all => sub {
     is(
         scalar @change_class_matches,
         2,
-        '2 sets of change note controls shown to normal user',
+        '2 sets of change edit note controls shown to normal user',
     );
 
     # We test this with /delete but the code for rejection is the same for /modify
@@ -74,7 +74,7 @@ test all => sub {
     html_ok($mech->content);
     $mech->content_contains(
         'You are modifying the following edit note',
-        'Can modify note followed by own notes only',
+        'Can modify note followed by own + ModBot notes only',
     );
 
     note('We remove the editor’s edit note privileges');
@@ -185,8 +185,8 @@ test all => sub {
     @change_class_matches = $mech->content =~ /$change_note_classname/g;
     is(
         scalar @change_class_matches,
-        5,
-        '5 sets of change note controls shown to admin',
+        6,
+        '6 sets of change edit note controls shown to admin',
     );
 
     $mech->get_ok('/edit-note/1/delete');

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -164,6 +164,8 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Edit::show',
   'Controller::Edit::subscribed',
   'Controller::Edit::subscribed_editors',
+  'Controller::EditNote::base',
+  'Controller::EditNote::delete',
   'Controller::Event::alias',
   'Controller::Event::aliases',
   'Controller::Event::annotation_diff',

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -166,6 +166,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Edit::subscribed_editors',
   'Controller::EditNote::base',
   'Controller::EditNote::delete',
+  'Controller::EditNote::modify',
   'Controller::Event::alias',
   'Controller::Event::aliases',
   'Controller::Event::annotation_diff',

--- a/t/sql/change_edit_note.sql
+++ b/t/sql/change_edit_note.sql
@@ -18,5 +18,5 @@ INSERT INTO edit_note (id, editor, edit, post_time, text)
     VALUES (1, 1, 1, '2014-12-05', 'Editor 1 says something'),
            (2, 2, 1, '2014-12-05', 'Editor 2 comments'),
            (3, 1, 1, '2014-12-05', 'Editor 1 replies'),
-           (4, 1, 1, NOW(), 'Editor 1 leaves another note years later'),
+           (4, 1, 1, NOW(), 'Editor 1 leaves another note years ltaer'),
            (5, 1, 1, NOW(), 'Editor 1 leaves an extra comment');

--- a/t/sql/change_edit_note.sql
+++ b/t/sql/change_edit_note.sql
@@ -1,0 +1,22 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO editor (id, name, password, privs, email, ha1, email_confirm_date, member_since) VALUES
+(1, 'editor1', '{CLEARTEXT}pass', 0, 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03'),
+(2, 'editor2', '{CLEARTEXT}pass', 0, 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
+(3, 'admin3', '{CLEARTEXT}pass', 128, 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05');
+
+INSERT INTO artist (id, gid, name, sort_name)
+    VALUES (1, 'a9d99e40-72d7-11de-8a39-0800200c9a66', 'Name', 'Name');
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (1, 1, 32, 1, NOW());
+INSERT INTO edit_data (edit, data)
+    VALUES (1, '{"entity":{"name":"Name","id":1},"new":{"name":"NewName"},"old":{"name":"Name"}}');
+INSERT INTO edit_artist (edit, artist)
+    VALUES (1, 1);
+
+INSERT INTO edit_note (id, editor, edit, post_time, text)
+    VALUES (1, 1, 1, '2014-12-05', 'Editor 1 says something'),
+           (2, 2, 1, '2014-12-05', 'Editor 2 comments'),
+           (3, 1, 1, '2014-12-05', 'Editor 1 replies'),
+           (4, 1, 1, NOW(), 'Editor 1 leaves another note years later'),
+           (5, 1, 1, NOW(), 'Editor 1 leaves an extra comment');

--- a/t/sql/change_edit_note.sql
+++ b/t/sql/change_edit_note.sql
@@ -19,4 +19,5 @@ INSERT INTO edit_note (id, editor, edit, post_time, text)
            (2, 2, 1, '2014-12-05', 'Editor 2 comments'),
            (3, 1, 1, '2014-12-05', 'Editor 1 replies'),
            (4, 1, 1, NOW(), 'Editor 1 leaves another note years ltaer'),
-           (5, 1, 1, NOW(), 'Editor 1 leaves an extra comment');
+           (5, 1, 1, NOW(), 'Editor 1 leaves an extra comment'),
+           (6, 4, 1, NOW(), 'ModBot says a thing');

--- a/t/sql/edit_note.sql
+++ b/t/sql/edit_note.sql
@@ -4,3 +4,34 @@ INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_s
 (1, 'editor1', '{CLEARTEXT}pass', 'editor1@example.com', '16a4862191803cb596ee4b16802bb7ee', now(), '2014-12-03'),
 (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-04'),
 (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-05');
+
+-- Test multiple edit_notes
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (1, 1, 111, 1, NOW());
+
+INSERT INTO edit_note (id, editor, edit, text)
+    VALUES (1, 1, 1, 'This is a note');
+
+INSERT INTO edit_note (id, editor, edit, text)
+    VALUES (2, 2, 1, 'This is a later note');
+
+-- Test a single note
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (2, 1, 111, 1, NOW());
+
+INSERT INTO edit_note (id, editor, edit, text)
+    VALUES (3, 1, 2, 'Another edit note');
+
+-- Test no edit_notes
+INSERT INTO edit (id, editor, type, status, expire_time)
+    VALUES (3, 1, 111, 1, NOW());
+
+INSERT INTO edit_data (edit, data) SELECT generate_series(1, 3), '{ "foo": "5" }';
+
+-- Dummy edits to allow editor 2 to vote
+INSERT INTO edit (id, editor, type, status, expire_time)
+    SELECT 3 + x, 2, 111, 2, now() FROM generate_series(1, 10) x;
+INSERT INTO edit_data (edit, data)
+    SELECT 3 + x, '{}' FROM generate_series(1, 10) x;
+
+ALTER SEQUENCE edit_note_id_seq RESTART 4;


### PR DESCRIPTION
### Implement MBS-4685 / MBS-13084

# Problem
There is no way for users to delete or fix their edit notes. While obviously this is not desirable all the time, it would be great to have a way for editors to delete or change an edit note if they, say, immediately notice they pasted the wrong thing (even more so if it's for example private data).

There's also no way for *admins* to delete or amend edit notes, which means notes with spam such as [this one](https://musicbrainz.org/edit/96631022#note-96631022-1) cannot be acted on.

# Solution
This adds a new table `edit_note_change` to track changes to edit notes.

Admins can edit or delete an edit note at any time of their choosing. For anyone else, the following conditions must apply:
1) the edit note is by the user (obviously)
2) the edit note hasn't already been deleted
3) the edit note isn't older than 24 hours
4) the edit note hasn't gotten a reply by anyone else than the editor or ModBot
5) the user isn’t disabled to add edit notes (by admin)

If the edit note is too old or has a reply, but the user really wants to edit it (say, someone answered to say "Is that your password? Whoops!"), then we tell them to contact us so an admin can make the necessary changes if they agree with the reasoning.

![Screenshot from 2021-12-08 16-39-22](https://user-images.githubusercontent.com/1069224/145383826-973143fe-efc7-40a0-85a6-91a0a8f40043.png)

# Testing
Manually, plus wrote a few tests.

Tested manually: 
* Added notes to stuff, tried removing them with a reason, without a reason, editing with a reason, without a reason, editing and deleting them as admin.

Covered in tests:
* The expected amount of modify note controls are shown for a non-admin editor and for an admin (so, the expected amount of notes are editable).
* Edit notes cannot be modified by non-admin non-owner even by navigating to the form directly.
* Edit notes with replies cannot be modified by non-admin owner even by navigating to the form directly.
* Old edit notes cannot be modified by non-admin owner even by navigating to the form directly (limit difference is 24 hours, but tested difference is many years).
* Edit notes cannot be modified by non-admin owner when their edit note privs are off, even by navigating to the form directly.
* Edit owner can modify edit note even if themselves and ModBot have left further notes, as long as nobody else has.
* Actually modifying the edit note as the owner works, and after modification the reason and date of the modification are listed.
* Actually deleting the edit note as the owner works, and after deletion the reason of the deletion is listed.
* Admins can delete old edit notes.
* Admins can "delete" already deleted edit notes to change the reason (for example if the deleting editor left an insult there).
* Actually deleting the edit note as an admin works, and after deletion the reason of the deletion (or the fact there was no reason) is listed.
* Edit notes cannot be edited to a blank string, or a string devoid of content like "a" (as with required edit note additions).
* Already deleted edit notes cannot be deleted again nor edited by their owner.