### PR TITLE
MBS-11904: Use all available space on "reorder relationships" edits

### DIFF
--- a/root/edit/details/ReorderRelationships.js
+++ b/root/edit/details/ReorderRelationships.js
@@ -19,13 +19,15 @@ type Props = {
 const ReorderRelationships = ({edit}: Props): React.MixedElement => (
   <table className="details reorder-relationships">
     <tr>
-      <th className="align-left">{l('Relationship')}</th>
+      <th className="align-left wide">{l('Relationship')}</th>
       <th className="narrow">{l('Old Order')}</th>
       <th className="narrow">{l('New Order')}</th>
     </tr>
     {edit.display_data.relationships.map((reorder, index) => (
       <tr key={index}>
-        <td><Relationship relationship={reorder.relationship} /></td>
+        <td className="wide">
+          <Relationship relationship={reorder.relationship} />
+        </td>
         <td className="align-right narrow old">{reorder.old_order}</td>
         <td className="align-right narrow new">{reorder.new_order}</td>
       </tr>

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -910,6 +910,10 @@ table.details {
         width: 1px;
     }
 
+    th.wide, td.wide {
+        width: auto;
+    }
+
     ul {
         margin: 0;
         padding: 0;


### PR DESCRIPTION
### Implement MBS-11904

Because we set the width of `table.details` headers to 240px by default, this was getting unnecessarily compressed. The relationship column contents are often very long, while the other two columns are specifically set to be as narrow as they can. As such, we should let the relationships column take as much space as it needs. Added a `wide` class, as a companion to the existing `narrow`, because I expect we might need this in a few other places at some point anyway.

The example on the ticket would now look like this in my screen, which seems a lot better:
![Screenshot from 2022-03-18 14-30-28](https://user-images.githubusercontent.com/1069224/159003403-e1237f7d-48c1-4725-bce3-e2ce325a6835.png)
