### PR TITLE
MBS-11655 / MBS-12136: Separate tag cloud into genre and non-genre tags, and add a text list

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -40,22 +40,34 @@ sub cloud : Path('/tags')
 {
     my ($self, $c, $name) = @_;
 
-    my $cloud = $c->model('Tag')->get_cloud(200);
-    my $hits = scalar @$cloud;
+    my $cloud = $c->model('Tag')->get_cloud();
+    my $genres = $cloud->{genres};
+    my $genre_hits = scalar @$genres;
+    my $tags = $cloud->{other_tags};
+    my $tag_hits = scalar @$tags;
 
     $c->stash(
         current_view => 'Node',
         component_path => 'tag/TagCloud',
         component_props => {
             %{$c->stash->{component_props}},
-            tagMaxCount => $hits ? $cloud->[0]->{count} + 0 : 0,
-            tags => $hits ? [
+            genreMaxCount => $genre_hits ? $genres->[0]->{count} + 0 : 0,
+            genres => $genre_hits ? [
                 map +{
                     count => $_->{count} + 0,
                     tag => to_json_object($_->{tag}),
                 },
                 sort { $a->{tag}->name cmp $b->{tag}->name }
-                @$cloud
+                @$genres
+            ] : [],
+            tagMaxCount => $tag_hits ? $tags->[0]->{count} + 0 : 0,
+            tags => $tag_hits ? [
+                map +{
+                    count => $_->{count},
+                    tag => to_json_object($_->{tag}),
+                },
+                sort { $a->{tag}->name cmp $b->{tag}->name }
+                @$tags
             ] : [],
         },
     );

--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -4,7 +4,7 @@ use Moose::Util qw( find_meta );
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
-use MusicBrainz::Server::Data::Utils qw( type_to_model );
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json type_to_model );
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
@@ -40,6 +40,8 @@ sub cloud : Path('/tags')
 {
     my ($self, $c, $name) = @_;
 
+    my $show_list = $c->req->params->{show_list} ? 1 : 0;
+
     my $cloud = $c->model('Tag')->get_cloud();
     my $genres = $cloud->{genres};
     my $genre_hits = scalar @$genres;
@@ -60,10 +62,11 @@ sub cloud : Path('/tags')
                 sort { $a->{tag}->name cmp $b->{tag}->name }
                 @$genres
             ] : [],
+            showList => boolean_to_json($show_list),
             tagMaxCount => $tag_hits ? $tags->[0]->{count} + 0 : 0,
             tags => $tag_hits ? [
                 map +{
-                    count => $_->{count},
+                    count => $_->{count} + 0,
                     tag => to_json_object($_->{tag}),
                 },
                 sort { $a->{tag}->name cmp $b->{tag}->name }

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -489,7 +489,9 @@ div.warning img.warning {
     }
 }
 
-#all-tags .tag-list li, #all-tags .genre-list li, .all-tags .tag-list li, .all-tags .genre-list li {
+#all-tags .tag-list li, #all-tags .genre-list li,
+.all-tags .tag-list li, .all-tags .genre-list li,
+.top-tag-list li {
     height: 24px;
     &.even { background: @even-table-row; }
 }

--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -11,12 +11,15 @@ import * as React from 'react';
 
 import Layout from '../layout';
 import TagLink from '../static/scripts/common/components/TagLink';
+import {sortByNumber} from '../static/scripts/common/utility/arrays';
 import {formatCount} from '../statistics/utilities';
+import loopParity from '../utility/loopParity';
 
 type Props = {
   +$c: CatalystContextT,
   +genreMaxCount: number,
   +genres: $ReadOnlyArray<AggregatedTagT>,
+  +showList?: boolean,
   +tagMaxCount: number,
   +tags: $ReadOnlyArray<AggregatedTagT>,
 };
@@ -64,22 +67,56 @@ function generateTagCloud($c, tags, maxCount) {
   );
 }
 
