### PR TITLE
Update dbmirror2 MasterSetup.sql with warning fix

### DIFF
--- a/admin/sql/dbmirror2/README
+++ b/admin/sql/dbmirror2/README
@@ -1,5 +1,5 @@
 ReplicationSetup.sql and MasterSetup.sql are copied from
-https://github.com/metabrainz/dbmirror2, commit 3abd0e1. (These are the only
+https://github.com/metabrainz/dbmirror2, commit 7ba6422. (These are the only
 two files we need, and submodules are "difficult.")
 
 This is not a fork; please do not make any changes to the files here without

--- a/admin/sql/updates/20220328-mbs-12250-master.sql
+++ b/admin/sql/updates/20220328-mbs-12250-master.sql
@@ -35,7 +35,9 @@ CREATE INDEX column_info_idx
 CREATE FUNCTION dbmirror2.recordchange()
 RETURNS trigger AS $$
 DECLARE
-    tablename   TEXT;
+    -- prefixed with an underscore to disambiguate it from the column names
+    -- pending_data.tablename and pending_keys.tablename
+    _tablename  TEXT;
     keys        TEXT[];
     jsonquery   TEXT;
     olddata     JSON;
@@ -54,7 +56,7 @@ DECLARE
                     ORDER BY seqid DESC
                     FOR UPDATE;
 BEGIN
-    tablename := (
+    _tablename := (
         quote_ident(TG_TABLE_SCHEMA) || '.' || quote_ident(TG_TABLE_NAME)
     );
 
@@ -64,7 +66,7 @@ BEGIN
 
     INSERT INTO dbmirror2.pending_keys (tablename, keys)
     VALUES (
-        tablename,
+        _tablename,
         (
             SELECT array_agg(column_name)
             FROM dbmirror2.column_info
@@ -127,6 +129,7 @@ BEGIN
         SELECT seqid, trgdepth INTO oooseqid, oootrgdepth
         FROM dbmirror2.pending_data
         WHERE xid = txid_current()
+        AND tablename = _tablename
         AND oldctid = NEW.ctid;
 
         IF FOUND THEN
@@ -135,7 +138,7 @@ BEGIN
                 -- known way for operations to arrive out of order. This
                 -- warning must be investigated if it's ever logged.
                 RAISE WARNING 'oootrgdepth (%) <= pg_trigger_depth() (%) (% ON %, OLD: %, NEW: %)',
-                    oootrgdepth, pg_trigger_depth(), TG_OP, tablename, OLD, NEW;
+                    oootrgdepth, pg_trigger_depth(), TG_OP, _tablename, OLD, NEW;
             END IF;
 
             FOR pdrecord IN pdcursor (oooseqid := oooseqid) LOOP
@@ -154,7 +157,7 @@ BEGIN
         (seqid, tablename, op, xid, olddata, newdata, oldctid, trgdepth)
     VALUES (
         nextseqid,
-        tablename,
+        _tablename,
         lower(left(TG_OP, 1)),
         txid_current(),
         olddata,


### PR DESCRIPTION
The README should make it self-explanatory that I'm just copying MasterSetup.sql from the dbmirror2 repository.

The only change from there is https://github.com/metabrainz/dbmirror2/commit/7ba642243b34ac22e02fd2a0a15eaf1543386a35.