### PR TITLE
Improve test documentation (XI): Shared tests (Edit)

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( capture_edits );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
@@ -23,18 +23,28 @@ test 'Editing a (non-ended) area' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+area_editing');
 
-    $mech->get_ok('/login');
-    $mech->submit_form(with_fields => { username => 'area_editor', password => 'pass' });
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'area_editor', password => 'pass' }
+    );
+
     $mech->get_ok(
         '/area/29a709d8-0320-493e-8d0c-f2c386662b7f/edit',
         'Fetched the area editing page',
     );
+    html_ok($mech->content);
+
     my @edits = capture_edits {
         $mech->submit_form_ok({
             with_fields => { 'edit-area.name' => 'wild onion' },
         },
         'The form returned a 2xx response code')
     } $c;
+
+    ok(
+        $mech->uri =~ qr{/area/29a709d8-0320-493e-8d0c-f2c386662b7f$},
+        'The user is redirected to the area page after entering the edit',
+    );
 
     is(@edits, 1, 'The edit was entered');
 
@@ -48,12 +58,24 @@ test 'Editing a (non-ended) area' => sub {
             entity => {
                 gid => '29a709d8-0320-493e-8d0c-f2c386662b7f',
                 id => 5099,
-                name => 'Chicago'
+                name => 'Chicago',
             },
             new => { name => 'wild onion' },
             old => { name => 'Chicago' },
         },
         'The edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Chicago',
+        'The edit page contains the old area name',
+    );
+    $mech->text_contains(
+        'wild onion',
+        'The edit page contains the new area name',
     );
 };
 
@@ -64,8 +86,11 @@ test 'Area editing is blocked for unprivileged users' => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+area_editing');
 
