### PR TITLE
Delete new triggers if exist before creating

### DIFF
--- a/admin/sql/updates/20210702-mbs-11760.sql
+++ b/admin/sql/updates/20210702-mbs-11760.sql
@@ -2,6 +2,11 @@
 
 BEGIN;
 
+DROP TRIGGER IF EXISTS delete_unused_tag ON event_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON place_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON recording_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON release_tag;
+
 CREATE CONSTRAINT TRIGGER delete_unused_tag
 AFTER DELETE ON event_tag DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE PROCEDURE trg_delete_unused_tag_ref();

--- a/admin/sql/updates/schema-change/27.standalone.sql
+++ b/admin/sql/updates/schema-change/27.standalone.sql
@@ -13,6 +13,11 @@ SET LOCAL statement_timeout = 0;
 SELECT '20210702-mbs-11760.sql';
 
 
+DROP TRIGGER IF EXISTS delete_unused_tag ON event_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON place_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON recording_tag;
+DROP TRIGGER IF EXISTS delete_unused_tag ON release_tag;
+
 CREATE CONSTRAINT TRIGGER delete_unused_tag
 AFTER DELETE ON event_tag DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE PROCEDURE trg_delete_unused_tag_ref();


### PR DESCRIPTION
This crashed for me locally during the schema change because I already had created the triggers locally for testing. Since these have been merged for a while and IIRC it's even already created in production, we will probably need this anyway for release.