### PR TITLE
MBS-12160: Use 'canonical' to display sorted edit data JSON

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -7,6 +7,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use Data::Page;
 use DBDefs;
+use JSON;
 use MusicBrainz::Server::EditRegistry;
 use MusicBrainz::Server::Edit::Utils qw( status_names );
 use MusicBrainz::Server::Constants qw( :quality );
@@ -102,7 +103,7 @@ sub data : Chained('load') RequireAuth
         component_path => 'edit/EditData',
         component_props => {
             edit => $edit->TO_JSON,
-            rawData => $c->json->pretty->encode($decoded_raw_data),
+            rawData => JSON->new->canonical->pretty->encode($decoded_raw_data),
             relatedEntities => \%entities,
         },
     );


### PR DESCRIPTION
### Implement MBS-12160

'`canonical`' ensures the JSON is sorted by key. This makes things relatively slower, but it makes it easier to compare different edits' data and to figure out if something is missing or weird. Since the main target of the edit data page are humans, it makes sense IMO to make it easier for them to use by adding this consistency, even if speed goes down a bit.