### PR TITLE
MBS-8193 / MBS-12332: Wrap absurdly long lines

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -10,6 +10,7 @@ body {
     font-family: @sans-serif;
     min-width: @min-width;
     margin: auto;
+    overflow-wrap: anywhere;
 
     @media @wide {
         padding: 0 10px;


### PR DESCRIPTION
### Fix MBS-8193 / MBS-12332

There's no real reason why we should not wrap anything that overflows anywhere in `<body>`. This includes very long URLs in edits, and also very long symbols-only names on entities.

This wasn't originally added to body because we were not sure whether it'd work, but testing a bit it does seem to do the trick anywhere where I've found this to be a problem in the past.