### PR TITLE
MBS-12260 / MBS-12262: Block Facebook and YouTube search URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4991,6 +4991,13 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url, id) {
+      if (/https:\/\/www\.youtube\.com\/results\?/.test(url)) {
+        return {
+          error: noLinkToSearchMsg(),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       switch (id) {
         case LINK_TYPES.youtube.artist:
         case LINK_TYPES.youtube.event:

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -365,6 +365,11 @@ const linkToChannelMsg = N_l(
    recordings or releases instead.`,
 );
 
+const noLinkToSearchMsg = N_l(
+  `This is a link to a search result. Please link to any page in the results
+   that is relevant to this entity instead, if available.`,
+);
+
 const linkToVideoMsg = N_l(
   `Please link to a specific video. Add channel pages
    to the relevant artist, label, etc. instead.`,
@@ -1981,6 +1986,13 @@ const CLEANUPS: CleanupEntries = {
       return url;
     },
     validate: function (url) {
+      if (/https:\/\/www\.facebook\.com\/search\//.test(url)) {
+        return {
+          error: noLinkToSearchMsg(),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       if (/facebook.com\/pages\//.test(url)) {
         return {
           result: /\/pages\/[^\/?#]+\/\d+/.test(url),

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1956,6 +1956,24 @@ limited_link_type_combinations: [
     expected_relationship_type: 'socialnetwork',
             expected_clean_url: 'https://www.facebook.com/TheSullivanSees',
   },
+  {
+                     input_url: 'https://www.facebook.com/searchingforabby',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.facebook.com/searchingforabby',
+  },
+  {
+                     input_url: 'https://www.facebook.com/search/top?q=oxxxymiron',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+            expected_clean_url: 'https://www.facebook.com/search/top?q=oxxxymiron',
+       input_relationship_type: 'socialnetwork',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'a link to a search result',
+                                  target: 'url',
+                                },
+  },
   // Finna.fi
   {
                      input_url: 'https://www.finna.fi/Record/viola.163990',

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5288,6 +5288,24 @@ limited_link_type_combinations: [
        input_relationship_type: 'youtube',
        only_valid_entity_types: [],
   },
+  {
+                     input_url: 'https://www.youtube.com/resultsarein',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'youtube',
+            expected_clean_url: 'https://www.youtube.com/resultsarein',
+       only_valid_entity_types: ['artist', 'event', 'label', 'place', 'series'],
+  },
+  {
+                     input_url: 'https://www.youtube.com/results?search_query=oxxxymiron',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'youtube',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'a link to a search result',
+                                  target: 'url',
+                                },
+  },
 ];
 /* eslint-enable indent, max-len, sort-keys */
 


### PR DESCRIPTION
### Implement MBS-12260 / MBS-12262

There is no situation where these are a wanted link, so we might as well block them. I made a generic, reusable error string because I'm sure there are more of these.

We have 2 of the FB one only, but we seem to have dozens of the YouTube ones.