### PR TITLE
Enable Plack::Middleware::AccessLog in production

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -65,6 +65,18 @@ builder {
     }
 
     enable 'Static', path => qr{^/(static/|browserconfig\.xml|favicon\.ico$)}, root => 'root';
+
+    # AccessLog is a default middleware when PLACK_ENV=development
+    # (the default) [1], but we also want it enabled in production to
+    # aid debugging.  The conditional ensures it's not enabled twice in
+    # development -- only in production when PLACK_ENV=deployment.
+    #
+    # [1] https://metacpan.org/pod/plackup#-E,-env,-the-PLACK_ENV-environment-variable.
+    enable_if {
+        my $plack_env = $ENV{PLACK_ENV};
+        defined $plack_env && $plack_env eq 'deployment'
+    } 'Plack::Middleware::AccessLog', format => 'combined';
+
     MusicBrainz::Server->psgi_app;
 };
 


### PR DESCRIPTION
As noted in https://github.com/metabrainz/syswiki/pull/45/files#r781430759, it's often helpful to see the last request preceding an error or warning in production.  Or the last request before a plackup process became stuck.

The AccessLog middleware is normally only enabled in development; if you use plackup in development, you should be used to seeing requests logged.  This enables the same logging in production.

This will increase the amount of logs generated by the website and web service containers by quite a lot.  However, assuming we aggressively fix spammy warnings and set the appropriate log-opts on the containers, this patch would help make debugging alerts much easier.