### PR TITLE
Improve test documentation (IX): Shared tests (Annotation/Details)

### DIFF
--- a/admin/sql/InsertTestData.sql
+++ b/admin/sql/InsertTestData.sql
@@ -48,8 +48,8 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name) VALUES (2
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
     (1, '123c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 2, 123456);
 
-INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES
-    (1, '234c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 2, 1);
+INSERT INTO release_group (id, gid, name, artist_credit, type, last_updated) VALUES
+    (1, '234c079d-374e-4436-9448-da92dedef3ce', 'Arrival', 2, 1, '2003-03-03');
 
 -- Test multiple release groups on a page
 INSERT INTO artist_credit (id, name, artist_count, gid) VALUES (4, 'Test Artist', 1, '261f02c2-75a6-313f-9dd8-1716f73f3ce8');
@@ -65,8 +65,8 @@ INSERT INTO release_group_alias (id, name, sort_name, release_group, type, edits
     VALUES (1, 'Test RG 1 Alias 1', 'Test RG 1 Alias Sort Name 1', 3, 1, 0),
            (2, 'Test RG 1 Alias 2', 'Test RG 1 Alias Sort Name 2', 3, 2, 0);
 
-INSERT INTO work (id, gid, name, type) VALUES
-    (1, '745c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 1);
+INSERT INTO work (id, gid, name, type, last_updated) VALUES
+    (1, '745c079d-374e-4436-9448-da92dedef3ce', 'Dancing Queen', 1, '1999-01-02 12:00');
 INSERT INTO iswc (work, iswc) VALUES (1, 'T-000.000.001-0');
 
 -- Special Labels
@@ -75,9 +75,11 @@ INSERT INTO label (id, gid, name, type) VALUES
 
 INSERT INTO label (id, gid, name, type, area, label_code,
                    begin_date_year, begin_date_month, begin_date_day,
-                   end_date_year, end_date_month, end_date_day, comment)
+                   end_date_year, end_date_month, end_date_day, comment,
+                   last_updated)
      VALUES (2, '46f0f4cd-8aab-4b33-b698-f459faf64190', 'Warp Records', 4, 221, 2070,
-             1989, 02, 03, 2008, 05, 19, 'Sheffield based electronica label');
+             1989, 02, 03, 2008, 05, 19, 'Sheffield based electronica label',
+             '2014-01-12 18:00:27.843631-06');
 
 -- recording contract relationships for Warp Records
 INSERT INTO link (attribute_count, begin_date_day, begin_date_month, begin_date_year, created, end_date_day, end_date_month, end_date_year, ended, id, link_type) VALUES
@@ -140,7 +142,7 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name) VALUES (3
 INSERT INTO release_group (id, gid, name, artist_credit, type) VALUES
     (2, '7c3218d7-75e0-4e8c-971f-f097b6c308c5', 'Aerial', 3, 1);
 
-INSERT INTO release (id, gid, name, artist_credit, release_group, status, barcode) VALUES (2, 'f205627f-b70a-409d-adbe-66289b614e80', 'Aerial', 3, 2, 1, '0094634396028');
+INSERT INTO release (id, gid, name, artist_credit, release_group, status, barcode, last_updated) VALUES (2, 'f205627f-b70a-409d-adbe-66289b614e80', 'Aerial', 3, 2, 1, '0094634396028', '2020-02-20');
 INSERT INTO release_country (release, country, date_year, date_month, date_day) VALUES (2, 221, 2005, 11, 7);
 
 INSERT INTO release_alias (id, name, sort_name, release, type, edits_pending)
@@ -161,8 +163,8 @@ INSERT INTO medium (id, release, position, format, name) VALUES (4, 2, 2, 1, 'A 
 INSERT INTO medium (id, release, position, format, name) VALUES (5, 3, 1, 1, 'A Sea of Honey');
 INSERT INTO medium (id, release, position, format, name) VALUES (6, 3, 2, 1, 'A Sky of Honey');
 
-INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
-    (2, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'King of the Mountain', 3, 293720);
+INSERT INTO recording (id, gid, name, artist_credit, length, last_updated) VALUES
+    (2, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'King of the Mountain', 3, 293720, '2020-02-20 19:00:00');
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
     (3, '659f405b-b4ee-4033-868a-0daa27784b89', 'π', 3, 369680);
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AddAnnotation.pm
@@ -24,7 +24,10 @@ test 'MBS-4091: Test submitting annotation starting with list syntax' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation',
+        'Fetched the edit annotation page',
+    );
     my @edits = capture_edits {
         $mech->submit_form_ok({
             with_fields => {
@@ -37,7 +40,8 @@ test 'MBS-4091: Test submitting annotation starting with list syntax' => sub {
 
     ok(
         $mech->uri =~ qr{/artist/745c079d-374e-4436-9448-da92dedef3ce/?$},
-        'The user is redirected to the artist page after entering the edit');
+        'The user is redirected to the artist page after entering the edit',
+    );
 
     is(@edits, 1, 'The edit was entered');
 
@@ -75,7 +79,10 @@ test 'MBS-12161: Test submitting annotation with too long changelog' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation',
+        'Fetched the edit annotation page',
+    );
     my @edits = capture_edits {
         $mech->submit_form_ok({
             with_fields => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
@@ -28,19 +28,19 @@ test 'Check details tab has all the expected data' => sub {
         'Fetched artist details page',
     );
     html_ok($mech->content);
-    $mech->content_contains(
-        'https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
         'The details tab contains the artist permalink',
     );
-    $mech->content_contains(
-        '>745c079d-374e-4436-9448-da92dedef3ce</',
+    $mech->text_contains(
+        'MBID:745c079d-374e-4436-9448-da92dedef3ce',
         'The details tab contains the MBID in plain text',
     );
-    $mech->content_contains(
-        '>2009-07-09 00:00 UTC</',
+    $mech->text_contains(
+        'Last updated:2009-07-09 00:00 UTC',
         'The details tab contains the last updated date',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         '/ws/2/artist/745c079d-374e-4436-9448-da92dedef3ce?',
         'The details tab contains a WS link',
     );

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Details.pm
@@ -13,7 +13,7 @@ This test checks that the artist details page contains all the expected data.
 
 =cut
 
-test 'Check details tab has all the expected data' => sub {
+test 'Details tab has all the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/AddAnnotation.pm
@@ -4,47 +4,75 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether adding annotations for labels works, including
+whether four spaces at the start of the annotation are left untrimmed
+(for list syntax).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding label annotations' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation');
-$mech->submit_form(
-    with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-        'edit-annotation.changelog' => 'Changelog here',
-    });
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-ok($mech->uri =~ qr{/label/4b4ccf60-658e-11de-8a39-0800200c9a66/?}, 'should redirect to label page via gid');
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAnnotation');
-is_deeply($edit->data, {
-    entity => {
-        id => 3,
-        name => 'Another Label'
-    },
-    text => "    * Test annotation for a label\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-    changelog => 'Changelog here',
-    editor_id => 1,
-    old_annotation_id => undef,
-});
+    $mech->get_ok(
+        '/label/4b4ccf60-658e-11de-8a39-0800200c9a66/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a label  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-$mech->content_contains('Changelog here', '..has changelog entry');
-$mech->content_contains('Another Label', '..has label name');
-$mech->content_like(qr{label/4b4ccf60-658e-11de-8a39-0800200c9a66/?"}, '..has a link to the label');
+    ok(
+        $mech->uri =~ qr{/label/4b4ccf60-658e-11de-8a39-0800200c9a66/?$},
+        'The user is redirected to the label page after entering the edit',
+    );
 
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 3,
+                name => 'Another Label',
+            },
+            text => "    * Test annotation for a label\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => undef,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains('Another Label', 'Edit page contains label name');
+    $mech->content_like(
+        qr{label/4b4ccf60-658e-11de-8a39-0800200c9a66/?"},
+        'Edit page has a link to the label',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Details.pm
@@ -7,24 +7,40 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that the label details page contains all the expected data.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/details',
-              'fetch label details page');
-html_ok($mech->content);
+test 'Details tab has all the expected data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->content_contains('https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
-                        '..has permanent link');
-# I don't think this test could be much more wrong, but it passes for now
-$mech->content_contains('>46f0f4cd-8aab-4b33-b698-f459faf64190</',
-                        '..has mbid in plain text');
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/details',
+        'Fetched label details page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+        'The details tab contains the label permalink',
+    );
+    $mech->text_contains(
+        'MBID:46f0f4cd-8aab-4b33-b698-f459faf64190',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:2014-01-13 00:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/label/46f0f4cd-8aab-4b33-b698-f459faf64190?',
+        'The details tab contains a WS link',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/AddAnnotation.pm
@@ -4,45 +4,78 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether adding annotations for recordings works, including
+whether four spaces at the start of the annotation are left untrimmed
+(for list syntax).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding recording annotations' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
-$mech->submit_form(
-    with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-        'edit-annotation.changelog' => 'Changelog here',
-    });
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::AddAnnotation');
-is_deeply($edit->data, {
-    entity => {
-        id => 1,
-        name => 'Dancing Queen'
-    },
-    text => "    * Test annotation for a recording\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-    changelog => 'Changelog here',
-    editor_id => 1,
-    old_annotation_id => 3,
-});
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-$mech->content_contains('Changelog here', '..has changelog entry');
-$mech->content_contains('Dancing Queen', '..has recording name');
-$mech->content_like(qr{recording/123c079d-374e-4436-9448-da92dedef3ce/?"}, '..has a link to the recording');
+    $mech->get_ok(
+        '/recording/123c079d-374e-4436-9448-da92dedef3ce/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a recording  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
+    ok(
+        $mech->uri =~ qr{/recording/123c079d-374e-4436-9448-da92dedef3ce/?$},
+        'The user is redirected to the recording page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Dancing Queen',
+            },
+            text => "    * Test annotation for a recording\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => 3,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains(
+        'Dancing Queen',
+        'Edit page contains recording name',
+    );
+    $mech->content_like(
+        qr{recording/123c079d-374e-4436-9448-da92dedef3ce/?"},
+        'Edit page has a link to the recording',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Details.pm
@@ -7,22 +7,40 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that the recording details page contains all the expected data.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/details',
-              'fetch recording details page');
-html_ok($mech->content);
-$mech->content_contains('https://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
-                        '..has permanent link');
-$mech->content_contains('>54b9d183-7dab-42ba-94a3-7388a66604b8</',
-                        '..has mbid in plain text');
+test 'Details tab has all the expected data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/details',
+        'Fetched recording details page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/recording/54b9d183-7dab-42ba-94a3-7388a66604b8',
+        'The details tab contains the recording permalink',
+    );
+    $mech->text_contains(
+        'MBID:54b9d183-7dab-42ba-94a3-7388a66604b8',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:2020-02-20 19:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/recording/54b9d183-7dab-42ba-94a3-7388a66604b8?',
+        'The details tab contains a WS link',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/AddAnnotation.pm
@@ -4,45 +4,76 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether adding annotations for releases works, including
+whether four spaces at the start of the annotation are left untrimmed
+(for list syntax). This tests only the edit annotation page, not submitting
+annotations through the release editor.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding release annotations' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation');
-$mech->submit_form(
-    with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-        'edit-annotation.changelog' => 'Changelog here',
-    });
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Release::AddAnnotation');
-is_deeply($edit->data, {
-    entity => {
-        id => 2,
-        name => 'Aerial'
-    },
-    text => "    * Test annotation for a release\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-    changelog => 'Changelog here',
-    editor_id => 1,
-    old_annotation_id => undef,
-});
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-$mech->content_contains('Changelog here', '..has changelog entry');
-$mech->content_contains('Aerial', '..has release name');
-$mech->content_like(qr{release/f205627f-b70a-409d-adbe-66289b614e80/?"}, '..has a link to the artist');
+    $mech->get_ok(
+        '/release/f205627f-b70a-409d-adbe-66289b614e80/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a release  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
+    ok(
+        $mech->uri =~ qr{/release/f205627f-b70a-409d-adbe-66289b614e80/?$},
+        'The user is redirected to the release page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Release::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 2,
+                name => 'Aerial',
+            },
+            text => "    * Test annotation for a release\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => undef,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains('Aerial', 'Edit page contains release name');
+    $mech->content_like(
+        qr{release/f205627f-b70a-409d-adbe-66289b614e80/?"},
+        'Edit page has a link to the release',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Details.pm
@@ -7,30 +7,67 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that the release details page contains all the expected data,
+and that it shows the release sidebar data as well.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/release/f205627f-b70a-409d-adbe-66289b614e80/details',
-              'fetch release details page');
-html_ok($mech->content);
-$mech->content_contains('https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
-                        '..has permanent link');
-$mech->content_contains('>f205627f-b70a-409d-adbe-66289b614e80</',
-                        '..has mbid in plain text');
+test 'Details tab has all the expected data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->content_contains('CD', 'contains medium type');
-$mech->content_contains('Official', 'contains release status');
-$mech->content_contains('Album', 'contains release group type');
-$mech->content_contains('343 960 2', 'has catalog number');
-$mech->content_contains('Warp Records', 'contains label name');
-$mech->content_contains('/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
-                        'has a link to the label');
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
+    $mech->get_ok(
+        '/release/f205627f-b70a-409d-adbe-66289b614e80/details',
+        'Fetched release details page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
+        'The details tab contains the release permalink',
+    );
+    $mech->text_contains(
+        'MBID:f205627f-b70a-409d-adbe-66289b614e80',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:2020-02-20 00:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/release/f205627f-b70a-409d-adbe-66289b614e80?',
+        'The details tab contains a WS link',
+    );
+
+    # Sidebar content
+    $mech->text_contains(
+        'CD',
+        'The details page displays the medium format',
+    );
+    $mech->text_contains(
+        'Official',
+        'The details page displays the release status',
+    );
+    $mech->text_contains(
+        'Album',
+        'The details page displays the release group type',
+    );
+    $mech->text_contains(
+        '343 960 2',
+        'The details page displays the catalog number',
+    );
+    $mech->text_contains(
+        'Warp Records',
+        'The details page displays the label name',
+    );
+    $mech->content_contains(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
+        'The details page contains a link to the label',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/AddAnnotation.pm
@@ -4,45 +4,78 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether adding annotations for release groups works,
+including whether four spaces at the start of the annotation are left
+untrimmed (for list syntax).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding release group annotations' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
-$mech->submit_form(
-    with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-        'edit-annotation.changelog' => 'Changelog here',
-    });
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::AddAnnotation');
-is_deeply($edit->data, {
-    entity => {
-        id => 1,
-        name => 'Arrival'
-    },
-    text => "    * Test annotation for a release group\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-    changelog => 'Changelog here',
-    editor_id => 1,
-    old_annotation_id => 5,
-});
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-$mech->content_contains('Changelog here', '..has changelog entry');
-$mech->content_contains('Arrival', '..has release group name');
-$mech->content_like(qr{release-group/234c079d-374e-4436-9448-da92dedef3ce/?"}, '..has a link to the release group');
+    $mech->get_ok(
+        '/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a release group  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $test->c;
 
+    ok(
+        $mech->uri =~ qr{/release-group/234c079d-374e-4436-9448-da92dedef3ce/?$},
+        'The user is redirected to the release group page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Arrival',
+            },
+            text => "    * Test annotation for a release group\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => 5,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains(
+        'Arrival',
+        'Edit page contains release group name',
+    );
+    $mech->content_like(
+        qr{release-group/234c079d-374e-4436-9448-da92dedef3ce/?"},
+        'Edit page has a link to the release group',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Details.pm
@@ -7,22 +7,41 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that the release group details page contains all the
+expected data.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/details',
-              'fetch release group details page');
-html_ok($mech->content);
-$mech->content_contains('https://musicbrainz.org/release-group/234c079d-374e-4436-9448-da92dedef3ce',
-                        '..has permanent link');
-$mech->content_contains('>234c079d-374e-4436-9448-da92dedef3ce</',
-                        '..has mbid in plain text');
+test 'Details tab has all the expected data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok(
+        '/release-group/234c079d-374e-4436-9448-da92dedef3ce/details',
+        'Fetched release group details page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/release-group/234c079d-374e-4436-9448-da92dedef3ce',
+        'The details tab contains the release group permalink',
+    );
+    $mech->text_contains(
+        'MBID:234c079d-374e-4436-9448-da92dedef3ce',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:2003-03-03 00:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/release-group/234c079d-374e-4436-9448-da92dedef3ce?',
+        'The details tab contains a WS link',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/AddAnnotation.pm
@@ -4,49 +4,78 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether adding annotations for series works, including
+whether four spaces at the start of the annotation are left untrimmed
+(for list syntax).
+
+=cut
+
+test 'Adding series annotations' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
+    my $c    = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+series');
 
     $mech->get_ok('/login');
     $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
 
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation');
-    $mech->submit_form(
-        with_fields => {
-            'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-            'edit-annotation.changelog' => 'And a changelog',
-        });
-
-    ok($mech->uri =~ qr{/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/?},
-       'should redirect to series page via gid');
-
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-    isa_ok($edit, 'MusicBrainz::Server::Edit::Series::AddAnnotation');
-
-    is_deeply($edit->data, {
-        entity => {
-            id => 1,
-            name => 'Test Recording Series'
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a series  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
         },
-        text => "    * Test annotation for a series\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-        changelog => 'And a changelog',
-        editor_id => 1,
-        old_annotation_id => undef,
-    });
+        'The form returned a 2xx response code')
+    } $test->c;
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    $mech->content_contains('And a changelog', '..has changelog entry');
-    $mech->content_contains('Test Recording Series', '..has series name');
-    $mech->content_like(qr{series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/?"}, '..has a link to the series');
+    ok(
+        $mech->uri =~ qr{/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/?$},
+        'The user is redirected to the series page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Series::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Test Recording Series',
+            },
+            text => "    * Test annotation for a series\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => undef,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains(
+        'Test Recording Series',
+        'Edit page contains series name',
+    );
+    $mech->content_like(
+        qr{series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/?"},
+        'Edit page has a link to the series',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Details.pm
@@ -5,26 +5,42 @@ use warnings;
 use Test::Routine;
 use MusicBrainz::Server::Test qw( html_ok );
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks that the series details page contains all the expected data.
+
+=cut
+
+test 'Details tab has all the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
-    my $c = $test->c;
+    my $c    = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+series');
 
-    $mech->get_ok('/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/details',
-                  'fetch series details page');
+    $mech->get_ok(
+        '/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d/details',
+        'Fetched series details page',
+    );
     html_ok($mech->content);
-
-    $mech->content_contains('https://musicbrainz.org/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d',
-                            '..has permanent link');
-
-    $mech->content_contains('>a8749d0c-4a5a-4403-97c5-f6cd018f8e6d</',
-                            '..has mbid in plain text');
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d',
+        'The details tab contains the series permalink',
+    );
+    $mech->text_contains(
+        'MBID:a8749d0c-4a5a-4403-97c5-f6cd018f8e6d',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:2002-02-20 00:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/series/a8749d0c-4a5a-4403-97c5-f6cd018f8e6d?',
+        'The details tab contains a WS link',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/AddAnnotation.pm
@@ -4,48 +4,75 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
+use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether adding annotations for works works, including
+whether four spaces at the start of the annotation are left untrimmed
+(for list syntax).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding work annotations' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation');
-$mech->submit_form(
-    with_fields => {
-        'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
-        'edit-annotation.changelog' => 'Changelog here',
-    }
-);
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::AddAnnotation');
-is_deeply(
-    $edit->data,
-    {
-        entity => {
-            id => 1,
-            name => 'Dancing Queen'
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/edit_annotation',
+        'Fetched the edit annotation page',
+    );
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-annotation.text' => "    * Test annotation\x{0007} for a work  \r\n\r\n\t\x{00A0}\r\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets  \t\t",
+                'edit-annotation.changelog' => 'Changelog here',
+            },
         },
-        text => "    * Test annotation for a work\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
-        changelog => 'Changelog here',
-        editor_id => 1,
-        old_annotation_id => 6,
-    }
-);
+        'The form returned a 2xx response code')
+    } $test->c;
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-$mech->content_contains('Changelog here', '..has changelog entry');
-$mech->content_contains('Dancing Queen', '..has work name');
-$mech->content_like(qr{work/745c079d-374e-4436-9448-da92dedef3ce/?"}, '..has a link to the work');
+    ok(
+        $mech->uri =~ qr{/work/745c079d-374e-4436-9448-da92dedef3ce/?$},
+        'The user is redirected to the work page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Work::AddAnnotation');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                name => 'Dancing Queen',
+            },
+            text => "    * Test annotation for a work\n\n    * This anno\x{200B}tation has\ttwo bul\x{00AD}lets",
+            changelog => 'Changelog here',
+            editor_id => 1,
+            old_annotation_id => 6,
+        },
+        'The edit contains the right data (with untrimmed initial spaces)',
+    );
+
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched edit page');
+
+    $mech->content_contains('Changelog here', 'Edit page contains changelog');
+    $mech->content_contains('Dancing Queen', 'Edit page contains work name');
+    $mech->content_like(
+        qr{work/745c079d-374e-4436-9448-da92dedef3ce/?"},
+        'Edit page has a link to the work',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Details.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Details.pm
@@ -7,23 +7,40 @@ use MusicBrainz::Server::Test qw( html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks that the work details page contains all the expected data.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/details',
-              'fetch work details page');
-html_ok($mech->content);
-$mech->content_contains('https://musicbrainz.org/work/745c079d-374e-4436-9448-da92dedef3ce',
-                        '..has permanent link');
-$mech->content_contains('>745c079d-374e-4436-9448-da92dedef3ce</',
-                        '..has mbid in plain text');
+test 'Details tab has all the expected data' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/details',
+        'Fetched work details page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Permanent link:https://musicbrainz.org/work/745c079d-374e-4436-9448-da92dedef3ce',
+        'The details tab contains the work permalink',
+    );
+    $mech->text_contains(
+        'MBID:745c079d-374e-4436-9448-da92dedef3ce',
+        'The details tab contains the MBID in plain text',
+    );
+    $mech->text_contains(
+        'Last updated:1999-01-02 12:00 UTC',
+        'The details tab contains the last updated date',
+    );
+    $mech->text_contains(
+        '/ws/2/work/745c079d-374e-4436-9448-da92dedef3ce?',
+        'The details tab contains a WS link',
+    );
 };
 
 1;

--- a/t/sql/series.sql
+++ b/t/sql/series.sql
@@ -1,9 +1,9 @@
 SET client_min_messages TO 'WARNING';
 
-INSERT INTO series (id, gid, name, comment, type, ordering_type)
-    VALUES (1, 'a8749d0c-4a5a-4403-97c5-f6cd018f8e6d', 'Test Recording Series', 'test comment 1', 3, 1),
-           (2, '2e8872b9-2745-4807-a84e-094d425ec267', 'Test Work Series', 'test comment 2', 4, 2),
-           (3, 'dbb23c50-d4e4-11e3-9c1a-0800200c9a66', 'Dumb Recording Series', '', 3, 1);
+INSERT INTO series (id, gid, name, comment, type, ordering_type, last_updated)
+    VALUES (1, 'a8749d0c-4a5a-4403-97c5-f6cd018f8e6d', 'Test Recording Series', 'test comment 1', 3, 1, '2002-02-20'),
+           (2, '2e8872b9-2745-4807-a84e-094d425ec267', 'Test Work Series', 'test comment 2', 4, 2, NOW()),
+           (3, 'dbb23c50-d4e4-11e3-9c1a-0800200c9a66', 'Dumb Recording Series', '', 3, 1, NOW());
 
 INSERT INTO series_alias (id, series, name, type, sort_name) VALUES
     (1, 1, 'Test Series Alias', 1, 'Test Series Alias');


### PR DESCRIPTION
I'm changing a lot of tests that we already had for several entities, because it seems a lot easier to see all the updates to them in one commit each rather than slowly doing them per entity.

See commit messages for further details.