### PR TITLE
Improve test documentation (VIII): Shared tests (Tags/Ratings)

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Tags.pm
@@ -11,7 +11,7 @@ up- and downvoting, plus withdrawing/removing tags.
 
 =cut
 
-test 'Test area tagging (up/downvoting, withdrawing)' => sub {
+test 'Area tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Ratings.pm
@@ -12,19 +12,17 @@ page, and that private ratings are hidden.
 
 =cut
 
-test 'Test artists rating page' => sub {
+test 'Artist rating page displays the right data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
     MusicBrainz::Server::Test->prepare_test_database(
-      $c,
-      '+controller_artist',
+        $c,
+        '+controller_ratings',
     );
-
     MusicBrainz::Server::Test->prepare_raw_test_database($c, <<~'SQL');
-        INSERT INTO artist_tag_raw (artist, editor, tag) 
-             VALUES (3, 1, 1), (3, 2, 1);
         INSERT INTO artist_rating_raw (artist, editor, rating)
              VALUES (3, 1, 20), (3, 2, 100);
         SQL

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Tags.pm
@@ -12,7 +12,7 @@ up- and downvoting, plus withdrawing/removing tags.
 
 =cut
 
-test 'Test artist tagging (up/downvoting, withdrawing)' => sub {
+test 'Artist tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Tags.pm
@@ -11,7 +11,7 @@ both up- and downvoting, plus withdrawing/removing tags.
 
 =cut
 
-test 'Test instrument tagging (up/downvoting, withdrawing)' => sub {
+test 'Instrument tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Ratings.pm
@@ -1,20 +1,67 @@
 package t::MusicBrainz::Server::Controller::Label::Ratings;
 use Test::Routine;
-use MusicBrainz::Server::Test qw( html_ok );
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether label ratings are properly displayed on the ratings
+page, and that private ratings are hidden.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/ratings', 'get label ratings');
-html_ok($mech->content);
+test 'Label rating page displays the right data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+    MusicBrainz::Server::Test->prepare_test_database(
+        $c,
+        '+controller_ratings',
+    );
+    MusicBrainz::Server::Test->prepare_raw_test_database($c, <<~'SQL');
+        INSERT INTO label_rating_raw (label, editor, rating)
+             VALUES (2, 1, 20), (2, 2, 100);
+        SQL
+
+    $mech->get_ok(
+      '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/ratings',
+      'Fetched label ratings',
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'new_editor',
+        'The editor who gave a public rating is named',
+    );
+    $mech->content_lacks(
+        'alice',
+        'The editor who gave a private rating is not named',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//li//span[@class="inline-rating"])',
+        1,
+        'One user rating is shown'
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[1]',
+        1,
+        'The public user rating is shown',
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[2]',
+        3,
+        'The average rating is shown',
+    );
+
+    $mech->content_contains(
+        '1 private rating not listed',
+        'The notice about a private rating is present',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Tags.pm
@@ -5,39 +5,78 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether label tagging is working correctly. It checks both
+up- and downvoting, plus withdrawing/removing tags.
+
+=cut
+
+test 'Label tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     MusicBrainz::Server::Test->prepare_test_database($test->c);
 
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags');
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags',
+        'Fetched the label tags page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('musical');
-    ok($mech->find_link(url_regex => qr{/tag/musical}), 'content links to the "musical" tag');
+    $mech->content_contains('musical', 'The "musical" tag is present');
+    ok(
+        $mech->find_link(
+        url_regex => qr{/tag/musical}),
+        'There is a link to the "musical" tag',
+    );
 
-    # Test tagging
     $mech->get_ok('/login');
     $mech->submit_form(with_fields => {username => 'new_editor', password => 'password'});
 
-    # Test tagging
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/upvote?tags=British, Electronic%3F');
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags');
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/upvote?tags=British, Electronic%3F',
+        'Upvoted tags "british" and "electronic?"',
+    );
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags',
+        'Fetched the label tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('british');
-    $mech->content_contains('electronic?');
+    $mech->content_contains('british', 'Upvoted tag "british" is present');
+    $mech->content_contains(
+        'electronic?',
+        'Upvoted tag "electronic?" is present',
+    );
 
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/withdraw?tags=British, Electronic%3F');
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags');
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/withdraw?tags=British, Electronic%3F',
+        'Withdrew tags "british" and "electronic?"',
+    );
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags',
+        'Fetched the label tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_lacks('british');
-    $mech->content_lacks('electronic?');
+    $mech->content_lacks('british', 'Withdrawn tag "british" is missing');
+    $mech->content_lacks(
+        'electronic?',
+        'Withdrawn tag "electronic?" is missing',
+    );
 
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/downvote?tags=British, Electronic%3F');
-    $mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags');
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags/downvote?tags=British, Electronic%3F',
+        'Downvoted tags "british" and "electronic?"',
+    );
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/tags',
+        'Fetched the label tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('british');
-    $mech->content_contains('electronic?');
+    $mech->content_contains('british', 'Downvoted tag "british" is present');
+    $mech->content_contains(
+        'electronic?',
+        'Downvoted tag "electronic?" is present',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Ratings.pm
@@ -1,20 +1,67 @@
 package t::MusicBrainz::Server::Controller::Recording::Ratings;
 use Test::Routine;
-use MusicBrainz::Server::Test qw( html_ok );
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether recording ratings are properly displayed on the
+ratings page, and that private ratings are hidden.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/ratings', 'get recording ratings');
-html_ok($mech->content);
+test 'Recording rating page displays the right data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+    MusicBrainz::Server::Test->prepare_test_database(
+        $c,
+        '+controller_ratings',
+    );
+    MusicBrainz::Server::Test->prepare_raw_test_database($c, <<~'SQL');
+        INSERT INTO recording_rating_raw (recording, editor, rating)
+             VALUES (1, 1, 20), (1, 2, 100);
+        SQL
+
+    $mech->get_ok(
+      '/recording/123c079d-374e-4436-9448-da92dedef3ce/ratings',
+      'Fetched recording ratings',
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'new_editor',
+        'The editor who gave a public rating is named',
+    );
+    $mech->content_lacks(
+        'alice',
+        'The editor who gave a private rating is not named',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//li//span[@class="inline-rating"])',
+        1,
+        'One user rating is shown'
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[1]',
+        1,
+        'The public user rating is shown',
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[2]',
+        3,
+        'The average rating is shown',
+    );
+
+    $mech->content_contains(
+        '1 private rating not listed',
+        'The notice about a private rating is present',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Ratings.pm
@@ -1,20 +1,67 @@
 package t::MusicBrainz::Server::Controller::ReleaseGroup::Ratings;
 use Test::Routine;
-use MusicBrainz::Server::Test qw( html_ok );
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether release group ratings are properly displayed on the
+ratings page, and that private ratings are hidden.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/ratings', 'get rg ratings');
-html_ok($mech->content);
+test 'Release group rating page displays the right data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+    MusicBrainz::Server::Test->prepare_test_database(
+        $c,
+        '+controller_ratings',
+    );
+    MusicBrainz::Server::Test->prepare_raw_test_database($c, <<~'SQL');
+        INSERT INTO release_group_rating_raw (release_group, editor, rating)
+             VALUES (2, 1, 20), (2, 2, 100);
+        SQL
+
+    $mech->get_ok(
+      '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/ratings',
+      'Fetched release group ratings',
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'new_editor',
+        'The editor who gave a public rating is named',
+    );
+    $mech->content_lacks(
+        'alice',
+        'The editor who gave a private rating is not named',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//li//span[@class="inline-rating"])',
+        1,
+        'One user rating is shown'
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[1]',
+        1,
+        'The public user rating is shown',
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[2]',
+        3,
+        'The average rating is shown',
+    );
+
+    $mech->content_contains(
+        '1 private rating not listed',
+        'The notice about a private rating is present',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Tags.pm
@@ -4,37 +4,85 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether release group tagging is working correctly. It checks
+both up- and downvoting, plus withdrawing/removing tags.
+
+=cut
+
+test 'Release group tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     MusicBrainz::Server::Test->prepare_test_database($test->c);
 
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags');
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags',
+        'Fetched the release group tags page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('Nobody has tagged this yet');
+    $mech->content_contains(
+        'Nobody has tagged this yet',
+        'The "not tagged yet" message is present',
+    );
 
-    # Test tagging
     $mech->get_ok('/login');
     $mech->submit_form(with_fields => {username => 'new_editor', password => 'password'});
 
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/upvote?tags=Art Rock, Progressive Rock');
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags');
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/upvote?tags=Art Rock, Progressive Rock',
+        'Upvoted tags "art rock" and "progressive rock"',
+    );
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags',
+        'Fetched the release group tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('art rock');
-    $mech->content_contains('progressive rock');
+    $mech->content_contains(
+        'art rock',
+        'Upvoted tag "art rock" is present',
+    );
+    $mech->content_contains(
+        'progressive rock',
+        'Upvoted tag "progressive rock" is present',
+    );
 
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/withdraw?tags=Art Rock, Progressive Rock');
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags');
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/withdraw?tags=Art Rock, Progressive Rock',
+        'Withdrew tags "art rock" and "progressive rock"',
+    );
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags',
+        'Fetched the release group tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_lacks('art rock');
-    $mech->content_lacks('progressive rock');
+    $mech->content_lacks(
+        'art rock',
+        'Withdrawn tag "art rock" is missing',
+    );
+    $mech->content_lacks(
+        'progressive rock',
+        'Withdrawn tag "progressive rock" is missing',
+    );
 
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/downvote?tags=Art Rock, Progressive Rock');
-    $mech->get_ok('/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags');
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags/downvote?tags=Art Rock, Progressive Rock',
+        'Downvoted tags "art rock" and "progressive rock"',
+    );
+    $mech->get_ok(
+        '/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5/tags',
+        'Fetched the release group tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('art rock');
-    $mech->content_contains('progressive rock');
+    $mech->content_contains(
+        'art rock',
+        'Downvoted tag "art rock" is present',
+    );
+    $mech->content_contains(
+        'progressive rock',
+        'Downvoted tag "progressive rock" is present',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Tags.pm
@@ -4,42 +4,81 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether series tagging is working correctly. It checks both
+up- and downvoting, plus withdrawing/removing tags.
+
+=cut
+
+test 'Series tagging (up/downvoting, withdrawing)' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
     MusicBrainz::Server::Test->prepare_test_database($test->c);
 
-    $test->c->sql->do(q{
+    $test->c->sql->do(<<~'SQL');
         INSERT INTO series (id, gid, name, comment, type, ordering_type)
         VALUES (1, 'cd58b3e5-371c-484e-b3fd-4084a6861e62', 'Test', '', 4, 1);
-    });
+        SQL
 
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags');
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags',
+        'Fetched the series tags page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('Nobody has tagged this yet');
+    $mech->content_contains(
+        'Nobody has tagged this yet',
+        'The "not tagged yet" message is present',
+    );
 
-    # Test tagging
     $mech->get_ok('/login');
     $mech->submit_form(with_fields => {username => 'new_editor', password => 'password'});
 
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/upvote?tags=World Music, Jazz');
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags');
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/upvote?tags=World Music, Jazz',
+        'Upvoted tags "jazzy" and "bassy"',
+    );
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags',
+        'Fetched the series tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('world music');
-    $mech->content_contains('jazz');
+    $mech->content_contains(
+        'world music',
+        'Upvoted tag "world music" is present',
+    );
+    $mech->content_contains('jazz', 'Upvoted tag "jazz" is present');
 
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/withdraw?tags=World Music, Jazz');
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags');
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/withdraw?tags=World Music, Jazz',
+        'Withdrew tags "jazzy" and "bassy"',
+    );
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags',
+        'Fetched the series tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_lacks('world music');
-    $mech->content_lacks('jazz');
+    $mech->content_lacks(
+        'world music',
+        'Withdrawn tag "world music" is missing',
+    );
+    $mech->content_lacks('jazz', 'Withdrawn tag "jazz" is missing');
 
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/downvote?tags=World Music, Jazz');
-    $mech->get_ok('/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags');
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags/downvote?tags=World Music, Jazz',
+        'Downvoted tags "jazzy" and "bassy"',
+    );
+    $mech->get_ok(
+        '/series/cd58b3e5-371c-484e-b3fd-4084a6861e62/tags',
+        'Fetched the series tags page again',
+    );
     html_ok($mech->content);
