### PR TITLE
MBS-12189: Support "names" prefix for DAHR artists

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1484,16 +1484,28 @@ const CLEANUPS: CleanupEntries = {
     },
   },
   'dahr': {
-    match: [new RegExp(
-      '^(https?://)?adp\\.library\\.ucsb\\.edu/index\\.php/' +
-      '(matrix|objects|talent)',
-      'i',
-    )],
+    match: [
+      new RegExp(
+        '^(https?://)?adp\\.library\\.ucsb\\.edu/index\\.php/' +
+        '(mastertalent|matrix|objects|talent)',
+        'i',
+      ),
+      new RegExp('^(https?://)?adp\\.library\\.ucsb\\.edu/names/', 'i'),
+    ],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?adp\.library\.ucsb\.edu\/index\.php\/([a-z]+)\/[a-z]+\/([\d]+).*$/, 'https://adp.library.ucsb.edu/index.php/$1/detail/$2');
+      url = url.replace(/^(?:https?:\/\/)?adp\.library\.ucsb\.edu\//, 'https://adp.library.ucsb.edu/');
+      url = url.replace(/^(https:\/\/adp\.library\.ucsb\.edu)\/index\.php\/([a-z]+)\/[a-z]+\/([\d]+).*$/, '$1/index.php/$2/detail/$3');
+      url = url.replace(/^(https:\/\/adp\.library\.ucsb\.edu)\/names\/([\d]+).*$/, '$1/names/$2');
+      // mastertalent URLs match 1:1 to a names permalink so we use that
+      url = url.replace(/^(https:\/\/adp\.library\.ucsb\.edu)\/index\.php\/mastertalent\/detail\/([\d]+).*$/, '$1/names/$2');
+      return url;
     },
     validate: function (url, id) {
+      const isNamesPermalink = url.match(/^https:\/\/adp\.library\.ucsb\.edu\/names\/[\d]+$/);
+      if (isNamesPermalink && id === LINK_TYPES.otherdatabases.artist) {
+        return {result: true};
+      }
       const m = /^https:\/\/adp\.library\.ucsb\.edu\/index\.php\/([a-z]+)\/detail\/[\d]+$/.exec(url);
       if (m) {
         const prefix = m[1];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1268,6 +1268,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://adp.library.ucsb.edu/index.php/mastertalent/detail/113214/Tapley_Daisy',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://adp.library.ucsb.edu/names/113214',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'http://adp.library.ucsb.edu/names/109217',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'https://adp.library.ucsb.edu/names/109217',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'https://adp.library.ucsb.edu/index.php/matrix/refer/2000308570#',
              input_entity_type: 'recording',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-12189

DAHR now has a permalink with the `/names` prefix for artists. It also has a new `/mastertalent` prefix for artists, which they
redirect to, but they do not call a permalink. As such, this accepts both, but cleans `/mastertalent` to `/names`.