### PR TITLE
MBS-12308: Clarify the missing artist errors

### DIFF
--- a/root/release/edit/information.tt
+++ b/root/release/edit/information.tt
@@ -27,7 +27,11 @@
         <td class="release-artist" data-bind="artistCreditEditor: $data"></td>
       </tr>
 
-      [% table_row_error(2, 'showErrorWhenTabIsSwitched: needsArtistCredit', l('You haven’t entered a complete artist credit.')) %]
+      [% table_row_error(
+        2,
+        'showErrorWhenTabIsSwitched: needsArtistCredit',
+        l('You must select an artist for the release (the background color of the artist field should be green). If you’ve entered an artist but the background remains uncolored, click the magnifying glass to match the name to a MusicBrainz artist. If the artist doesn’t exist yet, you can create it by selecting “{add_a_new_artist}” from the bottom of the search results drop-down.', { add_a_new_artist => l('Add a new artist') }),
+      ) %]
 
       <tr>
         <td><label for="release-group">[% l('Release Group:') %]</label></td>

--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -432,8 +432,12 @@
         [%~ l('Tracks are required. If you don’t know them, but do know some info (such as the format or number of media), tick the “I don’t know the tracklist for this medium” checkbox above and enter the available info. If you have no information about this release’s media, remove all media.') ~%]
       </p>
 
-      <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: needsTrackInfo">
-        [%~ l('You must enter a title and select an artist for every track.') ~%]
+      <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: needsTrackTitles">
+        [%~ l('You must enter a title for every track (if the track is untitled, enter “{untitled_track}”).', { untitled_track => '<code>[untitled]</code>' }) ~%]
+      </p>
+
+      <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: needsTrackArtists">
+        [%~ l('You must select an artist for every track (the background color of every artist field should be green). If you’ve entered an artist but the background remains uncolored, click the magnifying glass to match the name to a MusicBrainz artist. If the artist doesn’t exist yet, you can create it by selecting “{add_a_new_artist}” from the bottom of the search results drop-down.', { add_a_new_artist => l('Add a new artist') }) ~%]
       </p>
 
       <p class="error field-error" style="padding: 1em" data-bind="showErrorWhenTabIsSwitched: hasInvalidPregapLength">

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -313,9 +313,12 @@ class Track {
     this.recordingValue(value);
   }
 