-    $mech->content_contains('world music');
-    $mech->content_contains('jazz');
+    $mech->content_contains(
+        'world music',
+        'Downvoted tag "world music" is present',
+    );
+    $mech->content_contains('jazz', 'Downvoted tag "jazz" is present');
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Ratings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Ratings.pm
@@ -1,20 +1,67 @@
 package t::MusicBrainz::Server::Controller::Work::Ratings;
 use Test::Routine;
-use MusicBrainz::Server::Test qw( html_ok );
+use Test::More;
+use MusicBrainz::Server::Test qw( html_ok test_xpath_html );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether work ratings are properly displayed on the
+ratings page, and that private ratings are hidden.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/ratings');
-html_ok($mech->content);
+test 'Work rating page displays the right data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+    MusicBrainz::Server::Test->prepare_test_database(
+        $c,
+        '+controller_ratings',
+    );
+    MusicBrainz::Server::Test->prepare_raw_test_database($c, <<~'SQL');
+        INSERT INTO work_rating_raw (work, editor, rating)
+             VALUES (1, 1, 20), (1, 2, 100);
+        SQL
+
+    $mech->get_ok(
+      '/work/745c079d-374e-4436-9448-da92dedef3ce/ratings',
+      'Fetched work ratings',
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'new_editor',
+        'The editor who gave a public rating is named',
+    );
+    $mech->content_lacks(
+        'alice',
+        'The editor who gave a private rating is not named',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//li//span[@class="inline-rating"])',
+        1,
+        'One user rating is shown'
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[1]',
+        1,
+        'The public user rating is shown',
+    );
+    $tx->is(
+        '(//span[@class="current-rating"])[2]',
+        3,
+        'The average rating is shown',
+    );
+
+    $mech->content_contains(
+        '1 private rating not listed',
+        'The notice about a private rating is present',
+    );
 };
 
 1;

