### PR TITLE
MBS-11694: Cleanup /intent/user Twitter URLs

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4465,6 +4465,10 @@ const CLEANUPS: CleanupEntries = {
         'https://twitter.com/',
       );
       url = url.replace(
+        /^(https:\/\/twitter\.com)\/intent\/user\/?\?screen_name=([^\/?#]+)/,
+        '$1/$2',
+      );
+      url = url.replace(
         /^(https:\/\/twitter\.com)\/@?([^\/?#]+(?:\/status\/\d+)?)(?:[\/?#].*)?$/,
         '$1/$2',
       );

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4651,6 +4651,18 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://twitter.com/cirrhaniva',
   },
   {
+                     input_url: 'https://mobile.twitter.com/intent/user?screen_name=emily_doolittle',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://twitter.com/emily_doolittle',
+  },
+  {
+                     input_url: 'https://mobile.twitter.com/intent/user/?screen_name=emily_doolittle',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://twitter.com/emily_doolittle',
+  },
+  {
                      input_url: 'https://twitter.com/@UNIVERSAL_D',
              input_entity_type: 'label',
     expected_relationship_type: 'socialnetwork',


### PR DESCRIPTION
### Implement MBS-11694

These seem to just give the visitor a popup to follow the profile, seem otherwise trivial to clean up to the profile itself.