### PR TITLE
MBS-12131: PostgreSQL 14 compatibility

### DIFF
--- a/admin/sql/CreateFunctions.sql
+++ b/admin/sql/CreateFunctions.sql
@@ -1,7 +1,7 @@
 \set ON_ERROR_STOP 1
 BEGIN;
 
-CREATE OR REPLACE FUNCTION _median(anyarray) RETURNS anyelement AS $$
+CREATE OR REPLACE FUNCTION _median(INTEGER[]) RETURNS INTEGER AS $$
   WITH q AS (
       SELECT val
       FROM unnest($1) val
@@ -15,15 +15,12 @@ CREATE OR REPLACE FUNCTION _median(anyarray) RETURNS anyelement AS $$
   OFFSET greatest(0, floor((select count(*) FROM q) / 2.0) - ((select count(*) + 1 FROM q) % 2));
 $$ LANGUAGE sql IMMUTABLE;
 
-CREATE AGGREGATE median(anyelement) (
+CREATE AGGREGATE median(INTEGER) (
   SFUNC=array_append,
-  STYPE=anyarray,
+  STYPE=INTEGER[],
   FINALFUNC=_median,
   INITCOND='{}'
 );
-
--- We may want to create a CreateAggregate.sql script, but it seems silly to do that for one aggregate
-CREATE AGGREGATE array_accum (basetype = anyelement, sfunc = array_append, stype = anyarray, initcond = '{}');
 
 -- Generates UUID version 4 (random-based)
 CREATE OR REPLACE FUNCTION generate_uuid_v4() RETURNS uuid

--- a/admin/sql/DropFunctions.sql
+++ b/admin/sql/DropFunctions.sql
@@ -1,7 +1,7 @@
 -- Automatically generated, do not edit.
 \unset ON_ERROR_STOP
 
-DROP FUNCTION _median(anyarray);
+DROP FUNCTION _median(INTEGER[]);
 DROP FUNCTION a_del_alternative_medium_track();
 DROP FUNCTION a_del_alternative_release_or_track();
 DROP FUNCTION a_del_instrument();
@@ -103,4 +103,3 @@ DROP FUNCTION simplify_search_hints();
 DROP FUNCTION track_count_matches_cdtoc(medium, int);
 DROP FUNCTION trg_delete_unused_tag();
 DROP FUNCTION trg_delete_unused_tag_ref();
-DROP AGGREGATE array_accum (anyelement);

--- a/admin/sql/ReplicationSetup.sql
+++ b/admin/sql/ReplicationSetup.sql
@@ -8,9 +8,9 @@ BEGIN;
 --CREATE FUNCTION "recordchange" () RETURNS trigger AS
 --'$libdir/pending', 'recordchange' LANGUAGE C;
 
-CREATE AGGREGATE array_cat_agg(anyarray)(
+CREATE AGGREGATE array_cat_agg(int2[]) (
       sfunc       = array_cat,
-      stype       = anyarray,
+      stype       = int2[],
       initcond    = '{}'
 );
 

--- a/admin/sql/updates/20220426-mbs-12131.sql
+++ b/admin/sql/updates/20220426-mbs-12131.sql
@@ -1,0 +1,38 @@
+\set ON_ERROR_STOP 1
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION _median(INTEGER[]) RETURNS INTEGER AS $$
+  WITH q AS (
+      SELECT val
+      FROM unnest($1) val
+      WHERE VAL IS NOT NULL
+      ORDER BY val
+  )
+  SELECT val
+  FROM q
+  LIMIT 1
+  -- Subtracting (n + 1) % 2 creates a left bias
+  OFFSET greatest(0, floor((select count(*) FROM q) / 2.0) - ((select count(*) + 1 FROM q) % 2));
+$$ LANGUAGE sql IMMUTABLE;
+
+DROP AGGREGATE IF EXISTS median(anyelement);
+
+CREATE OR REPLACE AGGREGATE median(INTEGER) (
+  SFUNC=array_append,
+  STYPE=INTEGER[],
+  FINALFUNC=_median,
+  INITCOND='{}'
+);
+
+DROP AGGREGATE IF EXISTS array_accum(anyelement);
+
+DROP AGGREGATE IF EXISTS array_cat_agg(anyarray);
+
+CREATE OR REPLACE AGGREGATE array_cat_agg(int2[]) (
+      sfunc       = array_cat,
+      stype       = int2[],
+      initcond    = '{}'
+);
+
+COMMIT;

--- a/admin/sql/updates/schema-change/27.standalone.sql
+++ b/admin/sql/updates/schema-change/27.standalone.sql
@@ -10,6 +10,7 @@
 -- 20220314-mbs-12254-standalone.sql
 -- 20220314-mbs-12255-standalone.sql
 -- 20220322-mbs-12256-standalone.sql
+-- 20220426-mbs-12131.sql
 \set ON_ERROR_STOP 1
 BEGIN;
 SET search_path = musicbrainz, public;
@@ -1071,5 +1072,42 @@ CREATE TRIGGER update_aggregate_rating_for_update AFTER UPDATE ON work_rating_ra
 
 CREATE TRIGGER update_aggregate_rating_for_delete AFTER DELETE ON work_rating_raw
     FOR EACH ROW EXECUTE PROCEDURE update_aggregate_rating_for_raw_delete('work');
+
+--------------------------------------------------------------------------------
+SELECT '20220426-mbs-12131.sql';
+
+
+CREATE OR REPLACE FUNCTION _median(INTEGER[]) RETURNS INTEGER AS $$
+  WITH q AS (
+      SELECT val
+      FROM unnest($1) val
+      WHERE VAL IS NOT NULL
+      ORDER BY val
+  )
+  SELECT val
+  FROM q
+  LIMIT 1
+  -- Subtracting (n + 1) % 2 creates a left bias
+  OFFSET greatest(0, floor((select count(*) FROM q) / 2.0) - ((select count(*) + 1 FROM q) % 2));
+$$ LANGUAGE sql IMMUTABLE;
+
+DROP AGGREGATE IF EXISTS median(anyelement);
+
+CREATE OR REPLACE AGGREGATE median(INTEGER) (
+  SFUNC=array_append,
+  STYPE=INTEGER[],
+  FINALFUNC=_median,
+  INITCOND='{}'
+);
+
+DROP AGGREGATE IF EXISTS array_accum(anyelement);
+
+DROP AGGREGATE IF EXISTS array_cat_agg(anyarray);
+
+CREATE OR REPLACE AGGREGATE array_cat_agg(int2[]) (
+      sfunc       = array_cat,
+      stype       = int2[],
+      initcond    = '{}'
+);
 
 COMMIT;

--- a/upgrade.json
+++ b/upgrade.json
@@ -123,6 +123,7 @@
                    "20220314-mbs-12253-standalone.sql",
                    "20220314-mbs-12254-standalone.sql",
                    "20220314-mbs-12255-standalone.sql",
-                   "20220322-mbs-12256-standalone.sql"]
+                   "20220322-mbs-12256-standalone.sql",
+                   "20220426-mbs-12131.sql"]
   }
 }


### PR DESCRIPTION
This patch contains the schema changes required for PostgreSQL 14 to
work.  Note that these changes are also compatible with PostgreSQL 12.

For context, refer to the first incompatibility listed under
https://www.postgresql.org/docs/release/14.0/.

Because anycompatiblearray doesn't exist in v12, the ideal solution (and
the one used here) is to use more specific types.

 * The _median function is only used by the median aggregate, which is
   only used to calculate median recording lengths -- an integer value.

 * The array_accum aggregate was added in 33bd14e for tracklist_index, a
   table which was removed years ago.  The aggregate is unused and can
   be removed too.

 * array_cat_agg is only used internally by dbmirror.  (See
   https://github.com/metabrainz/dbmirror/blob/ca536c7/pending.c#L405.)
   Since pg_constraint.conkey is of type int2[], we can use that.