### PR TITLE
MBS-12137: Remove Gravatar

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -66,7 +66,6 @@ __PACKAGE__->config(
             'format_wikitext' => \&MusicBrainz::Server::Filters::format_wikitext,
             'format_editnote' => \&MusicBrainz::Server::Filters::format_editnote,
             'locale' => \&MusicBrainz::Server::Filters::locale,
-            'gravatar' => \&MusicBrainz::Server::Filters::gravatar,
             'coverart_https' => \&MusicBrainz::Server::Filters::coverart_https
         },
         RECURSION => 1,
@@ -678,7 +677,6 @@ sub set_csp_headers {
         q('self'),
         'data:',
         'staticbrainz.org',
-        'gravatar.com',
     );
 
     my @csp_frame_src = ('frame-src', q('self'));

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -107,7 +107,7 @@ sub serialize_user {
     return {
         deleted => boolean_to_json($user->deleted),
         entityType => 'editor',
-        gravatar => $user->gravatar,
+        avatar => $user->avatar,
         id => 0 + $user->id,
         is_limited => boolean_to_json($user->is_limited),
         name => $user->name,

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -467,20 +467,12 @@ sub load_for_collection {
     return unless $id; # nothing to do
 
     $self->load($collection);
-    my $query = 'SELECT ' . $self->_columns . ', ep.value AS show_gravatar
+    my $query = 'SELECT ' . $self->_columns . '
                  FROM ' . $self->_table . "
                  JOIN editor_collection_collaborator ecc ON editor.id = ecc.editor
-                 LEFT JOIN editor_preference ep ON ep.editor = editor.id AND ep.name = 'show_gravatar'
                  WHERE ecc.collection = $id
                  ORDER BY editor.name, editor.id";
-    my @collaborators = $self->query_to_list($query, undef, sub {
-        my ($model, $row) = @_;
-
-        my $collaborator = $model->_new_from_row($row);
-        $collaborator->preferences->show_gravatar($row->{show_gravatar})
-            if defined $row->{show_gravatar};
-        $collaborator;
-    });
+    my @collaborators = $self->query_to_list($query);
 
     $collection->collaborators(\@collaborators);
 }

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -4,7 +4,6 @@ use namespace::autoclean;
 
 use Authen::Passphrase;
 use DateTime;
-use Digest::MD5 qw( md5_hex );
 use Encode;
 use MusicBrainz::Server::Constants qw( $PASSPHRASE_BCRYPT_COST );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json datetime_to_iso8601 );
@@ -275,15 +274,13 @@ sub new_privileged {
     );
 }
 
