### PR TITLE
MBS-12294: Also run artworkViewer on edit lists

### DIFF
--- a/root/static/scripts/common/artworkViewer.js
+++ b/root/static/scripts/common/artworkViewer.js
@@ -213,7 +213,7 @@ $(function () {
    * Create separate dialogs for the sidebar and content, so that the
    * image "albums" are logically grouped.
    */
-  $('#sidebar, #content').each(function (index, container) {
+  $('#sidebar, #content, #edits').each(function (index, container) {
     var $artwork = $('a.artwork-image', container);
     if ($artwork.length === 0) {
       return;


### PR DESCRIPTION
### Fix MBS-12294

This was looking only for `#sidebar` or `#content`, but edit lists wrap the components in `#edits` instead, so the images on those pages were not getting a viewer, just getting loaded in-page when clicked.