### PR TITLE
MBS-12464: Also display event-work rels in Related Works

### DIFF
--- a/root/components/RelatedWorks.js
+++ b/root/components/RelatedWorks.js
@@ -18,6 +18,7 @@ import StaticRelationshipsDisplay from './StaticRelationshipsDisplay';
 const targetEntityTypes = [
   'area',
   'artist',
+  'event',
   'label',
   'place',
   'work',


### PR DESCRIPTION
### Fix MBS-12464

Not sure what was the reason to restrict it to these `targetEntityTypes` but it probably makes sense to list event here, if only for premiered at