### PR TITLE
Upgrade to Flow 0.171.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.169.0",
+    "flow-bin": "0.171.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/root/static/scripts/account/components/ApplicationForm.js
+++ b/root/static/scripts/account/components/ApplicationForm.js
@@ -46,12 +46,14 @@ class ApplicationForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {form: props.form};
-    this.handleOauthRedirectURIChange =
-      this.handleOauthRedirectURIChange.bind(this);
-    this.handleOauthTypeChange = this.handleOauthTypeChange.bind(this);
+    this.handleOauthRedirectURIChangeBound =
+      (e) => this.handleOauthRedirectURIChange(e);
+    this.handleOauthTypeChangeBound =
+      (e) => this.handleOauthTypeChange(e);
   }
 
-  handleOauthRedirectURIChange: (e: SyntheticEvent<HTMLInputElement>) => void;
+  handleOauthRedirectURIChangeBound:
+    (e: SyntheticEvent<HTMLInputElement>) => void;
 
   handleOauthRedirectURIChange(e: SyntheticEvent<HTMLInputElement>) {
     const selectedOauthRedirectURI = e.currentTarget.value;
@@ -60,7 +62,7 @@ class ApplicationForm extends React.Component<Props, State> {
     }));
   }
 
-  handleOauthTypeChange: (e: SyntheticEvent<HTMLSelectElement>) => void;
+  handleOauthTypeChangeBound: (e: SyntheticEvent<HTMLSelectElement>) => void;
 
   handleOauthTypeChange(e: SyntheticEvent<HTMLSelectElement>) {
     const selectedOauthType = e.currentTarget.value;
@@ -84,14 +86,14 @@ class ApplicationForm extends React.Component<Props, State> {
           field={this.state.form.field.oauth_type}
           frozen={this.props.action === 'edit'}
           label={addColonText(l('Type'))}
-          onChange={this.handleOauthTypeChange}
+          onChange={this.handleOauthTypeChangeBound}
           options={oauthTypeOptions}
           required
         />
         <FormRowURLLong
           field={this.state.form.field.oauth_redirect_uri}
           label={addColonText(l('Callback URL'))}
-          onChange={this.handleOauthRedirectURIChange}
+          onChange={this.handleOauthRedirectURIChangeBound}
           required={this.state.form.field.oauth_type.value === 'web'}
         />
         {this.state.form.field.oauth_type.value === 'web' ? null : (

--- a/root/static/scripts/account/components/EditProfileForm.js
+++ b/root/static/scripts/account/components/EditProfileForm.js
@@ -86,15 +86,12 @@ class EditProfileForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {form: props.form, languageOptions: props.language_options};
-    this.handleAreaChange = this.handleAreaChange.bind(this);
-    this.handleGenderChange = this.handleGenderChange.bind(this);
-    this.handleLanguageChange = this.handleLanguageChange.bind(this);
-    this.handleFluencyChange = this.handleFluencyChange.bind(this);
-    this.removeLanguage = this.removeLanguage.bind(this);
-    this.handleLanguageAdd = this.handleLanguageAdd.bind(this);
+    this.handleAreaChangeBound = (area) => this.handleAreaChange(area);
+    this.handleGenderChangeBound = (e) => this.handleGenderChange(e);
+    this.handleLanguageAddBound = () => this.handleLanguageAdd();
   }
 
-  handleAreaChange: (area: AreaClassT) => void;
+  handleAreaChangeBound: (area: AreaClassT) => void;
 
   handleAreaChange(area: AreaClassT) {
     this.setState(prevState => mutate<State, _>(prevState, newState => {
@@ -105,7 +102,7 @@ class EditProfileForm extends React.Component<Props, State> {
     }));
   }
 
-  handleGenderChange: (e: SyntheticEvent<HTMLSelectElement>) => void;
+  handleGenderChangeBound: (e: SyntheticEvent<HTMLSelectElement>) => void;
 
   handleGenderChange(e: SyntheticEvent<HTMLSelectElement>) {
     const selectedGender = e.currentTarget.value;
@@ -113,11 +110,6 @@ class EditProfileForm extends React.Component<Props, State> {
       newState.form.field.gender_id.value = parseInt(selectedGender, 10);
     }));
   }
-
-  handleLanguageChange: (
-    e: SyntheticEvent<HTMLSelectElement>,
-    languageIndex: number,
-  ) => void;
 
   handleLanguageChange(
     e: SyntheticEvent<HTMLSelectElement>,
@@ -129,11 +121,6 @@ class EditProfileForm extends React.Component<Props, State> {
       compound.field.language_id.value = selectedLanguage;
     }));
   }
