### PR TITLE
MBS-12472: Show genre edit history links for all users

### DIFF
--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -30,13 +30,15 @@ const GenreSidebar = ({genre}: Props): React.Element<'div'> => {
     <div id="sidebar">
       <ExternalLinks empty entity={genre} />
 
-      {isRelationshipEditor($c.user) ? (
-        <EditLinks entity={genre}>
-          <AnnotationLinks entity={genre} />
+      <EditLinks entity={genre}>
+        {isRelationshipEditor($c.user) ? (
+          <>
+            <AnnotationLinks entity={genre} />
 
-          <RemoveLink entity={genre} />
-        </EditLinks>
-      ) : null}
+            <RemoveLink entity={genre} />
+          </>
+        ) : null}
+      </EditLinks>
       <LastUpdated entity={genre} />
     </div>
   );


### PR DESCRIPTION
### Fix MBS-12472

I put the relationship editor check on the wrong level originally. Compare with `AreaSidebar`.