### PR TITLE
Fix echoing the command to be run

### DIFF
--- a/admin/run
+++ b/admin/run
@@ -47,6 +47,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PERL_CARTON_PATH=/home/musicbrainz/carton-local
 
 command_full_path=$(which "$1")
+command_verbatim=$1
 shift
 
 if [[ $command_full_path =~ admin/cron/.*\.sh$ ]]
@@ -71,7 +72,7 @@ then
   pre_command="sudo --preserve-env --set-home -u musicbrainz -- $pre_command"
 fi
 
-echo "Running '$*' and logging at '$log_file_path'..."
+echo "Running '$command_verbatim $*' and logging at '$log_file_path'..."
 if [[ -t 1 ]]
 then
   exec $pre_command "$command_full_path" "$@" 2>&1 | TZ=Z ts %FT%.TZ | tee -a "$log_file_path"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

`admin/run` prints command arguments only.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Save the command itself in a variable before shifting arguments, then use it when printing the command to be run.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Try `admin/run ls /` in a test container
* [x] Try `admin/run tac` in a test container