-    $mech->get_ok('/login');
-    $mech->submit_form(with_fields => { username => 'boring_editor', password => 'pass' });
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'boring_editor', password => 'pass' }
+    );
+
     $mech->get('/area/29a709d8-0320-493e-8d0c-f2c386662b7f/edit');
     is(
         $mech->status,

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Edit.pm
@@ -4,21 +4,18 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
-
-use List::AllUtils qw( sort_by );
 
 with 't::Mechanize', 't::Context';
 
 =head2 Test description
 
-This test checks that the artist edit form works properly, including when
+This test checks whether basic artist editing works, including when also
 updating artist credits.
 
 =cut
 
-test 'Test artist editing' => sub {
+test 'Editing an artist' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -28,10 +25,15 @@ test 'Test artist editing' => sub {
         '+controller_artist',
     );
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
 
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit');
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the artist editing page',
+    );
     html_ok($mech->content);
 
     my @edits = capture_edits {
@@ -67,13 +69,13 @@ test 'Test artist editing' => sub {
     my $edit = shift(@edits);
 
     isa_ok($edit, 'MusicBrainz::Server::Edit::Artist::Edit');
-    cmp_deeply(
+    is_deeply(
         $edit->data,
         {
             entity => {
                 id => 3,
-                gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-                name => 'Test Artist'
+                gid => '745c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Test Artist',
             },
             new => {
                 name => 'edit artist',
@@ -85,7 +87,7 @@ test 'Test artist editing' => sub {
                 begin_date => {
                     year => 1990,
                     month => 1,
-                    day => 2
+                    day => 2,
                 },
                 begin_area_id => 222,
                 end_date => {
@@ -105,13 +107,13 @@ test 'Test artist editing' => sub {
                 begin_date => {
                     year => 2008,
                     month => 1,
-                    day => 2
+                    day => 2,
                 },
                 begin_area_id => 221,
                 end_date => {
                     year => 2009,
                     month => 3,
-                    day => 4
+                    day => 4,
                 },
                 end_area_id => 221,
             }
@@ -180,17 +182,22 @@ test 'Test artist editing' => sub {
     );
 };
 
-test 'Looooooong disambiguation' => sub {
+test 'Too long disambiguation is rejected without ISE' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+controller_artist');
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
 
-    $mech->get_ok('/artist/745c079d-374e-4436-9448-da92dedef3ce/edit');
+    $mech->get_ok(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the artist editing page',
+    );
     html_ok($mech->content);
 
     my @edits = capture_edits {
@@ -212,13 +219,13 @@ test 'Looooooong disambiguation' => sub {
 
     is(@edits, 0, 'No edit was entered');
 
-    $mech->content_contains(
+    $mech->text_contains(
         'Field should not exceed 255 characters',
         'The "too long disambiguation" error is shown',
     );
 };
 
-test 'Test updating artist credits' => sub {
+test 'Updating artist credits' => sub {
     my $test = shift;
     my $c = $test->c;
     my $mech = $test->mech;
@@ -235,11 +242,18 @@ test 'Test updating artist credits' => sub {
             VALUES (1, 10, 'Alternative Name', 1, '');
         SQL
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/artist/9f0b3e1a-2431-400f-b6ff-2bcebbf0971a/edit',
+        'Fetched the artist editing page',
+    );
+    html_ok($mech->content);
 
     my @edits = capture_edits {
-        $mech->get_ok('/artist/9f0b3e1a-2431-400f-b6ff-2bcebbf0971a/edit');
         $mech->submit_form_ok({
             with_fields => {
                 'edit-artist.name' => 'test artist',
@@ -248,8 +262,6 @@ test 'Test updating artist credits' => sub {
         },
         'The form returned a 2xx response code');
     } $c;
-
-    @edits = sort_by { $_->id } @edits;
 
     is(@edits, 2, 'Two edits were entered');
     my ($edit_artist, $edit_ac) = @edits;

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Edit.pm
@@ -4,97 +4,157 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic label editing works.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Editing a label' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/label/46f0f4cd-8aab-4b33-b698-f459faf64190/edit');
-html_ok($mech->content);
-$mech->submit_form(
-    with_fields => {
-        'edit-label.name' => 'controller label',
-        'edit-label.type_id' => 2,
-        'edit-label.label_code' => 12345,
-        'edit-label.area_id' => 222,
-        'edit-label.period.begin_date.year' => 1990,
-        'edit-label.period.begin_date.month' => 1,
-        'edit-label.period.begin_date.day' => 2,
-        'edit-label.period.end_date.year' => 2003,
-        'edit-label.period.end_date.month' => 4,
-        'edit-label.period.end_date.day' => 15,
-        'edit-label.comment' => 'label created in controller_label.t',
-    }
-);
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Label::Edit');
-cmp_deeply($edit->data, {
-        entity => {
-            id => 2,
-            gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-            name => 'Warp Records'
-        },
-        new => {
-            name => 'controller label',
-            type_id => 2,
-            area_id => 222,
-            label_code => 12345,
-            comment => 'label created in controller_label.t',
-            begin_date => {
-                year => 1990,
-                month => 1,
-                day => 2
-            },
-            end_date => {
-                year => 2003,
-                month => 4,
-                day => 15
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/label/46f0f4cd-8aab-4b33-b698-f459faf64190/edit',
+        'Fetched the label editing page',
+    );
+    html_ok($mech->content);
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-label.name' => 'controller label',
+                'edit-label.type_id' => 2,
+                'edit-label.label_code' => 12345,
+                'edit-label.area_id' => 222,
+                'edit-label.period.begin_date.year' => 1990,
+                'edit-label.period.begin_date.month' => 1,
+                'edit-label.period.begin_date.day' => 2,
+                'edit-label.period.end_date.year' => 2003,
+                'edit-label.period.end_date.month' => 4,
+                'edit-label.period.end_date.day' => 15,
+                'edit-label.comment' => 'label created in controller_label.t',
             },
         },
-        old => {
-            name => 'Warp Records',
-            type_id => 4,
-            area_id => 221,
-            label_code => 2070,
-            comment => 'Sheffield based electronica label',
-            begin_date => {
-                year => 1989,
-                month => 2,
-                day => 3
-            },
-            end_date => {
-                year => 2008,
-                month => 5,
-                day => 19
-            },
-        }
-    });
+        'The form returned a 2xx response code')
+    } $c;
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-$mech->text_contains('controller label', '..has new name');
-$mech->text_contains('Warp Records', '..has old name');
-$mech->text_contains('Original Production', '..has new type');
-$mech->text_contains('Production', '..has old type');
-$mech->text_contains('United States', '..has new area');
-$mech->text_contains('United Kingdom', '..has old area');
-$mech->text_contains('12345', '..has new label code');
-$mech->text_contains('2070', '..has old label code');
-$mech->text_like(qr/2008\D+05\D+19/, '..has new date');
-$mech->text_like(qr/1989\D+02\D+03/, '..has old date');
+    ok(
+        $mech->uri =~ qr{/label/46f0f4cd-8aab-4b33-b698-f459faf64190$},
+        'The user is redirected to the label page after entering the edit',
+    );
 
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Label::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 2,
+                gid => '46f0f4cd-8aab-4b33-b698-f459faf64190',
+                name => 'Warp Records',
+            },
+            new => {
+                name => 'controller label',
+                type_id => 2,
+                area_id => 222,
+                label_code => 12345,
+                comment => 'label created in controller_label.t',
+                begin_date => {
+                    year => 1990,
+                    month => 1,
+                    day => 2,
+                },
+                end_date => {
+                    year => 2003,
+                    month => 4,
+                    day => 15,
+                },
+            },
+            old => {
+                name => 'Warp Records',
+                type_id => 4,
+                area_id => 221,
+                label_code => 2070,
+                comment => 'Sheffield based electronica label',
+                begin_date => {
+                    year => 1989,
+                    month => 2,
+                    day => 3,
+                },
+                end_date => {
+                    year => 2008,
+                    month => 5,
+                    day => 19,
+                },
+            },
+        },
+        'The edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Warp Records',
+        'The edit page contains the old label name',
+    );
+    $mech->text_contains(
+        'controller label',
+        'The edit page contains the new label name',
+    );
+    $mech->text_contains(
+        'Original Production',
+        'The edit page contains the new label type',
+    );
+    $mech->text_contains(
+        'United Kingdom',
+        'The edit page contains the old area',
+    );
+    $mech->text_contains(
+        'United States',
+        'The edit page contains the new area',
+    );
+    $mech->text_contains(
+        '12345',
+        'The edit page contains the old label code',
+    );
+    $mech->text_contains(
+        '2070',
+        'The edit page contains the new label code',
+    );
+    $mech->text_contains(
+        '1989-02-03',
+        'The edit page contains the old begin date',
+    );
+    $mech->text_contains(
+        '1990-01-02',
+        'The edit page contains the new begin date',
+    );
+    $mech->text_contains(
+        '2008-05-19',
+        'The edit page contains the old end date',
+    );
+    $mech->text_contains(
+        '2003-04-15',
+        'The edit page contains the new end date',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Edit.pm
@@ -4,46 +4,101 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use MusicBrainz::Server::Test qw( accept_edit html_ok );
+use MusicBrainz::Server::Test qw( accept_edit capture_edits html_ok );
+use utf8;
 
 with 't::Mechanize', 't::Context';
 
-test 'Remove coordinates from a place' => sub {
+=head2 Test description
+
+This test checks whether basic place editing works.
+
+=cut
+
+test 'Editing a place (remove coordinates)' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c);
     MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
-        INSERT INTO place (gid, name, type, coordinates)
-            VALUES ('a24c9284-a9d2-428b-bacd-fa79cf9a9108', 'Sydney Opera House', 2, POINT(-33.858667,151.214028));
+        INSERT INTO place (id, gid, name, type, coordinates)
+            VALUES (50, 'a24c9284-a9d2-428b-bacd-fa79cf9a9108',
+                    'Sydney Opera House', 2, POINT(-33.858667,151.214028))
         SQL
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
 
-    $mech->get_ok('/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108/edit');
-    html_ok($mech->content);
-    $mech->content_contains('33.858667S, 151.214028E', 'has coordinates');
+    $mech->get('/login');
     $mech->submit_form(
-        with_fields => {
-            'edit-place.coordinates' => '',
-        }
+        with_fields => { username => 'new_editor', password => 'password' }
     );
-    ok($mech->success);
 
-    ok($mech->uri =~ qr{/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108$}, 'redirected to place page');
+    $mech->get_ok(
+        '/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108/edit',
+        'Fetched the place editing page',
+    );
     html_ok($mech->content);
-    $mech->content_contains('Coordinates:', 'still has coordinates');
-    $mech->content_contains('33.858667', 'still has latitude');
+    $mech->content_contains(
+        '33.858667S, 151.214028E',
+        'The edit page lists the coordinates',
+    );
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-place.coordinates' => '',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $c;
+
+    ok(
+        $mech->uri =~ qr{/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108$},
+        'The user is redirected to the place page after entering the edit',
+    );
+
+    $mech->text_contains(
+        '33.858667°S, 151.214028°E',
+        'The place page still contains the coordinates',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
     isa_ok($edit, 'MusicBrainz::Server::Edit::Place::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 50,
+                gid => 'a24c9284-a9d2-428b-bacd-fa79cf9a9108',
+                name => 'Sydney Opera House',
+            },
+            new => {
+                coordinates => undef,
+            },
+            old => {
+                coordinates => {
+                    latitude => -33.858667,
+                    longitude => 151.214028,
+                },
+            },
+        },
+        'The edit contains the right data',
+    );
+
     accept_edit($c, $edit);
 
-    $mech->get_ok('/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108', 'reload the place page');
+    $mech->get_ok(
+        '/place/a24c9284-a9d2-428b-bacd-fa79cf9a9108/edit',
+        'Fetched the place page again after accepting the edit',
+    );
     html_ok($mech->content);
-    $mech->content_lacks('Coordinates:', 'no longer has coordinates');
-    $mech->content_lacks('33.858667', 'no longer has latitude');
+    $mech->text_lacks(
+        '33.858667°S, 151.214028°E',
+        'The place page no longer contains the coordinates',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Edit.pm
@@ -4,193 +4,273 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
 use MusicBrainz::Server::Test qw( capture_edits html_ok );
-use HTTP::Request::Common;
-use List::AllUtils qw( sort_by );
 
-with 't::Edit';
-with 't::Mechanize', 't::Context';
+with 't::Edit', 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic recording editing works, including replacing
+ISRCs. It also checks if it still works if you don't indicate
+the artist credit.
 
-$c->sql->do(<<~'SQL');
-    INSERT INTO artist (id, gid, name, sort_name, comment)
-        VALUES (3, '745c079d-374e-4436-9448-da92dedef3ce', 'ABBA', 'ABBA', 'A'),
-               (6, 'a45c079d-374e-4436-9448-da92dedef3cf', 'ABBA', 'ABBA', 'B'),
-               (4, '945c079d-374e-4436-9448-da92dedef3cf', 'ABBA', 'ABBA', 'C'),
-               (5, '5441c29d-3602-4898-b1a1-b77fa23b8e50', 'ABBA', 'ABBA', 'D');
+=cut
 
-    INSERT INTO artist_credit (id, name, artist_count, gid)
-        VALUES (1, 'ABBA', 1, '949a7fd5-fe73-3e8f-922e-01ff4ca958f7');
-    INSERT INTO artist_credit_name (artist_credit, position, artist, name)
-        VALUES (1, 0, 6, 'ABBA');
-    INSERT INTO recording (id, gid, name, artist_credit, length)
-        VALUES (1, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'Dancing Queen', 1, 123456);
-    INSERT INTO isrc (isrc, recording) VALUES ('DEE250800231', 1);
-    SQL
+test 'Editing a recording (inc. replacing ISRC)' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/login');
-$mech->submit_form(
-    with_fields => { username => 'editor', password => 'pass' } );
+    prepare_test($test);
 
-my @edits = capture_edits {
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/edit');
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/edit',
+        'Fetched the recording editing page',
+    );
     html_ok($mech->content);
-    my $request = POST $mech->uri, [
-        'edit-recording.length' => '1:23',
-        'edit-recording.comment' => 'A comment!',
-        'edit-recording.name' => 'Another name',
-        'edit-recording.artist_credit.names.0.name' => 'Foo',
-        'edit-recording.artist_credit.names.0.artist.name' => 'Bar',
-        'edit-recording.artist_credit.names.0.artist.id' => '3',
-        'edit-recording.artist_credit.names.1.name' => '',
-        'edit-recording.artist_credit.names.1.artist.name' => 'Queen',
-        'edit-recording.artist_credit.names.1.artist.id' => '4',
-        'edit-recording.artist_credit.names.2.name' => '',
-        'edit-recording.artist_credit.names.2.artist.name' => 'David Bowie',
-        'edit-recording.artist_credit.names.2.artist.id' => '5',
-        'edit-recording.isrcs.0' => 'USS1Z9900001'
-    ];
 
-    $mech->request($request);
-} $c;
+    my @edits = capture_edits {
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-recording.length' => '1:23',
+                'edit-recording.comment' => 'A comment!',
+                'edit-recording.name' => 'Another name',
+                'edit-recording.artist_credit.names.0.name' => 'Foo',
+                'edit-recording.artist_credit.names.0.artist.name' => 'Bar',
+                'edit-recording.artist_credit.names.0.artist.id' => '3',
+                'edit-recording.artist_credit.names.1.name' => '',
+                'edit-recording.artist_credit.names.1.artist.name' => 'Queen',
+                'edit-recording.artist_credit.names.1.artist.id' => '4',
+                'edit-recording.artist_credit.names.2.name' => '',
+                'edit-recording.artist_credit.names.2.artist.name' => 'David Bowie',
+                'edit-recording.artist_credit.names.2.artist.id' => '5',
+                'edit-recording.isrcs.0' => 'USS1Z9900001',
+            },
+            'The form returned a 2xx response code'
+        );
+    } $c;
 
-@edits = sort_by { $_->id } @edits;
+    ok(
+        $mech->uri =~ qr{/recording/54b9d183-7dab-42ba-94a3-7388a66604b8$},
+        'The user is redirected to the recording page after entering the edit',
+    );
 
-ok($mech->success);
-like($mech->uri, qr{/recording/54b9d183-7dab-42ba-94a3-7388a66604b8$});
-html_ok($mech->content);
+    is(@edits, 3, 'Three edits were entered');
 
-my $edit = $edits[0];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::Edit');
-cmp_deeply($edit->data, {
-    entity => {
-        id => 1,
-        gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-        name => 'Dancing Queen'
-    },
-    new => {
-        artist_credit => {
-            names => [
-                {
-                    artist => { id => 3, name => 'Bar' },
-                    name => 'Foo',
-                    join_phrase => ''
+    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Recording::Edit');
+
+    is_deeply(
+        $edits[0]->data,
+        {
+            entity => {
+                id => 1,
+                gid => '54b9d183-7dab-42ba-94a3-7388a66604b8',
+                name => 'Dancing Queen',
+            },
+            new => {
+                artist_credit => {
+                    names => [
+                        {
+                            artist => { id => 3, name => 'Bar' },
+                            name => 'Foo',
+                            join_phrase => '',
+                        },
+                        {
+                            artist => { id => 4, name => 'Queen' },
+                            name => 'Queen',
+                            join_phrase => '',
+                        },
+                        {
+                            artist => { id => 5, name => 'David Bowie' },
+                            name => 'David Bowie',
+                            join_phrase => '',
+                        }
+                    ],
                 },
-                {
-                    artist => { id => 4, name => 'Queen' },
-                    name => 'Queen',
-                    join_phrase => ''
+                name => 'Another name',
+                comment => 'A comment!',
+                length => 83000,
+            },
+            old => {
+                artist_credit => {
+                    names => [
+                        {
+                            artist => { id => 6, name => 'ABBA' },
+                            name => 'ABBA',
+                            join_phrase => '',
+                        }
+                    ],
                 },
-                {
-                    artist => { id => 5, name => 'David Bowie' },
-                    name => 'David Bowie',
-                    join_phrase => ''
-                }
-            ],
+                name => 'Dancing Queen',
+                comment => '',
+                length => 123456,
+            },
         },
-        name => 'Another name',
-        comment => 'A comment!',
-        length => 83000,
-    },
-    old => {
-        artist_credit => {
-            names => [
-                {
-                    artist => { id => 6, name => 'ABBA' },
-                    name => 'ABBA',
-                    join_phrase => '',
-                }
-            ],
-        },
-        name => 'Dancing Queen',
-        comment => '',
-        length => 123456,
-    }
-});
+        'The edit recording edit contains the right data',
+    );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-$mech->text_contains('Another name', '..has new name');
-$mech->text_contains('Dancing Queen', '..has old name');
-$mech->text_contains('1:23', '..has new length');
-$mech->text_contains('2:03', '..has old length');
-$mech->text_contains('A comment!', '..has new comment');
-$mech->text_contains('Foo', '..has new artist');
-$mech->content_contains('/artist/745c079d-374e-4436-9448-da92dedef3ce', '...and links to artist');
-$mech->text_contains('Queen', '..has new artist 2');
-$mech->content_contains('/artist/945c079d-374e-4436-9448-da92dedef3cf', '...and links to artist 2');
-$mech->text_contains('David Bowie', '..has new artist 3');
-$mech->content_contains('/artist/5441c29d-3602-4898-b1a1-b77fa23b8e50', '...and links to artist 3');
-$mech->text_contains('ABBA', '..has old artist');
-$mech->content_contains('/artist/a45c079d-374e-4436-9448-da92dedef3cf', '...and links to artist');
-
-$edit = $edits[1];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::AddISRCs', 'adds ISRCs');
-is_deeply($edit->data, {
-    isrcs => [ {
-        isrc => 'USS1Z9900001',
-        recording => {
-            id => 1,
-            name => 'Dancing Queen'
-        },
-        source => 0,
-    } ],
-    client_version => JSON::null
-}, 'add ISRC edit data is correct');
-
-$edit = $edits[2];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::RemoveISRC', 'also removes ISRCs');
-my @isrc = $c->model('ISRC')->find_by_isrc('DEE250800231');
-
-is_deeply($edit->data, {
-    isrc => {
-        id => $isrc[0]->id,
-        isrc => 'DEE250800231',
-    },
-    recording => {
-        id => 1,
-        name => 'Dancing Queen'
-    }
-}, 'remove ISRC data is correct');
-
-
-# test edit-recording submission without artist credit fields
-
-@edits = capture_edits {
-    $mech->get_ok('/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/edit');
+    # Test display of edit data
+    $mech->get_ok(
+        '/edit/' . $edits[0]->id,
+        'Fetched the edit recording edit page',
+    );
     html_ok($mech->content);
-    my $request = POST $mech->uri, [
-        'edit-recording.length' => '4:56',
-        'edit-recording.name' => 'Dancing Queen'
-    ];
+    $mech->text_contains(
+        'Dancing Queen',
+        'The edit page contains the old recording name',
+    );
+    $mech->text_contains(
+        'Another name',
+        'The edit page contains the new recording name',
+    );
+    $mech->text_contains(
+        '2:03',
+        'The edit page contains the old recording length',
+    );
+    $mech->text_contains(
+        '1:23',
+        'The edit page contains the new recording length',
+    );
+    $mech->text_contains(
+        'A comment!',
+        'The edit page contains the new disambiguation',
+    );
+    $mech->text_contains('Foo', 'The edit page lists the first new artist');
+    $mech->content_contains(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce',
+        'The edit page contains a link to the first new artist',
+    );
+    $mech->text_contains(
+        'Queen',
+        'The edit page lists the second new artist',
+    );
+    $mech->content_contains(
+        '/artist/945c079d-374e-4436-9448-da92dedef3cf',
+        'The edit page contains a link to the second new artist',
+    );
+    $mech->text_contains(
+        'David Bowie',
+        'The edit page lists the third new artist',
+    );
+    $mech->content_contains(
+        '/artist/5441c29d-3602-4898-b1a1-b77fa23b8e50',
+        'The edit page contains a link to the third new artist',
+    );
+    $mech->text_contains('ABBA', 'The edit page lists the old artist');
+    $mech->content_contains(
+        '/artist/a45c079d-374e-4436-9448-da92dedef3cf',
+        'The edit page contains a link to the old artist',
+    );
 
-    $mech->request($request);
-} $c;
+    isa_ok($edits[1], 'MusicBrainz::Server::Edit::Recording::AddISRCs');
+    is_deeply(
+        $edits[1]->data,
+        {
+            isrcs => [ {
+                isrc => 'USS1Z9900001',
+                recording => {
+                    id => 1,
+                    name => 'Dancing Queen'
+                },
+                source => 0,
+            } ],
+            client_version => JSON::null
+        },
+        'The add ISRC edit contains the right data',
+    );
 
-@edits = sort_by { $_->id } @edits;
+    isa_ok($edits[2], 'MusicBrainz::Server::Edit::Recording::RemoveISRC');
+    my @isrc = $c->model('ISRC')->find_by_isrc('DEE250800231');
 
-ok($mech->success);
-ok($mech->uri =~ qr{/recording/54b9d183-7dab-42ba-94a3-7388a66604b8$});
-html_ok($mech->content);
-
-$edit = $edits[0];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::Edit');
-cmp_deeply($edit->data, {
-    entity => {
-        id => 1,
-        gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-        name => 'Dancing Queen'
-    },
-    new => { length => 296000 },
-    old => { length => 123456 }
-});
-
+    is_deeply(
+        $edits[2]->data,
+        {
+            isrc => {
+                id => $isrc[0]->id,
+                isrc => 'DEE250800231',
+            },
+            recording => {
+                id => 1,
+                name => 'Dancing Queen',
+            },
+        },
+        'The remove ISRC edit contains the right data',
+    );
 };
+
+test 'Editing a recording without submitting the artist credit field' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    prepare_test($test);
+
+    $mech->get_ok(
+        '/recording/54b9d183-7dab-42ba-94a3-7388a66604b8/edit',
+        'Fetched the recording editing page',
+    );
+
+    my @edits = capture_edits {
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-recording.length' => '4:56',
+                'edit-recording.name' => 'Dancing Queen',
+                'edit-recording.isrcs.0' => 'DEE250800231',
+            },
+            'The form returned a 2xx response code'
+        );
+    } $c;
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Recording::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '54b9d183-7dab-42ba-94a3-7388a66604b8',
+                name => 'Dancing Queen',
+            },
+            new => { length => 296000 },
+            old => { length => 123456 },
+        },
+        'The edit contains the right data',
+    );
+};
+
+sub prepare_test {
+    my $test = shift;
+
+    $test->c->sql->do(<<~'SQL');
+        INSERT INTO artist (id, gid, name, sort_name, comment)
+             VALUES (3, '745c079d-374e-4436-9448-da92dedef3ce', 'ABBA', 'ABBA', 'A'),
+                    (6, 'a45c079d-374e-4436-9448-da92dedef3cf', 'ABBA', 'ABBA', 'B'),
+                    (4, '945c079d-374e-4436-9448-da92dedef3cf', 'ABBA', 'ABBA', 'C'),
+                    (5, '5441c29d-3602-4898-b1a1-b77fa23b8e50', 'ABBA', 'ABBA', 'D');
+
+        INSERT INTO artist_credit (id, name, artist_count, gid)
+            VALUES (1, 'ABBA', 1, '949a7fd5-fe73-3e8f-922e-01ff4ca958f7');
+
+        INSERT INTO artist_credit_name (artist_credit, position, artist, name)
+             VALUES (1, 0, 6, 'ABBA');
+
+        INSERT INTO recording (id, gid, name, artist_credit, length)
+             VALUES (1, '54b9d183-7dab-42ba-94a3-7388a66604b8', 'Dancing Queen', 1, 123456);
+
+        INSERT INTO isrc (isrc, recording)
+             VALUES ('DEE250800231', 1);
+        SQL
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' }
+    );
+}
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Edit.pm
@@ -4,83 +4,129 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
-use HTTP::Request::Common;
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic release group editing works.
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Editing a release group' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-$mech->get_ok('/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit');
-html_ok($mech->content);
+    MusicBrainz::Server::Test->prepare_test_database($c);
 
-my $request = POST $mech->uri, [
-    'edit-release-group.comment' => 'A comment!',
-    'edit-release-group.primary_type_id' => 2,
-    'edit-release-group.name' => 'Another name',
-    'edit-release-group.artist_credit.names.0.name' => 'Foo',
-    'edit-release-group.artist_credit.names.0.artist.name' => 'Bar',
-    'edit-release-group.artist_credit.names.0.artist.id' => '3',
-];
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
 
-$mech->request($request);
-ok($mech->success);
+    $mech->get_ok(
+        '/release-group/234c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the release group editing page',
+    );
+    html_ok($mech->content);
 
-my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
-isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::Edit');
-cmp_deeply($edit->data, {
-    new => {
-        artist_credit => {
-            names => [ {
-                artist => { id => 3, name => 'Bar' },
-                name => 'Foo',
-                join_phrase => '',
-            } ]
+    my @edits = capture_edits {
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-release-group.comment' => 'A comment!',
+                'edit-release-group.primary_type_id' => 2,
+                'edit-release-group.name' => 'Another name',
+                'edit-release-group.artist_credit.names.0.name' => 'Foo',
+                'edit-release-group.artist_credit.names.0.artist.name' => 'Bar',
+                'edit-release-group.artist_credit.names.0.artist.id' => '3',
+            },
+            'The form returned a 2xx response code'
+        );
+    } $c;
+
+    ok(
+        $mech->uri =~ qr{/release-group/234c079d-374e-4436-9448-da92dedef3ce$},
+        'The user is redirected to the release group page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '234c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Arrival',
+            },
+            new => {
+                artist_credit => {
+                    names => [ {
+                        artist => { id => 3, name => 'Bar' },
+                        name => 'Foo',
+                        join_phrase => '',
+                    } ],
+                },
+                name => 'Another name',
+                comment => 'A comment!',
+                type_id => 2,
+            },
+            old => {
+                artist_credit => {
+                    names => [ {
+                        artist => { id => 6, name => 'ABBA' },
+                        name => 'ABBA',
+                        join_phrase => '',
+                    } ],
+                },
+                name => 'Arrival',
+                comment => '',
+                type_id => 1,
+            },
         },
-        name => 'Another name',
-        comment => 'A comment!',
-        type_id => 2,
-    },
-    old => {
-        artist_credit => {
-            names => [ {
-                artist => { id => 6, name => 'ABBA' },
-                name => 'ABBA',
-                join_phrase => '',
-            } ] },
-        name => 'Arrival',
-        comment => '',
-        type_id => 1,
-    },
-    entity => {
-        id => 1,
-        gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-        name => 'Arrival'
-    }
-});
+        'The edit contains the right data',
+    );
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-$mech->text_contains('Arrival', '..has old release group name');
-$mech->text_contains('Another name', '..has new release group name');
-$mech->text_contains('A comment!', '..has new comment');
-$mech->text_contains('Album', '..has old type');
-$mech->text_contains('Single', '..has new type');
-$mech->text_contains('Foo', '..has new artist');
-$mech->content_contains('/artist/745c079d-374e-4436-9448-da92dedef3ce', '...and links to artist');
-$mech->text_contains('ABBA', '..has old artist');
-$mech->content_contains('/artist/a45c079d-374e-4436-9448-da92dedef3cf', '...and links to artist');
-
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Arrival',
+        'The edit page contains the old release group name',
+    );
+    $mech->text_contains(
+        'Another name',
+        'The edit page contains the new release group name',
+    );
+    $mech->text_contains(
+        'Album',
+        'The edit page contains the old release group type',
+    );
+    $mech->text_contains(
+        'Single',
+        'The edit page contains the new release group type',
+    );
+    $mech->text_contains(
+        'A comment!',
+        'The edit page contains the new disambiguation',
+    );
+    $mech->text_contains('Foo', 'The edit page lists the new artist');
+    $mech->content_contains(
+        '/artist/745c079d-374e-4436-9448-da92dedef3ce',
+        'The edit page contains a link to the new artist',
+    );
+    $mech->text_contains('ABBA', 'The edit page lists the old artist');
+    $mech->content_contains(
+        '/artist/a45c079d-374e-4436-9448-da92dedef3cf',
+        'The edit page contains a link to the old artist',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/URL/Edit.pm
@@ -4,12 +4,18 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply re );
-use MusicBrainz::Server::Test qw( html_ok );
+use MusicBrainz::Server::Test qw( capture_edits html_ok );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
+
+This test checks whether basic URL editing works, and whether clearing the
+credited-as fields works as expected.
+
+=cut
+
+test 'Editing a URL' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -17,41 +23,71 @@ test all => sub {
     MusicBrainz::Server::Test->prepare_test_database($c, '+url');
     MusicBrainz::Server::Test->prepare_test_database($c, '+editor');
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
-
-    # Test editing urls
-    $mech->get_ok('/url/9201840b-d810-4e0f-bb75-c791205f5b24/edit');
+    $mech->get('/login');
     $mech->submit_form(
-        with_fields => {
-            'edit-url.url' => 'http://link.example',
-        });
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
 
-    my $edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    $mech->get_ok(
+        '/url/9201840b-d810-4e0f-bb75-c791205f5b24/edit',
+        'Fetched the URL editing page',
+    );
+    html_ok($mech->content);
+
+    my @edits = capture_edits {
+        $mech->submit_form_ok({
+            with_fields => {
+                'edit-url.url' => 'http://link.example',
+            },
+        },
+        'The form returned a 2xx response code')
+    } $c;
+
+    ok(
+        $mech->uri =~ qr{/url/9201840b-d810-4e0f-bb75-c791205f5b24$},
+        'The user is redirected to the URL page after entering the edit',
+    );
+
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
     isa_ok($edit, 'MusicBrainz::Server::Edit::URL::Edit');
-    cmp_deeply($edit->data, {
-        entity => {
-            id => 1,
-            gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-            name => 'http://musicbrainz.org/'
-        },
-        new => {
-            url => 'http://link.example/',
-        },
-        old => {
-            url => 'http://musicbrainz.org/',
-        },
-        affects => 0, # not realistic, but true for the test data (unused URL entity)
-        is_merge => 0,
-    });
 
-    $mech->get_ok('/edit/' . $edit->id, 'Fetch edit page');
-    html_ok($mech->content, '..valid xml');
-    $mech->content_contains('http://link.example', '..has new URI');
-    $mech->content_contains('http://musicbrainz.org/', '..has old URI');
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '9201840b-d810-4e0f-bb75-c791205f5b24',
+                name => 'http://musicbrainz.org/'
+            },
+            new => {
+                url => 'http://link.example/',
+            },
+            old => {
+                url => 'http://musicbrainz.org/',
+            },
+            affects => 0, # not realistic, but true for the test data (unused URL entity)
+            is_merge => 0,
+        },
+        'The edit contains the right data',
+    );
+
+    # Test display of edit data
+    $mech->get_ok('/edit/' . $edit->id, 'Fetched the edit page');
+    html_ok($mech->content);
+    $mech->text_contains(
+        'http://musicbrainz.org/',
+        'The edit page contains the old URI',
+    );
+    $mech->text_contains(
+        'http://link.example',
+        'The edit page contains the new URI',
+    );
 };
 
