### PR TITLE
MBS-12191: Allow admins to see spammer profiles

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -14,6 +14,7 @@ import UserAccountLayout, {
 } from '../components/UserAccountLayout';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink';
+import Warning from '../static/scripts/common/components/Warning';
 import {FLUENCY_NAMES} from '../static/scripts/common/constants';
 import {compare} from '../static/scripts/common/i18n';
 import commaList from '../static/scripts/common/i18n/commaList';
@@ -859,7 +860,8 @@ const UserProfile = ({
   votes,
   addedEntities,
 }: UserProfileProps): React.Element<typeof UserAccountLayout> => {
-  const viewingOwnProfile = !!$c.user && $c.user.id === user.id;
+  const viewingOwnProfile = $c.user != null && $c.user.id === user.id;
+  const adminViewing = $c.user != null && isAccountAdmin($c.user);
   const encodedName = encodeURIComponent(user.name);
 
   return (
@@ -867,7 +869,7 @@ const UserProfile = ({
       entity={sanitizedAccountLayoutUser(user)}
       page="index"
     >
-      {isSpammer(user) ? (
+      {isSpammer(user) && !adminViewing ? (
         <>
           <h2>{l('Blocked Spam Account')}</h2>
           <p>
@@ -879,6 +881,15 @@ const UserProfile = ({
         </>
       ) : (
         <>
+          {isSpammer(user) && adminViewing ? (
+            <Warning
+              message={
+                l(`This user is marked as a spammer and is blocked
+                   for all non-admin users.`)
+              }
+            />
+          ) : null}
+
           <UserProfileInformation
             $c={$c}
             applicationCount={applicationCount}

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Show.pm
@@ -22,4 +22,73 @@ $mech->content_contains('Collection', 'Collection tab appears on own profile, ev
 
 };
 
+test 'Spammer editors are hidden, except for admins' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
+    # Add our spam editor
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+      INSERT INTO editor (
+                      id, name, password,
+                      privs, email, website, bio,
+                      member_since, email_confirm_date, last_login_date,
+                      ha1
+                  )
+           VALUES (
+                      5, 'SPAMVIKING', '{CLEARTEXT}SpamBaconSausageSpam',
+                      4096, 'spam@bromleycafe.com', '', 'spammy spam',
+                      '2010-03-25', '2010-03-25', now(),
+                      '1e30903480b84af674780f41ac54dfec'
+                  )
+      SQL
+
+    # Make kuno an account admin
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+        UPDATE editor SET privs = 128 WHERE id = 3;
+        SQL
+
+    $mech->get_ok('/user/SPAMVIKING', 'Fetched spammer page while logged out');
+    $mech->content_contains(
+        'Blocked Spam Account',
+        'Spammer user page is blocked for logged out users',
+    );
+    $mech->content_lacks(
+        'spammy spam',
+        'Spammer user bio is not visible for logged out users',
+    );
+
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'alice', password => 'secret1' }
+    );
+
+    $mech->get_ok('/user/SPAMVIKING', 'Fetched spammer page as normal user');
+    $mech->content_contains(
+        'Blocked Spam Account',
+        'Spammer user page is blocked for normal users',
+    );
+    $mech->content_lacks(
+        'spammy spam',
+        'Spammer user bio is not visible for normal users',
+    );
+
+    $mech->get('/logout');
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'kuno', password => 'byld' }
+    );
+
+    $mech->get_ok('/user/SPAMVIKING', 'Fetched spammer page as admin');
+    $mech->content_contains(
+        'This user is marked as a spammer',
+        'Spammer user warning is shown to admin',
+    );
+    $mech->content_contains(
+        'spammy spam',
+        'Spammer user bio is visible for admins',
+    );
+};
+
 1;


### PR DESCRIPTION
### Implement MBS-12191

I blocked these a bit too well, to the point where Freso himself cannot see them either anymore.
This allows admins to see the page, but adds a visible warning that they are already banned so that they don't have to go check the flags to make sure.