### PR TITLE
Delete CODE_OF_CONDUCT.md and use org default

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,9 +1,0 @@
-MetaBrainz Code of Conduct
-==========================
-
-This project follows the **[MetaBrainz code of conduct
-](https://metabrainz.org/code-of-conduct
-"Code of Conduct - MetaBrainz Foundation")**.
-
-For questions about the code of conduct or to get help, please email
-support@metabrainz.org or post on https://community.metabrainz.org/


### PR DESCRIPTION
This seems like an outdated copy of the org's CoC that adds nothing.
Removing so this uses the default .github repo one that is kept up to date.
Feel free to reject this PR if you want to keep a separate one for some reason, rather than this being a historical artifact :)