### PR TITLE
MBS-12168: Avoid breaking list formatting on user bios and collections

### DIFF
--- a/lib/MusicBrainz/Server/Form/Collection.pm
+++ b/lib/MusicBrainz/Server/Form/Collection.pm
@@ -19,6 +19,13 @@ has_field 'type_id' => (
 
 has_field 'description' => (
     type => 'TextArea',
+    trim => { transform => sub {
+        my $string = shift;
+        # Not trimming starting spaces to avoid breaking list formatting,
+        # consider trimming again once this uses Markdown 
+        $string =~ s/\s+$//;
+        return $string;
+    } },
     required => 0,
     not_nullable => 1,
 );

--- a/lib/MusicBrainz/Server/Form/Role/UserProfile.pm
+++ b/lib/MusicBrainz/Server/Form/Role/UserProfile.pm
@@ -15,6 +15,13 @@ has_field 'username' => (
 
 has_field 'biography' => (
     type => 'Text',
+    trim => { transform => sub {
+        my $string = shift;
+        # Not trimming starting spaces to avoid breaking list formatting,
+        # consider trimming again once this uses Markdown 
+        $string =~ s/\s+$//;
+        return $string;
+    } }
 );
 
 has_field 'website' => (


### PR DESCRIPTION
### Fix MBS-12168

This is the same as what we already do for annotations, which had the same problem (https://github.com/metabrainz/musicbrainz-server/pull/1160/). Tested by hand.