### PR TITLE
MBS-12264: Re-add missing space before editStatusClass

### DIFF
--- a/root/edit/components/ListEdit.js
+++ b/root/edit/components/ListEdit.js
@@ -41,7 +41,7 @@ const ListEdit = ({
         value={edit.id}
       />
 
-      <div className={`edit-actions c${editStatusClass}`}>
+      <div className={`edit-actions c ${editStatusClass}`}>
         <EditSummary $c={$c} edit={edit} index={index} />
       </div>
 


### PR DESCRIPTION
### Fix MBS-12264

This was causing a broken class name that meant the buttons were no longer centered as intended, but left-aligned.