### PR TITLE
MBS-12244: Block Amazon customer video URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -614,7 +614,7 @@ const CLEANUPS: CleanupEntries = {
         return 'https://www.amazon.' + tld + '/gp/product/' + asin;
       }
 
-      return '';
+      return url;
     },
     validate: function (url) {
       if (/amzn\.to\//i.test(url)) {

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -635,6 +635,17 @@ const CLEANUPS: CleanupEntries = {
         };
       }
 
+      if (/^https:\/\/www\.amazon\.[^\/]+\/vdp\//i.test(url)) {
+        return {
+          error: l(
+            `This is a link to a user video and should not be added. Please
+             add the product link instead, if relevant.`,
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
+
       // If you change this, please update the BadAmazonURLs report.
       return {
         result: /^https:\/\/www\.amazon\.(ae|at|com\.au|com\.br|ca|cn|com|de|es|fr|in|it|jp|co\.jp|com\.mx|nl|pl|se|sg|com\.tr|co\.uk)\//.test(url),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -431,6 +431,18 @@ const testData = [
        input_relationship_type: 'amazon',
        only_valid_entity_types: [],
   },
+  {
+                     input_url: 'https://www.amazon.com/vdp/08c6c18fc7bb4822a166db4834e123f1?ref=dp_vse_rvc_0',
+             input_entity_type: 'release',
+       input_relationship_type: 'amazon',
+    expected_relationship_type: undefined,
+       only_valid_entity_types: [],
+            expected_clean_url: 'https://www.amazon.com/vdp/08c6c18fc7bb4822a166db4834e123f1?ref=dp_vse_rvc_0',
+                expected_error: {
+                                  error: 'link to a user video',
+                                  target: 'url',
+                                },
+  },
   // amzn.to
   {
                      input_url: 'http://amzn.to/2n4b5k4',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5431,7 +5431,8 @@ function testErrorObject(subtest, relationshipType, st) {
     );
   } else {
     st.ok(
-      validationResult.error.includes(subtest.expected_error.error),
+      validationResult.error &&
+        validationResult.error.includes(subtest.expected_error.error),
       'Error message contains expected string',
     );
   }


### PR DESCRIPTION
### Implement MBS-12244

These were happily getting matched as ASIN, but that does not seem correct at all. AFAICT, these shouldn't be added to MB at all anyway, so this blocks them and gives the user a hopefully useful message.