### PR TITLE
MBS-12231: Don't try to load last annotation if there's no entity

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -143,7 +143,9 @@ role {
         }
 
         my $annotation_model = $self->_annotation_model;
-        my $latest_annotation = $annotation_model->get_latest($entity->id);
+        my $latest_annotation = $entity
+            ? $annotation_model->get_latest($entity->id)
+            : undef;
 
         $self->data({
             %opts,


### PR DESCRIPTION
### Fix MBS-12231

Previews are allowed to have no entity, but we were unconditionally trying to call for its id, which unsurprisingly fails.