### PR TITLE
MBS-12092: Serialize edit_action form after errors are added 

### DIFF
--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -153,11 +153,13 @@ sub edit_action
     $form_args{init_object} = $opts{item} if exists $opts{item};
     my $form = $c->form( form => $opts{form}, ctx => $c, %form_args );
 
-    $c->stash->{component_props}{form} = $form->TO_JSON;
     $opts{pre_validation}->($form) if exists $opts{pre_validation};
 
     if ($c->form_posted_and_valid($form, $c->req->body_params)) {
-        return if exists $opts{pre_creation} && !$opts{pre_creation}->($form);
+        if (exists $opts{pre_creation} && !$opts{pre_creation}->($form)) {
+            $c->stash->{component_props}{form} = $form->TO_JSON;
+            return;
+        }
 
         my @options = (map { $_->name => $_->value } $form->edit_fields);
         my %extra   = %{ $opts{edit_args} || {} };
@@ -183,6 +185,8 @@ sub edit_action
             }
         });
 
+        $c->stash->{component_props}{form} = $form->TO_JSON;
+
         if ($opts{redirect} && !$opts{no_redirect} &&
                 ($edit || !$c->stash->{makes_no_changes}) &&
                 !$c->stash->{needs_disambiguation} &&
@@ -198,6 +202,7 @@ sub edit_action
         $form->process( params => $merged );
         $form->clear_errors;
     }
+    $c->stash->{component_props}{form} = $form->TO_JSON;
 }
 
 sub _search_final_page

--- a/lib/MusicBrainz/Server/Controller/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Alias.pm
@@ -105,7 +105,6 @@ sub add_alias : Chained('load') PathPart('add-alias') Edit
         on_creation => sub { $self->_redir_to_aliases($c) },
         pre_validation => sub {
             my $form = shift;
-            $props{form} = $form->TO_JSON;
             $props{aliasTypes} = $form->options_type_id;
             $props{locales} = $form->options_locale;
         }
@@ -143,10 +142,6 @@ sub delete_alias : Chained('alias') PathPart('delete') Edit
                 entity => $c->stash->{ $self->{entity_name} }
             },
             on_creation => sub { $self->_redir_to_aliases($c) },
-            pre_validation => sub {
-                my $form = shift;
-                $props{form} = $form->TO_JSON;
-            }
         );
     });
 }
@@ -189,7 +184,6 @@ sub edit_alias : Chained('alias') PathPart('edit') Edit
         on_creation => sub { $self->_redir_to_aliases($c) },
         pre_validation => sub {
             my $form = shift;
-            $props{form} = $form->TO_JSON;
             $props{aliasTypes} = $form->options_type_id;
             $props{locales} = $form->options_locale;
         }


### PR DESCRIPTION
### Fix MBS-12092

Errors weren't being shown when a required edit note was missing, since the form was always being serialized before validation. This moves serialization to always happen after validation, but before the function returns.