### PR TITLE
MBS-12447: Also show area-series rels on series page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -16,7 +16,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'series',
     relationships => {
         cardinal => ['edit'],
-        subset => {show => ['artist', 'label', 'place', 'recording', 'release_group', 'series', 'url', 'work']},
+        subset => {show => ['area', 'artist', 'label', 'place', 'recording', 'release_group', 'series', 'url', 'work']},
         default => ['url']
     },
 };


### PR DESCRIPTION
### Fix MBS-12447

We now allow area-series "held in", but the rels won't be displayed once it gets used without this change.