### PR TITLE
MBS-11532: Don't pass undef ISO variable to localizeAreaName

### DIFF
--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -257,7 +257,7 @@ import formatTrackLength from './utility/formatTrackLength';
     toJSON() {
       return Object.assign(
         super.toJSON(),
-        {iso_3166_1_codes: this.iso_3166_1_codes},
+        {iso_3166_1_codes: this.iso_3166_1_codes || []},
       );
     }
 


### PR DESCRIPTION
### Fix MBS-11532

This is typed as always an array, but `entity.js` was potentially passing undefined instead, breaking the check in `localizeAreaName`. We now pass an empty array in that case for parity with the usual `TO_JSON`.