### PR TITLE
Rewrite "Test X" test names

### DIFF
--- a/t/lib/t/MusicBrainz/DataStore/Redis.pm
+++ b/t/lib/t/MusicBrainz/DataStore/Redis.pm
@@ -24,7 +24,7 @@ my $args = DBDefs->DATASTORE_REDIS_ARGS;
 $args->{database} = $args->{test_database};
 my $redis = MusicBrainz::DataStore::Redis->new(%$args);
 
-test 'Test database selected' => sub {
+test 'Database is still selected in new Redis copy' => sub {
     my $some_value = rand();
     $redis->set('26fe2bfb-73dd-4660-8946-bd14c899163b', $some_value);
 
@@ -38,7 +38,7 @@ test 'Test database selected' => sub {
     $redis->_connection->flushdb;
 };
 
-test 'Test key setting/retrieving' => sub {
+test 'Key setting/retrieving' => sub {
     is($redis->get('does-not-exist'), undef, 'Non-existent key returns undef');
 
     $redis->set('string', 'Esperándote');
@@ -65,7 +65,7 @@ test 'Test key setting/retrieving' => sub {
     $redis->_connection->flushdb;
 };
 
-test 'Test setting key expiration' => sub {
+test 'Setting key expiration' => sub {
     $redis->set('int', 23);
     is($redis->get('int'), 23, 'Retrieved expected integer');
 

--- a/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
+++ b/t/lib/t/MusicBrainz/DataStore/RedisMulti.pm
@@ -49,7 +49,7 @@ test 'Databases are separate' => sub {
     $redis2->clear;
 };
 
-test 'Test key setting/retrieving' => sub {
+test 'Key setting/retrieving' => sub {
     is($redis_multi->get('does-not-exist'), undef, 'Non-existent key returns undef');
 
     $redis_multi->set('string', 'Esperándote');
@@ -111,7 +111,7 @@ test 'Test key setting/retrieving' => sub {
     $redis_multi->clear;
 };
 
-test 'Test setting key expiration' => sub {
+test 'Setting key expiration' => sub {
     $redis_multi->set('int', 23);
     $redis_multi->expire_at('int', time() + 2);
     ok($redis_multi->exists('int'), 'int still exists');

--- a/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
+++ b/t/lib/t/MusicBrainz/Script/RemoveEmptyURLs.pm
@@ -15,7 +15,7 @@ and have no pending edits.
 
 =cut
 
-test 'Test the RemoveEmpty script for URLs' => sub {
+test 'The RemoveEmpty script deletes the expected URLs' => sub {
 
 my $test = shift;
 my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Admin/PrivilegeSearch.pm
@@ -29,7 +29,7 @@ test 'Privilege search is blocked for non-admins' => sub {
     );
 };
 
-test 'Test privilege search results' => sub {
+test 'Privilege search results are correct' => sub {
     my $test = shift;
     my $mech = $test->mech;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Create.pm
@@ -14,7 +14,7 @@ unprivileged users cannot create areas.
 
 =cut
 
-test 'Test adding a new (non-ended) area' => sub {
+test 'Adding a new (non-ended) area' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -57,7 +57,7 @@ test 'Test adding a new (non-ended) area' => sub {
     );
 };
 
-test 'Test area creation is blocked for unprivileged users' => sub {
+test 'Area creation is blocked for unprivileged users' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Edit.pm
@@ -14,7 +14,7 @@ unprivileged users cannot edit areas.
 
 =cut
 
-test 'Test editing a (non-ended) area' => sub {
+test 'Editing a (non-ended) area' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -55,7 +55,7 @@ test 'Test editing a (non-ended) area' => sub {
     );
 };
 
-test 'Test area editing is blocked for unprivileged users' => sub {
+test 'Area editing is blocked for unprivileged users' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/AnnotationRevision.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/AnnotationRevision.pm
@@ -10,7 +10,7 @@ and whether they display the entirety of the annotation.
 
 =cut
 
-test 'Test annotation revision pages' => sub {
+test 'Annotation revision pages display full annotation' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Create.pm
@@ -17,7 +17,7 @@ and minimal data, plus some edge cases.
 
 my $artist_page_regexp = qr{/artist/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})};
 
-test 'Test creating artist with most fields' => sub {
+test 'Creating artist with most fields filled in' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
@@ -124,7 +124,7 @@ test 'Test creating artist with most fields' => sub {
     );
 };
 
-test 'Test creating artists with only the minimal amount of fields' => sub {
+test 'Creating artist with only the minimal amount of fields' => sub {
     my $test = shift;
     my $mech = $test->mech;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditExternalLinks.pm
@@ -17,7 +17,7 @@ data does not enter link edits.
 
 =cut
 
-test 'Test editing external links for an artist' => sub {
+test 'Editing external links for an artist' => sub {
 
     my $test = shift;
     my $mech = $test->mech;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EditRelationships.pm
@@ -22,7 +22,7 @@ and modified when editing artists, including several edge cases.
 
 =cut
 
-test 'Test adding a relationship' => sub {
+test 'Adding a relationship' => sub {
     my $test = shift;
     my ($c, $mech) = ($test->c, $test->mech);
 
@@ -88,7 +88,7 @@ test 'Test adding a relationship' => sub {
 };
 
 
-test 'Test editing a relationship' => sub {
+test 'Editing a relationship' => sub {
     my $test = shift;
     my ($c, $mech) = ($test->c, $test->mech);
 
@@ -321,7 +321,7 @@ test 'Test editing a relationship' => sub {
 };
 
 
-test 'Test removing a relationship' => sub {
+test 'Removing a relationship' => sub {
     my $test = shift;
     my ($c, $mech) = ($test->c, $test->mech);
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Edits.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Edits.pm
@@ -12,7 +12,7 @@ This test checks whether artist edits are correctly listed under both the
 
 =cut
 
-test 'Test that edits appear on the edit lists' => sub {
+test 'Edits appear on the edit lists' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -12,7 +12,7 @@ in artist pages (RGs, recordings, works).
 
 =cut
 
-test 'Test overview (release group) filtering' => sub {
+test 'Overview (release group) filtering' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -156,7 +156,7 @@ test 'Test overview (release group) filtering' => sub {
     );
 };
 
-test 'Test event page filtering' => sub {
+test 'Event page filtering' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -239,7 +239,7 @@ test 'Test event page filtering' => sub {
     );
 };
 
-test 'Test recording page filtering' => sub {
+test 'Recording page filtering' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;
@@ -293,7 +293,7 @@ test 'Test recording page filtering' => sub {
     );
 };
 
-test 'Test work page filtering' => sub {
+test 'Work page filtering' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
@@ -11,7 +11,7 @@ recordings for the artist, both on the site itself and on the JSON-LD data.
 
 =cut
 
-test 'Test artists recording page' => sub {
+test 'Artist recordings page contains the expected data and JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
@@ -11,7 +11,7 @@ relationships for the artist, and also the expected JSON-LD data.
 
 =cut
 
-test 'Test artists relationships page' => sub {
+test 'Artist relationships page contains the expected data and JSON-LD' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Releases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Releases.pm
@@ -11,7 +11,7 @@ releases for the artist.
 
 =cut
 
-test 'Test artists releases page' => sub {
+test 'Artist releases page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Split.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Split.pm
@@ -67,7 +67,7 @@ test 'Split artist remove all collaboration relationships for that artist' => su
     );
 };
 
-test 'Test splitting an artist' => sub {
+test 'Splitting an artist creates the right edit' => sub {
     my $test = shift;
 
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/CDStub/Browse.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDStub/Browse.pm
@@ -11,7 +11,7 @@ This test checks whether the Browse CD Stubs page shows data as expected.
 
 =cut
 
-test 'Test data display on Browse CD Stubs page' => sub {
+test 'Browse CD Stubs page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/CDStub/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDStub/Show.pm
@@ -12,7 +12,7 @@ shows data as expected.
 
 =cut
 
-test 'Test CD stub page display' => sub {
+test 'CD stub page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/SetDurations.pm
@@ -12,7 +12,7 @@ entering edits.
 
 =cut
 
-test 'Test setting track lengths based on disc ID' => sub {
+test 'Setting track lengths based on disc ID' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/CDTOC/Show.pm
@@ -12,7 +12,7 @@ itself and the releases the disc ID is attached to.
 
 =cut
 
-test 'Test disc ID page display' => sub {
+test 'Disc ID page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/ISRC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ISRC/Show.pm
@@ -12,7 +12,7 @@ on the ISRC index page.
 
 =cut
 
-test 'Test ISRC index page' => sub {
+test 'ISRC index page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/ISWC/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ISWC/Show.pm
@@ -12,7 +12,7 @@ index page, and whether different ISWC formats all reach the same page.
 
 =cut
 
-test 'Test ISWC index page' => sub {
+test 'ISWC index page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
@@ -12,7 +12,7 @@ with 't::Mechanize', 't::Context';
 
 =cut
 
-test 'Test instrument artists page' => sub {
+test 'Instrument artists page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Create.pm
@@ -13,7 +13,7 @@ unprivileged users cannot create instruments.
 
 =cut
 
-test 'Test adding a new instrument' => sub {
+test 'Adding a new instrument' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -58,7 +58,7 @@ test 'Test adding a new instrument' => sub {
     );
 };
 
-test 'Test instrument creation is blocked for unprivileged users' => sub {
+test 'Instrument creation is blocked for unprivileged users' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Edit.pm
@@ -13,7 +13,7 @@ unprivileged users cannot edit instruments.
 
 =cut
 
-test 'Test editing an instrument' => sub {
+test 'Editing an instrument' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;
@@ -57,7 +57,7 @@ test 'Test editing an instrument' => sub {
     );
 };
 
-test 'Test instrument editing is blocked for unprivileged users' => sub {
+test 'Instrument editing is blocked for unprivileged users' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Recordings.pm
@@ -12,7 +12,7 @@ with 't::Mechanize', 't::Context';
 
 =cut
 
-test 'Test instrument recordings page' => sub {
+test 'Instrument recordings page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Releases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Releases.pm
@@ -11,7 +11,7 @@ with 't::Mechanize', 't::Context';
 
 =cut
 
-test 'Test instrument releases page' => sub {
+test 'Instrument releases page contains the expected data' => sub {
     my $test = shift;
     my $mech = $test->mech;
     my $c    = $test->c;

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/EditCoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/EditCoverArt.pm
@@ -6,7 +6,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Context', 't::Mechanize';
 
-test 'Test adding cover art' => sub {
+test 'Adding cover art' => sub {
     my $test = shift;
     my $c = $test->c;
     my $mech = $test->mech;

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/ReorderCoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/ReorderCoverArt.pm
@@ -6,7 +6,7 @@ use MusicBrainz::Server::Test qw( capture_edits );
 
 with 't::Context', 't::Mechanize';
 
-test 'Test reordering cover art' => sub {
+test 'Reordering cover art' => sub {
     my $test = shift;
     my $c = $test->c;
     my $mech = $test->mech;

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/GenreList.pm
@@ -13,7 +13,7 @@ This test ensures the full genre list at genre/all is working as intended.
 
 =cut
 
-test 'Test genre list is returned as expected' => sub {
+test 'Genre list is returned as expected' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/JSON/GenreList.pm
@@ -14,7 +14,7 @@ for fmt=json.
 
 =cut
 
-test 'Test genre list is returned as expected' => sub {
+test 'Genre list is returned as expected' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/2/TXT/GenreList.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/2/TXT/GenreList.pm
@@ -14,7 +14,7 @@ txt format.
 
 =cut
 
-test 'Test genre names list is returned as expected' => sub {
+test 'Genre names list is returned as expected' => sub {
     my $test = shift;
     my $c = $test->c;
 

--- a/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -19,7 +19,7 @@ my $c = $test->c;
 
 MusicBrainz::Server::Test->prepare_test_database($c, '+edit_relationship_delete');
 
-subtest 'Test edit creation/rejection' => sub {
+subtest 'Edit creation/rejection' => sub {
     my $rel = $c->model('Relationship')->get_by_id('artist', 'artist', 1);
     is($rel->edits_pending, 0);
 
@@ -66,8 +66,7 @@ subtest 'Creating as an auto-editor still requires voting' => sub {
     is($rel->edits_pending, 1, 'relationship should have an edit pending');
 };
 
-subtest 'Test edit acception' => sub {
-    # Test accepting the edit
+subtest 'Accepting the edit' => sub {
     my $edit = $c->model('Edit')->create(
         edit_type => $EDIT_RELATIONSHIP_DELETE,
         editor_id => 1,


### PR DESCRIPTION
This drops redundant "Test X" structure from test names, except those which just test one specific function, since "Test function_name" sounds fine to me there. This was suggested by @mwiencek. Nothing should break here, but submitting a PR rather than pushing to master so I can let the tests run before merge just in case I did a dumb.