### PR TITLE
Fix warning when displaying blank annotation text

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -69,11 +69,10 @@ role {
         my $annotation_model = $self->_annotation_model;
         my $old_annotation_id = $self->data->{old_annotation_id};
         my $old_annotation;
-        if (defined $old_annotation_id) {
-            $old_annotation = $old_annotation_id
-                ? $annotation_model->get_by_id($old_annotation_id)->{text}
-                : '';
-        }
+        $old_annotation = $annotation_model->get_by_id($old_annotation_id)->{text}
+            if defined $old_annotation_id && $old_annotation_id;
+        # blank annotation text is undefined even if annotation exists
+        $old_annotation = '' if !defined $old_annotation;
 
         my $data = {
             changelog      => $self->data->{changelog},


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Annotation text is stored as `Maybe[Str]` in the model `Entity/Annotation.pm` thus returning as undefined if blank. This triggered the following warning when displaying annotation edits:

    Use of uninitialized value $old_annotation in concatenation (.) or
    string at lib/MusicBrainz/Server/Edit/Annotation/Edit.pm line 81.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch appropriately defines `$old_annotation` so that it can be directly used as a string in the rest of the subroutine.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested with a local database by getting edits history after adding an annotation, reverting it and re-adding it.