-test 'MBS-8590: Clearing relationship credits' => sub {
+test 'Clearing relationship credits from URL rels (MBS-8590)' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -68,35 +104,57 @@ test 'MBS-8590: Clearing relationship credits' => sub {
             VALUES (1, 1, 3, 1, 'Bob Marley');
         SQL
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
 
     # Submitting without an edit-url.rel.0.entity0_credit field is a noop
-    $mech->post('/url/94d14d6f-d937-4f24-a814-423cdb977c74/edit', {
-        'edit-url.url' => 'http://www.bobmarley.com/',
-        'edit-url.rel.0.relationship_id' => '1',
-        'edit-url.rel.0.target' => '7aed3034-2bc3-4495-a0fb-f6d2a55c7b20',
-        'edit-url.rel.0.backward' => '1',
-        'edit-url.rel.0.link_type_id' => '183',
-        'edit-url.edit_note' => '',
-    });
+    $mech->post_ok(
+        '/url/94d14d6f-d937-4f24-a814-423cdb977c74/edit',
+        {
+            'edit-url.url' => 'http://www.bobmarley.com/',
+            'edit-url.rel.0.relationship_id' => '1',
+            'edit-url.rel.0.target' => '7aed3034-2bc3-4495-a0fb-f6d2a55c7b20',
+            'edit-url.rel.0.backward' => '1',
+            'edit-url.rel.0.link_type_id' => '183',
+            'edit-url.edit_note' => '',
+        },
+        'The form returned a 2xx response code when skipping entity0_credit field',
+    );
 
-    my $credit = $c->sql->select_single_value('SELECT entity0_credit FROM l_artist_url WHERE id = 1');
-    is($credit, 'Bob Marley');
+    my $credit = $c->sql->select_single_value(
+        'SELECT entity0_credit FROM l_artist_url WHERE id = 1',
+    );
+    is(
+        $credit,
+        'Bob Marley',
+        'The credit did not change when the credit field was simply omitted',
+    );
 
     # Submitting with an empty edit-url.rel.0.entity0_credit field clears the credit (MBS-8590)
-    $mech->post('/url/94d14d6f-d937-4f24-a814-423cdb977c74/edit', {
-        'edit-url.url' => 'http://www.bobmarley.com/',
-        'edit-url.rel.0.relationship_id' => '1',
-        'edit-url.rel.0.target' => '7aed3034-2bc3-4495-a0fb-f6d2a55c7b20',
-        'edit-url.rel.0.backward' => '1',
-        'edit-url.rel.0.link_type_id' => '183',
-        'edit-url.rel.0.entity0_credit' => '',
-        'edit-url.edit_note' => '',
-    });
+    $mech->post_ok(
+        '/url/94d14d6f-d937-4f24-a814-423cdb977c74/edit',
+        {
+            'edit-url.url' => 'http://www.bobmarley.com/',
+            'edit-url.rel.0.relationship_id' => '1',
+            'edit-url.rel.0.target' => '7aed3034-2bc3-4495-a0fb-f6d2a55c7b20',
+            'edit-url.rel.0.backward' => '1',
+            'edit-url.rel.0.link_type_id' => '183',
+            'edit-url.rel.0.entity0_credit' => '',
+            'edit-url.edit_note' => '',
+        },
+        'The form returned a 2xx response code when posting empty entity0_credit field',
+    );
 
-    $credit = $c->sql->select_single_value('SELECT entity0_credit FROM l_artist_url WHERE id = 1');
-    is($credit, '');
+    $credit = $c->sql->select_single_value(
+        'SELECT entity0_credit FROM l_artist_url WHERE id = 1',
+    );
+    is(
+        $credit,
+        '',
+        'The credit was removed when the credit field was explicitly blanked',
+    );
 };
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Edit.pm
@@ -4,100 +4,145 @@ use warnings;
 
 use Test::Routine;
 use Test::More;
-use Test::Deep qw( cmp_deeply ignore re );
+use Test::Deep qw( cmp_deeply ignore );
+use MusicBrainz::Server::Constants qw( $STATUS_APPLIED );
 use MusicBrainz::Server::Test qw( accept_edit capture_edits html_ok );
-use HTTP::Request::Common;
-use List::AllUtils qw( sort_by );
 
 with 't::Mechanize', 't::Context';
 
-test all => sub {
+=head2 Test description
 
-my $test = shift;
-my $mech = $test->mech;
-my $c    = $test->c;
+This test checks whether basic work editing works, and specifically tests
+work attributes and languages. It also ensures a work can be added to a series
+that already contains duplicate items, which used to ISE (MBS-8636).
 
-MusicBrainz::Server::Test->prepare_test_database($c);
+=cut
 
-$mech->get_ok('/login');
-$mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+test 'Editing a work' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
 
-my @edits = capture_edits {
-    $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/edit');
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the work editing page',
+    );
     html_ok($mech->content);
-    my $request = POST $mech->uri, [
-        'edit-work.comment' => 'A comment!',
-        'edit-work.type_id' => 26,
-        'edit-work.name' => 'Another name',
-        'edit-work.iswcs.0' => 'T-000.000.002-0'
-    ];
-    $mech->request($request);
-} $c;
 
-@edits = sort_by { $_->id } @edits;
+    my @edits = capture_edits {
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-work.comment' => 'A comment!',
+                'edit-work.type_id' => 26,
+                'edit-work.name' => 'Another name',
+                'edit-work.iswcs.0' => 'T-000.000.002-0'
+            },
+            'The form returned a 2xx response code',
+        );
+    } $c;
 
