### PR TITLE
MBS-12480 / MBS-12481: Support area-genre relationships

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -8,7 +8,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
     relationships   => {
         cardinal    => ['edit'],
         subset      => {
-            show => [qw( area artist label place series instrument release_group url )],
+            show => [qw( area artist genre label place series instrument release_group url )],
         },
         paged_subset => {
             recordings => ['recording'],

--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -225,6 +225,10 @@ import formatTrackLength from './utility/formatTrackLength';
 
   Event.prototype.entityType = 'event';
 
+  class Genre extends CoreEntity {}
+
+  Genre.prototype.entityType = 'genre';
+
   class Instrument extends CoreEntity {}
 
   Instrument.prototype.entityType = 'instrument';
@@ -506,6 +510,7 @@ import formatTrackLength from './utility/formatTrackLength';
   var coreEntityMapping = {
     artist:        Artist,
     event:         Event,
+    genre:         Genre,
     instrument:    Instrument,
     label:         Label,
     area:          Area,

--- a/root/static/scripts/relationship-editor/common/viewModel.js
+++ b/root/static/scripts/relationship-editor/common/viewModel.js
@@ -25,6 +25,7 @@ const addAnotherEntityLabels = {
   area: N_l('Add another area'),
   artist: N_l('Add another artist'),
   event: N_l('Add another event'),
+  genre: N_l('Add another genre'),
   instrument: N_l('Add another instrument'),
   label: N_l('Add another label'),
   place: N_l('Add another place'),


### PR DESCRIPTION
### Fix MBS-12480 / Implement MBS-12481

This allows using https://musicbrainz.org/relationship/25ed73f8-a864-42cf-8b9c-68db198dbe0e (which can only be added / edited from the area side at the moment, but that is ok since anyway both are privilege-editor only)