### PR TITLE
Improve test documentation (VII): Shared tests (Aliases)

### DIFF
--- a/admin/sql/InsertTestData.sql
+++ b/admin/sql/InsertTestData.sql
@@ -61,9 +61,9 @@ INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES
 INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES
     (4, '7348f3a0-454e-11de-8a39-0800200c9a66', 'Test RG 2', 4, 1);
 
-INSERT INTO release_group_alias (id, name, sort_name, release_group, edits_pending)
-    VALUES (1, 'Test RG 1 Alias 1', 'Test RG 1 Alias Sort Name 1', 3, 0),
-           (2, 'Test RG 1 Alias 2', 'Test RG 1 Alias Sort Name 2', 3, 0);
+INSERT INTO release_group_alias (id, name, sort_name, release_group, type, edits_pending)
+    VALUES (1, 'Test RG 1 Alias 1', 'Test RG 1 Alias Sort Name 1', 3, 1, 0),
+           (2, 'Test RG 1 Alias 2', 'Test RG 1 Alias Sort Name 2', 3, 2, 0);
 
 INSERT INTO work (id, gid, name, type) VALUES
     (1, '745c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 1);
@@ -143,8 +143,8 @@ INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES
 INSERT INTO release (id, gid, name, artist_credit, release_group, status, barcode) VALUES (2, 'f205627f-b70a-409d-adbe-66289b614e80', 'Aerial', 3, 2, 1, '0094634396028');
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (2, 221, 2005, 11, 7);
 
-INSERT INTO release_alias (id, name, sort_name, release, edits_pending)
-    VALUES (1, 'Ærial', 'Ærial', 2, 0);
+INSERT INTO release_alias (id, name, sort_name, release, type, edits_pending)
+    VALUES (1, 'Ærial', 'Ærial', 2, 1, 0);
 
 INSERT INTO release (id, gid, name, artist_credit, release_group, status, barcode) VALUES (3, '9b3d9383-3d2a-417f-bfbb-56f7c15f075b', 'Aerial', 3, 2, 1, '0827969777220');
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (3, 222, 2005, 11, 8);
@@ -195,8 +195,8 @@ INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
     (17, '1539ac10-5081-4469-b8f2-c5896132724e', 'Aerial', 3, 472880);
 
-INSERT INTO recording_alias (id, name, sort_name, recording, edits_pending)
-    VALUES (1, 'King of the Mt.', 'King of the Mt.', 2, 0);
+INSERT INTO recording_alias (id, name, sort_name, recording, type, edits_pending)
+    VALUES (1, 'King of the Mt.', 'King of the Mt.', 2, 1, 0);
 
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (4, '39164965-d4bd-49e6-925d-72026ad03dce', 3, 1, 1, 2, 'King of the Mountain', 3, 293720);
 INSERT INTO track (id, gid, medium, position, number, recording, name, artist_credit, length) VALUES (5, '82edb036-4097-484d-ac8a-cf4971451ca0', 3, 2, 2, 3, 'π', 3, 369680);

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
@@ -1,17 +1,18 @@
 package t::MusicBrainz::Server::Controller::Area::Aliases;
 use Test::Routine;
 use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
+use utf8;
 
 with 't::Mechanize', 't::Context';
 
 =head2 Test description
 
-This test checks whether area aliases are correctly listed in the JSON-LD
-of an area's alias page.
+This test checks whether area aliases are correctly listed on the area
+alias page, both on the site itself and on the JSON-LD data.
 
 =cut
 
-test 'Area alias appears on JSON-LD' => sub {
+test 'Area alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -23,6 +24,9 @@ test 'Area alias appears on JSON-LD' => sub {
         'Fetched area aliases page',
     );
     html_ok($mech->content);
+
+    $mech->text_contains('オーストラリア', 'Alias page lists the alias');
+    $mech->text_contains('Area name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAlias.pm
@@ -12,19 +12,22 @@ the sort name defaults to the name when not explicitly entered.
 
 =cut
 
-test 'Test adding alias with sort name' => sub {
+test 'Adding alias with sort name' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/add-alias');
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/add-alias',
+        'Fetched the add alias page',
+    );
 
     my @edits = capture_edits {
         $mech->submit_form_ok({
             with_fields => {
                 'edit-alias.name' => 'An alias',
-                'edit-alias.sort_name' => 'Artist, Test'
+                'edit-alias.sort_name' => 'Artist, Test',
             },
         },
         'The form returned a 2xx response code')
@@ -56,7 +59,7 @@ test 'Test adding alias with sort name' => sub {
                 day => undef
             },
             type_id => undef,
-            ended => 0
+            ended => 0,
         },
         'The edit contains the right data',
     );
@@ -76,14 +79,18 @@ test 'Test adding alias with sort name' => sub {
     );
 };
 
