### PR TITLE
MBS-12417: Update Soundcloud cleanup to remove ? parameters

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -4083,7 +4083,9 @@ const CLEANUPS: CleanupEntries = {
       },
     ],
     clean: function (url) {
-      return url.replace(/^(https?:\/\/)?((www|m)\.)?soundcloud\.com(\/#!)?/, 'https://soundcloud.com');
+      url = url.replace(/^(https?:\/\/)?((www|m)\.)?soundcloud\.com(\/#!)?/, 'https://soundcloud.com');
+      url = url.replace(/^(https:\/\/soundcloud\.com\/)(?!(?:search|tags)[\/?#])([^?]+).*$/, '$1$2');
+      return url;
     },
     validate: function (url) {
       return {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -4099,11 +4099,6 @@ limited_link_type_combinations: [
   },
   // SoundCloud
   {
-                     input_url: 'https://soundcloud.com/metro-luminal',
-             input_entity_type: 'artist',
-    expected_relationship_type: 'soundcloud',
-  },
-  {
                      input_url: 'http://m.soundcloud.com/octobersveryown',
              input_entity_type: 'artist',
     expected_relationship_type: 'soundcloud',
@@ -4120,6 +4115,12 @@ limited_link_type_combinations: [
              input_entity_type: 'artist',
     expected_relationship_type: 'soundcloud',
             expected_clean_url: 'https://soundcloud.com/alisonwonderland',
+  },
+  {
+                     input_url: 'https://soundcloud.com/erin-thomson-776648435?utm_source=clipboard&utm_medium=text&utm_campaign=social_sharing',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'soundcloud',
+            expected_clean_url: 'https://soundcloud.com/erin-thomson-776648435',
   },
   {
                      input_url: 'https://soundcloud.com/dimmakrecords',


### PR DESCRIPTION
### Implement MBS-12417

This makes an exception for search/tags pages since we want to keep the ? there to drop them more easily. Otherwise, these seem to be all tracking fluff.