### PR TITLE
MBS-12212: Add filtering to artists' events tab 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Ajax.pm
+++ b/lib/MusicBrainz/Server/Controller/Ajax.pm
@@ -3,11 +3,22 @@ BEGIN { use Moose; extends 'Catalyst::Controller' };
 
 use JSON qw( encode_json );
 use MusicBrainz::Server::FilterUtils qw(
+    create_artist_events_form
     create_artist_release_groups_form
     create_artist_releases_form
     create_artist_recordings_form
     create_artist_works_form
 );
+
+sub filter_artist_events_form : Local {
+    my ($self, $c) = @_;
+
+    my $artist_id = $c->req->query_params->{artist_id};
+    my $form = create_artist_events_form($c, $artist_id);
+
+    $c->res->body(encode_json($form->TO_JSON));
+    $c->res->content_type('application/json; charset=utf-8');
+}
 
 sub filter_artist_release_groups_form : Local {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -241,6 +241,10 @@ sub find_by_artist
                 push @where_args, $filter{type_id};
             }
         }
+        if (exists $filter{setlist}) {
+            push @where_query, 'event.setlist ILIKE ?';
+            push @where_args, '%' . $filter{setlist} . '%';
+        }
     }
 
     my $query =

--- a/lib/MusicBrainz/Server/FilterUtils.pm
+++ b/lib/MusicBrainz/Server/FilterUtils.pm
@@ -3,11 +3,23 @@ package MusicBrainz::Server::FilterUtils;
 use base 'Exporter';
 
 our @EXPORT_OK = qw(
+    create_artist_events_form
     create_artist_release_groups_form
     create_artist_releases_form
     create_artist_recordings_form
     create_artist_works_form
 );
