### PR TITLE
MBS-12302: Speed up large annotation diffing

### DIFF
--- a/lib/MusicBrainz/Server/Sitemap/Overall.pm
+++ b/lib/MusicBrainz/Server/Sitemap/Overall.pm
@@ -323,7 +323,8 @@ sub construct_url_lists($$$@) {
 
         if ($suffix_info{paginated}) {
             # 100 items per page, and the first page is covered by the base.
-            my $paginated_count = ceil($id_info->{$suffix_info{paginated}} / 100) - 1;
+            my $item_count = $id_info->{ $suffix_info{paginated} } // 0;
+            my $paginated_count = ceil($item_count / 100) - 1;
 
             # Since we exclude page 1 above, this is for anything above 0.
             if ($paginated_count > 0) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cookie": "0.4.1",
     "core-js": "3.6.5",
     "detect-node": "2.0.3",
+    "fast-diff": "1.2.0",
     "filesize": "2.0.4",
     "generic-diff": "1.0.1",
     "he": "1.1.1",

--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -65,6 +65,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
           label={l(addColonText('Annotation comparison'))}
           newText={display.text}
           oldText={oldAnnotation}
+          split="\s+"
         />
       )}
       {display.changelog ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,6 +2839,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-diff@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
# MBS-12302

Large annotation diffs like for edit #80101929 push the limits of generic-diff, which isn't really designed to diff arrays of thousands of characters.  It's so slow at doing this that edits like the one referenced will simply error due to the template renderer socket timing out and returning incomplete JSON.

The generic-diff README recommends fast-diff for efficient diffing of text.  This is very fast as the name suggests, but doesn't allow for custom "split" props, e.g. "\s+" for word diffing.  So we fall back to fast-diff if the text to be diffed is greater than some arbitrary "large string" length.  I picked 256 characters.

It also makes sense to use fast-diff if the "split" prop is an empty string, since we only perform character diffing in that case.