### PR TITLE
MBS-12125: Allow admins to see all users with specific privileges

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -709,30 +709,30 @@ sub privileged : Path('/privileged')
 {
     my ($self, $c) = @_;
 
-    my @bots = $c->model('Editor')->find_by_privileges($BOT_FLAG);
-    my @auto_editors = $c->model('Editor')->find_by_privileges($AUTO_EDITOR_FLAG);
-    my @transclusion_editors = $c->model('Editor')->find_by_privileges($WIKI_TRANSCLUSION_FLAG);
-    my @relationship_editors = $c->model('Editor')->find_by_privileges($RELATIONSHIP_EDITOR_FLAG);
-    my @location_editors = $c->model('Editor')->find_by_privileges($LOCATION_EDITOR_FLAG);
-    my @banner_editors = $c->model('Editor')->find_by_privileges($BANNER_EDITOR_FLAG);
-    my @account_admins = $c->model('Editor')->find_by_privileges($ACCOUNT_ADMIN_FLAG);
+    my ($bots, undef) = $c->model('Editor')->find_by_privileges($BOT_FLAG);
+    my ($auto_editors, undef) = $c->model('Editor')->find_by_privileges($AUTO_EDITOR_FLAG);
+    my ($transclusion_editors, undef) = $c->model('Editor')->find_by_privileges($WIKI_TRANSCLUSION_FLAG);
+    my ($relationship_editors, undef) = $c->model('Editor')->find_by_privileges($RELATIONSHIP_EDITOR_FLAG);
+    my ($location_editors, undef) = $c->model('Editor')->find_by_privileges($LOCATION_EDITOR_FLAG);
+    my ($banner_editors, undef) = $c->model('Editor')->find_by_privileges($BANNER_EDITOR_FLAG);
+    my ($account_admins, undef) = $c->model('Editor')->find_by_privileges($ACCOUNT_ADMIN_FLAG);
 
-    $c->model('Editor')->load_preferences(@bots);
-    $c->model('Editor')->load_preferences(@auto_editors);
-    $c->model('Editor')->load_preferences(@transclusion_editors);
-    $c->model('Editor')->load_preferences(@relationship_editors);
-    $c->model('Editor')->load_preferences(@location_editors);
-    $c->model('Editor')->load_preferences(@banner_editors);
-    $c->model('Editor')->load_preferences(@account_admins);
+    $c->model('Editor')->load_preferences(@$bots);
+    $c->model('Editor')->load_preferences(@$auto_editors);
+    $c->model('Editor')->load_preferences(@$transclusion_editors);
+    $c->model('Editor')->load_preferences(@$relationship_editors);
+    $c->model('Editor')->load_preferences(@$location_editors);
+    $c->model('Editor')->load_preferences(@$banner_editors);
+    $c->model('Editor')->load_preferences(@$account_admins);
 
     my %props = (
-        bots => to_json_array(\@bots),
-        autoEditors => to_json_array(\@auto_editors),
-        transclusionEditors => to_json_array(\@transclusion_editors),
-        relationshipEditors => to_json_array(\@relationship_editors),
-        locationEditors => to_json_array(\@location_editors),
-        bannerEditors => to_json_array(\@banner_editors),
-        accountAdmins => to_json_array(\@account_admins),
+        bots => to_json_array($bots),
+        autoEditors => to_json_array($auto_editors),
+        transclusionEditors => to_json_array($transclusion_editors),
+        relationshipEditors => to_json_array($relationship_editors),
+        locationEditors => to_json_array($location_editors),
+        bannerEditors => to_json_array($banner_editors),
+        accountAdmins => to_json_array($account_admins),
     );
 
     $c->stash(

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -221,12 +221,23 @@ sub find_by_area {
 
 sub find_by_privileges
 {
-    my ($self, $privs) = @_;
+    my ($self, $privs, $exact_only, $limit, $offset) = @_;
+
+    my $condition;
+    my $args;
+    if ($exact_only) {
+        $condition = 'privs = ?';
+        $args = [$privs];
+    } else {
+        $condition = '(privs & ?) = ?';
+        $args = [($privs) x 2];
+    }
+
     my $query = 'SELECT ' . $self->_columns . '
-                 FROM ' . $self->_table . '
-                 WHERE (privs & ?) > 0
-                 ORDER BY editor.name, editor.id';
-    $self->query_to_list($query, [$privs]);
+                 FROM ' . $self->_table . "
+                 WHERE $condition
+                 ORDER BY editor.name, editor.id";
+    $self->query_to_list_limited($query, $args, $limit, $offset);
 }
 
 sub find_by_subscribed_editor

--- a/lib/MusicBrainz/Server/Form/Admin/PrivilegeSearch.pm
+++ b/lib/MusicBrainz/Server/Form/Admin/PrivilegeSearch.pm
@@ -1,0 +1,75 @@
+package MusicBrainz::Server::Form::Admin::PrivilegeSearch;
+
+use HTML::FormHandler::Moose;
+
+extends 'MusicBrainz::Server::Form';
+
+has '+name' => ( default => 'privilege-search' );
+
+has_field 'auto_editor' => (
+    type => 'Boolean',
+);
+
+has_field 'bot' => (
+    type => 'Boolean',
+);
+
+has_field 'untrusted' => (
+    type => 'Boolean',
+);
+
+has_field 'spammer' => (
+    type => 'Boolean',
+);
+
+has_field 'link_editor' => (
+    type => 'Boolean',
+);
+
+has_field 'location_editor' => (
+    type => 'Boolean',
+);
+
+has_field 'no_nag' => (
+    type => 'Boolean',
+);
+
+has_field 'wiki_transcluder' => (
+    type => 'Boolean',
+);
+
+has_field 'banner_editor' => (
+    type => 'Boolean',
+);
+
+has_field 'mbid_submitter' => (
+    type => 'Boolean',
+);
+
+has_field 'account_admin' => (
+    type => 'Boolean',
+);
+
+has_field 'editing_disabled' => (
+    type => 'Boolean',
+);
+
+has_field 'adding_notes_disabled' => (
+    type => 'Boolean',
+);
+
+has_field 'show_exact' => (
+    type => 'Boolean',
+);
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/root/admin/PrivilegeSearch.js
+++ b/root/admin/PrivilegeSearch.js
@@ -1,0 +1,160 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2021 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import FormRowCheckbox from '../components/FormRowCheckbox';
+import FormSubmit from '../components/FormSubmit';
+import PaginatedResults from '../components/PaginatedResults';
+import Layout from '../layout';
+
+import UserList from './components/UserList';
+
+type Props = {
+  +form: FormT<{
+    +account_admin: ReadOnlyFieldT<boolean>,
+    +adding_notes_disabled: ReadOnlyFieldT<boolean>,
+    +auto_editor: ReadOnlyFieldT<boolean>,
+    +banner_editor: ReadOnlyFieldT<boolean>,
+    +bot: ReadOnlyFieldT<boolean>,
+    +editing_disabled: ReadOnlyFieldT<boolean>,
+    +link_editor: ReadOnlyFieldT<boolean>,
+    +location_editor: ReadOnlyFieldT<boolean>,
+    +mbid_submitter: ReadOnlyFieldT<boolean>,
+    +no_nag: ReadOnlyFieldT<boolean>,
+    +show_exact: ReadOnlyFieldT<boolean>,
+    +spammer: ReadOnlyFieldT<boolean>,
+    +untrusted: ReadOnlyFieldT<boolean>,
+    +wiki_transcluder: ReadOnlyFieldT<boolean>,
+  }>,
+  +pager?: PagerT,
+  +results: $ReadOnlyArray<UnsanitizedEditorT> | null,
+};
+
+const PrivilegeSearch = ({
+  form,
+  pager,
+  results,
+}: Props): React.Element<typeof Layout> => (
+  <Layout fullWidth title={l('Search users by privileges')}>
+    <div id="content">
+      <h1>{l('Search users by privileges')}</h1>
+
+      <form action="/admin/privilege-search" method="get">
+        <p>
+          {l(`Select the flags you want to match. Editors which have
+              other flags in addition to the selected ones will also be shown,
+              unless you select “Exact match only” below.`)}
+        </p>
+
+        <div className="checkbox-block">
+          <FormRowCheckbox
+            field={form.field.show_exact}
+            label={l('Exact match only')}
+            uncontrolled
+          />
+        </div>
+
+        <h2>{l('User permissions')}</h2>
+        <div className="checkbox-block">
+          <FormRowCheckbox
+            field={form.field.auto_editor}
+            label={l('Auto-editor')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.wiki_transcluder}
+            label={l('Transclusion editor')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.link_editor}
+            label={l('Relationship editor')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.location_editor}
+            label={l('Location editor')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.banner_editor}
+            label={l('Banner message editor')}
+            uncontrolled
+          />
+        </div>
+
+        <h2>{l('User sanctions')}</h2>
+        <div className="checkbox-block">
+          <FormRowCheckbox
+            field={form.field.spammer}
+            label={l('Spammer')}
+            uncontrolled
+          />
+
+          <FormRowCheckbox
+            field={form.field.editing_disabled}
+            label={l('Editing/voting disabled')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.adding_notes_disabled}
+            label={l('Edit notes disabled')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.untrusted}
+            label={l('Untrusted')}
+            uncontrolled
+          />
+        </div>
+
+        <h2>{l('Technical flags')}</h2>
+        <div className="checkbox-block">
+          <FormRowCheckbox
+            field={form.field.bot}
+            label={l('Bot')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.no_nag}
+            label={l('No nag')}
+            uncontrolled
+          />
+        </div>
+
+        <h2>{l('Administration flags')}</h2>
+        <div className="checkbox-block">
+          <FormRowCheckbox
+            field={form.field.mbid_submitter}
+            label={l('MBID submitter')}
+            uncontrolled
+          />
+          <FormRowCheckbox
+            field={form.field.account_admin}
+            label={l('Account admin')}
+            uncontrolled
+          />
+        </div>
+
+        <div className="row no-margin">
+          <FormSubmit label={l('Search')} />
+        </div>
+
+        {pager ? (
+          <PaginatedResults pager={pager}>
+            <UserList users={results || []} />
+          </PaginatedResults>
+        ) : null}
+      </form>
+    </div>
+  </Layout>
+);
+
+export default PrivilegeSearch;

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -168,6 +168,9 @@ const AdminMenu = ({user}: UserProp) => (
             <a href="/admin/email-search">{l('Email Search')}</a>
           </li>
           <li>
+            <a href="/admin/privilege-search">{l('Privilege Search')}</a>
+          </li>
+          <li>
             <a href="/admin/locked-usernames/search">
               {l('Locked Username Search')}
             </a>

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -41,6 +41,7 @@ module.exports = {
   'admin/IpLookup': require('../admin/IpLookup'),
   'admin/LockedUsernameSearch': require('../admin/LockedUsernameSearch'),
   'admin/LockedUsernameUnlock': require('../admin/LockedUsernameUnlock'),
+  'admin/PrivilegeSearch': require('../admin/PrivilegeSearch'),
   'admin/attributes/Attribute': require('../admin/attributes/Attribute'),
   'admin/attributes/CannotRemoveAttribute': require('../admin/attributes/CannotRemoveAttribute'),
   'admin/attributes/Index': require('../admin/attributes/Index'),

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -96,6 +96,13 @@ div.form-row-add {
 /* these rows are missing a <label> on the left and use a margin instead. */
 div.form-row-add.nolabel { margin-left: @form-label-width + @form-margin; }
 
+div.form-row-add.nolabel { margin-left: @form-label-width + @form-margin; }
+
+form div.checkbox-block div.row {
+    display: inline-block;
+    margin-left: 0;
+}
+
 .bubble {
     display: none;
     position: absolute;
@@ -156,6 +163,10 @@ form div.no-label,
 form p.no-label,
 form ul.errors {
     margin-left: @form-label-width + @form-margin;
+}
+
+form div.no-margin {
+    margin-left: 0;
 }
 
 #collaborators-form-list ul.errors { margin-left: 0; }

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
@@ -1,0 +1,116 @@
+package t::MusicBrainz::Server::Controller::Admin::PrivilegeSearch;
+use Test::Routine;
+use Test::More;
+use MusicBrainz::Server::Test qw( test_xpath_html );
+
+with 't::Mechanize', 't::Context';
+
+=head2 Test description
+
+This test checks whether the privilege search works as expected, and whether
+it's blocked for non-admins.
+
+=cut
+
+test 'Privilege search is blocked for non-admins' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+privileges');
+
+    $mech->get('/login');
+    $mech->submit_form( with_fields => { username => 'normal_editor', password => 'password' } );
+
+    $mech->get('/admin/privilege-search');
+    is(
+        $mech->status,
+        403,
+        'Normal user cannot access the privilege search page',
+    );
+};
+
+test 'Test privilege search results' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+privileges');
+
+    $mech->get('/login');
+    $mech->submit_form( with_fields => { username => 'admin', password => 'password' } );
+
+    $mech->get_ok(
+        '/admin/privilege-search',
+        'Admin can access the privilege search page',
+    );
+
+    $mech->get_ok(
+        '/admin/privilege-search?privilege-search.auto_editor=1',
+        'Fetch results for autoeditor search (not exact)',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the user list',
+    );
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the user list',
+    );
+    $tx->ok(
+        '//table[@class="tbl"]/tbody/tr/td[contains(.,"relationship_editor")]',
+        'An editor with more flags than just autoeditor is still shown',
+    );
+
+    $mech->get_ok(
+        '/admin/privilege-search?privilege-search.show_exact=1&privilege-search.auto_editor=1',
+        'Fetch results for autoeditor search (exact)',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the user list',
+    );
+    $tx->not_ok(
+        '//table[@class="tbl"]/tbody/tr/td[contains(.,"relationship_editor")]',
+        'An editor with more flags than just autoeditor is not shown',
+    );
+
+    $mech->get_ok(
+        '/admin/privilege-search?privilege-search.auto_editor=1&privilege-search.link_editor=1',
+        'Fetch results for autoeditor + relationship editor search (not exact)',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the user list',
+    );
+    $tx->ok(
+        '//table[@class="tbl"]/tbody/tr/td[contains(.,"admin")]',
+        'An editor with more flags than just autoeditor and relationship editor is still shown',
+    );
+
+    $mech->get_ok(
+      '/admin/privilege-search?privilege-search.show_exact=1&privilege-search.auto_editor=1&privilege-search.link_editor=1',
+      'Fetch results for autoeditor + relationship editor search (exact)',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the user list',
+    );
+    $tx->not_ok(
+        '//table[@class="tbl"]/tbody/tr/td[contains(.,"admin")]',
+        'An editor with more flags than just autoeditor and relationship editor is not shown',
+    );
+};
+
+1;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -84,6 +84,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Admin::email_search',
   'Controller::Admin::ip_lookup',
   'Controller::Admin::locked_username_search',
+  'Controller::Admin::privilege_search',
   'Controller::Admin::unlock_username',
   'Controller::Ajax::filter_artist_recordings_form',
   'Controller::Ajax::filter_artist_release_groups_form',

--- a/t/sql/privileges.sql
+++ b/t/sql/privileges.sql
@@ -1,0 +1,10 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO editor (id, name, privs, password, ha1)
+    VALUES (1, 'normal_editor', 0, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
+           (2, 'autoeditor', 1, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
+           (3, 'bot', 2, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
+           -- Reminder: Editor #4 is ModBot
+           (5, 'relationship_editor', 1+8, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
+           (6, 'admin', 1+8+32+128+256+512, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8'),
+           (7, 'autoeditor_bot', 1+2, '{CLEARTEXT}password', 'aa550c5b01407ef1f3f0d16daf9ec3c8');


### PR DESCRIPTION
### Implement MBS-12125

This gives admins a good way to, for example, find all users who have been blocked from editing. Since I saw no reason to limit the amount of searchable flags, this includes all of them.