### PR TITLE
MBS-12347: Also show RG artist in autocomplete if type is null

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -818,6 +818,11 @@ MB.Control.autocomplete_formatters = {
                  artist: item.artist,
                  release_group_type: item.l_type_name,
                })) + '</span>');
+    } else {
+      a.append('<br /><span class="autocomplete-comment">' +
+               he.escape(texp.l('Release group by {artist}', {
+                 artist: item.artist,
+               })) + '</span>');
     }
 
     return $('<li>').append(a).appendTo(ul);


### PR DESCRIPTION
### Fix MBS-12347

The artist credit is useful in the inline search results whether or not the release group has a type, so something should still be displayed when there's no `typeName`. I went with just "Release group by {artist}" since that seems the simplest while still not being misleading.