### PR TITLE
MBS-12226: Add allowed prefix of niconico video ID

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -3221,11 +3221,11 @@ const CLEANUPS: CleanupEntries = {
     restrict: [{...LINK_TYPES.streamingfree, ...LINK_TYPES.videochannel}],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?ch\.nicovideo\.jp\/([^\/]+).*$/, 'https://ch.nicovideo.jp/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?nicovideo\.jp\/(user\/[0-9]+|watch\/sm[0-9]+).*$/, 'https://www.nicovideo.jp/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?nicovideo\.jp\/(user\/[0-9]+|watch\/(?:sm|so|nm|ax|ca|cw|nl|z[a-d])[0-9]+).*$/, 'https://www.nicovideo.jp/$1');
       return url;
     },
     validate: function (url, id) {
-      const m = /^(?:https?:\/\/)?(ch|www)\.nicovideo\.jp\/(?:(user)\/[0-9]+|(watch)\/sm[0-9]+|[^\/]+)$/.exec(url);
+      const m = /^(?:https?:\/\/)?(ch|www)\.nicovideo\.jp\/(?:(user)\/[0-9]+|(watch)\/(?:sm|so|nm|ax|ca|cw|nl|z[a-d])[0-9]+|[^\/]+)$/.exec(url);
       if (m) {
         const subdomain = m[1];
         const prefix = m[2] || m[3];

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -3238,6 +3238,20 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['recording', 'release'],
   },
   {
+                     input_url: 'https://www.nicovideo.jp/watch/so26654381?',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.nicovideo.jp/watch/so26654381',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
+                     input_url: 'https://www.nicovideo.jp/watch/nm6049209?',
+             input_entity_type: 'recording',
+    expected_relationship_type: 'streamingfree',
+            expected_clean_url: 'https://www.nicovideo.jp/watch/nm6049209',
+       only_valid_entity_types: ['recording', 'release'],
+  },
+  {
                      input_url: 'https://www.nicovideo.jp/user/1050860/top',
              input_entity_type: 'artist',
     expected_relationship_type: 'videochannel',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

See https://tickets.metabrainz.org/browse/MBS-12226


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Add allowed prefix of niconico video ID to regular expression.

currently, video that have a these prefix can be watch.

- sm
- so
- nm
- ax
- ca
- cw
- cw
- nl
- /z[a-d]/

other prefix also exist, but they are not available to watch currently.
(mostly due to channel that owns video are closed)