-test 'MBS-6896: Test adding alias without sort name' => sub {
+test 'MBS-6896: Adding alias without sort name defaults it to name' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     prepare_test($test);
 
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/add-alias',
+        'Fetched the add alias page',
+    );
+
     my @edits = capture_edits {
-        $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/add-alias');
         $mech->submit_form_ok({
             with_fields => {
                 'edit-alias.name' => 'Another alias',

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
@@ -12,7 +12,6 @@ alias page, both on the site itself and on the JSON-LD data.
 =cut
 
 test 'Artist alias appears on alias page content and on JSON-LD' => sub {
-
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -24,15 +23,17 @@ test 'Artist alias appears on alias page content and on JSON-LD' => sub {
 
     $mech->get_ok(
         '/artist/745c079d-374e-4436-9448-da92dedef3ce/aliases',
-        'Fetched artist alias page',
+        'Fetched artist aliases page',
     );
     html_ok($mech->content);
-    $mech->content_contains('Test Alias', 'Alias page lists the alias');
-    $mech->content_contains(
+
+    $mech->text_contains('Test Alias', 'Alias page lists the alias');
+    $mech->text_contains('Artist name', 'Alias page lists the alias type');
+    $mech->text_contains(
         '2000-01-01',
         'Alias page lists the alias begin date',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         '2005-05-06',
         'Alias page lists the alias end date',
     );

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
@@ -12,20 +12,16 @@ an edit note.
 
 =cut
 
-test 'Test alias deletion' => sub {
+test 'Deleting an alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c    = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database(
-        $c,
-        '+controller_artist',
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/delete',
+        'Fetched the delete alias page',
     );
-
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
-
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/delete');
     my @edits = capture_edits {
         $mech->submit_form_ok({
                 with_fields => {
@@ -35,7 +31,7 @@ test 'Test alias deletion' => sub {
             },
             'The form returned a 2xx response code',
         );
-    } $c;
+    } $test->c;
 
     is(@edits, 1, 'The edit was entered');
 
@@ -82,20 +78,16 @@ test 'Test alias deletion' => sub {
     );
 };
 
-test 'Test edit note is required' => sub {
+test 'Edit note is required' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c    = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database(
-        $c,
-        '+controller_artist',
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/delete',
+        'Fetched the delete alias page',
     );
-
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
-
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/delete');
     my @edits = capture_edits {
         $mech->submit_form_ok({
                 with_fields => {
@@ -104,7 +96,7 @@ test 'Test edit note is required' => sub {
             },
             'The form returned a 2xx response code',
         );
-    } $c;
+    } $test->c;
 
     is(@edits, 0, 'No edit was entered');
 
@@ -113,5 +105,19 @@ test 'Test edit note is required' => sub {
         'Contains warning about edit note being required',
     );
 };
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $test->c,
+        '+controller_artist',
+    );
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/DeleteAlias.pm
@@ -61,7 +61,7 @@ test 'Deleting an alias' => sub {
                 day => 6
             },
             ended => 1,
-            type_id => undef
+            type_id => 1,
         },
         'The edit contains the right data',
     );

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
@@ -12,14 +12,17 @@ the sort name defaults to the name when not explicitly entered (blanked).
 
 =cut
 
-test 'Test editing alias' => sub {
+test 'Editing alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     prepare_test($test);
 
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/edit',
+        'Fetched the edit alias page',
+    );
     my @edits = capture_edits {
-        $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/edit');
         $mech->submit_form(
             with_fields => {
                 'edit-alias.name' => 'Edited alias'
@@ -65,14 +68,18 @@ test 'Test editing alias' => sub {
     );
 };
 
-test 'MBS-6896: Test editing alias and emptying sort name' => sub {
+test 'MBS-6896: Removing alias sort name defaults it to name' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     prepare_test($test);
 
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+
     my @edits = capture_edits {
-        $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/alias/1/edit');
         $mech->submit_form(
             with_fields => {
                 'edit-alias.name' => 'Edit #2',

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditAlias.pm
@@ -25,7 +25,10 @@ test 'Editing alias' => sub {
     my @edits = capture_edits {
         $mech->submit_form(
             with_fields => {
-                'edit-alias.name' => 'Edited alias'
+                'edit-alias.name' => 'Edited alias',
+                # HTML::Form doesn't understand selected=""
+                # so we need to specifically set this
+                'edit-alias.type_id' => '1',
             });
     } $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAlias.pm
@@ -5,69 +5,122 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether alias adding for labels works, including whether
+the sort name defaults to the name when not explicitly entered.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding alias with sort name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
 
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/add-alias');
-$mech->submit_form(
-    with_fields => {
-        'edit-alias.name' => 'An alias',
-        'edit-alias.sort_name' => 'An alias sort name'
-    });
+    prepare_test($test);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAlias');
-is_deeply($edit->data, {
-    entity => {
-        id => 2,
-        name => 'Warp Records'
-    },
-    name => 'An alias',
-    sort_name => 'An alias sort name',
-    locale => undef,
-    primary_for_locale => 0,
-    begin_date => {
-        year => undef,
-        month => undef,
-        day => undef
-    },
-    end_date => {
-        year => undef,
-        month => undef,
-        day => undef
-    },
-    type_id => undef,
-    ended => 0
-});
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/add-alias',
+        'Fetched the add alias page',
+    );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-html_ok($mech->content);
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-alias.name' => 'An alias',
+                'edit-alias.sort_name' => 'An alias sort name',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
-$mech->content_contains('Warp Records', '..contains label name');
-$mech->content_contains('/label/46f0f4cd-8aab-4b33-b698-f459faf64190', '..contains label link');
-$mech->content_contains('An alias', '..contains alias name');
-$mech->content_contains('An alias sort name', '..contains alias sort name');
+    is(@edits, 1, 'The edit was entered');
 
-# A sortname isn't required (MBS-6896)
-($edit) = capture_edits {
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/add-alias');
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'Another alias',
-        });
-} $c;
+    my $edit = shift(@edits);
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAlias');
 
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAlias');
-is($edit->data->{sort_name}, 'Another alias', 'sort_name defaults to name');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 2,
+                name => 'Warp Records'
+            },
+            name => 'An alias',
+            sort_name => 'An alias sort name',
+            locale => undef,
+            primary_for_locale => 0,
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            type_id => undef,
+            ended => 0,
+        },
+        'The edit contains the right data',
+    );
 
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+
+    $mech->content_contains('Warp Records', 'Edit page contains label name');
+    $mech->content_contains(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+        'Edit page contains artist link',
+    );
+    $mech->content_contains('An alias', 'Edit page contains alias name');
+    $mech->content_contains(
+        'An alias sort name',
+        'Edit page contains the selected alias sort name',
+    );
 };
+
+test 'MBS-6896: Adding alias without sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/add-alias',
+        'Fetched the add alias page',
+    );
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-alias.name' => 'Another alias',
+            }
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAlias');
+    is(
+        $edit->data->{sort_name},
+        'Another alias',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
@@ -4,17 +4,28 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether label aliases are correctly listed on the label
+alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Label alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c);
 
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/aliases', 'get label aliases');
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/aliases',
+        'Fetched label aliases page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('Test Label Alias', 'has the label alias');
-    $mech->content_contains('Label name', 'has the label alias type');
+
+    $mech->text_contains('Test Label Alias', 'Alias page lists the alias');
+    $mech->text_contains('Label name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         'foundingDate' => '1989-02-03',

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/DeleteAlias.pm
@@ -1,58 +1,120 @@
 package t::MusicBrainz::Server::Controller::Label::DeleteAlias;
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that label alias deletion works, and that it requires
+an edit note.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Deleting an alias' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
 
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/delete');
-$mech->submit_form(
-    with_fields => {
-        'confirm.edit_note' => 'This is required now.'
-    });
+    prepare_test($test);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::DeleteAlias');
-is_deeply($edit->data, {
-    entity => {
-        id => 2,
-        name => 'Warp Records'
-    },
-    alias_id  => 1,
-    name      => 'Test Label Alias',
-    sort_name => 'Test Label Alias',
-    begin_date => {
-        year => undef,
-        month => undef,
-        day => undef
-    },
-    end_date => {
-        year => undef,
-        month => undef,
-        day => undef
-    },
-    ended => 0,
-    type_id => 1,
-    locale => undef,
-    primary_for_locale => 0
-});
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' =>
+                        q(Some edit note since it's required)
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-html_ok($mech->content);
-$mech->content_contains('Warp Records', '..has label name');
-$mech->content_contains('Test Label Alias', '..has alias name');
+    is(@edits, 1, 'The edit was entered');
 
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::DeleteAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 2,
+                name => 'Warp Records'
+            },
+            alias_id  => 1,
+            name      => 'Test Label Alias',
+            sort_name => 'Test Label Alias',
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            ended => 0,
+            type_id => 1,
+            locale => undef,
+            primary_for_locale => 0,
+        },
+        'The edit contains the right data',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Warp Records',
+        'The edit page contains the label name',
+    );
+    $mech->content_contains(
+        'Test Label Alias',
+        'The edit page contains the alias name',
+    );
 };
+
+test 'Edit note is required' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' => ''
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
+
+    is(@edits, 0, 'No edit was entered');
+
+    $mech->content_contains(
+        'You must provide an edit note',
+        'Contains warning about edit note being required',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/EditAlias.pm
@@ -5,62 +5,112 @@ use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether alias editing for labels works, including whether
+the sort name defaults to the name when not explicitly entered (blanked).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Editing alias' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
 
-# Test deleting aliases
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/edit');
-$mech->submit_form(
-    with_fields => {
-        'edit-alias.name' => 'Edited alias',
-        # HTML::Form doesn't understand selected=""
-        # so we need to specifically set this
-        'edit-alias.type_id' => '1'
-    });
+    prepare_test($test);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::EditAlias');
-is_deeply($edit->data, {
-    entity => {
-        id => 2,
-        name => 'Warp Records'
-    },
-    alias_id  => 1,
-    new => {
-        name => 'Edited alias',
-    },
-    old => {
-        name => 'Test Label Alias',
-    }
-});
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edited alias',
+                # HTML::Form doesn't understand selected=""
+                # so we need to specifically set this
+                'edit-alias.type_id' => '1',
+            });
+    } $test->c;
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-html_ok($mech->content);
-$mech->text_contains('Warp Records', '..has label name');
-$mech->text_contains('Test Label Alias', '..has old alias name');
-$mech->text_contains('Edited alias', '..has new alias name');
+    is(@edits, 1, 'The edit was entered');
 
