### PR TITLE
Use release_coverart_backup

### DIFF
--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -466,15 +466,22 @@ my %stats = (
         CALC => sub {
             my ($self, $sql) = @_;
 
-            my $data = $sql->select_list_of_lists(<<~'SQL');
-                SELECT (cover_art_url ~ '^https?://.*.images-amazon.com')::int AS is_amazon, COUNT(*) FROM release_coverart
-                  WHERE cover_art_url IS NOT NULL
-                    AND NOT EXISTS (
-                      SELECT TRUE FROM cover_art_archive.cover_art ca
-                        JOIN cover_art_archive.cover_art_type cat ON ca.id = cat.id
-                      WHERE ca.release = release_coverart.id AND cat.type_id = 1)
-                GROUP BY is_amazon
-                SQL
+            my $has_release_coverart_backup = $sql->select_single_value(
+                q(SELECT 1 FROM pg_tables WHERE schemaname = 'musicbrainz' AND tablename = 'release_coverart_backup'),
+            ) ? 1 : 0;
+
+            my $data = [];
+            if ($has_release_coverart_backup) {
+                $data = $sql->select_list_of_lists(<<~'SQL');
+                    SELECT (cover_art_url ~ '^https?://.*.images-amazon.com')::int AS is_amazon, COUNT(*) FROM release_coverart_backup
+                    WHERE cover_art_url IS NOT NULL
+                        AND NOT EXISTS (
+                        SELECT TRUE FROM cover_art_archive.cover_art ca
+                            JOIN cover_art_archive.cover_art_type cat ON ca.id = cat.id
+                        WHERE ca.release = release_coverart_backup.id AND cat.type_id = 1)
+                    GROUP BY is_amazon
+                    SQL
+            }
 
             my %dist = map { @$_ } @$data;
 

--- a/lib/MusicBrainz/Server/Report/ReleasesWithAmazonCoverArt.pm
+++ b/lib/MusicBrainz/Server/Report/ReleasesWithAmazonCoverArt.pm
@@ -10,13 +10,13 @@ sub query {
             r.id AS release_id,
             row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
         FROM (
-            SELECT release_coverart.id
-            FROM release_coverart
+            SELECT release_coverart_backup.id
+            FROM release_coverart_backup
             WHERE cover_art_url ~ '^https?://.*.images-amazon.com'
             AND NOT EXISTS (
                 SELECT TRUE FROM cover_art_archive.cover_art ca
                 JOIN cover_art_archive.cover_art_type cat ON ca.id = cat.id
-                WHERE ca.release = release_coverart.id AND cat.type_id = 1
+                WHERE ca.release = release_coverart_backup.id AND cat.type_id = 1
             )
           ) rca
         JOIN release r ON rca.id = r.id 

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -52,54 +52,6 @@ is($rel->link->type->id, 104);
 is($rel->link->begin_date->year, 1994);
 is($rel->link->end_date->year, 1995);
 
-subtest 'creating cover art relationships should update the releases coverart' => sub {
-    my $url = 'http://web.archive.org/web/20100820183338/wiki.jpopstop.com/images/8/8d/alan_-_Kaze_ni_Mukau_Hana_CDDVD_mu-mo.jpg';
-
-    $c->sql->do('UPDATE link_type SET is_deprecated = FALSE WHERE id = 78');
-
-    $c->model('Edit')->create(
-        edit_type => $EDIT_RELATIONSHIP_CREATE,
-        editor_id => 1,
-        type0 => 'release',
-        type1 => 'url',
-        entity0 => $c->model('Release')->get_by_id(1),
-        entity1 => $c->model('URL')->find_or_insert($url),
-        link_type => $c->model('LinkType')->get_by_id(78),
-        ended => 0,
-    );
-
-    $c->sql->do('UPDATE link_type SET is_deprecated = TRUE WHERE id = 78');
-
-    my $release = $c->model('Release')->get_by_id(1);
-    $c->model('Release')->load_meta($release);
-    is($release->cover_art_url, $url);
-};
-
-subtest 'creating asin relationships should update the releases coverart' => sub {
-    if (DBDefs->AWS_PUBLIC && DBDefs->AWS_PRIVATE)
-    {
-        my $e0 = $c->model('Release')->get_by_id(2);
-        $c->model('Edit')->create(
-            edit_type => $EDIT_RELATIONSHIP_CREATE,
-            editor_id => 1,
-            type0 => 'release',
-            type1 => 'url',
-            entity0 => $e0,
-            entity1 => $c->model('URL')->find_or_insert('http://www.amazon.co.jp/gp/product/B00005EIIB'),
-            link_type => $c->model('LinkType')->get_by_id(77),
-            ended => 1
-        );
-
-        my $release = $c->model('Release')->get_by_id(2);
-        $c->model('Release')->load_meta($release);
-        ok($release->cover_art_url);
-    }
-    else
-    {
-        plan skip_all => 'Amazon keys not configured';
-    }
-};
-
 subtest 'Text attributes of value 0 are supported' => sub {
     my $e0 = $c->model('Artist')->get_by_id(3);
     my $e1 = $c->model('Event')->get_by_id(1);


### PR DESCRIPTION
Columns in the release_coverart table have been getting cleared since eb9637f469e18a236dd35f37651e22b48423731a was deployed.  I'm not sure exactly how this is happening, but likely through the RebuildCoverArt script, which I thought was disabled.

Unfortunately, this table is only in the private dump (where none is available prior to 1/31), but I managed to find an older database dump from May 2021 with a snapshot of the table.  For now I've imported that into release_coverart_backup so that we can get the reports working again.