### PR TITLE
MBS-12420: Support comma-separated IDs for edit search types again

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditIDSet.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditIDSet.pm
@@ -1,0 +1,23 @@
+package MusicBrainz::Server::EditSearch::Predicate::EditIDSet;
+use Moose;
+use namespace::autoclean;
+use List::AllUtils qw( any );
+use MusicBrainz::Server::Validation qw( is_integer );
+
+extends 'MusicBrainz::Server::EditSearch::Predicate::Set';
+
+sub valid {
+    my ($self) = @_;
+
+    return 0 unless $self->arguments > 0;
+
+    # We support one edit type having multiple IDs (for historical edits)
+    for my $argument ($self->arguments) {
+        my @ids = split(/,/, $argument);
+        return 0 if any { !is_integer($_) } @ids;
+    }
+
+    return 1;
+}
+
+1;

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Set.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Set.pm
@@ -16,10 +16,12 @@ sub operator_cardinality_map {
 sub valid {
     my ($self) = @_;
 
+    return 0 unless $self->arguments > 0;
+
     # If you want to allow non-integer sets, please create ::IntegerSet, etc
     return 0 if any { !is_integer($_) } $self->arguments;
 
-    return $self->arguments > 0;
+    return 1;
 }
 
 sub combine_with_query {

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -8,6 +8,7 @@ use Moose::Util::TypeConstraints qw( enum role_type );
 use MusicBrainz::Server::Constants qw( $LIMIT_FOR_EDIT_LISTING entities_with );
 use MusicBrainz::Server::EditSearch::Predicate::Date;
 use MusicBrainz::Server::EditSearch::Predicate::ID;
+use MusicBrainz::Server::EditSearch::Predicate::EditIDSet;
 use MusicBrainz::Server::EditSearch::Predicate::Set;
 use MusicBrainz::Server::EditSearch::Predicate::Entity;
 use MusicBrainz::Server::EditSearch::Predicate::Editor;
@@ -32,7 +33,7 @@ my %field_map = (
     open_time => 'MusicBrainz::Server::EditSearch::Predicate::Date',
     close_time => 'MusicBrainz::Server::EditSearch::Predicate::Date',
     expire_time => 'MusicBrainz::Server::EditSearch::Predicate::Date',
-    type => 'MusicBrainz::Server::EditSearch::Predicate::Set',
+    type => 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet',
     status => 'MusicBrainz::Server::EditSearch::Predicate::Set',
     vote_count => 'MusicBrainz::Server::EditSearch::Predicate::VoteCount',
     editor => 'MusicBrainz::Server::EditSearch::Predicate::Editor',

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -60,13 +60,10 @@
                predicate_id(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::VoteCount';
                predicate_vote_count(field.field_name, field);
+             CASE 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet';
+               predicate_set(field.field_name, edit_types, field, 15, 1);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::Set';
-               SWITCH field.field_name;
-                 CASE 'type';
-                   predicate_set(field.field_name, edit_types, field, 15, 1);
-                 CASE 'status';
-                   predicate_set(field.field_name, status, field, 8);
-               END;
+               predicate_set(field.field_name, status, field, 8);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditNoteContent';
                predicate_edit_note_content(field.field_name, field);
              CASE 'MusicBrainz::Server::EditSearch::Predicate::EditSubscription';

--- a/t/lib/t/MusicBrainz/Server/EditSearch/Predicate/EditIDSet.pm
+++ b/t/lib/t/MusicBrainz/Server/EditSearch/Predicate/EditIDSet.pm
@@ -1,0 +1,90 @@
+package t::MusicBrainz::Server::EditSearch::Predicate::EditIDSet;
+use Test::Routine;
+use Test::More;
+use Test::Deep qw( cmp_set );
+
+use aliased 'MusicBrainz::Server::EditSearch::Query';
+use aliased 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet' => 'Field';
+
+test 'operator BETWEEN' => sub {
+    my $test = shift;
+    my $field = Field->new_from_input(
+        'type' =>
+        {
+            operator => '=',
+            args => [ 1, 2, 3, 4, 5 ]
+        }
+    );
+
+    ok(defined $field, 'did construct a field');
+    isa_ok($field, 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet');
+    is($field->operator, '=', 'handles the correct operator');
+    is($field->arguments, 5, 'has correct arguments');
+    cmp_set([$field->arguments], [1, 2, 3, 4, 5], 'has correct arguments');
+    is($field->valid, 1, 'is a valid set field');
+
+    my $query = Query->new( fields => [ $field ] );
+    $field->combine_with_query($query);
+
+    my ($where_clause) = $query->where;
+    my ($sql, $arglist) = @$where_clause;
+    is($sql, 'edit.type = any(?)', 'The WHERE clause is correct');
+
+    my @args = @$arglist;
+    cmp_set(
+      $args[0],
+      [1, 2, 3, 4, 5],
+      'The WHERE clause arguments are correct',
+    );
+    is(@args, 1, 'Only one array argument is passed');
+};
+
+test 'Comma-separated integer arguments are allowed' => sub {
+    my $test = shift;
+    my $field = Field->new_from_input(
+        'type' =>
+        {
+            operator => '=',
+            args => [ 1, 2, 3, '4,5' ]
+        }
+    );
+
+    ok(defined $field, 'did construct a field');
+    isa_ok($field, 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet');
+    is($field->arguments, 4, 'has correct arguments');
+    cmp_set([$field->arguments], [1, 2, 3, '4,5'], 'has correct arguments');
+    is($field->valid, 1, 'is a valid set field');
+
+    my $query = Query->new( fields => [ $field ] );
+    $field->combine_with_query($query);
+
+    my ($where_clause) = $query->where;
+    my ($sql, $arglist) = @$where_clause;
+    is($sql, 'edit.type = any(?)', 'The WHERE clause is correct');
+
+    my @args = @$arglist;
+    cmp_set(
+      $args[0],
+      [1, 2, 3, 4, 5],
+      'The WHERE clause arguments are correct',
+    );
+    is(@args, 1, 'Only one array argument is passed');
+};
+
+test 'Other non-integer arguments are rejected' => sub {
+    my $test = shift;
+    my $field = Field->new_from_input(
+        'type' =>
+        {
+            operator => '=',
+            args => [ 1, 2, 3, 'undefined' ]
+        }
+    );
+
+    ok(defined $field, 'did construct a field');
+    isa_ok($field, 'MusicBrainz::Server::EditSearch::Predicate::EditIDSet');
+    cmp_set([$field->arguments], [1, 2, 3, 'undefined'], 'has correct arguments');
+    is($field->valid, 0, 'is not a valid set field');
+};
+
+1;


### PR DESCRIPTION
### Fix MBS-12420

This was removed as a hack, but it was actually intended; it was only intended for edit type searches though, where the same edit type can have one current and one or more historical IDs and we want to search them as a group.
As such, rather than re-allow it for every set, I made a separate predicate for edit types. This still makes sure that either integers or comma-separated integers are passed.