-sub gravatar {
+# TODO: Add support for returning avatars from Discourse.
+# (This should perhaps become an attribute instead of a method,
+# and be loaded from somewhere.)
+sub avatar {
     my $self = shift;
 
-    if ($self->preferences->show_gravatar && $self->email) {
-        my $hex = md5_hex(lc $self->email);
-        return "//gravatar.com/avatar/$hex?d=mm";
-    }
-
-    return '//gravatar.com/avatar/placeholder?d=mm';
+    return '';
 }
 
 sub _unsanitized_json {
@@ -323,9 +320,9 @@ sub TO_JSON {
     my ($self) = @_;
 
     return {
+        avatar => $self->avatar,
         deleted => boolean_to_json($self->deleted),
         entityType => 'editor',
-        gravatar => $self->gravatar,
         id => $self->id,
         is_limited => boolean_to_json($self->is_limited),
         name => $self->name,

--- a/lib/MusicBrainz/Server/Entity/Preferences.pm
+++ b/lib/MusicBrainz/Server/Entity/Preferences.pm
@@ -60,13 +60,6 @@ has 'subscriptions_email_period' => (
     lazy => 1,
 );
 
-has 'show_gravatar' => (
-    isa => 'Bool',
-    default => 0,
-    is => 'rw',
-    lazy => 1
-);
-
 sub TO_JSON {
     my ($self) = @_;
 
@@ -80,7 +73,6 @@ sub TO_JSON {
         public_ratings => boolean_to_json($self->public_ratings),
         public_subscriptions => boolean_to_json($self->public_subscriptions),
         public_tags => boolean_to_json($self->public_tags),
-        show_gravatar => boolean_to_json($self->show_gravatar),
         subscribe_to_created_artists => boolean_to_json($self->subscribe_to_created_artists),
         subscribe_to_created_labels => boolean_to_json($self->subscribe_to_created_labels),
         subscribe_to_created_series => boolean_to_json($self->subscribe_to_created_series),

--- a/lib/MusicBrainz/Server/Filters.pm
+++ b/lib/MusicBrainz/Server/Filters.pm
@@ -5,12 +5,10 @@ use utf8;
 use strict;
 use warnings;
 
-use Digest::MD5 qw( md5_hex );
 use Encode;
 use MusicBrainz::Server::Track;
 use MusicBrainz::Server::Validation qw( encode_entities );
 use MusicBrainz::Server::Constants qw( entities_with );
-use Text::Trim qw( trim );
 use Text::WikiFormat;
 use Try::Tiny;
 use URI::Escape;
@@ -165,11 +163,6 @@ sub locale
     catch {
         return;
     }
-}
-
-sub gravatar {
-    my $email = shift;
-    return sprintf '//gravatar.com/avatar/%s?d=mm', md5_hex(lc(trim($email)));
 }
 
 sub _amazon_https {

--- a/lib/MusicBrainz/Server/Form/User/Preferences.pm
+++ b/lib/MusicBrainz/Server/Form/User/Preferences.pm
@@ -22,8 +22,6 @@ has_field 'subscribe_to_created_artists' => ( type => 'Boolean' );
 has_field 'subscribe_to_created_labels' => ( type => 'Boolean' );
 has_field 'subscribe_to_created_series' => ( type => 'Boolean' );
 
-has_field 'show_gravatar' => ( type => 'Boolean' );
-
 has_field 'subscriptions_email_period' => (
     type => 'Select',
     required => 1,

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -16,9 +16,9 @@ import sanitizedEditor from '../utility/sanitizedEditor';
 import UserAccountTabs from './UserAccountTabs';
 
 export type AccountLayoutUserT = {
+  +avatar: string,
   +deleted: boolean,
   +entityType: 'editor',
-  +gravatar: string,
   +id: number,
   +is_limited: boolean,
   +name: string,

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -287,7 +287,7 @@ END -%]
             CASE 'show_dates';
                 content _ bracketedWithSpace(dates);
             CASE 'avatar'; # add. parameter: avatar
-                '<img src="' _ avatar _ '" height="' _ image_size _ '" width="' _ image_size _ '" class="gravatar" alt="" />' _ content;
+                '<img src="' _ avatar _ '" height="' _ image_size _ '" width="' _ image_size _ '" class="avatar" alt="" />' _ content;
             CASE 'video';
                 '<span class="video" title="' _ html_escape(l('This recording is a video')) _ '"></span>' _ content;
         END;
@@ -446,17 +446,10 @@ END -%]
     INCLUDE _link_other_entity content=text action=action type='cdstub' default_content=cdstub.discid;
 END -%]
 
-[%~ MACRO gravatar(email) FILTER gravatar; email; END -%]
-
 [%~ MACRO link_editor(editor, action, text, size) BLOCK;
     DEFAULT action = 'profile';
     DEFAULT size = 12;
-    IF editor.preferences.show_gravatar;
-      image_url = gravatar(editor.email) _ '&amp;s=' _ size*2;
-    ELSE;
-      image_url = '//gravatar.com/avatar/placeholder?d=mm&amp;s=' _ size*2;
-    END;
-    INCLUDE _link_other_entity content=text action=action type='user' default_content=editor.name avatar=image_url image_size=size;
+    INCLUDE _link_other_entity content=text action=action type='user' default_content=editor.name avatar=editor.avatar image_size=size;
 END -%]
 
 [%~ MACRO link_edit(edit, action, text) BLOCK; # Converted to React at root/static/scripts/common/components/EditLink.js

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -28,7 +28,6 @@ type PreferencesFormT = FormT<{
   +public_ratings: FieldT<boolean>,
   +public_subscriptions: FieldT<boolean>,
   +public_tags: FieldT<boolean>,
-  +show_gravatar: FieldT<boolean>,
   +subscribe_to_created_artists: FieldT<boolean>,
   +subscribe_to_created_labels: FieldT<boolean>,
   +subscribe_to_created_series: FieldT<boolean>,
@@ -198,11 +197,6 @@ class PreferencesForm extends React.Component<Props, State> {
           <FormRowCheckbox
             field={field.public_ratings}
             label={l('Allow other users to see my ratings')}
-            uncontrolled
-          />
-          <FormRowCheckbox
-            field={field.show_gravatar}
-            label={l('Show my Gravatar')}
             uncontrolled
           />
         </fieldset>

--- a/root/static/scripts/common/components/EditorLink.js
+++ b/root/static/scripts/common/components/EditorLink.js
@@ -51,19 +51,14 @@ const EditorLink = ({
     avatarSize = 12;
   }
 
-  let gravatar;
-  if (editor.gravatar) {
-    gravatar = editor.gravatar + '&s=' + (avatarSize * 2);
-  }
-
   return (
     <a href={entityHref(editor, subPath)}>
-      {gravatar ? (
+      {nonEmpty(editor.avatar) ? (
         <img
           alt=""
-          className="gravatar"
+          className="avatar"
           height={avatarSize}
-          src={gravatar}
+          src={editor.avatar}
           width={avatarSize}
         />
       ) : null}

--- a/root/static/scripts/tests/autocomplete2.js
+++ b/root/static/scripts/tests/autocomplete2.js
@@ -70,8 +70,8 @@ $(function () {
   }
 
   const activeUser = {
+    avatar: '',
     entityType: 'editor',
-    gravatar: '',
     has_confirmed_email_address: true,
     id: 1,
     name: 'user',

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -150,7 +150,7 @@ table.vote-tally {
         background: @highlight-table-row;
     }
 
-    /* Adding voting icons to gravatars */
+    /* Adding voting icons to avatars */
     h3.Approve, h3.No, h3.Yes {
         position: relative;
 

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -176,7 +176,7 @@ pre code {
                 float: left;
                 ul.menu {
                     li {
-                        img.gravatar {
+                        img.avatar {
                             vertical-align: text-top;
                         }
                     }
@@ -318,7 +318,7 @@ pre code {
     }
 }
 
-img.gravatar {
+img.avatar {
     display: inline;
     max-height: 1em;
     vertical-align: middle;

--- a/root/types/editor.js
+++ b/root/types/editor.js
@@ -18,7 +18,7 @@ declare type ActiveEditorPreferencesT = {
  */
 declare type ActiveEditorT = {
   ...EntityRoleT<'editor'>,
-  +gravatar: string,
+  +avatar: string,
   +has_confirmed_email_address: boolean,
   +name: string,
   +preferences: ActiveEditorPreferencesT,
@@ -33,8 +33,8 @@ declare type EditorLanguageT = {
 // MusicBrainz::Server::Entity::Editor::TO_JSON
 declare type EditorT = {
   ...EntityRoleT<'editor'>,
+  +avatar: string,
   +deleted: boolean,
-  +gravatar: string,
   +is_limited: boolean,
   +name: string,
   +privileges: number,
@@ -54,7 +54,6 @@ declare type UnsanitizedEditorPreferencesT = {
   +public_ratings: boolean,
   +public_subscriptions: boolean,
   +public_tags: boolean,
-  +show_gravatar: boolean,
   +subscribe_to_created_artists: boolean,
   +subscribe_to_created_labels: boolean,
   +subscribe_to_created_series: boolean,
@@ -67,13 +66,13 @@ declare type UnsanitizedEditorT = $ReadOnly<{
   ...EntityRoleT<'editor'>,
   +age: number | null,
   +area: AreaT | null,
+  +avatar: string,
   +biography: string | null,
   +birth_date: PartialDateT | null,
   +deleted: boolean,
   +email: string | null,
   +email_confirmation_date: string | null,
   +gender: GenderT | null,
-  +gravatar: string,
   +has_confirmed_email_address: boolean,
   +has_email_address: boolean,
   +is_charter: boolean,

--- a/root/utility/activeSanitizedEditor.js
+++ b/root/utility/activeSanitizedEditor.js
@@ -15,7 +15,7 @@ function activeSanitizedEditor(
 ) /*: ActiveEditorT */ {
   return {
     entityType: 'editor',
-    gravatar: editor.gravatar,
+    avatar: editor.avatar,
     has_confirmed_email_address: editor.has_confirmed_email_address,
     id: editor.id,
     name: editor.name,

--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -43,7 +43,7 @@ if (__DEV__) {
   const sanitizedEditorProps = new Set([
     'deleted',
     'entityType',
-    'gravatar',
+    'avatar',
     'id',
     'is_limited',
     'name',

--- a/root/utility/sanitizedEditor.js
+++ b/root/utility/sanitizedEditor.js
@@ -35,7 +35,7 @@ function sanitizedEditor(
   return {
     deleted: editor.deleted,
     entityType: 'editor',
-    gravatar: editor.gravatar,
+    avatar: editor.avatar,
     id: editor.id,
     is_limited: editor.is_limited,
     name: editor.name,

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Users.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Users.pm
@@ -27,8 +27,6 @@ test 'MBS-6511: List of editors in the area' => sub {
     $test->c->sql->do(q{
         INSERT INTO editor (id, area, name, password, ha1, email)
         VALUES (666, 222, 'Editor 2', 'hunter2', '', 'hunter2@hotmail.com');
-        INSERT INTO editor_preference (id, editor, name, value)
-        VALUES (1, 666, 'show_gravatar', '1');
     });
 
     $mech->get_ok('/area/489ce91b-6658-3307-9877-795b68554c98/users');
@@ -36,7 +34,6 @@ test 'MBS-6511: List of editors in the area' => sub {
     $mech->content_contains('There are currently 2 users in this area');
     $mech->content_contains('Editor 1');
     $mech->content_contains('Editor 2');
-    $mech->content_contains('//gravatar.com/avatar/125f744ce5589e8582fba3a7acc1d1b8?d=mm&amp;s=24');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/OAuth2.pm
@@ -90,7 +90,7 @@ sub csp_headers_ok {
         q(frame-ancestors 'none'; ) .
         q(script-src 'self' 'nonce-[0-9A-Za-z\+/]{43}=' staticbrainz\.org; ) .
         q(style-src 'self' staticbrainz\.org; ) .
-        q(img-src 'self' data: staticbrainz\.org gravatar\.com; ) .
+        q(img-src 'self' data: staticbrainz\.org; ) .
         q(frame-src 'self');
     like($response->header('Content-Security-Policy'), qr{^$csp_pattern$});
 }


### PR DESCRIPTION
# MBS-12137

Related to MBS-9725.  Gravatar was scraped and email address hashes were cracked.  We should migrate away from their service.

I left in support for avatars in the codebase to minimize the amount of work required to add in support for Discourse avatars in the future.