-  hasNameAndArtist() {
-    return !isBlank(this.name()) &&
-            isCompleteArtistCredit(this.artistCredit());
+  hasArtist() {
+    return isCompleteArtistCredit(this.artistCredit());
+  }
+
+  hasTitle() {
+    return !isBlank(this.name());
   }
 
   hasVariousArtists() {
@@ -430,9 +433,13 @@ class Medium {
       return !self.tracksUnknownToUser() &&
              self.tracks().some(t => t.needsRecording());
     });
-    this.hasTrackInfo = ko.computed(function () {
+    this.hasTrackArtists = ko.computed(function () {
       return self.tracksUnknownToUser() ||
-             self.tracks().every(t => t.hasNameAndArtist());
+             self.tracks().every(t => t.hasArtist());
+    });
+    this.hasTrackTitles = ko.computed(function () {
+      return self.tracksUnknownToUser() ||
+             self.tracks().every(t => t.hasTitle());
     });
     this.hasVariousArtistTracks = ko.computed(function () {
       return !self.tracksUnknownToUser() &&
@@ -462,8 +469,11 @@ class Medium {
       return /^(Cassette|CD|Dis[ck]|DVD|SACD|Vinyl)\s*\d+/i.test(self.name());
     });
     this.confirmedMediumTitle = ko.observable(this.hasUselessMediumTitle());
-    this.needsTrackInfo = ko.computed(function () {
-      return !self.hasTrackInfo();
+    this.needsTrackArtists = ko.computed(function () {
+      return !self.hasTrackArtists();
+    });
+    this.needsTrackTitles = ko.computed(function () {
+      return !self.hasTrackTitles();
     });
 
     if (data.id != null) {
@@ -1077,7 +1087,8 @@ class Release extends mbEntity.Release {
     this.original = ko.observable(mbEdit.fields.release(this));
 
     this.loadedMediums = this.mediums.filter('loaded');
-    this.hasTrackInfo = this.loadedMediums.all('hasTrackInfo');
+    this.hasTrackArtists = this.loadedMediums.all('hasTrackArtists');
+    this.hasTrackTitles = this.loadedMediums.all('hasTrackTitles');
     this.hasTracks = this.mediums.any('hasTracks');
     this.hasUnknownTracklist = ko.observable(
       !this.mediums().length && releaseEditor.action === 'edit',
@@ -1098,8 +1109,11 @@ class Release extends mbEntity.Release {
       errorField(this.mediums.any('hasUnconfirmedUselessMediumTitle'));
     this.needsFormat = errorField(this.mediums.any('needsFormat'));
     this.needsTracks = errorField(this.mediums.any('needsTracks'));
-    this.needsTrackInfo = errorField(function () {
-      return !self.hasTrackInfo();
+    this.needsTrackArtists = errorField(function () {
+      return !self.hasTrackArtists();
+    });
+    this.needsTrackTitles = errorField(function () {
+      return !self.hasTrackTitles();
     });
     this.hasInvalidPregapLength = errorField(
       this.mediums.any('hasInvalidPregapLength'),

--- a/root/static/scripts/release-editor/init.js
+++ b/root/static/scripts/release-editor/init.js
@@ -163,7 +163,7 @@ releaseEditor.init = function (options) {
        * (because there are many discs), we should still allow the
        * user to edit the recordings if that's all they want to do.
        */
-      tabEnabled = release.hasTrackInfo();
+      tabEnabled = release.hasTrackArtists() && release.hasTrackTitles();
     }
 
     var tabNumber = addingRelease ? 3 : 2;

--- a/root/static/scripts/tests/release-editor/validation.js
+++ b/root/static/scripts/tests/release-editor/validation.js
@@ -29,7 +29,7 @@ function validationTest(name, callback) {
 validationTest((
   'non-loaded mediums validate, even though they have no tracks (MBS-7222)'
 ), function (t) {
-  t.plan(8);
+  t.plan(10);
 
   releaseEditor.action = 'edit';
 
@@ -44,11 +44,13 @@ validationTest((
 
   t.ok(!medium.loaded(), 'medium is not loaded');
   t.ok(!medium.needsTracks(), "medium doesn't require tracks");
-  t.ok(!medium.needsTrackInfo(), "medium doesn't require track info");
+  t.ok(!medium.needsTrackArtists(), "medium doesn't lack track artists");
+  t.ok(!medium.needsTrackTitles(), "medium doesn't lack track titles");
   t.ok(!medium.needsRecordings(), "medium doesn't require recordings");
   t.ok(!release.needsMediums(), "release doesn't need mediums");
   t.ok(!release.needsTracks(), "release doesn't need tracks");
-  t.ok(!release.needsTrackInfo(), "release doesn't need track info");
+  t.ok(!release.needsTrackArtists(), "release doesn't lack track artists");
+  t.ok(!release.needsTrackTitles(), "release doesn't lack track titles");
   t.ok(!release.needsRecordings(), "release doesn't need recordings");
 });
 


### PR DESCRIPTION
### Implement MBS-12308

# Problem
Beginners keep getting confused by "artist is missing" errors in the release editor, because they have typed an artist, so clearly it is not missing! They don't really understand the artist needs to be selected from the DB.

# Solution
This adds errors that specify what exactly means to select an artist.

I couldn't see any reason why we combine missing title and missing artist, which are very different issues with very different solutions. As such, I split the error into two to give a properly useful error message for each.

# Testing
Tested manually in the release editor by leaving titles empty and artists unselected and making sure I got the correct errors.