### PR TITLE
Add editor_collection_deleted_entity to @PRIVATE_TABLE_LIST

### DIFF
--- a/lib/MusicBrainz/Server/Constants.pm
+++ b/lib/MusicBrainz/Server/Constants.pm
@@ -792,6 +792,7 @@ Readonly our @PRIVATE_TABLE_LIST => qw(
     editor_collection_area
     editor_collection_artist
     editor_collection_collaborator
+    editor_collection_deleted_entity
     editor_collection_event
     editor_collection_gid_redirect
     editor_collection_instrument


### PR DESCRIPTION
Although this table is empty and seems to be currently unused (see MBS-8287 for context), it should at least be included in the private dump so that if we start using it a backup exists.