### PR TITLE
Remove parallel processing on prove

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
               --source pgTAP \
               --source Perl \
               -I lib \
-              -j 9 \
               t/critic.t \
               t/pgtap/* \
               t/pgtap/unused-tags/* \

--- a/t/lib/t/MusicBrainz/Server/Data/Recording.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Recording.pm
@@ -120,8 +120,8 @@ $results = $appears->{1}->{results};
 is ($appears->{8}->{results}->[0]->name, 'Aerial', 'recording 8 appears on Aerial');
 is ($appears->{1}->{hits}, 4, 'recording 1 appears on four release groups');
 is (scalar @$results, 2, ' ... of which two have been returned');
-is ($results->[0]->name, 'Aerial', 'recording 1 appears on Aerial');
-is ($results->[1]->name, 'エアリアル', 'recording 1 appears on エアリアル');
+is ($results->[0]->name, 'エアリアル', 'recording 0 appears on エアリアル');
+is ($results->[1]->name, 'Aerial', 'recording 1 appears on Aerial');
 
 };
 

--- a/t/sql/recording.sql
+++ b/t/sql/recording.sql
@@ -18,6 +18,9 @@ INSERT INTO release (id, name, release_group, artist_credit, gid)
            (23, 'King of the Mountain', 23, 1, '785a5e34-bf47-40f2-8148-65b1ed631ac5'),
            (24, 'Brit Awards 2006', 24, 1, 'ac6e8393-2694-4e47-a5b3-82dc93477c5f');
 
+INSERT INTO release_unknown_country (release, date_year)
+     VALUES (22, 2005);
+
 INSERT INTO medium (id, release, position, format, name)
        VALUES (22, 22, 1, 1, 'A Sea of Honey'),
               (23, 23, 1, 1, ''),


### PR DESCRIPTION
We've been getting spurious failures on CircleCI which I have a feeling are due to running certain tests in parallel; usually it's one of the dump scripts under t/script/ that fail, but I'm not sure which tests are conflicting with them.  Let's try disabling this and seeing if it significantly affects the run-time.
