### PR TITLE
MBS-8875: Improve CatNoLooksLikeASIN regexp

### DIFF
--- a/lib/MusicBrainz/Server/Report/CatNoLooksLikeASIN.pm
+++ b/lib/MusicBrainz/Server/Report/CatNoLooksLikeASIN.pm
@@ -16,7 +16,8 @@ sub query {
             JOIN release r
             ON r.id = rl.release
             JOIN artist_credit ac ON r.artist_credit = ac.id
-        WHERE rl.catalog_number ~ '^B0[0-9A-Z]{8}$'
+            -- Please keep in sync with catNoLooksLikeASIN on release-editor/bubbles.js
+        WHERE rl.catalog_number ~ '^B0(?=.*[A-Z])([0-9A-Z]{8})$'
     }
 }
 

--- a/root/static/scripts/release-editor/bubbles.js
+++ b/root/static/scripts/release-editor/bubbles.js
@@ -46,7 +46,8 @@ releaseEditor.labelBubble = bubbleDoc({
   },
 
   catNoLooksLikeASIN: function (catNo) {
-    return /^B00[0-9A-Z]{7}$/.test(catNo);
+    // Please keep in sync with CatNoLooksLikeASIN report
+    return /^B0(?=.*[A-Z])([0-9A-Z]{8})$/.test(catNo);
   },
 });
 


### PR DESCRIPTION
### Fix MBS-8875

ASINs can be B plus any 9 letters or numbers, but doing this creates a crazy amount of false positives because it matches the catno layout of several labels, including UMG. The best we can probably do is this: B + 0 (still by far the most common) + 8 letters and digits, of which at least one is a letter (since that still includes most ASINs but excludes the UMG catnos).

Changed the catno in the release editor code to match and added comments to keep them in sync.