### PR TITLE
Remove seemingly useless test sql files

### DIFF
--- a/t/lib/t/MusicBrainz/Server/Data/MediumFormat.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/MediumFormat.pm
@@ -13,7 +13,6 @@ with 't::Context';
 test all => sub {
 
 my $test = shift;
-MusicBrainz::Server::Test->prepare_test_database($test->c, '+mediumformat');
 
 my $mf_data = MusicBrainz::Server::Data::MediumFormat->new(c => $test->c);
 

--- a/t/lib/t/MusicBrainz/Server/Data/ReleaseGroupType.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ReleaseGroupType.pm
@@ -13,7 +13,6 @@ with 't::Context';
 test all => sub {
 
 my $test = shift;
-MusicBrainz::Server::Test->prepare_test_database($test->c, '+releasegrouptype');
 
 my $rgt_data = MusicBrainz::Server::Data::ReleaseGroupType->new(c => $test->c);
 

--- a/t/lib/t/MusicBrainz/Server/Data/ReleaseStatus.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/ReleaseStatus.pm
@@ -13,7 +13,6 @@ with 't::Context';
 test all => sub {
 
 my $test = shift;
-MusicBrainz::Server::Test->prepare_test_database($test->c, '+releasestatus');
 
 my $lt_data = MusicBrainz::Server::Data::ReleaseStatus->new(c => $test->c);
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Release/Create.pm
@@ -122,13 +122,11 @@ sub create_edit
 sub prepare {
     my $c = shift;
     MusicBrainz::Server::Test->prepare_test_database($c);
-    MusicBrainz::Server::Test->prepare_test_database($c, '+releasestatus');
-    MusicBrainz::Server::Test->prepare_test_database($c, <<'SQL');
-    SET client_min_messages TO warning;
-    SET CONSTRAINTS ALL IMMEDIATE;
-    TRUNCATE release CASCADE;
-SQL
-
+    MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
+        SET client_min_messages TO warning;
+        SET CONSTRAINTS ALL IMMEDIATE;
+        TRUNCATE release CASCADE;
+        SQL
 }
 
 1;

--- a/t/lib/t/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
@@ -16,12 +16,11 @@ my $test = shift;
 my $c = $test->c;
 
 MusicBrainz::Server::Test->prepare_test_database($c);
-MusicBrainz::Server::Test->prepare_test_database($c, '+releasegrouptype');
-MusicBrainz::Server::Test->prepare_test_database($c, <<'SQL');
+MusicBrainz::Server::Test->prepare_test_database($c, <<~'SQL');
     SET client_min_messages TO warning;
     SET CONSTRAINTS ALL IMMEDIATE;
     TRUNCATE release_group CASCADE;
-SQL
+    SQL
 
 my $edit = create_edit($c);
 isa_ok($edit, 'MusicBrainz::Server::Edit::ReleaseGroup::Create');

--- a/t/sql/create_tracklist.sql
+++ b/t/sql/create_tracklist.sql
@@ -1,5 +1,0 @@
-
-SET client_min_messages TO WARNING;
-
-
-

--- a/t/sql/mediumformat.sql
+++ b/t/sql/mediumformat.sql
@@ -1,1 +1,0 @@
-SET client_min_messages TO 'WARNING';

--- a/t/sql/releasegrouptype.sql
+++ b/t/sql/releasegrouptype.sql
@@ -1,7 +1,0 @@
-
-SET client_min_messages TO 'warning';
-
-
-
-
-

--- a/t/sql/releasestatus.sql
+++ b/t/sql/releasestatus.sql
@@ -1,3 +1,0 @@
-
-SET client_min_messages TO 'warning';
-


### PR DESCRIPTION
These used to be useful 10 years ago but all the needed data is now in the initial database set, so they do effectively nothing. `create_tracklist` isn't even called anywhere.