-ok($mech->success, 'POST request success');
-ok($mech->uri =~ qr{/work/745c079d-374e-4436-9448-da92dedef3ce$}, 'redirected to correct work page');
-html_ok($mech->content);
+    ok(
+        $mech->uri =~ qr{/work/745c079d-374e-4436-9448-da92dedef3ce$},
+        'The user is redirected to the work page after entering the edit',
+    );
 
-my $edit = $edits[0];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::Edit');
-cmp_deeply($edit->data, {
-    entity => {
-        id => 1,
-        gid => re('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
-        name => 'Dancing Queen'
-    },
-    new => {
-        name => 'Another name',
-        type_id => 26,
-        comment => 'A comment!',
-    },
-    old => {
-        type_id => 1,
-        comment => '',
-        name => 'Dancing Queen'
-    }
-});
+    is(@edits, 3, 'Three edits were entered');
 
-$mech->get_ok('/edit/' . $edit->id, 'Fetch the edit page');
-html_ok($mech->content);
-$mech->text_contains('Another name', '..has new name');
-$mech->text_contains('Dancing Queen', '..has old name');
-$mech->text_contains('Beijing opera', '..has new work type');
-$mech->text_contains('Aria', '..has old work type');
-$mech->text_contains('A comment!', '..has new comment');
+    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Work::Edit');
 
-$edit = $edits[1];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::AddISWCs', 'adds ISWCs');
-is_deeply($edit->data, {
-    iswcs => [ {
-        iswc => 'T-000.000.002-0',
-        work => {
-            id => 1,
-            name => 'Dancing Queen'
-        }
-    } ]
-}, 'add ISWC data looks correct');
+    is_deeply(
+        $edits[0]->data,
+        {
+            entity => {
+                id => 1,
+                gid => '745c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Dancing Queen'
+            },
+            new => {
+                name => 'Another name',
+                type_id => 26,
+                comment => 'A comment!',
+            },
+            old => {
+                type_id => 1,
+                comment => '',
+                name => 'Dancing Queen'
+            },
+        },
+        'The edit work edit contains the right data',
+    );
 
-$edit = $edits[2];
-isa_ok($edit, 'MusicBrainz::Server::Edit::Work::RemoveISWC', 'also removes ISWCs');
-my @iswc = $c->model('ISWC')->find_by_iswc('T-000.000.001-0');
+    # Test display of edit data
+    $mech->get_ok(
+        '/edit/' . $edits[0]->id,
+        'Fetched the edit work edit page',
+    );
+    html_ok($mech->content);
+    $mech->text_contains(
+        'Dancing Queen',
+        'The edit page contains the old work name',
+    );
+    $mech->text_contains(
+        'Another name',
+        'The edit page contains the new work name',
+    );
+    $mech->text_contains(
+        'Aria',
+        'The edit page contains the old work type',
+    );
+    $mech->text_contains(
+        'Beijing opera',
+        'The edit page contains the new work type',
+    );
+    $mech->text_contains(
+        'A comment!',
+        'The edit page contains the new disambiguation',
+    );
 
-is_deeply($edit->data, {
-    iswc => {
-        id => $iswc[0]->id,
-        iswc => 'T-000.000.001-0',
-    },
-    work => {
-        id => 1,
-        name => 'Dancing Queen'
-    }
-}, 'remove ISWC data looks correct');
+    isa_ok($edits[1], 'MusicBrainz::Server::Edit::Work::AddISWCs', 'adds ISWCs');
 
+    is_deeply(
+        $edits[1]->data,
+        {
+            iswcs => [ {
+                iswc => 'T-000.000.002-0',
+                work => {
+                    id => 1,
+                    name => 'Dancing Queen',
+                },
+            } ],
+        },
+        'The add ISWC edit contains the right data',
+    );
+
+    isa_ok($edits[2], 'MusicBrainz::Server::Edit::Work::RemoveISWC', 'also removes ISWCs');
+    my @iswc = $c->model('ISWC')->find_by_iswc('T-000.000.001-0');
+
+    is_deeply(
+        $edits[2]->data,
+        {
+            iswc => {
+                id => $iswc[0]->id,
+                iswc => 'T-000.000.001-0',
+            },
+            work => {
+                id => 1,
+                name => 'Dancing Queen',
+            },
+        },
+        'The remove ISWC edit contains the right data',
+    );
 };
 
