### PR TITLE
MBS-11556: Standardise / clean up YouTube Music URLs

### DIFF
--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5621,6 +5621,41 @@ limited_link_type_combinations: [
                                   target: 'url',
                                 },
   },
+  // YouTube Music
+  {
+                     input_url: 'http://music.youtube.com/channel/UCj-kjIXQvPmn_rtobjiszEg',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'youtubemusic',
+            expected_clean_url: 'https://music.youtube.com/channel/UCj-kjIXQvPmn_rtobjiszEg',
+       only_valid_entity_types: ['artist'],
+  },
+  {
+                     input_url: 'https://music.youtube.com/playlist?list=OLAK5uy_lcx2mROj6Pf7bLJzgYWtl73ILCEKjnrKY&src=Linkfire&lId=c8d7d454-d63c-4bba-a34c-2512e803dadb&cId=d3d58fd7-4c47-11e6-9fd0-066c3e7a8751',
+             input_entity_type: 'release',
+       input_relationship_type: 'streamingfree',
+limited_link_type_combinations: ['streamingfree', 'streamingpaid'],
+            expected_clean_url: 'https://music.youtube.com/playlist?list=OLAK5uy_lcx2mROj6Pf7bLJzgYWtl73ILCEKjnrKY',
+       only_valid_entity_types: ['label', 'release'],
+  },
+  {
+                     input_url: 'https://music.youtube.com/watch?v=fpEC3cj33cA&list=OLAK5uy_kg1hU8SEra2vk_5muDDv7XG9AfTjWXc-8',
+             input_entity_type: 'recording',
+       input_relationship_type: 'streamingfree',
+limited_link_type_combinations: ['streamingfree', 'streamingpaid'],
+            expected_clean_url: 'https://music.youtube.com/watch?v=fpEC3cj33cA',
+       only_valid_entity_types: ['label', 'recording'],
+  },
+  {
+                     input_url: 'https://music.youtube.com/search?q=nublu',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'youtubemusic',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'a link to a search result',
+                                  target: 'url',
+                                },
+  },
 ];
 /* eslint-enable indent, max-len, sort-keys */
 


### PR DESCRIPTION
### Implement MBS-11556

As far as I can tell, YouTube Music uses mostly five kinds of URLs:
1) watch (YouTube videos) for tracks
2) playlist for releases (and also other playlists)
3) channel for artists
4) search for search
5) browse for things like discography lists and, apparently, users' own videos and private stuff.

This supports watch for recording, playlist for release, channel for artist, and does not support browse or search links at all.
I didn't find label, series, etc channels, so I didn't touch those.
I added a new YouTube Music relationship for artists to avoid users having to check for each artist whether there's some paid content or all is free (which might anyway change later).
Label reltypes are not affected at all rn, meaning that streamingfree.label is technically still allowed. We could choose to use the restrict block here to "support" label and then reject the links, but I'm not sure that's useful, so I didn't now.