### PR TITLE
MBS-12263: Only display "VIAF: " on VIAF pretty links when on sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/VIAF.pm
@@ -19,12 +19,18 @@ sub pretty_name
     my $name = $self->decoded_local_part;
     $name =~ s{^/viaf/}{};
 
+    return $name;
+}
+
+sub sidebar_name
+{
+    my $self = shift;
+
+    my $name = $self->pretty_name;
     $name = "VIAF: $name";
 
     return $name;
 }
-
-sub sidebar_name { shift->pretty_name }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
### Implement MBS-12263

This was always showing as `VIAF: $id`, which makes sense on the sidebar but looks a bit ridiculous elsewhere when the full display is `VIAF ID: VIAF: $id`. Changing it to only add `VIAF: ` for the sidebar, as `URL::Wikidata` already does.
