### PR TITLE
MBS-12336: Validate that Predicate::Set is being passed integers

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Set.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Set.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::EditSearch::Predicate::Set;
 use Moose;
 use namespace::autoclean;
+use List::AllUtils qw( any );
+use MusicBrainz::Server::Validation qw( is_integer );
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
 
@@ -13,6 +15,10 @@ sub operator_cardinality_map {
 
 sub valid {
     my ($self) = @_;
+
+    # If you want to allow non-integer sets, please create ::IntegerSet, etc
+    return 0 if any { !is_integer($_) } $self->arguments;
+
     return $self->arguments > 0;
 }
 

--- a/t/lib/t/MusicBrainz/Server/EditSearch/Predicate/Set.pm
+++ b/t/lib/t/MusicBrainz/Server/EditSearch/Predicate/Set.pm
@@ -12,15 +12,16 @@ test 'operator BETWEEN' => sub {
         'type' =>
         {
             operator => '=',
-            args => [ 1, 2, 3, '4,5' ]
+            args => [ 1, 2, 3, 4, 5 ]
         }
     );
 
     ok(defined $field, 'did construct a field');
     isa_ok($field, 'MusicBrainz::Server::EditSearch::Predicate::Set', 'is a set field');
     is($field->operator, '=', 'handles the correct operator');
-    is($field->arguments, 4, 'has correct arguments');
-    cmp_set([$field->arguments], [1, 2, 3, '4,5'], 'has correct arguments');
+    is($field->arguments, 5, 'has correct arguments');
+    cmp_set([$field->arguments], [1, 2, 3, 4, 5], 'has correct arguments');
+    is($field->valid, 1, 'is a valid set field');
 
     my $query = Query->new( fields => [ $field ] );
     $field->combine_with_query($query);
@@ -32,6 +33,22 @@ test 'operator BETWEEN' => sub {
     my @args = @$arglist;
     cmp_set($args[0], [1, 2, 3, 4, 5]);
     is(@args, 1);
+};
+
+test 'Non-integer arguments are rejected' => sub {
+    my $test = shift;
+    my $field = Field->new_from_input(
+        'type' =>
+        {
+            operator => '=',
+            args => [ 1, 2, 3, '4,5' ]
+        }
+    );
+
+    ok(defined $field, 'did construct a field');
+    isa_ok($field, 'MusicBrainz::Server::EditSearch::Predicate::Set', 'is a set field');
+    cmp_set([$field->arguments], [1, 2, 3, '4,5'], 'has correct arguments');
+    is($field->valid, 0, 'is not a valid set field');
 };
 
 1;


### PR DESCRIPTION
### Fix MBS-12336

We always want an integer here (they're mostly rowIDs, except for privileges and data quality which are also ints). Default data quality is -1, so we can't restrict to *positive* integers.

Notice from the test that for some reason we semi-supported passing the arguments in a comma-only list ('4,5' rather than two arguments 4 and 5). That *did* get the intended results returned from the DB, but it breaks display (no actual values are shown as selected in the search form) and it seems like a huge hack, so I'm disallowing it with this rather than special-casing it.