### PR TITLE
Bump some isolated JS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-table": "7.3.2",
     "redux": "3.6.0",
     "shell-quote": "1.7.2",
-    "shelljs": "0.8.4",
+    "shelljs": "0.8.5",
     "sliced": "1.0.1",
     "tablesorter": "2.31.3",
     "terser-webpack-plugin": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-loader": "8.2.2",
     "balanced-match": "0.2.0",
     "canonical-json": "0.0.4",
-    "cookie": "0.4.0",
+    "cookie": "0.4.1",
     "core-js": "3.6.5",
     "detect-node": "2.0.3",
     "filesize": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-dom": "17.0.1",
     "react-table": "7.3.2",
     "redux": "3.6.0",
-    "shell-quote": "1.7.2",
+    "shell-quote": "1.7.3",
     "shelljs": "0.8.5",
     "sliced": "1.0.1",
     "tablesorter": "2.31.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5168,10 +5168,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
-  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+shell-quote@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
+  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
 shelljs@0.8.5:
   version "0.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@ convert-source-map@^1.1.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
-  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookie@^0.3.1:
   version "0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,10 +5173,10 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+shelljs@0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
# Problem

Some isolated JS dependencies have security updates, that doesn’t affect MusicBrainz Server though.

# Solution

* Bump [ShellJS to v0.8.5](https://github.com/shelljs/shelljs/releases/tag/v0.8.5)
* Bump [shell-quote to v1.7.3](https://github.com/substack/node-shell-quote/compare/v1.7.2...1.7.3)
* Bump [cookie to v0.4.1](https://github.com/jshttp/cookie/releases/tag/v0.4.1)