### PR TITLE
MBS-12368: Add annotations, rels and aliases to genre WS

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
@@ -12,18 +12,19 @@ use MusicBrainz::Server::Validation qw( is_guid );
 my $ws_defs = Data::OptList::mkopt([
     genre => {
         method   => 'GET',
-        # TODO: Add include when implementing MBS-10062
-        # inc      => [ qw(aliases) ],
+        inc      => [ qw( aliases annotation _relations ) ],
         optional => [ qw(fmt limit offset) ],
         linked   => [ qw( collection ) ],
     },
     genre => {
         method   => 'GET',
+        inc      => [ qw( aliases annotation _relations ) ],
         optional => [ qw(fmt limit offset) ],
     },
     genre => {
         action   => '/ws/2/genre/lookup',
         method   => 'GET',
+        inc      => [ qw( aliases annotation _relations ) ],
         optional => [ qw(fmt) ],
     },
 ]);
@@ -48,8 +49,26 @@ sub serializers {
 
 sub base : Chained('root') PathPart('genre') CaptureArgs(0) { }
 
-# Nothing extra to load yet, but this is required by Role::Lookup
-sub genre_toplevel {}
+sub genre_toplevel {
+    my ($self, $c, $stash, $genres) = @_;
+
+    my $inc = $c->stash->{inc};
+    my @genres = @{$genres};
+
+    $c->model('Genre')->annotation->load_latest(@genres)
+        if $inc->annotation;
+
+    if ($inc->aliases) {
+        my $aliases = $c->model('Genre')->alias->find_by_entity_ids(
+            map { $_->id } @genres,
+        );
+        for (@genres) {
+            $stash->store($_)->{aliases} = $aliases->{$_->id};
+        }
+    }
+
+    $self->load_relationships($c, $stash, @genres);
+}
 
 sub genre_browse : Private {
     my ($self, $c) = @_;
@@ -100,6 +119,9 @@ sub genre_all : Chained('base') PathPart('all') {
     } else {
         my ($genres, $hits) =
             $c->model('Genre')->get_all_limited($limit, $offset);
+
+        $self->genre_toplevel($c, $stash, $genres);
+
         $genre_list = $self->make_list($genres, $hits, $offset);
     }
 

--- a/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/XMLSerializer.pm
@@ -1414,8 +1414,18 @@ sub _serialize_genre
 {
     my ($self, $parent_node, $genre, $inc, $stash, $toplevel) = @_;
 
+    my $opts = $stash->store($genre);
+
     my $genre_node = $parent_node->addNewChild(undef, 'genre');
     _serialize_genre_common($genre_node, $genre);
+
+    $self->_serialize_annotation($genre_node, $genre, $inc, $stash) if $toplevel;
+
+    $self->_serialize_alias_list($genre_node, $opts->{aliases}, $inc, $stash)
+        if ($inc->aliases && $opts->{aliases});
+
+    $self->_serialize_relation_lists($genre_node, $genre, $genre->relationships, $inc, $stash)
+        if $inc->has_rels;
 }
 
 sub _serialize_user_tag_list

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
@@ -61,4 +61,60 @@ test 'Genre list is returned as expected' => sub {
 </metadata>';
 };
 
+test 'Test genre list includes' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+    MusicBrainz::Server::Test->prepare_test_database(
+      $c,
+      '+webservice_annotation',
+    );
+
+    ws2_test_xml 'genre list',
+        '/genre/all?inc=aliases+annotation' =>
+        '<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+  <genre-list count="10">
+    <genre id="aac07ae0-8acf-4249-b5c0-2762b53947a2">
+      <name>big beat</name>
+    </genre>
+    <genre id="1b50083b-1afa-4778-82c8-548b309af783">
+      <name>dubstep</name>
+    </genre>
+    <genre id="89255676-1f14-4dd8-bbad-fca839d6aff4">
+      <name>electronic</name>
+    </genre>
+    <genre id="53a3cea3-17af-4421-a07a-5824b540aeb5">
+      <name>electronica</name>
+    </genre>
+    <genre id="18b010d7-7d85-4445-a4a8-1889a4688308">
+      <name>glitch</name>
+    </genre>
+    <genre id="51cfaac4-6696-480b-8f1b-27cfc789109c">
+      <name>grime</name>
+      <disambiguation>stuff</disambiguation>
+      <annotation>
+        <text>this is a genre annotation</text>
+      </annotation>
+      <alias-list count="1">
+        <alias locale="en" sort-name="dirt">dirt</alias>
+      </alias-list>
+    </genre>
+    <genre id="a2782cb6-1cd0-477c-a61d-b3f8b42dd1b3">
+      <name>house</name>
+    </genre>
+    <genre id="eba7715e-ee26-4989-8d49-9db382955419">
+      <name>j-pop</name>
+    </genre>
+    <genre id="b74b3b6c-0700-46b1-aa55-1f2869a3bd1a">
+      <name>k-pop</name>
+    </genre>
+    <genre id="911c7bbb-172d-4df8-9478-dbff4296e791">
+      <name>pop</name>
+    </genre>
+  </genre-list>
+</metadata>';
+};
+
 1;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
@@ -80,4 +80,104 @@ test 'Genre list is returned as expected' => sub {
     };
 };
 
