### PR TITLE
MBS-12506: Reorder quick links in more intuitive order

### DIFF
--- a/root/edit/components/ListHeader.js
+++ b/root/edit/components/ListHeader.js
@@ -46,9 +46,82 @@ const ListHeader = ({
           {l('Quick links:')}
         </th>
         <td>
-          {isSearch ? null : (
-            <a href="/search/edits">{l('Search for edits')}</a>
-          )}
+          {nonEmpty(username) && page === 'user_all' ? (
+            <>
+              <a href={`/user/${username}/edits/open`}>
+                <strong>
+                  {exp.l('Open edits for {user}', {user: username})}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {nonEmpty(username) && page !== 'user_all' ? (
+            <>
+              <a href={`/user/${username}/edits`}>
+                <strong>
+                  {exp.l('All edits for {user}', {user: username})}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {entity && entityUrlFragment && isEntityAllPage ? (
+            <>
+              <a href={`/${entityUrlFragment}/${entity.gid}/open_edits`}>
+                <strong>
+                  {entity.entityType === 'collection'
+                    ? l('Open edits for this collection')
+                    : l('Open edits for this entity')}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {entity && entityUrlFragment && isEntityOpenPage ? (
+            <>
+              <a href={`/${entityUrlFragment}/${entity.gid}/edits`}>
+                <strong>
+                  {entity.entityType === 'collection'
+                    ? l('All edits for this collection')
+                    : l('All edits for this entity')}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {page === 'subscribed' && !(openParam === '1') ? (
+            <>
+              <a href="/edit/subscribed?open=1">
+                <strong>
+                  {l('Open edits for your subscribed entities')}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {page === 'subscribed' && openParam === '1' ? (
+            <>
+              <a href="/edit/subscribed?open=0">
+                <strong>
+                  {l('All edits for your subscribed entities')}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {page === 'subscribed_editors' && !(openParam === '1') ? (
+            <>
+              <a href="/edit/subscribed_editors?open=1">
+                <strong>
+                  {l('Open edits for your subscribed editors')}
+                </strong>
+              </a>
+            </>
+          ) : null}
+          {page === 'subscribed_editors' && openParam === '1' ? (
+            <>
+              <a href="/edit/subscribed_editors?open=0">
+                <strong>
+                  {l('All edits for your subscribed editors')}
+                </strong>
+              </a>
+            </>
+          ) : null}
           {refineUrlArgs ? (
             <>
               {' | '}
@@ -58,86 +131,12 @@ const ListHeader = ({
                   refineUrlArgs,
                 )}
               >
-                {l('Refine this search')}
+                <strong>
+                  {l('Refine this search')}
+                </strong>
               </a>
             </>
           ) : null}
-          {nonEmpty(username) && page === 'user_all' ? (
-            <>
-              {' | '}
-              <a href={`/user/${username}/edits/open`}>
-                {exp.l('Open edits for {user}', {user: username})}
-              </a>
-            </>
-          ) : null}
-          {nonEmpty(username) && page !== 'user_all' ? (
-            <>
-              {' | '}
-              <a href={`/user/${username}/edits`}>
-                {exp.l('All edits for {user}', {user: username})}
-              </a>
-            </>
-          ) : null}
-          {entity && entityUrlFragment && isEntityAllPage ? (
-            <>
-              {' | '}
-              <a href={`/${entityUrlFragment}/${entity.gid}/open_edits`}>
-                {entity.entityType === 'collection'
-                  ? l('Open edits for this collection')
-                  : l('Open edits for this entity')}
-              </a>
-            </>
-          ) : null}
-          {entity && entityUrlFragment && isEntityOpenPage ? (
-            <>
-              {' | '}
-              <a href={`/${entityUrlFragment}/${entity.gid}/edits`}>
-                {entity.entityType === 'collection'
-                  ? l('All edits for this collection')
-                  : l('All edits for this entity')}
-              </a>
-            </>
-          ) : null}
-          {page === 'subscribed' && !(openParam === '1') ? (
-            <>
-              {' | '}
-              <a href="/edit/subscribed?open=1">
-                {l('Open edits for your subscribed entities')}
-              </a>
-            </>
-          ) : null}
-          {page === 'subscribed' && openParam === '1' ? (
-            <>
-              {' | '}
-              <a href="/edit/subscribed?open=0">
-                {l('All edits for your subscribed entities')}
-              </a>
-            </>
-          ) : null}
-          {page === 'subscribed_editors' && !(openParam === '1') ? (
-            <>
-              {' | '}
-              <a href="/edit/subscribed_editors?open=1">
-                {l('Open edits for your subscribed editors')}
-              </a>
-            </>
-          ) : null}
-          {page === 'subscribed_editors' && openParam === '1' ? (
-            <>
-              {' | '}
-              <a href="/edit/subscribed_editors?open=0">
-                {l('All edits for your subscribed editors')}
-              </a>
-            </>
-          ) : null}
-          {page === 'open' ? null : (
-            <>
-              {' | '}
-              <a href="/edit/open">
-                {l('Open edits')}
-              </a>
-            </>
-          )}
           {$c.user && page !== 'subscribed' ? (
             <>
               {' | '}
@@ -154,6 +153,14 @@ const ListHeader = ({
               </a>
             </>
           ) : null}
+          {page === 'open' ? null : (
+            <>
+              {' | '}
+              <a href="/edit/open">
+                {l('Open edits')}
+              </a>
+            </>
+          )}
           {$c.user ? (
             <>
               {' | '}
@@ -162,6 +169,14 @@ const ListHeader = ({
               </a>
             </>
           ) : null}
+          {isSearch ? null : (
+            <>
+              {' | '}
+              <a href="/search/edits">
+                {l('Search for edits')}
+              </a>
+            </>
+          )}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
[MBS-12506](https://tickets.metabrainz.org/browse/MBS-12506): Reorder quick links in more intuitive order


# Problem

Please look at the header ***Quick links*** link list in any basic edit list page (user, collection or entity edit history, for instance):

> **Quick links:**
> (1) Search for edits
> (2) Refine this search
> (3) All/Open edits for user/collection/entity
> (4) Open edits
> (5) All/Open edits for your subscribed entities/editors
> (6) Voting suggestions

Preview (current):

> **Quick links:** [Search for edits](https://musicbrainz.org/search/edits) | [Refine this search](https://musicbrainz.org/search/edits?conditions.0.name=David+Bowie&auto_edit_filter=&conditions.0.args.0=956&form_only=yes&order=desc&combinator=and&conditions.0.field=artist&negation=0&conditions.0.operator=%3D) | [All/Open edits for user/collection/entity](https://musicbrainz.org/artist/5441c29d-3602-4898-b1a1-b77fa23b8e50/open_edits) | [Open edits](https://musicbrainz.org/edit/open) | [All/Open edits for your subscribed entities/editors](https://musicbrainz.org/edit/subscribed) | [Voting suggestions](https://musicbrainz.org/vote)


The most often used important contextual links (2 and 3) are in the middle of general links, hard to find or notice and target with the mouse.


# Solution

Put contextual links first (and **in bold**) and generic links last:

> **Quick links:**
> (3) **All/Open edits for user/collection/entity**
> (2) **Refine this search**
> (5) All/Open edits for your subscribed entities/editors
> (4) Open edits
> (6) Voting suggestions
> (1) Search for edits

Preview:

> **Quick links:** [**All/Open edits for user/collection/entity**](https://musicbrainz.org/artist/5441c29d-3602-4898-b1a1-b77fa23b8e50/open_edits) | [**Refine this search**](https://musicbrainz.org/search/edits?conditions.0.name=David+Bowie&auto_edit_filter=&conditions.0.args.0=956&form_only=yes&order=desc&combinator=and&conditions.0.field=artist&negation=0&conditions.0.operator=%3D) | [All/Open edits for your subscribed entities/editors](https://musicbrainz.org/edit/subscribed) | [Open edits](https://musicbrainz.org/edit/open) | [Voting suggestions](https://musicbrainz.org/vote) | [Search for edits](https://musicbrainz.org/search/edits)

## Comparison when logged in

### Before

![image](https://user-images.githubusercontent.com/1401086/179980446-cadbdd7c-9dfa-49d8-a918-6d2367a51310.png)

### After

![image](https://user-images.githubusercontent.com/1401086/179981561-1e280802-ccd1-485a-8ceb-85b4c360dbed.png)

## Comparison when logged out

### Before

![image](https://user-images.githubusercontent.com/1401086/179981696-c8061ef3-3743-41d8-bbe4-a0455dec29d7.png)

### After

![image](https://user-images.githubusercontent.com/1401086/179982122-6d9140c1-ba71-4cfd-8929-4f0387ea0192.png)

# Action

**Maybe it's too much of a personal choice?** Please advise.
