### PR TITLE
MBS-12457: Wrap overly long words in annotations

### DIFF
--- a/root/edit/details/AddAnnotation.js
+++ b/root/edit/details/AddAnnotation.js
@@ -47,6 +47,7 @@ const AddAnnotation = ({edit}: Props): React.Element<'table'> => {
           {display.html
             ? (
               <span
+                className="annotation-body"
                 dangerouslySetInnerHTML={{__html: display.html}}
               />
             ) : (

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -1101,6 +1101,10 @@ div.artwork { position: relative; width: 250px; }
     overflow: auto;
 }
 
+.annotation-body {
+    overflow-wrap: anywhere;
+}
+
 .annotation-collapsed,
 .review-collapsed,
 .wikipedia-extract-collapsed,


### PR DESCRIPTION
### Implement MBS-12457

This is a problem both in annotation pages and in annotation edits, so adding `"annotation-body"` to the annotations in edits
and just adding `overflow-wrap` to that. `position: relative` and `overflow: auto` don't seem to be problematic for the edit display.
