### PR TITLE
Bump react-table to 7.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "querystring": "0.2.0",
     "react": "18.1.0",
     "react-dom": "18.1.0",
-    "react-table": "7.3.2",
+    "react-table": "7.8.0",
     "redux": "3.6.0",
     "shell-quote": "1.7.3",
     "shelljs": "0.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,10 +4678,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-table@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.3.2.tgz#def43b9777e0ef5839608104a557c3f1c365b2ff"
-  integrity sha512-n8ZvC8tzuDa3qK9PFlcXmo58JCRfxg/3LlvG8YJywvsQKiCnTfK6lDSp8a3WsAOBcZvBtGgyeoke7pBfAdB8jA==
+react-table@7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
+  integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
 
 react@18.1.0:
   version "18.1.0"


### PR DESCRIPTION
This fixes a warning about incorrect peer dependencies since upgrading React to v18.

Reviewing the react-table changelog, I didn't spot any breaking changes. Mostly just bug fixes and feature improvements.