### PR TITLE
Remove MooseX::ABC

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -63,7 +63,6 @@ requires 'Method::Signatures::Simple'                 => '1.07';
 requires 'MIME::Base64'                               => '3.13';
 requires 'Module::Pluggable'                          => '5.1';
 requires 'Moose'                                      => '2.1600';
-requires 'MooseX::ABC'                                => '0.06';
 requires 'MooseX::Clone'                              => '0.05';
 requires 'MooseX::Getopt'                             => '0.59';
 requires 'MooseX::MethodAttributes'                   => '0.29';

--- a/lib/MusicBrainz/Server/CoverArt.pm
+++ b/lib/MusicBrainz/Server/CoverArt.pm
@@ -13,7 +13,7 @@ has 'image_uri' => (
 );
 
 has 'provider' => (
-    isa => 'MusicBrainz::Server::CoverArt::Provider',
+    does => 'MusicBrainz::Server::CoverArt::Provider',
     is  => 'ro',
 );
 

--- a/lib/MusicBrainz/Server/CoverArt/Provider.pm
+++ b/lib/MusicBrainz/Server/CoverArt/Provider.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::CoverArt::Provider;
-use Moose;
-use MooseX::ABC;
+use Moose::Role;
 
 has 'name' => (
     isa      => 'Str',
@@ -18,8 +17,7 @@ requires 'lookup_cover_art';
 
 sub fallback_meta { return undef; }
 
-__PACKAGE__->meta->make_immutable;
-no Moose;
+no Moose::Role;
 
 1;
 

--- a/lib/MusicBrainz/Server/CoverArt/Provider/RegularExpression.pm
+++ b/lib/MusicBrainz/Server/CoverArt/Provider/RegularExpression.pm
@@ -3,7 +3,7 @@ use Moose;
 
 use aliased 'MusicBrainz::Server::CoverArt';
 
-extends 'MusicBrainz::Server::CoverArt::Provider';
+with 'MusicBrainz::Server::CoverArt::Provider';
 
 has 'uri_expression' => (
     isa      => 'Str',

--- a/lib/MusicBrainz/Server/CoverArt/Provider/WebService/Amazon.pm
+++ b/lib/MusicBrainz/Server/CoverArt/Provider/WebService/Amazon.pm
@@ -6,7 +6,7 @@ use XML::XPath;
 
 use aliased 'MusicBrainz::Server::CoverArt::Amazon' => 'CoverArt';
 
-extends 'MusicBrainz::Server::CoverArt::Provider';
+with 'MusicBrainz::Server::CoverArt::Provider';
 
 has '+link_type_name' => (
     default => 'amazon asin',

--- a/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::Alias::Delete;
 use Moose;
-use MooseX::ABC;
 
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -1,7 +1,6 @@
 package MusicBrainz::Server::Edit::Alias::Edit;
 use 5.10.0;
 use Moose;
-use MooseX::ABC;
 
 use Moose::Util::TypeConstraints qw( as subtype find_type_constraint );
 use MooseX::Types::Moose qw( Bool Int Str );

--- a/lib/MusicBrainz/Server/Edit/Generic/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Create.pm
@@ -1,14 +1,17 @@
 package MusicBrainz::Server::Edit::Generic::Create;
 use utf8;
 use Moose;
-use MooseX::ABC;
 
 use Clone qw( clone );
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Role::Insert';
 
-requires '_create_model';
+# Sub-classes are required to implement `_create_model`.
+#
+# N.B. This is not checked at compile-time.
+
+sub _create_model { die 'Unimplemented' }
 
 sub edit_kind { 'add' }
 

--- a/lib/MusicBrainz/Server/Edit/Generic/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Delete.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::Generic::Delete;
 use Moose;
-use MooseX::ABC;
 
 use MusicBrainz::Server::Data::Artist;
 use MusicBrainz::Server::Edit::Exceptions;
@@ -12,8 +11,14 @@ use MooseX::Types::Structured qw( Dict );
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 
 extends 'MusicBrainz::Server::Edit';
-requires '_delete_model';
+
 with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+
+# Sub-classes are required to implement `_delete_model`.
+#
+# N.B. This is not checked at compile-time.
+
+sub _delete_model { die 'Unimplemented' }
 
 sub edit_kind { 'remove' }
 

--- a/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::Generic::Edit;
 use Moose;
-use MooseX::ABC;
 
 use Clone qw( clone );
 
@@ -13,7 +12,17 @@ use Try::Tiny;
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-requires 'change_fields', '_edit_model', '_conflicting_entity_path';
+
+# Sub-classes are required to implement `_edit_model` and `change_fields`.
+#
+# Sub-classes that consume `Edit::Role::CheckDuplicates` are required to
+# implement `_conflicting_entity_path`.
+#
+# N.B. This is not checked at compile-time.
+
+sub _conflicting_entity_path { die 'Unimplemented' }
+sub _edit_model { die 'Unimplemented' }
+sub change_fields { die 'Unimplemented' }
 
 sub edit_kind { 'edit' }
 
@@ -136,8 +145,6 @@ override allow_auto_edit => sub {
 
     return 1;
 };
-
-sub _conflicting_entity_path { die 'Undefined' };
 
 sub _edit_hash
 {

--- a/lib/MusicBrainz/Server/Edit/Generic/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Merge.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::Generic::Merge;
 use Moose;
-use MooseX::ABC;
 
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 use MusicBrainz::Server::Edit::Exceptions;
@@ -9,8 +8,14 @@ use MooseX::Types::Moose qw( ArrayRef Int Str );
 use MooseX::Types::Structured qw( Dict );
 
 extends 'MusicBrainz::Server::Edit';
-requires '_merge_model';
+
 with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+
+# Sub-classes are required to implement `_merge_model`.
+#
+# N.B. This is not checked at compile-time.
+
+sub _merge_model { die 'Unimplemented' }
 
 sub edit_kind { 'merge' }
 

--- a/lib/MusicBrainz/Server/Edit/Historic.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::Historic;
 use Moose;
-use MooseX::ABC;
 use MooseX::Types::Moose qw( Int HashRef Maybe Object Str );
 
 use MusicBrainz::Server::Translation qw( l );

--- a/lib/MusicBrainz/Server/Edit/WithDifferences.pm
+++ b/lib/MusicBrainz/Server/Edit/WithDifferences.pm
@@ -1,6 +1,5 @@
 package MusicBrainz::Server::Edit::WithDifferences;
 use Moose;
-use MooseX::ABC;
 
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Data::Utils qw( remove_equal );


### PR DESCRIPTION
According to the documentation at https://metacpan.org/pod/MooseX::ABC,

> This module is almost certainly a bad idea. You really want to just be using a role instead!

In most cases we can't easily convert ABC packages into roles, because they extend `MusicBrainz::Server:Edit`, which would also have to become a role.  But then we run into issues where required methods are provided by adjacent roles (triggering compile-time errors), and where attributes can no longer be extended with `+` (common for `data`), which is not possible in a role.

So instead, in most cases I've replaced `required` method lists with stubs that die.  However this means that it's no longer checked that these methods are implemented by the non-abstract classes at compile-time, only at run-time.

This patch incidentally fixes the following warning on plackup start:

> Argument "Moose::Meta::Method=HASH(0x556ed49cc448)" isn't numeric in numeric eq (==) at /home/michael/perl5/lib/perl5/MooseX/ABC/Trait/Class.pm line 61.