### PR TITLE
MBS-12280 (I): Add target _blank to edit form links

### DIFF
--- a/root/artist/edit_form.tt
+++ b/root/artist/edit_form.tt
@@ -1,6 +1,6 @@
 [% script_manifest('edit.js') %]
 
-<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => doc_link('Artist'), doc_styleguide => doc_link('Style/Artist')}) -%]</p>
+<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => { href => doc_link('Artist'), target => '_blank' }, doc_styleguide => { href => doc_link('Style/Artist'), target => '_blank' }}) -%]</p>
 
 <form action="[% c.req.uri %]" method="post" class="edit-artist">
     [%- USE r = FormRenderer(form) -%]

--- a/root/recording/edit_form.tt
+++ b/root/recording/edit_form.tt
@@ -14,7 +14,7 @@
 [% script_manifest('edit.js') %]
 [% script_manifest('recording/edit.js', {async => 'async'}) %]
 
-<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => doc_link('Recording'), doc_styleguide => doc_link('Style/Recording')}) -%]</p>
+<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => { href => doc_link('Recording'), target => '_blank' }, doc_styleguide => { href => doc_link('Style/Recording'), target => '_blank' }}) -%]</p>
 
 <form action="[% c.req.uri %]" method="post" class="edit-recording">
   [%- USE r = FormRenderer(form) -%]

--- a/root/release_group/edit_form.tt
+++ b/root/release_group/edit_form.tt
@@ -2,7 +2,7 @@
 
 [% script_manifest('edit.js') %]
 
-<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => doc_link('Release_Group'), doc_styleguide => doc_link('Style/Release_Group')}) -%]</p>
+<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => { href => doc_link('Release_Group'), target => '_blank' }, doc_styleguide => { href => doc_link('Style/Release_Group'), target => '_blank' }}) -%]</p>
 
 <form action="[% c.req.uri %]" method="post">
   [%- USE r = FormRenderer(form) -%]

--- a/root/series/edit_form.tt
+++ b/root/series/edit_form.tt
@@ -1,6 +1,6 @@
 [% script_manifest('edit.js') %]
 
-<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => doc_link('Series'), doc_styleguide => doc_link('Style/Series')}) -%]</p>
+<p>[%- l('For more information, check the {doc_doc|documentation} and {doc_styleguide|style guidelines}.', {doc_doc => { href => doc_link('Series'), target => '_blank' }, doc_styleguide => { href => doc_link('Style/Series'), target => '_blank' }}) -%]</p>
 
 <form action="[% c.req.uri %]" method="post" class="edit-series">
     [%- USE r = FormRenderer(form) -%]


### PR DESCRIPTION
### Fix (most of) MBS-12280

These are causing a content security issue that crashes the iframe if the user eventually navigates outside mb.org
(e.g. to the forums). In any case, it seems unlikely the user ever wants to load the documentation inside the iframe.

There's a separate link that needs the same changes in the description of the instrument relationship attribute, which cannot be edited from the site. As such, marking this as part 1 of the ticket only.