### PR TITLE
MBS-12183: Display previous value of annotation in AddAnnotation edits

### DIFF
--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -13,6 +13,8 @@ import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink';
 import formatEntityTypeName
   from '../../static/scripts/common/utility/formatEntityTypeName';
+import Diff from '../../static/scripts/edit/components/edit/Diff';
+import {addColonText} from '../../static/scripts/common/i18n/addColon';
 
 type Props = {
   +edit: AddAnnotationEditT,
@@ -21,6 +23,7 @@ type Props = {
 const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
   const display = edit.display_data;
   const entityType = display.entity_type;
+  const oldAnnotation = display.old_annotation;
 
   return (
     <table
@@ -60,6 +63,13 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
               )}
           </td>
         </tr>
+        {oldAnnotation == null ? null : (
+          <Diff
+            label={l(addColonText('Annotation comparison'))}
+            newText={display.text}
+            oldText={oldAnnotation}
+          />
+        )}
         {display.changelog ? (
           <tr>
             <th>{addColonText(l('Summary'))}</th>

--- a/root/types/edit_types.js
+++ b/root/types/edit_types.js
@@ -14,6 +14,7 @@ declare type AddAnnotationEditGenericT = $ReadOnly<{
     +entity_type: AnnotatedEntityTypeT,
     [annotatedEntityType: AnnotatedEntityTypeT]: AnnotatedEntityT,
     +html: string,
+    +old_annotation?: string,
     +text: string,
   },
   +edit_type: EDIT_AREA_ADD_ANNOTATION_T,

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -49,7 +49,8 @@ test 'MBS-4091: Test submitting annotation starting with list syntax' => sub {
             },
             text => "    * Test annotation for an artist\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
             changelog => 'Changelog here',
-            editor_id => 1
+            editor_id => 1,
+            old_annotation_id => 1,
         },
         'The edit contains the right data (with untrimmed initial spaces)',
     );

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -33,7 +33,8 @@ is_deeply($edit->data, {
     },
     text => "    * Test annotation for a label\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
-    editor_id => 1
+    editor_id => 1,
+    old_annotation_id => undef,
 });
 
 $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -31,7 +31,8 @@ is_deeply($edit->data, {
     },
     text => "    * Test annotation for a recording\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
-    editor_id => 1
+    editor_id => 1,
+    old_annotation_id => 3,
 });
 
 $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -31,7 +31,8 @@ is_deeply($edit->data, {
     },
     text => "    * Test annotation for a release\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
-    editor_id => 1
+    editor_id => 1,
+    old_annotation_id => undef,
 });
 
 $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -31,7 +31,8 @@ is_deeply($edit->data, {
     },
     text => "    * Test annotation for a release group\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     changelog => 'Changelog here',
-    editor_id => 1
+    editor_id => 1,
+    old_annotation_id => 5,
 });
 
 $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -36,7 +36,8 @@ test all => sub {
         },
         text => "    * Test annotation for a series\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'And a changelog',
-        editor_id => 1
+        editor_id => 1,
+        old_annotation_id => undef,
     });
 
     $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -680,9 +680,10 @@ test 'previewing/creating/editing a release group and release' => sub {
     isa_ok($edits[0], 'MusicBrainz::Server::Edit::Release::AddAnnotation');
 
     cmp_deeply($edits[0]->data, {
-        editor_id       => 1,
-        entity          => { id => $release_id, name => 'Vision Creation Newsun' },
-        text            => "    * Test annotation in release editor\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+        editor_id         => 1,
+        entity            => { id => $release_id, name => 'Vision Creation Newsun' },
+        old_annotation_id => undef,
+        text              => "    * Test annotation in release editor\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
     });
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -34,7 +34,8 @@ is_deeply(
         },
         text => "    * Test annotation for a work\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
         changelog => 'Changelog here',
-        editor_id => 1
+        editor_id => 1,
+        old_annotation_id => 6,
     }
 );
 

--- a/t/selenium/release-editor/The_Downward_Spiral.json5
+++ b/t/selenium/release-editor/The_Downward_Spiral.json5
@@ -1064,6 +1064,7 @@
           },
           editor_id: 5,
           annotation_id: 1,
+          old_annotation_id: null,
         },
       },
     },


### PR DESCRIPTION
### Implement MBS-12183

We call everything "AddAnnotation", since they add a new revision of the annotation, but there's quite a big difference between cases where an annotation replaces another, deletes it, or adds one where nothing existed.
This makes it so that a diff is shown when modifying an existing annotation, similarly to the annotations-differences page.

![Screenshot from 2022-01-31 14-04-28](https://user-images.githubusercontent.com/1069224/151791714-693e13d7-edf0-4b04-af0a-b7ce87c95e1d.png)