-
-  handleFluencyChange: (
-    e: SyntheticEvent<HTMLSelectElement>,
-    languageIndex: number,
-  ) => void;
 
   handleFluencyChange(
     e: SyntheticEvent<HTMLSelectElement>,
@@ -154,15 +141,13 @@ class EditProfileForm extends React.Component<Props, State> {
     }));
   }
 
-  removeLanguage: (languageIndex: number) => void;
-
   removeLanguage(languageIndex: number) {
     this.setState(prevState => mutate<State, _>(prevState, newState => {
       newState.form.field.languages.field.splice(languageIndex, 1);
     }));
   }
 
-  handleLanguageAdd: () => void;
+  handleLanguageAddBound: () => void;
 
   handleLanguageAdd() {
     this.setState(prevState => mutate<State, _>(prevState, newState => {
@@ -219,7 +204,7 @@ class EditProfileForm extends React.Component<Props, State> {
           allowEmpty
           field={field.gender_id}
           label={l('Gender:')}
-          onChange={this.handleGenderChange}
+          onChange={this.handleGenderChangeBound}
           options={genderOptions}
         />
 
@@ -237,7 +222,7 @@ class EditProfileForm extends React.Component<Props, State> {
             entity="area"
             inputID={'id-' + areaField.name.html_name}
             inputName={areaField.name.html_name}
-            onChange={this.handleAreaChange}
+            onChange={this.handleAreaChangeBound}
           >
             <input
               name={field.area_id.html_name}
@@ -307,7 +292,7 @@ class EditProfileForm extends React.Component<Props, State> {
               <span className="buttons">
                 <button
                   className="another"
-                  onClick={this.handleLanguageAdd}
+                  onClick={this.handleLanguageAddBound}
                   type="button"
                 >
                   {l('Add a language')}

--- a/root/static/scripts/account/components/PreferencesForm.js
+++ b/root/static/scripts/account/components/PreferencesForm.js
@@ -84,15 +84,15 @@ class PreferencesForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {form: props.form, timezoneOptions: props.timezone_options};
-    this.handleTimezoneChange = this.handleTimezoneChange.bind(this);
-    this.handleTimezoneGuess = this.handleTimezoneGuess.bind(this);
-    this.handleDateTimeFormatChange =
-      this.handleDateTimeFormatChange.bind(this);
-    this.handleSubscriptionsEmailPeriodChange =
-      this.handleSubscriptionsEmailPeriodChange.bind(this);
+    this.handleTimezoneChangeBound = (e) => this.handleTimezoneChange(e);
+    this.handleTimezoneGuessBound = () => this.handleTimezoneGuess();
+    this.handleDateTimeFormatChangeBound =
+      (e) => this.handleDateTimeFormatChange(e);
+    this.handleSubscriptionsEmailPeriodChangeBound =
+      (e) => this.handleSubscriptionsEmailPeriodChange(e);
   }
 
-  handleTimezoneChange: (e: SyntheticEvent<HTMLSelectElement>) => void;
+  handleTimezoneChangeBound: (e: SyntheticEvent<HTMLSelectElement>) => void;
 
   handleTimezoneChange(e: SyntheticEvent<HTMLSelectElement>) {
     const selectedTimezone = e.currentTarget.value;
@@ -101,7 +101,7 @@ class PreferencesForm extends React.Component<Props, State> {
     }));
   }
 
-  handleTimezoneGuess: () => void;
+  handleTimezoneGuessBound: () => void;
 
   handleTimezoneGuess() {
     let maybeGuess;
@@ -123,7 +123,8 @@ class PreferencesForm extends React.Component<Props, State> {
     }
   }
 
-  handleDateTimeFormatChange: (e: SyntheticEvent<HTMLSelectElement>) => void;
+  handleDateTimeFormatChangeBound:
+    (e: SyntheticEvent<HTMLSelectElement>) => void;
 
   handleDateTimeFormatChange(e: SyntheticEvent<HTMLSelectElement>) {
     const selectedDateTimeFormat = e.currentTarget.value;
@@ -132,8 +133,8 @@ class PreferencesForm extends React.Component<Props, State> {
     }));
   }
 
-  handleSubscriptionsEmailPeriodChange: (e: SyntheticEvent<HTMLSelectElement>)
-    => void;
+  handleSubscriptionsEmailPeriodChangeBound:
+    (e: SyntheticEvent<HTMLSelectElement>) => void;
 
   handleSubscriptionsEmailPeriodChange(e: SyntheticEvent<HTMLSelectElement>) {
     const selectedSubscriptionsEmailPeriod = e.currentTarget.value;
@@ -158,14 +159,14 @@ class PreferencesForm extends React.Component<Props, State> {
                 {' '}
                 <button
                   className="guess-timezone icon"
-                  onClick={this.handleTimezoneGuess}
+                  onClick={this.handleTimezoneGuessBound}
                   title={l('Guess timezone')}
                   type="button"
                 />
               </>
             }
             label={l('Timezone:')}
-            onChange={this.handleTimezoneChange}
+            onChange={this.handleTimezoneChangeBound}
             options={this.state.timezoneOptions}
           />
           <SanitizedCatalystContext.Consumer>
@@ -173,7 +174,7 @@ class PreferencesForm extends React.Component<Props, State> {
               <FormRowSelect
                 field={field.datetime_format}
                 label={l('Date/time format:')}
-                onChange={this.handleDateTimeFormatChange}
+                onChange={this.handleDateTimeFormatChangeBound}
                 options={buildDateTimeFormatOptions(
                   $c,
                   field.timezone.value,
@@ -230,7 +231,7 @@ class PreferencesForm extends React.Component<Props, State> {
           <FormRowSelect
             field={field.subscriptions_email_period}
             label={l('Send me mails with edits to my subscriptions:')}
-            onChange={this.handleSubscriptionsEmailPeriodChange}
+            onChange={this.handleSubscriptionsEmailPeriodChangeBound}
             options={subscriptionsEmailPeriodOptions}
           />
         </fieldset>

--- a/root/static/scripts/common/components/Collapsible.js
+++ b/root/static/scripts/common/components/Collapsible.js
@@ -26,7 +26,7 @@ class Collapsible extends React.Component<Props, State> {
       isCollapsed: false,
       isCollapsible: false,
     };
-    this.handleToggle = this.handleToggle.bind(this);
+    this.handleToggleBound = (event) => this.handleToggle(event);
     this.containerRef = React.createRef();
   }
 
@@ -42,7 +42,7 @@ class Collapsible extends React.Component<Props, State> {
 
   containerRef: {current: null | React.ElementRef<'div'>};
 
-  handleToggle: (event: SyntheticEvent<HTMLAnchorElement>) => void;
+  handleToggleBound: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 
   handleToggle(event: SyntheticEvent<HTMLAnchorElement>) {
     event.preventDefault();
@@ -71,7 +71,7 @@ class Collapsible extends React.Component<Props, State> {
             <a
               className={className + '-toggle'}
               href="#"
-              onClick={this.handleToggle}
+              onClick={this.handleToggleBound}
             >
               {isCollapsed ? l('Show more...') : l('Show less...')}
             </a>

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -220,19 +220,17 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
   debouncePendingVotes: () => void;
 
-  flushPendingVotes: (asap?: boolean) => void;
-
   genreMap: {+[genreName: string]: GenreT, ...};
 
   genreOptions: $ReadOnlyArray<{+label: string, +value: string}>;
 
-  handleSubmit: (SyntheticEvent<HTMLFormElement>) => void;
+  handleSubmitBound: (SyntheticEvent<HTMLFormElement>) => void;
 
-  onBeforeUnload: () => void;
+  onBeforeUnloadBound: () => void;
 
   pendingVotes: Map<string, PendingVoteT>;
 
-  setTagsInput: (TagsInputT) => void;
+  setTagsInputBound: (TagsInputT) => void;
 
   constructor(props: TagEditorProps) {
     super(props);
@@ -242,10 +240,9 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
       tags: createInitialTagState(props.aggregatedTags, props.userTags),
     };
 
-    this.flushPendingVotes = this.flushPendingVotes.bind(this);
-    this.onBeforeUnload = this.onBeforeUnload.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.setTagsInput = this.setTagsInput.bind(this);
+    this.onBeforeUnloadBound = () => this.onBeforeUnload();
+    this.handleSubmitBound = (event) => this.handleSubmit(event);
+    this.setTagsInputBound = (input) => this.setTagsInput(input);
 
     this.genreMap = props.genreMap ?? {};
     this.genreOptions =
@@ -259,7 +256,8 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
     this.pendingVotes = new Map();
     this.debouncePendingVotes = debounce(
-      this.flushPendingVotes, VOTE_DELAY,
+      (asap) => this.flushPendingVotes(asap),
+      VOTE_DELAY,
     );
   }
 
@@ -299,11 +297,11 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
   componentDidMount() {
     require('../../../lib/jquery-ui');
-    window.addEventListener('beforeunload', this.onBeforeUnload);
+    window.addEventListener('beforeunload', this.onBeforeUnloadBound);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.onBeforeUnload);
+    window.removeEventListener('beforeunload', this.onBeforeUnloadBound);
   }
 
   createTagRows() {
@@ -601,9 +599,9 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
                   {tagdocs: '/doc/Folksonomy_Tagging'},
                 )}
               </p>
-              <form id="tag-form" onSubmit={this.handleSubmit}>
+              <form id="tag-form" onSubmit={this.handleSubmitBound}>
                 <p>
-                  <textarea cols="50" ref={this.setTagsInput} rows="5" />
+                  <textarea cols="50" ref={this.setTagsInputBound} rows="5" />
                 </p>
                 <button className="styled-button" type="submit">
                   {l('Submit tags')}
@@ -655,12 +653,12 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
             </p>
           ) : null}
 
-          <form id="tag-form" onSubmit={this.handleSubmit}>
+          <form id="tag-form" onSubmit={this.handleSubmitBound}>
             <div style={{display: 'flex'}}>
               <input
                 className="tag-input"
                 name="tags"
-                ref={this.setTagsInput}
+                ref={this.setTagsInputBound}
                 style={{flexGrow: 2}}
                 type="text"
               />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,10 +2945,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.169.0:
-  version "0.169.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.169.0.tgz#3c25ecefc165929159f30b8eb5b8b74cc7ead9a7"
-  integrity sha512-CflYPrd4KiMh5RyvoJbkM5Az1PKDzFBCu3tHqNcZkHeCbYgtLAcYVTs1w8aKDXfTiBSPZ7B9u5KT5RdmsY2mzQ==
+flow-bin@0.171.0:
+  version "0.171.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.171.0.tgz#43902cf3ab10704a9c8a96bd16f789d92490ba1c"
+  integrity sha512-2HEiXAyE60ztGs+loFk6XSskL69THL6tSjzopUcbwgfrdbuZ5Jhv23qh1jUKP5AZJh0NNwxaFZ6To2p6xR+GEA==
 
 follow-redirects@^1.0.0:
   version "1.11.0"


### PR DESCRIPTION
In some class-based components, we use a technique where we bind certain methods to `this` in the constructor so that we can pass them as event handlers directly.

Flow doesn't like how we're doing this anymore.  For one, we previously had to declare the method signature again to be able to assign it in the constructor; Flow now sees this as a duplicate member declaration and errors.  But even once that's fixed, it also doesn't like `this.foo.bind(this)` anymore where `this.foo` is a method, because it views it as unbinding it from the class context (which isn't really true).

We could use `$FlowIssue` comments for these, but it's easier to just change them to arrow functions, and give a different name to the bound functions (I appended `Bound` to all of the names).

Some of these bound functions aren't or weren't even needed; I removed a few, but others could just use arrow functions in `render`.  There are still cases where we'd want to keep the same function reference though: when passing to `removeEventListener` and when passing to a `React.memo` component.