### PR TITLE
Respond with Bad Request for "invalid session ID"

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -1,15 +1,18 @@
 package MusicBrainz::Server::Controller::Root;
+use Carp qw( croak );
 use Digest::MD5 qw( md5_hex );
 use Moose;
 use Try::Tiny;
 use List::AllUtils qw( max );
 use Readonly;
+use Scalar::Util qw( blessed );
 use URI::QueryParam;
 
 BEGIN { extends 'Catalyst::Controller' }
 
 # Import MusicBrainz libraries
 use DBDefs;
+use MusicBrainz::Errors qw( capture_exceptions );
 use MusicBrainz::Server::Constants qw( $VARTIST_GID $CONTACT_URL );
 use MusicBrainz::Server::ControllerUtils::SSL qw( ensure_ssl );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json type_to_model );
@@ -249,7 +252,28 @@ sub begin : Private
     $c->stats->enable(1) if DBDefs->DEVELOPMENT_SERVER;
 
     # Can we automatically login?
-    if (!$c->user) {
+    my $needs_login;
+    capture_exceptions(
+        # This may throw if someone sets an invalid musicbrainz_server_session
+        # cookie.  In that case we'd prefer to respond with Bad Request rather
+        # than Internal Server Error.  The exception is sent to Sentry in any
+        # case.
+        sub { $needs_login = !$c->user },
+        sub {
+            my $error = $_;
+            if (
+                blessed($error) &&
+                $error->isa('Catalyst::Exception') &&
+                $error->message =~ /^Tried to set invalid session ID/
+            ) {
+                $c->stash->{message} = $error->message;
+                $c->detach('/error_400');
+            } else {
+                croak $error;
+            }
+        },
+    );
+    if ($needs_login) {
         $c->forward('/user/cookie_login');
     }
 


### PR DESCRIPTION
If someone submits a ton of requests with invalid `musicbrainz_server_session` cookies, each request will trigger an internal server error (due to an exception being thrown by Catalyst).  We'd rather respond to these with Bad Request, while still logging them to Sentry, so they at least don't trigger any 5xx alerts.