### PR TITLE
MBS-12470: Fix broken unknown language statistics

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -247,6 +247,9 @@ sub languages_scripts : Path('languages-scripts')
     my %languages = map { $_->iso_code_3 => $_ }
         grep { defined $_->iso_code_3 } $c->model('Language')->get_all();
 
+    # Since we look at the language (not the stat) list later, we need this
+    $languages{'null'} = undef;
+
     my $script_prefix = 'count.release.script';
     my %scripts = map { $_->iso_code => $_ } $c->model('Script')->get_all();
 

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -999,7 +999,7 @@ my %stats = (
                 q{SELECT COALESCE(l.iso_code_3::text, 'null'), COUNT(r.gid) AS count
                 FROM release r FULL OUTER JOIN language l
                     ON r.language=l.id
-                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0
+                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0 OR l.id IS NULL
                 GROUP BY l.iso_code_3},
             );
 

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -776,10 +776,11 @@ my %stats = (
             my ($self, $sql) = @_;
 
             my $data = $sql->select_list_of_lists(
-                q{SELECT COALESCE(l.iso_code_3::text, 'null'), COUNT(wl.work) AS count
-                FROM work_language wl FULL OUTER JOIN language l
-                    ON wl.language=l.id
-                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0
+                q{SELECT COALESCE(l.iso_code_3::text, 'null'), COUNT(w.gid) AS count
+                FROM work w
+                LEFT JOIN work_language wl ON wl.work=w.id
+                FULL OUTER JOIN language l ON wl.language=l.id
+                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0 OR l.id IS NULL
                 GROUP BY l.iso_code_3},
             );
 

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -775,14 +775,17 @@ my %stats = (
         CALC => sub {
             my ($self, $sql) = @_;
 
-            my $data = $sql->select_list_of_lists(
-                q{SELECT COALESCE(l.iso_code_3::text, 'null'), COUNT(w.gid) AS count
-                FROM work w
-                LEFT JOIN work_language wl ON wl.work=w.id
+            my $data = $sql->select_list_of_lists(<<~'SQL');
+                         SELECT coalesce(l.iso_code_3::text, 'null'),
+                                count(w.gid) AS count
+                           FROM work w
+                      LEFT JOIN work_language wl ON wl.work=w.id
                 FULL OUTER JOIN language l ON wl.language=l.id
-                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0 OR l.id IS NULL
-                GROUP BY l.iso_code_3},
-            );
+                          WHERE l.iso_code_2t IS NOT NULL
+                             OR l.frequency > 0
+                             OR l.id IS NULL
+                       GROUP BY l.iso_code_3
+                SQL
 
             my %dist = map { @$_ } @$data;
 
@@ -996,13 +999,16 @@ my %stats = (
         CALC => sub {
             my ($self, $sql) = @_;
 
-            my $data = $sql->select_list_of_lists(
-                q{SELECT COALESCE(l.iso_code_3::text, 'null'), COUNT(r.gid) AS count
-                FROM release r FULL OUTER JOIN language l
-                    ON r.language=l.id
-                WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0 OR l.id IS NULL
-                GROUP BY l.iso_code_3},
-            );
+            my $data = $sql->select_list_of_lists(<<~'SQL');
+                         SELECT coalesce(l.iso_code_3::text, 'null'),
+                                count(r.gid) AS count
+                           FROM release r
+                FULL OUTER JOIN language l ON r.language=l.id
+                          WHERE l.iso_code_2t IS NOT NULL
+                             OR l.frequency > 0
+                             OR l.id IS NULL
+                       GROUP BY l.iso_code_3
+                SQL
 
             my %dist = map { @$_ } @$data;
 

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -885,6 +885,11 @@ const stats = {
     color: '#ff0000',
     label: l('Works with ISWCs'),
   },
+  'count.work.language.null': {
+    category: 'work-languages',
+    color: '#ff0000',
+    label: l('Works with no language set'),
+  },
   'count.work.type.null': {
     category: 'work-types',
     color: '#ff0000',


### PR DESCRIPTION
### Fix MBS-12470

See commit messages. No getting back the 10 years of lost stats, but...

The number collected in the meantime is not 0 because I guess there's some languages `WHERE l.iso_code_2t IS NOT NULL OR l.frequency > 0` which do not have an `iso_code_3` but still have releases or works using them? Didn't look too deep into it, but maybe we should.