### PR TITLE
MBS-12201: Show any non-part-of rels on series page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -16,7 +16,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'series',
     relationships => {
         cardinal => ['edit'],
-        subset => {show => ['artist', 'label', 'place', 'series', 'url']},
+        subset => {show => ['artist', 'label', 'place', 'recording', 'release_group', 'series', 'url', 'work']},
         default => ['url']
     },
 };


### PR DESCRIPTION
### Fix MBS-12201

We already filter out part-of rels, so there's no good reason not to show any entities here which have non part-of rels to series. Right now that seems to be RG and Work. Recording only has a relationship hidden by cardinality from the series page, but also preemptively allowing it.