### PR TITLE
RunExport: remove --nodbmirror2 from ExportAllTables

### DIFF
--- a/admin/RunExport
+++ b/admin/RunExport
@@ -63,7 +63,6 @@ echo Making database snapshot
     --compress \
     --replication-callback "$MB_SERVER_ROOT/admin/CopyReplication $TEMP_DIR" \
     --database MAINTENANCE \
-    --nodbmirror2 \
     || exit $?
 
 if [ "$WITH_FULL_EXPORT" ]


### PR DESCRIPTION
By removing this flag, the `--dbmirror2` value will default to `REPLICATION_USE_DBMIRROR2` from DBDefs.pm, which will be set to 1 in the production-cron container. This will cause ExportAllTables to dump both dbmirror v1 and v2 packets.