### PR TITLE
MBS-12272: Split unicode text properly in DiffSide

### DIFF
--- a/root/static/scripts/edit/components/edit/DiffSide.js
+++ b/root/static/scripts/edit/components/edit/DiffSide.js
@@ -23,7 +23,7 @@ function splitText(text, split = '') {
     split = '(' + split + ')';
   }
   // the capture group becomes a separate part of the split output
-  return text.split(new RegExp(split));
+  return text.split(new RegExp(split, 'u'));
 }
 
 type Props = {


### PR DESCRIPTION
Splitting a string by `''` to get an array of characters doesn't work here, because it splits the string by UTF-16 code units, not characters. Adding the `u` flag to our split `RegExp` tells it to handle 4-byte characters properly.