### PR TITLE
Improve test documentation (X): Shared tests (Create)

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
@@ -1,11 +1,11 @@
 package t::MusicBrainz::Server::Controller::Artist::Create;
-use utf8;
 use strict;
 use warnings;
 
 use Test::Routine;
 use Test::More;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
+use utf8;
 
 with 't::Mechanize', 't::Context';
 
@@ -26,7 +26,10 @@ test 'Creating artist with most fields filled in' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/create');
+    $mech->get_ok(
+        '/artist/create',
+        'Fetched the artist creation page',
+    );
     html_ok($mech->content);
 
     my @edits = capture_edits {
@@ -93,35 +96,35 @@ test 'Creating artist with most fields filled in' => sub {
     # Test display of edit data
     $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
     html_ok($mech->content);
-    $mech->content_contains(
+    $mech->text_contains(
         'controller artist',
         'The edit page contains the artist name',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'artist, controller',
         'The edit page contains the artist sort name',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'Person',
         'The edit page contains the artist type',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'United States',
         'The edit page contains the area',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'Female',
         'The edit page contains the artist gender',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'artist created in controller_artist.t',
         'The edit page contains the disambiguation',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         '1990-01-02',
         'The edit page contains the artist begin date',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         '2003-04-15',
         'The edit page contains the artist end date',
     );
@@ -133,7 +136,10 @@ test 'Creating artist with only the minimal amount of fields' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/create');
+    $mech->get_ok(
+        '/artist/create',
+        'Fetched the artist creation page',
+    );
     html_ok($mech->content);
 
     my @edits = capture_edits {
@@ -193,11 +199,11 @@ test 'Creating artist with only the minimal amount of fields' => sub {
     # Test display of edit data
     $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
     html_ok($mech->content);
-    $mech->content_contains(
+    $mech->text_contains(
         'Alice Artist',
         'The edit page contains the artist name',
     );
-    $mech->content_contains(
+    $mech->text_contains(
         'Artist, Alice',
         'The edit page contains the artist sort name',
     );
@@ -209,7 +215,10 @@ test 'MBS-10976: No ISE if only invalid characters are submitted' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/create');
+    $mech->get_ok(
+        '/artist/create',
+        'Fetched the artist creation page',
+    );
 
     my $invalid = "\x{200B}\x{00AD}\x{FEFF}";
 
@@ -230,7 +239,7 @@ test 'MBS-10976: No ISE if only invalid characters are submitted' => sub {
 
     is(@edits, 0, 'No edit was entered');
 
-    $mech->content_contains(
+    $mech->text_contains(
         'The characters you’ve entered are invalid or not allowed.',
         'contains error for invalid characters',
     );
@@ -242,7 +251,10 @@ test 'MBS-10976: Private use characters U+E000..U+F8FF are allowed' => sub {
 
     prepare_test($test);
 
-    $mech->get_ok('/artist/create');
+    $mech->get_ok(
+        '/artist/create',
+        'Fetched the artist creation page',
+    );
 
     my $klingon = "\x{F8D3}\x{F8D4}\x{F8D5}";
     my $other_private_use = "\x{E000}\x{F8FF}";

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( capture_edits );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
@@ -25,12 +25,17 @@ test 'Adding a new instrument' => sub {
       '+instrument_editing',
     );
 
-    $mech->get_ok('/login');
-    $mech->submit_form(with_fields => { username => 'instrument_editor', password => 'pass' });
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'instrument_editor', password => 'pass' }
+    );
+
     $mech->get_ok(
         '/instrument/create',
         'Fetched the instrument creation page',
     );
+    html_ok($mech->content);
+
     my @edits = capture_edits {
         $mech->submit_form_ok({
             with_fields => {
@@ -41,6 +46,11 @@ test 'Adding a new instrument' => sub {
         },
         'The form returned a 2xx response code')
     } $c;
+
+    ok(
+        $mech->uri =~ qr{/instrument/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})},
+        'The user is redirected to the instrument page after entering the edit',
+    );
 
     is(@edits, 1, 'The edit was entered');
 
@@ -57,6 +67,22 @@ test 'Adding a new instrument' => sub {
             type_id => undef,
         },
         'The edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'New Instrument',
+        'The edit page contains the instrument name',
+    );
+    $mech->text_contains(
+        'This is made up!',
+        'The edit page contains the instrument description',
+    );
+    $mech->text_contains(
+        'a newly invented instrument',
+        'The edit page contains the disambiguation',
     );
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Create.pm
@@ -4,74 +4,121 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic label creation works.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding a new label' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
 
-$mech->get_ok('/label/create');
-html_ok($mech->content);
-$mech->submit_form(
-    with_fields => {
-        'edit-label.name' => 'controller label',
-        'edit-label.type_id' => 4,
-        'edit-label.label_code' => 12345,
-        'edit-label.area_id' => 221,
-        'edit-label.period.begin_date.year' => 1990,
-        'edit-label.period.begin_date.month' => 1,
-        'edit-label.period.begin_date.day' => 2,
-        'edit-label.period.end_date.year' => 2003,
-        'edit-label.period.end_date.month' => 4,
-        'edit-label.period.end_date.day' => 15,
-        'edit-label.comment' => 'label created in controller_label.t',
-    }
-);
-ok($mech->success);
-ok($mech->uri =~ qr{/label/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})}, 'should redirect to label page via gid');
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::Create');
-is_deeply($edit->data, {
-        name => 'controller label',
-        type_id => 4,
-        area_id => 221,
-        label_code => 12345,
-        comment => 'label created in controller_label.t',
-        begin_date => {
-            year => 1990,
-            month => 1,
-            day => 2
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/label/create',
+        'Fetched the label creation page',
+    );
+    html_ok($mech->content);
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-label.name' => 'controller label',
+                'edit-label.type_id' => 4,
+                'edit-label.label_code' => 12345,
+                'edit-label.area_id' => 221,
+                'edit-label.period.begin_date.year' => 1990,
+                'edit-label.period.begin_date.month' => 1,
+                'edit-label.period.begin_date.day' => 2,
+                'edit-label.period.end_date.year' => 2003,
+                'edit-label.period.end_date.month' => 4,
+                'edit-label.period.end_date.day' => 15,
+                'edit-label.comment' => 'label created in controller_label.t',
+            },
         },
-        end_date => {
-            year => 2003,
-            month => 4,
-            day => 15
+        'The form returned a 2xx response code')
+    } $test->c;
+
+    ok(
+        $mech->uri =~ qr{/label/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})},
+        'The user is redirected to the label page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::Create');
+
+    is_deeply(
+        $edit->data,
+        {
+            name => 'controller label',
+            type_id => 4,
+            area_id => 221,
+            label_code => 12345,
+            comment => 'label created in controller_label.t',
+            begin_date => {
+                year => 1990,
+                month => 1,
+                day => 2,
+            },
+            end_date => {
+                year => 2003,
+                month => 4,
+                day => 15,
+            },
+            ended => 1,
+            ipi_codes => [],
+            isni_codes => [],
         },
-        ended => 1,
-        ipi_codes => [],
-        isni_codes => [],
-    });
+        'The edit contains the right data',
+    );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-$mech->content_contains('controller label', '..has name');
-$mech->content_contains('label created in controller_label.t', '..has comment');
-$mech->content_like(qr/1990\D+01\D+02/, '..has begin date');
-$mech->content_like(qr/2003\D+04\D+15/, '..has end date');
-$mech->content_contains('Original Production', '..has type name');
-$mech->content_contains('United Kingdom', '..has area');
-$mech->content_contains('12345', '..has label code');
 
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'controller label',
+        'The edit page contains the label name',
+    );
+    $mech->text_contains(
+        'Original Production',
+        'The edit page contains the label type',
+    );
+    $mech->text_contains(
+        'United Kingdom',
+        'The edit page contains the area',
+    );
+    $mech->text_contains(
+        'label created in controller_label.t',
+        'The edit page contains the disambiguation',
+    );
+    $mech->text_contains(
+        '1990-01-02',
+        'The edit page contains the label begin date',
+    );
+    $mech->text_contains(
+        '2003-04-15',
+        'The edit page contains the label end date',
+    );
+    $mech->text_contains(
+        '12345',
+        'The edit page contains the label code',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
@@ -20,6 +20,7 @@ test 'Place alias appears on alias page content and on JSON-LD' => sub {
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+area');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+area_hierarchy');
     MusicBrainz::Server::Test->prepare_test_database($c, '+place');
 
     $mech->get_ok(
@@ -34,9 +35,19 @@ test 'Place alias appears on alias page content and on JSON-LD' => sub {
     page_test_jsonld $mech => {
         'foundingDate' => '2013',
         'containedIn' => {
-            '@type' => 'Country',
-            '@id' => 'http://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
-            'name' => 'Europe'
+            'name' => 'London',
+            '@id' => 'http://musicbrainz.org/area/f03d09b3-39dc-4083-afd6-159e3f0d462f',
+            '@type' => 'City',
+            'containedIn' => {
+                'name' => 'England',
+                '@id' => 'http://musicbrainz.org/area/9d5dd675-3cf4-4296-9e39-67865ebee758',
+                '@type' => 'AdministrativeArea',
+                'containedIn' => {
+                    'name' => 'United Kingdom',
+                    '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+                    '@type' => 'Country',
+                },
+            },
         },
         'alternateName' => ['A Test Alias'],
         'geo' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
@@ -4,11 +4,18 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
+use utf8;
 
 with 't::Mechanize', 't::Context';
 
-test 'Area and area containment shown in conjunction with place' => sub {
+=head2 Test description
+
+This test checks whether basic place creation works.
+
+=cut
+
+test 'Adding a new place' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -16,29 +23,100 @@ test 'Area and area containment shown in conjunction with place' => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+area');
     MusicBrainz::Server::Test->prepare_test_database($c, '+area_hierarchy');
     MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'Alice', password => 'secret1' } );
 
-    $mech->get_ok('/place/create');
-    html_ok($mech->content);
+    $mech->get('/login');
     $mech->submit_form(
-        with_fields => {
-            'edit-place.name' => 'Somewhere',
-            'edit-place.area_id' => 1178,
-        }
+        with_fields => { username => 'Alice', password => 'secret1' }
     );
-    ok($mech->success);
 
-    ok($mech->uri =~ qr{/place/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$}, 'redirected to new place page');
+    $mech->get_ok(
+        '/place/create',
+        'Fetched the place creation page',
+    );
     html_ok($mech->content);
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-place.name' => 'Somewhere',
+                'edit-place.address' => 'Silly Road 1',
+                'edit-place.coordinates' => '51.4795478N, 0.096023W',
+                'edit-place.area_id' => 1178,
+                'edit-place.type_id' => 1,
+            },
+        },
+        'The form returned a 2xx response code')
+    } $c;
+
+    ok(
+        $mech->uri =~ qr{/place/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$},
+        'The user is redirected to the place page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
     isa_ok($edit, 'MusicBrainz::Server::Edit::Place::Create');
-    $mech->get_ok('/edit/' . $edit->id, 'fetch the edit page');
+
+    is_deeply(
+        $edit->data,
+        {
+            address => 'Silly Road 1',
+            area_id => 1178,
+            begin_date => {
+                year => undef,
+                month => undef,
+                day => undef,
+            },
+            comment => '',
+            coordinates => {
+                latitude => '51.479548',
+                longitude => '-0.096023',
+            },
+            end_date => {
+                day => undef,
+                month => undef,
+                year => undef,
+            },
+            ended => 0,
+            name => 'Somewhere',
+            type_id => 1,
+        },
+        'The edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
     html_ok($mech->content);
-    $mech->content_contains('London', 'mentions area');
-    $mech->content_contains('England', 'mentions containing subdivision');
-    $mech->content_contains('United Kingdom', 'mentions containing country');
+    $mech->text_contains(
+        'Somewhere',
+        'The edit page contains the place name',
+    );
+    $mech->text_contains(
+        'Studio',
+        'The edit page contains the place type',
+    );
+    $mech->text_contains(
+        'Silly Road 1',
+        'The edit page contains the place address',
+    );
+    $mech->text_contains(
+        '51.479548°N, 0.096023°W',
+        'The edit page contains the place coordinates',
+    );
+    $mech->text_contains(
+        'London',
+        'The edit page contains the place area',
+    );
+    $mech->text_contains(
+        'England',
+        'The edit page contains the containing subdivision',
+    );
+    $mech->text_contains(
+        'United Kingdom',
+        'The edit page contains the containing country',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Create.pm
@@ -31,9 +31,6 @@ test 'Area and area containment shown in conjunction with place' => sub {
 
     ok($mech->uri =~ qr{/place/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$}, 'redirected to new place page');
     html_ok($mech->content);
-    $mech->content_contains('London', 'mentions area');
-    $mech->content_contains('England', 'mentions containing subdivision');
-    $mech->content_contains('United Kingdom', 'mentions containing country');
 
     my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
     isa_ok($edit, 'MusicBrainz::Server::Edit::Place::Create');

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
@@ -13,16 +13,31 @@ test all => sub {
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+area');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+area_hierarchy');
     MusicBrainz::Server::Test->prepare_test_database($c, '+place');
 
     $mech->get_ok('/place/df9269dd-0470-4ea2-97e8-c11e46080edd', 'fetch place index page');
     html_ok($mech->content);
 
+    $mech->content_contains('London', 'mentions area');
+    $mech->content_contains('England', 'mentions containing subdivision');
+    $mech->content_contains('United Kingdom', 'mentions containing country');
+
     page_test_jsonld $mech => {
         'containedIn' => {
-            'name' => 'Europe',
-            '@id' => 'http://musicbrainz.org/area/89a675c2-3e37-3518-b83c-418bad59a85a',
-            '@type' => 'Country'
+            'name' => 'London',
+            '@id' => 'http://musicbrainz.org/area/f03d09b3-39dc-4083-afd6-159e3f0d462f',
+            '@type' => 'City',
+            'containedIn' => {
+                'name' => 'England',
+                '@id' => 'http://musicbrainz.org/area/9d5dd675-3cf4-4296-9e39-67865ebee758',
+                '@type' => 'AdministrativeArea',
+                'containedIn' => {
+                    'name' => 'United Kingdom',
+                    '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
+                    '@type' => 'Country',
+                },
+            },
         },
         'name' => 'A Test Place',
         'geo' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Create.pm
@@ -8,26 +8,37 @@ use Test::Routine;
 use Test::More;
 use MusicBrainz::Server::Test qw( html_ok capture_edits );
 
-with 't::Edit';
-with 't::Mechanize';
-with 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether basic series creation works, including adding
+relationships during the creation process.
+
+=cut
+
+test 'Adding a new series, including relationships' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+series');
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' }
+    );
 
-    $mech->get_ok('/series/create');
+    $mech->get_ok(
+        '/series/create',
+        'Fetched the series creation page',
+    );
     html_ok($mech->content);
 
     my @edits = capture_edits {
         $mech->post_ok(
-            '/series/create', {
+            '/series/create',
+            {
                 'edit-series.name' => 'totally nonexistent series',
                 'edit-series.comment' => 'a comment longer than the name :(',
                 'edit-series.type_id' => 4,
@@ -44,49 +55,65 @@ test all => sub {
                 'edit-series.rel.1.link_order' => 2,
                 'edit-series.rel.1.attributes.0.type.gid' => 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a',
                 'edit-series.rel.1.attributes.0.text_value' => 'Bar',
-            }
+            },
+            'The form returned a 2xx response code'
         );
     } $c;
 
-    ok($mech->success);
-    ok($mech->uri =~ qr{/series/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})},
-       'should redirect to series page via gid');
-    $mech->content_contains('//en.wikipedia.org/wiki/Totally_Nonexistent_Series', '..has wikipedia link');
+    ok(
+        $mech->uri =~ qr{/series/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$},
+        'The user is redirected to the series page after entering the edit',
+    );
+
+    $mech->content_contains(
+        '//en.wikipedia.org/wiki/Totally_Nonexistent_Series',
+        'Series page contains added Wikipedia link',
+    );
+
+    is(@edits, 4, 'Four edits were entered');
 
     isa_ok($edits[0], 'MusicBrainz::Server::Edit::Series::Create');
 
-    cmp_deeply($edits[0]->data, {
-        name => 'totally nonexistent series',
-        comment => 'a comment longer than the name :(',
-        type_id => 4,
-        ordering_type_id => 2,
-    });
+    cmp_deeply(
+        $edits[0]->data,
+        {
+            name => 'totally nonexistent series',
+            comment => 'a comment longer than the name :(',
+            type_id => 4,
+            ordering_type_id => 2,
+        },
+        'The first edit contains the right data',
+    );
 
     isa_ok($edits[1], 'MusicBrainz::Server::Edit::Relationship::Create');
 
-    cmp_deeply($edits[1]->data, {
-        type0 => 'series',
-        type1 => 'url',
-        entity0 => {
-            name => 'totally nonexistent series',
-            id => 4,
-            gid => ignore()
+    cmp_deeply(
+        $edits[1]->data,
+        {
+            type0 => 'series',
+            type1 => 'url',
+            entity0 => {
+                name => 'totally nonexistent series',
+                id => 4,
+                gid => ignore()
+            },
+            entity1 => {
+                name => 'http://en.wikipedia.org/wiki/Totally_Nonexistent_Series',
+                id => 1,
+                gid => ignore()
+            },
+            link_type => {
+                long_link_phrase => 'has a Wikipedia page at',
+                link_phrase => 'Wikipedia',
+                name => 'wikipedia',
+                id => 744,
+                reverse_link_phrase => 'Wikipedia page for'
+            },
+            ended => 0,
+            edit_version => 2,
         },
-        entity1 => {
-            name => 'http://en.wikipedia.org/wiki/Totally_Nonexistent_Series',
-            id => 1,
-            gid => ignore()
-        },
-        link_type => {
-            long_link_phrase => 'has a Wikipedia page at',
-            link_phrase => 'Wikipedia',
-            name => 'wikipedia',
-            id => 744,
-            reverse_link_phrase => 'Wikipedia page for'
-        },
-        ended => 0,
-        edit_version => 2,
-    });
+        'The second edit contains the right data',
+    );
 
     my $number_attribute = {
         type => {
@@ -103,65 +130,90 @@ test all => sub {
 
     isa_ok($edits[2], 'MusicBrainz::Server::Edit::Relationship::Create');
 
-    cmp_deeply($edits[2]->data, {
-        type0 => 'series',
-        type1 => 'work',
-        entity0 => {
-            name => 'totally nonexistent series',
-            id => 4,
-            gid => ignore()
+    cmp_deeply(
+        $edits[2]->data,
+        {
+            type0 => 'series',
+            type1 => 'work',
+            entity0 => {
+                name => 'totally nonexistent series',
+                id => 4,
+                gid => ignore()
+            },
+            entity1 => {
+                name => 'Wōrk1',
+                id => 1,
+                gid => '7e0e3ea0-d674-11e3-9c1a-0800200c9a66'
+            },
+            link_type => {
+                long_link_phrase => 'has part',
+                link_phrase => 'has parts',
+                name => 'part of',
+                id => 743,
+                reverse_link_phrase => 'part of'
+            },
+            ended => 0,
+            link_order => 1,
+            attributes => [{ %$number_attribute, text_value => 'Foo' }],
+            edit_version => 2,
         },
-        entity1 => {
-            name => 'Wōrk1',
-            id => 1,
-            gid => '7e0e3ea0-d674-11e3-9c1a-0800200c9a66'
-        },
-        link_type => {
-            long_link_phrase => 'has part',
-            link_phrase => 'has parts',
-            name => 'part of',
-            id => 743,
-            reverse_link_phrase => 'part of'
-        },
-        ended => 0,
-        link_order => 1,
-        attributes => [{ %$number_attribute, text_value => 'Foo' }],
-        edit_version => 2,
-    });
+        'The third edit contains the right data',
+    );
 
     isa_ok($edits[3], 'MusicBrainz::Server::Edit::Relationship::Create');
 
-    cmp_deeply($edits[3]->data, {
-        type0 => 'series',
-        type1 => 'work',
-        entity0 => {
-            name => 'totally nonexistent series',
-            id => 4,
-            gid => ignore()
+    cmp_deeply(
+        $edits[3]->data,
+        {
+            type0 => 'series',
+            type1 => 'work',
+            entity0 => {
+                name => 'totally nonexistent series',
+                id => 4,
+                gid => ignore()
+            },
+            entity1 => {
+                name => 'Wōrk2',
+                id => 2,
+                gid => 'f89a8de8-f0e3-453c-9516-5bc3edd2fd88'
+            },
+            link_type => {
+                long_link_phrase => 'has part',
+                link_phrase => 'has parts',
+                name => 'part of',
+                id => 743,
+                reverse_link_phrase => 'part of'
+            },
+            ended => 0,
+            link_order => 2,
+            attributes => [{ %$number_attribute, text_value => 'Bar' }],
+            edit_version => 2,
         },
-        entity1 => {
-            name => 'Wōrk2',
-            id => 2,
-            gid => 'f89a8de8-f0e3-453c-9516-5bc3edd2fd88'
-        },
-        link_type => {
-            long_link_phrase => 'has part',
-            link_phrase => 'has parts',
-            name => 'part of',
-            id => 743,
-            reverse_link_phrase => 'part of'
-        },
-        ended => 0,
-        link_order => 2,
-        attributes => [{ %$number_attribute, text_value => 'Bar' }],
-        edit_version => 2,
-    });
+        'The fourth edit contains the right data',
+    );
 
-    $mech->get_ok('/edit/' . $edits[0]->id, 'Fetch the edit page');
-    $mech->content_contains('totally nonexistent series', '..has name');
-    $mech->content_contains('a comment longer than the name :(', '..has comment');
-    $mech->content_contains('Work', '..has type name');
-    $mech->content_contains('Manual', '..has ordering type name');
+    # Test display of edit data
+    $mech->get_ok(
+        '/edit/' . $edits[0]->id,
+        'Fetched the Add series edit page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'totally nonexistent series',
+        'The edit page contains the series name',
+    );
+    $mech->text_contains(
+        'Work series',
+        'The edit page contains the series type',
+    );
+    $mech->text_contains(
+        'a comment longer than the name :(',
+        'The edit page contains the disambiguation',
+    );
+    $mech->text_contains(
+        'Manual',
+        'The edit page contains the ordering type name',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Series/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Series/Show.pm
@@ -21,7 +21,7 @@ test all => sub {
     $mech->title_like(qr/Test Recording Series/, 'title has series name');
     $mech->content_like(qr/Test Recording Series/, 'content has series name');
     $mech->content_like(qr/test comment 1/, 'disambiguation comments');
-    $mech->content_like(qr/Recording/, 'has series type');
+    $mech->content_like(qr/Recording series/, 'has series type');
     $mech->content_like(qr/Automatic/, 'has ordering type');
 
     # Check recordings

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Create.pm
@@ -4,89 +4,134 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use HTTP::Request::Common;
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
-use List::AllUtils qw( nsort_by );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic work creation works, including adding ISWCs
+during the creation process.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Adding a new work, including ISWCs' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-my @edits = capture_edits {
-    $mech->get_ok('/work/create');
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/work/create',
+        'Fetched the work creation page',
+    );
     html_ok($mech->content);
 
-    my $request = POST $mech->uri, [
-        'edit-work.comment' => 'A comment!',
-        'edit-work.type_id' => 26,
-        'edit-work.name' => 'Enchanted',
-        'edit-work.iswcs.0' => 'T-000.000.003-0',
-        'edit-work.iswcs.1' => 'T-000.000.004-0',
-        'edit-work.languages.0' => '120',
-        'edit-work.languages.1' => '134',
-    ];
+    my @edits = capture_edits {
+        $mech->post_ok(
+            '/work/create',
+            {
+                'edit-work.comment' => 'A comment!',
+                'edit-work.type_id' => 26,
+                'edit-work.name' => 'Enchanted',
+                'edit-work.iswcs.0' => 'T-000.000.003-0',
+                'edit-work.iswcs.1' => 'T-000.000.004-0',
+                'edit-work.languages.0' => '120',
+                'edit-work.languages.1' => '134',
+            },
+            'The form returned a 2xx response code'
+        );
+    } $c;
 
-    $mech->request($request);
-} $c;
+    ok(
+        $mech->uri =~ qr{/work/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$},
+        'The user is redirected to the work page after entering the edit',
+    );
 
-@edits = nsort_by { $_->id } @edits;
+    is(@edits, 2, 'Two edits were entered');
 
-ok($mech->success);
+    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Work::Create');
 
-my $edit = $edits[0];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::Create');
-is_deeply($edit->data, {
-    name          => 'Enchanted',
-    comment       => 'A comment!',
-    type_id       => 26,
-    attributes    => [],
-    languages     => [120, 134],
-});
-
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-my ($details) = $mech->scrape_text_by_attr('class', 'details add-work');
-like($details, qr/Enchanted/, '..has work name');
-like($details, qr/A comment!/, '..has comment');
-like($details, qr/Beijing opera/, '..has type');
-like($details, qr/English, French/, '..has languages');
-
-$edit = $edits[1];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::AddISWCs');
-is_deeply($edit->data, {
-    iswcs => [
+    is_deeply(
+        $edits[0]->data,
         {
-            iswc => 'T-000.000.003-0',
-            work => {
-                id => $edits[0]->entity_id,
-                name => 'Enchanted'
-            }
+            name          => 'Enchanted',
+            comment       => 'A comment!',
+            type_id       => 26,
+            attributes    => [],
+            languages     => [120, 134],
         },
+        'The first edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok(
+        '/edit/' . $edits[0]->id,
+        'Fetched the Add work edit page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Enchanted',
+        'The edit page contains the work name',
+    );
+    $mech->text_contains(
+        'Beijing opera',
+        'The edit page contains the work type',
+    );
+    $mech->text_contains(
+        'A comment!',
+        'The edit page contains the disambiguation',
+    );
+    $mech->text_contains(
+        'English, French',
+        'The edit page contains the work languages',
+    );
+
+    isa_ok($edits[1], 'MusicBrainz::Server::Edit::Work::AddISWCs');
+
+    is_deeply(
+        $edits[1]->data,
         {
-            iswc => 'T-000.000.004-0',
-            work => {
-                id => $edits[0]->entity_id,
-                name => 'Enchanted'
-            }
+            iswcs => [
+                {
+                    iswc => 'T-000.000.003-0',
+                    work => {
+                        id => $edits[0]->entity_id,
+                        name => 'Enchanted',
+                    },
+                },
+                {
+                    iswc => 'T-000.000.004-0',
+                    work => {
+                        id => $edits[0]->entity_id,
+                        name => 'Enchanted',
+                    },
+                },
+            ],
         },
-    ]
-});
+        'The second edit contains the right data',
+    );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-($details) = $mech->scrape_text_by_attr('class', 'details add-iswcs');
-like($details, qr/T-000\.000\.003-0/, '..has ISWC 1');
-like($details, qr/T-000\.000\.004-0/, '..has ISWC 2');
-
+    # Test display of edit data
+    $mech->get_ok(
+        '/edit/' . $edits[1]->id,
+        'Fetched the Add ISWCs edit page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'T-000.000.003-0',
+        'The edit page contains the first ISWC',
+    );
+    $mech->text_contains(
+        'T-000.000.004-0',
+        'The edit page contains the second ISWC',
+    );
 };
 
 1;

--- a/t/sql/place.sql
+++ b/t/sql/place.sql
@@ -1,6 +1,6 @@
 SET client_min_messages TO 'WARNING';
 
-INSERT INTO place (id, gid, name, type, address, area, coordinates, comment, edits_pending, last_updated, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, ended) VALUES (1, 'df9269dd-0470-4ea2-97e8-c11e46080edd', 'A Test Place', 2, 'An Address', 241, '(0.323,1.234)', 'A PLACE!', 0, '2013-09-07 14:40:22.041309+00', 2013, NULL, NULL, NULL, NULL, NULL, '0');
+INSERT INTO place (id, gid, name, type, address, area, coordinates, comment, edits_pending, last_updated, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, ended) VALUES (1, 'df9269dd-0470-4ea2-97e8-c11e46080edd', 'A Test Place', 2, 'An Address', 1178, '(0.323,1.234)', 'A PLACE!', 0, '2013-09-07 14:40:22.041309+00', 2013, NULL, NULL, NULL, NULL, NULL, '0');
 
 INSERT INTO place_alias (id, name, sort_name, place, type, edits_pending)
     VALUES (1, 'A Test Alias', 'A Test Alias', 1, 1, 0);


### PR DESCRIPTION
I'm changing a lot of tests that we already had for several entities, because it seems a lot easier to see all the updates to them in one go each rather than slowly doing them per entity.

See commit messages for further details.

For some reason, a bunch of entities are completely missing Create tests. Documenting it for now, we can add them later when we get to the specific folders.