### PR TITLE
MBS-4960 / MBS-12361: Allow navigation from donation check page and improve error handling

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -698,15 +698,21 @@ sub donation : Local RequireAuth HiddenOnSlaves
     my ($self, $c) = @_;
 
     my $result = $c->model('Editor')->donation_check($c->user);
-    $c->detach('/error_500') unless $result;
+    my $check_failed = 0;
+    my $nag = 0;
 
-    # If nag is 0, don't nag - if 1 or -1 then nag
-    my $nag = $result->{nag} != 0;
+    if (defined $result) {
+        # If nag is 0, don't nag - if 1 or -1 then nag
+        $nag = $result->{nag} != 0;
+    } else {
+        $check_failed = 1;
+    }
 
     $c->stash(
         current_view => 'Node',
         component_path => 'account/Donation',
         component_props => {
+            checkFailed => boolean_to_json($check_failed),
             days => sprintf('%.0f', $result->{days}),
             nag => boolean_to_json($nag),
             user => $c->controller('User')->serialize_user($c->user),

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -709,6 +709,7 @@ sub donation : Local RequireAuth HiddenOnSlaves
         component_props => {
             days => sprintf('%.0f', $result->{days}),
             nag => boolean_to_json($nag),
+            user => $c->controller('User')->serialize_user($c->user),
         }
     );
 }

--- a/root/account/Donation.js
+++ b/root/account/Donation.js
@@ -9,16 +9,28 @@
 
 import * as React from 'react';
 
+import UserAccountLayout, {
+  sanitizedAccountLayoutUser,
+} from '../components/UserAccountLayout';
 import {CONTACT_URL, DONATE_URL} from '../constants';
-import StatusPage from '../components/StatusPage';
 
 type Props = {
   +days: number,
   +nag: boolean,
+  +user: UnsanitizedEditorT,
 };
 
-const Donation = ({days, nag}: Props): React.Element<typeof StatusPage> => (
-  <StatusPage title={l('Donation Check')}>
+const Donation = ({
+  days,
+  nag,
+  user,
+}: Props): React.Element<typeof UserAccountLayout> => (
+  <UserAccountLayout
+    entity={sanitizedAccountLayoutUser(user)}
+    page="donation"
+    title={l('Donation Check')}
+  >
+    <h2>{l('Donation Check')}</h2>
     {nag
       ? (
         <>
@@ -31,8 +43,8 @@ const Donation = ({days, nag}: Props): React.Element<typeof StatusPage> => (
           <p>
             {exp.l(
               `If you would like to make a donation,
-               {donate|you can do that here}. If you have donated, but
-               you are still being nagged, please {contact|contact us}.`,
+                {donate|you can do that here}. If you have donated, but
+                you are still being nagged, please {contact|contact us}.`,
               {contact: CONTACT_URL, donate: DONATE_URL},
             )}
           </p>
@@ -57,7 +69,7 @@ const Donation = ({days, nag}: Props): React.Element<typeof StatusPage> => (
             )}
         </>
       )}
-  </StatusPage>
+  </UserAccountLayout>
 );
 
 export default Donation;

--- a/root/account/Donation.js
+++ b/root/account/Donation.js
@@ -13,14 +13,17 @@ import UserAccountLayout, {
   sanitizedAccountLayoutUser,
 } from '../components/UserAccountLayout';
 import {CONTACT_URL, DONATE_URL} from '../constants';
+import Warning from '../static/scripts/common/components/Warning';
 
 type Props = {
+  +checkFailed: boolean,
   +days: number,
   +nag: boolean,
   +user: UnsanitizedEditorT,
 };
 
 const Donation = ({
+  checkFailed,
   days,
   nag,
   user,
@@ -31,44 +34,50 @@ const Donation = ({
     title={l('Donation Check')}
   >
     <h2>{l('Donation Check')}</h2>
-    {nag
-      ? (
-        <>
-          <p>
-            {l(`We have not received a donation from you recently. If you have
-                just made a PayPal donation, then we have not received a
-                notification from PayPal yet. Please wait a few minutes and
-                reload this page to check again.`)}
-          </p>
-          <p>
-            {exp.l(
-              `If you would like to make a donation,
-                {donate|you can do that here}. If you have donated, but
-                you are still being nagged, please {contact|contact us}.`,
-              {contact: CONTACT_URL, donate: DONATE_URL},
-            )}
-          </p>
-        </>
-      ) : (
-        <>
-          <p>
-            {l('Thank you for contributing to MusicBrainz.')}
-          </p>
-          {days > 0
-            ? (
-              <p>
-                {texp.l(
-                  'You will not be nagged for another {days} days.',
-                  {days: days},
-                )}
-              </p>
-            ) : (
-              <p>
-                {l('You will never be nagged again!')}
-              </p>
-            )}
-        </>
-      )}
+    {checkFailed ? (
+      <Warning
+        message={
+          l(`We were not able to check your donation status right now.
+             Please try again later.`)
+        }
+      />
+    ) : nag ? (
+      <>
+        <p>
+          {l(`We have not received a donation from you recently. If you have
+              just made a PayPal donation, then we have not received a
+              notification from PayPal yet. Please wait a few minutes and
+              reload this page to check again.`)}
+        </p>
+        <p>
+          {exp.l(
+            `If you would like to make a donation,
+             {donate|you can do that here}. If you have donated, but
+             you are still being nagged, please {contact|contact us}.`,
+            {contact: CONTACT_URL, donate: DONATE_URL},
+          )}
+        </p>
+      </>
+    ) : (
+      <>
+        <p>
+          {l('Thank you for contributing to MusicBrainz.')}
+        </p>
+        {days > 0
+          ? (
+            <p>
+              {texp.l(
+                'You will not be nagged for another {days} days.',
+                {days: days},
+              )}
+            </p>
+          ) : (
+            <p>
+              {l('You will never be nagged again!')}
+            </p>
+          )}
+      </>
+    )}
   </UserAccountLayout>
 );
 


### PR DESCRIPTION
### Implement MBS-4960 / MBS-12361

The donation check page can be reached as a tab from your own user page, but didn't itself contain the user header and tab navigation, so the user couldn't continue navigating elsewhere from it as expected. Having the header doesn't add much complexity, so we might as well.

We were just detaching to 500 with no info if hitting the MeB donations endpoint failed. It seems a lot more sensible to give the user a proper warning instead.