-# A sortname isn't required (MBS-6896)
-($edit) = capture_edits {
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/edit');
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'Edit #2',
-            'edit-alias.sort_name' => '',
-        });
-} $c;
+    my $edit = shift(@edits);
 
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::EditAlias');
-is($edit->data->{new}{sort_name}, 'Edit #2', 'sort_name defaults to name');
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::EditAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 2,
+                name => 'Warp Records'
+            },
+            alias_id  => 1,
+            new => {
+                name => 'Edited alias',
+            },
+            old => {
+                name => 'Test Label Alias',
+            }
+        },
+        'The edit contains the right data',
+    );
 
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Warp Records',
+        'Edit page contains artist name',
+    );
+    $mech->content_contains(
+        'Test Label Alias',
+        'Edit page contains old alias name',
+    );
+    $mech->content_contains(
+        'Edited alias',
+        'Edit page contains new alias name',
+    );
 };
+
+test 'MBS-6896: Removing alias sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edit #2',
+                'edit-alias.sort_name' => '',
+            });
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::EditAlias');
+    is(
+        $edit->data->{new}{sort_name},
+        'Edit #2',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
@@ -4,7 +4,14 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether place aliases are correctly listed on the place
+alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Place alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -12,8 +19,14 @@ test all => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+area');
     MusicBrainz::Server::Test->prepare_test_database($c, '+place');
 
-    $mech->get_ok('/place/df9269dd-0470-4ea2-97e8-c11e46080edd/aliases', 'fetch place aliases page');
+    $mech->get_ok(
+        '/place/df9269dd-0470-4ea2-97e8-c11e46080edd/aliases',
+        'Fetched place aliases page',
+    );
     html_ok($mech->content);
+
+    $mech->text_contains('A Test Alias', 'Alias page lists the alias');
+    $mech->text_contains('Place name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         'foundingDate' => '2013',

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAlias.pm
@@ -4,72 +4,131 @@ use Test::More;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
 use utf8;
 
-with 't::Mechanize';
-with 't::Context';
+with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether alias adding for recordings works, including whether
+the sort name defaults to the name when not explicitly entered.
+
+=cut
+
+test 'Adding alias with sort name' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($test->c, '+tracklist');
-    MusicBrainz::Server::Test->prepare_test_database($c, '+recording');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'password' } );
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/add-alias');
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/add-alias',
+        'Fetched the add alias page',
+    );
 
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'Now that’s what I call a recording',
-            'edit-alias.sort_name' => 'recording, Now that’s what I call a'
-        });
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-alias.name' => 'Now that’s what I call a recording',
+                'edit-alias.sort_name' => 'recording, Now that’s what I call a'
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
     isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::AddAlias');
 
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'King of the Mountain',
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'King of the Mountain',
+            },
+            name => 'Now that’s what I call a recording',
+            sort_name => 'recording, Now that’s what I call a',
+            locale => undef,
+            primary_for_locale => 0,
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            type_id => undef,
+            ended => 0,
         },
