### PR TITLE
MBS-12333: Block smart links: share.amuse.io

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1626,6 +1626,7 @@ const URL_SHORTENERS = [
   'push.fm',
   'rb.gy',
   'rubyurl.com',
+  'share.amuse.io',
   'smarturl.it',
   'snd.click',
   'song.link',


### PR DESCRIPTION
### Implement MBS-12333

These are the same people we were already blocking as amu.se. They claim to also run a label, so not blocking stuff outside the share. subdomain in case they actually eventually have legit pages.