+function generateTagList($c, tags) {
+  const sortedTags = sortByNumber(tags, tag => -tag.count);
+  return (
+    <ul className="tag-list top-tag-list">
+      {sortedTags.map((tag, index) => (
+        <li className={loopParity(index)} key={tag.tag.id}>
+          <TagLink tag={tag.tag.name} />
+          <span className="tag-vote-buttons">
+            <span className="tag-count">{formatCount($c, tag.count)}</span>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 const TagCloud = ({
   $c,
   genreMaxCount,
   genres,
+  showList = false,
   tagMaxCount,
   tags,
 }: Props): React.Element<typeof Layout> => (
   <Layout fullWidth title={l('Tags')}>
     <div id="content">
-      <h1>{l('Genres')}</h1>
+      <h1>{l('Tags')}</h1>
+      <p>
+        {l('These are the most used genres and other tags in the database.')}
+        {' '}
+        {showList ? (
+          <a href="/tags?show_list=0">{l('Show as a cloud instead.')}</a>
+        ) : (
+          <a href="/tags?show_list=1">{l('Show as a list instead.')}</a>
+        )}
+      </p>
+
+      <h2>{l('Genres')}</h2>
       {genres.length ? (
-        generateTagCloud($c, genres, genreMaxCount)
+        showList
+          ? generateTagList($c, genres)
+          : generateTagCloud($c, genres, genreMaxCount)
+
       ) : l('No genre tags have been used yet.')}
-      <h1>{l('Other tags')}</h1>
+
+      <h2>{l('Other tags')}</h2>
       {tags.length ? (
-        generateTagCloud($c, tags, tagMaxCount)
+        showList
+          ? generateTagList($c, tags)
+          : generateTagCloud($c, tags, tagMaxCount)
       ) : l('No non-genre tags have been used yet.')}
     </div>
   </Layout>

--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -15,6 +15,8 @@ import {formatCount} from '../statistics/utilities';
 
 type Props = {
   +$c: CatalystContextT,
+  +genreMaxCount: number,
+  +genres: $ReadOnlyArray<AggregatedTagT>,
   +tagMaxCount: number,
   +tags: $ReadOnlyArray<AggregatedTagT>,
 };
@@ -42,33 +44,43 @@ function getTagSize(count: number, tagMaxCount: number) {
   return 'tag7';
 }
 
+function generateTagCloud($c, tags, maxCount) {
+  return (
+    <ul className="tag-cloud">
+      {tags.map(({count, tag}) => (
+        <li
+          className={getTagSize(count, maxCount)}
+          key={tag.name}
+          title={texp.l(
+            "'{tag}' has been used {num} times",
+            {num: formatCount($c, count), tag: tag.name},
+          )}
+        >
+          <TagLink tag={tag.name} />
+          {' '}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 const TagCloud = ({
   $c,
+  genreMaxCount,
+  genres,
   tagMaxCount,
   tags,
 }: Props): React.Element<typeof Layout> => (
   <Layout fullWidth title={l('Tags')}>
     <div id="content">
-      <h1>{l('Tags')}</h1>
-      <p>
-        {tags.length ? (
-          <ul className="tag-cloud">
-            {tags.map(({count, tag}) => (
-              <li
-                className={getTagSize(count, tagMaxCount)}
-                key={tag.name}
-                title={texp.l(
-                  "'{tag}' has been used {num} times",
-                  {num: formatCount($c, count), tag: tag.name},
-                )}
-              >
-                <TagLink tag={tag.name} />
-                {' '}
-              </li>
-            ))}
-          </ul>
-        ) : l('The database has no tags.')}
-      </p>
+      <h1>{l('Genres')}</h1>
+      {genres.length ? (
+        generateTagCloud($c, genres, genreMaxCount)
+      ) : l('No genre tags have been used yet.')}
+      <h1>{l('Other tags')}</h1>
+      {tags.length ? (
+        generateTagCloud($c, tags, tagMaxCount)
+      ) : l('No non-genre tags have been used yet.')}
     </div>
   </Layout>
 );


### PR DESCRIPTION
### Implement MBS-11655 / MBS-12136

See commit messages for details. Tested manually with `pink` data.