### PR TITLE
MBS-12147: State that an email search had no results

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -159,12 +159,14 @@ sub email_search : Path('/admin/email-search') Args(0) RequireAuth(account_admin
 
     my $form = $c->form(form => 'Admin::EmailSearch');
     my @results;
+    my $searched = 0;
 
     if ($c->form_posted_and_valid($form, $c->req->body_params)) {
         try {
             @results = $c->model('Editor')->search_by_email(
                 $form->field('email')->value // '',
             );
+            $searched = 1;
         } catch {
             my $error = $_;
             if ("$error" =~ m/invalid regular expression/) {
@@ -181,7 +183,7 @@ sub email_search : Path('/admin/email-search') Args(0) RequireAuth(account_admin
         component_path => 'admin/EmailSearch',
         component_props => {
             form => $form->TO_JSON,
-            @results ? (
+            $searched ? (
                 results => [map { $c->unsanitized_editor_json($_) } @results],
             ) : (),
         },

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -77,8 +77,12 @@ const EmailSearch = ({
           />
         </div>
 
-        {results?.length ? (
-          <UserList users={results} />
+        {results ? (
+          results.length ? (
+            <UserList users={results} />
+          ) : (
+            <p>{l('No results found.')}</p>
+          )
         ) : null}
       </form>
     </div>


### PR DESCRIPTION
### Implement MBS-12147

Currently there's no clear way to differentiate an empty search from a not-yet-submitted one - both just show the email address in the form. This makes it so that after a search that returned no results a message stating that fact is shown.