### PR TITLE
MBS-11879: Fail better when trying to add deleted entity to collection

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::Collection;
 use Moose;
+use utf8;
 use Scalar::Util qw( looks_like_number );
 use List::AllUtils qw( first uniq );
+use MusicBrainz::Server::Translation qw( l );
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };
 
@@ -69,6 +71,11 @@ sub _do_add_or_remove {
 
     if ($entity_id) {
         my $entity = $c->model(type_to_model($entity_type))->get_by_id($entity_id);
+
+        unless ($entity) {
+            $c->stash->{message} = l('“{id}” is not a valid row ID; the entity might have been merged or deleted.', { id => $entity_id });
+            $c->detach('/error_400');
+        }
 
         $c->model('Collection')->$func_name($entity_type, $collection->id, $entity_id);
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Collection/AddAndRemove.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Collection/AddAndRemove.pm
@@ -1,0 +1,83 @@
+package t::MusicBrainz::Server::Controller::Collection::AddAndRemove;
+use Test::Routine;
+use Test::More;
+use utf8;
+
+around run_test => sub {
+    my ($orig, $test, @args) = @_;
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+collection');
+
+    $test->mech->get('/login');
+    $test->mech->submit_form(
+        with_fields => { username => 'editor1', password => 'pass' }
+    );
+
+    $test->$orig(@args);
+};
+
+with 't::Mechanize', 't::Context';
+
+=head2 Test description
+
+This test checks whether adding entities to collections and removing them
+works, and whether trying to add a non-existing entity fails gracefully.
+
+=cut
+
+test 'Can add release to collection from release page ' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    $mech->get_ok(
+        '/release/c34c079d-374e-4436-9448-da92dedef3ce',
+        'Fetched a release page',
+    );
+    $mech->text_contains(
+        'Add to collection1',
+        'The link to add the release to an existing collection is shown',
+    );
+    $mech->follow_link_ok(
+        { text => 'Add to collection1' },
+        'Could follow the "Add to collection1" link',
+    );
+    ok(
+        $mech->uri =~ qr{/release/c34c079d-374e-4436-9448-da92dedef3ce},
+        'We are still/again on the release page',
+    );
+    $mech->text_contains(
+        'Remove from collection1',
+        'The link to remove the release from the collection is now shown',
+    );
+    $mech->follow_link_ok(
+        { text => 'Remove from collection1' },
+        'Could follow the "Remove from collection1" link',
+    );
+    ok(
+        $mech->uri =~ qr{/release/c34c079d-374e-4436-9448-da92dedef3ce},
+        'We are still/again on the release page',
+    );
+    $mech->text_contains(
+        'Add to collection1',
+        'The link to add the release to the collection is shown once again',
+    );
+};
+
+test 'Trying to add incorrect ids to collection fails gracefully' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    $mech->get(
+        '/collection/f34c079d-374e-4436-9448-da92dedef3cd/collection_collaborator/add?release=hahahahano',
+    );
+    is(
+        $mech->status,
+        400,
+        'Trying to add an invalid id to a collection fails',
+    );
+    $mech->text_contains(
+        '“hahahahano” is not a valid row ID',
+        'The expected error message is shown',
+    );
+};
+
+1;


### PR DESCRIPTION
### Fix MBS-11879

I don't think there's a point creating a specific `NotFound` template for this; it's a fairly rare situation, and I think giving the user an understandable error message is good enough here.

![Screenshot from 2022-03-23 12-11-36](https://user-images.githubusercontent.com/1069224/159675738-ecc31371-b8d3-4238-8a56-945237362ffc.png)
