### PR TITLE
Sync JSON dump container fixes to git

### DIFF
--- a/lib/MusicBrainz/Script/JSONDump.pm
+++ b/lib/MusicBrainz/Script/JSONDump.pm
@@ -77,7 +77,7 @@ our $TMP_EXPORT_DIR = tempdir(
     CLEANUP => 0,
 );
 
-Readonly our $BATCH_SIZE => 500;
+Readonly our $BATCH_SIZE => 100;
 
 sub create_json_dump {
     my ($self, $c, $table_name, %mbdump_options) = @_;

--- a/lib/MusicBrainz/Script/JSONDump/Incremental.pm
+++ b/lib/MusicBrainz/Script/JSONDump/Incremental.pm
@@ -83,6 +83,8 @@ sub handle_update_path($$$$) {
 sub should_follow_table($) {
     my ($self, $table) = @_;
 
+    return 0 if $table =~ /^documentation\./;
+
     return 0 if $table eq 'musicbrainz.area_type';
     return 0 if $table eq 'musicbrainz.artist_type';
     return 0 if $table eq 'musicbrainz.cdtoc';

--- a/lib/MusicBrainz/Script/Role/IncrementalDump.pm
+++ b/lib/MusicBrainz/Script/Role/IncrementalDump.pm
@@ -127,6 +127,11 @@ sub should_fetch_document($$) {
 sub should_follow_primary_key($) {
     my $pk = shift;
 
+    # Tag tables currently generate too many updates to process
+    # efficiently.
+    return 0 if $pk eq 'musicbrainz.tag.id';
+    return 0 if $pk =~ /_tag/;
+
     # Nothing in mbserver should update an artist_credit row on its own; we
     # treat them as immutable using a find_or_insert method. (It's possible
     # an upgrade script changed them, but that's unlikely.)

--- a/lib/MusicBrainz/Server/JSONLookup.pm
+++ b/lib/MusicBrainz/Server/JSONLookup.pm
@@ -28,6 +28,7 @@ sub json_lookup {
     # of this module. To lookup entity JSON without going through Catalyst.
     $c->stash({ inc => $inc });
     my $stash = WebServiceStash->new;
+    $stash->_data->{_json_dump} = 1;
 
     my $model = $ENTITIES{$entity_type}{model};
     my @entities = values %{ $c->model($model)->get_by_ids(@{$ids}) };


### PR DESCRIPTION
The following changes have been running in the production
musicbrainz-json-dump container, but weren't synced to git:

 * Documentation tables are ignored.

 * Tag tables are not followed for changes.  It's been determined that
   the current JSON dumps implementation can't keep up with the number
   of entities linked to these on an hourly basis.

 * The 500-track limit on recording relationships is disabled for JSON
   dumps.  This fixes an issue where we were hitting said limit for each
   batch of releases that exceeded 500 recordings in the batch.

 * The batch size is scaled down from 500 to 100 to help account for any
   increase in recording relationships for release batches.

 * Relationships for each release batch are loaded 500 entities at a
   time.