### PR TITLE
MBS-12133: Allow % in jazzmusicarchives URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2370,7 +2370,7 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
-      const m = /^https:\/\/www\.jazzmusicarchives\.com\/(\w+)\/(?:[\w-]+\/)?[\w-]*$/.exec(url);
+      const m = /^https:\/\/www\.jazzmusicarchives\.com\/(\w+)\/(?:[\w%-]+\/)?[\w%-]*$/.exec(url);
       if (m) {
         const type = m[1];
         switch (id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2290,6 +2290,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'http://www.jazzmusicarchives.com/artist/peppino-d%E2%80%99agostino',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://www.jazzmusicarchives.com/artist/peppino-d%E2%80%99agostino',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://www.jazzmusicarchives.com/album/ron-carter/ron-carter-jack-dejohnette-and-gonzalo-rubalcaba-skyline#specialists-reviews',
              input_entity_type: 'release_group',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Fix MBS-12133

I didn't find any URL like this when originally writing the validation, but they do use % for escaping and those URLs are currently deemed invalid.