### PR TITLE
MBS-12318 / MBS-12323 / MBS-12324: Improvements to ArtistsThatMayBe reports

### DIFF
--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
@@ -4,16 +4,30 @@ use Moose;
 with 'MusicBrainz::Server::Report::ArtistReport',
      'MusicBrainz::Server::Report::FilterForEditor::ArtistID';
 
-sub query {
-    q{SELECT DISTINCT ON (artist.id) artist.id AS artist_id,
-       row_number() OVER (ORDER BY artist.name COLLATE musicbrainz, artist.id)
-     FROM artist
-     JOIN l_artist_artist ON l_artist_artist.entity1=artist.id
-     JOIN link ON link.id=l_artist_artist.link
-     JOIN link_type ON link_type.id=link.link_type
-     WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
-       AND link_type.name IN ('collaboration', 'member of band', 'conductor position')};
-}
+sub query {<<~'SQL'}
+  WITH possible_groups_entity0 AS (
+         SELECT artist.id, artist.name
+         FROM artist
+         JOIN l_artist_artist laa ON laa.entity0 = artist.id
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
+         WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
+         AND link_type.name IN ('subgroup')),
+       possible_groups_entity1 AS (
+         SELECT artist.id, artist.name
+         FROM artist
+         JOIN l_artist_artist laa ON laa.entity1 = artist.id
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
+         WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
+         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'subgroup'))
+  SELECT possible_groups.id AS artist_id,
+         row_number() OVER (ORDER BY possible_groups.name COLLATE musicbrainz, possible_groups.id)
+  FROM
+    (SELECT * FROM possible_groups_entity0
+        UNION
+     SELECT * FROM possible_groups_entity1) AS possible_groups
+  SQL
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
@@ -20,7 +20,7 @@ sub query {<<~'SQL'}
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
-         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'subgroup'))
+         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'artistic director', 'composer-in-residence', 'subgroup')),
   SELECT possible_groups.id AS artist_id,
          row_number() OVER (ORDER BY possible_groups.name COLLATE musicbrainz, possible_groups.id)
   FROM

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBeGroups.pm
@@ -10,17 +10,32 @@ sub query {<<~'SQL'}
          FROM artist
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
-         JOIN link_type ON link_type.id = link.link_type
-         WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
-         AND link_type.name IN ('subgroup')),
+         WHERE (
+            artist.type NOT IN (2, 5, 6) -- group, orchestra, choir
+            OR
+            artist.type IS NULL
+         )
+         AND link.link_type IN (722)), -- subgroup
        possible_groups_entity1 AS (
          SELECT artist.id, artist.name
          FROM artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
-         WHERE (artist.type NOT IN (2, 5, 6) OR artist.type IS NULL)
-         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'artistic director', 'composer-in-residence', 'subgroup')),
+         WHERE (
+            artist.type NOT IN (2, 5, 6) -- group, orchestra, choir
+            OR
+            artist.type IS NULL
+         )
+         AND link.link_type IN (
+            103, -- member of band
+            102, -- collaboration
+            305, -- conductor position
+            965, -- artistic director
+            855, -- composer-in-residence
+            722  -- subgroup
+         )
+       )
   SELECT possible_groups.id AS artist_id,
          row_number() OVER (ORDER BY possible_groups.name COLLATE musicbrainz, possible_groups.id)
   FROM

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -11,49 +11,78 @@ WITH groups_entity0 AS (
          FROM artist
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
-         JOIN link_type ON link_type.id = link.link_type
          WHERE (
-            artist.type NOT IN (1, 4)
+            artist.type NOT IN (1, 4) -- person, character
             OR
             artist.type IS NULL
          )
-         AND link_type.name IN ('subgroup')),
+         AND link.link_type IN (722)), -- subgroup
      groups_entity1 AS (
          SELECT artist.id, artist.name
          FROM artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
-         JOIN link_type ON link_type.id = link.link_type
          WHERE (
-            artist.type NOT IN (1, 4)
+            artist.type NOT IN (1, 4) -- person, character
             OR
             artist.type IS NULL
          )
-         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'artistic director', 'composer-in-residence', 'subgroup')),
+         AND link.link_type IN (
+            103, -- member of band
+            102, -- collaboration
+            305, -- conductor position
+            965, -- artistic director
+            855, -- composer-in-residence
+            722  -- subgroup
+         )
+     ),
      persons_entity0 AS (
          SELECT artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
-         JOIN link_type ON link_type.id = link.link_type
          WHERE (
-            artist.type NOT IN (1, 4)
+            artist.type NOT IN (1, 4) -- person, character
             OR
             artist.type IS NULL
          )
-         AND link_type.name IN ('member of band', 'supporting musician', 'collaboration', 'voice actor', 'conductor position', 'artistic director', 'composer-in-residence', 'teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
+         AND link.link_type IN (
+            103, -- member of band
+            104, -- supporting musician
+            107, -- vocal supporting musician
+            105, -- instrumental supporting musician
+            102, -- collaboration
+            292, -- voice actor
+            305, -- conductor position
+            965, -- artistic director
+            855, -- composer-in-residence
+            847, -- teacher
+            108, -- is person
+            111, -- married
+            110, -- sibling
+            109, -- parent
+            112  -- involved with
+         )
+     ),
      persons_entity1 AS (
          SELECT artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
-         JOIN link_type ON link_type.id = link.link_type
          WHERE (
-            artist.type NOT IN (1, 4)
+            artist.type NOT IN (1, 4) -- person, character
             OR
             artist.type IS NULL
          )
-         AND link_type.name IN ('teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
+         AND link.link_type IN (
+            847, -- teacher
+            108, -- is person
+            111, -- married
+            110, -- sibling
+            109, -- parent
+            112  -- involved with
+         )
+     ),
      artists AS (
          SELECT id, name FROM
              (SELECT * FROM persons_entity0

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -37,7 +37,7 @@ WITH groups_entity0 AS (
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
-         AND link_type.name IN ('teacher', 'catalogued', 'is person', 'married', 'sibling', 'parent', 'involved with')),
+         AND link_type.name IN ('teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      artists AS (
          SELECT id, name FROM
              (SELECT * FROM persons_entity0

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -6,16 +6,24 @@ with 'MusicBrainz::Server::Report::ArtistReport',
 
 sub query {
     q{
-WITH groups AS (
-         SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
-         artist
+WITH groups_entity0 AS (
+         SELECT artist.id, artist.name
+         FROM artist
+         JOIN l_artist_artist laa ON laa.entity0 = artist.id
+         JOIN link ON link.id = laa.link
+         JOIN link_type ON link_type.id = link.link_type
+         WHERE artist.type IS DISTINCT FROM 1
+         AND link_type.name IN ('subgroup')),
+     groups_entity1 AS (
+         SELECT artist.id, artist.name
+         FROM artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
-         AND link_type.name IN ('member of band', 'collaboration', 'conductor position')),
+         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'subgroup')),
      persons_entity0 AS (
-         SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
+         SELECT artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
@@ -23,7 +31,7 @@ WITH groups AS (
          WHERE artist.type IS DISTINCT FROM 1
          AND link_type.name IN ('member of band', 'collaboration', 'voice actor', 'conductor position', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      persons_entity1 AS (
-         SELECT DISTINCT ON (artist.id) artist.id, artist.name FROM
+         SELECT artist.id, artist.name FROM
          artist
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
@@ -31,13 +39,17 @@ WITH groups AS (
          WHERE artist.type IS DISTINCT FROM 1
          AND link_type.name IN ('catalogued', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      artists AS (
-         SELECT DISTINCT ON (id) id, name FROM
+         SELECT id, name FROM
              (SELECT * FROM persons_entity0
                   UNION
               SELECT * FROM persons_entity1) AS persons
           EXCEPT
-              SELECT * FROM groups)
-SELECT DISTINCT ON (artists.id) artists.id AS artist_id, row_number() OVER (ORDER BY artists.name COLLATE musicbrainz, artists.id)
+              SELECT * FROM 
+                (SELECT * FROM groups_entity0
+                  UNION
+                 SELECT * FROM groups_entity1) AS groups
+     )
+SELECT artists.id AS artist_id, row_number() OVER (ORDER BY artists.name COLLATE musicbrainz, artists.id)
     FROM artists
     };
 }

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -21,7 +21,7 @@ WITH groups_entity0 AS (
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
-         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'subgroup')),
+         AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'artistic director', 'composer-in-residence', 'subgroup')),
      persons_entity0 AS (
          SELECT artist.id, artist.name FROM
          artist
@@ -29,7 +29,7 @@ WITH groups_entity0 AS (
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
-         AND link_type.name IN ('member of band', 'collaboration', 'voice actor', 'conductor position', 'is person', 'married', 'sibling', 'parent', 'involved with')),
+         AND link_type.name IN ('member of band', 'supporting musician', 'collaboration', 'voice actor', 'conductor position', 'artistic director', 'composer-in-residence', 'teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      persons_entity1 AS (
          SELECT artist.id, artist.name FROM
          artist
@@ -37,7 +37,7 @@ WITH groups_entity0 AS (
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
          WHERE artist.type IS DISTINCT FROM 1
-         AND link_type.name IN ('catalogued', 'is person', 'married', 'sibling', 'parent', 'involved with')),
+         AND link_type.name IN ('teacher', 'catalogued', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      artists AS (
          SELECT id, name FROM
              (SELECT * FROM persons_entity0

--- a/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistsThatMayBePersons.pm
@@ -12,7 +12,11 @@ WITH groups_entity0 AS (
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
-         WHERE artist.type IS DISTINCT FROM 1
+         WHERE (
+            artist.type NOT IN (1, 4)
+            OR
+            artist.type IS NULL
+         )
          AND link_type.name IN ('subgroup')),
      groups_entity1 AS (
          SELECT artist.id, artist.name
@@ -20,7 +24,11 @@ WITH groups_entity0 AS (
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
-         WHERE artist.type IS DISTINCT FROM 1
+         WHERE (
+            artist.type NOT IN (1, 4)
+            OR
+            artist.type IS NULL
+         )
          AND link_type.name IN ('member of band', 'collaboration', 'conductor position', 'artistic director', 'composer-in-residence', 'subgroup')),
      persons_entity0 AS (
          SELECT artist.id, artist.name FROM
@@ -28,7 +36,11 @@ WITH groups_entity0 AS (
          JOIN l_artist_artist laa ON laa.entity0 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
-         WHERE artist.type IS DISTINCT FROM 1
+         WHERE (
+            artist.type NOT IN (1, 4)
+            OR
+            artist.type IS NULL
+         )
          AND link_type.name IN ('member of band', 'supporting musician', 'collaboration', 'voice actor', 'conductor position', 'artistic director', 'composer-in-residence', 'teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      persons_entity1 AS (
          SELECT artist.id, artist.name FROM
@@ -36,7 +48,11 @@ WITH groups_entity0 AS (
          JOIN l_artist_artist laa ON laa.entity1 = artist.id
          JOIN link ON link.id = laa.link
          JOIN link_type ON link_type.id = link.link_type
-         WHERE artist.type IS DISTINCT FROM 1
+         WHERE (
+            artist.type NOT IN (1, 4)
+            OR
+            artist.type IS NULL
+         )
          AND link_type.name IN ('teacher', 'is person', 'married', 'sibling', 'parent', 'involved with')),
      artists AS (
          SELECT id, name FROM

--- a/root/report/ArtistsThatMayBePersons.js
+++ b/root/report/ArtistsThatMayBePersons.js
@@ -21,12 +21,12 @@ const ArtistsThatMayBePersons = ({
   <ReportLayout
     canBeFiltered={canBeFiltered}
     description={l(
-      `This report lists artists that have their type set to other
-       than Person, but may be a person, based on their relationships.
+      `This report lists artists that have their type set to other than Person
+       or Character, but may be a person, based on their relationships.
        For example, an artist will appear here if it is listed
        as a member of another. If you find that an artist here is indeed
-       a person, change its type. If it is not, please make sure that
-       all the relationships are correct and make sense.`,
+       a person (or a character), change its type. If it is not, please make
+       sure that all the relationships are correct and make sense.`,
     )}
     entityType="artist"
     filtered={filtered}


### PR DESCRIPTION
### Implement MBS-12318 / MBS-12323 / MBS-12324

# Problem
The ArtistsThatMayBe(Persons|Groups) reports are kind of a mess. They have a fair amount of false positives and do not cover a lot of the relationships and artist types added in the last few years.

# Solution
This updates the reports to check for (or ignore) additional relationship types, plus it makes it so that the Persons report does not try to turn all characters into people. See each commit message for additional details.

# Testing
Tested with sample data to check the new results of the reports seem to make sense.