### PR TITLE
Add custom hydration event for userscripts

### DIFF
--- a/root/utility/hydrate.js
+++ b/root/utility/hydrate.js
@@ -139,6 +139,8 @@ export default function hydrate<
               </React.StrictMode>,
             );
           });
+          // Custom event that userscripts can listen for.
+          root.dispatchEvent(new Event('mb-hydration', {bubbles: true}));
         }
       }
     });


### PR DESCRIPTION
Currently it's difficult for userscripts to determine when hydration is completed so that it's safe to modify the page.  This adds a custom mb-hydration event that scripts can listen for.

Based on a suggestion by @ROpdebee in https://github.com/jesus2099/konami-command/issues/596#issuecomment-1154386261

I tested this by creating a new Greasemonkey script with the following code and observing that several events were logged.

```JS
document.addEventListener('mb-hydration', (event) => {
  console.log('Got mb-hydration event:', event);
});
```