### PR TITLE
MBS-12418: Also format artists in setlists if there's no MBID link

### DIFF
--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -592,14 +592,18 @@ test('formatSetlist', function (t) {
     '</strong> post-text<br/><br/>' +
     'e <a href="/work/b831b5a4-e1a9-4516-bb50-b6eed446fc9b">work 1</a> ' +
       '[not a link]<br/>' +
-    'plain text artist<br/>' +
+    '<strong>Artist: ' +
+    'plain text artist' +
+    '</strong><br/>' +
     '<span class="comment">' +
       'comment [b831b5a4-e1a9-4516-bb50-b6eed446fc9b|not a link]' +
     '</span><br/>' +
     '<span class="comment">' +
       'comment &lt;a href=&quot;#&quot;&gt;also not a link&lt;/a&gt;' +
     '</span><br/>' +
-    'nor a link &lt;a href=&quot;#&quot;&gt;here&lt;/a&gt;<br/>' +
+    '<strong>Artist: ' +
+    'nor a link &lt;a href=&quot;#&quot;&gt;here&lt;/a&gt;' +
+    '</strong><br/>' +
     'plain text work<br/><br/><br/>',
   );
 });


### PR DESCRIPTION
### Implement MBS-12418:

I think having no "Artist:" nor `<strong>` for artist lines unless there is an MBID link was actually not really intended, and in any case it seems silly - it means that unless a link is added, there's literally no point in adding `@ ` vs `* ` in the setlist.
This makes it so that artist lines are always displayed starting with "Artist: " and in bold.