### PR TITLE
Use text versions of functions

### DIFF
--- a/root/account/applications/Index.js
+++ b/root/account/applications/Index.js
@@ -13,7 +13,8 @@ import {ACCESS_SCOPE_PERMISSIONS} from '../../constants';
 import {compare} from '../../static/scripts/common/i18n';
 import Layout from '../../layout';
 import PaginatedResults from '../../components/PaginatedResults';
-import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
+import {commaOnlyListText}
+  from '../../static/scripts/common/i18n/commaOnlyList';
 import loopParity from '../../utility/loopParity';
 
 type Props = {
@@ -71,7 +72,7 @@ function formatScopes(token: EditorOAuthTokenT) {
 
   lScopes.sort(compare);
 
-  return commaOnlyList(lScopes);
+  return commaOnlyListText(lScopes);
 }
 
 const Index = ({

--- a/root/artist_credit/ArtistCreditIndex.js
+++ b/root/artist_credit/ArtistCreditIndex.js
@@ -95,7 +95,7 @@ const ArtistCreditIndex = (
           {name.artist.name === name.name ? null : (
             <>
               {' '}
-              {exp.l(
+              {texp.l(
                 'credited as “{credit}”',
                 {credit: name.name},
               )}

--- a/root/components/FormRowSelectList.js
+++ b/root/components/FormRowSelectList.js
@@ -43,7 +43,7 @@ const FormRowSelectList = <S: {+id: number, ...}>({
   repeatable,
 }: Props<S>): React.Element<typeof FormRow> => (
   <FormRow>
-    <label>{addColon(label)}</label>
+    <label>{addColonText(label)}</label>
     <div className="form-row-select-list">
       {repeatable.field.map((subfield, index) => (
         <div className="select-list-row" key={subfield.id}>

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -331,7 +331,7 @@ const RelationshipsTable = ({
 
   if (pagedLinkTypeGroup /*:: && pager */) {
     const linkPhrase = getLinkPhraseForGroup(pagedLinkTypeGroup);
-    finalHeading = linkPhrase ? exp.l(
+    finalHeading = linkPhrase ? texp.l(
       '“{link_phrase}” relationships',
       {link_phrase: getLinkPhraseForGroup(pagedLinkTypeGroup)},
     ) : l('Invalid relationship type');

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -130,7 +130,7 @@ const EditHeader = ({
                     <div>
                       {user ? null : (
                         <>
-                          <strong>{addColon(l('Vote tally'))}</strong>
+                          <strong>{addColonText(l('Vote tally'))}</strong>
                           {' '}
                         </>
                       )}
@@ -143,7 +143,7 @@ const EditHeader = ({
                 <td className="edit-expiration" colSpan="2">
                   {edit.is_open ? (
                     <>
-                      <strong>{addColon(l('Voting'))}</strong>
+                      <strong>{addColonText(l('Voting'))}</strong>
                       {' '}
                       <VotingPeriod
                         $c={$c}
@@ -152,13 +152,13 @@ const EditHeader = ({
                     </>
                   ) : editWasApproved ? (
                     <>
-                      <strong>{addColon(l('Approved'))}</strong>
+                      <strong>{addColonText(l('Approved'))}</strong>
                       {' '}
                       {formatUserDate($c, edit.close_time)}
                     </>
                   ) : (
                     <>
-                      <strong>{addColon(l('Closed'))}</strong>
+                      <strong>{addColonText(l('Closed'))}</strong>
                       {' '}
                       {formatUserDate($c, edit.close_time)}
                     </>

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -32,7 +32,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
         {display[entityType] || !edit.preview /*:: === true */ ? (
           <tr>
             <th>
-              {addColon(formatEntityTypeName(entityType))}
+              {addColonText(formatEntityTypeName(entityType))}
             </th>
             <td>
               <DescriptiveLink
@@ -42,7 +42,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
           </tr>
         ) : null}
         <tr>
-          <th>{addColon(l('Text'))}</th>
+          <th>{addColonText(l('Text'))}</th>
           <td>
             {display.html
               ? (
@@ -62,7 +62,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
         </tr>
         {display.changelog ? (
           <tr>
-            <th>{addColon(l('Summary'))}</th>
+            <th>{addColonText(l('Summary'))}</th>
             <td>
               {display.changelog}
             </td>

--- a/root/edit/details/AddArea.js
+++ b/root/edit/details/AddArea.js
@@ -9,7 +9,8 @@
 
 import * as React from 'react';
 
-import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
+import {commaOnlyListText}
+  from '../../static/scripts/common/i18n/commaOnlyList';
 import formatDate from '../../static/scripts/common/utility/formatDate';
 import isDateEmpty from '../../static/scripts/common/utility/isDateEmpty';
 import DescriptiveLink
@@ -67,21 +68,21 @@ const AddArea = ({edit}: Props): React.MixedElement => {
         {display.iso_3166_1 ? (
           <tr>
             <th>{addColonText(l('ISO 3166-1'))}</th>
-            <td>{commaOnlyList(display.iso_3166_1)}</td>
+            <td>{commaOnlyListText(display.iso_3166_1)}</td>
           </tr>
         ) : null}
 
         {display.iso_3166_2 ? (
           <tr>
             <th>{addColonText(l('ISO 3166-2'))}</th>
-            <td>{commaOnlyList(display.iso_3166_2)}</td>
+            <td>{commaOnlyListText(display.iso_3166_2)}</td>
           </tr>
         ) : null}
 
         {display.iso_3166_3 ? (
           <tr>
             <th>{addColonText(l('ISO 3166-3'))}</th>
-            <td>{commaOnlyList(display.iso_3166_3)}</td>
+            <td>{commaOnlyListText(display.iso_3166_3)}</td>
           </tr>
         ) : null}
 

--- a/root/edit/details/AddArea.js
+++ b/root/edit/details/AddArea.js
@@ -28,7 +28,7 @@ const AddArea = ({edit}: Props): React.MixedElement => {
     <>
       <table className="details">
         <tr>
-          <th>{addColon(l('Area'))}</th>
+          <th>{addColonText(l('Area'))}</th>
           <td>
             <DescriptiveLink
               entity={display.area}
@@ -39,68 +39,68 @@ const AddArea = ({edit}: Props): React.MixedElement => {
 
       <table className="details add-area">
         <tr>
-          <th>{addColon(l('Name'))}</th>
+          <th>{addColonText(l('Name'))}</th>
           <td>{display.name}</td>
         </tr>
 
         {nonEmpty(display.sort_name) ? (
           <tr>
-            <th>{addColon(l('Sort name'))}</th>
+            <th>{addColonText(l('Sort name'))}</th>
             <td>{display.sort_name}</td>
           </tr>
         ) : null}
 
         {nonEmpty(display.comment) ? (
           <tr>
-            <th>{addColon(l('Disambiguation'))}</th>
+            <th>{addColonText(l('Disambiguation'))}</th>
             <td>{display.comment}</td>
           </tr>
         ) : null}
 
         {areaType ? (
           <tr>
-            <th>{addColon(l('Type'))}</th>
+            <th>{addColonText(l('Type'))}</th>
             <td>{lp_attributes(areaType.name, 'area_type')}</td>
           </tr>
         ) : null}
 
         {display.iso_3166_1 ? (
           <tr>
-            <th>{addColon(l('ISO 3166-1'))}</th>
+            <th>{addColonText(l('ISO 3166-1'))}</th>
             <td>{commaOnlyList(display.iso_3166_1)}</td>
           </tr>
         ) : null}
 
         {display.iso_3166_2 ? (
           <tr>
-            <th>{addColon(l('ISO 3166-2'))}</th>
+            <th>{addColonText(l('ISO 3166-2'))}</th>
             <td>{commaOnlyList(display.iso_3166_2)}</td>
           </tr>
         ) : null}
 
         {display.iso_3166_3 ? (
           <tr>
-            <th>{addColon(l('ISO 3166-3'))}</th>
+            <th>{addColonText(l('ISO 3166-3'))}</th>
             <td>{commaOnlyList(display.iso_3166_3)}</td>
           </tr>
         ) : null}
 
         {isDateEmpty(display.begin_date) ? null : (
           <tr>
-            <th>{addColon(l('Begin date'))}</th>
+            <th>{addColonText(l('Begin date'))}</th>
             <td>{formatDate(display.begin_date)}</td>
           </tr>
         )}
 
         {isDateEmpty(display.end_date) ? null : (
           <tr>
-            <th>{addColon(l('End date'))}</th>
+            <th>{addColonText(l('End date'))}</th>
             <td>{formatDate(display.end_date)}</td>
           </tr>
         )}
 
         <tr>
-          <th>{addColon(l('Ended'))}</th>
+          <th>{addColonText(l('Ended'))}</th>
           <td>{yesNo(display.ended)}</td>
         </tr>
       </table>

--- a/root/edit/details/AddCoverArt.js
+++ b/root/edit/details/AddCoverArt.js
@@ -10,7 +10,8 @@
 import * as React from 'react';
 
 import EditArtwork from '../components/EditArtwork';
-import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
+import {commaOnlyListText}
+  from '../../static/scripts/common/i18n/commaOnlyList';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 
@@ -34,7 +35,7 @@ const AddCoverArt = ({edit}: Props): React.Element<'table'> => {
         <th>{l('Types:')}</th>
         <td>
           {display.artwork.types?.length ? (
-            commaOnlyList(display.artwork.types.map(
+            commaOnlyListText(display.artwork.types.map(
               type => lp_attributes(type, 'cover_art_type'),
             ))
           ) : lp('(none)', 'type')}

--- a/root/edit/details/AddEvent.js
+++ b/root/edit/details/AddEvent.js
@@ -26,7 +26,7 @@ const AddEvent = ({edit}: Props): React.MixedElement => {
     <>
       <table className="details">
         <tr>
-          <th>{addColon(l('Event'))}</th>
+          <th>{addColonText(l('Event'))}</th>
           <td>
             <EntityLink
               entity={display.event}
@@ -37,53 +37,53 @@ const AddEvent = ({edit}: Props): React.MixedElement => {
 
       <table className="details add-event">
         <tr>
-          <th>{addColon(l('Name'))}</th>
+          <th>{addColonText(l('Name'))}</th>
           <td>{display.name}</td>
         </tr>
 
         {display.comment ? (
           <tr>
-            <th>{addColon(l('Disambiguation'))}</th>
+            <th>{addColonText(l('Disambiguation'))}</th>
             <td>{display.comment}</td>
           </tr>
         ) : null}
 
         <tr>
-          <th>{addColon(l('Cancelled'))}</th>
+          <th>{addColonText(l('Cancelled'))}</th>
           <td>{yesNo(display.cancelled)}</td>
         </tr>
 
         {eventType ? (
           <tr>
-            <th>{addColon(l('Type'))}</th>
+            <th>{addColonText(l('Type'))}</th>
             <td>{lp_attributes(eventType.name, 'event_type')}</td>
           </tr>
         ) : null}
 
         {isDateEmpty(display.begin_date) ? null : (
           <tr>
-            <th>{addColon(l('Begin date'))}</th>
+            <th>{addColonText(l('Begin date'))}</th>
             <td>{formatDate(display.begin_date)}</td>
           </tr>
         )}
 
         {isDateEmpty(display.end_date) ? null : (
           <tr>
-            <th>{addColon(l('End date'))}</th>
+            <th>{addColonText(l('End date'))}</th>
             <td>{formatDate(display.end_date)}</td>
           </tr>
         )}
 
         {nonEmpty(display.time) ? (
           <tr>
-            <th>{addColon(l('Time'))}</th>
+            <th>{addColonText(l('Time'))}</th>
             <td>{display.time}</td>
           </tr>
         ) : null}
 
         {display.setlist ? (
           <tr>
-            <th>{addColon(l('Setlist'))}</th>
+            <th>{addColonText(l('Setlist'))}</th>
             <td>{display.setlist}</td>
           </tr>
         ) : null}

--- a/root/edit/details/AddRelationshipType.js
+++ b/root/edit/details/AddRelationshipType.js
@@ -52,7 +52,7 @@ const AddRelationshipType = ({
       {relType ? (
         <table className="details">
           <tr>
-            <th>{addColon(l('Relationship Type'))}</th>
+            <th>{addColonText(l('Relationship Type'))}</th>
             <td>
               <EntityLink entity={relType} />
             </td>
@@ -170,7 +170,7 @@ const AddRelationshipType = ({
               <ul>
                 {display.attributes.map((attribute, index) => (
                   <li key={'attribute-' + index}>
-                    {addColon(l_relationships(attribute.typeName))}
+                    {addColonText(l_relationships(attribute.typeName))}
                     {' '}
                     {attribute.min}
                     {'-'}

--- a/root/edit/details/EditAlias.js
+++ b/root/edit/details/EditAlias.js
@@ -11,7 +11,8 @@ import * as React from 'react';
 
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
-import bracketed from '../../static/scripts/common/utility/bracketed';
+import bracketed, {bracketedText}
+  from '../../static/scripts/common/utility/bracketed';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 import EntityLink from '../../static/scripts/common/components/EntityLink';
@@ -67,7 +68,7 @@ const EditAlias = ({edit}: Props): React.Element<'table'> => {
                 <>
                   {isolateText(aliasName)}
                   {' '}
-                  {bracketed(
+                  {bracketedText(
                     aliasPrimaryForLocale
                       ? texp.l('primary for {locale}',
                                {locale: locales[aliasLocale]})

--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -45,7 +45,7 @@ function formatLongLinkPhrase(longLinkPhrase: string): string {
 function formatAttribute(attribute, index) {
   return (
     <li key={'attribute-' + index}>
-      {addColon(l_relationships(attribute.typeName))}
+      {addColonText(l_relationships(attribute.typeName))}
       {' '}
       {attribute.min}
       {'-'}
@@ -140,7 +140,7 @@ const EditRelationshipType = ({
       {relType ? (
         <table className="details">
           <tr>
-            <th>{addColon(l('Relationship Type'))}</th>
+            <th>{addColonText(l('Relationship Type'))}</th>
             <td>
               <EntityLink entity={relType} />
             </td>

--- a/root/edit/details/EditRelease.js
+++ b/root/edit/details/EditRelease.js
@@ -161,7 +161,7 @@ const EditRelease = ({edit}: Props): React.MixedElement => {
 
       {display.update_tracklists /*:: === true */ ? (
         <tr>
-          <th>{addColon(l('Note'))}</th>
+          <th>{addColonText(l('Note'))}</th>
           <td>{l('This edit also changed the track artists.')}</td>
         </tr>
       ) : null}

--- a/root/edit/details/RemoveCoverArt.js
+++ b/root/edit/details/RemoveCoverArt.js
@@ -10,7 +10,8 @@
 import * as React from 'react';
 
 import EditArtwork from '../components/EditArtwork';
-import commaOnlyList from '../../static/scripts/common/i18n/commaOnlyList';
+import {commaOnlyListText}
+  from '../../static/scripts/common/i18n/commaOnlyList';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 
@@ -34,7 +35,7 @@ const RemoveCoverArt = ({edit}: Props): React.Element<'table'> => {
         <th>{l('Types:')}</th>
         <td>
           {display.artwork.types?.length ? (
-            commaOnlyList(display.artwork.types.map(
+            commaOnlyListText(display.artwork.types.map(
               type => lp_attributes(type, 'cover_art_type'),
             ))
           ) : lp('(none)', 'type')}

--- a/root/edit/details/RemoveMedium.js
+++ b/root/edit/details/RemoveMedium.js
@@ -25,7 +25,7 @@ const RemoveMedium = ({edit}: Props): React.Element<'table'> => {
   return (
     <table className="details remove-medium">
       <tr>
-        <th>{addColon(l('Medium'))}</th>
+        <th>{addColonText(l('Medium'))}</th>
         <td>
           <MediumLink medium={display.medium} />
         </td>

--- a/root/edit/details/RemoveRelationshipType.js
+++ b/root/edit/details/RemoveRelationshipType.js
@@ -121,7 +121,7 @@ const RemoveRelationshipType = ({edit}: Props): React.Element<'table'> => {
             <ul>
               {display.attributes.map((attribute, index) => (
                 <li key={'attribute-' + index}>
-                  {addColon(l_relationships(attribute.typeName))}
+                  {addColonText(l_relationships(attribute.typeName))}
                   {' '}
                   {attribute.min}
                   {'-'}

--- a/root/edit/details/historic/AddReleaseAnnotation.js
+++ b/root/edit/details/historic/AddReleaseAnnotation.js
@@ -24,7 +24,7 @@ const AddReleaseAnnotation = ({edit}: Props): React.Element<'table'> => {
         releases={display.releases}
       />
       <tr>
-        <th>{addColon(l('Text'))}</th>
+        <th>{addColonText(l('Text'))}</th>
         <td>
           {display.html
             ? (
@@ -42,7 +42,7 @@ const AddReleaseAnnotation = ({edit}: Props): React.Element<'table'> => {
       </tr>
       {display.changelog ? (
         <tr>
-          <th>{addColon(l('Summary'))}</th>
+          <th>{addColonText(l('Summary'))}</th>
           <td>
             {display.changelog}
           </td>

--- a/root/layout/components/Footer.js
+++ b/root/layout/components/Footer.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import {CatalystContext} from '../../context';
 import DBDefs from '../../static/scripts/common/DBDefs';
 import {DONATE_URL} from '../../constants';
-import bracketed from '../../static/scripts/common/utility/bracketed';
+import {bracketedText} from '../../static/scripts/common/utility/bracketed';
 import formatUserDate from '../../utility/formatUserDate';
 import {returnToCurrentPage} from '../../utility/returnUri';
 
@@ -71,7 +71,7 @@ const Footer = (): React.Element<'div'> => {
                 >
                   {DBDefs.GIT_BRANCH}
                   {' '}
-                  {bracketed(DBDefs.GIT_SHA)}
+                  {bracketedText(DBDefs.GIT_SHA)}
                 </span>
               ),
             })}

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeInUse.js
@@ -22,7 +22,7 @@ const RelationshipAttributeTypeInUse = ({
     <div className="content">
       <h1>{l('Relationship attribute in use')}</h1>
       <p>
-        {exp.l(
+        {texp.l(
           `The relationship attribute type “{type}” can’t be deleted
            because it’s still in use.`,
           {type: type.name},

--- a/root/relationship/linktype/RelationshipTypeInUse.js
+++ b/root/relationship/linktype/RelationshipTypeInUse.js
@@ -22,7 +22,7 @@ const RelationshipTypeInUse = ({
     <div className="content">
       <h1>{l('Relationship Type In Use')}</h1>
       <p>
-        {exp.l(
+        {texp.l(
           `The relationship type "{type}" can’t be deleted
            because it’s still in use.`,
           {type: type.name},

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -187,7 +187,7 @@ const RelationshipTypePairTree = ({
         </p>
 
         <h2>
-          {exp.l(
+          {texp.l(
             '{type0}-{type1} relationship types',
             {type0: formattedType0, type1: formattedType1},
           )}
@@ -196,7 +196,7 @@ const RelationshipTypePairTree = ({
         {isRelationshipEditor($c.user) ? (
           <p>
             <a href={'/relationships/' + type0 + '-' + type1 + '/create'}>
-              {exp.l(
+              {texp.l(
                 'Create a new {type0}-{type1} relationship',
                 {type0: formattedType0, type1: formattedType1},
               )}
@@ -230,7 +230,7 @@ const RelationshipTypePairTree = ({
           </>
         ) : (
           <p>
-            {exp.l(
+            {texp.l(
               'No {type0}-{type1} relationship types found.',
               {type0: formattedType0, type1: formattedType1},
             )}

--- a/root/relationship/linktype/RelationshipTypesList.js
+++ b/root/relationship/linktype/RelationshipTypesList.js
@@ -38,7 +38,7 @@ const TypesTable = ({table, types}: Props) => (
             <td key={'cell' + index}>
               {cellTypes ? (
                 <a href={'/relationships/' + cellTypes.join('-')}>
-                  {exp.l(
+                  {texp.l(
                     '{type0}-{type1}',
                     {
                       type0: formatEntityTypeName(cellTypes[0]),

--- a/root/search/components/ResultsLayout.js
+++ b/root/search/components/ResultsLayout.js
@@ -34,7 +34,7 @@ const ResultsLayout = ({
         <h1>{l('Search Results')}</h1>
         {nonEmpty(lastUpdated) ? (
           <p>
-            {exp.l(
+            {texp.l(
               'Last updated: {date}',
               {date: formatUserDate($c, lastUpdated)},
             )}

--- a/root/static/scripts/area/places-map.js
+++ b/root/static/scripts/area/places-map.js
@@ -106,7 +106,7 @@ if (places.length) {
   places.forEach(function (place) {
     const placeType = place.typeName || l('No type');
     const placeName = place.ended
-      ? exp.l('{place_name} (closed)', {place_name: place.name})
+      ? texp.l('{place_name} (closed)', {place_name: place.name})
       : place.name;
     const icon = place.ended
       ? icons['0']

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -16,7 +16,7 @@ import AddEntityDialog, {
 } from '../../../edit/components/AddEntityDialog';
 import {ENTITIES, MAX_RECENT_ENTITIES} from '../../constants';
 import mbEntity from '../../entity';
-import commaOnlyList from '../../i18n/commaOnlyList';
+import {commaOnlyListText} from '../../i18n/commaOnlyList';
 import localizeLanguageName from '../../i18n/localizeLanguageName';
 import {reduceArtistCredit} from '../../immutable-entities';
 import MB from '../../MB';
@@ -32,7 +32,7 @@ import {
   isRelationshipEditor,
 } from '../../utility/privileges';
 import {localStorage} from '../../utility/storage';
-import bracketed, {bracketedText} from '../../utility/bracketed';
+import {bracketedText} from '../../utility/bracketed';
 
 import '../../../../lib/jquery-ui';
 
@@ -674,7 +674,8 @@ MB.Control.autocomplete_formatters = {
 
     if (comment.length) {
       a.append(' <span class="autocomplete-comment">' +
-               he.escape(bracketed(commaOnlyList(comment))) + '</span>');
+               he.escape(bracketedText(commaOnlyListText(comment))) +
+               '</span>');
     }
 
     return $('<li>').append(a).appendTo(ul);
@@ -714,7 +715,7 @@ MB.Control.autocomplete_formatters = {
       a.append(
         '<br /><span class="autocomplete-appears">' +
         he.escape(addColonText(l('appears on'))) + ' ' +
-        he.escape(commaOnlyList(rgs)) + '</span>',
+        he.escape(commaOnlyListText(rgs)) + '</span>',
       );
     } else if (item.appearsOn && item.appearsOn.hits === 0) {
       a.append(
@@ -727,7 +728,7 @@ MB.Control.autocomplete_formatters = {
       a.append(
         '<br /><span class="autocomplete-isrcs">' +
         he.escape(addColonText(l('ISRCs'))) + ' ' +
-        he.escape(commaOnlyList(item.isrcs.map(isrc => isrc.isrc))) +
+        he.escape(commaOnlyListText(item.isrcs.map(isrc => isrc.isrc))) +
         '</span>',
       );
     }
@@ -835,7 +836,9 @@ MB.Control.autocomplete_formatters = {
     if (item.type) {
       a.append(
         ' <span class="autocomplete-comment">' +
-        he.escape(bracketedText(lp_attributes(item.type.name, 'series_type'))) +
+        he.escape(
+          bracketedText(lp_attributes(item.type.name, 'series_type')),
+        ) +
         '</span>',
       );
     }
@@ -850,7 +853,7 @@ MB.Control.autocomplete_formatters = {
     if (item.languages && item.languages.length) {
       a.prepend(
         '<span class="autocomplete-language">' +
-        he.escape(commaOnlyList(
+        he.escape(commaOnlyListText(
           item.languages.map(wl => localizeLanguageName(wl.language, true)),
         )) + '</span>',
       );
@@ -866,7 +869,8 @@ MB.Control.autocomplete_formatters = {
 
     if (comment.length) {
       a.append(' <span class="autocomplete-comment">' +
-               he.escape(bracketed(commaOnlyList(comment))) + '</span>');
+               he.escape(bracketedText(commaOnlyListText(comment))) +
+               '</span>');
     }
 
     if (item.typeName) {
@@ -886,7 +890,7 @@ MB.Control.autocomplete_formatters = {
 
         a.append(
           '<br /><span class="autocomplete-comment">' +
-          prefix + ': ' + he.escape(commaOnlyList(toRender)) + '</span>',
+          prefix + ': ' + he.escape(commaOnlyListText(toRender)) + '</span>',
         );
       }
     };
@@ -916,7 +920,7 @@ MB.Control.autocomplete_formatters = {
         items.push(renderContainingAreas(item));
       }
       a.append('<br /><span class="autocomplete-comment">' +
-               he.escape(commaOnlyList(items)) + '</span>');
+               he.escape(commaOnlyListText(items)) + '</span>');
     }
 
     return $('<li>').append(a).appendTo(ul);
@@ -937,7 +941,8 @@ MB.Control.autocomplete_formatters = {
 
     if (comment.length) {
       a.append(' <span class="autocomplete-comment">' +
-               he.escape(bracketed(commaOnlyList(comment))) + '</span>');
+               he.escape(bracketedText(commaOnlyListText(comment))) +
+               '</span>');
     }
 
     var area = item.area;
@@ -953,7 +958,7 @@ MB.Control.autocomplete_formatters = {
         }
       }
       a.append('<br /><span class="autocomplete-comment">' +
-               he.escape(commaOnlyList(items)) + '</span>');
+               he.escape(commaOnlyListText(items)) + '</span>');
     }
 
     return $('<li>').append(a).appendTo(ul);
@@ -978,7 +983,8 @@ MB.Control.autocomplete_formatters = {
 
     if (comment.length) {
       a.append(' <span class="autocomplete-comment">' +
-               he.escape(bracketed(commaOnlyList(comment))) + '</span>');
+               he.escape(bracketedText(commaOnlyListText(comment))) +
+               '</span>');
     }
 
     if (item.description) {
@@ -1007,7 +1013,8 @@ MB.Control.autocomplete_formatters = {
 
     if (comment.length) {
       a.append(' <span class="autocomplete-comment">' +
-               he.escape(bracketed(commaOnlyList(comment))) + '</span>');
+               he.escape(bracketedText(commaOnlyListText(comment))) +
+               '</span>');
     }
 
     if (item.typeName) {
@@ -1035,7 +1042,7 @@ MB.Control.autocomplete_formatters = {
 
         a.append(
           '<br /><span class="autocomplete-comment">' +
-          prefix + ': ' + he.escape(commaOnlyList(toRender)) + '</span>',
+          prefix + ': ' + he.escape(commaOnlyListText(toRender)) + '</span>',
         );
       }
     };
@@ -1072,7 +1079,7 @@ function renderContainingAreas(area) {
   if (!area.containment) {
     return '';
   }
-  return commaOnlyList(area.containment.map(x => x.name));
+  return commaOnlyListText(area.containment.map(x => x.name));
 }
 
 /*

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -713,7 +713,7 @@ MB.Control.autocomplete_formatters = {
 
       a.append(
         '<br /><span class="autocomplete-appears">' +
-        he.escape(addColon(l('appears on'))) + ' ' +
+        he.escape(addColonText(l('appears on'))) + ' ' +
         he.escape(commaOnlyList(rgs)) + '</span>',
       );
     } else if (item.appearsOn && item.appearsOn.hits === 0) {
@@ -726,7 +726,7 @@ MB.Control.autocomplete_formatters = {
     if (item.isrcs && item.isrcs.length) {
       a.append(
         '<br /><span class="autocomplete-isrcs">' +
-        he.escape(addColon(l('ISRCs'))) + ' ' +
+        he.escape(addColonText(l('ISRCs'))) + ' ' +
         he.escape(commaOnlyList(item.isrcs.map(isrc => isrc.isrc))) +
         '</span>',
       );
@@ -872,7 +872,7 @@ MB.Control.autocomplete_formatters = {
     if (item.typeName) {
       a.append(
         '<br /><span class="autocomplete-comment">' +
-        he.escape(addColon(l('Type')) + ' ' +
+        he.escape(addColonText(l('Type')) + ' ' +
         lp_attributes(item.typeName, 'work_type')) + '</span>',
       );
     }

--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -32,7 +32,7 @@ import {
   isRelationshipEditor,
 } from '../../utility/privileges';
 import {localStorage} from '../../utility/storage';
-import bracketed from '../../utility/bracketed';
+import bracketed, {bracketedText} from '../../utility/bracketed';
 
 import '../../../../lib/jquery-ui';
 
@@ -690,7 +690,7 @@ MB.Control.autocomplete_formatters = {
 
     if (item.comment) {
       a.append('<span class="autocomplete-comment">' +
-               he.escape(bracketed(item.comment)) + '</span>');
+               he.escape(bracketedText(item.comment)) + '</span>');
     }
 
     if (item.video) {
@@ -803,12 +803,12 @@ MB.Control.autocomplete_formatters = {
 
     if (item.firstReleaseDate) {
       a.append('<span class="autocomplete-comment">' +
-               bracketed(item.firstReleaseDate) + '</span>');
+               bracketedText(item.firstReleaseDate) + '</span>');
     }
 
     if (item.comment) {
       a.append('<span class="autocomplete-comment">' +
-               he.escape(bracketed(item.comment)) + '</span>');
+               he.escape(bracketedText(item.comment)) + '</span>');
     }
 
     if (item.typeName) {
@@ -828,14 +828,14 @@ MB.Control.autocomplete_formatters = {
     if (item.comment) {
       a.append(
         '<span class="autocomplete-comment">' +
-        he.escape(bracketed(item.comment)) + '</span>',
+        he.escape(bracketedText(item.comment)) + '</span>',
       );
     }
 
     if (item.type) {
       a.append(
         ' <span class="autocomplete-comment">' +
-        he.escape(bracketed(lp_attributes(item.type.name, 'series_type'))) +
+        he.escape(bracketedText(lp_attributes(item.type.name, 'series_type'))) +
         '</span>',
       );
     }
@@ -904,7 +904,7 @@ MB.Control.autocomplete_formatters = {
 
     if (item.comment) {
       a.append('<span class="autocomplete-comment">' +
-               he.escape(bracketed(item.comment)) + '</span>');
+               he.escape(bracketedText(item.comment)) + '</span>');
     }
 
     if (item.typeName || (item.containment && item.containment.length)) {
@@ -1013,7 +1013,7 @@ MB.Control.autocomplete_formatters = {
     if (item.typeName) {
       a.append(
         ' <span class="autocomplete-comment">' +
-        he.escape(bracketed(lp_attributes(item.typeName, 'event_type'))) +
+        he.escape(bracketedText(lp_attributes(item.typeName, 'event_type'))) +
         '</span>',
       );
     }

--- a/root/static/scripts/common/components/ArtistRoles.js
+++ b/root/static/scripts/common/components/ArtistRoles.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 
-import commaOnlyList from '../i18n/commaOnlyList';
+import {commaOnlyListText} from '../i18n/commaOnlyList';
 import localizeArtistRoles from '../i18n/localizeArtistRoles';
 
 import CollapsibleList from './CollapsibleList';
@@ -35,7 +35,7 @@ const buildArtistRoleRow = (relation: RelationT) => {
             entity={relation.entity}
           />
         ),
-        roles: commaOnlyList(localizeArtistRoles(relation.roles)),
+        roles: commaOnlyListText(localizeArtistRoles(relation.roles)),
       })}
     </li>
   );

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -131,7 +131,7 @@ const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
     {' '}
     <DeletedLink
       allowNew={allowNew}
-      name={bracketed(l('info'), {type: '[]'})}
+      name={bracketedText(l('info'), {type: '[]'})}
     />
   </>
 );

--- a/root/static/scripts/common/components/Warning.js
+++ b/root/static/scripts/common/components/Warning.js
@@ -27,7 +27,7 @@ const Warning = ({
   >
     <WarningIcon />
     <p>
-      <strong>{addColon(l('Warning'))}</strong>
+      <strong>{addColonText(l('Warning'))}</strong>
       {' '}
       {message}
     </p>

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -65,7 +65,7 @@ import formatTrackLength from './utility/formatTrackLength';
     }
 
     entityTypeLabel() {
-      return addColon(ENTITY_NAMES[this.entityType]());
+      return addColonText(ENTITY_NAMES[this.entityType]());
     }
 
     html(...args) {

--- a/root/static/scripts/release-editor/dialogs.js
+++ b/root/static/scripts/release-editor/dialogs.js
@@ -11,7 +11,7 @@ import ko from 'knockout';
 import * as ReactDOMServer from 'react-dom/server';
 
 import {reduceArtistCredit} from '../common/immutable-entities';
-import bracketed from '../common/utility/bracketed';
+import {bracketedText} from '../common/utility/bracketed';
 import formatTrackLength from '../common/utility/formatTrackLength';
 import isBlank from '../common/utility/isBlank';
 import request from '../common/utility/request';
@@ -151,7 +151,7 @@ class SearchResult {
       entity: (
         <>
           <bdi>{this.name}</bdi>
-          {formatString ? ' ' + bracketed(formatString) : null}
+          {formatString ? ' ' + bracketedText(formatString) : null}
         </>
       ),
       artist: <bdi>{this.artist}</bdi>,

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -745,7 +745,7 @@ class Medium {
   confirmMediumTitleMessage() {
     const name = this.name();
 
-    return exp.l(
+    return texp.l(
       'I confirm this medium is actually titled “{medium_title}”.',
       {medium_title: name},
     );

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -47,7 +47,7 @@ const Edits = ({
       <table className="database-statistics">
         <tbody>
           <tr>
-            <th colSpan="2">{addColon(l('Edits'))}</th>
+            <th colSpan="2">{addColonText(l('Edits'))}</th>
             <td>
               {formatCount($c, stats['count.edit'])}
               {' '}

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -702,7 +702,7 @@ const Index = ({
             <th colSpan="4">{l('Types')}</th>
           </tr>
           <tr>
-            <th colSpan="2">{addColon(l('Labels'))}</th>
+            <th colSpan="2">{addColonText(l('Labels'))}</th>
             <td>{fc('label')}</td>
             <td />
           </tr>
@@ -1283,25 +1283,25 @@ const Index = ({
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{addColon(lp('Approve', 'vote'))}</th>
+            <th colSpan="3">{addColonText(lp('Approve', 'vote'))}</th>
             <td>{fc('vote.approve')}</td>
             <td>{fp('vote.approve', 'vote')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{addColon(lp('Yes', 'vote'))}</th>
+            <th colSpan="3">{addColonText(lp('Yes', 'vote'))}</th>
             <td>{fc('vote.yes')}</td>
             <td>{fp('vote.yes', 'vote')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{addColon(lp('No', 'vote'))}</th>
+            <th colSpan="3">{addColonText(lp('No', 'vote'))}</th>
             <td>{fc('vote.no')}</td>
             <td>{fp('vote.no', 'vote')}</td>
           </tr>
           <tr>
             <th />
-            <th colSpan="3">{addColon(lp('Abstain', 'vote'))}</th>
+            <th colSpan="3">{addColonText(lp('Abstain', 'vote'))}</th>
             <td>{fc('vote.abstain')}</td>
             <td>{fp('vote.abstain', 'vote')}</td>
           </tr>

--- a/root/user/UserCollections.js
+++ b/root/user/UserCollections.js
@@ -59,8 +59,8 @@ function formatCollaboratorNumber(
   );
 
   return isCollaborator ? (
-    exp.l('{collaborator_number} (including you)',
-          {collaborator_number: collaborators.length})
+    texp.l('{collaborator_number} (including you)',
+           {collaborator_number: collaborators.length})
   ) : (
     collaborators.length
   );
@@ -181,7 +181,7 @@ const UserCollections = ({
           {viewingOwnProfile ? (
             l('You have no collections.')
           ) : (
-            exp.l('{user} has no public collections.', {user: user.name})
+            texp.l('{user} has no public collections.', {user: user.name})
           )}
         </p>
       )}
@@ -202,8 +202,8 @@ const UserCollections = ({
           {viewingOwnProfile ? (
             l('You aren’t collaborating in any collections.')
           ) : (
-            exp.l('{user} isn’t collaborating in any public collections.',
-                  {user: user.name})
+            texp.l('{user} isn’t collaborating in any public collections.',
+                   {user: user.name})
           )}
         </p>
       )}

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -186,7 +186,7 @@ const UserProfileInformation = ({
               {viewingOwnProfile ? email : l('(hidden)')}
               {' '}
               {nonEmpty(user.email_confirmation_date) ? (
-                exp.l('(verified at {date})', {
+                texp.l('(verified at {date})', {
                   date: formatUserDate($c, user.email_confirmation_date),
                 })
               ) : (


### PR DESCRIPTION
This uses `addColonText`, `bracketedText`, `commaOnlyListText` and `texp` instead of the generic versions where it seemed sensible.