### PR TITLE
MBS-12412: Fail gracefully if requesting an invalid ID in edit-cover-art 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -599,10 +599,14 @@ sub edit_cover_art : Chained('load') PathPart('edit-cover-art') Args(1) Edit {
 
     my @artwork = @{
         $c->model('Artwork')->find_by_release($entity)
-    } or $c->detach('/error_404');
+    } or $c->detach('/error_404', [ l('This release has no artwork.') ]);
+
     $c->model('CoverArtType')->load_for(@artwork);
 
-    my $artwork = first { $_->id == $id } @artwork;
+    my $artwork = first { $_->id == $id } @artwork or $c->detach(
+        '/error_404',
+        [ l('Found no artwork with ID “{id}”.', { id => $id }) ],
+    );
 
     $c->stash({
         artwork => $artwork,


### PR DESCRIPTION
### Fix MBS-12412

This would ISE if the user requested an ID that could not be found by the `first{}` call, since we later tried to access `$artwork->types`.

This fails more gracefully now, like we already did when the release had no artwork at all; I also added specific messages for the 404 page for both cases.