### PR TITLE
MBS-12525: Add fallback sucrase loader for Node.js < 16.12.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,7 +72,18 @@ Prerequisites
 
     Node.js is required to build (and optionally minify) our JavaScript and CSS.
     If you plan on accessing musicbrainz-server inside a web browser, you should
-    install Node and the package manager Yarn. Do this by running:
+    install Node and the package manager Yarn.
+
+    We currently run Node.js v16.16.0 in production.  While we try to support
+    all 16.x versions of Node, it's recommended to install one greater than or
+    equal to v16.13.0, as this is when the LTS line started and better matches
+    what we use and know works.  If your release of Ubuntu doesn't have such a
+    version of Node.js in its repositories, we can recommended the NodeSource
+    binary distributions, which we also use in production:
+
+        https://github.com/nodesource/distributions#installation-instructions
+
+    To install Node.js from either the Ubuntu or NodeSource repositories, run:
 
         sudo apt-get install nodejs
 

--- a/bin/sucrase-node
+++ b/bin/sucrase-node
@@ -2,7 +2,28 @@
 
 MB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 
+NODE_VERSION="$(node --version)"
+if [[ $NODE_VERSION =~ ^v16\. ]]
+then
+    NODE_MINOR_VERSION=$(echo "$NODE_VERSION" | sed 's/^v16\.\([0-9]\+\)\.[0-9]\+$/\1/')
+else
+    echo 'Node.js >= v16 is required. An LTS release (>= v16.13.0) is strongly recommended.'
+    exit 1
+fi
+
+# The "Experimental ESM Loader Hooks API" was updated in Node.js v16.12.0:
+# https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#2021-10-20-version-16120-current-richardlau
+#
+# It appears that version v16.13.0 (the first LTS release) is identical to
+# v16.12.0.
+if (( $NODE_MINOR_VERSION >= 12 ))
+then
+    LOADER="$MB_SERVER_ROOT"/root/utility/sucraseLoader.mjs
+else
+    LOADER="$MB_SERVER_ROOT"/root/utility/sucraseLoader.pre_v16_LTS.mjs
+fi
+
 exec node \
-    --experimental-loader "$MB_SERVER_ROOT"/root/utility/sucraseLoader.mjs \
+    --experimental-loader "$LOADER" \
     --no-warnings \
     "$@"

--- a/root/utility/sucraseLoader.mjs
+++ b/root/utility/sucraseLoader.mjs
@@ -34,12 +34,16 @@ const sucraseOptions = Object.freeze({
   transforms: ['jsx', 'flow'],
 });
 
+export function runSucraseTransform(rawSource) {
+  return sucraseTransform(rawSource.toString(), sucraseOptions).code;
+}
+
 export async function load(url, context, defaultLoad) {
   if (await isModule(url)) {
     const {source: rawSource} = await defaultLoad(url, {format: 'module'});
     return {
       format: 'module',
-      source: sucraseTransform(rawSource.toString(), sucraseOptions).code,
+      source: runSucraseTransform(rawSource),
     };
   }
   return defaultLoad(url, context, defaultLoad);
@@ -55,7 +59,7 @@ globalThis.React = require('react');\
 `;
 }
 
-async function isModule(url) {
+export async function isModule(url) {
   const ext = extname(url);
   if (ext === '.cjs') {
     return false;

--- a/root/utility/sucraseLoader.pre_v16_LTS.mjs
+++ b/root/utility/sucraseLoader.pre_v16_LTS.mjs
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import {
+  isModule,
+  runSucraseTransform,
+} from './sucraseLoader.mjs';
+
+export {
+  globalPreload as getGlobalPreloadCode,
+} from './sucraseLoader.mjs';
+
+export async function getFormat(url, context, defaultGetFormat) {
+  if (await isModule(url)) {
+    return {format: 'module'};
+  }
+  return defaultGetFormat(url, context, defaultGetFormat);
+}
+
+export async function transformSource(url, context, defaultTransformSource) {
+  if (context.format === 'module') {
+    const {source: rawSource} =
+      await defaultTransformSource(url, context, defaultTransformSource);
+    return {source: runSucraseTransform(rawSource)};
+  }
+  return defaultTransformSource(url, context, defaultTransformSource);
+}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12525

The bin/sucrase-node script added in 6aefc88 doesn't work in versions of Node.js prior to 16.12.0.  (16.13.0 was the first LTS release, and from the changelog appears to be identical to 16.12.0.)  This is because the ESM loader hooks API changed.

Since our INSTALL guide doesn't specify that you need an LTS release of v16, we should support older versions too.  A fallback loader using the pre-v16.12 API has been added for this cause.

I tested this inside a musicbrainz-docker dev container which still has Node v16.1.0 installed by simply running `./script/compile_resources.sh`.