### PR TITLE
MBS-12289: Avoid crashing on untyped series form

### DIFF
--- a/root/components/relationship-editor.tt
+++ b/root/components/relationship-editor.tt
@@ -116,6 +116,13 @@
       <!-- /ko -->
     </td>
   </tr>
+  <!-- ko if: isUntypedSeries() -->
+    <tr>
+      <td colspan="2">
+        [% l('To add parts to this series, please select a series type first.') %]
+      </td>
+    </tr>
+  <!-- /ko -->
 </script>
 
 <script type="text/html" id="template.dialog-date">

--- a/root/static/scripts/series/edit.js
+++ b/root/static/scripts/series/edit.js
@@ -13,8 +13,10 @@ $(function () {
   function updateAllowedTypes(seriesHasItems) {
     $type_options.each(function () {
       const type = MB.seriesTypesByID[this.value];
-      if (seriesHasItems &&
-          type.item_entity_type !== series.type().item_entity_type) {
+      const seriesEntityType = series.type()?.item_entity_type;
+      const isTypeAllowed =
+        type && type.item_entity_type === seriesEntityType;
+      if (seriesHasItems && !isTypeAllowed) {
         this.setAttribute('disabled', 'disabled');
       } else {
         this.removeAttribute('disabled');


### PR DESCRIPTION
### Fix MBS-12289

This was crashing because we now do not select a type by default (even though a type is eventually still required).
I amended the check to disallow *all* part of series reltypes if there's no series type selected, and I'm also adding an explanatory message saying the user can't add parts until they select a type.
Also made changes to avoid a similar crash on `updateAllowedTypes`.
