### PR TITLE
MBS-12335: Link to attribute docs from reltype docs

### DIFF
--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -27,10 +27,59 @@ import {isRelationshipEditor}
   from '../../static/scripts/common/utility/privileges';
 import {upperFirst} from '../../static/scripts/common/utility/strings';
 
+type UsedAttributesListProps = {
+  +attributes?: $ReadOnlyArray<LinkAttrTypeT>,
+  +relType: LinkTypeT,
+};
+
 type Props = {
   +$c: CatalystContextT,
   +relType: LinkTypeT,
 };
+
+const UsedAttributesList = ({
+  attributes,
+  relType,
+}: UsedAttributesListProps) => (
+  <>
+    <h2>{l('Attributes')}</h2>
+    {!attributes?.length && !relType.has_dates ? (
+      <p>{l('This relationship type doesn\'t allow any attributes.')}</p>
+    ) : (
+      <>
+        <p>
+          {l(`The following attributes can be used
+              with this relationship type:`)}
+        </p>
+        {attributes ? (
+          attributes.map(attributeType => (
+            <React.Fragment key={attributeType.id}>
+              <h3>
+                <a href={'/relationship-attribute/' + attributeType.gid}>
+                  {l_relationships(attributeType.name)}
+                </a>
+              </h3>
+              <p>
+                {expand2react(l_relationships(
+                  attributeType.description,
+                ))}
+              </p>
+            </React.Fragment>
+          ))
+        ) : null}
+        {relType.has_dates ? (
+          <>
+            <h3>{l('start date')}</h3>
+            <p />
+
+            <h3>{l('end date')}</h3>
+            <p />
+          </>
+        ) : null}
+      </>
+    )}
+  </>
+);
 
 const RelationshipTypeIndex = ({
   $c,
@@ -162,38 +211,10 @@ const RelationshipTypeIndex = ({
               </ul>
             </p>
 
-            <h2>{l('Attributes')}</h2>
-            <p>
-              {!possibleAttributes.length && !relType.has_dates ? (
-                l('This relationship type doesn\'t allow any attributes.')
-              ) : (
-                <>
-                  {l(`The following attributes can be used
-                      with this relationship type:`)}
-                  {possibleAttributes ? (
-                    possibleAttributes.map(attributeType => (
-                      <React.Fragment key={attributeType.id}>
-                        <h3>{l_relationships(attributeType.name)}</h3>
-                        <p>
-                          {expand2react(l_relationships(
-                            attributeType.description,
-                          ))}
-                        </p>
-                      </React.Fragment>
-                    ))
-                  ) : null}
-                  {relType.has_dates ? (
-                    <>
-                      <h3>{l('start date')}</h3>
-                      <p />
-
-                      <h3>{l('end date')}</h3>
-                      <p />
-                    </>
-                  ) : null}
-                </>
-              )}
-            </p>
+            <UsedAttributesList
+              attributes={possibleAttributes}
+              relType={relType}
+            />
 
             {nonEmpty(relType.documentation) ||
               type0 === 'url' || type1 === 'url' ? (


### PR DESCRIPTION
### Implement MBS-12335

Since we now have pages for the attributes, it seems useful to link to them. At the very least, this provides an easy way to get the attribute MBID if someone wants to use it.

I also changed the formatting a bit because having `<h3>` inside a `<p>` seemed odd (is that even valid?). It should make more sense now.