### PR TITLE
MBS-12515: Check _gid_redirect table exists before trying to use it

### DIFF
--- a/lib/MusicBrainz/Script/EntityDump.pm
+++ b/lib/MusicBrainz/Script/EntityDump.pm
@@ -266,7 +266,7 @@ sub core_entity {
         handle_rows($c, "${entity_type}_meta", 'id', $ids);
     }
 
-    if ($dump_gid_redirects) {
+    if ($dump_gid_redirects && $entity_properties->{mbid}{multiple}) {
         handle_rows($c, "${entity_type}_gid_redirect", 'new_id', $ids);
     }
 


### PR DESCRIPTION
### Fix MBS-12515

This was crashing on genres (now that they have relationships so this code can get run on them) since they don't have a _gid_redirect table, but the code assumed they all had. Changed to do the same kind of check we do for meta_table.