### PR TITLE
MBS-12042: Allow providing an edit note when editing annotation

### DIFF
--- a/root/annotation/EditAnnotation.js
+++ b/root/annotation/EditAnnotation.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import EnterEditNote from '../components/EnterEditNote';
 import EnterEdit from '../components/EnterEdit';
 import FormRowText from '../components/FormRowText';
 import FormRowTextArea from '../components/FormRowTextArea';
@@ -82,6 +83,8 @@ const EditAnnotation = ({
           size={50}
           uncontrolled
         />
+
+        <EnterEditNote field={form.field.edit_note} />
 
         <EnterEdit form={form}>
           <button


### PR DESCRIPTION
### Implement MBS-12042

Sometimes you want to provide a source for some data you add to the annotation, or a detailed reason why you're changing something; the changelog (which is supposed to be a short thing anyway) does not seem too appropriate for this.
More generally, I do wonder whether we should drop the changelog completely; almost nobody uses it anyway AFAICT as anything else than a place to put sources, which can now be put on the edit note.

On top of https://github.com/metabrainz/musicbrainz-server/pull/2491