### PR TITLE
MBS-12132: Allow Apple Music music-video links for releases

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -821,7 +821,7 @@ const CLEANUPS: CleanupEntries = {
           case LINK_TYPES.downloadpurchase.release:
           case LINK_TYPES.streamingpaid.release:
             return {
-              result: prefix === 'album',
+              result: prefix === 'album' || prefix === 'music-video',
               target: ERROR_TARGETS.ENTITY,
             };
         }


### PR DESCRIPTION
### Implement MBS-12132

These have their own barcodes, so users feel they should be added as releases.
For the future, it would be good if `only_valid_entity_types` could also be validated against all options in `limited_link_type_combinations`.