### PR TITLE
MBS-12162: Do not require auth for non-private tag WS queries

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -319,7 +319,8 @@ role {
 
             # Check if authorization is required.
             $c->stash->{authorization_required} = $inc->{user_tags} || $inc->{user_genres} || $inc->{user_ratings} ||
-                $resource eq 'tag' || $resource eq 'rating' ||
+                $resource eq 'rating' ||
+                ($resource eq 'tag' && ($c->req->method eq 'POST' || exists $c->stash->{args}->{id})) ||
                 ($resource eq 'release' && $c->req->method eq 'POST') ||
                 ($resource eq 'recording' && $c->req->method eq 'POST');
 


### PR DESCRIPTION
### Fix MBS-12162

We were requiring auth for anything related to the tag resource, but as per `WS::2::Tag` only `tag_lookup` and `tag_submit`
should require auth (since they actually interact with the user's own tags). Tag search, which just searches for tag names matching a string, should not require any sort of authentication, since it's equivalent to other public searches.

Tested by actually going to both `/ws/2/tag/?query=shoegaze` and `/ws/2/tag?id=ed35bc92-2b5a-4ddf-96d2-51af9ab239e7&entity=artist` and making sure the first no longer requires logging in, while the second still does.