### PR TITLE
MBS-11742: Also clean non-/user YouTube channels

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4912,13 +4912,19 @@ const CLEANUPS: CleanupEntries = {
       url = url.replace(/^(https?:\/\/)?([^\/]+\.)?youtube\.com(?:\/#)?/, 'https://www.youtube.com');
       // YouTube /c/ user channels (/c/ is unneeded)
       url = url.replace(/^https:\/\/www\.youtube\.com\/c\//, 'https://www.youtube.com/');
+      // Drop channel subsections (/user or /channel version)
+      url = url.replace(/\/(channel|user)\/([^\/?#]+).*$/, '/$1/$2');
+      // Drop channel subsections (channel name only version)
+      url = url.replace(
+        /^https:\/\/www\.youtube\.com\/([a-zA-Z0-9_-]+)\/(?:about|channels|community|featured|playlists|videos)(?:[\/?&#].*)?$/,
+        'https://www.youtube.com/$1',
+      );
       // YouTube URL shortener
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?youtu\.be\/([a-zA-Z0-9_-]+).*$/, 'https://www.youtube.com/watch?v=$1');
       // YouTube standard watch URL
       url = url.replace(/^https:\/\/www\.youtube\.com\/.*[?&](v=[a-zA-Z0-9_-]+).*$/, 'https://www.youtube.com/watch?$1');
       // YouTube embeds
       url = url.replace(/^https:\/\/www\.youtube\.com\/(?:embed|v)\/([a-zA-Z0-9_-]+).*$/, 'https://www.youtube.com/watch?v=$1');
-      url = url.replace(/\/user\/([^\/?#]+).*$/, '/user/$1');
       return url;
     },
     validate: function (url, id) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5055,6 +5055,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
   },
   {
+                     input_url: 'https://www.youtube.com/c/communitymusiclearning/about?view_as=subscriber',
+             input_entity_type: 'label',
+    expected_relationship_type: 'youtube',
+            expected_clean_url: 'https://www.youtube.com/communitymusiclearning',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.youtube.com/channel/UCKG8UEfkMG_86SaCkapjTMQ/featured?view_as=subscriber',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'youtube',
+            expected_clean_url: 'https://www.youtube.com/channel/UCKG8UEfkMG_86SaCkapjTMQ',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
                      input_url: 'http://youtu.be/UmHdefsaL6I',
              input_entity_type: 'recording',
     expected_relationship_type: 'streamingfree',


### PR DESCRIPTION
### Implement MBS-11742

YouTube has channels using /user, /channel, /c and no prefix. No idea *why*, but in any case while you can remove /c
you can't remove /channel, for example. So to be safe I just deal with them separately here. While for /channel, like for /user, it's probably fine to just remove anything at the end, for the ones with the username only it's harder to be confident on a wide regex, so just removing the main tabs from the YouTube channel page.