### PR TITLE
MBS-12484: Fix genre alias edit links display

### DIFF
--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -24,6 +24,7 @@ function canEdit($c: CatalystContextT, entityType: string) {
     switch (entityType) {
       case 'area':
         return isLocationEditor($c.user);
+      case 'genre':
       case 'instrument':
         return isRelationshipEditor($c.user);
       default:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem: MBS-12484
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Genre aliases page is showing edit links to non-privileged editors


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Update the React component `Aliases` to handle genre the same as instrument.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested in a local sample database by checking [aliases for “classical” genre](http://localhost:5000/genre/bf9955d6-c3eb-466d-95ca-30f3848fc9ea/aliases) as a relationship editor, then as a logged-in but unprivileged editor.