### PR TITLE
MBS-12353: Actually check proposed ratings are allowed

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -3,7 +3,8 @@ use Moose;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
-use Scalar::Util qw( looks_like_number );
+use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Validation qw( is_integer );
 
 =head1 NAME
 
@@ -33,8 +34,13 @@ sub rate : Local RequireAuth DenyWhenReadonly
     my $entity_id = $c->request->params->{entity_id};
     my $rating = $c->request->params->{rating};
 
-    unless (looks_like_number($rating)) {
-        $self->error( $c, message => 'rating must be a number', status => 400 );
+    unless (is_integer($rating) && $rating >= 0 && $rating <= 100) {
+        $c->stash(
+            message  => l(
+                'The rating should be an integer between 0 and 100.',
+            ),
+        );
+        $c->detach('/error_400');
     }
 
     my $model = $c->model(type_to_model($entity_type));

--- a/t/lib/t/MusicBrainz/Server/Controller/Rating.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Rating.pm
@@ -38,4 +38,24 @@ test 'Cannot rate without a confirmed email address' => sub {
     is ($mech->status, 401, 'Rating rejected without confirmed address');
 };
 
+test 'Invalid ratings are rejected gracefully' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c);
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'new_editor', password => 'password' } );
+
+    $mech->get('/rating/rate/?entity_type=label&entity_id=2&rating=420');
+    is ($mech->status, 400, 'Rating > 100 is rejected');
+
+    $mech->get('/rating/rate/?entity_type=label&entity_id=2&rating=-20');
+    is ($mech->status, 400, 'Rating < 0 is rejected');
+
+    $mech->get('/rating/rate/?entity_type=label&entity_id=2&rating=asdfg');
+    is ($mech->status, 400, 'Non-numeric rating is rejected');
+};
+
 1;


### PR DESCRIPTION
### Fix MBS-12353

This just checked whether the rating is a number, but that doesn't help avoid ISEs when someone tries to rate, say, 700 instead of just asdfg.