-test 'Editing works with attributes' => sub {
+test 'Editing work attributes' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -108,116 +153,149 @@ test 'Editing works with attributes' => sub {
         DELETE FROM iswc;
         SQL
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the work editing page',
+    );
 
     my @edits = capture_edits {
-        $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/edit');
-        html_ok($mech->content);
-        my $request = POST $mech->uri, [
-            'edit-work.name' => 'Work name',
-            'edit-work.attributes.0.type_id' => 6,
-            'edit-work.attributes.0.value' => 'Free text',
-            'edit-work.attributes.1.type_id' => 1,
-            'edit-work.attributes.1.value' => '13'
-        ];
-        $mech->request($request);
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-work.name' => 'Dancing Queen',
+                'edit-work.type_id' => 1,
+                'edit-work.attributes.0.type_id' => 6,
+                'edit-work.attributes.0.value' => 'Free text',
+                'edit-work.attributes.1.type_id' => 1,
+                'edit-work.attributes.1.value' => '13',
+            },
+            'The form returned a 2xx response code',
+        );
     } $c;
 
-    is(@edits, 1, 'An edit was created');
+    is(@edits, 1, 'The edit was entered');
+
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Work::Edit');
+
     is_deeply(
-        $edits[0]->data->{new}{attributes},
-        [
-            {
-                attribute_text => 'Free text',
-                attribute_type_id => 6,
-                attribute_value_id => undef
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '745c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Dancing Queen'
             },
-            {
-                attribute_text => undef,
-                attribute_type_id => 1,
-                attribute_value_id => 13
-            }
-        ]
+            new => {
+                attributes => [
+                    {
+                        attribute_text => 'Free text',
+                        attribute_type_id => 6,
+                        attribute_value_id => undef,
+                    },
+                    {
+                        attribute_text => undef,
+                        attribute_type_id => 1,
+                        attribute_value_id => 13,
+                    },
+                ],
+            },
+            old => {
+                attributes => [],
+            },
+        },
+        'The edit contains the right data',
     );
 };
 
