### PR TITLE
MBS-12437 / MBS-12438: Limit overflow-wrap even more

### DIFF
--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -35,7 +35,7 @@ const EntityHeader = ({
   subHeading,
 }: Props): React.Element<typeof React.Fragment> => (
   <>
-    <div className={headerClass}>
+    <div className={'entityheader ' + headerClass}>
       {preHeader || null}
       <h1>
         {heading || <EntityLink entity={entity} />}

--- a/root/edit/details/EditUrl.js
+++ b/root/edit/details/EditUrl.js
@@ -38,7 +38,7 @@ const EditUrl = ({edit}: Props): React.Element<typeof React.Fragment> => {
           <tr>
             <th>{addColonText(l('URL'))}</th>
             <td className="old">
-              <a href={uri.old}>
+              <a className="url-entity-link" href={uri.old}>
                 <DiffSide
                   filter={DELETE}
                   newText={uri.new}
@@ -47,7 +47,7 @@ const EditUrl = ({edit}: Props): React.Element<typeof React.Fragment> => {
               </a>
             </td>
             <td className="new">
-              <a href={uri.new}>
+              <a className="url-entity-link" href={uri.new}>
                 <DiffSide
                   filter={INSERT}
                   newText={uri.new}

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -127,7 +127,7 @@ const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
       >
         {isolateText(url)}
       </span>
-    ) : <a href={url}>{url}</a>}
+    ) : <a className="url-entity-link" href={url}>{url}</a>}
     {' '}
     <DeletedLink
       allowNew={allowNew}
@@ -154,6 +154,7 @@ type EntityLinkProps = {
   +subPath?: string,
 
   // ...anchorProps
+  className?: string,
   href?: string,
   title?: string,
   +target?: '_blank',
@@ -243,9 +244,15 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   }
 
   anchorProps.href = href;
+
   if (hover) {
     anchorProps.title = hover;
   }
+
+  if (entity.entityType === 'url') {
+    anchorProps.className = 'url-entity-link';
+  }
+
   content = disableLink
     ? (
       <span

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -19,7 +19,6 @@ body {
 a {
     color:@link-default;
     text-decoration: none;
-    overflow-wrap: anywhere;
 
     &:visited {
         color:@link-visited;
@@ -157,11 +156,6 @@ pre code {
     margin-left: 16px;
     margin-right: 16px;
     clear: both;
-
-    a {
-        // So menu links don't wrap (TODO: review with responsive header)
-        overflow-wrap: normal;
-    }
 
     img.logo {
         width: @logo-width;
@@ -1070,6 +1064,10 @@ div.artwork { position: relative; width: 250px; }
 .homepage div.artwork img {
     max-width: 125px;
     max-height: 125px;
+}
+
+.entityheader, .url-entity-link {
+    overflow-wrap: anywhere;
 }
 
 .artwork-image, .artwork-pdf {


### PR DESCRIPTION
### Fix MBS-12437 / MBS-12438

Still a bunch of things are wrapping that probably should not, so let's do this the other way around and start from the minimum
amount of wrapped things. This wraps only entity headers (where anything too long will break the interface for no good use), and URL entity links, which can get really long, both on EntityLink and in the Edit URL edit display.
Edit note texts and tags on tag lists already wrap in what seems to be a useful way without complaints, so leaving those in too.

Examples that *should* still wrap: 
* https://musicbrainz.org/edit/78435051 (edit URL display with a very long URL)
* https://musicbrainz.org/edit/87598821 (remove URL rel display, with long URL that has been removed)
* https://musicbrainz.org/release/77b12c1f-9fa7-4985-b291-9b717b7454b8 (release page with an absurdly long one-word title)
* https://musicbrainz.org/edit/31405687 (edit with a crazy long one-word edit note)

Examples that no longer wrap, but do in beta:
* https://musicbrainz.org/artist/9f16acb6-58de-4690-82dd-14771cfc3d08/recordings
* https://musicbrainz.org/edit/90192268