-        name => 'Now that’s what I call a recording',
-        sort_name => 'recording, Now that’s what I call a',
-        locale => undef,
-        primary_for_locale => 0,
-        begin_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        end_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        type_id => undef,
-        ended => 0
-    });
+        'The edit contains the right data',
+    );
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
 
-    $mech->content_contains('King of the Mountain', '..contains recording name');
-    $mech->content_contains('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8', '..contains recording link');
-    $mech->content_contains('Now that’s what I call a recording', '..contains alias name');
-    $mech->content_contains('recording, Now that’s what I call a', '..contains alias sort name');
+    $mech->content_contains(
+        'King of the Mountain',
+        'Edit page contains series name',
+    );
+    $mech->content_contains(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
+        'Edit page contains series link',
+    );
+    $mech->content_contains(
+        'Now that’s what I call a recording',
+        'Edit page contains alias name',
+    );
+    $mech->content_contains(
+        'recording, Now that’s what I call a',
+        'Edit page contains the selected alias sort name',
+    );
+};
 
-    # A sortname isn't required (MBS-6896)
-    ($edit) = capture_edits {
-        $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/add-alias');
-        $mech->submit_form(
+test 'MBS-6896: Adding alias without sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/add-alias',
+        'Fetched the add alias page',
+    );
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
             with_fields => {
                 'edit-alias.name' => 'Now that’s what I call another recording',
-            });
-    } $c;
+            }
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
 
     isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::AddAlias');
-    is($edit->data->{sort_name}, 'Now that’s what I call another recording', 'sort_name defaults to name');
+    is(
+        $edit->data->{sort_name},
+        'Now that’s what I call another recording',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
 };
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+tracklist');
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+recording');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
@@ -4,15 +4,28 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether recording aliases are correctly listed on the
+recording alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Recording alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c);
 
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/aliases', 'fetch recording aliases');
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/aliases',
+        'Fetched recording aliases page',
+    );
     html_ok($mech->content);
+
+    $mech->text_contains('King of the Mt.', 'Alias page lists the alias');
+    $mech->text_contains('Recording name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
@@ -1,61 +1,121 @@
 package t::MusicBrainz::Server::Controller::Recording::DeleteAlias;
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
-with 't::Mechanize';
-with 't::Context';
+with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks that recording alias deletion works, and that it requires
+an edit note.
+
+=cut
+
+test 'Deleting an alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+tracklist');
-    MusicBrainz::Server::Test->prepare_test_database($c, '+recording');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'password' } );
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' =>
+                        q(Some edit note since it's required)
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
 
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/delete');
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->submit_form(
-        with_fields => {
-            'confirm.edit_note' => 'remove this now!'
-        }
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::DeleteAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'King of the Mountain'
+            },
+            alias_id  => 1,
+            name      => 'Test Recording Alias',
+            sort_name => 'Test Recording Alias',
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            ended => 0,
+            type_id => 2,
+            locale => undef,
+            primary_for_locale => 0,
+        },
+        'The edit contains the right data',
     );
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-    isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::DeleteAlias');
-
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'King of the Mountain'
-        },
-        alias_id  => 1,
-        name => 'Test Recording Alias',
-        sort_name => 'Test Recording Alias',
-        begin_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        end_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        ended => 0,
-        type_id => 2,
-        locale => undef,
-        primary_for_locale => 0
-    });
-
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
-    $mech->content_contains('King of the Mountain', '..has recording name');
-    $mech->content_contains('Test Recording Alias', '..has alias name');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'King of the Mountain',
+        'The edit page contains the recording name',
+    );
+    $mech->content_contains(
+        'Test Recording Alias',
+        'The edit page contains the alias name',
+    );
 };
+
+test 'Edit note is required' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' => ''
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
+
+    is(@edits, 0, 'No edit was entered');
+
+    $mech->content_contains(
+        'You must provide an edit note',
+        'Contains warning about edit note being required',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+tracklist');
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+recording');
+
+    $test->mech->get_ok('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' },
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/DeleteAlias.pm
@@ -59,7 +59,7 @@ test 'Deleting an alias' => sub {
                 day => undef
             },
             ended => 0,
-            type_id => 2,
+            type_id => 1,
             locale => undef,
             primary_for_locale => 0,
         },

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/EditAlias.pm
@@ -3,67 +3,164 @@ use Test::Routine;
 use Test::More;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
