### PR TITLE
MBS-12419: Block Genius.com links at release level

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -375,6 +375,12 @@ const linkToVideoMsg = N_l(
    to the relevant artist, label, etc. instead.`,
 );
 
+const linkAsLyricsMsg = N_l(
+  `This is a lyrics site. As such, links to the site should be added
+   at the release group level with the “lyrics” relationship,
+   rather than directly to any specific release.`,
+);
+
 /*
  * CLEANUPS entries have 2 to 5 of the following properties:
  *
@@ -5175,6 +5181,13 @@ entitySpecificRules.release = function (url) {
          Please add this Wikidata link to the release group instead,
          if appropriate.`,
       ),
+      result: false,
+      target: ERROR_TARGETS.ENTITY,
+    };
+  }
+  if (/^(https?:\/\/)?([^.\/]+\.)?genius\.com\//.test(url)) {
+    return {
+      error: linkAsLyricsMsg(),
       result: false,
       target: ERROR_TARGETS.ENTITY,
     };

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -2107,6 +2107,17 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://genius.com/The-beatles-she-loves-you-lyrics',
        only_valid_entity_types: ['work'],
   },
+  {
+                     input_url: 'http://genius.com/albums/The-dream/Terius-nash-1977',
+             input_entity_type: 'release',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'discographyentry',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'at the release group level',
+                                  target: 'entity',
+                                },
+  },
   // GeoNames
   {
                      input_url: 'http://www.geonames.org/6255147/asia.html',


### PR DESCRIPTION
### Implement MBS-12419

People seem to add quite a few of this as discography entry, or as a free download link if there is any link from the page to a place where it can be downloaded (or, sometimes, even if there isn't any).