### PR TITLE
MBS-11916: Report for recordings marked both karaoke and instrumental

### DIFF
--- a/lib/MusicBrainz/Server/Report/KaraokePlusInstrumentalRecordings.pm
+++ b/lib/MusicBrainz/Server/Report/KaraokePlusInstrumentalRecordings.pm
@@ -1,0 +1,63 @@
+package MusicBrainz::Server::Report::KaraokePlusInstrumentalRecordings;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport';
+
+sub query {<<~'SQL'}
+    SELECT
+          DISTINCT r.id AS recording_id,
+          row_number() OVER (ORDER BY r.artist_credit, r.name)
+     FROM recording r
+     JOIN artist_credit_name acn ON acn.artist_credit = r.artist_credit
+    WHERE (
+        EXISTS (
+            SELECT 1
+            FROM l_recording_recording lrr
+            JOIN link l ON lrr.link = l.id
+            JOIN link_type lt ON l.link_type = lt.id
+            WHERE lrr.entity1 = r.id
+            AND lt.gid = '39a08d0e-26e4-44fb-ae19-906f5fe9435d' --karaoke
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM l_recording_work lrw
+            JOIN link l ON lrw.link = l.id
+            JOIN link_attribute la ON la.link = l.id
+            JOIN link_attribute_type lat ON lat.id = la.attribute_type
+            WHERE lrw.entity0 = r.id
+            AND lat.gid = 'c031ed4f-c9bb-4394-8cf5-e8ce4db512ae' --instrumental
+        )
+    ) OR (
+        EXISTS (
+            SELECT 1
+            FROM l_recording_recording lrr
+            JOIN link l ON lrr.link = l.id
+            JOIN link_type lt ON l.link_type = lt.id
+            WHERE lrr.entity1 = r.id
+            AND lt.gid = '9fc01a58-7801-4bd2-b07d-61cc7ffacf90' --instrumental
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM l_recording_work lrw
+            JOIN link l ON lrw.link = l.id
+            JOIN link_attribute la ON la.link = l.id
+            JOIN link_attribute_type lat ON lat.id = la.attribute_type
+            WHERE lrw.entity0 = r.id
+            AND lat.gid = '3d984f6e-bbe2-4620-9425-5f32e945b60d' --karaoke
+        )
+    )
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -61,6 +61,7 @@ my @all = qw(
     InstrumentsWithoutWikidata
     ISRCsWithManyRecordings
     ISWCsWithManyWorks
+    KaraokePlusInstrumentalRecordings
     LabelsDisambiguationSameName
     LimitedEditors
     LinksWithMultipleEntities
@@ -166,6 +167,7 @@ use MusicBrainz::Server::Report::InstrumentsWithoutAnImage;
 use MusicBrainz::Server::Report::InstrumentsWithoutWikidata;
 use MusicBrainz::Server::Report::ISRCsWithManyRecordings;
 use MusicBrainz::Server::Report::ISWCsWithManyWorks;
+use MusicBrainz::Server::Report::KaraokePlusInstrumentalRecordings;
 use MusicBrainz::Server::Report::LabelsDisambiguationSameName;
 use MusicBrainz::Server::Report::LimitedEditors;
 use MusicBrainz::Server::Report::LinksWithMultipleEntities;

--- a/root/report/KaraokePlusInstrumentalRecordings.js
+++ b/root/report/KaraokePlusInstrumentalRecordings.js
@@ -1,0 +1,63 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import RecordingList from './components/RecordingList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportRecordingT} from './types.js';
+
+component KaraokePlusInstrumentalRecordings(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        `This report shows recordings which have a
+         {doc_karaoke_rel|“karaoke” relationship} to another recording,
+         but are linked to a work with the
+         {doc_instrumental_attr|“instrumental” attribute}, or the other
+         way around, with an
+         {doc_instrumental_rel|“instrumental” relationship} and the
+         {doc_karaoke_attr|“karaoke” attribute}.`,
+        {
+          doc_instrumental_attr: '/relationship-attributes#instrumental',
+          doc_instrumental_rel:
+            '/relationship/9fc01a58-7801-4bd2-b07d-61cc7ffacf90',
+          doc_karaoke_attr: '/relationship-attributes#karaoke',
+          doc_karaoke_rel:
+            '/relationship/39a08d0e-26e4-44fb-ae19-906f5fe9435d',
+        },
+      )}
+      entityType="relationship"
+      extraInfo={l(
+        `Keep in mind that “instrumental” in MusicBrainz implies the lyrics
+         are not relevant to the recording. Since lyrics are by definition
+         relevant to karaoke recordings, “instrumental” should not be used
+         on them (use “karaoke” instead). Alternatively, if this is not
+         a karaoke recording, but just a standard instrumental recording,
+         it shouldn’t be linked to another recording with a “karaoke”
+         relationship, but with an “instrumental” one.`,
+      )}
+      filtered={filtered}
+      generated={generated}
+      title={l('Recordings marked as both karaoke and instrumental')}
+      totalEntries={pager.total_entries}
+    >
+      <RecordingList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default KaraokePlusInstrumentalRecordings;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -555,6 +555,10 @@ component ReportsIndex() {
             content={l('Non-video recordings with video relationships')}
             reportName="VideoRelationshipsOnNonVideos"
           />
+          <ReportsIndexEntry
+            content={l('Recordings marked as both karaoke and instrumental')}
+            reportName="KaraokePlusInstrumentalRecordings"
+          />
         </ul>
 
         <h2>{l('Places')}</h2>

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -266,6 +266,7 @@ export default {
   'report/InstrumentsWithoutWikidata': (): Promise<mixed> => import('../report/InstrumentsWithoutWikidata.js'),
   'report/IsrcsWithManyRecordings': (): Promise<mixed> => import('../report/IsrcsWithManyRecordings.js'),
   'report/IswcsWithManyWorks': (): Promise<mixed> => import('../report/IswcsWithManyWorks.js'),
+  'report/KaraokePlusInstrumentalRecordings': (): Promise<mixed> => import('../report/KaraokePlusInstrumentalRecordings.js'),
   'report/LabelsDisambiguationSameName': (): Promise<mixed> => import('../report/LabelsDisambiguationSameName.js'),
   'report/LimitedEditors': (): Promise<mixed> => import('../report/LimitedEditors.js'),
   'report/LinksWithMultipleEntities': (): Promise<mixed> => import('../report/LinksWithMultipleEntities.js'),


### PR DESCRIPTION
### Implement MBS-11916

# Problem
A recording should never be marked both karaoke and instrumental: lyrics are relevant for karaoke recordings, and proper instrumental recordings should not be linked as karaoke. This is a relatively common mistake though, and we currently have no good way to find it when it happens.

# Solution
This adds a report for users to be able to clean up these (it usually requires figuring out which of the options is correct in a case by case basis so a report is a good fit).

# Testing
By hand, running the report and checking that the recordings in it (for the sample data) seem to fit the requirements indeed.