-with 't::Mechanize';
-with 't::Context';
+with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether alias editing for recordings works, including whether
+the sort name defaults to the name when not explicitly entered (blanked).
+It also checks that editing an alias to be a search hint automatically sets
+the sort name to match the name.
+
+=cut
+
+test 'Editing alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+tracklist');
-    MusicBrainz::Server::Test->prepare_test_database($c, '+recording');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'password' } );
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edited alias',
+                # HTML::Form doesn't understand selected=""
+                # so we need to specifically set this
+                'edit-alias.type_id' => '1',
+            });
+    } $test->c;
 
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/edit');
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'brand new alias',
-            # HTML::Form doesn't understand selected=""
-            # so we need to specifically set this
-            'edit-alias.type_id' => '2'
-        });
+    my $edit = shift(@edits);
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
     isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::EditAlias');
-
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'King of the Mountain',
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'King of the Mountain'
+            },
+            alias_id  => 1,
+            new => {
+                name => 'Edited alias',
+            },
+            old => {
+                name => 'Test Recording Alias',
+            }
         },
-        alias_id  => 1,
-        new => {
-            name => 'brand new alias',
-            sort_name => 'brand new alias',
-        },
-        old => {
-            name => 'Test Recording Alias',
-            sort_name => 'Test Recording Alias',
-        }
-    });
+        'The edit contains the right data',
+    );
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
-    $mech->text_contains('King of the Mountain', '..has recording name');
-    $mech->text_contains('Test Recording Alias', '..has old alias name');
-    $mech->text_contains('brand new alias', '..has new alias name');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'King of the Mountain',
+        'Edit page contains recording name',
+    );
+    $mech->content_contains(
+        'Test Recording Alias',
+        'Edit page contains old alias name',
+    );
+    $mech->content_contains(
+        'Edited alias',
+        'Edit page contains new alias name',
+    );
+};
 
-    # A sortname isn't required (MBS-6896)
-    ($edit) = capture_edits {
-        $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/edit');
+test 'MBS-6896: Removing alias sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+
+    my @edits = capture_edits {
         $mech->submit_form(
             with_fields => {
                 'edit-alias.name' => 'Edit #2',
                 'edit-alias.sort_name' => '',
             });
-    } $c;
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
 
     isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::EditAlias');
-    is($edit->data->{new}{sort_name}, 'Edit #2', 'sort_name defaults to name');
+    is(
+        $edit->data->{new}{sort_name},
+        'Edit #2',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
 };
+
+test 'Changing alias type to search hint overrides sort name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edited alias',
+                # Change to search hint
+                'edit-alias.type_id' => '2',
+            });
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::EditAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'King of the Mountain'
+            },
+            alias_id  => 1,
+            new => {
+                name => 'Edited alias',
+                sort_name => 'Edited alias',
+                type_id => '2',
+            },
+            old => {
+                name => 'Test Recording Alias',
+                sort_name => 'Test Recording Alias',
+                type_id => '1',
+            }
+        },
+        'The edit contains the right data, including changed sort names',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+tracklist');
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+recording');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'password' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -1,18 +1,32 @@
 package t::MusicBrainz::Server::Controller::Release::Aliases;
 use Test::Routine;
 use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
+use utf8;
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether release aliases are correctly listed on the release
+alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Release alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c);
 
-    $mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/aliases', 'fetch release aliases tab');
+    $mech->get_ok(
+        '/release/f205627f-b70a-409d-adbe-66289b614e80/aliases',
+        'Fetched release aliases page',
+    );
     html_ok($mech->content);
+
+    $mech->text_contains('Ærial', 'Alias page lists the alias');
+    $mech->text_contains('Release name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         'gtin14' => '0094634396028',

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
@@ -5,15 +5,42 @@ use utf8;
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether release group aliases are correctly listed on the
+release group alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Release group alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c);
 
-    $mech->get_ok('/release-group/ecc33260-454c-11de-8a39-0800200c9a66/aliases', 'fetch release group');
+    $mech->get_ok(
+        '/release-group/ecc33260-454c-11de-8a39-0800200c9a66/aliases',
+        'Fetched release group aliases page',
+    );
     html_ok($mech->content);
+
+    $mech->text_contains(
+        'Test RG 1 Alias 1',
+        'Alias page lists the first alias',
+    );
+    $mech->text_contains(
+        'Release group name',
+        'Alias page lists the first alias type',
+    );
+    $mech->text_contains(
+        'Test RG 1 Alias 2',
+        'Alias page lists the second alias',
+    );
+    $mech->text_contains(
+        'Search hint',
+        'Alias page lists the first alias type',
+    );
 
     page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/release-group/ecc33260-454c-11de-8a39-0800200c9a66',
@@ -24,10 +51,8 @@ test all => sub {
             'name' => 'Test Artist'
         },
         'creditedTo' => 'Test Artist',
-        'alternateName' => [
-            'Test RG 1 Alias 1',
-            'Test RG 1 Alias 2'
-        ],
+        # Search hint should not appear on JSON-LD
+        'alternateName' => ['Test RG 1 Alias 1'],
         'albumProductionType' => 'http://schema.org/StudioAlbum',
         'name' => 'Test RG 1',
         '@type' => 'MusicAlbum',

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAlias.pm
@@ -4,72 +4,130 @@ use Test::More;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
 use utf8;
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether alias adding for series works, including whether
+the sort name defaults to the name when not explicitly entered.
+
+=cut
+
+test 'Adding alias with sort name' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+series');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/add-alias');
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/add-alias',
+        'Fetched the add alias page',
+    );
 
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'Now that’s what I call a series',
-            'edit-alias.sort_name' => 'series, Now that’s what I call a'
-        });
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-alias.name' => 'Now that’s what I call a series',
+                'edit-alias.sort_name' => 'series, Now that’s what I call a',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
     isa_ok($edit, 'MusicBrainz::Server::Edit::Series::AddAlias');
 
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'Test Recording Series',
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Test Recording Series',
+            },
+            name => 'Now that’s what I call a series',
+            sort_name => 'series, Now that’s what I call a',
+            locale => undef,
+            primary_for_locale => 0,
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            type_id => undef,
+            ended => 0,
         },
