### PR TITLE
MBS-12459: Mimic native tooltip position offset

### DIFF
--- a/root/static/scripts/timeline.js
+++ b/root/static/scripts/timeline.js
@@ -495,8 +495,8 @@ class TimelineLine {
       .css({
         'position': 'absolute',
         'display': 'none',
-        'top': y + 5,
-        'left': x + 5,
+        'top': y + 16,
+        'left': x + 12,
         'border': '1px solid #fdd',
         'padding': '2px',
         'background-color': '#fee',


### PR DESCRIPTION
# Problem

Timeline custom tooltips are very nice but they are always partially covered by my mouse cursor.
I have noticed that the timeline custom tooltips were closer to the mouse than were the native tooltips (`<*** title="native tooltip">`).

See [MBS-12459](https://tickets.metabrainz.org/browse/MBS-12459) for before/after photos on Windows 10.

# Solution

I changed the timeline.js custom tooltip position offset to match the position, relative to mouse cursor, of the native tooltip.

# Checklist for review

- [x] Test on Windows 10
- [x] Test on Linux
- [ ] Test on Mac (if anyone can do this)
- [x] Test on mobile (maybe custom tooltip will look too far away from the triggering line) (no native tooltip on mobile)