### PR TITLE
MBS-12117: Use CSS specificity to fix error highlighting in RE tabs

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -383,14 +383,25 @@ div.warning img.warning {
     height: 32px;
 }
 
-.error-tab, .private-tab:not(.sel) {
+.ui-tabs .ui-tabs-nav li.error-tab, .private-tab:not(.sel) {
     background-color: @negative-light-bg;
     background-image: data-uri('../images/icons/warning.png');
     background-repeat: no-repeat;
-    background-position: left 0.5em top 0.5em;
     background-size: 16px 16px;
 }
-.error-tab a, .private-tab:not(.sel) a { padding-left: 2em !important; }
+
+.ui-tabs .ui-tabs-nav li.error-tab {
+    background-position: left 0.5em top 0.5em;
+}
+
+.private-tab:not(.sel) {
+    background-position: left 0.25em top 0.25em;
+}
+
+.ui-tabs .ui-tabs-nav li.error-tab a,
+.private-tab:not(.sel) a {
+    padding-left: 2em;
+}
 
 #content,
 #sidebar {


### PR DESCRIPTION
### Fix MBS-12117

This broke when I moved it from release-editor.less to layout.less because jquery-ui took over. By specifying the extra classes this takes over and is again considered more relevant, see https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity

Also changed the background position for the non-release-editor tabs because those are smaller and as such the image needs smaller margins to be centered.