### PR TITLE
MBS-12458: Error if trying to load annotation for wrong entity

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Annotation.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Annotation.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Annotation;
 use Moose::Role -traits => 'MooseX::MethodAttributes::Role::Meta::Role';
 
+use List::AllUtils qw( any );
 use MusicBrainz::Server::Constants qw( :annotation entities_with );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
@@ -69,7 +70,10 @@ sub annotation_revision : Chained('load') PathPart('annotation') Args(1)
     }
 
     my $annotation = $c->model($self->{model})->annotation->get_by_id($id)
-        or $c->detach('/error_404');
+        or $c->detach(
+            '/error_404',
+            [ l('Found no annotation with ID “{id}”.', { id => $id }) ],
+        );
 
     $c->model('Editor')->load($annotation);
 
@@ -79,6 +83,16 @@ sub annotation_revision : Chained('load') PathPart('annotation') Args(1)
             $annotation_model->get_history($entity->id, @_);
         }
     );
+
+    if (!(scalar @$annotations) || !(any { $id == $_->{id} } @$annotations)) {
+        $c->stash(
+            message => l(
+                'The annotation with ID “{id}” is not associated with this entity.',
+                { id => $id },
+            )
+        );
+        $c->detach('/error_400')
+    }
 
     my %props = (
         annotation => $annotation->TO_JSON,


### PR DESCRIPTION
### Fix MBS-12458

The code was more than happy to load whichever annotation the passed ID was for, and then present it as if it was an annotation for the entity in question. This actually checks that the requested annotation is in the annotation history for that entity, and returns a bad request error otherwise.
I also added an actual message to the not found error returned if the ID does not exist, since the default "message: $id" was useless.