### PR TITLE
MBS-12293: Fix broken link to /vote page

### DIFF
--- a/root/edit/components/ListHeader.js
+++ b/root/edit/components/ListHeader.js
@@ -157,7 +157,7 @@ const ListHeader = ({
           {$c.user ? (
             <>
               {' | '}
-              <a href="/vote/index">
+              <a href="/vote">
                 {l('Voting suggestions')}
               </a>
             </>


### PR DESCRIPTION
### Fix MBS-12293

I think wrongly followed TT, which used the action rather than the link.