-        name => 'Now that’s what I call a series',
-        sort_name => 'series, Now that’s what I call a',
-        locale => undef,
-        primary_for_locale => 0,
-        begin_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        end_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        type_id => undef,
-        ended => 0
-    });
+        'The edit contains the right data',
+    );
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
 
-    $mech->content_contains('Test Recording Series', '..contains series name');
-    $mech->content_contains('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d', '..contains series link');
-    $mech->content_contains('Now that’s what I call a series', '..contains alias name');
-    $mech->content_contains('series, Now that’s what I call a', '..contains alias sort name');
+    $mech->content_contains(
+        'Test Recording Series',
+        'Edit page contains series name',
+    );
+    $mech->content_contains(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d',
+        'Edit page contains series link',
+    );
+    $mech->content_contains(
+        'Now that’s what I call a series',
+        'Edit page contains alias name',
+    );
+    $mech->content_contains(
+        'series, Now that’s what I call a',
+        'Edit page contains the selected alias sort name',
+    );
+};
 
-    # A sortname isn't required (MBS-6896)
-    ($edit) = capture_edits {
-        $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/add-alias');
-        $mech->submit_form(
+test 'MBS-6896: Adding alias without sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/add-alias',
+        'Fetched the add alias page',
+    );
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
             with_fields => {
                 'edit-alias.name' => 'Now that’s what I call another series',
-            });
-    } $c;
+            }
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
 
     isa_ok($edit, 'MusicBrainz::Server::Edit::Series::AddAlias');
-    is($edit->data->{sort_name}, 'Now that’s what I call another series', 'sort_name defaults to name');
+    is(
+        $edit->data->{sort_name},
+        'Now that’s what I call another series',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
 };
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+series');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
@@ -16,7 +16,7 @@ test all => sub {
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/aliases', 'get series aliases');
     html_ok($mech->content);
     $mech->content_contains('Test Series Alias', 'has the series alias');
-    $mech->content_contains('Search hint', 'has the series alias type');
+    $mech->content_contains('Series name', 'has the series alias type');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
@@ -15,7 +15,7 @@ test all => sub {
 
     $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/aliases', 'get series aliases');
     html_ok($mech->content);
-    $mech->content_contains('Test Recording Series Alias', 'has the series alias');
+    $mech->content_contains('Test Series Alias', 'has the series alias');
     $mech->content_contains('Search hint', 'has the series alias type');
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Aliases.pm
@@ -6,17 +6,28 @@ with 't::Edit';
 with 't::Mechanize';
 with 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether series aliases are correctly listed on the series
+alias page.
+
+=cut
+
+test 'Series alias appears on alias page content' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+series');
 
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/aliases', 'get series aliases');
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/aliases',
+        'Fetched series aliases page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('Test Series Alias', 'has the series alias');
-    $mech->content_contains('Series name', 'has the series alias type');
+
+    $mech->text_contains('Test Series Alias', 'Alias page lists the alias');
+    $mech->text_contains('Series name', 'Alias page lists the alias type');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
@@ -59,7 +59,7 @@ test 'Deleting an alias' => sub {
                 day => undef
             },
             ended => 0,
-            type_id => 2,
+            type_id => 1,
             locale => undef,
             primary_for_locale => 0,
         },

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/DeleteAlias.pm
@@ -1,61 +1,120 @@
 package t::MusicBrainz::Server::Controller::Series::DeleteAlias;
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks that series alias deletion works, and that it requires
+an edit note.
+
+=cut
+
+test 'Deleting an alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+series');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' =>
+                        q(Some edit note since it's required)
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
 
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/delete');
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->submit_form(
-        with_fields => {
-            'confirm.edit_note' => 'remove this now!'
-        }
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Series::DeleteAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Test Recording Series'
+            },
+            alias_id  => 1,
+            name      => 'Test Series Alias',
+            sort_name => 'Test Series Alias',
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            end_date => {
+                year => undef,
+                month => undef,
+                day => undef
+            },
+            ended => 0,
+            type_id => 2,
+            locale => undef,
+            primary_for_locale => 0,
+        },
+        'The edit contains the right data',
     );
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-    isa_ok($edit, 'MusicBrainz::Server::Edit::Series::DeleteAlias');
-
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'Test Recording Series'
-        },
-        alias_id  => 1,
-        name => 'Test Recording Series Alias',
-        sort_name => 'Test Recording Series Alias',
-        begin_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        end_date => {
-            year => undef,
-            month => undef,
-            day => undef
-        },
-        ended => 0,
-        type_id => 2,
-        locale => undef,
-        primary_for_locale => 0
-    });
-
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
-    $mech->content_contains('Test Recording Series', '..has series name');
-    $mech->content_contains('Test Recording Series Alias', '..has alias name');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Test Recording Series',
+        'The edit page contains the series name',
+    );
+    $mech->content_contains(
+        'Test Series Alias',
+        'The edit page contains the alias name',
+    );
 };
