### PR TITLE
ExportAllTables.t: remove --nodbmirror2 flags

### DIFF
--- a/script/create_test_db.sh
+++ b/script/create_test_db.sh
@@ -26,6 +26,7 @@ echo "
   DROP SCHEMA IF EXISTS wikidocs CASCADE;
   DROP SCHEMA IF EXISTS sitemaps CASCADE;
   DROP SCHEMA IF EXISTS json_dump CASCADE;
+  DROP SCHEMA IF EXISTS dbmirror2 CASCADE;
 
   CREATE SCHEMA musicbrainz;
   CREATE SCHEMA statistics;
@@ -34,7 +35,8 @@ echo "
   CREATE SCHEMA event_art_archive;
   CREATE SCHEMA wikidocs;
   CREATE SCHEMA sitemaps;
-  CREATE SCHEMA json_dump;" | ./admin/psql $DATABASE 2>&1
+  CREATE SCHEMA json_dump;
+  CREATE SCHEMA dbmirror2;" | ./admin/psql $DATABASE 2>&1
 ` || ( echo "$OUTPUT" && exit 1 )
 
 echo `date` : Creating MusicBrainz Schema
@@ -96,6 +98,7 @@ OUTPUT=`./admin/psql $DATABASE <./admin/sql/json_dump/CreateIndexes.sql 2>&1` ||
 
 echo `date` : Creating replication setup
 OUTPUT=`./admin/psql $DATABASE <./admin/sql/ReplicationSetup.sql 2>&1` || ( echo "$OUTPUT" && exit 1 )
+OUTPUT=`./admin/psql $DATABASE <./admin/sql/dbmirror2/ReplicationSetup.sql 2>&1` || ( echo "$OUTPUT" && exit 1 )
 
 echo `date` : Set up pgtap extension
 OUTPUT=`echo "CREATE EXTENSION pgtap WITH SCHEMA public;" | ./admin/psql $DATABASE 2>&1` || ( echo "$OUTPUT" && exit 1 )

--- a/t/script/ExportAllTables.t
+++ b/t/script/ExportAllTables.t
@@ -75,7 +75,6 @@ test all => sub {
         '--output-dir', $output_dir,
         '--database', 'TEST_FULL_EXPORT',
         '--compress',
-        '--nodbmirror2',
     );
 
     my $quoted_output_dir = shell_quote($output_dir);
@@ -106,7 +105,6 @@ test all => sub {
         '--output-dir', $output_dir,
         '--database', 'TEST_FULL_EXPORT',
         '--compress',
-        '--nodbmirror2',
     );
 
     my $system_db = Databases->get('SYSTEM');
@@ -129,6 +127,9 @@ test all => sub {
     );
 
     my $replication_setup = File::Spec->catfile($root, 'admin/sql/ReplicationSetup.sql');
+    system 'sh', '-c' => "$psql TEST_FULL_EXPORT < $replication_setup";
+
+    $replication_setup = File::Spec->catfile($root, 'admin/sql/dbmirror2/ReplicationSetup.sql');
     system 'sh', '-c' => "$psql TEST_FULL_EXPORT < $replication_setup";
 
     $exec_sql->(<<~"SQL");


### PR DESCRIPTION
Although the tests in ExportAllTables.t don't test dbmirror2 packets (t/script/dbmirror2.t exists for that), it's useful to have them enabled in order to check that having them enabled doesn't interfere with the production of old packets.

Note that removing the flag from ExportAllTables doesn't actually produce v2 packets in this test, because the v1 packets are created by manually inserting rows into the dbmirror_pending* tables, not via replication triggers (so there is no data to be dumped from the dbmirror2 schema).  This is why I've kept the --nodbmirror2 flag on the LoadReplicationChanges invocation: there is no v2 packet to load here.