### PR TITLE
Add a HACKING-PROD file and document cpanfile updates

### DIFF
--- a/HACKING-PROD.md
+++ b/HACKING-PROD.md
@@ -1,0 +1,35 @@
+
+Introduction
+============
+
+This file contains specific instructions that apply mostly or exclusively
+to the MusicBrainz production servers.
+
+Updating Docker files after cpanfile modifications
+=======
+
+If you modify the cpanfile, especially if you add new packages to it,
+you will also need to update the files used to build Docker images.
+
+The first step is to generate a new `cpanfile.snapshot`. To do this, assuming
+you have a Docker service running, run:
+
+    $ ./docker/generate_cpanfile_snapshot.sh 
+
+Generating the snapshot will take quite a while. Once it is done, commit it
+and push it.
+
+Then you will need to create a Docker `musicbrainz-tests` image. This step
+also takes quite a while, so you might want to consider running it inside a
+MetaBrainz server to make it faster. In any case, inside a musicbrainz-server
+checkout running the updated branch, you should run (note the dot at the end):
+
+    $ docker build --tag metabrainz/musicbrainz-tests:v-YYYY-MM --file docker/Dockerfile.tests .
+
+Then log into Docker Hub with `docker login` (the credentials are in the
+syswiki repo) and push the created image to Docker Hub:
+
+    $ docker push metabrainz/musicbrainz-tests:v-YYYY-MM
+
+Finally, you will need to update [.circleci/config.yml](.circleci/config.yml),
+update the listed `musicbrainz-tests` image version and push the changes.


### PR DESCRIPTION
This is for stuff that is not private (so should not be on syswiki) but is also not relevant for most local users of MBS, just for running our production setup.

I was doing this today with help from @mwiencek for one of my PRs and I thought we could document it properly so I don't have to ask again next time :)