+
+test 'Edit note is required' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/delete',
+        'Fetched the delete alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+                with_fields => {
+                    'confirm.edit_note' => ''
+                }
+            },
+            'The form returned a 2xx response code',
+        );
+    } $test->c;
+
+    is(@edits, 0, 'No edit was entered');
+
+    $mech->content_contains(
+        'You must provide an edit note',
+        'Contains warning about edit note being required',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+series');
+
+    $test->mech->get_ok('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' },
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
@@ -3,67 +3,163 @@ use Test::Routine;
 use Test::More;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether alias editing for series works, including whether
+the sort name defaults to the name when not explicitly entered (blanked).
+It also checks that editing an alias to be a search hint automatically sets
+the sort name to match the name.
+
+=cut
+
+test 'Editing alias' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
 
-    MusicBrainz::Server::Test->prepare_test_database($c, '+series');
+    prepare_test($test);
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edited alias',
+                # HTML::Form doesn't understand selected=""
+                # so we need to specifically set this
+                'edit-alias.type_id' => '1',
+            });
+    } $test->c;
 
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/edit');
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->submit_form(
-        with_fields => {
-            'edit-alias.name' => 'brand new alias',
-            # HTML::Form doesn't understand selected=""
-            # so we need to specifically set this
-            'edit-alias.type_id' => '2'
-        });
+    my $edit = shift(@edits);
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
     isa_ok($edit, 'MusicBrainz::Server::Edit::Series::EditAlias');
-
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'Test Recording Series'
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Test Recording Series'
+            },
+            alias_id  => 1,
+            new => {
+                name => 'Edited alias',
+            },
+            old => {
+                name => 'Test Series Alias',
+            }
         },
-        alias_id  => 1,
-        new => {
-            name => 'brand new alias',
-            sort_name => 'brand new alias',
-        },
-        old => {
-            name => 'Test Series Alias',
-            sort_name => 'Test Series Alias',
-        }
-    });
+        'The edit contains the right data',
+    );
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
-    $mech->text_contains('Test Recording Series', '..has series name');
-    $mech->text_contains('Test Series Alias', '..has old alias name');
-    $mech->text_contains('brand new alias', '..has new alias name');
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Test Recording Series',
+        'Edit page contains series name',
+    );
+    $mech->content_contains(
+        'Test Series Alias',
+        'Edit page contains old alias name',
+    );
+    $mech->content_contains(
+        'Edited alias',
+        'Edit page contains new alias name',
+    );
+};
 
-    # A sortname isn't required (MBS-6896)
-    ($edit) = capture_edits {
-        $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/edit');
+test 'MBS-6896: Removing alias sort name defaults it to name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+
+    my @edits = capture_edits {
         $mech->submit_form(
             with_fields => {
                 'edit-alias.name' => 'Edit #2',
                 'edit-alias.sort_name' => '',
             });
-    } $c;
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
 
     isa_ok($edit, 'MusicBrainz::Server::Edit::Series::EditAlias');
-    is($edit->data->{new}{sort_name}, 'Edit #2', 'sort_name defaults to name');
+    is(
+        $edit->data->{new}{sort_name},
+        'Edit #2',
+        'The (not specified) sort name in the edit data defaults to the name',
+    );
 };
+
+test 'Changing alias type to search hint overrides sort name' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/alias/1/edit',
+        'Fetched the edit alias page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form(
+            with_fields => {
+                'edit-alias.name' => 'Edited alias',
+                # Change to search hint
+                'edit-alias.type_id' => '2',
+            });
+    } $test->c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Series::EditAlias');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Test Recording Series'
+            },
+            alias_id  => 1,
+            new => {
+                name => 'Edited alias',
+                sort_name => 'Edited alias',
+                type_id => '2',
+            },
+            old => {
+                name => 'Test Series Alias',
+                sort_name => 'Test Series Alias',
+                type_id => '1',
+            }
+        },
+        'The edit contains the right data, including changed sort names',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+series');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/EditAlias.pm
@@ -41,15 +41,15 @@ test all => sub {
             sort_name => 'brand new alias',
         },
         old => {
-            name => 'Test Recording Series Alias',
-            sort_name => 'Test Recording Series Alias',
+            name => 'Test Series Alias',
+            sort_name => 'Test Series Alias',
         }
     });
 
     $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
     html_ok($mech->content, '..valid xml');
     $mech->text_contains('Test Recording Series', '..has series name');
-    $mech->text_contains('Test Recording Series Alias', '..has old alias name');
+    $mech->text_contains('Test Series Alias', '..has old alias name');
     $mech->text_contains('brand new alias', '..has new alias name');
 
     # A sortname isn't required (MBS-6896)

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
@@ -4,15 +4,29 @@ use MusicBrainz::Server::Test qw( html_ok page_test_jsonld );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether work aliases are correctly listed on the work
+alias page, both on the site itself and on the JSON-LD data.
+
+=cut
+
+test 'Work alias appears on alias page content and on JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+controller_work');
 
-    $mech->get_ok('/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e/aliases', 'fetch work aliases tab');
+    $mech->get_ok(
+        '/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e/aliases',
+        'Fetched release aliases page',
+    );
     html_ok($mech->content);