--- a/t/sql/controller_artist.sql
+++ b/t/sql/controller_artist.sql
@@ -43,9 +43,6 @@ INSERT INTO editor (id, name, password, privs, email, website, bio, email_confir
 
 INSERT INTO editor (id, name, password, ha1) VALUES (2, 'alice', '{CLEARTEXT}password', '343cbae85500be826a413b9b6b242669');
 
--- Alice has private ratings.
-INSERT INTO editor_preference (editor, name, value) VALUES (2, 'public_ratings', '0');
-
 INSERT INTO annotation (id, editor, text) VALUES
     (1, 1, 'Test annotation 1' || chr(10) || chr(10) || 'More annotation');
 

--- a/t/sql/controller_ratings.sql
+++ b/t/sql/controller_ratings.sql
@@ -1,0 +1,14 @@
+SET client_min_messages TO 'warning';
+
+INSERT INTO editor (id, name, password, ha1)
+     VALUES (2, 'alice', '{CLEARTEXT}password', '343cbae85500be826a413b9b6b242669');
+
+-- new_editor (from InsertTestData.sql) has public ratings
+UPDATE editor_preference
+   SET value = '1'
+ WHERE editor = 1
+   AND name = 'public_ratings';
+
+-- Alice has private ratings.
+INSERT INTO editor_preference (editor, name, value)
+     VALUES (2, 'public_ratings', '0');


### PR DESCRIPTION
I'm changing a lot of tests that we already had for several entities, because it seems a lot easier to see all the updates to them in one commit each rather than slowly doing them per entity.

See commit messages for further details.