### PR TITLE
MBS-12395: Report for videos in mediums that shouldn't support video

### DIFF
--- a/lib/MusicBrainz/Server/Report/VideosInNonVideoMediums.pm
+++ b/lib/MusicBrainz/Server/Report/VideosInNonVideoMediums.pm
@@ -1,0 +1,91 @@
+package MusicBrainz::Server::Report::VideosInNonVideoMediums;
+use Moose;
+
+with 'MusicBrainz::Server::Report::RecordingReport',
+     'MusicBrainz::Server::Report::FilterForEditor::RecordingID';
+
+my $NON_VIDEO_FORMATS = join(',', (
+    1, # CD
+    3, # SACD
+    6, # MiniDisc
+    7, # Vinyl
+    8, # Cassette
+    10, # Reel-to-reel
+    14, # Wax Cylinder
+    15, # Piano Roll
+    16, # DCC
+    25, # HDCD
+    29, # 7" Vinyl
+    30, # 10" Vinyl
+    31, # 12" Vinyl
+    34, # 8cm CD
+    36, # SHM-CD
+    37, # HQCD
+    38, # Hybrid SACD
+    42, # Enhanced CD
+    44, # DTS CD
+    50, # Edison Diamond Disc
+    51, # Flexi-disc
+    52, # 7" Flexi-disc
+    53, # Shellac
+    54, # 10" Shellac
+    55, # 12" Shellac
+    56, # 7" Shellac
+    57, # SHM-SACD
+    58, # Pathé disc
+    61, # Copy Control CD
+    63, # Hybrid SACD (CD layer)
+    64, # Hybrid SACD (SACD layer)
+    67, # DualDisc (CD side)
+    70, # DVDplus (CD side)
+    73, # Phonograph record
+    74, # PlayTape
+    75, # HiPac
+    81, # VinylDisc (Vinyl side)
+    82, # VinylDisc (CD side)
+    83, # Microcassette
+    84, # SACD (2 channels)
+    85, # SACD (multichannel)
+    86, # Hybrid SACD (SACD layer, multichannel)
+    87, # Hybrid SACD (SACD layer, 2 channels)
+    88, # SHM-SACD (multichannel)
+    89, # SHM-SACD (2 channels)
+    90, # Tefifon
+    128, # DataPlay
+    129, # Mixed Mode CD
+));
+
+sub query {<<~"SQL"}
+    SELECT
+        q.id AS recording_ID,
+        row_number() OVER (ORDER BY q.aname COLLATE musicbrainz, q.rname COLLATE musicbrainz)
+    FROM (
+        SELECT DISTINCT
+            r.id,
+            ac.name AS aname,
+            r.name AS rname
+        FROM
+            recording r
+            JOIN artist_credit ac ON r.artist_credit = ac.id
+            JOIN track t ON t.recording = r.id
+            JOIN medium m ON t.medium = m.id
+        WHERE
+            r.video IS TRUE
+            AND t.is_data_track IS FALSE
+            AND m.format IN ($NON_VIDEO_FORMATS)
+    ) AS q
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -104,6 +104,7 @@ use MusicBrainz::Server::PagedReport;
     TracksWithoutTimes
     TracksWithSequenceIssues
     UnlinkedPseudoReleases
+    VideosInNonVideoMediums
     WikidataLinksWithMultipleEntities
     WorkSameTypeAsParent
 );
@@ -201,6 +202,7 @@ use MusicBrainz::Server::Report::TracksNamedWithSequence;
 use MusicBrainz::Server::Report::TracksWithoutTimes;
 use MusicBrainz::Server::Report::TracksWithSequenceIssues;
 use MusicBrainz::Server::Report::UnlinkedPseudoReleases;
+use MusicBrainz::Server::Report::VideosInNonVideoMediums;
 use MusicBrainz::Server::Report::WikidataLinksWithMultipleEntities;
 use MusicBrainz::Server::Report::WorkSameTypeAsParent;
 

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -513,6 +513,10 @@ const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
           content={l('Recordings with dates in the future')}
           reportName="RecordingsWithFutureDates"
         />
+        <ReportsIndexEntry
+          content={l('Video recordings in non-video mediums')}
+          reportName="VideosInNonVideoMediums"
+        />
       </ul>
 
       <h2>{l('Places')}</h2>

--- a/root/report/VideosInNonVideoMediums.js
+++ b/root/report/VideosInNonVideoMediums.js
@@ -1,0 +1,49 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import RecordingList from './components/RecordingList';
+import ReportLayout from './components/ReportLayout';
+import type {ReportDataT, ReportRecordingT} from './types';
+
+const VideosInNonVideoMediums = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportRecordingT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows recordings marked as video, but that appear in
+       at least one medium that does not support videos.`,
+    )}
+    entityType="recording"
+    extraInfo={exp.l(
+      `There are two main possibilities here: either the recording being
+       marked as a video is correct, but the format is not (a CD should be a
+       VCD, for example), or the recording is being used for both a video and 
+       and audio-only recording, in which case the two should be split since
+       video recordings should always be separate. If you split the
+       recordings, consider whether it makes sense to link them with a
+       {doc_link|music video relationship}.`,
+      {doc_link: '/relationship/ce3de655-7451-44d1-9224-87eb948c205d'},
+    )}
+    filtered={filtered}
+    generated={generated}
+    title={l('Video recordings in non-video mediums')}
+    totalEntries={pager.total_entries}
+  >
+    <RecordingList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default VideosInNonVideoMediums;

--- a/root/server/components.js
+++ b/root/server/components.js
@@ -269,6 +269,7 @@ module.exports = {
   'report/TracksWithSequenceIssues': require('../report/TracksWithSequenceIssues'),
   'report/TracksWithoutTimes': require('../report/TracksWithoutTimes'),
   'report/UnlinkedPseudoReleases': require('../report/UnlinkedPseudoReleases'),
+  'report/VideosInNonVideoMediums': require('../report/VideosInNonVideoMediums'),
   'report/WikidataLinksWithMultipleEntities': require('../report/WikidataLinksWithMultipleEntities'),
   'report/WorkSameTypeAsParent': require('../report/WorkSameTypeAsParent'),
   'search/SearchIndex': require('../search/SearchIndex'),


### PR DESCRIPTION
### Implement MBS-12395

This will help find both videos that have been wrongly reused in audio-only releases, and stuff like video CDs marked as just "CD". I hand-picked a list of formats that do not support video rather than a list of those that can because I'd rather have missing entries if we add a new format that doesn't support video than false positives if we add a new format that does.