### PR TITLE
MBS-12142 / MBS-12164: Use formatCount in more places

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -48,10 +48,10 @@ sub cloud : Path('/tags')
         component_path => 'tag/TagCloud',
         component_props => {
             %{$c->stash->{component_props}},
-            tagMaxCount => $hits ? $cloud->[0]->{count} : 0,
+            tagMaxCount => $hits ? $cloud->[0]->{count} + 0 : 0,
             tags => $hits ? [
                 map +{
-                    count => $_->{count},
+                    count => $_->{count} + 0,
                     tag => to_json_object($_->{tag}),
                 },
                 sort { $a->{tag}->name cmp $b->{tag}->name }

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {CatalystContext} from '../context';
+import {formatCount} from '../statistics/utilities';
 
 import Paginator from './Paginator';
 
@@ -30,11 +31,8 @@ const PaginatedResults = ({
   search = false,
   total = false,
 }: Props): React.Element<typeof React.Fragment> => {
-  const paginator = (
-    <CatalystContext.Consumer>
-      {$c => <Paginator $c={$c} pageVar={pageVar} pager={pager} />}
-    </CatalystContext.Consumer>
-  );
+  const $c = React.useContext(CatalystContext);
+  const paginator = <Paginator $c={$c} pageVar={pageVar} pager={pager} />;
   return (
     <>
       {paginator}
@@ -44,7 +42,7 @@ const PaginatedResults = ({
             texp.ln(
               'Found {n} result', 'Found {n} results',
               pager.total_entries,
-              {n: Number(pager.total_entries).toLocaleString()},
+              {n: formatCount($c, Number(pager.total_entries))},
             )
           ) : (
             texp.ln(
@@ -52,7 +50,7 @@ const PaginatedResults = ({
               'Found {n} results for "{q}"',
               pager.total_entries,
               {
-                n: Number(pager.total_entries).toLocaleString(),
+                n: formatCount($c, Number(pager.total_entries)),
                 q: query,
               },
             )

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -42,7 +42,7 @@ const PaginatedResults = ({
             texp.ln(
               'Found {n} result', 'Found {n} results',
               pager.total_entries,
-              {n: formatCount($c, Number(pager.total_entries))},
+              {n: formatCount($c, pager.total_entries)},
             )
           ) : (
             texp.ln(
@@ -50,7 +50,7 @@ const PaginatedResults = ({
               'Found {n} results for "{q}"',
               pager.total_entries,
               {
-                n: formatCount($c, Number(pager.total_entries)),
+                n: formatCount($c, pager.total_entries),
                 q: query,
               },
             )

--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -11,8 +11,10 @@ import * as React from 'react';
 
 import Layout from '../layout';
 import TagLink from '../static/scripts/common/components/TagLink';
+import {formatCount} from '../statistics/utilities';
 
 type Props = {
+  +$c: CatalystContextT,
   +tagMaxCount: number,
   +tags: $ReadOnlyArray<AggregatedTagT>,
 };
@@ -41,6 +43,7 @@ function getTagSize(count: number, tagMaxCount: number) {
 }
 
 const TagCloud = ({
+  $c,
   tagMaxCount,
   tags,
 }: Props): React.Element<typeof Layout> => (
@@ -56,7 +59,7 @@ const TagCloud = ({
                 key={tag.name}
                 title={texp.l(
                   "'{tag}' has been used {num} times",
-                  {num: count.toLocaleString(), tag: tag.name},
+                  {num: formatCount($c, count), tag: tag.name},
                 )}
               >
                 <TagLink tag={tag.name} />


### PR DESCRIPTION
### Fix MBS-12142 / MBS-12164

Fixes two places that used `toLocaleString()` (always using English number formatting) rather than using the actual selected locale via `formatCount`.