+
+sub create_artist_events_form {
+    my ($c, $artist_id) = @_;
+
+    my %form_args = (
+        entity_type => 'event',
+        types => [ $c->model('EventType')->get_all ],
+    );
+
+    return $c->form(filter_form => 'Filter::Event', %form_args);
+}
 
 sub create_artist_release_groups_form {
     my ($c, $artist_id) = @_;

--- a/lib/MusicBrainz/Server/Form/Filter/Event.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Event.pm
@@ -1,0 +1,47 @@
+package MusicBrainz::Server::Form::Filter::Event;
+use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( lp );
+extends 'MusicBrainz::Server::Form::Filter::Generic';
+
+has 'types' => (
+    isa => 'ArrayRef[EventType]',
+    is => 'ro',
+    required => 1,
+);
+
+has_field 'type_id' => (
+    type => 'Select',
+);
+
+sub filter_field_names {
+    return qw/ name type_id /;
+}
+
+sub options_type_id {
+    my ($self, $field) = @_;
+    return [
+        { value => '-1', label => lp('[none]', 'event type') },
+        map +{ value => $_->id, label => $_->l_name },
+        @{ $self->types }
+    ];
+}
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{options_type_id} = $self->options_type_id;
+    return $json;
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Form/Filter/Event.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Event.pm
@@ -9,12 +9,17 @@ has 'types' => (
     required => 1,
 );
 
+has_field 'setlist' => (
+    type => '+MusicBrainz::Server::Form::Field::Text',
+    default => '',
+);
+
 has_field 'type_id' => (
     type => 'Select',
 );
 
 sub filter_field_names {
-    return qw/ name type_id /;
+    return qw/ name setlist type_id /;
 }
 
 sub options_type_id {

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -11,25 +11,39 @@ import * as React from 'react';
 
 import EventList from '../components/list/EventList';
 import PaginatedResults from '../components/PaginatedResults';
+import Filter from '../static/scripts/common/components/Filter';
+import {type FilterFormT}
+  from '../static/scripts/common/components/FilterForm';
 import {returnToCurrentPage} from '../utility/returnUri';
 
 import ArtistLayout from './ArtistLayout';
 
 type Props = {
   +$c: CatalystContextT,
+  +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +events: $ReadOnlyArray<EventT>,
+  +filterForm: ?FilterFormT,
+  +hasFilter: boolean,
   +pager: PagerT,
 };
 
 const ArtistEvents = ({
   $c,
+  ajaxFilterFormUrl,
   artist,
   events,
+  filterForm,
+  hasFilter,
   pager,
 }: Props): React.Element<typeof ArtistLayout> => (
   <ArtistLayout entity={artist} page="events" title={l('Events')}>
     <h2>{l('Events')}</h2>
+
+    <Filter
+      ajaxFormUrl={ajaxFilterFormUrl}
+      initialFilterForm={filterForm}
+    />
 
     {events.length > 0 ? (
       <form
@@ -59,7 +73,9 @@ const ArtistEvents = ({
       </form>
     ) : (
       <p>
-        {l('This artist is not currently associated with any events.')}
+        {hasFilter
+          ? l('No events found that match this search.')
+          : l('This artist is not currently associated with any events.')}
       </p>
     )}
   </ArtistLayout>

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -21,6 +21,7 @@ export type FilterFormT = $ReadOnly<{
     +name: ReadOnlyFieldT<string>,
     +role_type?: ReadOnlyFieldT<number>,
     +secondary_type_id?: ReadOnlyFieldT<number>,
+    +setlist?: ReadOnlyFieldT<string>,
     +type_id?: ReadOnlyFieldT<number>,
   }>,
   entity_type: 'recording' | 'release' | 'release_group',
@@ -63,6 +64,7 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
   const dateField = form.field.date;
   const roleTypeField = form.field.role_type;
   const roleTypeOptions = form.options_role_type;
+  const setlistField = form.field.setlist;
 
   return (
     <div id="filter">
@@ -186,6 +188,23 @@ const FilterForm = ({form}: Props): React.Element<'div'> => {
                     type="text"
                   />
                   <FieldErrors field={dateField} />
+                </td>
+              </tr>
+            ) : null}
+
+            {setlistField ? (
+              <tr>
+                <td>
+                  {addColonText(l('Setlist contains'))}
+                </td>
+                <td>
+                  <input
+                    defaultValue={setlistField.value ?? ''}
+                    name={setlistField.html_name}
+                    size="47"
+                    type="text"
+                  />
+                  <FieldErrors field={setlistField} />
                 </td>
               </tr>
             ) : null}

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -37,6 +37,8 @@ type Props = {
 
 function getSubmitText(type: string) {
   switch (type) {
+    case 'event':
+      return l('Filter events');
     case 'recording':
       return l('Filter recordings');
     case 'release':

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -156,6 +156,89 @@ test 'Test overview (release group) filtering' => sub {
     );
 };
 
+test 'Test event page filtering' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+filtering');
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events',
+        'Fetched artist events page',
+    );
+
+    my $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '4',
+        'There are four entries in the unfiltered event table',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.name=Schnittke',
+        'Fetched artist events page with name filter "Schnittke"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the event table after filtering by name',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Berliner Philharmoniker plays Schnittke and Shostakovich',
+        'The entry is named "Berliner Philharmoniker plays Schnittke and Shostakovich"',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.type_id=1',
+        'Fetched artist events page with type filter "Concert"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the event table after filtering by "Concert" type',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.type_id=-1',
+        'Fetched artist events page with type filter "[none]"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the event table after filtering by no type',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Uncertain',
+        'The entry is named "Uncertain"',
+    );
+
+    $mech->get_ok(
+        '/artist/dea28aa9-1086-4ffa-8739-0ccc759de1ce/events?filter.setlist=world+premiere',
+        'Fetched artist events page with setlist filter "world premiere"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the event table after filtering by setlist',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr[1]/td[1]',
+        '[concert]',
+        'The first entry is named [concert]',
+    );
+};
+
 test 'Test recording page filtering' => sub {
     my $test = shift;
     my $mech = $test->mech;

--- a/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/UnconfirmedEmailAddresses.pm
@@ -86,6 +86,7 @@ test 'Paths that allow browsing without a confirmed email address' => sub {
   'Controller::Admin::locked_username_search',
   'Controller::Admin::privilege_search',
   'Controller::Admin::unlock_username',
+  'Controller::Ajax::filter_artist_events_form',
   'Controller::Ajax::filter_artist_recordings_form',
   'Controller::Ajax::filter_artist_release_groups_form',
   'Controller::Ajax::filter_artist_releases_form',

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -19,6 +19,7 @@ INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phra
            (3401, 1, 3400, 'Witold Lutosławski', ''),
            (3402, 0, 3402, 'Sinfonia Varsovia', ', '),
            (3402, 1, 3400, 'Witold Lutosławski', '');
+
 -- RGs
 
 INSERT INTO release_group (id, gid, name, artist_credit, type)
@@ -31,6 +32,15 @@ INSERT INTO release_group (id, gid, name, artist_credit, type)
 
 INSERT INTO release_group_secondary_type_join (release_group, secondary_type)
     VALUES (3403, 6), (3405, 6);
+
+-- Events
+
+INSERT INTO event (id, gid, name, type, setlist)
+    VALUES (3400, 'c681f4a3-26db-49e6-80a2-0dbc0a758161', 'Berliner Philharmoniker plays Schnittke and Shostakovich', 1, ''),
+           (3401, '96d6b7d0-90ed-449e-91d3-a05fd4d54b06', '[concert]', 1, '* [e42cce08-f3f1-4e9b-8bfe-11670ad22d52|Asteroid 4179: Toutatis] (Kaija Saariaho) (world premiere)\r* [439c1605-bf74-4e0c-b2d9-6f4f89619ec6|The Planets, op. 32] (Gustav Holst)'),
+           (3402, '5411fa48-5756-45f7-aadb-5aa3e5bd5954', '[concert]', 1, '* [1637948a-63f8-4cf5-bbb3-8faae3964b13|Seht die Sonne] (Magnus Lindberg) (world premiere)'),
+           (3403, '033c9bf9-eef9-409b-9bff-c8d2dea671f5', 'Uncertain', NULL, '');
+
 
 -- Recordings
 
@@ -54,8 +64,12 @@ INSERT INTO work (id, gid, name, type)
 INSERT INTO link (id, link_type, attribute_count)
     VALUES (3400, 278, 0), (3401, 278, 0), (3402, 278, 0), (3403, 278, 0), -- performance
            (3404, 151, 0), (3405, 151, 0), (3406, 151, 0), (3407, 151, 0), -- conductor
-           (3408, 150, 0), (3409, 150, 0), (3410, 150, 0), (3411, 150, 0), -- orchestra
-           (3412, 168, 0), (3413, 168, 0), (3414, 168, 0), (3415, 168, 0), (3416, 168, 0); -- composer
+           (3408, 150, 0), (3409, 150, 0), (3410, 150, 0), (3411, 150, 0), -- orchestra (recording)
+           (3412, 168, 0), (3413, 168, 0), (3414, 168, 0), (3415, 168, 0), (3416, 168, 0), -- composer
+           (3417, 807, 0), (3418, 807, 0), (3419, 807, 0), (3420, 807, 0); -- orchestra (event)
+
+INSERT INTO l_artist_event (id, link, entity0, entity1)
+    VALUES (3400, 3417, 3401, 3400), (3401, 3418, 3401, 3401), (3402, 3419, 3401, 3402), (3403, 3420, 3401, 3403);
 
 INSERT INTO l_artist_recording (id, link, entity0, entity1)
     VALUES (3400, 3404, 3400, 3400), (3401, 3405, 3400, 3401), (3402, 3406, 3400, 3402), (3403, 3407, 3400, 3403), -- conductor


### PR DESCRIPTION
### Implement MBS-12212

First commit adds basic filters on event name and event type.
Second adds an option to filter based on setlist content