### PR TITLE
MBS-12215 / MBS-12216: Load annotation entity when possible on search results

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -467,8 +467,14 @@ sub schema_fixup
     {
         my $parent_type = $data->{type};
         $parent_type =~ s/-/_/g;
-        my $entity_model = $self->c->model( type_to_model($parent_type) )->_entity_class;
-        $data->{parent} = $entity_model->new( { name => $data->{name}, gid => $data->{entity} });
+        my $entity_model = $self->c->model( type_to_model($parent_type) );
+        my $entity = $entity_model->get_by_gid($data->{entity});
+        $data->{parent} = defined $entity
+            ? $entity
+            : $entity_model->_entity_class->new({
+                name => $data->{name},
+                gid => $data->{entity},
+            });
         delete $data->{entity};
         delete $data->{type};
     }


### PR DESCRIPTION
### Fix MBS-12215 / MBS-12216

This was just creating a generic entity based on indexed data, but that means we lack a lot of useful info, such as sort names for artists. As such, this now loads the entity if possible and only shows the mock version if we cannot find more.

This also effectively resolves MBS-12216, an old search ticket that called for the entity disambiguation being displayed.

Not sure if results for deleted entities should actually be returned (that's a separate open search ticket) but I guess that even then, there's likely to be a few cases where the index hasn't caught up with an entity removal yet.
