### PR TITLE
MBS-9234: Don't select a default type when adding new series

### DIFF
--- a/lib/MusicBrainz/Server/Form/Series.pm
+++ b/lib/MusicBrainz/Server/Form/Series.pm
@@ -3,6 +3,7 @@ use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Entity::SeriesOrderingType;
 use MusicBrainz::Server::Entity::SeriesType;
 use MusicBrainz::Server::Form::Utils qw( select_options_tree );
+use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Form';
 
@@ -22,6 +23,7 @@ has_field 'comment' => (
 
 has_field 'type_id' => (
     type => 'Select',
+    messages => { required => N_l('A type is required.') },
     required => 1,
 );
 

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -12,7 +12,8 @@
         [%- duplicate_entities_section() -%]
         [%- form_row_text_long(r, 'comment', add_colon(l('Disambiguation'))) -%]
         [%- disambiguation_error() -%]
-        [%- form_row_select(r, 'type_id', l('Type:')) -%]
+        [%# When porting this, remember no_default is equivalent to allowEmpty %]
+        [%- form_row_select(r, 'type_id', l('Type:'), undef, {no_default => 1}) -%]
         [%- form_row_select(r, 'ordering_type_id', l('Ordering Type:')) -%]
       </fieldset>
 


### PR DESCRIPTION
### Implement MBS-9234

Adding a series defaults to RG, and clearly many people are wrongly adding RG series when they want something else. We know this because they keep then hitting ISEs trying to add releases to them (different bug, MBS-9125, but clear indicator).