### PR TITLE
MBS-12328: Add #content to entity/Edits for artwork display

### DIFF
--- a/root/entity/Edits.js
+++ b/root/entity/Edits.js
@@ -82,20 +82,22 @@ const Edits = ({
 
   return (
     <Layout fullWidth title={pageTitle}>
-      <div className={className}>
-        <h1>{pageHeading}</h1>
-        <SubHeader subHeading={pageSubHeading} />
+      <div id="content">
+        <div className={className}>
+          <h1>{pageHeading}</h1>
+          <SubHeader subHeading={pageSubHeading} />
+        </div>
+        <EditList
+          $c={$c}
+          editCountLimit={editCountLimit}
+          edits={edits}
+          entity={entity}
+          guessSearch
+          page={entity.entityType + '_' + (showingOpenOnly ? 'open' : 'all')}
+          pager={pager}
+          refineUrlArgs={refineUrlArgs}
+        />
       </div>
-      <EditList
-        $c={$c}
-        editCountLimit={editCountLimit}
-        edits={edits}
-        entity={entity}
-        guessSearch
-        page={entity.entityType + '_' + (showingOpenOnly ? 'open' : 'all')}
-        pager={pager}
-        refineUrlArgs={refineUrlArgs}
-      />
     </Layout>
   );
 };

--- a/root/static/scripts/common/artworkViewer.js
+++ b/root/static/scripts/common/artworkViewer.js
@@ -213,7 +213,7 @@ $(function () {
    * Create separate dialogs for the sidebar and content, so that the
    * image "albums" are logically grouped.
    */
-  $('#sidebar, #content, #edits').each(function (index, container) {
+  $('#sidebar, #content').each(function (index, container) {
     var $artwork = $('a.artwork-image', container);
     if ($artwork.length === 0) {
       return;


### PR DESCRIPTION
### Fix MBS-12328

This got fixed with MBS-12294 (https://github.com/metabrainz/musicbrainz-server/pull/2474) by also checking for artwork inside #edits but it turns out a bunch of pages have both #content and #edits, leading to images being loaded into boxes twice. On a quick check, it seems entity/Edits is the only edit list missing #content anyway, for no clear reason, so it seems a lot easier to just add a #content div to it and revert the previous patch.
