### PR TITLE
Add basic event-related tests

### DIFF
--- a/admin/sql/InsertTestData.sql
+++ b/admin/sql/InsertTestData.sql
@@ -251,6 +251,9 @@ INSERT INTO artist (id, gid, name, sort_name)
 INSERT INTO artist (id, gid, name, sort_name, comment) VALUES
     (9, '2fed031c-0e89-406e-b9f0-3d192637907a', 'Test Alias', 'Kate Bush', 'Second');
 
+INSERT INTO event (id, gid, name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, time, type, cancelled, setlist, comment, ended)
+    VALUES (59357, 'ca1d24c1-1999-46fd-8a95-3d4108df5cb2', 'BBC Open Music Prom', 2022, 9, 1, 2022, 9, 1, '19:30:00', 1, 'f', NULL, '2022, Prom 60', 't');
+
 INSERT INTO l_artist_recording (id, link, entity0, entity1) VALUES (1, 1, 8, 2);
 INSERT INTO l_artist_recording (id, link, entity0, entity1, edits_pending) VALUES (2, 1, 9, 2, 1);
 INSERT INTO l_artist_recording (id, link, entity0, entity1) VALUES (3, 2, 8, 3);

--- a/lib/MusicBrainz/Server/Data/Role/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Area.pm
@@ -16,7 +16,7 @@ sub find_by_area {
     my $table = $self->can('_find_by_area_table') ? $self->_find_by_area_table : $self->_table;
     my $columns = $self->_columns;
     my $order_by = $self->can('_find_by_area_order') ? $self->_find_by_area_order : 'name, id';
-    my $extra_conditions;
+    my $extra_conditions = '';
 
     if ($table eq 'editor') {
         $extra_conditions = " AND (editor.privs & $SPAMMER_FLAG) = 0";

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Events.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Events.pm
@@ -1,0 +1,45 @@
+package t::MusicBrainz::Server::Controller::Area::Events;
+use strict;
+use warnings;
+
+use Test::Routine;
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Mechanize', 't::Context';
+
+=head1 DESCRIPTION
+
+This test checks whether the Events tab for an area correctly lists events
+from places located in another area contained in this one.
+
+=cut
+
+test 'Events from contained areas are shown' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+event');
+
+    $mech->get_ok(
+      '/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed/events',
+      'Fetch the area events page',
+    );
+    html_ok($mech->content);
+
+    $mech->content_contains(
+        'BBC Open Music Prom',
+        'An event from a contained area is present',
+    );
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Places.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Places.pm
@@ -1,0 +1,45 @@
+package t::MusicBrainz::Server::Controller::Area::Places;
+use strict;
+use warnings;
+
+use Test::Routine;
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Mechanize', 't::Context';
+
+=head1 DESCRIPTION
+
+This test checks whether the Places tab for an area correctly lists places
+located in another area contained in this one.
+
+=cut
+
+test 'Places from contained areas are shown' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c, '+event');
+
+    $mech->get_ok(
+      '/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed/places',
+      'Fetch the area places page',
+    );
+    html_ok($mech->content);
+
+    $mech->content_contains(
+        'Royal Albert Hall',
+        'An place from a contained area is present',
+    );
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/lib/t/MusicBrainz/Server/Controller/Event/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Event/Show.pm
@@ -1,0 +1,56 @@
+package t::MusicBrainz::Server::Controller::Event::Show;
+use strict;
+use warnings;
+
+use Test::Routine;
+use MusicBrainz::Server::Test qw( html_ok );
+use utf8;
+
+with 't::Mechanize', 't::Context';
+
+=head1 DESCRIPTION
+
+This test checks whether basic event data is correctly listed on an event's
+index (main) page.
+
+=cut
+
+test 'Basic event data appears the index page' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+event');
+
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2',
+        'Fetched event index page',
+    );
+    html_ok($mech->content);
+
+    $mech->title_like(
+        qr/BBC Open Music Prom/,
+        'The page title contains the event name',
+    );
+    $mech->content_like(qr/Kwamé Ryan/, 'The first performer name is listed');
+    $mech->content_like(
+        qr/BBC Concert Orchestra/,
+        'The second performer name is listed',
+    );
+    $mech->content_like(qr/2022-09-01/, 'The event date is listed');
+    $mech->content_like(qr/19:30/, 'The event time is listed');
+    $mech->content_like(qr/Concert/, 'The event type is listed');
+    $mech->content_like(qr/Royal Albert Hall/, 'The place is listed');
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/lib/t/MusicBrainz/Server/Controller/Event/Tags.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Event/Tags.pm
@@ -1,0 +1,89 @@
+package t::MusicBrainz::Server::Controller::Event::Tags;
+use strict;
+use warnings;
+
+use Test::Routine;
+use MusicBrainz::Server::Test qw( html_ok );
+
+with 't::Mechanize', 't::Context';
+
+=head1 DESCRIPTION
+
+This test checks whether event tagging is working correctly. It checks both
+up- and downvoting, plus withdrawing/removing tags.
+
+=cut
+
+test 'Event tagging (up/downvoting, withdrawing)' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+
+    MusicBrainz::Server::Test->prepare_test_database($test->c);
+
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags',
+        'Fetched the event tags page',
+    );
+    html_ok($mech->content);
+    $mech->content_contains(
+        'Nobody has tagged this yet',
+        'The "not tagged yet" message is present',
+    );
+
+    $mech->get_ok('/login');
+    $mech->submit_form(
+        with_fields => {username => 'new_editor', password => 'password'},
+    );
+
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags/upvote?tags=Broken, Fixmeplz',
+        'Upvoted tags "broken" and "fixmeplz"',
+    );
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags',
+        'Fetched the event tags page again',
+    );
+    html_ok($mech->content);
+    $mech->content_contains('broken', 'Upvoted tag "broken" is present');
+    $mech->content_contains('fixmeplz', 'Upvoted tag "fixmeplz" is present');
+
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags/withdraw?tags=Broken, Fixmeplz',
+        'Withdrew tags "broken" and "fixmeplz"',
+    );
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags',
+        'Fetched the event tags page again',
+    );
+    html_ok($mech->content);
+    $mech->content_lacks('broken', 'Withdrawn tag "broken" is missing');
+    $mech->content_lacks('fixmeplz', 'Withdrawn tag "fixmeplz" is missing');
+
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags/downvote?tags=Broken, Fixmeplz',
+        'Downvoted tags "broken" and "fixmeplz"',
+    );
+    $mech->get_ok(
+        '/event/ca1d24c1-1999-46fd-8a95-3d4108df5cb2/tags',
+        'Fetched the event tags page again',
+    );
+    html_ok($mech->content);
+    $mech->content_contains('broken', 'Downvoted tag "broken" is present');
+    $mech->content_contains(
+        'fixmeplz',
+        'Downvoted tag "fixmeplz" is present',
+    );
+
+};
+
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/t/sql/event.sql
+++ b/t/sql/event.sql
@@ -1,0 +1,27 @@
+SET client_min_messages TO 'WARNING';
+
+INSERT INTO area (id, gid, name, type) VALUES
+  (3983, 'b9576171-3434-4d1b-8883-165ed6e65d2f', 'Kensington and Chelsea', 2),
+  ( 221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1),
+  (  38, '71bbafaa-e825-3e15-8ca9-017dcad1748b', 'Canada', 1);
+
+INSERT INTO country_area (area) VALUES (38), (221);
+INSERT INTO iso_3166_1 (area, code) VALUES (38, 'CA'), (221, 'GB');
+
+INSERT INTO place (id, gid, name, type, address, area, coordinates, begin_date_year)
+    VALUES (729, '4352063b-a833-421b-a420-e7fb295dece0', 'Royal Albert Hall', 2, 'Kensington Gore, London SW7 2AP', 3983, '(51.50105,-0.17748)', 1871);
+
+INSERT INTO event (id, gid, name, begin_date_year, begin_date_month, begin_date_day, end_date_year, end_date_month, end_date_day, time, type, cancelled, setlist, comment, ended)
+    VALUES (59357, 'ca1d24c1-1999-46fd-8a95-3d4108df5cb2', 'BBC Open Music Prom', 2022, 9, 1, 2022, 9, 1, '19:30:00', 1, 'f', NULL, '2022, Prom 60', 't');
+
+INSERT INTO artist (id, gid, name, sort_name, begin_date_year, begin_date_month, type, area, gender)
+    VALUES (1294951, 'f72a5b32-449f-4090-9a2a-ebbdd8d3c2e5', 'Kwamé Ryan', 'Ryan, Kwamé', 1970, NULL, 1, 38, 1),
+           (831634, 'dfeba5ea-c967-4ad2-9cdd-3cffb4320143', 'BBC Concert Orchestra', 'BBC Concert Orchestra', 1952, 1, 5, 221, NULL);
+
+INSERT INTO link (id, link_type) VALUES (199471, 794), (199854, 807), (199871, 806), (199999, 356);
+
+INSERT INTO l_area_area (id, link, entity0, entity1) VALUES (400588, 199999, 221, 3983);
+
+INSERT INTO l_event_place (id, link, entity0, entity1) VALUES (51345, 199471, 59357, 729);
+
+INSERT INTO l_artist_event (id, link, entity0, entity1) VALUES (160762, 199854, 831634, 59357), (160763, 199871, 1294951, 59357);


### PR DESCRIPTION
Since @amCap1712 put together some basic event test data for Sir, I thought I might as well use it to write a few event and event-adjacent tests. It's not a full suite of tests for event or anything, but it's a bit better than nothing at all.