### PR TITLE
Eslint fixes: react/prefer-stateless-function

### DIFF
--- a/.eslintrc.unfixed.yaml
+++ b/.eslintrc.unfixed.yaml
@@ -39,7 +39,6 @@ rules:
   react/no-access-state-in-setstate: error
   react/no-multi-comp: [warn, {ignoreStateless: true}]
   react/no-render-return-value: warn
-  react/prefer-stateless-function: warn
   react/jsx-no-bind: [warn, {ignoreDOMComponents: true}]
   flowtype/no-types-missing-file-annotation: error
   flowtype/no-weak-types: warn

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -269,6 +269,7 @@ rules:
   react/no-unused-state: error
   react/no-will-update-set-state: error
   react/prefer-es6-class: off
+  react/prefer-stateless-function: warn
   react/prop-types: off
   # react-in-jsx-scope is not needed now that we've enabled
   # https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -167,7 +167,7 @@ class VoteButtons extends React.Component<VoteButtonsProps> {
   }
 }
 
-type TagRowProps = {
+type TagRowPropsT = {
   $c: CatalystContextT,
   callback: (VoteT) => void,
   count: number,
@@ -176,18 +176,24 @@ type TagRowProps = {
   tag: TagT,
 };
 
-class TagRow extends React.Component<TagRowProps> {
-  render() {
-    const {tag, index} = this.props;
-
-    return (
-      <li className={loopParity(index)} key={tag.name}>
-        <TagLink tag={tag.name} />
-        <VoteButtons {...this.props} />
-      </li>
-    );
-  }
-}
+const TagRow = ({
+  $c,
+  callback,
+  count,
+  currentVote,
+  index,
+  tag,
+}: TagRowPropsT): React.Element<'li'> => (
+  <li className={loopParity(index)} key={tag.name}>
+    <TagLink tag={tag.name} />
+    <VoteButtons
+      $c={$c}
+      callback={callback}
+      count={count}
+      currentVote={currentVote}
+    />
+  </li>
+);
 
 type TagEditorProps = {
   +$c: CatalystContextT,

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -71,68 +71,78 @@ function splitTags(tags) {
 
 type VoteT = 1 | 0 | -1;
 
-type VoteButtonProps = {
-  activeTitle: string | () => string,
+type GenericVoteButtonPropsT = {
   callback: (VoteT) => void,
   currentVote: VoteT,
+};
+
+type VoteButtonPropsT = {
+  ...GenericVoteButtonPropsT,
+  activeTitle: string | () => string,
   text: string,
   title: string | () => string,
   vote: VoteT,
-  ...
 };
 
-class VoteButton extends React.Component<VoteButtonProps> {
-  render() {
-    const {
-      activeTitle,
-      callback,
-      currentVote,
-      text,
-      title,
-      vote,
-    } = this.props;
-    const isActive = vote === currentVote;
-    const className = 'tag-vote tag-' + VOTE_ACTIONS[vote];
-    const buttonTitle = isActive
-      ? unwrapNl(activeTitle)
-      : (currentVote === 0 ? unwrapNl(title) : l('Withdraw vote'));
+const VoteButton = ({
+  activeTitle,
+  callback,
+  currentVote,
+  text,
+  title,
+  vote,
+}: VoteButtonPropsT): React.Element<'button'> => {
+  const isActive = vote === currentVote;
+  const className = 'tag-vote tag-' + VOTE_ACTIONS[vote];
+  const buttonTitle = isActive
+    ? unwrapNl(activeTitle)
+    : (currentVote === 0 ? unwrapNl(title) : l('Withdraw vote'));
 
-    return (
-      <button
-        className={className}
-        disabled={isActive}
-        onClick={isActive
-          ? null
-          : ((...args) => callback(
-            currentVote === 0 ? vote : 0,
-            ...args,
-          ))}
-        title={buttonTitle}
-        type="button"
-      >
-        {text}
-      </button>
-    );
-  }
-}
+  return (
+    <button
+      className={className}
+      disabled={isActive}
+      onClick={isActive
+        ? null
+        : ((...args) => callback(
+          currentVote === 0 ? vote : 0,
+          ...args,
+        ))}
+      title={buttonTitle}
+      type="button"
+    >
+      {text}
+    </button>
+  );
+};
 
-class UpvoteButton extends VoteButton {
-  static defaultProps = {
-    activeTitle: N_l('You’ve upvoted this tag'),
-    text: '+',
-    title: N_l('Upvote'),
-    vote: 1,
-  }
-}
+const UpvoteButton = ({
+  callback,
+  currentVote,
+}: GenericVoteButtonPropsT): React.Element<typeof VoteButton> => (
+  <VoteButton
+    activeTitle={l('You’ve upvoted this tag')}
+    callback={callback}
+    currentVote={currentVote}
+    text="+"
+    title={l('Upvote')}
+    vote={1}
+  />
+);
 
-class DownvoteButton extends VoteButton {
-  static defaultProps = {
-    activeTitle: N_l('You’ve downvoted this tag'),
-    text: '\u2212',
-    title: N_l('Downvote'),
-    vote: -1,
-  }
-}
+const DownvoteButton = ({
+  callback,
+  currentVote,
+}: GenericVoteButtonPropsT): React.Element<typeof VoteButton> => (
+  <VoteButton
+    activeTitle={l('You’ve downvoted this tag')}
+    callback={callback}
+    currentVote={currentVote}
+    text={'\u2212'}
+    title={l('Downvote')}
+    vote={-1}
+  />
+);
 
 type VoteButtonsPropsT = {
   $c: CatalystContextT,

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -134,38 +134,39 @@ class DownvoteButton extends VoteButton {
   }
 }
 
-type VoteButtonsProps = {
+type VoteButtonsPropsT = {
   $c: CatalystContextT,
   callback: (VoteT) => void,
   count: number,
   currentVote: VoteT,
-  ...
 };
 
-class VoteButtons extends React.Component<VoteButtonsProps> {
-  render() {
-    const currentVote = this.props.currentVote;
-    let className = '';
+const VoteButtons = ({
+  $c,
+  callback,
+  count,
+  currentVote,
+}: VoteButtonsPropsT): React.Element<'span'> => {
+  let className = '';
 
-    if (currentVote === 1) {
-      className = ' tag-upvoted';
-    } else if (currentVote === -1) {
-      className = ' tag-downvoted';
-    }
-
-    return (
-      <span className={'tag-vote-buttons' + className}>
-        {this.props.$c.user?.has_confirmed_email_address ? (
-          <>
-            <UpvoteButton {...this.props} />
-            <DownvoteButton {...this.props} />
-          </>
-        ) : null}
-        <span className="tag-count">{this.props.count}</span>
-      </span>
-    );
+  if (currentVote === 1) {
+    className = ' tag-upvoted';
+  } else if (currentVote === -1) {
+    className = ' tag-downvoted';
   }
-}
+
+  return (
+    <span className={'tag-vote-buttons' + className}>
+      {$c.user?.has_confirmed_email_address ? (
+        <>
+          <UpvoteButton callback={callback} currentVote={currentVote} />
+          <DownvoteButton callback={callback} currentVote={currentVote} />
+        </>
+      ) : null}
+      <span className="tag-count">{count}</span>
+    </span>
+  );
+};
 
 type TagRowPropsT = {
   $c: CatalystContextT,

--- a/root/static/scripts/edit/components/PossibleDuplicates.js
+++ b/root/static/scripts/edit/components/PossibleDuplicates.js
@@ -1,4 +1,5 @@
 /*
+ * @flow strict-local
  * Copyright (C) 2015 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -10,44 +11,50 @@ import * as React from 'react';
 
 import EntityLink from '../../common/components/EntityLink';
 
-class PossibleDuplicates extends React.Component {
-  render() {
-    return (
-      <div>
-        <h3>{l('Possible Duplicates')}</h3>
-        <p>{l('We found the following entities with very similar names:')}</p>
-        <ul>
-          {this.props.duplicates.map(dupe => (
-            <li key={dupe.gid}>
-              <EntityLink entity={dupe} target="_blank" />
-            </li>
-          ))}
-        </ul>
-        <p>
-          <label>
-            <input onChange={this.props.onCheckboxChange} type="checkbox" />
-            {' '}
-            {texp.l(
-              'Yes, I still want to enter “{entity_name}”.',
-              {entity_name: this.props.name},
-            )}
-          </label>
-        </p>
-        <p>
-          {exp.l(
-            `Please enter a {doc_disambiguation|disambiguation}
-             to help distinguish this entity from the others.`,
-            {
-              doc_disambiguation: {
-                href: '/doc/Disambiguation_Comment',
-                target: '_blank',
-              },
-            },
-          )}
-        </p>
-      </div>
-    );
-  }
-}
+type PropsT = {
+  duplicates: $ReadOnlyArray<CoreEntityT>,
+  name: string,
+  onCheckboxChange: (event: SyntheticEvent<HTMLInputElement>) => void,
+};
+
+const PossibleDuplicates = ({
+  duplicates,
+  name,
+  onCheckboxChange,
+}: PropsT): React.Element<'div'> => (
+  <div>
+    <h3>{l('Possible Duplicates')}</h3>
+    <p>{l('We found the following entities with very similar names:')}</p>
+    <ul>
+      {duplicates.map(dupe => (
+        <li key={dupe.gid}>
+          <EntityLink entity={dupe} target="_blank" />
+        </li>
+      ))}
+    </ul>
+    <p>
+      <label>
+        <input onChange={onCheckboxChange} type="checkbox" />
+        {' '}
+        {texp.l(
+          'Yes, I still want to enter “{entity_name}”.',
+          {entity_name: name},
+        )}
+      </label>
+    </p>
+    <p>
+      {exp.l(
+        `Please enter a {doc_disambiguation|disambiguation}
+          to help distinguish this entity from the others.`,
+        {
+          doc_disambiguation: {
+            href: '/doc/Disambiguation_Comment',
+            target: '_blank',
+          },
+        },
+      )}
+    </p>
+  </div>
+);
 
 export default PossibleDuplicates;

--- a/root/static/scripts/edit/components/RemoveButton.js
+++ b/root/static/scripts/edit/components/RemoveButton.js
@@ -1,4 +1,5 @@
 /*
+ * @flow strict
  * Copyright (C) 2015 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,
@@ -8,18 +9,24 @@
 
 import * as React from 'react';
 
-class RemoveButton extends React.Component {
-  render() {
-    return (
-      <button
-        className="nobutton icon remove-item"
-        data-index={this.props['data-index']}
-        onClick={this.props.onClick}
-        title={this.props.title}
-        type="button"
-      />
-    );
-  }
-}
+type PropsT = {
+  dataIndex?: number,
+  onClick: (event: SyntheticEvent<HTMLInputElement>) => void,
+  title: string,
+};
+
+const RemoveButton = ({
+  dataIndex,
+  onClick,
+  title,
+}: PropsT): React.Element<'button'> => (
+  <button
+    className="nobutton icon remove-item"
+    data-index={dataIndex}
+    onClick={onClick}
+    title={title}
+    type="button"
+  />
+);
 
 export default RemoveButton;

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -932,7 +932,7 @@ export class ExternalLinksEditor
   }
 }
 
-type LinkTypeSelectProps = {
+type LinkTypeSelectPropsT = {
   +handleTypeBlur:
     (SyntheticFocusEvent<HTMLSelectElement>) => void,
   +handleTypeChange:
@@ -941,40 +941,42 @@ type LinkTypeSelectProps = {
   +type: number | null,
 };
 
-class LinkTypeSelect extends React.Component<LinkTypeSelectProps> {
-  render(): React.Element<'select'> {
-    const {options, type} = this.props;
-    const optionAvailable = options.some(option => option.value === type);
-    // If the selected type is not available, display it as placeholder
-    const linkType = type ? linkedEntities.link_type[type] : null;
-    const placeholder = (optionAvailable || !linkType)
-      ? '\xA0'
-      : l_relationships(
-        linkType.link_phrase,
-      );
-
-    return (
-      <select
-        // If the selected type is not available, display an error indicator
-        className={optionAvailable || !type ? 'link-type' : 'link-type error'}
-        onBlur={this.props.handleTypeBlur}
-        onChange={this.props.handleTypeChange}
-        value={type || ''}
-      >
-        <option value="">{placeholder}</option>
-        {options.map(option => (
-          <option
-            disabled={option.disabled}
-            key={option.value}
-            value={option.value}
-          >
-            {option.text}
-          </option>
-        ))}
-      </select>
+const LinkTypeSelect = ({
+  handleTypeBlur,
+  handleTypeChange,
+  options,
+  type,
+}: LinkTypeSelectPropsT): React.Element<'select'> => {
+  const optionAvailable = options.some(option => option.value === type);
+  // If the selected type is not available, display it as placeholder
+  const linkType = type ? linkedEntities.link_type[type] : null;
+  const placeholder = (optionAvailable || !linkType)
+    ? '\xA0'
+    : l_relationships(
+      linkType.link_phrase,
     );
-  }
-}
+
+  return (
+    <select
+      // If the selected type is not available, display an error indicator
+      className={optionAvailable || !type ? 'link-type' : 'link-type error'}
+      onBlur={handleTypeBlur}
+      onChange={handleTypeChange}
+      value={type || ''}
+    >
+      <option value="">{placeholder}</option>
+      {options.map(option => (
+        <option
+          disabled={option.disabled}
+          key={option.value}
+          value={option.value}
+        >
+          {option.text}
+        </option>
+      ))}
+    </select>
+  );
+};
 
 type TypeDescriptionProps = {
   +type: number | null,

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1213,7 +1213,7 @@ export class ExternalLink extends React.Component<LinkProps> {
           <td className="link-actions">
             {notEmpty ? (
               <RemoveButton
-                data-index={props.index}
+                dataIndex={props.index}
                 onClick={() => props.onUrlRemove()}
                 title={l('Remove Link')}
               />


### PR DESCRIPTION
We might still want to convert a bunch more that *do* use state to use hooks (is there a rule for that?) but this at least allows us to move one more rule to the fixed folder, AFAICT.