### PR TITLE
MBS-12520: Don't fail on removed annotations

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -69,17 +69,24 @@ role {
         my $annotation_model = $self->_annotation_model;
         my $old_annotation_id = $self->data->{old_annotation_id};
         my $old_annotation;
-        $old_annotation = $annotation_model->get_by_id($old_annotation_id)->{text}
+        my $old_annotation_text;
+
+        $old_annotation = $annotation_model->get_by_id($old_annotation_id)
             if defined $old_annotation_id && $old_annotation_id;
-        # blank annotation text is undefined even if annotation exists
-        $old_annotation = '' if !defined $old_annotation;
+
+        # If the annotated entity has been deleted, the annotation is gone
+        if (defined $old_annotation) {
+            $old_annotation_text = $old_annotation->{text};
+            # blank annotation text is undefined even if annotation exists
+            $old_annotation_text = '' if !defined $old_annotation_text;
+        }
 
         my $data = {
             changelog      => $self->data->{changelog},
             text           => $self->data->{text} || '',
             html           => format_wikitext($self->data->{text}),
             entity_type    => $entity_type,
-            defined $old_annotation_id ? ( old_annotation => '' . $old_annotation ) : (),
+            defined $old_annotation ? ( old_annotation => '' . $old_annotation_text ) : (),
         };
 
         unless ($self->preview) {


### PR DESCRIPTION
### Fix MBS-12520

When implementing this I forgot that if an entity is removed, so are all annotations for it, so the old annotation call on the edit will return undef.

I considered giving a different "This annotation was removed" message in this case, but honestly it does not seem useful for the editor since there's no diff to check anyway.