### PR TITLE
MBS-12121: Actually show parent changes in EditRelationshipType

### DIFF
--- a/root/edit/details/EditRelationshipType.js
+++ b/root/edit/details/EditRelationshipType.js
@@ -106,7 +106,7 @@ const EditRelationshipType = ({
   const documentation = display.documentation;
   const deprecated = display.is_deprecated;
   const hasDates = display.has_dates;
-  const parentId = display.parent_id;
+  const parent = display.parent;
   const linkPhrase = display.link_phrase;
   const reverseLinkPhrase = display.reverse_link_phrase;
   const longLinkPhrase = display.long_link_phrase;
@@ -299,11 +299,11 @@ const EditRelationshipType = ({
           </tr>
         ) : null}
 
-        {parentId ? (
+        {parent ? (
           <FullChangeDiff
             label={l('Parent:')}
-            newContent={parentId.new}
-            oldContent={parentId.old}
+            newContent={parent.new ? <EntityLink entity={parent.new} /> : ''}
+            oldContent={parent.old ? <EntityLink entity={parent.old} /> : ''}
           />
         ) : null}
 

--- a/root/types/edit_types.js
+++ b/root/types/edit_types.js
@@ -861,7 +861,7 @@ declare type EditRelationshipTypeEditT = $ReadOnly<{
     +long_link_phrase?: CompT<string>,
     +name: CompT<string>,
     +orderable_direction?: CompT<number>,
-    +parent_id?: CompT<number | string>,
+    +parent?: CompT<LinkTypeT | null>,
     +relationship_type: LinkTypeT,
     +reverse_link_phrase: CompT<string>,
   },


### PR DESCRIPTION
### Fix MBS-12121

This was actually passing `parent`, not `parentId`, so the previous setup didn't work at all. `parent` seems better anyway (if we can show a link why not show a link), so this just actually uses it.

Tested by just checking the edit search for Edit relationship type changes.