-test 'MBS-8636: Adding a relationship to a series which contains duplicate items' => sub {
+test 'Relationship can be added to series which contains duplicates (MBS-8636)' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
 
     MusicBrainz::Server::Test->prepare_test_database($c, '+mbs-8636');
 
-    $c->sql->do(<<~'SQL');
-        INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
-            VALUES (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo@example.com', now());
-        SQL
-
-    $mech->get_ok('/login');
-    $mech->submit_form(with_fields => { username => 'editor', password => 'pass' });
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'editor', password => 'pass' }
+    );
 
     my @edits = capture_edits {
-        $mech->post('/work/02bfb89e-8877-47c0-a19d-b574bae78198/edit', {
-            'edit-work.comment' => '',
-            'edit-work.edit_note' => '',
-            'edit-work.iswcs.0' => '',
-            'edit-work.languages.0' => '486',
-            'edit-work.name' => 'Concerto and Fugue in C minor, BWV 909',
-            'edit-work.rel.0.attributes.0.text_value' => 'BWV 909',
-            'edit-work.rel.0.attributes.0.type.gid' => 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a',
-            'edit-work.rel.0.backward' => '1',
-            'edit-work.rel.0.entity0_credit' => '',
-            'edit-work.rel.0.entity1_credit' => '',
-            'edit-work.rel.0.link_order' => '0',
-            'edit-work.rel.0.link_type_id' => '743',
-            'edit-work.rel.0.target' => 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582',
-            'edit-work.type_id' => '',
-        });
+        $mech->post_ok(
+            '/work/02bfb89e-8877-47c0-a19d-b574bae78198/edit',
+            {
+                'edit-work.languages.0' => '486',
+                'edit-work.name' => 'Concerto and Fugue in C minor, BWV 909',
+                'edit-work.rel.0.attributes.0.text_value' => 'BWV 909',
+                'edit-work.rel.0.attributes.0.type.gid' => 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a',
+                'edit-work.rel.0.backward' => '1',
+                'edit-work.rel.0.link_order' => '0',
+                'edit-work.rel.0.link_type_id' => '743',
+                'edit-work.rel.0.target' => 'd977f7fd-96c9-4e3e-83b5-eb484a9e6582',
+            },
+            'The form returned a 2xx response code',
+        );
     } $c;
 
