### PR TITLE
MBS-11920: Report for releases with low data quality

### DIFF
--- a/lib/MusicBrainz/Server/Report/LowQualityReleases.pm
+++ b/lib/MusicBrainz/Server/Report/LowQualityReleases.pm
@@ -1,0 +1,30 @@
+package MusicBrainz::Server::Report::LowQualityReleases;
+use Moose;
+
+use MusicBrainz::Server::Constants qw( $QUALITY_LOW );
+
+with 'MusicBrainz::Server::Report::ReleaseReport';
+with 'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~"SQL"}
+    SELECT
+        r.id AS release_id,
+        row_number() OVER (ORDER BY ac.name COLLATE musicbrainz, r.name COLLATE musicbrainz)
+    FROM release r
+    JOIN artist_credit ac ON r.artist_credit = ac.id
+    WHERE r.quality = $QUALITY_LOW
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -62,6 +62,7 @@ my @all = qw(
     LabelsDisambiguationSameName
     LimitedEditors
     LinksWithMultipleEntities
+    LowQualityReleases
     MediumsWithOrderInTitle
     MediumsWithSequenceIssues
     MislinkedPseudoReleases
@@ -160,6 +161,7 @@ use MusicBrainz::Server::Report::ISWCsWithManyWorks;
 use MusicBrainz::Server::Report::LabelsDisambiguationSameName;
 use MusicBrainz::Server::Report::LimitedEditors;
 use MusicBrainz::Server::Report::LinksWithMultipleEntities;
+use MusicBrainz::Server::Report::LowQualityReleases;
 use MusicBrainz::Server::Report::MediumsWithOrderInTitle;
 use MusicBrainz::Server::Report::MediumsWithSequenceIssues;
 use MusicBrainz::Server::Report::MislinkedPseudoReleases;

--- a/root/report/LowQualityReleases.js
+++ b/root/report/LowQualityReleases.js
@@ -1,0 +1,43 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+const LowQualityReleases = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows releases that have been marked as low quality.
+       If you have some time, you can review them and try to improve the data
+       as much as possible before changing their quality back to Normal
+       (or even to High, if you add all the possible data!). If a release
+       has already been improved but the quality wasn’t changed accordingly,
+       just enter a data quality change to remove it from this report.`,
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases marked as low quality')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default LowQualityReleases;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -457,6 +457,10 @@ const ReportsIndex = (): React$Element<typeof Layout> => {
             )}
             reportName="NonBootlegsOnBootlegLabels"
           />
+          <ReportsIndexEntry
+            content={l('Releases marked as low quality')}
+            reportName="LowQualityReleases"
+          />
         </ul>
 
         <h2>{l('Recordings')}</h2>

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -255,6 +255,7 @@ export default {
   'report/LabelsDisambiguationSameName': (): Promise<mixed> => import('../report/LabelsDisambiguationSameName.js'),
   'report/LimitedEditors': (): Promise<mixed> => import('../report/LimitedEditors.js'),
   'report/LinksWithMultipleEntities': (): Promise<mixed> => import('../report/LinksWithMultipleEntities.js'),
+  'report/LowQualityReleases': (): Promise<mixed> => import('../report/LowQualityReleases.js'),
   'report/MediumsWithOrderInTitle': (): Promise<mixed> => import('../report/MediumsWithOrderInTitle.js'),
   'report/MediumsWithSequenceIssues': (): Promise<mixed> => import('../report/MediumsWithSequenceIssues.js'),
   'report/MislinkedPseudoReleases': (): Promise<mixed> => import('../report/MislinkedPseudoReleases.js'),


### PR DESCRIPTION
### Implement MBS-11920

# Problem
There's no easy way for a user to find all low quality releases for entities in their subscriptions in order to help improve them.

# Solution
This adds a report listing all low quality releases, which as usual can be filtered to show only releases for entities in the user's subscriptions.

This existing should also make it less stressful to just mark something as low quality if an editor has no time or skill to fix it, since now they will know other users (or even themselves when they have the time) will be able to find it and hopefully work on it.

# Testing
By hand, running the report and checking that the releases in it (for the sample data) are all low quality.