### PR TITLE
MBS-2313: Avoid pointless empty annotation edits

### DIFF
--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -977,7 +977,7 @@ class Release extends mbEntity.Release {
     this.packagingID = ko.observable(data.packagingID);
     this.barcode = new Barcode(data.barcode);
     this.comment = ko.observable(data.comment);
-    const annotationText = data.latest_annotation
+    const annotationText = data.latest_annotation?.text
       ? data.latest_annotation.text
       : '';
     this.annotation = ko.observable(annotationText);

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -977,9 +977,7 @@ class Release extends mbEntity.Release {
     this.packagingID = ko.observable(data.packagingID);
     this.barcode = new Barcode(data.barcode);
     this.comment = ko.observable(data.comment);
-    const annotationText = data.latest_annotation?.text
-      ? data.latest_annotation.text
-      : '';
+    const annotationText = data.latest_annotation?.text ?? '';
     this.annotation = ko.observable(annotationText);
     this.annotation.original = ko.observable(annotationText);
 


### PR DESCRIPTION
### Fix MBS-2313

This was only checking if latest_annotation existed before happily using 'text', but 'text' is actually nullable. It seems like emptying an annotation through the release editor will not null it, but emptying it through the usual edit annotation page will. As such, the release editor will replace the null annotation with an empty string one, in what is a completely pointless exercise.

It might be preferable to just make annotation NOT NULL and always ensure it's an empty string when blanked.