+test 'Test genre list includes' => sub {
+    my $test = shift;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+webservice');
+    MusicBrainz::Server::Test->prepare_test_database(
+      $c,
+      '+webservice_annotation',
+    );
+
+    ws2_test_json 'genre list', '/genre/all?inc=aliases+annotation' => {
+        'genre-count' => 10,
+        'genre-offset' => 0,
+        'genres' => [
+            {
+                id => 'aac07ae0-8acf-4249-b5c0-2762b53947a2',
+                name => 'big beat',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '1b50083b-1afa-4778-82c8-548b309af783',
+                name => 'dubstep',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '89255676-1f14-4dd8-bbad-fca839d6aff4',
+                name => 'electronic',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '53a3cea3-17af-4421-a07a-5824b540aeb5',
+                name => 'electronica',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '18b010d7-7d85-4445-a4a8-1889a4688308',
+                name => 'glitch',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '51cfaac4-6696-480b-8f1b-27cfc789109c',
+                name => 'grime',
+                disambiguation => 'stuff',
+                annotation => 'this is a genre annotation',
+                aliases => [
+                    {
+                        end => JSON::null,
+                        name => 'dirt',
+                        primary => JSON::false,
+                        locale => 'en',
+                        begin => JSON::null,
+                        ended => JSON::false,
+                        'sort-name' => 'dirt',
+                        'type-id' => JSON::null,
+                        type => JSON::null,
+                    },
+                ],
+            },
+            {
+                id => 'a2782cb6-1cd0-477c-a61d-b3f8b42dd1b3',
+                name => 'house',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => 'eba7715e-ee26-4989-8d49-9db382955419',
+                name => 'j-pop',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => 'b74b3b6c-0700-46b1-aa55-1f2869a3bd1a',
+                name => 'k-pop',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+            {
+                id => '911c7bbb-172d-4df8-9478-dbff4296e791',
+                name => 'pop',
+                disambiguation => '',
+                annotation => JSON::null,
+                aliases => [],
+            },
+        ],
+    };
+};
+
 1;

--- a/t/sql/webservice.sql
+++ b/t/sql/webservice.sql
@@ -1204,6 +1204,8 @@ INSERT INTO genre (id, gid, name) VALUES (8, 'aac07ae0-8acf-4249-b5c0-2762b53947
 INSERT INTO genre (id, gid, name) VALUES (9, 'a2782cb6-1cd0-477c-a61d-b3f8b42dd1b3', 'house');
 INSERT INTO genre (id, gid, name) VALUES (10, '18b010d7-7d85-4445-a4a8-1889a4688308', 'glitch');
 
+INSERT INTO genre_alias (genre, id, locale, name, primary_for_locale, sort_name, type) VALUES (3, 1, 'en', 'dirt', '0', 'dirt', NULL);
+
 INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (242, 95821, 34, 't');
 INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (242, 100000001, 34, 't');
 INSERT INTO artist_tag_raw (artist, editor, tag, is_upvote) VALUES (242, 100000002, 34, 't');

--- a/t/sql/webservice_annotation.sql
+++ b/t/sql/webservice_annotation.sql
@@ -7,7 +7,8 @@ INSERT INTO annotation (id, editor, text)
                (4, 1, 'this is a release annotation'),
                (5, 1, 'this is a release group annotation'),
                (6, 1, 'this is a work annotation'),
-               (7, 1, 'this is a place annotation');
+               (7, 1, 'this is a place annotation'),
+               (8, 1, 'this is a genre annotation');
 
 INSERT INTO artist_annotation (artist, annotation) VALUES (427385, 1);
 INSERT INTO label_annotation (label, annotation) VALUES (46, 2);
@@ -16,3 +17,4 @@ INSERT INTO release_annotation (release, annotation) VALUES (246898, 4);
 INSERT INTO release_group_annotation (release_group, annotation) VALUES (597897, 5);
 INSERT INTO work_annotation (work, annotation) VALUES (1542684, 6);
 INSERT INTO place_annotation (place, annotation) VALUES (1, 7);
+INSERT INTO genre_annotation (genre, annotation) VALUES (3, 8);


### PR DESCRIPTION
### Implement MBS-12368

This also allows includes in the non-text genre list, since we had specifically talked about that as the reason we wanted to have limit / offset there while having a names-only text list.

mmd-schema changes (merged): https://github.com/metabrainz/mmd-schema/pull/27