### PR TITLE
MBS-12304: Only run guess feat on nonempty names

### DIFF
--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -202,6 +202,13 @@ function expandCredit(fullName, artists, isProbablyClassical) {
 }
 
 export default function guessFeat(entity) {
+  const name = entity.name();
+
+  if (!nonEmpty(name)) {
+    // Nothing to guess from an empty name
+    return;
+  }
+
   let relatedArtists = entity.relatedArtists;
   if (typeof relatedArtists === 'function') {
     relatedArtists = relatedArtists.call(entity);
@@ -212,7 +219,6 @@ export default function guessFeat(entity) {
     isProbablyClassical = isProbablyClassical.call(entity);
   }
 
-  const name = entity.name();
   const match = extractFeatCredits(
     name, relatedArtists, isProbablyClassical, false,
   );


### PR DESCRIPTION
### Fix MBS-12304

It's pointless to try to guess feat artists from an empty name, since it will obviously not contain any artist names.
This also avoids a warning when the name field is undefined, rather than an empty string (e.g. when a blank release editor is created and nobody has typed on the release name field).