### PR TITLE
MBS-12138: Drop parens from Amazon Music pretty name

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/AmazonMusic.pm
@@ -19,7 +19,7 @@ sub pretty_name
         $country = 'US' if $country eq 'com';
         $country =~ tr/a-z/A-Z/;
 
-        return "Amazon Music ($country)";
+        return "Amazon Music $country";
     }
 
     return $self->url->as_string;


### PR DESCRIPTION
### Implement MBS-12138

We don't use these in any of the other pretty names that include countries (Apple and Napster just do "Site CountryCode", and ASIN does CountryCode: ASIN). As such, it seems more consistent to drop them from here too.