-    is(scalar @edits, 1);
-    isa_ok($edits[0], 'MusicBrainz::Server::Edit::Relationship::Create');
+    is(@edits, 1, 'The edit was entered');
 
-    my $relationships = $c->sql->select_list_of_hashes('SELECT * FROM l_series_work ORDER BY id');
-    cmp_deeply($relationships, [
-          {
-            edits_pending => 1,
-            entity0 => 25,
-            entity0_credit => '',
-            entity1 => 10465539,
-            entity1_credit => '',
-            id => 2025,
-            last_updated => ignore(),
-            link => 170801,
-            link_order => 749,
-          },
-          {
-            edits_pending => 0,
-            entity0 => 25,
-            entity0_credit => '',
-            entity1 => 10465539,
-            entity1_credit => '',
-            id => 15120,
-            last_updated => ignore(),
-            link => 170801,
-            link_order => 2,
-          },
-          {
-            edits_pending => 0,
-            entity0 => 25,
-            entity0_credit => '',
-            entity1 => 12894254,
-            entity1_credit => '',
-            id => 15121,
-            last_updated => ignore(),
-            link => 170802,
-            link_order => 1,
-          },
-    ]);
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Relationship::Create');
+
+    is($edit->status, $STATUS_APPLIED, 'The edit was applied');
+
+    my $relationships = $c->sql->select_list_of_hashes(
+        'SELECT * FROM l_series_work ORDER BY id',
+    );
+    cmp_deeply(
+        $relationships,
+        [
+            {
+                edits_pending => 1,
+                entity0 => 25,
+                entity0_credit => '',
+                entity1 => 10465539,
+                entity1_credit => '',
+                id => 2025,
+                last_updated => ignore(),
+                link => 170801,
+                link_order => 749,
+            },
+            {
+                edits_pending => 0,
+                entity0 => 25,
+                entity0_credit => '',
+                entity1 => 10465539,
+                entity1_credit => '',
+                id => 15120,
+                last_updated => ignore(),
+                link => 170801,
+                link_order => 2,
+            },
+            {
+                edits_pending => 0,
+                entity0 => 25,
+                entity0_credit => '',
+                entity1 => 12894254,
+                entity1_credit => '',
+                id => 15121,
+                last_updated => ignore(),
+                link => 170802,
+                link_order => 1,
+            },
+        ],
+        'The relationship data in the database is as expected',
+    );
 };
 