+
+    $mech->text_contains('WA1', 'Alias page lists the first alias');
+    $mech->text_contains('WA2', 'Alias page lists the second alias');
+    $mech->text_contains('Work name', 'Alias page lists the alias type');
 
     page_test_jsonld $mech => {
         'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',

--- a/t/sql/area.sql
+++ b/t/sql/area.sql
@@ -11,8 +11,8 @@ INSERT INTO area (id, gid, name, type) VALUES
 INSERT INTO country_area (area) VALUES ( 13), ( 81), (107), (221), (222), (241);
 INSERT INTO iso_3166_1 (area, code) VALUES ( 13, 'AU'), ( 81, 'DE'), (107, 'JP'), (221, 'GB'), (222, 'US'), (241, 'XE');
 
-INSERT INTO area_alias (id, name, sort_name, area, edits_pending)
-    VALUES (1, 'オーストラリア', 'オーストラリア', 13, 0);
+INSERT INTO area_alias (id, name, sort_name, type, area, edits_pending)
+    VALUES (1, 'オーストラリア', 'オーストラリア', 1, 13, 0);
 
 INSERT INTO link VALUES (118734, 356, NULL, NULL, NULL, NULL, NULL, NULL, 0, '2013-05-17 20:05:50.534145+00', FALSE);
 INSERT INTO l_area_area VALUES (4892, 118734, 13, 5126, 0, '2013-05-24 20:32:44.702487+00', 0, '', '');

--- a/t/sql/controller_artist.sql
+++ b/t/sql/controller_artist.sql
@@ -24,9 +24,9 @@ INSERT INTO artist (id, gid, name, sort_name) VALUES
     (5, '089302a3-dda1-4bdf-b996-c2e941b5c41f', 'Seekrit Identity', 'Seekrit Identity');
 
 INSERT INTO artist_alias
-    (id, name, sort_name, artist, edits_pending, begin_date_year, begin_date_month, begin_date_day,
+    (id, name, sort_name, artist, type, edits_pending, begin_date_year, begin_date_month, begin_date_day,
      end_date_year, end_date_month, end_date_day)
-    VALUES (1, 'Test Alias', 'Test Alias', 3, 2, 2000, 1, 1, 2005, 5, 6);
+    VALUES (1, 'Test Alias', 'Test Alias', 3, 1, 2, 2000, 1, 1, 2005, 5, 6);
 
 INSERT INTO artist_credit (id, name, artist_count, gid) VALUES (1, 'Test Artist', 1, '949a7fd5-fe73-3e8f-922e-01ff4ca958f7');
 INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phrase) VALUES (1, 1, 3, 'Test Artist', '');

--- a/t/sql/controller_work.sql
+++ b/t/sql/controller_work.sql
@@ -25,9 +25,9 @@ INSERT INTO iswc (id, work, iswc)
 INSERT INTO work_gid_redirect
     VALUES ('a30a4245-a7ec-4979-8b1e-b549f2782239', 1);
 
-INSERT INTO work_alias (id, name, sort_name, work, edits_pending)
-    VALUES (1, 'WA1', 'WA1', 1, 0),
-           (2, 'WA2', 'WA2', 1, 0);
+INSERT INTO work_alias (id, name, sort_name, work, type, edits_pending)
+    VALUES (1, 'WA1', 'WA1', 1, 1, 0),
+           (2, 'WA2', 'WA2', 1, 1, 0);
 
 INSERT INTO recording (id, gid, name, artist_credit, length)
     VALUES (1, 'aeb9b50a-e14a-4330-a2e6-7c8a311a9822', 'R', 1, 300000);

--- a/t/sql/place.sql
+++ b/t/sql/place.sql
@@ -2,5 +2,5 @@ SET client_min_messages TO 'WARNING';
 
 INSERT INTO place (id, gid, name, type, address, area, coordinates, comment, edits_pending, last_updated, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, ended) VALUES (1, 'df9269dd-0470-4ea2-97e8-c11e46080edd', 'A Test Place', 2, 'An Address', 241, '(0.323,1.234)', 'A PLACE!', 0, '2013-09-07 14:40:22.041309+00', 2013, NULL, NULL, NULL, NULL, NULL, '0');
 
-INSERT INTO place_alias (id, name, sort_name, place, edits_pending)
-    VALUES (1, 'A Test Alias', 'A Test Alias', 1, 0);
+INSERT INTO place_alias (id, name, sort_name, place, type, edits_pending)
+    VALUES (1, 'A Test Alias', 'A Test Alias', 1, 1, 0);

--- a/t/sql/recording.sql
+++ b/t/sql/recording.sql
@@ -32,4 +32,4 @@ INSERT INTO track (id, gid, medium, position, number, recording, name, artist_cr
               (64, '13103972-499f-4407-b248-3d04c1afcc24', 24, 1, 1, 1, 'King of the Mountain', 1, NULL);
 
 INSERT INTO recording_alias (id, recording, name, type, sort_name) VALUES
-    (1, 1, 'Test Recording Alias', 2, 'Test Recording Alias');
+    (1, 1, 'Test Recording Alias', 1, 'Test Recording Alias');

--- a/t/sql/series.sql
+++ b/t/sql/series.sql
@@ -6,7 +6,7 @@ INSERT INTO series (id, gid, name, comment, type, ordering_type)
            (3, 'dbb23c50-d4e4-11e3-9c1a-0800200c9a66', 'Dumb Recording Series', '', 3, 1);
 
 INSERT INTO series_alias (id, series, name, type, sort_name) VALUES
-    (1, 1, 'Test Recording Series Alias', 2, 'Test Recording Series Alias');
+    (1, 1, 'Test Series Alias', 2, 'Test Series Alias');
 
 INSERT INTO link (id, link_type, attribute_count) VALUES
     (1, 740, 1), (2, 740, 1), (3, 740, 1), (4, 740, 1),

--- a/t/sql/series.sql
+++ b/t/sql/series.sql
@@ -6,7 +6,7 @@ INSERT INTO series (id, gid, name, comment, type, ordering_type)
            (3, 'dbb23c50-d4e4-11e3-9c1a-0800200c9a66', 'Dumb Recording Series', '', 3, 1);
 
 INSERT INTO series_alias (id, series, name, type, sort_name) VALUES
-    (1, 1, 'Test Series Alias', 2, 'Test Series Alias');
+    (1, 1, 'Test Series Alias', 1, 'Test Series Alias');
 
 INSERT INTO link (id, link_type, attribute_count) VALUES
     (1, 740, 1), (2, 740, 1), (3, 740, 1), (4, 740, 1),


### PR DESCRIPTION
I'm changing a lot of tests that we already had for several entities, because it seems a lot easier to see all the updates to them in one commit each rather than slowly doing them per entity.

See commit messages for further details.