### PR TITLE
MBS-12303: Display non-diff annotation data over all columns 

### DIFF
--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -34,7 +34,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
           <th>
             {addColonText(formatEntityTypeName(entityType))}
           </th>
-          <td>
+          <td colSpan={2}>
             <DescriptiveLink
               entity={display[entityType]}
             />
@@ -43,7 +43,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
       ) : null}
       <tr>
         <th>{addColonText(l('Text'))}</th>
-        <td>
+        <td colSpan={2}>
           {display.html
             ? (
               <span
@@ -70,7 +70,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
       {display.changelog ? (
         <tr>
           <th>{addColonText(l('Summary'))}</th>
-          <td>
+          <td colSpan={2}>
             {display.changelog}
           </td>
         </tr>

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -29,56 +29,52 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
     <table
       className={`details add-${entityType}-annotation`}
     >
-      <table
-        className={`details add-${entityType}-annotation`}
-      >
-        {display[entityType] || !edit.preview /*:: === true */ ? (
-          <tr>
-            <th>
-              {addColonText(formatEntityTypeName(entityType))}
-            </th>
-            <td>
-              <DescriptiveLink
-                entity={display[entityType]}
-              />
-            </td>
-          </tr>
-        ) : null}
+      {display[entityType] || !edit.preview /*:: === true */ ? (
         <tr>
-          <th>{addColonText(l('Text'))}</th>
+          <th>
+            {addColonText(formatEntityTypeName(entityType))}
+          </th>
           <td>
-            {display.html
-              ? (
-                <span
-                  dangerouslySetInnerHTML={{__html: display.html}}
-                />
-              ) : (
-                <p>
-                  <span
-                    className="comment"
-                  >
-                    {l('This annotation is empty.')}
-                  </span>
-                </p>
-              )}
+            <DescriptiveLink
+              entity={display[entityType]}
+            />
           </td>
         </tr>
-        {oldAnnotation == null ? null : (
-          <Diff
-            label={l(addColonText('Annotation comparison'))}
-            newText={display.text}
-            oldText={oldAnnotation}
-          />
-        )}
-        {display.changelog ? (
-          <tr>
-            <th>{addColonText(l('Summary'))}</th>
-            <td>
-              {display.changelog}
-            </td>
-          </tr>
-        ) : null}
-      </table>
+      ) : null}
+      <tr>
+        <th>{addColonText(l('Text'))}</th>
+        <td>
+          {display.html
+            ? (
+              <span
+                dangerouslySetInnerHTML={{__html: display.html}}
+              />
+            ) : (
+              <p>
+                <span
+                  className="comment"
+                >
+                  {l('This annotation is empty.')}
+                </span>
+              </p>
+            )}
+        </td>
+      </tr>
+      {oldAnnotation == null ? null : (
+        <Diff
+          label={l(addColonText('Annotation comparison'))}
+          newText={display.text}
+          oldText={oldAnnotation}
+        />
+      )}
+      {display.changelog ? (
+        <tr>
+          <th>{addColonText(l('Summary'))}</th>
+          <td>
+            {display.changelog}
+          </td>
+        </tr>
+      ) : null}
     </table>
   );
 };


### PR DESCRIPTION
### Fix MBS-12303

There's no reason to stick all the data into the first column when having a Diff element adds a second one. The easiest solution seems to be to just add a colspan of 2; even when the Diff is not present, all shows as normal since everything then has the same colspan.