-test 'Editing works with multiple languages' => sub {
+test 'Editing (multiple) work languages' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -228,46 +306,122 @@ test 'Editing works with multiple languages' => sub {
         DELETE FROM iswc;
         SQL
 
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+    $mech->get('/login');
+    $mech->submit_form(
+        with_fields => { username => 'new_editor', password => 'password' }
+    );
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the work editing page',
+    );
 
     my @edits = capture_edits {
-        $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/edit');
-        my $request = POST $mech->uri, [
-            'edit-work.name' => 'Dancing Queen',
-            'edit-work.languages.0' => '120',
-            'edit-work.languages.1' => '145',
-            'edit-work.languages.2' => '198',
-        ];
-        $mech->request($request);
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-work.name' => 'Dancing Queen',
+                'edit-work.type_id' => 1,
+                'edit-work.languages.0' => '120',
+                'edit-work.languages.1' => '145',
+                'edit-work.languages.2' => '198',
+            },
+            'The form returned a 2xx response code',
+        );
     } $c;
 
-    is(@edits, 1, 'An edit was created');
-    accept_edit($c, $edits[0]);
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce', 'Fetch the work page');
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Work::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '745c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Dancing Queen'
+            },
+            new => {
+                languages => ['120', '145', '198'],
+            },
+            old => {
+                languages => [],
+            },
+        },
+        'The edit adding languages contains the right data',
+    );
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce',
+        'Fetched the work page',
+    );
     my ($languages) = $mech->scrape_text_by_attr('class', 'lyrics-language');
-    like($languages, qr/English/, '..has English');
-    like($languages, qr/German/, '..has German');
-    like($languages, qr/Japanese/, '..has Japanese');
+    like($languages, qr/English/, 'The languages section lists English');
+    like($languages, qr/German/, 'The languages section lists German');
+    like($languages, qr/Japanese/, 'The languages section lists Japanese');
 
-    @edits = capture_edits {
-        $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce/edit');
-        my $request = POST $mech->uri, [
-            'edit-work.name' => 'Dancing Queen',
-            'edit-work.languages.0' => '145',
-        ];
-        $mech->request($request);
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce/edit',
+        'Fetched the work editing page',
+    );
+
+    my @edits = capture_edits {
+        $mech->post_ok(
+            $mech->uri,
+            {
+                'edit-work.name' => 'Dancing Queen',
+                'edit-work.type_id' => 1,
+                'edit-work.languages.0' => '145',
+            },
+            'The form returned a 2xx response code',
+        );
     } $c;
 
-    is(@edits, 1, 'An edit was created');
-    accept_edit($c, $edits[0]);
+    is(@edits, 1, 'The edit was entered');
 
-    $mech->get_ok('/work/745c079d-374e-4436-9448-da92dedef3ce', 'Fetch the work page');
-    ($languages) = $mech->scrape_text_by_attr('class', 'lyrics-language');
-    unlike($languages, qr/English/, '..does not have English');
-    like($languages, qr/German/, '..has German');
-    unlike($languages, qr/Japanese/, '..does not have Japanese');
+    my $edit = shift(@edits);
+
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Work::Edit');
+
+    is_deeply(
+        $edit->data,
+        {
+            entity => {
+                id => 1,
+                gid => '745c079d-374e-4436-9448-da92dedef3ce',
+                name => 'Dancing Queen'
+            },
+            new => {
+                languages => ['145'],
+            },
+            old => {
+                languages => ['120', '145', '198'],
+            },
+        },
+        'The edit removing some languages contains the right data',
+    );
+
+    accept_edit($c, $edit);
+
+    $mech->get_ok(
+        '/work/745c079d-374e-4436-9448-da92dedef3ce',
+        'Fetched the work page again after accepting the new edit',
+    );
+    my ($languages) = $mech->scrape_text_by_attr('class', 'lyrics-language');
+    unlike(
+        $languages,
+        qr/English/,
+        'The languages section no longer lists English',
+    );
+    like($languages, qr/German/, 'The languages section still lists German');
+    unlike(
+        $languages,
+        qr/Japanese/,
+        'The languages section no longer lists Japanese',
+    );
 };
 
 1;

--- a/t/sql/mbs-8636.sql
+++ b/t/sql/mbs-8636.sql
@@ -18,3 +18,6 @@ INSERT INTO link_attribute_text_value (link, attribute_type, text_value)
 INSERT INTO l_series_work (id, link, entity0, entity1, edits_pending, last_updated, link_order, entity0_credit, entity1_credit)
     VALUES (15120, 170801, 25, 10465539, 0, '2015-11-11 16:23:07.850893+00', 0, '', ''),
            (2025, 170801, 25, 10465539, 1, '2014-05-21 06:35:59.318332+00', 749, '', '');
+
+INSERT INTO editor (id, name, password, ha1, email, email_confirm_date)
+    VALUES (1, 'editor', '{CLEARTEXT}pass', '3f3edade87115ce351d63f42d92a1834', 'foo@example.com', now());


### PR DESCRIPTION
I'm changing a lot of tests that we already had for several entities, because it seems a lot easier to see all the updates to them in one go each rather than slowly doing them per entity.

See commit messages for further details.