### PR TITLE
MBS-12477: Hide "Log in to edit" for privileged editor-only entities

### DIFF
--- a/root/layout/components/sidebar/AreaSidebar.js
+++ b/root/layout/components/sidebar/AreaSidebar.js
@@ -99,7 +99,7 @@ const AreaSidebar = ({area}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={area} />
 
-      <EditLinks entity={area}>
+      <EditLinks entity={area} requiresPrivileges>
         {isLocationEditor($c.user) ? (
           <>
             <AnnotationLinks entity={area} />

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -16,11 +16,13 @@ import EntityLink from '../../../static/scripts/common/components/EntityLink';
 type Props = {
   +children?: React.Node,
   +entity: CoreEntityT,
+  +requiresPrivileges?: boolean,
 };
 
 const EditLinks = ({
   children,
   entity,
+  requiresPrivileges = false,
 }: Props): React.Element<typeof React.Fragment> => {
   const $c = React.useContext(CatalystContext);
 
@@ -28,7 +30,7 @@ const EditLinks = ({
     <>
       <h2 className="editing">{l('Editing')}</h2>
       <ul className="links">
-        {$c.user ? children : (
+        {$c.user ? children : requiresPrivileges ? null : (
           <>
             <li>
               <RequestLogin $c={$c} text={l('Log in to edit')} />

--- a/root/layout/components/sidebar/GenreSidebar.js
+++ b/root/layout/components/sidebar/GenreSidebar.js
@@ -30,7 +30,7 @@ const GenreSidebar = ({genre}: Props): React.Element<'div'> => {
     <div id="sidebar">
       <ExternalLinks empty entity={genre} />
 
-      <EditLinks entity={genre}>
+      <EditLinks entity={genre} requiresPrivileges>
         {isRelationshipEditor($c.user) ? (
           <>
             <AnnotationLinks entity={genre} />

--- a/root/layout/components/sidebar/InstrumentSidebar.js
+++ b/root/layout/components/sidebar/InstrumentSidebar.js
@@ -61,7 +61,7 @@ const InstrumentSidebar = ({instrument}: Props): React.Element<'div'> => {
 
       <ExternalLinks empty entity={instrument} />
 
-      <EditLinks entity={instrument}>
+      <EditLinks entity={instrument} requiresPrivileges>
         {isRelationshipEditor($c.user) ? (
           <>
             <AnnotationLinks entity={instrument} />


### PR DESCRIPTION
### Implement MBS-12477

Since the vast majority of editors can't edit areas, genres or instruments when logged in, it seems better not to show "Log in to edit" when logged out in those entity types that require privileges. Privileged editors will know how to log in elsewhere anyway.