### PR TITLE
MBS-9188: Improve LinkedIn URL cleanup

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -2731,7 +2731,7 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?([^/]+\\.)?linkedin\\.com/', 'i')],
     restrict: [LINK_TYPES.socialnetwork],
     clean: function (url) {
-      return url.replace(/^https?:\/\/([^/]+\.)?linkedin\.com/, 'https://$1linkedin.com');
+      return url.replace(/^https?:\/\/(?:[^/]+\.)?linkedin\.com\/([^?#]+).*$/, 'https://www.linkedin.com/$1');
     },
   },
   'livefans': {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2727,12 +2727,13 @@ limited_link_type_combinations: [
                      input_url: 'http://www.linkedin.com/pub/trevor-muzzy/5/282/538',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
+            expected_clean_url: 'https://www.linkedin.com/pub/trevor-muzzy/5/282/538',
   },
   {
-                     input_url: 'http://www.linkedin.com/in/legselectric',
+                     input_url: 'http://ca.linkedin.com/in/didier-charette-0630b1b6?original_referer=https%3A%2F%2Fduckduckgo.com%2F',
              input_entity_type: 'artist',
     expected_relationship_type: 'socialnetwork',
-            expected_clean_url: 'https://www.linkedin.com/in/legselectric',
+            expected_clean_url: 'https://www.linkedin.com/in/didier-charette-0630b1b6',
   },
   // livedoor
   {


### PR DESCRIPTION
### Implement MBS-9188

The subdomain is apparently just for display language and whatnot but does not change the content nor block it, so we should
standardize to the www. default.
It seems that no ? parameters are useful (seem to be for tracking only) so we should drop them too.
