### PR TITLE
MBS-12243: Block smart links: found.ee

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1587,6 +1587,7 @@ const URL_SHORTENERS = [
   'eventlink.to',
   'fanlink.to',
   'ffm.to',
+  'found.ee',
   'fty.li',
   'fur.ly',
   'g.co',


### PR DESCRIPTION
### Implement MBS-12243

These can be shortlinks or geolinks, but in either case we should not link to them: https://blog.found.ee/en/articles/4202319-make-a-shortlink-or-a-geolink