### PR TITLE
MBS-12387: Add titles to URL editor edit buttons

### DIFF
--- a/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
+++ b/root/static/scripts/edit/components/ExternalLinkAttributeDialog.js
@@ -231,6 +231,7 @@ const ExternalLinkAttributeDialog = (props: PropsT): React.MixedElement => {
       buttonContent={null}
       buttonProps={{
         className: 'icon edit-item',
+        title: l('Edit Attributes'),
       }}
       buttonRef={buttonRef}
       id="external-link-attribute-dialog"

--- a/root/static/scripts/edit/components/URLInputPopover.js
+++ b/root/static/scripts/edit/components/URLInputPopover.js
@@ -144,7 +144,7 @@ const URLInputPopover = (props: PropsT): React.MixedElement => {
     <ButtonPopover
       buildChildren={buildPopoverChildren}
       buttonContent={null}
-      buttonProps={{className: 'icon edit-item'}}
+      buttonProps={{className: 'icon edit-item', title: l('Edit URL')}}
       buttonRef={popoverButtonRef}
       id="url-input-popover"
       isOpen={isOpen}


### PR DESCRIPTION
### Implement MBS-12387

It's not always clear what the pencil means, especially when there's one for the URL itself and one for each relationship the URL is used in. This adds the titles directly to the popover/dialog files, since they are only used for this.