### PR TITLE
MBS-11303: Access $c via React context APIs

### DIFF
--- a/root/account/EditProfile.js
+++ b/root/account/EditProfile.js
@@ -12,21 +12,17 @@ import * as React from 'react';
 import UserAccountLayout, {
   sanitizedAccountLayoutUser,
 } from '../components/UserAccountLayout.js';
+import {CatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import EditProfileForm
   from '../static/scripts/account/components/EditProfileForm.js';
 import type {EditProfileFormPropsT}
   from '../static/scripts/account/components/EditProfileForm.js';
 
-type Props = {
-  ...EditProfileFormPropsT,
-  +$c: CatalystContextT,
-};
-
-const EditProfile = ({
-  $c,
-  ...props
-}: Props): React.Element<typeof UserAccountLayout> | null => {
+const EditProfile = (
+  props: EditProfileFormPropsT,
+): React.Element<typeof UserAccountLayout> | null => {
+  const $c = React.useContext(CatalystContext);
   const user = $c.user;
   if (!user) {
     return null;

--- a/root/account/LostUsername.js
+++ b/root/account/LostUsername.js
@@ -16,7 +16,6 @@ import FormSubmit from '../components/FormSubmit.js';
 import Layout from '../layout/index.js';
 
 type LostUsernameFormT = FormT<{
-  +$c: CatalystContextT,
   +email: ReadOnlyFieldT<string>,
 }>;
 

--- a/root/account/Preferences.js
+++ b/root/account/Preferences.js
@@ -12,29 +12,31 @@ import * as React from 'react';
 import UserAccountLayout, {
   sanitizedAccountLayoutUser,
 } from '../components/UserAccountLayout.js';
+import {CatalystContext} from '../context.mjs';
 import PreferencesForm
   from '../static/scripts/account/components/PreferencesForm.js';
 import type {PreferencesFormPropsT}
   from '../static/scripts/account/components/PreferencesForm.js';
 import * as manifest from '../static/manifest.mjs';
 
-type Props = {
-  ...PreferencesFormPropsT,
-  +$c: $ReadOnly<{...CatalystContextT, user: UnsanitizedEditorT}>,
+const Preferences = (
+  props: PreferencesFormPropsT,
+): React.Element<typeof UserAccountLayout> | null => {
+  const $c = React.useContext(CatalystContext);
+  const user = $c.user;
+  if (!user) {
+    return null;
+  }
+  return (
+    <UserAccountLayout
+      entity={sanitizedAccountLayoutUser(user)}
+      page="preferences"
+      title={l('Preferences')}
+    >
+      <PreferencesForm {...props} />
+      {manifest.js('account/preferences')}
+    </UserAccountLayout>
+  );
 };
-
-const Preferences = ({
-  $c,
-  ...props
-}: Props): React.Element<typeof UserAccountLayout> => (
-  <UserAccountLayout
-    entity={sanitizedAccountLayoutUser($c.user)}
-    page="preferences"
-    title={l('Preferences')}
-  >
-    <PreferencesForm {...props} />
-    {manifest.js('account/preferences')}
-  </UserAccountLayout>
-);
 
 export default Preferences;

--- a/root/account/PreferencesSaved.js
+++ b/root/account/PreferencesSaved.js
@@ -10,25 +10,25 @@
 import * as React from 'react';
 
 import StatusPage from '../components/StatusPage.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 
-type Props = {
-  +$c: CatalystContextT,
+const PreferencesSaved = (): React.Element<typeof StatusPage> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <StatusPage title={l('Preferences')}>
+      <p>
+        {exp.l(
+          `Your preferences have been saved. Click {link|here} to
+           continue to your user page.`,
+          {
+            link: $c.user
+              ? '/user/' + encodeURIComponent($c.user.name)
+              : '/register',
+          },
+        )}
+      </p>
+    </StatusPage>
+  );
 };
-
-const PreferencesSaved = ({$c}: Props): React.Element<typeof StatusPage> => (
-  <StatusPage title={l('Preferences')}>
-    <p>
-      {exp.l(
-        `Your preferences have been saved. Click {link|here} to
-         continue to your user page.`,
-        {
-          link: $c.user
-            ? '/user/' + encodeURIComponent($c.user.name)
-            : '/register',
-        },
-      )}
-    </p>
-  </StatusPage>
-);
 
 export default PreferencesSaved;

--- a/root/admin/LockedUsernameUnlock.js
+++ b/root/admin/LockedUsernameUnlock.js
@@ -15,13 +15,11 @@ import Layout from '../layout/index.js';
 import expand2text from '../static/scripts/common/i18n/expand2text.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: SecureConfirmFormT,
   +username: string,
 };
 
 const LockedUsernameUnlock = ({
-  $c,
   form,
   username,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const LockedUsernameUnlock = ({
           {username: username},
         )}
       </p>
-      <form action={$c.req.uri} method="post" name="confirm">
+      <form method="post" name="confirm">
         <FormCsrfToken form={form} />
         <FormSubmit
           label="Yes, I’m sure"

--- a/root/admin/statistics-events/DeleteStatisticsEvent.js
+++ b/root/admin/statistics-events/DeleteStatisticsEvent.js
@@ -16,12 +16,10 @@ import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import type {StatisticsEventT} from './types.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +event: StatisticsEventT,
 };
 
 const DeleteStatisticsEvent = ({
-  $c,
   event,
 }: PropsT): React.Element<typeof Layout> => (
   <Layout fullWidth title={l('Remove statistics event')}>
@@ -47,7 +45,7 @@ const DeleteStatisticsEvent = ({
     <p>
       {l('Are you sure you want to remove this statistics event?')}
     </p>
-    <form action={$c.req.uri} method="post">
+    <form method="post">
       <FormSubmit label={l('Remove statistics event')} />
     </form>
   </Layout>

--- a/root/admin/statistics-events/StatisticsEventEditForm.js
+++ b/root/admin/statistics-events/StatisticsEventEditForm.js
@@ -12,7 +12,6 @@ import * as React from 'react';
 import FormCsrfToken from '../../components/FormCsrfToken.js';
 import FormRowTextLong from '../../components/FormRowTextLong.js';
 import FormSubmit from '../../components/FormSubmit.js';
-import {CatalystContext} from '../../context.mjs';
 
 import type {StatisticsEventFormT} from './types.js';
 
@@ -22,43 +21,40 @@ type PropsT = {
 
 const StatisticsEventForm = ({
   form,
-}: PropsT): React.Element<'form'> => {
-  const $c = React.useContext(CatalystContext);
-  return (
-    <form action={$c.req.uri} method="post">
-      <FormCsrfToken form={form} />
-      <div className="half-width">
-        <fieldset>
-          <legend>{l('Statistics event details')}</legend>
-          <FormRowTextLong
-            field={form.field.date}
-            label={addColonText(l('Date'))}
-            required
-            uncontrolled
-          />
-          <FormRowTextLong
-            field={form.field.title}
-            label={addColonText(l('Title'))}
-            required
-            uncontrolled
-          />
-          <FormRowTextLong
-            field={form.field.description}
-            label={addColonText(l('Description'))}
-            uncontrolled
-          />
-          <FormRowTextLong
-            field={form.field.link}
-            label={addColonText(l('Link'))}
-            uncontrolled
-          />
-        </fieldset>
-      </div>
-      <div className="row no-label">
-        <FormSubmit label={l('Submit')} />
-      </div>
-    </form>
-  );
-};
+}: PropsT): React.Element<'form'> => (
+  <form method="post">
+    <FormCsrfToken form={form} />
+    <div className="half-width">
+      <fieldset>
+        <legend>{l('Statistics event details')}</legend>
+        <FormRowTextLong
+          field={form.field.date}
+          label={addColonText(l('Date'))}
+          required
+          uncontrolled
+        />
+        <FormRowTextLong
+          field={form.field.title}
+          label={addColonText(l('Title'))}
+          required
+          uncontrolled
+        />
+        <FormRowTextLong
+          field={form.field.description}
+          label={addColonText(l('Description'))}
+          uncontrolled
+        />
+        <FormRowTextLong
+          field={form.field.link}
+          label={addColonText(l('Link'))}
+          uncontrolled
+        />
+      </fieldset>
+    </div>
+    <div className="row no-label">
+      <FormSubmit label={l('Submit')} />
+    </div>
+  </form>
+);
 
 export default StatisticsEventForm;

--- a/root/admin/wikidoc/CreateWikiDoc.js
+++ b/root/admin/wikidoc/CreateWikiDoc.js
@@ -16,7 +16,6 @@ import FormSubmit from '../../components/FormSubmit.js';
 import Layout from '../../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: FormT<{
     +csrf_token: FieldT<string>,
     +page: FieldT<string>,
@@ -25,13 +24,12 @@ type Props = {
 };
 
 const CreateWikiDoc = ({
-  $c,
   form,
 }: Props): React.Element<typeof Layout> => (
   <Layout fullWidth title={l('Add Page')}>
     <div id="content">
       <h1>{l('Add Page')}</h1>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <FormCsrfToken form={form} />
         <FormRowTextLong
           field={form.field.page}

--- a/root/admin/wikidoc/DeleteWikiDoc.js
+++ b/root/admin/wikidoc/DeleteWikiDoc.js
@@ -14,13 +14,11 @@ import FormSubmit from '../../components/FormSubmit.js';
 import Layout from '../../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: SecureConfirmFormT,
   +page: string,
 };
 
 const DeleteWikiDoc = ({
-  $c,
   form,
   page,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const DeleteWikiDoc = ({
                  page_uri: '/doc/' + encodeURIComponent(page),
                })}
       </p>
-      <form action={$c.req.uri} method="post" name="confirm">
+      <form method="post" name="confirm">
         <FormCsrfToken form={form} />
         <FormSubmit
           label={l('Yes, I\'m sure')}

--- a/root/admin/wikidoc/EditWikiDoc.js
+++ b/root/admin/wikidoc/EditWikiDoc.js
@@ -15,7 +15,6 @@ import FormSubmit from '../../components/FormSubmit.js';
 import Layout from '../../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +currentVersion: number,
   +form: FormT<{
     +csrf_token: FieldT<string>,
@@ -25,7 +24,6 @@ type Props = {
 };
 
 const EditWikiDoc = ({
-  $c,
   currentVersion,
   form,
   page,
@@ -33,7 +31,7 @@ const EditWikiDoc = ({
   <Layout fullWidth title={l('Update Page')}>
     <div id="content">
       <h1>{l('Update Page')}</h1>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <FormCsrfToken form={form} />
         <div className="row">
           <label>{l('Page:')}</label>

--- a/root/admin/wikidoc/WikiDocIndex.js
+++ b/root/admin/wikidoc/WikiDocIndex.js
@@ -12,6 +12,7 @@ import type {CellRenderProps} from 'react-table';
 
 import Layout from '../../layout/index.js';
 import Table from '../../components/Table.js';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import {isWikiTranscluder}
   from '../../static/scripts/common/utility/privileges.js';
@@ -19,7 +20,6 @@ import {isWikiTranscluder}
 import type {WikiDocT} from './types.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +pages: $ReadOnlyArray<WikiDocT>,
   +updatesRequired: boolean,
   +wikiIsUnreachable: boolean,
@@ -27,11 +27,11 @@ type PropsT = {
 };
 
 const WikiDocTable = ({
-  $c,
   pages,
   updatesRequired,
   wikiServer,
 }: PropsT) => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const columns = React.useMemo(
     () => {
       const nameColumn = {
@@ -145,50 +145,53 @@ const WikiDocTable = ({
   );
 };
 
-const WikiDocIndex = (props: PropsT): React.Element<typeof Layout> => (
-  <Layout fullWidth title={l('Transclusion Table')}>
-    <div className="content">
-      <h1>{l('Transclusion Table')}</h1>
-      <p>
-        {exp.l(
-          `Read the {doc|WikiDocs} documentation for an overview of how
-           transclusion works.`,
-          {doc: '/doc/WikiDocs'},
-        )}
-      </p>
-      {isWikiTranscluder(props.$c.user) ? (
-        <>
-          <ul>
-            <li key="create">
-              <a href="/admin/wikidoc/create">
-                {l('Add a new entry')}
-              </a>
-            </li>
-            <li key="history">
-              <a href="/admin/wikidoc/history">
-                {l('View transclusion history')}
-              </a>
-            </li>
-          </ul>
-          <p>
-            {exp.l(`<strong>Note:</strong> MediaWiki does not check to
-                    see if the version number matches the page name,
-                    it will take the version number and provide
-                    whatever page is associated with it. Make sure to
-                    double check your work when updating a page!`)}
-          </p>
-        </>
-      ) : null}
-
-      {props.wikiIsUnreachable ? (
-        <p style={{color: 'red', fontWeight: 'bold'}}>
-          {l('There was a problem accessing the wiki API.')}
+const WikiDocIndex = (props: PropsT): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <Layout fullWidth title={l('Transclusion Table')}>
+      <div className="content">
+        <h1>{l('Transclusion Table')}</h1>
+        <p>
+          {exp.l(
+            `Read the {doc|WikiDocs} documentation for an overview of how
+             transclusion works.`,
+            {doc: '/doc/WikiDocs'},
+          )}
         </p>
-      ) : null}
-    </div>
+        {isWikiTranscluder($c.user) ? (
+          <>
+            <ul>
+              <li key="create">
+                <a href="/admin/wikidoc/create">
+                  {l('Add a new entry')}
+                </a>
+              </li>
+              <li key="history">
+                <a href="/admin/wikidoc/history">
+                  {l('View transclusion history')}
+                </a>
+              </li>
+            </ul>
+            <p>
+              {exp.l(`<strong>Note:</strong> MediaWiki does not check to
+                      see if the version number matches the page name,
+                      it will take the version number and provide
+                      whatever page is associated with it. Make sure to
+                      double check your work when updating a page!`)}
+            </p>
+          </>
+        ) : null}
 
-    <WikiDocTable {...props} />
-  </Layout>
-);
+        {props.wikiIsUnreachable ? (
+          <p style={{color: 'red', fontWeight: 'bold'}}>
+            {l('There was a problem accessing the wiki API.')}
+          </p>
+        ) : null}
+      </div>
+
+      <WikiDocTable {...props} />
+    </Layout>
+  );
+};
 
 export default WikiDocIndex;

--- a/root/annotation/AnnotationComparison.js
+++ b/root/annotation/AnnotationComparison.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import ENTITIES from '../../entities.mjs';
+import {SanitizedCatalystContext} from '../context.mjs';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import DiffSide from '../static/scripts/edit/components/edit/DiffSide.js';
 import {INSERT, DELETE} from '../static/scripts/edit/utility/editDiff.js';
@@ -17,7 +18,6 @@ import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 import formatUserDate from '../utility/formatUserDate.js';
 
 type AnnotationComparisonProps = {
-  +$c: CatalystContextT,
   +entity: AnnotatedEntityT,
   +newAnnotation: AnnotationT,
   +numberOfRevisions: number,
@@ -25,12 +25,12 @@ type AnnotationComparisonProps = {
 };
 
 const AnnotationComparison = ({
-  $c,
   entity,
   newAnnotation,
   numberOfRevisions,
   oldAnnotation,
 }: AnnotationComparisonProps): React.MixedElement => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const entityType = entity.entityType;
   const entityUrlFragment = ENTITIES[entityType].url;
   const LayoutComponent = chooseLayoutComponent(entityType);

--- a/root/annotation/AnnotationHistory.js
+++ b/root/annotation/AnnotationHistory.js
@@ -18,14 +18,12 @@ import AnnotationHistoryTable
 import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 
 type AnnotationHistoryProps = {
-  +$c: CatalystContextT,
   +annotations: $ReadOnlyArray<AnnotationT>,
   +entity: AnnotatedEntityT,
   +pager: PagerT,
 };
 
 const AnnotationHistory = ({
-  $c,
   annotations,
   entity,
   pager,
@@ -50,7 +48,6 @@ const AnnotationHistory = ({
         >
           <PaginatedResults pager={pager}>
             <AnnotationHistoryTable
-              $c={$c}
               annotations={annotations}
               baseUrl={baseUrl}
             />

--- a/root/annotation/EditAnnotation.js
+++ b/root/annotation/EditAnnotation.js
@@ -24,7 +24,6 @@ type EditAnnotationFormT = FormT<{
 }>;
 
 type EditAnnotationProps = {
-  +$c: CatalystContextT,
   +entity: AnnotatedEntityT,
   +form: EditAnnotationFormT,
   +preview?: string,
@@ -32,7 +31,6 @@ type EditAnnotationProps = {
 };
 
 const EditAnnotation = ({
-  $c,
   entity,
   form,
   preview,
@@ -69,7 +67,7 @@ const EditAnnotation = ({
         </>
       ) : null}
 
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <FormRowTextArea
           cols={80}
           field={form.field.text}

--- a/root/area/AreaArtists.js
+++ b/root/area/AreaArtists.js
@@ -11,55 +11,57 @@ import * as React from 'react';
 
 import ArtistList from '../components/list/ArtistList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +artists: ?$ReadOnlyArray<ArtistT>,
   +pager: PagerT,
 };
 
 const AreaArtists = ({
-  $c,
   area,
   artists,
   pager,
-}: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout entity={area} page="artists" title={l('Artists')}>
-    <h2>{l('Artists')}</h2>
+}: Props): React.Element<typeof AreaLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <AreaLayout entity={area} page="artists" title={l('Artists')}>
+      <h2>{l('Artists')}</h2>
 
-    {artists?.length ? (
-      <form
-        action={'/artist/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <ArtistList
-            artists={artists}
-            checkboxes="add-to-merge"
-            showBeginEnd
-            showRatings
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected artists for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('This area is not currently associated with any artists.')}
-      </p>
-    )}
-  </AreaLayout>
-);
+      {artists?.length ? (
+        <form
+          action={'/artist/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <ArtistList
+              artists={artists}
+              checkboxes="add-to-merge"
+              showBeginEnd
+              showRatings
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected artists for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('This area is not currently associated with any artists.')}
+        </p>
+      )}
+    </AreaLayout>
+  );
+};
 
 export default AreaArtists;

--- a/root/area/AreaEvents.js
+++ b/root/area/AreaEvents.js
@@ -11,57 +11,59 @@ import * as React from 'react';
 
 import EventList from '../components/list/EventList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +events: $ReadOnlyArray<EventT>,
   +pager: PagerT,
 };
 
 const AreaEvents = ({
-  $c,
   area,
   events,
   pager,
-}: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout entity={area} page="events" title={l('Events')}>
-    <h2>{l('Events')}</h2>
+}: Props): React.Element<typeof AreaLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <AreaLayout entity={area} page="events" title={l('Events')}>
+      <h2>{l('Events')}</h2>
 
-    {events.length > 0 ? (
-      <form
-        action={'/event/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <EventList
-            checkboxes="add-to-merge"
-            events={events}
-            showArtists
-            showLocation
-            showRatings
-            showType
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected events for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('This area is not currently associated with any events.')}
-      </p>
-    )}
-  </AreaLayout>
-);
+      {events.length > 0 ? (
+        <form
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <EventList
+              checkboxes="add-to-merge"
+              events={events}
+              showArtists
+              showLocation
+              showRatings
+              showType
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected events for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('This area is not currently associated with any events.')}
+        </p>
+      )}
+    </AreaLayout>
+  );
+};
 
 export default AreaEvents;

--- a/root/area/AreaLabels.js
+++ b/root/area/AreaLabels.js
@@ -11,54 +11,56 @@ import * as React from 'react';
 
 import LabelList from '../components/list/LabelList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +labels: $ReadOnlyArray<LabelT>,
   +pager: PagerT,
 };
 
 const AreaLabels = ({
-  $c,
   area,
   labels,
   pager,
-}: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout entity={area} page="labels" title={l('Labels')}>
-    <h2>{l('Labels')}</h2>
+}: Props): React.Element<typeof AreaLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <AreaLayout entity={area} page="labels" title={l('Labels')}>
+      <h2>{l('Labels')}</h2>
 
-    {labels.length > 0 ? (
-      <form
-        action={'/label/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <LabelList
-            checkboxes="add-to-merge"
-            labels={labels}
-            showRatings
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected labels for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('This area is not currently associated with any labels.')}
-      </p>
-    )}
-  </AreaLayout>
-);
+      {labels.length > 0 ? (
+        <form
+          action={'/label/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <LabelList
+              checkboxes="add-to-merge"
+              labels={labels}
+              showRatings
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected labels for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('This area is not currently associated with any labels.')}
+        </p>
+      )}
+    </AreaLayout>
+  );
+};
 
 export default AreaLabels;

--- a/root/area/AreaMerge.js
+++ b/root/area/AreaMerge.js
@@ -18,13 +18,11 @@ import AreaList from '../components/list/AreaList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<AreaT>,
 };
 
 const AreaMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const AreaMerge = ({
         {l(`You are about to merge all these areas into a single one.
             Please select the area all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <AreaList
           areas={sortByEntityName(toMerge)}
           mergeForm={form}

--- a/root/area/AreaPlaces.js
+++ b/root/area/AreaPlaces.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PlaceList from '../components/list/PlaceList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import DBDefs from '../static/scripts/common/DBDefs-client.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
@@ -18,7 +19,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +mapDataArgs: {places: $ReadOnlyArray<PlaceT>},
   +pager: PagerT,
@@ -26,58 +26,60 @@ type Props = {
 };
 
 const AreaPlaces = ({
-  $c,
   area,
   mapDataArgs,
   pager,
   places,
-}: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout entity={area} page="places" title={l('Places')}>
-    <h2>{l('Places')}</h2>
+}: Props): React.Element<typeof AreaLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <AreaLayout entity={area} page="places" title={l('Places')}>
+      <h2>{l('Places')}</h2>
 
-    {places?.length ? (
-      <>
-        {DBDefs.MAPBOX_ACCESS_TOKEN ? (
-          <>
-            <div id="largemap" />
-            {manifest.js('area/places-map', {'data-args': mapDataArgs})}
-          </>
-        ) : (
-          <p>
-            {l(
-              `A map cannot be shown because no maps service access token has
-               been set for this server.`,
-            )}
-          </p>
-        )}
-        <form
-          action={'/place/merge_queue?' + returnToCurrentPage($c)}
-          method="post"
-        >
-          <PaginatedResults pager={pager}>
-            <PlaceList
-              checkboxes="add-to-merge"
-              places={places}
-              showRatings
-            />
-          </PaginatedResults>
-          {$c.user ? (
-            <div className="row">
-              <span className="buttons">
-                <button type="submit">
-                  {l('Add selected places for merging')}
-                </button>
-              </span>
-            </div>
-          ) : null}
-        </form>
-      </>
-    ) : (
-      <p>
-        {l('This area is not currently associated with any places.')}
-      </p>
-    )}
-  </AreaLayout>
-);
+      {places?.length ? (
+        <>
+          {DBDefs.MAPBOX_ACCESS_TOKEN ? (
+            <>
+              <div id="largemap" />
+              {manifest.js('area/places-map', {'data-args': mapDataArgs})}
+            </>
+          ) : (
+            <p>
+              {l(
+                `A map cannot be shown because no maps service access token
+                 has been set for this server.`,
+              )}
+            </p>
+          )}
+          <form
+            action={'/place/merge_queue?' + returnToCurrentPage($c)}
+            method="post"
+          >
+            <PaginatedResults pager={pager}>
+              <PlaceList
+                checkboxes="add-to-merge"
+                places={places}
+                showRatings
+              />
+            </PaginatedResults>
+            {$c.user ? (
+              <div className="row">
+                <span className="buttons">
+                  <button type="submit">
+                    {l('Add selected places for merging')}
+                  </button>
+                </span>
+              </div>
+            ) : null}
+          </form>
+        </>
+      ) : (
+        <p>
+          {l('This area is not currently associated with any places.')}
+        </p>
+      )}
+    </AreaLayout>
+  );
+};
 
 export default AreaPlaces;

--- a/root/area/AreaRecordings.js
+++ b/root/area/AreaRecordings.js
@@ -14,21 +14,18 @@ import RelationshipsTable from '../components/RelationshipsTable.js';
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: ?PagerT,
 };
 
 const AreaRecordings = ({
-  $c,
   area,
   pagedLinkTypeGroup,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
   <AreaLayout entity={area} page="recordings" title={l('Recordings')}>
     <RelationshipsTable
-      $c={$c}
       entity={area}
       fallbackMessage={l(
         'This area has no relationships to any recordings.',

--- a/root/area/AreaReleases.js
+++ b/root/area/AreaReleases.js
@@ -12,12 +12,12 @@ import * as React from 'react';
 import ReleaseList from '../components/list/ReleaseList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import RelationshipsTable from '../components/RelationshipsTable.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: PagerT,
@@ -25,54 +25,54 @@ type Props = {
 };
 
 const AreaReleases = ({
-  $c,
   area,
   pagedLinkTypeGroup,
   pager,
   releases,
-}: Props): React.Element<typeof AreaLayout> => (
-  <AreaLayout entity={area} page="releases" title={l('Releases')}>
-    {pagedLinkTypeGroup ? null : (
-      <>
-        <h2>{l('Releases')}</h2>
+}: Props): React.Element<typeof AreaLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <AreaLayout entity={area} page="releases" title={l('Releases')}>
+      {pagedLinkTypeGroup ? null : (
+        <>
+          <h2>{l('Releases')}</h2>
 
-        {releases?.length ? (
-          <form
-            action={'/release/merge_queue?' + returnToCurrentPage($c)}
-            method="post"
-          >
-            <PaginatedResults pager={pager}>
-              <ReleaseList checkboxes="add-to-merge" releases={releases} />
-            </PaginatedResults>
-            {$c.user ? (
-              <div className="row">
-                <span className="buttons">
-                  <button type="submit">
-                    {l('Add selected releases for merging')}
-                  </button>
-                </span>
-              </div>
-            ) : null}
-          </form>
-        ) : (
-          <p>
-            {l('This area is not currently associated with any releases.')}
-          </p>
-        )}
-      </>
-    )}
-
-    <RelationshipsTable
-      $c={$c}
-      entity={area}
-      fallbackMessage={l(
-        'This area has no relationships to any releases.',
+          {releases?.length ? (
+            <form
+              action={'/release/merge_queue?' + returnToCurrentPage($c)}
+              method="post"
+            >
+              <PaginatedResults pager={pager}>
+                <ReleaseList checkboxes="add-to-merge" releases={releases} />
+              </PaginatedResults>
+              {$c.user ? (
+                <div className="row">
+                  <span className="buttons">
+                    <button type="submit">
+                      {l('Add selected releases for merging')}
+                    </button>
+                  </span>
+                </div>
+              ) : null}
+            </form>
+          ) : (
+            <p>
+              {l('This area is not currently associated with any releases.')}
+            </p>
+          )}
+        </>
       )}
-      heading={l('Relationships')}
-      pagedLinkTypeGroup={pagedLinkTypeGroup}
-      pager={pager}
-    />
-  </AreaLayout>
-);
+      <RelationshipsTable
+        entity={area}
+        fallbackMessage={l(
+          'This area has no relationships to any releases.',
+        )}
+        heading={l('Relationships')}
+        pagedLinkTypeGroup={pagedLinkTypeGroup}
+        pager={pager}
+      />
+    </AreaLayout>
+  );
+};
 
 export default AreaReleases;

--- a/root/area/AreaWorks.js
+++ b/root/area/AreaWorks.js
@@ -14,21 +14,18 @@ import RelationshipsTable from '../components/RelationshipsTable.js';
 import AreaLayout from './AreaLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +area: AreaT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: ?PagerT,
 };
 
 const AreaWorks = ({
-  $c,
   area,
   pagedLinkTypeGroup,
   pager,
 }: Props): React.Element<typeof AreaLayout> => (
   <AreaLayout entity={area} page="works" title={l('Works')}>
     <RelationshipsTable
-      $c={$c}
       entity={area}
       fallbackMessage={l(
         'This area has no relationships to any works.',

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import EventList from '../components/list/EventList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
 import {type FilterFormT}
   from '../static/scripts/common/components/FilterForm.js';
@@ -19,7 +20,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import ArtistLayout from './ArtistLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +events: $ReadOnlyArray<EventT>,
@@ -29,56 +29,58 @@ type Props = {
 };
 
 const ArtistEvents = ({
-  $c,
   ajaxFilterFormUrl,
   artist,
   events,
   filterForm,
   hasFilter,
   pager,
-}: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout entity={artist} page="events" title={l('Events')}>
-    <h2>{l('Events')}</h2>
+}: Props): React.Element<typeof ArtistLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <ArtistLayout entity={artist} page="events" title={l('Events')}>
+      <h2>{l('Events')}</h2>
 
-    <Filter
-      ajaxFormUrl={ajaxFilterFormUrl}
-      initialFilterForm={filterForm}
-    />
+      <Filter
+        ajaxFormUrl={ajaxFilterFormUrl}
+        initialFilterForm={filterForm}
+      />
 
-    {events.length > 0 ? (
-      <form
-        action={'/event/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <EventList
-            artist={artist}
-            artistRoles
-            checkboxes="add-to-merge"
-            events={events}
-            showLocation
-            showRatings
-            showType
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected events for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {hasFilter
-          ? l('No events found that match this search.')
-          : l('This artist is not currently associated with any events.')}
-      </p>
-    )}
-  </ArtistLayout>
-);
+      {events.length > 0 ? (
+        <form
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <EventList
+              artist={artist}
+              artistRoles
+              checkboxes="add-to-merge"
+              events={events}
+              showLocation
+              showRatings
+              showType
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected events for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {hasFilter
+            ? l('No events found that match this search.')
+            : l('This artist is not currently associated with any events.')}
+        </p>
+      )}
+    </ArtistLayout>
+  );
+};
 
 export default ArtistEvents;

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -25,6 +25,7 @@ import RecordingList from '../components/list/RecordingList.js';
 import ReleaseGroupList from '../components/list/ReleaseGroupList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import RelatedEntitiesDisplay from '../components/RelatedEntitiesDisplay.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import entityHref from '../static/scripts/common/utility/entityHref.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
@@ -42,7 +43,6 @@ type FooterSwitchProps = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +eligibleForCleanup: boolean,
@@ -192,7 +192,6 @@ const FooterSwitch = ({
 };
 
 const ArtistIndex = ({
-  $c,
   ajaxFilterFormUrl,
   artist,
   eligibleForCleanup,
@@ -214,6 +213,7 @@ const ArtistIndex = ({
   showingVariousArtistsOnly,
   wikipediaExtract,
 }: Props): React.Element<typeof ArtistLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const existingRecordings = recordings?.length ? recordings : null;
   const existingReleaseGroups = releaseGroups?.length ? releaseGroups : null;
 

--- a/root/artist/ArtistMerge.js
+++ b/root/artist/ArtistMerge.js
@@ -19,13 +19,11 @@ import ArtistList from '../components/list/ArtistList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<ArtistT>,
 };
 
 const ArtistMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -36,7 +34,7 @@ const ArtistMerge = ({
         {l(`You are about to merge all these artists into a single one.
             Please select the artist all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <ArtistList
           artists={sortByEntityName(toMerge)}
           mergeForm={form}

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import FormSubmit from '../components/FormSubmit.js';
 import RecordingList from '../components/list/RecordingList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
 import {type FilterFormT}
   from '../static/scripts/common/components/FilterForm.js';
@@ -30,7 +31,6 @@ type FooterSwitchProps = {
 
 type Props = {
   ...ReleaseGroupAppearancesRoleT,
-  +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +filterForm: ?FilterFormT,
@@ -124,7 +124,6 @@ const FooterSwitch = ({
 };
 
 const ArtistRecordings = ({
-  $c,
   ajaxFilterFormUrl,
   artist,
   filterForm,
@@ -136,55 +135,58 @@ const ArtistRecordings = ({
   releaseGroupAppearances,
   standaloneOnly,
   videoOnly,
-}: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout
-    entity={artist}
-    page="recordings"
-    title={l('Recordings')}
-  >
-    <h2>{l('Recordings')}</h2>
+}: Props): React.Element<typeof ArtistLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <ArtistLayout
+      entity={artist}
+      page="recordings"
+      title={l('Recordings')}
+    >
+      <h2>{l('Recordings')}</h2>
 
-    <Filter
-      ajaxFormUrl={ajaxFilterFormUrl}
-      initialFilterForm={filterForm}
-    />
+      <Filter
+        ajaxFormUrl={ajaxFilterFormUrl}
+        initialFilterForm={filterForm}
+      />
 
-    {recordings.length ? (
-      <form
-        action={'/recording/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <RecordingList
-            checkboxes="add-to-merge"
-            recordings={recordings}
-            releaseGroupAppearances={releaseGroupAppearances}
-            showRatings
-            showReleaseGroups
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <FormSubmit label={l('Add selected recordings for merging')} />
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {hasFilter
-          ? l('No recordings found that match this search.')
-          : l('No recordings found.')}
-      </p>
-    )}
+      {recordings.length ? (
+        <form
+          action={'/recording/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <RecordingList
+              checkboxes="add-to-merge"
+              recordings={recordings}
+              releaseGroupAppearances={releaseGroupAppearances}
+              showRatings
+              showReleaseGroups
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <FormSubmit label={l('Add selected recordings for merging')} />
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {hasFilter
+            ? l('No recordings found that match this search.')
+            : l('No recordings found.')}
+        </p>
+      )}
 
-    <FooterSwitch
-      artist={artist}
-      hasStandalone={hasStandalone}
-      hasVideo={hasVideo}
-      standaloneOnly={standaloneOnly}
-      videoOnly={videoOnly}
-    />
-  </ArtistLayout>
-);
+      <FooterSwitch
+        artist={artist}
+        hasStandalone={hasStandalone}
+        hasVideo={hasVideo}
+        standaloneOnly={standaloneOnly}
+        videoOnly={videoOnly}
+      />
+    </ArtistLayout>
+  );
+};
 
 export default ArtistRecordings;

--- a/root/artist/ArtistRelationships.js
+++ b/root/artist/ArtistRelationships.js
@@ -13,18 +13,15 @@ import RelationshipsTable from '../components/RelationshipsTable.js';
 import Relationships
   from '../static/scripts/common/components/Relationships.js';
 
-
 import ArtistLayout from './ArtistLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +artist: ArtistT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: ?PagerT,
 };
 
 const ArtistRelationships = ({
-  $c,
   artist,
   pagedLinkTypeGroup,
   pager,
@@ -38,7 +35,6 @@ const ArtistRelationships = ({
       <Relationships showIfEmpty source={artist} />
     )}
     <RelationshipsTable
-      $c={$c}
       entity={artist}
       heading={l('Appearances')}
       pagedLinkTypeGroup={pagedLinkTypeGroup}

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import FormSubmit from '../components/FormSubmit.js';
 import ReleaseList from '../components/list/ReleaseList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
 import {type FilterFormT}
   from '../static/scripts/common/components/FilterForm.js';
@@ -20,7 +21,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import ArtistLayout from './ArtistLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +filterForm: ?FilterFormT,
@@ -32,7 +32,6 @@ type Props = {
 };
 
 const ArtistReleases = ({
-  $c,
   ajaxFilterFormUrl,
   artist,
   filterForm,
@@ -41,65 +40,68 @@ const ArtistReleases = ({
   releases,
   showingVariousArtistsOnly,
   wantVariousArtistsOnly,
-}: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout entity={artist} page="releases" title={l('Releases')}>
-    <h2>{l('Releases')}</h2>
+}: Props): React.Element<typeof ArtistLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <ArtistLayout entity={artist} page="releases" title={l('Releases')}>
+      <h2>{l('Releases')}</h2>
 
-    <Filter
-      ajaxFormUrl={ajaxFilterFormUrl}
-      initialFilterForm={filterForm}
-    />
+      <Filter
+        ajaxFormUrl={ajaxFilterFormUrl}
+        initialFilterForm={filterForm}
+      />
 
-    {releases.length ? (
-      <form
-        action={'/release/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <ReleaseList checkboxes="add-to-merge" releases={releases} />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <FormSubmit label={l('Add selected releases for merging')} />
-          </div>
-        ) : null}
-      </form>
-    ) : null}
+      {releases.length ? (
+        <form
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <ReleaseList checkboxes="add-to-merge" releases={releases} />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <FormSubmit label={l('Add selected releases for merging')} />
+            </div>
+          ) : null}
+        </form>
+      ) : null}
 
-    {releases.length === 0 ? (
-      <p>
-        {hasFilter
-          ? l('No releases found that match this search.')
-          : l('No releases found.')}
-      </p>
-    ) : null}
+      {releases.length === 0 ? (
+        <p>
+          {hasFilter
+            ? l('No releases found that match this search.')
+            : l('No releases found.')}
+        </p>
+      ) : null}
 
-    {wantVariousArtistsOnly ? (
-      exp.l(
-        `Showing Various Artist releases.
-         {show_subset|Show releases by this artist instead}.`,
-        {show_subset: `/artist/${artist.gid}/releases?va=0`},
-      )
-    ) : showingVariousArtistsOnly ? (
-      /*
-       * The user didn't specifically ask for VA releases, but nothing
-       * else was found, so we're showing them anyway.
-       */
-      <p>
-        {hasFilter ? (
-          l('This search only found releases by various artists.')
-        ) : (
-          l('This artist only has releases by various artists.')
-        )}
-      </p>
-    ) : (
-      exp.l(
-        `Showing releases by this artist.
-         {show_all|Show Various Artist releases instead}.`,
-        {show_all: `/artist/${artist.gid}/releases?va=1`},
-      )
-    )}
-  </ArtistLayout>
-);
+      {wantVariousArtistsOnly ? (
+        exp.l(
+          `Showing Various Artist releases.
+           {show_subset|Show releases by this artist instead}.`,
+          {show_subset: `/artist/${artist.gid}/releases?va=0`},
+        )
+      ) : showingVariousArtistsOnly ? (
+        /*
+         * The user didn't specifically ask for VA releases, but nothing
+         * else was found, so we're showing them anyway.
+         */
+        <p>
+          {hasFilter ? (
+            l('This search only found releases by various artists.')
+          ) : (
+            l('This artist only has releases by various artists.')
+          )}
+        </p>
+      ) : (
+        exp.l(
+          `Showing releases by this artist.
+           {show_all|Show Various Artist releases instead}.`,
+          {show_all: `/artist/${artist.gid}/releases?va=1`},
+        )
+      )}
+    </ArtistLayout>
+  );
+};
 
 export default ArtistReleases;

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import WorkList from '../components/list/WorkList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
 import {type FilterFormT}
   from '../static/scripts/common/components/FilterForm.js';
@@ -19,7 +20,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import ArtistLayout from './ArtistLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +filterForm: ?FilterFormT,
@@ -29,52 +29,54 @@ type Props = {
 };
 
 const ArtistWorks = ({
-  $c,
   ajaxFilterFormUrl,
   artist,
   filterForm,
   hasFilter,
   pager,
   works,
-}: Props): React.Element<typeof ArtistLayout> => (
-  <ArtistLayout entity={artist} page="works" title={l('Works')}>
-    <h2>{l('Works')}</h2>
+}: Props): React.Element<typeof ArtistLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <ArtistLayout entity={artist} page="works" title={l('Works')}>
+      <h2>{l('Works')}</h2>
 
-    <Filter
-      ajaxFormUrl={ajaxFilterFormUrl}
-      initialFilterForm={filterForm}
-    />
+      <Filter
+        ajaxFormUrl={ajaxFilterFormUrl}
+        initialFilterForm={filterForm}
+      />
 
-    {works?.length ? (
-      <form
-        action={'/work/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <WorkList
-            checkboxes="add-to-merge"
-            showRatings
-            works={works}
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected works for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {hasFilter
-          ? l('No works found that match this search.')
-          : l('This artist is not currently associated with any works.')}
-      </p>
-    )}
-  </ArtistLayout>
-);
+      {works?.length ? (
+        <form
+          action={'/work/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <WorkList
+              checkboxes="add-to-merge"
+              showRatings
+              works={works}
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected works for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {hasFilter
+            ? l('No works found that match this search.')
+            : l('This artist is not currently associated with any works.')}
+        </p>
+      )}
+    </ArtistLayout>
+  );
+};
 
 export default ArtistWorks;

--- a/root/artist_credit/ArtistCreditIndex.js
+++ b/root/artist_credit/ArtistCreditIndex.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import ENTITIES from '../../entities.mjs';
+import {CatalystContext} from '../context.mjs';
 import ArtistCreditUsageLink
   from '../static/scripts/common/components/ArtistCreditUsageLink.js';
 import DescriptiveLink
@@ -22,7 +23,6 @@ import {formatCount} from '../statistics/utilities.js';
 import ArtistCreditLayout from './ArtistCreditLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +artistCredit: $ReadOnly<{...ArtistCreditT, +id: number}>,
   +creditedEntities: {
     +[entityType: string]: {
@@ -33,6 +33,7 @@ type Props = {
 };
 
 function buildSection(
+  $c: CatalystContextT,
   props: Props,
   entityType: string,
   title: string,
@@ -67,7 +68,7 @@ function buildSection(
                 artistCredit={props.artistCredit}
                 content={expand2text(
                   seeAllMessage(entities.count),
-                  {num: formatCount(props.$c, entities.count)},
+                  {num: formatCount($c, entities.count)},
                 )}
                 subPath={entityUrlFragment}
               />
@@ -81,79 +82,86 @@ function buildSection(
 
 const ArtistCreditIndex = (
   props: Props,
-): React.Element<typeof ArtistCreditLayout> => (
-  <ArtistCreditLayout
-    artistCredit={props.artistCredit}
-    page=""
-  >
-    <p>
-      {l('This artist credit is composed of the following artists:')}
-    </p>
-    <ul id="artist-credit-artists">
-      {props.artistCredit.names.map((name, index) => (
-        <li key={'name-' + index}>
-          <DescriptiveLink entity={name.artist} />
-          {name.artist.name === name.name ? null : (
-            <>
-              {' '}
-              {texp.l(
-                'credited as “{credit}”',
-                {credit: name.name},
-              )}
-            </>
-          )}
-        </li>
-      ))}
-    </ul>
-    <h2>{l('Uses')}</h2>
-    {/*
-      * The below use N_ln so languages with non-Germanic pluralization
-      * rules (i.e., any that make number distinctions above the
-      * threshold where we'll actually show the string) can translate
-      * properly. However, the strings are the same in English because
-      * we do not make a distinction other than for 1, which will never
-      * show in this case.
-      */}
-    {buildSection(
-      props,
-      'release_group',
-      l('Release Groups'),
-      N_ln(
-        'See all {num} release groups',
-        'See all {num} release groups',
-      ),
-      'artist-credit-release-groups',
-    )}
-    {buildSection(
-      props,
-      'release',
-      l('Releases'), N_ln(
-        'See all {num} releases',
-        'See all {num} releases',
-      ),
-      'artist-credit-releases',
-    )}
-    {buildSection(
-      props,
-      'recording',
-      l('Recordings'),
-      N_ln(
-        'See all {num} recordings',
-        'See all {num} recordings',
-      ),
-      'artist-credit-recordings',
-    )}
-    {buildSection(
-      props,
-      'track',
-      l('Tracks'),
-      N_ln(
-        'See all {num} tracks',
-        'See all {num} tracks',
-      ),
-      'artist-credit-tracks',
-    )}
-  </ArtistCreditLayout>
-);
+): React.Element<typeof ArtistCreditLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ArtistCreditLayout
+      artistCredit={props.artistCredit}
+      page=""
+    >
+      <p>
+        {l('This artist credit is composed of the following artists:')}
+      </p>
+      <ul id="artist-credit-artists">
+        {props.artistCredit.names.map((name, index) => (
+          <li key={'name-' + index}>
+            <DescriptiveLink entity={name.artist} />
+            {name.artist.name === name.name ? null : (
+              <>
+                {' '}
+                {texp.l(
+                  'credited as “{credit}”',
+                  {credit: name.name},
+                )}
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+      <h2>{l('Uses')}</h2>
+      {/*
+        * The below use N_ln so languages with non-Germanic pluralization
+        * rules (i.e., any that make number distinctions above the
+        * threshold where we'll actually show the string) can translate
+        * properly. However, the strings are the same in English because
+        * we do not make a distinction other than for 1, which will never
+        * show in this case.
+        */}
+      {buildSection(
+        $c,
+        props,
+        'release_group',
+        l('Release Groups'),
+        N_ln(
+          'See all {num} release groups',
+          'See all {num} release groups',
+        ),
+        'artist-credit-release-groups',
+      )}
+      {buildSection(
+        $c,
+        props,
+        'release',
+        l('Releases'), N_ln(
+          'See all {num} releases',
+          'See all {num} releases',
+        ),
+        'artist-credit-releases',
+      )}
+      {buildSection(
+        $c,
+        props,
+        'recording',
+        l('Recordings'),
+        N_ln(
+          'See all {num} recordings',
+          'See all {num} recordings',
+        ),
+        'artist-credit-recordings',
+      )}
+      {buildSection(
+        $c,
+        props,
+        'track',
+        l('Tracks'),
+        N_ln(
+          'See all {num} tracks',
+          'See all {num} tracks',
+        ),
+        'artist-credit-tracks',
+      )}
+    </ArtistCreditLayout>
+  );
+};
 
 export default ArtistCreditIndex;

--- a/root/artist_credit/EntityList.js
+++ b/root/artist_credit/EntityList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import PaginatedResults from '../components/PaginatedResults.js';
+import {CatalystContext} from '../context.mjs';
 import EntityLink
   from '../static/scripts/common/components/EntityLink.js';
 import expand2text from '../static/scripts/common/i18n/expand2text.js';
@@ -35,7 +36,6 @@ const noEntitiesText = {
 };
 
 type Props = {
-  +$c: CatalystContextT,
   +artistCredit: $ReadOnly<{...ArtistCreditT, +id: number}>,
   +entities: $ReadOnlyArray<CoreEntityT | TrackT>,
   +entityType: string,
@@ -44,37 +44,39 @@ type Props = {
 };
 
 const EntityList = ({
-  $c,
   artistCredit,
   entities,
   entityType,
   page,
   pager,
-}: Props): React.Element<typeof ArtistCreditLayout> => (
-  <ArtistCreditLayout artistCredit={artistCredit} page={page}>
-    <h2>
-      {expand2text(
-        headingsText[entityType](pager.total_entries),
-        {num: formatCount($c, pager.total_entries)},
-      )}
-    </h2>
+}: Props): React.Element<typeof ArtistCreditLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ArtistCreditLayout artistCredit={artistCredit} page={page}>
+      <h2>
+        {expand2text(
+          headingsText[entityType](pager.total_entries),
+          {num: formatCount($c, pager.total_entries)},
+        )}
+      </h2>
 
-    {entities.length ? (
-      <PaginatedResults pager={pager}>
-        <ul>
-          {entities.map(entity => (
-            <li key={entity.id}>
-              {entity.entityType === 'track' ? (
-                <a href={`/track/${entity.gid}`}>
-                  {entity.name}
-                </a>
-              ) : <EntityLink entity={entity} />}
-            </li>
-          ))}
-        </ul>
-      </PaginatedResults>
-    ) : <p>{noEntitiesText[entityType]()}</p>}
-  </ArtistCreditLayout>
-);
+      {entities.length ? (
+        <PaginatedResults pager={pager}>
+          <ul>
+            {entities.map(entity => (
+              <li key={entity.id}>
+                {entity.entityType === 'track' ? (
+                  <a href={`/track/${entity.gid}`}>
+                    {entity.name}
+                  </a>
+                ) : <EntityLink entity={entity} />}
+              </li>
+            ))}
+          </ul>
+        </PaginatedResults>
+      ) : <p>{noEntitiesText[entityType]()}</p>}
+    </ArtistCreditLayout>
+  );
+};
 
 export default EntityList;

--- a/root/collection/CollectionHeader.js
+++ b/root/collection/CollectionHeader.js
@@ -12,21 +12,21 @@ import * as React from 'react';
 import EntityTabLink from '../components/EntityTabLink.js';
 import SubHeader from '../components/SubHeader.js';
 import Tabs from '../components/Tabs.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import bracketed from '../static/scripts/common/utility/bracketed.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +collection: CollectionT,
   +page: string,
 };
 
 const CollectionHeader = ({
-  $c,
   collection,
   page,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const owner = collection.editor;
   const viewingOwnCollection = Boolean(
     $c.user && owner && owner.id === $c.user.id,

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -23,6 +23,7 @@ import ReleaseList from '../components/list/ReleaseList.js';
 import SeriesList from '../components/list/SeriesList.js';
 import WorkList from '../components/list/WorkList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import expand2react from '../static/scripts/common/i18n/expand2react.js';
 import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName.js';
@@ -31,7 +32,6 @@ import UserInlineList from '../user/components/UserInlineList.js';
 import CollectionLayout from './CollectionLayout.js';
 
 type PropsForEntity<T: CoreEntityT> = {
-  +$c: CatalystContextT,
   +collection: CollectionT,
   +collectionEntityType: T['entityType'],
   +entities: $ReadOnlyArray<T>,
@@ -159,8 +159,8 @@ const listPicker = (
 
 const CollectionIndex = (props: Props):
 React.Element<typeof CollectionLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const {
-    $c,
     collection,
     collectionEntityType,
     entities,

--- a/root/collection/CollectionIndex.js
+++ b/root/collection/CollectionIndex.js
@@ -200,7 +200,7 @@ React.Element<typeof CollectionLayout> => {
       </div>
       <h2>{formatPluralEntityTypeName(collectionEntityType)}</h2>
       {entities.length > 0 ? (
-        <form action={$c.req.uri} method="post">
+        <form method="post">
           <PaginatedResults pager={pager}>
             {listPicker(props, canRemoveFromCollection)}
           </PaginatedResults>

--- a/root/collection/CollectionLayout.js
+++ b/root/collection/CollectionLayout.js
@@ -9,7 +9,6 @@
 
 import * as React from 'react';
 
-import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import CollectionSidebar
   from '../layout/components/sidebar/CollectionSidebar.js';
@@ -31,7 +30,6 @@ const CollectionLayout = ({
   page,
   title,
 }: Props): React.Element<typeof Layout> => {
-  const $c = React.useContext(CatalystContext);
   const mainTitle = texp.l(
     'Collection “{collection}”',
     {collection: collection.name},
@@ -43,7 +41,6 @@ const CollectionLayout = ({
     >
       <div id="content">
         <CollectionHeader
-          $c={$c}
           collection={collection}
           page={page}
         />

--- a/root/collection/CollectionMerge.js
+++ b/root/collection/CollectionMerge.js
@@ -28,7 +28,6 @@ import {
 } from '../utility/tableColumns.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +privaciesDiffer?: boolean,
   +toMerge: $ReadOnlyArray<CollectionT>,
@@ -99,7 +98,6 @@ const CollectionMergeTable = ({
 };
 
 const CollectionMerge = ({
-  $c,
   form,
   privaciesDiffer,
   toMerge,
@@ -156,7 +154,7 @@ const CollectionMerge = ({
             </p>
           </div>
         ) : null}
-        <form action={$c.req.uri} method="post">
+        <form method="post">
           <CollectionMergeTable collections={collections} form={form} />
 
           {collaborators.length ? (

--- a/root/collection/DeleteCollection.js
+++ b/root/collection/DeleteCollection.js
@@ -15,12 +15,10 @@ import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import CollectionLayout from './CollectionLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +collection: CollectionT,
 };
 
 const DeleteCollection = ({
-  $c,
   collection,
 }: Props): React.Element<typeof CollectionLayout> => (
   <CollectionLayout
@@ -34,7 +32,7 @@ const DeleteCollection = ({
       {exp.l('Are you sure you want to remove the collection {collection}?',
              {collection: <EntityLink entity={collection} />})}
     </p>
-    <form action={$c.req.uri} method="post">
+    <form method="post">
       <FormSubmit label={l('Remove collection')} />
     </form>
 

--- a/root/components/Aliases/ArtistCreditList.js
+++ b/root/components/Aliases/ArtistCreditList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink.js';
 import ArtistCreditUsageLink
@@ -18,16 +19,15 @@ import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import loopParity from '../../utility/loopParity.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +artistCredits: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
   +entity: CoreEntityT,
 };
 
 const ArtistCreditList = ({
-  $c,
   artistCredits,
   entity,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   return (
     <>
       <h2>{l('Artist credits')}</h2>

--- a/root/components/Aliases/index.js
+++ b/root/components/Aliases/index.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import entityHref from '../../static/scripts/common/utility/entityHref.js';
 import {
@@ -35,12 +36,12 @@ function canEdit($c: CatalystContextT, entityType: string) {
 }
 
 type Props = {
-  +$c: CatalystContextT,
   +aliases: ?$ReadOnlyArray<AliasT>,
   +entity: CoreEntityT,
 };
 
-const Aliases = ({$c, aliases, entity}: Props): React.MixedElement => {
+const Aliases = ({aliases, entity}: Props): React.MixedElement => {
+  const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const allowEditing = canEdit($c, entityType);
   return (

--- a/root/components/PaginatedResults.js
+++ b/root/components/PaginatedResults.js
@@ -36,7 +36,6 @@ const PaginatedResults = ({
   const $c = React.useContext(CatalystContext);
   const paginator = (
     <Paginator
-      $c={$c}
       guessSearch={guessSearch}
       pageVar={pageVar}
       pager={pager}

--- a/root/components/Paginator.js
+++ b/root/components/Paginator.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import mapRange from '../static/scripts/common/utility/mapRange.js';
 import uriWith from '../utility/uriWith.js';
 
@@ -16,7 +17,6 @@ type PageQueryParam = 'apps_page' | 'page' | 'tokens_page';
 type PageQueryObject = {[pageVar: PageQueryParam]: number, ...};
 
 type Props = {
-  +$c: CatalystContextT,
   +guessSearch?: boolean,
   +hash?: string,
   +pager: PagerT,
@@ -40,14 +40,14 @@ function uriPage(
 }
 
 const Paginator = ({
-  $c,
   guessSearch = false,
   hash,
   pager,
   pageVar = 'page',
 }: Props): React.Element<'nav'> | null => {
-  const lastPage = pager.last_page;
+  const $c = React.useContext(SanitizedCatalystContext);
 
+  const lastPage = pager.last_page;
   if (lastPage <= 1) {
     return null;
   }

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import loopParity from '../utility/loopParity.js';
 import ArtistCreditLink
@@ -29,7 +30,6 @@ import uriWith from '../utility/uriWith.js';
 import PaginatedResults from './PaginatedResults.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
   +fallbackMessage?: string,
   +heading: string,
@@ -75,13 +75,14 @@ const getDirectionInteger = (backward: boolean) => {
 };
 
 const RelationshipsTable = ({
-  $c,
   entity,
   fallbackMessage,
   heading,
   pagedLinkTypeGroup,
   pager,
 }: Props): React.MixedElement | null => {
+  const $c = React.useContext(CatalystContext);
+
   if (pagedLinkTypeGroup && !pager) {
     throw new Error('Expected a pager');
   }

--- a/root/components/RemoveFromMergeTableCell.js
+++ b/root/components/RemoveFromMergeTableCell.js
@@ -10,20 +10,20 @@
 import * as React from 'react';
 
 import ENTITIES from '../../entities.mjs';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
   +toMerge: $ReadOnlyArray<CoreEntityT>,
 };
 
 // Converted to react-table at root/utility/tableColumns.js
 const RemoveFromMergeTableCell = ({
-  $c,
   entity,
   toMerge,
 }: Props): React.Element<'td'> | null => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const url = ENTITIES[entity.entityType].url;
   return (
     toMerge.length > 2 ? (

--- a/root/components/RequestLogin.js
+++ b/root/components/RequestLogin.js
@@ -9,14 +9,20 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import returnUri from '../utility/returnUri.js';
 
-type Props = {+$c: CatalystContextT, text?: string};
+type Props = {
+  +text?: string,
+};
 
-const RequestLogin = ({$c, text}: Props): React.Element<'a'> => (
-  <a href={returnUri($c, '/login')}>
-    {nonEmpty(text) ? text : l('Log in')}
-  </a>
-);
+const RequestLogin = ({text}: Props): React.Element<'a'> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <a href={returnUri($c, '/login')}>
+      {nonEmpty(text) ? text : l('Log in')}
+    </a>
+  );
+};
 
 export default RequestLogin;

--- a/root/components/TagEntitiesList.js
+++ b/root/components/TagEntitiesList.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import {type AccountLayoutUserT} from '../components/UserAccountLayout.js';
+import {CatalystContext} from '../context.mjs';
 import {ENTITIES} from '../static/scripts/common/constants.js';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
@@ -20,7 +21,6 @@ import {formatCount} from '../statistics/utilities.js';
 import UserTagFilters from '../user/components/UserTagFilters.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +showDownvoted?: boolean,
   +showLink?: boolean,
   +showVotesSelect?: boolean,
@@ -39,7 +39,6 @@ type Props = {
 };
 
 const TagEntitiesList = ({
-  $c,
   showDownvoted = false,
   showLink = false,
   showVotesSelect = false,
@@ -47,6 +46,8 @@ const TagEntitiesList = ({
   taggedEntities,
   user,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+
   const totalCount = Object.values(taggedEntities)
     // $FlowIssue[incompatible-use]
     .reduce((count, info) => count + info.count, 0);

--- a/root/components/TagEntitiesList.js
+++ b/root/components/TagEntitiesList.js
@@ -135,7 +135,6 @@ const TagEntitiesList = ({
       </h2>
       {showVotesSelect ? (
         <UserTagFilters
-          $c={$c}
           showDownvoted={showDownvoted}
           showVotesSelect
         />

--- a/root/components/VotingPeriod.js
+++ b/root/components/VotingPeriod.js
@@ -7,18 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as React from 'react';
+
+import {SanitizedCatalystContext} from '../context.mjs';
 import {formatUserDateObject} from '../utility/formatUserDate.js';
 import parseIsoDate from '../utility/parseIsoDate.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +closingDate: string,
 };
 
 const VotingPeriod = ({
-  $c,
   closingDate,
 }: PropsT): Expand2ReactOutput | null => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const date = parseIsoDate(closingDate);
   if (!date) {
     return null;

--- a/root/doc/DocError.js
+++ b/root/doc/DocError.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import bugTrackerURL from '../static/scripts/common/utility/bugTrackerURL.js';
@@ -16,14 +17,14 @@ import bugTrackerURL from '../static/scripts/common/utility/bugTrackerURL.js';
 import DocSearchBox from './components/DocSearchBox.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +id: string,
 };
 
 const DocError = ({
-  $c,
   id,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
+
   // We check whether we have a Google Custom Search engine
   const useGoogleCustomSearch = !!DBDefs.GOOGLE_CUSTOM_SEARCH;
 

--- a/root/edit/EditIndex.js
+++ b/root/edit/EditIndex.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import Layout from '../layout/index.js';
 import FormSubmit from '../components/FormSubmit.js';
 import RequestLogin from '../components/RequestLogin.js';
+import {CatalystContext} from '../context.mjs';
 import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
 import EditLink from '../static/scripts/common/components/EditLink.js';
@@ -29,16 +30,15 @@ import VoteTally from './components/VoteTally.js';
 import getEditDetailsElement from './utility/getEditDetailsElement.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: $ReadOnly<{...EditT, +id: number}>,
   +fullWidth?: boolean,
 };
 
 const EditIndex = ({
-  $c,
   edit,
   fullWidth = false,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
   const canAddNote = Boolean($c.user && editorMayAddNote(edit, $c.user));
   const isOwnEdit = Boolean($c.user && $c.user.id === edit.editor_id);
   const canVote = Boolean($c.user && editorMayVote(edit, $c.user));
@@ -47,7 +47,7 @@ const EditIndex = ({
   return (
     <Layout fullWidth={fullWidth} title={texp.l('Edit #{id}', {id: edit.id})}>
       <div id="content">
-        <EditHeader $c={$c} edit={edit} />
+        <EditHeader edit={edit} />
 
         <h2>{l('Changes')}</h2>
         {edit.data ? detailsElement : (
@@ -81,7 +81,7 @@ const EditIndex = ({
                   <tr className="noborder">
                     <th>{l('My vote:')}</th>
                     <td className="vote">
-                      <Vote $c={$c} edit={edit} />
+                      <Vote edit={edit} />
                     </td>
                   </tr>
                 ) : null}
@@ -147,7 +147,7 @@ const EditIndex = ({
             <p>
               {l('You must be logged in to vote on edits.')}
               {' '}
-              <RequestLogin $c={$c} />
+              <RequestLogin />
             </p>
           )}
 
@@ -165,14 +165,14 @@ const EditIndex = ({
             <p>
               {l('You must be logged in to see edit notes.')}
               {' '}
-              <RequestLogin $c={$c} />
+              <RequestLogin />
             </p>
           )}
         </form>
       </div>
 
       {fullWidth ? null : (
-        <EditSidebar $c={$c} edit={edit} />
+        <EditSidebar edit={edit} />
       )}
     </Layout>
   );

--- a/root/edit/OpenEdits.js
+++ b/root/edit/OpenEdits.js
@@ -14,7 +14,6 @@ import Layout from '../layout/index.js';
 import EditList from './components/EditList.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +pager: PagerT,
@@ -22,7 +21,6 @@ type Props = {
 };
 
 const OpenEdits = ({
-  $c,
   editCountLimit,
   edits,
   pager,
@@ -32,7 +30,6 @@ const OpenEdits = ({
     <div id="content">
       <h1>{l('Open Edits')}</h1>
       <EditList
-        $c={$c}
         editCountLimit={editCountLimit}
         edits={edits}
         guessSearch

--- a/root/edit/SubscribedEditorEdits.js
+++ b/root/edit/SubscribedEditorEdits.js
@@ -14,7 +14,6 @@ import Layout from '../layout/index.js';
 import EditList from './components/EditList.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +pager: PagerT,
@@ -22,7 +21,6 @@ type Props = {
 };
 
 const SubscribedEditorEdits = ({
-  $c,
   editCountLimit,
   edits,
   pager,
@@ -32,7 +30,6 @@ const SubscribedEditorEdits = ({
     <div id="content">
       <h1>{l('Edits by Your Subscribed Editors')}</h1>
       <EditList
-        $c={$c}
         editCountLimit={editCountLimit}
         edits={edits}
         guessSearch

--- a/root/edit/SubscribedEdits.js
+++ b/root/edit/SubscribedEdits.js
@@ -14,7 +14,6 @@ import Layout from '../layout/index.js';
 import EditList from './components/EditList.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +pager: PagerT,
@@ -22,7 +21,6 @@ type Props = {
 };
 
 const SubscribedEdits = ({
-  $c,
   editCountLimit,
   edits,
   pager,
@@ -32,7 +30,6 @@ const SubscribedEdits = ({
     <div id="content">
       <h1>{l('Edits for Your Subscribed Entities')}</h1>
       <EditList
-        $c={$c}
         editCountLimit={editCountLimit}
         edits={edits}
         guessSearch

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -13,6 +13,7 @@ import {EDIT_VOTE_APPROVE} from '../../constants.js';
 import RequestLogin from '../../components/RequestLogin.js';
 import SubHeader from '../../components/SubHeader.js';
 import VotingPeriod from '../../components/VotingPeriod.js';
+import {CatalystContext} from '../../context.mjs';
 import linkedEntities from '../../static/scripts/common/linkedEntities.mjs';
 import EditLink from '../../static/scripts/common/components/EditLink.js';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
@@ -32,7 +33,6 @@ import {returnToCurrentPage} from '../../utility/returnUri.js';
 import VoteTally from './VoteTally.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: GenericEditWithIdT,
   +isSummary?: boolean,
   +voter?: UnsanitizedEditorT,
@@ -62,11 +62,11 @@ const EditorTypeInfo = ({editor}: {editor: EditorT}) => (
 );
 
 const EditHeader = ({
-  $c,
   edit,
   isSummary = false,
   voter,
 }: Props): React.Element<'div'> => {
+  const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayApprove = editorMayApprove(edit, user);
   const mayCancel = editorMayCancel(edit, user);
@@ -111,7 +111,7 @@ const EditHeader = ({
       <EditorTypeInfo editor={editEditor} />
       {' '}
       {bracketed(
-        <RequestLogin $c={$c} text={l('log in to see who')} />,
+        <RequestLogin text={l('log in to see who')} />,
       )}
     </>
   );
@@ -169,7 +169,6 @@ const EditHeader = ({
                       <strong>{addColonText(l('Voting'))}</strong>
                       {' '}
                       <VotingPeriod
-                        $c={$c}
                         closingDate={edit.expires_time}
                       />
                     </>

--- a/root/edit/components/EditList.js
+++ b/root/edit/components/EditList.js
@@ -13,12 +13,12 @@ import ListEdit from '../components/ListEdit.js';
 import ListHeader from '../components/ListHeader.js';
 import FormSubmit from '../../components/FormSubmit.js';
 import PaginatedResults from '../../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import * as manifest from '../../static/manifest.mjs';
 import {isAutoEditor}
   from '../../static/scripts/common/utility/privileges.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +entity?: CoreEntityT | CollectionT,
@@ -32,7 +32,6 @@ type Props = {
 };
 
 const EditList = ({
-  $c,
   editCountLimit,
   edits,
   entity,
@@ -44,6 +43,8 @@ const EditList = ({
   username,
   voter,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+
   /*
    * guessSearch is used when we don't necessarily know the total
    * number of entries on the first page (and usually a few after), due
@@ -101,7 +102,6 @@ const EditList = ({
             <form action="/edit/enter_votes" method="post">
               {edits.map((edit, index) => (
                 <ListEdit
-                  $c={$c}
                   edit={edit}
                   index={index}
                   key={index}

--- a/root/edit/components/EditSidebar.js
+++ b/root/edit/components/EditSidebar.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import VotingPeriod from '../../components/VotingPeriod.js';
 import {EDIT_STATUS_OPEN} from '../../constants.js';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import {
   SidebarProperties,
   SidebarProperty,
@@ -23,78 +24,79 @@ import {
 import formatUserDate from '../../utility/formatUserDate.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: GenericEditWithIdT,
 };
 
 const EditSidebar = ({
-  $c,
   edit,
-}: Props): React.Element<'div'> => (
-  <div id="sidebar">
-    <SidebarProperties className="edit-status">
-      <SidebarProperty className="" label={lp('Status:', 'edit status')}>
-        {getEditStatusName(edit)}
-      </SidebarProperty>
-    </SidebarProperties>
-
-    <p>{getEditStatusDescription(edit)}</p>
-
-    <SidebarProperties>
-      <SidebarProperty className="" label={l('Opened:')}>
-        {formatUserDate($c, edit.created_time)}
-      </SidebarProperty>
-
-      {edit.status === EDIT_STATUS_OPEN ? (
-        <SidebarProperty className="" label={addColonText(l('Voting'))}>
-          <div className="edit-expiration">
-            <VotingPeriod $c={$c} closingDate={edit.expires_time} />
-          </div>
+}: Props): React.Element<'div'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <div id="sidebar">
+      <SidebarProperties className="edit-status">
+        <SidebarProperty className="" label={lp('Status:', 'edit status')}>
+          {getEditStatusName(edit)}
         </SidebarProperty>
-      ) : (
-        <SidebarProperty className="" label={l('Closed:')}>
-          <div className="edit-expiration">
-            {formatUserDate($c, edit.close_time)}
-          </div>
-        </SidebarProperty>
-      )}
+      </SidebarProperties>
 
-      <SidebarProperty
-        className=""
-        label={addColonText(l('For quicker closing'))}
-      >
-        {texp.ln(
-          '1 vote',
-          '{n} unanimous votes',
-          edit.conditions.votes,
-          {n: edit.conditions.votes},
+      <p>{getEditStatusDescription(edit)}</p>
+
+      <SidebarProperties>
+        <SidebarProperty className="" label={l('Opened:')}>
+          {formatUserDate($c, edit.created_time)}
+        </SidebarProperty>
+
+        {edit.status === EDIT_STATUS_OPEN ? (
+          <SidebarProperty className="" label={addColonText(l('Voting'))}>
+            <div className="edit-expiration">
+              <VotingPeriod closingDate={edit.expires_time} />
+            </div>
+          </SidebarProperty>
+        ) : (
+          <SidebarProperty className="" label={l('Closed:')}>
+            <div className="edit-expiration">
+              {formatUserDate($c, edit.close_time)}
+            </div>
+          </SidebarProperty>
         )}
-      </SidebarProperty>
 
-      <SidebarProperty
-        className=""
-        label={addColonText(l('If no votes cast'))}
-      >
-        {getEditExpireAction(edit)}
-      </SidebarProperty>
-    </SidebarProperties>
+        <SidebarProperty
+          className=""
+          label={addColonText(l('For quicker closing'))}
+        >
+          {texp.ln(
+            '1 vote',
+            '{n} unanimous votes',
+            edit.conditions.votes,
+            {n: edit.conditions.votes},
+          )}
+        </SidebarProperty>
 
-    <p>
-      {$c.user ? (
-        <a href={`/edit/${edit.id}/data`}>
-          <bdi>{l('Raw edit data for this edit')}</bdi>
-        </a>
-      ) : null}
-    </p>
+        <SidebarProperty
+          className=""
+          label={addColonText(l('If no votes cast'))}
+        >
+          {getEditExpireAction(edit)}
+        </SidebarProperty>
+      </SidebarProperties>
 
-    <p>{l('For more information:')}</p>
+      <p>
+        {$c.user ? (
+          <a href={`/edit/${edit.id}/data`}>
+            <bdi>{l('Raw edit data for this edit')}</bdi>
+          </a>
+        ) : null}
+      </p>
 
-    <ul className="links">
-      <li><a href="/doc/Introduction_to_Voting">{l('Voting FAQ')}</a></li>
-      <li><a href="/doc/Editing_FAQ">{l('Editing FAQ')}</a></li>
-      <li><a href="/doc/Edit_Types">{l('Edit Types')}</a></li>
-    </ul>
-  </div>
-);
+      <p>{l('For more information:')}</p>
+
+      <ul className="links">
+        <li><a href="/doc/Introduction_to_Voting">{l('Voting FAQ')}</a></li>
+        <li><a href="/doc/Editing_FAQ">{l('Editing FAQ')}</a></li>
+        <li><a href="/doc/Edit_Types">{l('Edit Types')}</a></li>
+      </ul>
+    </div>
+  );
+};
 
 export default EditSidebar;

--- a/root/edit/components/EditSummary.js
+++ b/root/edit/components/EditSummary.js
@@ -13,6 +13,7 @@ import {
   EDIT_STATUS_OPEN,
   EDIT_STATUS_APPLIED,
 } from '../../constants.js';
+import {CatalystContext} from '../../context.mjs';
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 import {
   editorMayAddNote,
@@ -25,16 +26,15 @@ import returnUri from '../../utility/returnUri.js';
 import Vote from './Vote.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: GenericEditWithIdT,
   +index: number,
 };
 
 const EditSummary = ({
-  $c,
   edit,
   index,
 }: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
   const user = $c.user;
   const mayAddNote = editorMayAddNote(edit, user);
   const mayApprove = editorMayApprove(edit, user);
@@ -49,7 +49,7 @@ const EditSummary = ({
           </div>
         ) : null}
 
-      <Vote $c={$c} edit={edit} index={index} summary />
+      <Vote edit={edit} index={index} summary />
 
       {($c.user && !DBDefs.DB_READ_ONLY &&
         (mayAddNote || mayApprove || mayCancel)

--- a/root/edit/components/ListEdit.js
+++ b/root/edit/components/ListEdit.js
@@ -13,27 +13,27 @@ import {getEditStatusClass} from '../../utility/edit.js';
 import EditHeader from '../components/EditHeader.js';
 import EditNotes from '../components/EditNotes.js';
 import EditSummary from '../components/EditSummary.js';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import getEditDetailsElement from '../utility/getEditDetailsElement.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edit: $ReadOnly<{...EditT, +id: number}>,
   +index: number,
   +voter?: UnsanitizedEditorT,
 };
 
 const ListEdit = ({
-  $c,
   edit,
   index,
   voter,
 }: Props): React.Element<'div'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const editStatusClass = getEditStatusClass(edit);
   const detailsElement = getEditDetailsElement(edit);
 
   return (
     <div className="edit-list">
-      <EditHeader $c={$c} edit={edit} isSummary voter={voter} />
+      <EditHeader edit={edit} isSummary voter={voter} />
 
       <input
         name={`enter-vote.vote.${index}.edit_id`}
@@ -42,7 +42,7 @@ const ListEdit = ({
       />
 
       <div className={`edit-actions c ${editStatusClass}`}>
-        <EditSummary $c={$c} edit={edit} index={index} />
+        <EditSummary edit={edit} index={index} />
       </div>
 
       <div className="edit-details">

--- a/root/edit/components/Vote.js
+++ b/root/edit/components/Vote.js
@@ -16,6 +16,7 @@ import {
   EDIT_VOTE_NO,
   EDIT_VOTE_YES,
 } from '../../constants.js';
+import {CatalystContext} from '../../context.mjs';
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 import {
   editorMayVote,
@@ -58,18 +59,17 @@ const VoteCheckbox = ({
 };
 
 type VoteProps = {
-  +$c: CatalystContextT,
   +edit: GenericEditWithIdT,
   +index?: number,
   +summary?: boolean,
 };
 
 const Vote = ({
-  $c,
   edit,
   index = 0,
   summary = false,
 }: VoteProps): React.Element<'div'> | null => {
+  const $c = React.useContext(CatalystContext);
   const user = $c.user;
   if (DBDefs.DB_READ_ONLY || !user || !editorMayVote(edit, user)) {
     return null;

--- a/root/elections/ElectionDetails.js
+++ b/root/elections/ElectionDetails.js
@@ -14,113 +14,120 @@ import bracketed from '../static/scripts/common/utility/bracketed.js';
 import formatUserDate from '../utility/formatUserDate.js';
 import {votesVisible} from '../utility/voting.js';
 import VotingPeriod from '../components/VotingPeriod.js';
+import {CatalystContext} from '../context.mjs';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +election: AutoEditorElectionT,
 };
 
-const ElectionDetails = ({$c, election}: PropsT): React.MixedElement => (
-  <>
-    <h2>{l('Details')}</h2>
-    <table className="properties">
-      <tr>
-        <th>{l('Candidate:')}</th>
-        <td><EditorLink editor={election.candidate} /></td>
-      </tr>
-      <tr>
-        <th>{l('Proposer:')}</th>
-        <td><EditorLink editor={election.proposer} /></td>
-      </tr>
-      <tr>
-        <th>{l('1st seconder:')}</th>
-        <td>
-          {election.seconder_1
-            ? <EditorLink editor={election.seconder_1} />
-            : '-'}
-        </td>
-      </tr>
-      <tr>
-        <th>{l('2nd seconder:')}</th>
-        <td>
-          {election.seconder_2
-            ? <EditorLink editor={election.seconder_2} />
-            : '-'}
-        </td>
-      </tr>
-      {votesVisible(election, $c.user)
-        ? (
-          <>
-            <tr>
-              <th>{l('Votes for:')}</th>
-              <td>{election.yes_votes}</td>
-            </tr>
-            <tr>
-              <th>{l('Votes against:')}</th>
-              <td>{election.no_votes}</td>
-            </tr>
-          </>
-        ) : (
-          election.is_open
-            ? (
+const ElectionDetails = ({election}: PropsT): React.MixedElement => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <>
+      <h2>{l('Details')}</h2>
+      <table className="properties">
+        <tr>
+          <th>{l('Candidate:')}</th>
+          <td><EditorLink editor={election.candidate} /></td>
+        </tr>
+        <tr>
+          <th>{l('Proposer:')}</th>
+          <td><EditorLink editor={election.proposer} /></td>
+        </tr>
+        <tr>
+          <th>{l('1st seconder:')}</th>
+          <td>
+            {election.seconder_1
+              ? <EditorLink editor={election.seconder_1} />
+              : '-'}
+          </td>
+        </tr>
+        <tr>
+          <th>{l('2nd seconder:')}</th>
+          <td>
+            {election.seconder_2
+              ? <EditorLink editor={election.seconder_2} />
+              : '-'}
+          </td>
+        </tr>
+        {votesVisible(election, $c.user)
+          ? (
+            <>
               <tr>
-                <th>{l('Votes for/against:')}</th>
-                <td>
-                  {l(`The tally of votes cast will only be shown
-                      when the election is complete.`)}
-                </td>
+                <th>{l('Votes for:')}</th>
+                <td>{election.yes_votes}</td>
               </tr>
-            ) : null
-        )
-      }
-      <tr>
-        <th>{lp('Status:', 'election status')}</th>
-        <td>
-          {election.is_open && nonEmpty(election.open_time)
-            ? (
-              texp.lp(election.status_name, 'autoeditor election status', {
-                date: formatUserDate($c, election.open_time),
-              })
-            ) : null}
+              <tr>
+                <th>{l('Votes against:')}</th>
+                <td>{election.no_votes}</td>
+              </tr>
+            </>
+          ) : (
+            election.is_open
+              ? (
+                <tr>
+                  <th>{l('Votes for/against:')}</th>
+                  <td>
+                    {l(`The tally of votes cast will only be shown
+                        when the election is complete.`)}
+                  </td>
+                </tr>
+              ) : null
+          )
+        }
+        <tr>
+          <th>{lp('Status:', 'election status')}</th>
+          <td>
+            {election.is_open && nonEmpty(election.open_time)
+              ? (
+                texp.lp(election.status_name, 'autoeditor election status', {
+                  date: formatUserDate($c, election.open_time),
+                })
+              ) : null}
 
-          {election.is_pending
-            ? lp(election.status_name, 'autoeditor election status')
-            : null}
+            {election.is_pending
+              ? lp(election.status_name, 'autoeditor election status')
+              : null}
 
-          {election.is_pending || election.is_open
-            ? (
-              <>
-                {' '}
-                {bracketed(
-                  <VotingPeriod
-                    $c={$c}
-                    closingDate={election.current_expiration_time}
-                  />,
-                )}
-              </>
-            ) : null}
+            {election.is_pending || election.is_open
+              ? (
+                <>
+                  {' '}
+                  {bracketed(
+                    <VotingPeriod
+                      closingDate={election.current_expiration_time}
+                    />,
+                  )}
+                </>
+              ) : null}
 
-          {election.is_closed
-            ? (
-              nonEmpty(election.close_time)
-                ? (
-                  texp.lp(election.status_name, 'autoeditor election status',
-                          {
-                            date: formatUserDate($c, election.close_time),
-                          })
-                ) : (
-                  lp(election.status_name_short,
-                     'autoeditor election status (short)')
-                )
-            ) : null}
+            {election.is_closed
+              ? (
+                nonEmpty(election.close_time)
+                  ? (
+                    texp.lp(
+                      election.status_name,
+                      'autoeditor election status',
+                      {
+                        date: formatUserDate($c, election.close_time),
+                      },
+                    )
+                  ) : (
+                    lp(
+                      election.status_name_short,
+                      'autoeditor election status (short)',
+                    )
+                  )
+              ) : null}
 
-          {(election.is_open || election.is_pending || election.is_closed)
-            ? null
-            : lp(election.status_name, 'autoeditor election status')}
-        </td>
-      </tr>
-    </table>
-  </>
-);
+            {(election.is_open || election.is_pending || election.is_closed)
+              ? null
+              : lp(election.status_name, 'autoeditor election status')}
+          </td>
+        </tr>
+      </table>
+    </>
+  );
+};
 
 export default ElectionDetails;

--- a/root/elections/ElectionTable/ElectionTableRows.js
+++ b/root/elections/ElectionTable/ElectionTableRows.js
@@ -9,69 +9,68 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
 import formatUserDate from '../../utility/formatUserDate.js';
 import {votesVisible} from '../../utility/voting.js';
 
 type RowProps = {
-  +$c: CatalystContextT,
   +election: AutoEditorElectionT,
   +index: number,
 };
 
 const ElectionTableRow = ({
-  $c,
   election,
   index,
-}: RowProps): React.Element<'tr'> => (
-  <tr className={index % 2 ? 'even' : 'odd'}>
-    <td><EditorLink editor={election.candidate} /></td>
-    <td>
-      {lp(election.status_name_short, 'autoeditor election status (short)')}
-    </td>
-    <td>{formatUserDate($c, election.propose_time)}</td>
-    <td>
-      {nonEmpty(election.close_time)
-        ? formatUserDate($c, election.close_time)
-        : '-'}
-    </td>
-    <td><EditorLink editor={election.proposer} /></td>
-    <td>
-      {election.seconder_1
-        ? <EditorLink editor={election.seconder_1} />
-        : '-'}
-    </td>
-    <td>
-      {election.seconder_2
-        ? <EditorLink editor={election.seconder_2} />
-        : '-'}
-    </td>
-    <td>
-      {votesVisible(election, $c.user)
-        ? election.yes_votes
-        : '-'}
-    </td>
-    <td>
-      {votesVisible(election, $c.user)
-        ? election.no_votes
-        : '-'}
-    </td>
-    <td><a href={`/election/${election.id}`}>{l('View details')}</a></td>
-  </tr>
-);
+}: RowProps): React.Element<'tr'> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <tr className={index % 2 ? 'even' : 'odd'}>
+      <td><EditorLink editor={election.candidate} /></td>
+      <td>
+        {lp(election.status_name_short, 'autoeditor election status (short)')}
+      </td>
+      <td>{formatUserDate($c, election.propose_time)}</td>
+      <td>
+        {nonEmpty(election.close_time)
+          ? formatUserDate($c, election.close_time)
+          : '-'}
+      </td>
+      <td><EditorLink editor={election.proposer} /></td>
+      <td>
+        {election.seconder_1
+          ? <EditorLink editor={election.seconder_1} />
+          : '-'}
+      </td>
+      <td>
+        {election.seconder_2
+          ? <EditorLink editor={election.seconder_2} />
+          : '-'}
+      </td>
+      <td>
+        {votesVisible(election, $c.user)
+          ? election.yes_votes
+          : '-'}
+      </td>
+      <td>
+        {votesVisible(election, $c.user)
+          ? election.no_votes
+          : '-'}
+      </td>
+      <td><a href={`/election/${election.id}`}>{l('View details')}</a></td>
+    </tr>
+  );
+};
 
 type Props = {
-  +$c: CatalystContextT,
   +elections: $ReadOnlyArray<AutoEditorElectionT>,
 };
 
 const ElectionTableRows = ({
-  $c,
   elections,
 }: Props): $ReadOnlyArray<React.Element<typeof ElectionTableRow>> => (
   elections.map((election, index) => (
     <ElectionTableRow
-      $c={$c}
       election={election}
       index={index}
       key={election.id}

--- a/root/elections/ElectionTable/index.js
+++ b/root/elections/ElectionTable/index.js
@@ -12,12 +12,10 @@ import * as React from 'react';
 import Rows from './ElectionTableRows.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +elections: $ReadOnlyArray<AutoEditorElectionT>,
 };
 
 const ElectionTable = ({
-  $c,
   elections,
 }: PropsT): React.Element<'table'> => (
   <table className="tbl" style={{width: 'auto'}}>
@@ -36,7 +34,7 @@ const ElectionTable = ({
       </tr>
     </thead>
     <tbody>
-      <Rows $c={$c} elections={elections} />
+      <Rows elections={elections} />
     </tbody>
   </table>
 );

--- a/root/elections/ElectionVotes.js
+++ b/root/elections/ElectionVotes.js
@@ -9,37 +9,40 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import formatUserDate from '../utility/formatUserDate.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +election: AutoEditorElectionT,
 };
 
-const ElectionVotes = ({$c, election}: PropsT): React.Element<'table'> => (
-  <table className="tbl" style={{width: 'auto'}}>
-    <thead>
-      <tr>
-        <th>{l('Voter')}</th>
-        <th>{l('Vote')}</th>
-        <th>{l('Date')}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {election.votes.map((vote, index) => (
-        <tr className={index % 2 ? 'even' : 'odd'} key={vote.voter.id}>
-          <td><EditorLink editor={vote.voter} /></td>
-          <td>
-            {$c.user && $c.user.id === vote.voter.id
-              ? lp(vote.vote_name, 'vote')
-              : l('(private)')}
-          </td>
-          <td>{formatUserDate($c, vote.vote_time)}</td>
+const ElectionVotes = ({election}: PropsT): React.Element<'table'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <table className="tbl" style={{width: 'auto'}}>
+      <thead>
+        <tr>
+          <th>{l('Voter')}</th>
+          <th>{l('Vote')}</th>
+          <th>{l('Date')}</th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody>
+        {election.votes.map((vote, index) => (
+          <tr className={index % 2 ? 'even' : 'odd'} key={vote.voter.id}>
+            <td><EditorLink editor={vote.voter} /></td>
+            <td>
+              {$c.user && $c.user.id === vote.voter.id
+                ? lp(vote.vote_name, 'vote')
+                : l('(private)')}
+            </td>
+            <td>{formatUserDate($c, vote.vote_time)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 export default ElectionVotes;

--- a/root/elections/ElectionVoting.js
+++ b/root/elections/ElectionVoting.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {canCancel, canSecond, canVote, isInvolved}
   from '../utility/voting.js';
 import {
@@ -16,11 +17,11 @@ import {
 } from '../static/scripts/common/utility/privileges.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +election: AutoEditorElectionT,
 };
 
-const ElectionVoting = ({$c, election}: PropsT): React.MixedElement => {
+const ElectionVoting = ({election}: PropsT): React.MixedElement => {
+  const $c = React.useContext(CatalystContext);
   let message = exp.l(
     'To find out if you can vote for this candidate, please {url|log in}.',
     {url: '/login'},

--- a/root/elections/Index.js
+++ b/root/elections/Index.js
@@ -14,15 +14,14 @@ import Layout from '../layout/index.js';
 import ElectionTable from './ElectionTable/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +elections: $ReadOnlyArray<AutoEditorElectionT>,
 };
 
-const Index = ({$c, elections}: Props): React.Element<typeof Layout> => (
+const Index = ({elections}: Props): React.Element<typeof Layout> => (
   <Layout fullWidth title={l('Auto-editor elections')}>
     <h1>{l('Auto-editor elections')}</h1>
     {elections.length
-      ? <ElectionTable $c={$c} elections={elections} />
+      ? <ElectionTable elections={elections} />
       : <p>{l('No elections found.')}</p>}
   </Layout>
 );

--- a/root/elections/Show.js
+++ b/root/elections/Show.js
@@ -16,11 +16,10 @@ import ElectionVotes from './ElectionVotes.js';
 import ElectionVoting from './ElectionVoting.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +election: AutoEditorElectionT,
 };
 
-const Show = ({$c, election}: Props): React.Element<typeof Layout> | null => {
+const Show = ({election}: Props): React.Element<typeof Layout> | null => {
   if (!election) {
     return null;
   }
@@ -31,11 +30,11 @@ const Show = ({$c, election}: Props): React.Element<typeof Layout> | null => {
       <p>
         <a href="/elections">{l('Back to elections')}</a>
       </p>
-      <ElectionDetails $c={$c} election={election} />
+      <ElectionDetails election={election} />
       <h2>{l('Voting')}</h2>
-      <ElectionVoting $c={$c} election={election} />
+      <ElectionVoting election={election} />
       <h2>{l('Votes cast')}</h2>
-      <ElectionVotes $c={$c} election={election} />
+      <ElectionVotes election={election} />
     </Layout>
   );
 };

--- a/root/entity/Aliases.js
+++ b/root/entity/Aliases.js
@@ -14,14 +14,12 @@ import AliasesComponent from '../components/Aliases/index.js';
 import ArtistCreditList from '../components/Aliases/ArtistCreditList.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +aliases: $ReadOnlyArray<AliasT>,
   +artistCredits?: $ReadOnlyArray<{+id: number} & ArtistCreditT>,
   +entity: CoreEntityT,
 };
 
 const Aliases = ({
-  $c,
   aliases,
   artistCredits,
   entity,
@@ -35,10 +33,9 @@ const Aliases = ({
       page="aliases"
       title={l('Aliases')}
     >
-      <AliasesComponent $c={$c} aliases={aliases} entity={entity} />
+      <AliasesComponent aliases={aliases} entity={entity} />
       {artistCredits?.length ? (
         <ArtistCreditList
-          $c={$c}
           artistCredits={artistCredits}
           entity={entity}
         />

--- a/root/entity/Details.js
+++ b/root/entity/Details.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {ENTITIES} from '../static/scripts/common/constants.js';
 import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
@@ -27,8 +28,8 @@ type WSLinkProps = {
   +isJson?: boolean,
   +isSecureConnection: boolean,
 };
+
 type DetailsProps = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT,
 };
 
@@ -72,9 +73,9 @@ const WSLink = ({
 };
 
 const Details = ({
-  $c,
   entity,
 }: DetailsProps): React.MixedElement => {
+  const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const entityProperties = ENTITIES[entityType];
   const entityTypeForUrl = entityProperties.url

--- a/root/entity/Edits.js
+++ b/root/entity/Edits.js
@@ -19,7 +19,6 @@ import localizeTypeNameForEntity
   from '../static/scripts/common/i18n/localizeTypeNameForEntity.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +entity: CoreEntityT | CollectionT,
@@ -30,7 +29,6 @@ type Props = {
 };
 
 const Edits = ({
-  $c,
   editCountLimit,
   edits,
   entity,
@@ -88,7 +86,6 @@ const Edits = ({
           <SubHeader subHeading={pageSubHeading} />
         </div>
         <EditList
-          $c={$c}
           editCountLimit={editCountLimit}
           edits={edits}
           entity={entity}

--- a/root/entity/Ratings.js
+++ b/root/entity/Ratings.js
@@ -22,7 +22,6 @@ import {
 } from '../static/scripts/common/components/RatingStars.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: RatableT | ReviewableT,
   +mostPopularReview: CritiqueBrainzReviewT,
   +mostRecentReview: CritiqueBrainzReviewT,

--- a/root/entity/Subscribers.js
+++ b/root/entity/Subscribers.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import isSpecialPurpose
   from '../static/scripts/common/utility/isSpecialPurpose.js';
@@ -16,7 +17,6 @@ import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: CoreEntityT | CollectionT | EditorT,
   +isSpecialEntity: boolean,
   +privateEditors: number,
@@ -25,12 +25,12 @@ type Props = {
 };
 
 const Subscribers = ({
-  $c,
   entity,
   privateEditors,
   publicEditors,
   subscribed,
 }: Props): React.MixedElement => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const entityType = entity.entityType;
   const LayoutComponent = chooseLayoutComponent(entityType);
   const returnTo = '&' + returnToCurrentPage($c);

--- a/root/entity/Tags.js
+++ b/root/entity/Tags.js
@@ -9,12 +9,12 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import chooseLayoutComponent from '../utility/chooseLayoutComponent.js';
 import {MainTagEditor}
   from '../static/scripts/common/components/TagEditor.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +allTags: $ReadOnlyArray<AggregatedTagT>,
   +entity: CoreEntityT,
   +moreTags: boolean,
@@ -22,19 +22,18 @@ type Props = {
 };
 
 const Tags = ({
-  $c,
   allTags,
   entity,
   moreTags,
   userTags,
 }: Props): React.MixedElement => {
+  const $c = React.useContext(CatalystContext);
   const entityType = entity.entityType;
   const LayoutComponent = chooseLayoutComponent(entityType);
 
   return (
     <LayoutComponent entity={entity} page="tags" title={l('Tags')}>
       <MainTagEditor
-        $c={$c}
         aggregatedTags={allTags}
         entity={entity}
         genreMap={$c.stash.genre_map}

--- a/root/entity/alias/AddOrEditAlias.js
+++ b/root/entity/alias/AddOrEditAlias.js
@@ -18,7 +18,6 @@ import {ENTITIES} from '../../static/scripts/common/constants.js';
 import type {AliasEditFormT} from './types.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +aliasTypes: SelectOptionsT,
   +entity: CoreEntityT,
   +form: AliasEditFormT,
@@ -28,7 +27,6 @@ type Props = {
 };
 
 const AddOrEditAlias = ({
-  $c,
   aliasTypes,
   entity,
   form,
@@ -51,7 +49,6 @@ const AddOrEditAlias = ({
     >
       <h2>{header}</h2>
       <AliasEditForm
-        $c={$c}
         aliasTypes={aliasTypes}
         entity={entity}
         form={form}

--- a/root/entity/alias/DeleteAlias.js
+++ b/root/entity/alias/DeleteAlias.js
@@ -16,7 +16,6 @@ import EnterEditNote from '../../components/EnterEditNote.js';
 import type {AliasDeleteFormT} from './types.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +alias: AliasT,
   +entity: CoreEntityT,
   +form: AliasDeleteFormT,
@@ -24,7 +23,6 @@ type Props = {
 };
 
 const DeleteAlias = ({
-  $c,
   alias,
   entity,
   form,
@@ -54,7 +52,7 @@ const DeleteAlias = ({
         )}
       </p>
 
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <EnterEditNote field={form.field.edit_note} />
         <EnterEdit form={form} />
       </form>

--- a/root/event/EventMerge.js
+++ b/root/event/EventMerge.js
@@ -18,13 +18,11 @@ import EventList from '../components/list/EventList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<EventT>,
 };
 
 const EventMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const EventMerge = ({
         {l(`You are about to merge all these events into a single one.
             Please select the event all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <EventList
           events={sortByEntityName(toMerge)}
           mergeForm={form}

--- a/root/genre/CreateGenre.js
+++ b/root/genre/CreateGenre.js
@@ -17,7 +17,6 @@ import GenreEditForm
 import type {GenreFormT} from './types.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +attrInfo: LinkAttrTypeOptionsT,
   +form: GenreFormT,
   +sourceEntity: {entityType: 'genre'},
@@ -25,7 +24,6 @@ type Props = {
 };
 
 const CreateGenre = ({
-  $c,
   attrInfo,
   form,
   sourceEntity,
@@ -35,7 +33,6 @@ const CreateGenre = ({
     <div id="content">
       <h1>{l('Add a new genre')}</h1>
       <GenreEditForm
-        $c={$c}
         attrInfo={attrInfo}
         form={form}
         sourceEntity={sourceEntity}

--- a/root/genre/DeleteGenre.js
+++ b/root/genre/DeleteGenre.js
@@ -17,13 +17,11 @@ import GenreLayout from './GenreLayout.js';
 import type {GenreDeleteFormT} from './types.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +entity: GenreT,
   +form: GenreDeleteFormT,
 };
 
 const DeleteGenre = ({
-  $c,
   entity: genre,
   form,
 }: Props): React.Element<typeof GenreLayout> => (
@@ -39,7 +37,7 @@ const DeleteGenre = ({
              {genre: <EntityLink entity={genre} />})}
     </p>
 
-    <form action={$c.req.uri} method="post">
+    <form method="post">
       <EnterEditNote field={form.field.edit_note} />
       <EnterEdit form={form} />
     </form>

--- a/root/genre/EditGenre.js
+++ b/root/genre/EditGenre.js
@@ -17,7 +17,6 @@ import GenreLayout from './GenreLayout.js';
 import type {GenreFormT} from './types.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +attrInfo: LinkAttrTypeOptionsT,
   +entity: GenreT,
   +form: GenreFormT,
@@ -26,7 +25,6 @@ type Props = {
 };
 
 const EditGenre = ({
-  $c,
   attrInfo,
   entity,
   form,
@@ -40,7 +38,6 @@ const EditGenre = ({
     title={l('Edit genre')}
   >
     <GenreEditForm
-      $c={$c}
       attrInfo={attrInfo}
       form={form}
       sourceEntity={sourceEntity}

--- a/root/instrument/InstrumentArtists.js
+++ b/root/instrument/InstrumentArtists.js
@@ -11,62 +11,64 @@ import * as React from 'react';
 
 import ArtistList from '../components/list/ArtistList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
 type Props = {|
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +artists: $ReadOnlyArray<ArtistT>,
   +instrument: InstrumentT,
   +pager: PagerT,
 |};
 
 const InstrumentArtists = ({
-  $c,
   artists,
   instrument,
   instrumentCreditsAndRelTypes,
   pager,
-}: Props): React.Element<typeof InstrumentLayout> => (
-  <InstrumentLayout
-    entity={instrument}
-    page="artists"
-    title={l('Artists')}
-  >
-    <h2>{l('Artists')}</h2>
+}: Props): React.Element<typeof InstrumentLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <InstrumentLayout
+      entity={instrument}
+      page="artists"
+      title={l('Artists')}
+    >
+      <h2>{l('Artists')}</h2>
 
-    {artists && artists.length > 0 ? (
-      <form
-        action={'/artist/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <ArtistList
-            artists={artists}
-            checkboxes="add-to-merge"
-            instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
-            showInstrumentCreditsAndRelTypes
-            showRatings
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected artists for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('No artists found.')}
-      </p>
-    )}
-  </InstrumentLayout>
-);
+      {artists && artists.length > 0 ? (
+        <form
+          action={'/artist/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <ArtistList
+              artists={artists}
+              checkboxes="add-to-merge"
+              instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+              showInstrumentCreditsAndRelTypes
+              showRatings
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected artists for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('No artists found.')}
+        </p>
+      )}
+    </InstrumentLayout>
+  );
+};
 
 export default InstrumentArtists;

--- a/root/instrument/InstrumentMerge.js
+++ b/root/instrument/InstrumentMerge.js
@@ -18,13 +18,11 @@ import InstrumentList from '../components/list/InstrumentList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<InstrumentT>,
 };
 
 const InstrumentMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const InstrumentMerge = ({
         {l(`You are about to merge all these instruments into a single one.
             Please select the instrument all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <InstrumentList
           instruments={sortByEntityName(toMerge)}
           mergeForm={form}

--- a/root/instrument/InstrumentRecordings.js
+++ b/root/instrument/InstrumentRecordings.js
@@ -11,62 +11,64 @@ import * as React from 'react';
 
 import RecordingList from '../components/list/RecordingList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
 type Props = {|
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +instrument: InstrumentT,
   +pager: PagerT,
   +recordings: $ReadOnlyArray<RecordingWithArtistCreditT>,
 |};
 
 const InstrumentRecordings = ({
-  $c,
   instrument,
   instrumentCreditsAndRelTypes,
   pager,
   recordings,
-}: Props): React.Element<typeof InstrumentLayout> => (
-  <InstrumentLayout
-    entity={instrument}
-    page="recordings"
-    title={l('Recordings')}
-  >
-    <h2>{l('Recordings')}</h2>
+}: Props): React.Element<typeof InstrumentLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <InstrumentLayout
+      entity={instrument}
+      page="recordings"
+      title={l('Recordings')}
+    >
+      <h2>{l('Recordings')}</h2>
 
-    {recordings && recordings.length > 0 ? (
-      <form
-        action={'/recording/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <RecordingList
-            checkboxes="add-to-merge"
-            instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
-            recordings={recordings}
-            showInstrumentCreditsAndRelTypes
-            showRatings
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected recordings for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('No recordings found.')}
-      </p>
-    )}
-  </InstrumentLayout>
-);
+      {recordings && recordings.length > 0 ? (
+        <form
+          action={'/recording/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <RecordingList
+              checkboxes="add-to-merge"
+              instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+              recordings={recordings}
+              showInstrumentCreditsAndRelTypes
+              showRatings
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected recordings for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('No recordings found.')}
+        </p>
+      )}
+    </InstrumentLayout>
+  );
+};
 
 export default InstrumentRecordings;

--- a/root/instrument/InstrumentReleases.js
+++ b/root/instrument/InstrumentReleases.js
@@ -11,61 +11,63 @@ import * as React from 'react';
 
 import ReleaseList from '../components/list/ReleaseList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import InstrumentLayout from './InstrumentLayout.js';
 
 type Props = {|
   ...InstrumentCreditsAndRelTypesRoleT,
-  +$c: CatalystContextT,
   +instrument: InstrumentT,
   +pager: PagerT,
   +releases: $ReadOnlyArray<ReleaseT>,
 |};
 
 const InstrumentReleases = ({
-  $c,
   instrument,
   instrumentCreditsAndRelTypes,
   pager,
   releases,
-}: Props): React.Element<typeof InstrumentLayout> => (
-  <InstrumentLayout
-    entity={instrument}
-    page="releases"
-    title={l('Releases')}
-  >
-    <h2>{l('Releases')}</h2>
+}: Props): React.Element<typeof InstrumentLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <InstrumentLayout
+      entity={instrument}
+      page="releases"
+      title={l('Releases')}
+    >
+      <h2>{l('Releases')}</h2>
 
-    {releases && releases.length > 0 ? (
-      <form
-        action={'/release/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <ReleaseList
-            checkboxes="add-to-merge"
-            instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
-            releases={releases}
-            showInstrumentCreditsAndRelTypes
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected releases for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('No releases found.')}
-      </p>
-    )}
-  </InstrumentLayout>
-);
+      {releases && releases.length > 0 ? (
+        <form
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <ReleaseList
+              checkboxes="add-to-merge"
+              instrumentCreditsAndRelTypes={instrumentCreditsAndRelTypes}
+              releases={releases}
+              showInstrumentCreditsAndRelTypes
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected releases for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('No releases found.')}
+        </p>
+      )}
+    </InstrumentLayout>
+  );
+};
 
 export default InstrumentReleases;

--- a/root/isrc/Index.js
+++ b/root/isrc/Index.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import ArtistCreditLink
   from '../static/scripts/common/components/ArtistCreditLink.js';
@@ -20,16 +21,15 @@ import loopParity from '../utility/loopParity.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +isrcs: $ReadOnlyArray<IsrcT>,
   +recordings: $ReadOnlyArray<RecordingWithArtistCreditT>,
 };
 
 const Index = ({
-  $c,
   isrcs,
   recordings,
 }: PropsT): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const userExists = !!$c.user;
   const isrc = isrcs[0];
   return (

--- a/root/iswc/Index.js
+++ b/root/iswc/Index.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import CodeLink from '../static/scripts/common/components/CodeLink.js';
 import WorkListEntry
@@ -16,12 +17,12 @@ import WorkListEntry
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +iswcs: $ReadOnlyArray<IswcT>,
   +works: $ReadOnlyArray<WorkT>,
 };
 
-const Index = ({$c, iswcs, works}: Props): React.Element<typeof Layout> => {
+const Index = ({iswcs, works}: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const userExists = !!$c.user;
   const iswc = iswcs[0];
   return (

--- a/root/label/LabelIndex.js
+++ b/root/label/LabelIndex.js
@@ -13,6 +13,7 @@ import CleanupBanner from '../components/CleanupBanner.js';
 import FormRow from '../components/FormRow.js';
 import FormSubmit from '../components/FormSubmit.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
 import WikipediaExtract
@@ -27,7 +28,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import LabelLayout from './LabelLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +label: LabelT,
   +numberOfRevisions: number,
@@ -39,7 +39,6 @@ type Props = {
 };
 
 const LabelIndex = ({
-  $c,
   eligibleForCleanup,
   label,
   numberOfRevisions,
@@ -48,59 +47,62 @@ const LabelIndex = ({
   renamedFrom,
   renamedInto,
   wikipediaExtract,
-}: Props): React.Element<typeof LabelLayout> => (
-  <LabelLayout entity={label} page="index">
-    {eligibleForCleanup ? (
-      <CleanupBanner entityType="label" />
-    ) : null}
-    <Annotation
-      annotation={label.latest_annotation}
-      collapse
-      entity={label}
-      numberOfRevisions={numberOfRevisions}
-    />
-    {renamedFrom.length ? (
-      <RelatedEntitiesDisplay title={l('Previously known as')}>
-        {commaOnlyList(renamedFrom.map(
-          label => <DescriptiveLink entity={label} key={label.gid} />,
-        ))}
-      </RelatedEntitiesDisplay>
-    ) : null}
-    {renamedInto.length ? (
-      <RelatedEntitiesDisplay title={l('Renamed to')}>
-        {commaOnlyList(renamedInto.map(
-          label => <DescriptiveLink entity={label} key={label.gid} />,
-        ))}
-      </RelatedEntitiesDisplay>
-    ) : null}
-    <WikipediaExtract
-      cachedWikipediaExtract={wikipediaExtract}
-      entity={label}
-    />
-    <h2 className="releases">{l('Releases')}</h2>
-    {releases?.length ? (
-      <form
-        action={'/release/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <ReleaseList
-            checkboxes="add-to-merge"
-            filterLabel={label}
-            releases={releases}
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <FormRow>
-            <FormSubmit label={l('Add selected releases for merging')} />
-          </FormRow>
-        ) : null}
-      </form>
-    ) : (
-      <p>{l('This label does not have any releases.')}</p>
-    )}
-    {manifest.js('label/index', {async: 'async'})}
-  </LabelLayout>
-);
+}: Props): React.Element<typeof LabelLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <LabelLayout entity={label} page="index">
+      {eligibleForCleanup ? (
+        <CleanupBanner entityType="label" />
+      ) : null}
+      <Annotation
+        annotation={label.latest_annotation}
+        collapse
+        entity={label}
+        numberOfRevisions={numberOfRevisions}
+      />
+      {renamedFrom.length ? (
+        <RelatedEntitiesDisplay title={l('Previously known as')}>
+          {commaOnlyList(renamedFrom.map(
+            label => <DescriptiveLink entity={label} key={label.gid} />,
+          ))}
+        </RelatedEntitiesDisplay>
+      ) : null}
+      {renamedInto.length ? (
+        <RelatedEntitiesDisplay title={l('Renamed to')}>
+          {commaOnlyList(renamedInto.map(
+            label => <DescriptiveLink entity={label} key={label.gid} />,
+          ))}
+        </RelatedEntitiesDisplay>
+      ) : null}
+      <WikipediaExtract
+        cachedWikipediaExtract={wikipediaExtract}
+        entity={label}
+      />
+      <h2 className="releases">{l('Releases')}</h2>
+      {releases?.length ? (
+        <form
+          action={'/release/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <ReleaseList
+              checkboxes="add-to-merge"
+              filterLabel={label}
+              releases={releases}
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <FormRow>
+              <FormSubmit label={l('Add selected releases for merging')} />
+            </FormRow>
+          ) : null}
+        </form>
+      ) : (
+        <p>{l('This label does not have any releases.')}</p>
+      )}
+      {manifest.js('label/index', {async: 'async'})}
+    </LabelLayout>
+  );
+};
 
 export default LabelIndex;

--- a/root/label/LabelMerge.js
+++ b/root/label/LabelMerge.js
@@ -18,13 +18,11 @@ import LabelList from '../components/list/LabelList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<LabelT>,
 };
 
 const LabelMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const LabelMerge = ({
         {l(`You are about to merge all these labels into a single one.
             Please select the label all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <LabelList
           labels={sortByEntityName(toMerge)}
           mergeForm={form}

--- a/root/label/LabelRelationships.js
+++ b/root/label/LabelRelationships.js
@@ -16,14 +16,12 @@ import Relationships
 import LabelLayout from './LabelLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +label: LabelT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: ?PagerT,
 };
 
 const LabelRelationships = ({
-  $c,
   label,
   pagedLinkTypeGroup,
   pager,
@@ -37,7 +35,6 @@ const LabelRelationships = ({
       <Relationships showIfEmpty source={label} />
     )}
     <RelationshipsTable
-      $c={$c}
       entity={label}
       heading={l('Appearances')}
       pagedLinkTypeGroup={pagedLinkTypeGroup}

--- a/root/layout/components/BottomMenu.js
+++ b/root/layout/components/BottomMenu.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 
-import {CatalystContext} from '../../context.mjs';
+import {SanitizedCatalystContext} from '../../context.mjs';
 import {VARTIST_GID} from '../../static/scripts/common/constants.js';
 import {capitalize} from '../../static/scripts/common/utility/strings.js';
 import {returnToCurrentPage} from '../../utility/returnUri.js';
@@ -46,66 +46,68 @@ function languageName(
 }
 
 type LanguageLinkPropsT = {
-  +$c: CatalystContextT,
   language: ServerLanguageT,
 };
 
 const LanguageLink = ({
-  $c,
   language,
-}: LanguageLinkPropsT) => (
-  <a
-    href={
-      '/set-language/' + encodeURIComponent(language.name) +
-      '?' + returnToCurrentPage($c)
-    }
-  >
-    {languageName(language, false)}
-  </a>
-);
+}: LanguageLinkPropsT) => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <a
+      href={
+        '/set-language/' + encodeURIComponent(language.name) +
+        '?' + returnToCurrentPage($c)
+      }
+    >
+      {languageName(language, false)}
+    </a>
+  );
+};
 
 type LanguageMenuProps = {
-  +$c: CatalystContextT,
   +currentBCP47Language: string,
   +serverLanguages: $ReadOnlyArray<ServerLanguageT>,
 };
 
 const LanguageMenu = ({
-  $c,
   currentBCP47Language,
   serverLanguages,
-}: LanguageMenuProps) => (
-  <li className="language-selector" tabIndex="-1">
-    <span className="menu-header">
-      {languageName(
-        serverLanguages.find(x => x.name === currentBCP47Language),
-        true,
-      )}
-    </span>
-    <ul>
-      {serverLanguages.map(function (language, index) {
-        let inner: React.MixedElement =
-          <LanguageLink $c={$c} language={language} />;
+}: LanguageMenuProps) => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <li className="language-selector" tabIndex="-1">
+      <span className="menu-header">
+        {languageName(
+          serverLanguages.find(x => x.name === currentBCP47Language),
+          true,
+        )}
+      </span>
+      <ul>
+        {serverLanguages.map(function (language, index) {
+          let inner: React.MixedElement =
+            <LanguageLink language={language} />;
 
-        if (language.name === currentBCP47Language) {
-          inner = <strong>{inner}</strong>;
-        }
+          if (language.name === currentBCP47Language) {
+            inner = <strong>{inner}</strong>;
+          }
 
-        return <li key={index}>{inner}</li>;
-      })}
-      <li>
-        <a href={'/set-language/unset?' + returnToCurrentPage($c)}>
-          {l('(reset language)')}
-        </a>
-      </li>
-      <li className="separator">
-        <a href="https://www.transifex.com/musicbrainz/musicbrainz/">
-          {l('Help Translate')}
-        </a>
-      </li>
-    </ul>
-  </li>
-);
+          return <li key={index}>{inner}</li>;
+        })}
+        <li>
+          <a href={'/set-language/unset?' + returnToCurrentPage($c)}>
+            {l('(reset language)')}
+          </a>
+        </li>
+        <li className="separator">
+          <a href="https://www.transifex.com/musicbrainz/musicbrainz/">
+            {l('Help Translate')}
+          </a>
+        </li>
+      </ul>
+    </li>
+  );
+};
 
 const AboutMenu = () => (
   <li className="about" tabIndex="-1">
@@ -326,7 +328,7 @@ const DocumentationMenu = () => (
 );
 
 const BottomMenu = (): React.Element<'div'> => {
-  const $c = React.useContext(CatalystContext);
+  const $c = React.useContext(SanitizedCatalystContext);
   const serverLanguages = $c.stash.server_languages;
   return (
     <div className="bottom">
@@ -338,7 +340,6 @@ const BottomMenu = (): React.Element<'div'> => {
         <DocumentationMenu />
         {serverLanguages && serverLanguages.length > 1 ? (
           <LanguageMenu
-            $c={$c}
             currentBCP47Language={$c.stash.current_language.replace('_', '-')}
             serverLanguages={serverLanguages}
           />

--- a/root/layout/components/TopMenu.js
+++ b/root/layout/components/TopMenu.js
@@ -29,46 +29,49 @@ function userLink(userName: string, path: string) {
 
 type UserProp = {+user: UnsanitizedEditorT};
 
-const AccountMenu = ({
-  $c,
-  user,
-}: {
-  +$c: CatalystContextT,
+type AccountMenuPropsT = {
   +user: UnsanitizedEditorT,
-}) => (
-  <li className="account" tabIndex="-1">
-    <span className="menu-header">
-      {user.name}
-      {'\xA0\u25BE'}
-    </span>
-    <ul>
-      <li>
-        <a href={userLink(user.name, '')}>{l('Profile')}</a>
-      </li>
-      <li>
-        <a href="/account/applications">{l('Applications')}</a>
-      </li>
-      <li>
-        <a href={userLink(user.name, '/subscriptions/artist')}>
-          {l('Subscriptions')}
-        </a>
-      </li>
-      <li>
-        <a
-          href={
-            '/logout' + (
-              $c.stash.current_action_requires_auth === true
-                ? ''
-                : ('?' + returnToCurrentPage($c))
-            )
-          }
-        >
-          {l('Log Out')}
-        </a>
-      </li>
-    </ul>
-  </li>
-);
+};
+
+const AccountMenu = ({
+  user,
+}: AccountMenuPropsT) => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <li className="account" tabIndex="-1">
+      <span className="menu-header">
+        {user.name}
+        {'\xA0\u25BE'}
+      </span>
+      <ul>
+        <li>
+          <a href={userLink(user.name, '')}>{l('Profile')}</a>
+        </li>
+        <li>
+          <a href="/account/applications">{l('Applications')}</a>
+        </li>
+        <li>
+          <a href={userLink(user.name, '/subscriptions/artist')}>
+            {l('Subscriptions')}
+          </a>
+        </li>
+        <li>
+          <a
+            href={
+              '/logout' + (
+                $c.stash.current_action_requires_auth === true
+                  ? ''
+                  : ('?' + returnToCurrentPage($c))
+              )
+            }
+          >
+            {l('Log Out')}
+          </a>
+        </li>
+      </ul>
+    </li>
+  );
+};
 
 const DataMenu = ({user}: UserProp) => {
   const userName = user.name;
@@ -187,14 +190,14 @@ const UserMenu = () => {
     <ul className="menu" tabIndex="-1">
       {$c.user ? (
         <>
-          <AccountMenu $c={$c} user={$c.user} />
+          <AccountMenu user={$c.user} />
           <DataMenu user={$c.user} />
           {isAdmin($c.user) ? <AdminMenu user={$c.user} /> : null}
         </>
       ) : (
         <>
           <li>
-            <RequestLogin $c={$c} text={l('Log In')} />
+            <RequestLogin text={l('Log In')} />
           </li>
           <li>
             <a href={returnUri($c, '/register')}>

--- a/root/layout/components/sidebar/EditLinks.js
+++ b/root/layout/components/sidebar/EditLinks.js
@@ -26,7 +26,6 @@ const EditLinks = ({
   requiresPrivileges = false,
 }: Props): React.Element<typeof React.Fragment> => {
   const $c = React.useContext(CatalystContext);
-
   return (
     <>
       <h2 className="editing">{l('Editing')}</h2>
@@ -34,7 +33,7 @@ const EditLinks = ({
         {$c.user ? children : requiresPrivileges ? null : (
           <>
             <li>
-              <RequestLogin $c={$c} text={l('Log in to edit')} />
+              <RequestLogin text={l('Log in to edit')} />
             </li>
             <li className="separator" role="separator" />
           </>

--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -59,7 +59,6 @@ const SidebarTags = ({
         {($c.user?.has_confirmed_email_address &&
           aggregatedTags && userTags) ? (
             <SidebarTagEditor
-              $c={$c}
               aggregatedTags={aggregatedTags}
               entity={entity}
               genreMap={$c.stash.genre_map}

--- a/root/layout/index.js
+++ b/root/layout/index.js
@@ -55,7 +55,8 @@ function showBirthdayBanner($c: CatalystContextT) {
          !getRequestCookie($c.req, 'birthday_message_dismissed_mtime');
 }
 
-const AnniversaryBanner = ({$c}: {+$c: CatalystContextT}) => {
+const AnniversaryBanner = () => {
+  const $c = React.useContext(CatalystContext);
   const registrationDate = $c.user ? $c.user.registration_date : null;
   if (registrationDate == null) {
     return null;
@@ -261,7 +262,7 @@ const Layout = ({
           </div>
         ) : null}
 
-        <AnniversaryBanner $c={$c} />
+        <AnniversaryBanner />
 
         {showNewEditNotesBanner ? (
           <div className="banner new-edit-notes">

--- a/root/main/ConfirmSeed.js
+++ b/root/main/ConfirmSeed.js
@@ -48,7 +48,7 @@ const ConfirmSeed = ({
             Below this line, you can review the data being sent and make any
             modifications if desired.`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         {postParameters ? <PostParameters params={postParameters} /> : null}
         <ConfirmSeedButtons />
       </form>

--- a/root/main/ConfirmSeed.js
+++ b/root/main/ConfirmSeed.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import * as manifest from '../static/manifest.mjs';
 import ConfirmSeedButtons
@@ -18,16 +19,15 @@ import PostParameters, {
 } from '../static/scripts/common/components/PostParameters.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +origin: string,
   +postParameters: PostParametersT | null,
 };
 
 const ConfirmSeed = ({
-  $c,
   origin,
   postParameters,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const title = l('Confirm Form Submission');
   return (
     <Layout fullWidth title={title}>

--- a/root/main/error/Error400.js
+++ b/root/main/error/Error400.js
@@ -17,13 +17,11 @@ import ErrorEnvironment from './components/ErrorEnvironment.js';
 import ErrorInfo from './components/ErrorInfo.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +message?: string,
   +useLanguages: boolean,
 };
 
 const Error400 = ({
-  $c,
   message,
   useLanguages,
 }: Props): React.Element<typeof ErrorLayout> => (
@@ -55,7 +53,7 @@ const Error400 = ({
 
     <h2>{l('Technical Information')}</h2>
 
-    <ErrorEnvironment $c={$c} useLanguages={useLanguages} />
+    <ErrorEnvironment useLanguages={useLanguages} />
   </ErrorLayout>
 );
 

--- a/root/main/error/Error401.js
+++ b/root/main/error/Error401.js
@@ -9,40 +9,39 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
+
 import ErrorLayout from './ErrorLayout.js';
 
-type Props = {
-  +$c: CatalystContextT,
-};
+const Error401 = (): React.Element<typeof ErrorLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ErrorLayout title={l('Unauthorized Request')}>
+      <p>
+        <strong>
+          {l('Sorry, you are not authorized to view this page.')}
+        </strong>
+      </p>
 
-const Error401 = ({
-  $c,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout title={l('Unauthorized Request')}>
-    <p>
-      <strong>
-        {l('Sorry, you are not authorized to view this page.')}
-      </strong>
-    </p>
+      {$c.user && !$c.user.has_confirmed_email_address ? (
+        <p>
+          {exp.l(
+            `You must first {url|add and verify your email address} before
+            being able to edit or add anything to the database.`,
+            {url: '/account/edit'},
+          )}
+        </p>
+      ) : null}
 
-    {$c.user && !$c.user.has_confirmed_email_address ? (
       <p>
         {exp.l(
-          `You must first {url|add and verify your email address} before
-           being able to edit or add anything to the database.`,
-          {url: '/account/edit'},
+          `If you think this is a mistake, please contact
+          <code>support@musicbrainz.org</code>
+          with the name of your account.`,
         )}
       </p>
-    ) : null}
-
-    <p>
-      {exp.l(
-        `If you think this is a mistake, please contact
-         <code>support@musicbrainz.org</code>
-         with the name of your account.`,
-      )}
-    </p>
-  </ErrorLayout>
-);
+    </ErrorLayout>
+  );
+};
 
 export default Error401;

--- a/root/main/error/Error403.js
+++ b/root/main/error/Error403.js
@@ -9,44 +9,42 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import bugTrackerURL
   from '../../static/scripts/common/utility/bugTrackerURL.js';
 
 import ErrorLayout from './ErrorLayout.js';
 
-type Props = {
-  +$c: CatalystContextT,
+const Error403 = (): React.Element<typeof ErrorLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ErrorLayout title={l('Forbidden Request')}>
+      <p>
+        <strong>
+          {l('The page you requested is private.')}
+        </strong>
+      </p>
+      <p>
+        {exp.l(
+          'Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',
+          {doc: '/doc/MusicBrainz_Documentation', faq: '/doc/FAQ'},
+        )}
+      </p>
+      <p>
+        {exp.l(
+          `If you followed a link on our site to get here,
+          please {report|report a bug} and the URL
+          of the page that sent you here.`,
+          {
+            report: bugTrackerURL(
+              'Forbidden page: ' + $c.req.uri + '\n' +
+              'Referrer: ' + ($c.req.headers.referer || ''),
+            ),
+          },
+        )}
+      </p>
+    </ErrorLayout>
+  );
 };
-
-const Error403 = ({
-  $c,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout title={l('Forbidden Request')}>
-    <p>
-      <strong>
-        {l('The page you requested is private.')}
-      </strong>
-    </p>
-    <p>
-      {exp.l(
-        'Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',
-        {doc: '/doc/MusicBrainz_Documentation', faq: '/doc/FAQ'},
-      )}
-    </p>
-    <p>
-      {exp.l(
-        `If you followed a link on our site to get here,
-         please {report|report a bug} and the URL
-         of the page that sent you here.`,
-        {
-          report: bugTrackerURL(
-            'Forbidden page: ' + $c.req.uri + '\n' +
-            'Referrer: ' + ($c.req.headers.referer || ''),
-          ),
-        },
-      )}
-    </p>
-  </ErrorLayout>
-);
 
 export default Error403;

--- a/root/main/error/Error404.js
+++ b/root/main/error/Error404.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import bugTrackerURL
   from '../../static/scripts/common/utility/bugTrackerURL.js';
 
@@ -20,45 +21,46 @@ import ErrorLayout from './ErrorLayout.js';
  */
 
 type Props = {
-  +$c: CatalystContextT,
   +message?: string,
 };
 
 const Error404 = ({
-  $c,
   message,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout title={l('Page Not Found')}>
-    <p>
-      <strong>
-        {l(`Sorry, the page you're looking for does not exist.`)}
-      </strong>
-    </p>
-    {nonEmpty(message) ? (
+}: Props): React.Element<typeof ErrorLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ErrorLayout title={l('Page Not Found')}>
       <p>
-        <strong>{l('Error message: ')}</strong>
-        <code>{message}</code>
+        <strong>
+          {l(`Sorry, the page you're looking for does not exist.`)}
+        </strong>
       </p>
-    ) : null}
-    <p>
-      {exp.l(
-        'Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',
-        {doc: '/doc/MusicBrainz_Documentation', faq: '/doc/FAQ'},
-      )}
-    </p>
-    <p>
-      {exp.l(
-        `Found a broken link on our site? Please {report|report a bug}
-          and include any error message that is shown above.`,
-        {
-          report: bugTrackerURL(
-            'Nonexistent page: ' + $c.req.uri + '\n' +
-            'Referrer: ' + ($c.req.headers.referer || ''),
-          ),
-        },
-      )}
-    </p>
-  </ErrorLayout>
-);
+      {nonEmpty(message) ? (
+        <p>
+          <strong>{l('Error message: ')}</strong>
+          <code>{message}</code>
+        </p>
+      ) : null}
+      <p>
+        {exp.l(
+          'Looking for help? Check out our {doc|documentation} or {faq|FAQ}.',
+          {doc: '/doc/MusicBrainz_Documentation', faq: '/doc/FAQ'},
+        )}
+      </p>
+      <p>
+        {exp.l(
+          `Found a broken link on our site? Please {report|report a bug}
+            and include any error message that is shown above.`,
+          {
+            report: bugTrackerURL(
+              'Nonexistent page: ' + $c.req.uri + '\n' +
+              'Referrer: ' + ($c.req.headers.referer || ''),
+            ),
+          },
+        )}
+      </p>
+    </ErrorLayout>
+  );
+};
 
 export default Error404;

--- a/root/main/error/Error500.js
+++ b/root/main/error/Error500.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EditLink from '../../static/scripts/common/components/EditLink.js';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
 import bugTrackerURL
@@ -19,7 +20,6 @@ import ErrorEnvironment from './components/ErrorEnvironment.js';
 import ErrorInfo from './components/ErrorInfo.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +edits?: $ReadOnlyArray<GenericEditWithIdT>,
   +formattedErrors?: $ReadOnlyArray<string>,
   +hostname?: string,
@@ -27,72 +27,73 @@ type Props = {
 };
 
 const Error500 = ({
-  $c,
   edits,
   formattedErrors,
   hostname,
   useLanguages,
-}: Props): React.Element<typeof ErrorLayout> => (
-  <ErrorLayout title={l('Internal Server Error')}>
-    <p>
-      <strong>
-        {l('Oops, something went wrong!')}
-      </strong>
-    </p>
+}: Props): React.Element<typeof ErrorLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ErrorLayout title={l('Internal Server Error')}>
+      <p>
+        <strong>
+          {l('Oops, something went wrong!')}
+        </strong>
+      </p>
 
-    <ErrorInfo formattedErrors={formattedErrors} />
+      <ErrorInfo formattedErrors={formattedErrors} />
 
-    {edits?.length ? (
-      <>
-        <p>
-          <strong>
-            {l('Edits loaded for the page:')}
-          </strong>
-        </p>
-        <ul>
-          {edits.map(edit => (
-            <li key={edit.id}>
-              <EditLink content={edit.id.toString()} edit={edit} />
-              {' '}
-              {bracketed(
-                <EditLink
-                  content={l('raw edit data')}
-                  edit={edit}
-                  subPath="data"
-                />,
-              )}
-              {edit.is_loaded ? ('; ' + l('fully loaded')) : null}
-            </li>
-          ))}
-        </ul>
-      </>
-    ) : null}
+      {edits?.length ? (
+        <>
+          <p>
+            <strong>
+              {l('Edits loaded for the page:')}
+            </strong>
+          </p>
+          <ul>
+            {edits.map(edit => (
+              <li key={edit.id}>
+                <EditLink content={edit.id.toString()} edit={edit} />
+                {' '}
+                {bracketed(
+                  <EditLink
+                    content={l('raw edit data')}
+                    edit={edit}
+                    subPath="data"
+                  />,
+                )}
+                {edit.is_loaded ? ('; ' + l('fully loaded')) : null}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
 
-    <ErrorEnvironment
-      $c={$c}
-      hostname={hostname}
-      useLanguages={useLanguages}
-    />
+      <ErrorEnvironment
+        hostname={hostname}
+        useLanguages={useLanguages}
+      />
 
-    <p>
-      {l(`We’re terribly sorry for this problem.
-          Please wait a few minutes and repeat
-          your request — the problem may go away.`)}
-    </p>
+      <p>
+        {l(`We’re terribly sorry for this problem.
+            Please wait a few minutes and repeat
+            your request — the problem may go away.`)}
+      </p>
 
-    <p>
-      {exp.l(
-        `If the problem persists, please {report|report a bug}
-         and include any error message that is shown above.`,
-        {
-          report: bugTrackerURL(
-            'Internal server error on  ' + $c.req.uri + '\n' +
-            'Referrer: ' + ($c.req.headers.referer || ''),
-          ),
-        },
-      )}
-    </p>
-  </ErrorLayout>
-);
+      <p>
+        {exp.l(
+          `If the problem persists, please {report|report a bug}
+           and include any error message that is shown above.`,
+          {
+            report: bugTrackerURL(
+              'Internal server error on  ' + $c.req.uri + '\n' +
+              'Referrer: ' + ($c.req.headers.referer || ''),
+            ),
+          },
+        )}
+      </p>
+    </ErrorLayout>
+  );
+};
 
 export default Error500;

--- a/root/main/error/TimeoutError.js
+++ b/root/main/error/TimeoutError.js
@@ -14,14 +14,12 @@ import ErrorEnvironment from './components/ErrorEnvironment.js';
 import ErrorInfo from './components/ErrorInfo.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +formattedErrors?: $ReadOnlyArray<string>,
   +hostname?: string,
   +useLanguages: boolean,
 };
 
 const TimeoutError = ({
-  $c,
   formattedErrors,
   hostname,
   useLanguages,
@@ -41,7 +39,6 @@ const TimeoutError = ({
       <h2>{l('Technical Information')}</h2>
       <ErrorInfo formattedErrors={formattedErrors} />
       <ErrorEnvironment
-        $c={$c}
         hostname={hostname}
         useLanguages={useLanguages}
       />

--- a/root/main/error/components/ErrorEnvironment.js
+++ b/root/main/error/components/ErrorEnvironment.js
@@ -9,57 +9,60 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../../context.mjs';
+
 type Props = {
-  +$c: CatalystContextT,
   +hostname?: string,
   +useLanguages?: boolean,
 };
 
 const ErrorEnvironment = ({
-  $c,
   hostname,
   useLanguages = false,
-}: Props): React.Element<typeof React.Fragment> => (
-  <>
-    <p>
-      <strong>{l('Time:')}</strong>
-      {' '}
-      {new Date().toISOString()}
-    </p>
-
-    {nonEmpty(hostname) ? (
+}: Props): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <>
       <p>
-        <strong>{l('Host:')}</strong>
+        <strong>{l('Time:')}</strong>
         {' '}
-        {hostname}
+        {new Date().toISOString()}
       </p>
-    ) : null}
 
-    {useLanguages ? (
+      {nonEmpty(hostname) ? (
+        <p>
+          <strong>{l('Host:')}</strong>
+          {' '}
+          {hostname}
+        </p>
+      ) : null}
+
+      {useLanguages ? (
+        <p>
+          <strong>{l('Interface language:')}</strong>
+          {' '}
+          {$c.stash.current_language}
+        </p>
+      ) : null}
+
       <p>
-        <strong>{l('Interface language:')}</strong>
+        <strong>{l('URL:')}</strong>
         {' '}
-        {$c.stash.current_language}
+        <code>{$c.req.uri}</code>
       </p>
-    ) : null}
 
-    <p>
-      <strong>{l('URL:')}</strong>
-      {' '}
-      <code>{$c.req.uri}</code>
-    </p>
+      <p>
+        <strong>{l('Request data:')}</strong>
+        <pre>
+          {JSON.stringify({
+            body_parameters: $c.req.body_params,
+            query_parameters: $c.req.query_params,
+          }, null, 2)}
+        </pre>
+      </p>
 
-    <p>
-      <strong>{l('Request data:')}</strong>
-      <pre>
-        {JSON.stringify({
-          body_parameters: $c.req.body_params,
-          query_parameters: $c.req.query_params,
-        }, null, 2)}
-      </pre>
-    </p>
-
-  </>
-);
+    </>
+  );
+};
 
 export default ErrorEnvironment;

--- a/root/oauth2/OAuth2Authorize.js
+++ b/root/oauth2/OAuth2Authorize.js
@@ -30,7 +30,10 @@ const OAuth2Authorize = ({
     <h1>{l('Authorization')}</h1>
 
     <p>
-      {texp.l('{app} is requesting permission to:', {app: application.name})}
+      {texp.l(
+        '{app} is requesting permission to:',
+        {app: application.name},
+      )}
     </p>
 
     <ul>

--- a/root/oauth2/OAuth2Authorize.js
+++ b/root/oauth2/OAuth2Authorize.js
@@ -14,7 +14,6 @@ import {ACCESS_SCOPE_PERMISSIONS} from '../constants.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +application: ApplicationT,
   +form: SecureConfirmFormT,
   +offline: boolean,
@@ -22,7 +21,6 @@ type Props = {
 };
 
 const OAuth2Authorize = ({
-  $c,
   application,
   form,
   offline,
@@ -47,7 +45,7 @@ const OAuth2Authorize = ({
       ) : null}
     </ul>
 
-    <form action={$c.req.uri} method="post" name="confirm">
+    <form method="post" name="confirm">
       <FormCsrfToken form={form} />
       <span className="buttons">
         <button

--- a/root/place/PlaceEvents.js
+++ b/root/place/PlaceEvents.js
@@ -11,56 +11,58 @@ import * as React from 'react';
 
 import EventList from '../components/list/EventList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
 import PlaceLayout from './PlaceLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +events: $ReadOnlyArray<EventT>,
   +pager: PagerT,
   +place: PlaceT,
 };
 
 const PlaceEvents = ({
-  $c,
   events,
   pager,
   place,
-}: Props): React.Element<typeof PlaceLayout> => (
-  <PlaceLayout entity={place} page="events" title={l('Events')}>
-    <h2>{l('Events')}</h2>
+}: Props): React.Element<typeof PlaceLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <PlaceLayout entity={place} page="events" title={l('Events')}>
+      <h2>{l('Events')}</h2>
 
-    {events.length > 0 ? (
-      <form
-        action={'/event/merge_queue?' + returnToCurrentPage($c)}
-        method="post"
-      >
-        <PaginatedResults pager={pager}>
-          <EventList
-            checkboxes="add-to-merge"
-            events={events}
-            showArtists
-            showRatings
-            showType
-          />
-        </PaginatedResults>
-        {$c.user ? (
-          <div className="row">
-            <span className="buttons">
-              <button type="submit">
-                {l('Add selected events for merging')}
-              </button>
-            </span>
-          </div>
-        ) : null}
-      </form>
-    ) : (
-      <p>
-        {l('This place is not currently associated with any events.')}
-      </p>
-    )}
-  </PlaceLayout>
-);
+      {events.length > 0 ? (
+        <form
+          action={'/event/merge_queue?' + returnToCurrentPage($c)}
+          method="post"
+        >
+          <PaginatedResults pager={pager}>
+            <EventList
+              checkboxes="add-to-merge"
+              events={events}
+              showArtists
+              showRatings
+              showType
+            />
+          </PaginatedResults>
+          {$c.user ? (
+            <div className="row">
+              <span className="buttons">
+                <button type="submit">
+                  {l('Add selected events for merging')}
+                </button>
+              </span>
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <p>
+          {l('This place is not currently associated with any events.')}
+        </p>
+      )}
+    </PlaceLayout>
+  );
+};
 
 export default PlaceEvents;

--- a/root/place/PlaceMerge.js
+++ b/root/place/PlaceMerge.js
@@ -18,13 +18,11 @@ import PlaceList from '../components/list/PlaceList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<PlaceT>,
 };
 
 const PlaceMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const PlaceMerge = ({
         {l(`You are about to merge all these places into a single one.
             Please select the place all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <PlaceList
           mergeForm={form}
           places={sortByEntityName(toMerge)}

--- a/root/place/PlacePerformances.js
+++ b/root/place/PlacePerformances.js
@@ -14,14 +14,12 @@ import RelationshipsTable from '../components/RelationshipsTable.js';
 import PlaceLayout from './PlaceLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
   +pager: ?PagerT,
   +place: PlaceT,
 };
 
 const PlacePerformances = ({
-  $c,
   pagedLinkTypeGroup,
   pager,
   place,
@@ -32,7 +30,6 @@ const PlacePerformances = ({
     title={l('Performances')}
   >
     <RelationshipsTable
-      $c={$c}
       entity={place}
       fallbackMessage={l(
         'No recordings, releases or release groups are linked to this place.',

--- a/root/recording/RecordingIndex.js
+++ b/root/recording/RecordingIndex.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import PaginatedResults from '../components/PaginatedResults.js';
 import ReleaseLabelList from '../components/ReleaseLabelList.js';
 import ReleaseCatnoList from '../components/ReleaseCatnoList.js';
+import {CatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import Annotation from '../static/scripts/common/components/Annotation.js';
 import ArtistCreditLink
@@ -31,7 +32,6 @@ import TaggerIcon from '../static/scripts/common/components/TaggerIcon.js';
 import RecordingLayout from './RecordingLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +numberOfRevisions: number,
   +pager: PagerT,
   +recording: RecordingWithArtistCreditT,
@@ -39,126 +39,128 @@ type Props = {
 };
 
 const RecordingAppearancesTable = ({
-  $c,
   recording,
   tracks,
 }: {
-  $c: CatalystContextT,
   recording: RecordingWithArtistCreditT,
   tracks: Props['tracks'],
-}) => (
-  <table className="tbl">
-    <thead>
-      <tr>
-        <th className="t pos">{l('#')}</th>
-        <th>{l('Title')}</th>
-        <th className="treleases">{l('Length')}</th>
-        <th>{l('Track Artist')}</th>
-        <th>{l('Release Title')}</th>
-        <th>{l('Release Artist')}</th>
-        <th>{l('Release Group Type')}</th>
-        <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
-        <th>{l('Label')}</th>
-        <th>{l('Catalog#')}</th>
-        {$c?.session?.tport == null
-          ? null
-          : <th>{l('Tagger')}</th>}
-      </tr>
-    </thead>
-    <tbody>
-      {tracks.map((tracksWithReleaseStatus) => {
-        const sampleRelease =
-          linkedEntities.release[
-            tracksWithReleaseStatus[0].medium.release_id
-          ];
-        const status = sampleRelease.status;
-        return (
-          <React.Fragment key={status ? status.name : 'no-status'}>
-            <tr className="subh">
-              <th colSpan={$c?.session?.tport == null ? 10 : 11}>
-                {status
-                  ? lp_attributes(status.name, 'release_status')
-                  : lp('(unknown)', 'release status')
-                }
-              </th>
-            </tr>
-            {tracksWithReleaseStatus.map((track, index) => {
-              const release =
-                linkedEntities.release[track.medium.release_id];
-              return (
-                <tr className={loopParity(index)} key={track.gid}>
-                  <td>
-                    <a
-                      href={`/track/${track.gid}`}
-                      title={texp.l(
-                        'Medium {medium_num}, track {track_num}',
-                        {
-                          medium_num: track.medium.position,
-                          track_num: track.position,
-                        },
-                      )}
-                    >
-                      {`${track.medium.position}.${track.position}`}
-                    </a>
-                  </td>
-                  <td>{isolateText(track.name)}</td>
-                  <td>{formatTrackLength(track.length)}</td>
-                  {/* The class being added is for usage with userscripts */}
-                  <td className={
-                    track.artistCredit.id === recording.artistCredit.id
-                      ? null
-                      : 'artist-credit-variation'}
-                  >
-                    <ArtistCreditLink artistCredit={track.artistCredit} />
-                  </td>
-                  <td>
-                    <EntityLink entity={release} />
-                  </td>
-                  <td>
-                    <ArtistCreditLink artistCredit={release.artistCredit} />
-                  </td>
-                  <td>
-                    {release.releaseGroup &&
-                      nonEmpty(release.releaseGroup.typeName)
-                      ? lp_attributes(
-                        release.releaseGroup.typeName,
-                        'release_group_primary_type',
-                      )
-                      : null}
-                  </td>
-                  <td>
-                    <ReleaseEvents events={release.events} />
-                    {manifest.js(
-                      'common/components/ReleaseEvents',
-                      {async: 'async'},
-                    )}
-                  </td>
-                  <td>
-                    <ReleaseLabelList labels={release.labels} />
-                  </td>
-                  <td>
-                    <ReleaseCatnoList labels={release.labels} />
-                  </td>
-                  {$c.session?.tport == null ? null : (
+}) => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <table className="tbl">
+      <thead>
+        <tr>
+          <th className="t pos">{l('#')}</th>
+          <th>{l('Title')}</th>
+          <th className="treleases">{l('Length')}</th>
+          <th>{l('Track Artist')}</th>
+          <th>{l('Release Title')}</th>
+          <th>{l('Release Artist')}</th>
+          <th>{l('Release Group Type')}</th>
+          <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
+          <th>{l('Label')}</th>
+          <th>{l('Catalog#')}</th>
+          {$c?.session?.tport == null
+            ? null
+            : <th>{l('Tagger')}</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {tracks.map((tracksWithReleaseStatus) => {
+          const sampleRelease =
+            linkedEntities.release[
+              tracksWithReleaseStatus[0].medium.release_id
+            ];
+          const status = sampleRelease.status;
+          return (
+            <React.Fragment key={status ? status.name : 'no-status'}>
+              <tr className="subh">
+                <th colSpan={$c.session?.tport == null ? 10 : 11}>
+                  {status
+                    ? lp_attributes(status.name, 'release_status')
+                    : lp('(unknown)', 'release status')
+                  }
+                </th>
+              </tr>
+              {tracksWithReleaseStatus.map((track, index) => {
+                const release =
+                  linkedEntities.release[track.medium.release_id];
+                return (
+                  <tr className={loopParity(index)} key={track.gid}>
                     <td>
-                      <TaggerIcon
-                        entityType="release"
-                        gid={release.gid}
-                      />
+                      <a
+                        href={`/track/${track.gid}`}
+                        title={texp.l(
+                          'Medium {medium_num}, track {track_num}',
+                          {
+                            medium_num: track.medium.position,
+                            track_num: track.position,
+                          },
+                        )}
+                      >
+                        {`${track.medium.position}.${track.position}`}
+                      </a>
                     </td>
-                  )}
-                </tr>
-              );
-            })}
-          </React.Fragment>
-        );
-      })}
-    </tbody>
-  </table>
-);
+                    <td>{isolateText(track.name)}</td>
+                    <td>{formatTrackLength(track.length)}</td>
+                    {/*
+                      * The class being added is for usage with userscripts.
+                      */}
+                    <td className={
+                      track.artistCredit.id === recording.artistCredit.id
+                        ? null
+                        : 'artist-credit-variation'}
+                    >
+                      <ArtistCreditLink artistCredit={track.artistCredit} />
+                    </td>
+                    <td>
+                      <EntityLink entity={release} />
+                    </td>
+                    <td>
+                      <ArtistCreditLink artistCredit={release.artistCredit} />
+                    </td>
+                    <td>
+                      {release.releaseGroup &&
+                        nonEmpty(release.releaseGroup.typeName)
+                        ? lp_attributes(
+                          release.releaseGroup.typeName,
+                          'release_group_primary_type',
+                        )
+                        : null}
+                    </td>
+                    <td>
+                      <ReleaseEvents events={release.events} />
+                      {manifest.js(
+                        'common/components/ReleaseEvents',
+                        {async: 'async'},
+                      )}
+                    </td>
+                    <td>
+                      <ReleaseLabelList labels={release.labels} />
+                    </td>
+                    <td>
+                      <ReleaseCatnoList labels={release.labels} />
+                    </td>
+                    {$c.session?.tport == null ? null : (
+                      <td>
+                        <TaggerIcon
+                          entityType="release"
+                          gid={release.gid}
+                        />
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </React.Fragment>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
 
 const RecordingIndex = ({
-  $c,
   numberOfRevisions,
   pager,
   recording,
@@ -175,7 +177,6 @@ const RecordingIndex = ({
     <PaginatedResults pager={pager}>
       {tracks?.length ? (
         <RecordingAppearancesTable
-          $c={$c}
           recording={recording}
           tracks={tracks}
         />

--- a/root/recording/RecordingMerge.js
+++ b/root/recording/RecordingMerge.js
@@ -18,14 +18,12 @@ import RecordingList from '../components/list/RecordingList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +isrcsDiffer?: boolean,
   +toMerge: $ReadOnlyArray<RecordingWithArtistCreditT>,
 };
 
 const RecordingMerge = ({
-  $c,
   form,
   isrcsDiffer = false,
   toMerge,
@@ -49,7 +47,7 @@ const RecordingMerge = ({
           </p>
         </div>
       ) : null}
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <RecordingList
           mergeForm={form}
           recordings={sortByEntityName(toMerge)}

--- a/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypeIndex.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
 import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import linkedEntities from '../../static/scripts/common/linkedEntities.mjs';
@@ -22,7 +23,6 @@ import {upperFirst} from '../../static/scripts/common/utility/strings.js';
 import compareChildren from '../utility/compareChildren.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +attribute: LinkAttrTypeT,
   +relationships: Array<LinkTypeT>,
 };
@@ -65,10 +65,10 @@ const AttributeTree = ({
 };
 
 const RelationshipAttributeTypeIndex = ({
-  $c,
   attribute,
   relationships,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const isInstrumentRoot = attribute.id === 14;
   const isInstrumentChild = attribute.root_id === 14 && !isInstrumentRoot;
 

--- a/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
+++ b/root/relationship/linkattributetype/RelationshipAttributeTypesList.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
 import expand2react from '../../static/scripts/common/i18n/expand2react.js';
 import bracketed, {bracketedText}
@@ -20,26 +21,23 @@ import compareChildren from '../utility/compareChildren.js';
 import RelationshipsHeader from '../RelationshipsHeader.js';
 
 type AttributeTreeProps = {
-  +$c: CatalystContextT,
   +attribute: LinkAttrTypeT,
 };
 
 type AttributeDetailsProps = {
-  +$c: CatalystContextT,
   +attribute: LinkAttrTypeT,
   +topLevel?: boolean,
 };
 
 type AttributesListProps = {
-  +$c: CatalystContextT,
   +root: LinkAttrTypeT,
 };
 
 const AttributeDetails = ({
-  $c,
   attribute,
   topLevel = false,
 }: AttributeDetailsProps) => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const isInstrumentRoot = attribute.id === 14;
   const childrenAttrs = attribute.children || [];
   const translatedDescription = attribute.description
@@ -99,7 +97,7 @@ const AttributeDetails = ({
   );
 };
 
-const AttributeTree = ({$c, attribute}: AttributeTreeProps) => {
+const AttributeTree = ({attribute}: AttributeTreeProps) => {
   const childrenAttrs = attribute.children || [];
   return (
     <li style={{marginTop: '0.25em'}}>
@@ -107,7 +105,7 @@ const AttributeTree = ({$c, attribute}: AttributeTreeProps) => {
 
       {' '}
 
-      <AttributeDetails $c={$c} attribute={attribute} />
+      <AttributeDetails attribute={attribute} />
 
       {childrenAttrs.length ? (
         <ul>
@@ -116,7 +114,6 @@ const AttributeTree = ({$c, attribute}: AttributeTreeProps) => {
             .sort(compareChildren)
             .map(attribute => (
               <AttributeTree
-                $c={$c}
                 attribute={attribute}
                 key={attribute.id}
               />
@@ -127,7 +124,7 @@ const AttributeTree = ({$c, attribute}: AttributeTreeProps) => {
   );
 };
 
-const AttributesList = ({$c, root}: AttributesListProps) => {
+const AttributesList = ({root}: AttributesListProps) => {
   const childrenAttrs = root.children || [];
   return (
     childrenAttrs.length ? (
@@ -142,7 +139,7 @@ const AttributesList = ({$c, root}: AttributesListProps) => {
                 {upperFirst(l_relationships(attribute.name))}
               </h2>
 
-              <AttributeDetails $c={$c} attribute={attribute} topLevel />
+              <AttributeDetails attribute={attribute} topLevel />
 
               {childrenAttrs.length ? (
                 <>
@@ -155,7 +152,6 @@ const AttributesList = ({$c, root}: AttributesListProps) => {
                       .sort(compareChildren)
                       .map(attribute => (
                         <AttributeTree
-                          $c={$c}
                           attribute={attribute}
                           key={attribute.id}
                         />
@@ -173,22 +169,24 @@ const AttributesList = ({$c, root}: AttributesListProps) => {
 };
 
 const RelationshipAttributeTypesList = ({
-  $c,
   root,
-}: AttributesListProps): React.Element<typeof Layout> => (
-  <Layout fullWidth noIcons title={l('Relationship Attributes')}>
-    <div id="content">
-      <RelationshipsHeader page="attributes" />
-      {isRelationshipEditor($c.user) ? (
-        <p>
-          <a href="/relationship-attributes/create">
-            {l('Create a new relationship attribute')}
-          </a>
-        </p>
-      ) : null}
-      <AttributesList $c={$c} root={root} />
-    </div>
-  </Layout>
-);
+}: AttributesListProps): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <Layout fullWidth noIcons title={l('Relationship Attributes')}>
+      <div id="content">
+        <RelationshipsHeader page="attributes" />
+        {isRelationshipEditor($c.user) ? (
+          <p>
+            <a href="/relationship-attributes/create">
+              {l('Create a new relationship attribute')}
+            </a>
+          </p>
+        ) : null}
+        <AttributesList root={root} />
+      </div>
+    </Layout>
+  );
+};
 
 export default RelationshipAttributeTypesList;

--- a/root/relationship/linktype/RelationshipTypeIndex.js
+++ b/root/relationship/linktype/RelationshipTypeIndex.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
 import Cardinality
   from '../../static/scripts/common/components/Cardinality.js';
@@ -29,14 +30,13 @@ import {isRelationshipEditor}
 import {upperFirst} from '../../static/scripts/common/utility/strings.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +relType: LinkTypeT,
 };
 
 const RelationshipTypeIndex = ({
-  $c,
   relType,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const childrenTypes = relType.children || [];
   const typeName = upperFirst(l_relationships(relType.name));
   const title = l('Relationship Type') + ' / ' + typeName;

--- a/root/relationship/linktype/RelationshipTypePairTree.js
+++ b/root/relationship/linktype/RelationshipTypePairTree.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import Layout from '../../layout/index.js';
 import * as manifest from '../../static/manifest.mjs';
 import Cardinality
@@ -24,19 +25,17 @@ import compareChildren from '../utility/compareChildren.js';
 import RelationshipsHeader from '../RelationshipsHeader.js';
 
 type RelationshipTypeDetailsProps = {
-  +$c: CatalystContextT,
   +relType: LinkTypeT,
 };
 
 type RelationshipTypePairTreeProps = {
-  +$c: CatalystContextT,
   +root: LinkTypeT,
 };
 
 const RelationshipTypeDetails = ({
-  $c,
   relType,
 }: RelationshipTypeDetailsProps) => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const childrenTypes = relType.children || [];
   return (
     <li style={{paddingTop: '0.5em'}}>
@@ -145,7 +144,6 @@ const RelationshipTypeDetails = ({
             .sort(compareChildren)
             .map(childrenType => (
               <RelationshipTypeDetails
-                $c={$c}
                 key={childrenType.gid}
                 relType={childrenType}
               />
@@ -157,9 +155,9 @@ const RelationshipTypeDetails = ({
 };
 
 const RelationshipTypePairTree = ({
-  $c,
   root,
 }: RelationshipTypePairTreeProps): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const childrenTypes = root.children || [];
   const type0 = root.type0;
   const type1 = root.type1;
@@ -222,7 +220,6 @@ const RelationshipTypePairTree = ({
                 .sort(compareChildren)
                 .map(childrenType => (
                   <RelationshipTypeDetails
-                    $c={$c}
                     key={childrenType.gid}
                     relType={childrenType}
                   />

--- a/root/release/CoverArt.js
+++ b/root/release/CoverArt.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import {Artwork} from '../components/Artwork.js';
 import RequestLogin from '../components/RequestLogin.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import {commaOnlyListText}
   from '../static/scripts/common/i18n/commaOnlyList.js';
@@ -18,7 +19,6 @@ import {commaOnlyListText}
 import ReleaseLayout from './ReleaseLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +coverArt: $ReadOnlyArray<ArtworkT>,
   +release: ReleaseT,
 };
@@ -50,10 +50,10 @@ const CoverArtLinks = ({
 );
 
 const CoverArt = ({
-  $c,
   coverArt,
   release,
 }: Props): React.Element<typeof ReleaseLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const title = l('Cover Art');
 
   return (
@@ -158,7 +158,7 @@ const CoverArt = ({
           </div>
         ) : (
           <p>
-            <RequestLogin $c={$c} text={l('Log in to upload cover art')} />
+            <RequestLogin text={l('Log in to upload cover art')} />
           </p>
         )
       ) : null}

--- a/root/release/RemoveCoverArt.js
+++ b/root/release/RemoveCoverArt.js
@@ -19,14 +19,12 @@ import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import ReleaseLayout from './ReleaseLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +artwork: ArtworkT,
   +form: ConfirmFormT,
   +release: ReleaseT,
 };
 
 const RemoveCoverArt = ({
-  $c,
   artwork,
   form,
   release,
@@ -49,7 +47,7 @@ const RemoveCoverArt = ({
       <p className="artwork">
         <Artwork artwork={artwork} />
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <EnterEditNote field={form.field.edit_note} />
         <EnterEdit form={form} />
       </form>

--- a/root/release_group/ReleaseGroupIndex.js
+++ b/root/release_group/ReleaseGroupIndex.js
@@ -15,6 +15,7 @@ import Relationships
 import WikipediaExtract
   from '../static/scripts/common/components/WikipediaExtract.js';
 import PaginatedResults from '../components/PaginatedResults.js';
+import {CatalystContext} from '../context.mjs';
 import TaggerIcon from '../static/scripts/common/components/TaggerIcon.js';
 import loopParity from '../utility/loopParity.js';
 import ArtistCreditLink
@@ -35,7 +36,6 @@ import {returnToCurrentPage} from '../utility/returnUri.js';
 import ReleaseGroupLayout from './ReleaseGroupLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +numberOfRevisions: number,
   +pager: PagerT,
@@ -111,83 +111,84 @@ function buildReleaseStatusTable(
 }
 
 const ReleaseGroupIndex = ({
-  $c,
   eligibleForCleanup,
   pager,
   numberOfRevisions,
   releaseGroup,
   releases,
   wikipediaExtract,
-}: Props): React.Element<typeof ReleaseGroupLayout> => (
-  <ReleaseGroupLayout
-    $c={$c}
-    entity={releaseGroup}
-    page="index"
-  >
-    {eligibleForCleanup ? (
-      <CleanupBanner entityType="release_group" />
-    ) : null}
-    <Annotation
-      annotation={releaseGroup.latest_annotation}
-      collapse
+}: Props): React.Element<typeof ReleaseGroupLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ReleaseGroupLayout
       entity={releaseGroup}
-      numberOfRevisions={numberOfRevisions}
-    />
-    <WikipediaExtract
-      cachedWikipediaExtract={wikipediaExtract}
-      entity={releaseGroup}
-    />
-    {releases.length ? (
-      <>
-        <h2>{releaseGroupType(releaseGroup)}</h2>
-        <form
-          action={'/release/merge_queue?' + returnToCurrentPage($c)}
-          method="post"
-        >
-          <PaginatedResults pager={pager}>
-            <table className="tbl">
-              <thead>
-                <tr>
-                  {$c.user ? (
-                    <th className="checkbox-cell">
-                      <input type="checkbox" />
-                    </th>
-                  ) : null}
-                  <th>{l('Release')}</th>
-                  <th>{l('Artist')}</th>
-                  <th>{l('Format')}</th>
-                  <th>{l('Tracks')}</th>
-                  <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
-                  <th>{l('Label')}</th>
-                  <th>{l('Catalog#')}</th>
-                  <th>{l('Barcode')}</th>
-                  {$c.session?.tport
-                    ? <th>{l('Tagger')}</th> : null}
-                </tr>
-              </thead>
-              <tbody>
-                {releases.map(releaseStatusGroup => buildReleaseStatusTable(
-                  $c,
-                  releaseStatusGroup,
-                  releaseGroup.artistCredit.id,
-                ))}
-              </tbody>
-            </table>
-          </PaginatedResults>
-          {$c.user ? (
-            <FormRow>
-              <FormSubmit label={l('Add selected releases for merging')} />
-            </FormRow>
-          ) : null}
-        </form>
-      </>
-    ) : (
-      <p>{l('No releases found.')}</p>
-    )}
-    <Relationships source={releaseGroup} />
-    {manifest.js('release-group/index', {async: 'async'})}
-    {manifest.js('common/components/TaggerIcon', {async: 'async'})}
-  </ReleaseGroupLayout>
-);
+      page="index"
+    >
+      {eligibleForCleanup ? (
+        <CleanupBanner entityType="release_group" />
+      ) : null}
+      <Annotation
+        annotation={releaseGroup.latest_annotation}
+        collapse
+        entity={releaseGroup}
+        numberOfRevisions={numberOfRevisions}
+      />
+      <WikipediaExtract
+        cachedWikipediaExtract={wikipediaExtract}
+        entity={releaseGroup}
+      />
+      {releases.length ? (
+        <>
+          <h2>{releaseGroupType(releaseGroup)}</h2>
+          <form
+            action={'/release/merge_queue?' + returnToCurrentPage($c)}
+            method="post"
+          >
+            <PaginatedResults pager={pager}>
+              <table className="tbl">
+                <thead>
+                  <tr>
+                    {$c.user ? (
+                      <th className="checkbox-cell">
+                        <input type="checkbox" />
+                      </th>
+                    ) : null}
+                    <th>{l('Release')}</th>
+                    <th>{l('Artist')}</th>
+                    <th>{l('Format')}</th>
+                    <th>{l('Tracks')}</th>
+                    <th>{l('Country') + lp('/', 'and') + l('Date')}</th>
+                    <th>{l('Label')}</th>
+                    <th>{l('Catalog#')}</th>
+                    <th>{l('Barcode')}</th>
+                    {$c.session?.tport
+                      ? <th>{l('Tagger')}</th> : null}
+                  </tr>
+                </thead>
+                <tbody>
+                  {releases.map(releaseStatusGroup => buildReleaseStatusTable(
+                    $c,
+                    releaseStatusGroup,
+                    releaseGroup.artistCredit.id,
+                  ))}
+                </tbody>
+              </table>
+            </PaginatedResults>
+            {$c.user ? (
+              <FormRow>
+                <FormSubmit label={l('Add selected releases for merging')} />
+              </FormRow>
+            ) : null}
+          </form>
+        </>
+      ) : (
+        <p>{l('No releases found.')}</p>
+      )}
+      <Relationships source={releaseGroup} />
+      {manifest.js('release-group/index', {async: 'async'})}
+      {manifest.js('common/components/TaggerIcon', {async: 'async'})}
+    </ReleaseGroupLayout>
+  );
+};
 
 export default ReleaseGroupIndex;

--- a/root/release_group/ReleaseGroupLayout.js
+++ b/root/release_group/ReleaseGroupLayout.js
@@ -18,7 +18,6 @@ import {reduceArtistCredit}
 import ReleaseGroupHeader from './ReleaseGroupHeader.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +children: React.Node,
   +entity: ReleaseGroupT,
   +fullWidth?: boolean,

--- a/root/release_group/ReleaseGroupMerge.js
+++ b/root/release_group/ReleaseGroupMerge.js
@@ -18,13 +18,11 @@ import {ReleaseGroupListTable} from '../components/list/ReleaseGroupList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<ReleaseGroupT>,
 };
 
 const ReleaseGroupMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -36,7 +34,7 @@ const ReleaseGroupMerge = ({
             Please select the release group all others
             should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <ReleaseGroupListTable
           mergeForm={form}
           releaseGroups={sortByEntityName(toMerge)}

--- a/root/report/DuplicateArtists.js
+++ b/root/report/DuplicateArtists.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import PaginatedResults from '../components/PaginatedResults.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import loopParity from '../utility/loopParity.js';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import FormRow from '../components/FormRow.js';
@@ -20,13 +21,14 @@ import ReportLayout from './components/ReportLayout.js';
 import type {ReportArtistT, ReportDataT} from './types.js';
 
 const DuplicateArtists = ({
-  $c,
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
 }: ReportDataT<ReportArtistT>): React.Element<typeof ReportLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+
   let currentKey: ?string = '';
   let lastKey: ?string = '';
 

--- a/root/report/FilterLink.js
+++ b/root/report/FilterLink.js
@@ -9,14 +9,15 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import uriWith from '../utility/uriWith.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +filtered: boolean,
 };
 
-const FilterLink = ({$c, filtered = false}: Props): React.Element<'li'> => {
+const FilterLink = ({filtered = false}: Props): React.Element<'li'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const reqUri = $c.req.uri;
 
   return (

--- a/root/report/LimitedEditors.js
+++ b/root/report/LimitedEditors.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {isAccountAdmin} from '../static/scripts/common/utility/privileges.js';
 
 import EditorList from './components/EditorList.js';
@@ -16,31 +17,33 @@ import ReportLayout from './components/ReportLayout.js';
 import type {ReportDataT, ReportEditorT} from './types.js';
 
 const LimitedEditors = ({
-  $c,
   canBeFiltered,
   filtered,
   generated,
   items,
   pager,
-}: ReportDataT<ReportEditorT>): React.Element<typeof ReportLayout> => (
-  <ReportLayout
-    canBeFiltered={canBeFiltered}
-    description={exp.l(
-      'This report lists {url|beginner/limited editors}.',
-      {url: '/doc/How_to_Create_an_Account'},
-    )}
-    entityType="editor"
-    filtered={filtered}
-    generated={generated}
-    title={l('Beginner/limited editors')}
-    totalEntries={pager.total_entries}
-  >
-    {isAccountAdmin($c.user) ? (
-      <EditorList items={items} pager={pager} />
-    ) : (
-      <p>{l('Sorry, you are not authorized to view this page.')}</p>
-    )}
-  </ReportLayout>
-);
+}: ReportDataT<ReportEditorT>): React.Element<typeof ReportLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={exp.l(
+        'This report lists {url|beginner/limited editors}.',
+        {url: '/doc/How_to_Create_an_Account'},
+      )}
+      entityType="editor"
+      filtered={filtered}
+      generated={generated}
+      title={l('Beginner/limited editors')}
+      totalEntries={pager.total_entries}
+    >
+      {isAccountAdmin($c.user) ? (
+        <EditorList items={items} pager={pager} />
+      ) : (
+        <p>{l('Sorry, you are not authorized to view this page.')}</p>
+      )}
+    </ReportLayout>
+  );
+};
 
 export default LimitedEditors;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import {
   isAccountAdmin,
@@ -18,10 +19,6 @@ import {
 type ReportsIndexEntryProps = {
   +content: string,
   +reportName: string,
-};
-
-type Props = {
-  +$c: CatalystContextT,
 };
 
 const ReportsIndexEntry = ({
@@ -36,585 +33,593 @@ const ReportsIndexEntry = ({
 
 );
 
-const ReportsIndex = ({$c}: Props): React.Element<typeof Layout> => (
-  <Layout fullWidth title={l('Reports')}>
-    <div id="content">
-      <h1>{l('Reports')}</h1>
+const ReportsIndex = (): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <Layout fullWidth title={l('Reports')}>
+      <div id="content">
+        <h1>{l('Reports')}</h1>
 
-      <p>
-        {exp.l(
-          `If you'd like to participate in the editing process, but do not
-           know where to start, the following reports should be useful. These
-           reports scour the database looking for data that might require
-           fixing, either to comply with the {style|style guidelines}, or in
-           other cases where administrative "clean up" tasks are required.`,
-          {style: '/doc/Style'},
-        )}
-      </p>
-
-      <h2>{l('Artists')}</h2>
-
-      <ul>
-        <ReportsIndexEntry
-          content={l('Artists that may be groups')}
-          reportName="ArtistsThatMayBeGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Artists that may be persons')}
-          reportName="ArtistsThatMayBePersons"
-        />
-        <ReportsIndexEntry
-          content={l('Artists with no subscribers')}
-          reportName="ArtistsWithNoSubscribers"
-        />
-        <ReportsIndexEntry
-          content={l('Possibly duplicate artists')}
-          reportName="DuplicateArtists"
-        />
-        <ReportsIndexEntry
-          content={l('Artists which have collaboration relationships')}
-          reportName="CollaborationRelationships"
-        />
-        <ReportsIndexEntry
-          content={l('Artists which look like collaborations')}
-          reportName="PossibleCollaborations"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Artists containing disambiguation comments in their name',
+        <p>
+          {exp.l(
+            `If you'd like to participate in the editing process, but do not
+             know where to start, the following reports should be useful.
+             These reports scour the database looking for data that might
+             require fixing, either to comply with the
+             {style|style guidelines}, or in other cases where administrative
+             "clean up" tasks are required.`,
+            {style: '/doc/Style'},
           )}
-          reportName="ArtistsContainingDisambiguationComments"
-        />
-        <ReportsIndexEntry
-          content={l('Discogs URLs linked to multiple artists')}
-          reportName="DiscogsLinksWithMultipleArtists"
-        />
-        <ReportsIndexEntry
-          content={l('Artists with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsArtists"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Artists occurring multiple times in the same artist credit',
-          )}
-          reportName="ArtistsWithMultipleOccurrencesInArtistCredits"
-        />
-        <ReportsIndexEntry
-          content={l('Artists with deprecated relationships')}
-          reportName="DeprecatedRelationshipArtists"
-        />
-        <ReportsIndexEntry
-          content={l('Artists with annotations')}
-          reportName="AnnotationsArtists"
-        />
-        <ReportsIndexEntry
-          content={l('Artists with disambiguation the same as the name')}
-          reportName="ArtistsDisambiguationSameName"
-        />
-      </ul>
+        </p>
 
-      <h2>{l('Artist credits')}</h2>
+        <h2>{l('Artists')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Artist credits with dubious trailing join phrases')}
-          reportName="ArtistCreditsWithDubiousTrailingPhrases"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Artists that may be groups')}
+            reportName="ArtistsThatMayBeGroups"
+          />
+          <ReportsIndexEntry
+            content={l('Artists that may be persons')}
+            reportName="ArtistsThatMayBePersons"
+          />
+          <ReportsIndexEntry
+            content={l('Artists with no subscribers')}
+            reportName="ArtistsWithNoSubscribers"
+          />
+          <ReportsIndexEntry
+            content={l('Possibly duplicate artists')}
+            reportName="DuplicateArtists"
+          />
+          <ReportsIndexEntry
+            content={l('Artists which have collaboration relationships')}
+            reportName="CollaborationRelationships"
+          />
+          <ReportsIndexEntry
+            content={l('Artists which look like collaborations')}
+            reportName="PossibleCollaborations"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Artists containing disambiguation comments in their name',
+            )}
+            reportName="ArtistsContainingDisambiguationComments"
+          />
+          <ReportsIndexEntry
+            content={l('Discogs URLs linked to multiple artists')}
+            reportName="DiscogsLinksWithMultipleArtists"
+          />
+          <ReportsIndexEntry
+            content={l('Artists with possible duplicate relationships')}
+            reportName="DuplicateRelationshipsArtists"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Artists occurring multiple times in the same artist credit',
+            )}
+            reportName="ArtistsWithMultipleOccurrencesInArtistCredits"
+          />
+          <ReportsIndexEntry
+            content={l('Artists with deprecated relationships')}
+            reportName="DeprecatedRelationshipArtists"
+          />
+          <ReportsIndexEntry
+            content={l('Artists with annotations')}
+            reportName="AnnotationsArtists"
+          />
+          <ReportsIndexEntry
+            content={l('Artists with disambiguation the same as the name')}
+            reportName="ArtistsDisambiguationSameName"
+          />
+        </ul>
 
-      {isAccountAdmin($c.user) ? (
-        <>
-          <h2>{l('Editors')}</h2>
+        <h2>{l('Artist credits')}</h2>
 
-          <ul>
-            <ReportsIndexEntry
-              content={l('Beginner/limited editors')}
-              reportName="LimitedEditors"
-            />
-          </ul>
-        </>
-      ) : null}
+        <ul>
+          <ReportsIndexEntry
+            content={l('Artist credits with dubious trailing join phrases')}
+            reportName="ArtistCreditsWithDubiousTrailingPhrases"
+          />
+        </ul>
 
-      <h2>{l('Events')}</h2>
+        {isAccountAdmin($c.user) ? (
+          <>
+            <h2>{l('Editors')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Events with annotations')}
-          reportName="AnnotationsEvents"
-        />
-        <ReportsIndexEntry
-          content={l('Possibly duplicate events')}
-          reportName="DuplicateEvents"
-        />
-        <ReportsIndexEntry
-          content={l('Events which should be part of series or larger event')}
-          reportName="EventSequenceNotInSeries"
-        />
-      </ul>
+            <ul>
+              <ReportsIndexEntry
+                content={l('Beginner/limited editors')}
+                reportName="LimitedEditors"
+              />
+            </ul>
+          </>
+        ) : null}
 
-      {isRelationshipEditor($c.user) ? (
-        <>
-          <h2>{l('Instruments')}</h2>
+        <h2>{l('Events')}</h2>
 
-          <ul>
-            <ReportsIndexEntry
-              content={l('Instruments without an image')}
-              reportName="InstrumentsWithoutAnImage"
-            />
-            <ReportsIndexEntry
-              content={l('Instruments without a link to Wikidata')}
-              reportName="InstrumentsWithoutWikidata"
-            />
-          </ul>
-        </>
-      ) : null}
+        <ul>
+          <ReportsIndexEntry
+            content={l('Events with annotations')}
+            reportName="AnnotationsEvents"
+          />
+          <ReportsIndexEntry
+            content={l('Possibly duplicate events')}
+            reportName="DuplicateEvents"
+          />
+          <ReportsIndexEntry
+            content={
+              l('Events which should be part of series or larger event')
+            }
+            reportName="EventSequenceNotInSeries"
+          />
+        </ul>
 
-      <h2>{l('Labels')}</h2>
+        {isRelationshipEditor($c.user) ? (
+          <>
+            <h2>{l('Instruments')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Discogs URLs linked to multiple labels')}
-          reportName="DiscogsLinksWithMultipleLabels"
-        />
-        <ReportsIndexEntry
-          content={l('Labels with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsLabels"
-        />
-        <ReportsIndexEntry
-          content={l('Labels with deprecated relationships')}
-          reportName="DeprecatedRelationshipLabels"
-        />
-        <ReportsIndexEntry
-          content={l('Labels with annotations')}
-          reportName="AnnotationsLabels"
-        />
-        <ReportsIndexEntry
-          content={l('Labels with disambiguation the same as the name')}
-          reportName="LabelsDisambiguationSameName"
-        />
-      </ul>
+            <ul>
+              <ReportsIndexEntry
+                content={l('Instruments without an image')}
+                reportName="InstrumentsWithoutAnImage"
+              />
+              <ReportsIndexEntry
+                content={l('Instruments without a link to Wikidata')}
+                reportName="InstrumentsWithoutWikidata"
+              />
+            </ul>
+          </>
+        ) : null}
 
-      <h2>{l('Release groups')}</h2>
+        <h2>{l('Labels')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Release groups that might need to be merged')}
-          reportName="SetInDifferentRG"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Release groups with titles containing featuring artists',
-          )}
-          reportName="FeaturingReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Discogs URLs linked to multiple release groups')}
-          reportName="DiscogsLinksWithMultipleReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Release groups with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Release groups with deprecated relationships')}
-          reportName="DeprecatedRelationshipReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Possible duplicate release groups')}
-          reportName="DuplicateReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l('Release groups with annotations')}
-          reportName="AnnotationsReleaseGroups"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Release groups not credited to "Various Artists"
-             but linked to VA`,
-          )}
-          reportName="ReleaseGroupsWithoutVACredit"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Release groups credited to "Various Artists"
-             but not linked to VA`,
-          )}
-          reportName="ReleaseGroupsWithoutVALink"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Discogs URLs linked to multiple labels')}
+            reportName="DiscogsLinksWithMultipleLabels"
+          />
+          <ReportsIndexEntry
+            content={l('Labels with possible duplicate relationships')}
+            reportName="DuplicateRelationshipsLabels"
+          />
+          <ReportsIndexEntry
+            content={l('Labels with deprecated relationships')}
+            reportName="DeprecatedRelationshipLabels"
+          />
+          <ReportsIndexEntry
+            content={l('Labels with annotations')}
+            reportName="AnnotationsLabels"
+          />
+          <ReportsIndexEntry
+            content={l('Labels with disambiguation the same as the name')}
+            reportName="LabelsDisambiguationSameName"
+          />
+        </ul>
 
-      <h2>{l('Releases')}</h2>
+        <h2>{l('Release groups')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l(
-            'Releases which might need converting to "multiple artists"',
-          )}
-          reportName="ReleasesToConvert"
-        />
-        <ReportsIndexEntry
-          content={l('Releases without language')}
-          reportName="NoLanguage"
-        />
-        <ReportsIndexEntry
-          content={l('Releases without script')}
-          reportName="NoScript"
-        />
-        <ReportsIndexEntry
-          content={l('Releases which have unexpected Amazon URLs')}
-          reportName="BadAmazonURLs"
-        />
-        <ReportsIndexEntry
-          content={l('Releases which have multiple ASINs')}
-          reportName="MultipleASINs"
-        />
-        <ReportsIndexEntry
-          content={l('Releases which have multiple Discogs links')}
-          reportName="MultipleDiscogsLinks"
-        />
-        <ReportsIndexEntry
-          content={l('Amazon URLs linked to multiple releases')}
-          reportName="ASINsWithMultipleReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Discogs URLs linked to multiple releases')}
-          reportName="DiscogsLinksWithMultipleReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Releases which have part of set relationships')}
-          reportName="PartOfSetRelationships"
-        />
-        <ReportsIndexEntry
-          content={l('Discs entered as separate releases')}
-          reportName="SeparateDiscs"
-        />
-        <ReportsIndexEntry
-          content={l('Tracks whose names include their sequence numbers')}
-          reportName="TracksNamedWithSequence"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with non-sequential track numbers')}
-          reportName="TracksWithSequenceIssues"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with superfluous data tracks')}
-          reportName="SuperfluousDataTracks"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with titles containing featuring artists')}
-          reportName="FeaturingReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Releases released too early')}
-          reportName="ReleasedTooEarly"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Releases where some (but not all) mediums
-             have no format set`,
-          )}
-          reportName="SomeFormatsUnset"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with catalog numbers that look like ASINs')}
-          reportName="CatNoLooksLikeASIN"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with catalog numbers that look like ISRCs')}
-          reportName="CatNoLooksLikeISRC"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases with catalog numbers that look like Label Codes',
-          )}
-          reportName="CatNoLooksLikeLabelCode"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Translated/Transliterated Pseudo-Releases
-             marked as the original version`,
-          )}
-          reportName="MislinkedPseudoReleases"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Translated/Transliterated Pseudo-Releases
-             not linked to an original version`,
-          )}
-          reportName="UnlinkedPseudoReleases"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Releases that have Amazon cover art
-             but no Cover Art Archive front cover`,
-          )}
-          reportName="ReleasesWithAmazonCoverArt"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Releases in the Cover Art Archive
-             where no cover art piece has types`,
-          )}
-          reportName="ReleasesWithCAANoTypes"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with mediums named after their position')}
-          reportName="MediumsWithOrderInTitle"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with non-sequential mediums')}
-          reportName="MediumsWithSequenceIssues"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with unlikely language/script pairs')}
-          reportName="ReleasesWithUnlikelyLanguageScript"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with unknown track times')}
-          reportName="TracksWithoutTimes"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with a single medium that has a name')}
-          reportName="SingleMediumReleasesWithMediumTitles"
-        />
-        <ReportsIndexEntry
-          content={l('Non-digital releases with digital relationships')}
-          reportName="ReleasesWithDownloadRelationships"
-        />
-        <ReportsIndexEntry
-          content={l('Digital releases with mail order relationships')}
-          reportName="ReleasesWithMailOrderRelationships"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with deprecated relationships')}
-          reportName="DeprecatedRelationshipReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with annotations')}
-          reportName="AnnotationsReleases"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with no mediums')}
-          reportName="ReleasesWithNoMediums"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with empty mediums')}
-          reportName="ReleasesWithEmptyMediums"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases not credited to "Various Artists" but linked to VA',
-          )}
-          reportName="ReleasesWithoutVACredit"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases credited to "Various Artists" but not linked to VA',
-          )}
-          reportName="ReleasesWithoutVALink"
-        />
-        <ReportsIndexEntry
-          content={l('Releases missing disc IDs')}
-          reportName="ReleasesMissingDiscIDs"
-        />
-        <ReportsIndexEntry
-          content={l('Releases with conflicting disc IDs')}
-          reportName="ReleasesConflictingDiscIDs"
-        />
-        <ReportsIndexEntry
-          content={l('Releases that have disc IDs, but shouldn’t')}
-          reportName="ShouldNotHaveDiscIDs"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases where artist name and label name are the same',
-          )}
-          reportName="ReleaseLabelSameArtist"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases with a different name than their release group',
-          )}
-          reportName="ReleaseRGDifferentName"
-        />
-        <ReportsIndexEntry
-          content={l(
-            'Releases with the same barcode in different release groups',
-          )}
-          reportName="ReleasesSameBarcode"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Release groups that might need to be merged')}
+            reportName="SetInDifferentRG"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Release groups with titles containing featuring artists',
+            )}
+            reportName="FeaturingReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={l('Discogs URLs linked to multiple release groups')}
+            reportName="DiscogsLinksWithMultipleReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={
+              l('Release groups with possible duplicate relationships')
+            }
+            reportName="DuplicateRelationshipsReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={l('Release groups with deprecated relationships')}
+            reportName="DeprecatedRelationshipReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={l('Possible duplicate release groups')}
+            reportName="DuplicateReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={l('Release groups with annotations')}
+            reportName="AnnotationsReleaseGroups"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Release groups not credited to "Various Artists"
+               but linked to VA`,
+            )}
+            reportName="ReleaseGroupsWithoutVACredit"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Release groups credited to "Various Artists"
+               but not linked to VA`,
+            )}
+            reportName="ReleaseGroupsWithoutVALink"
+          />
+        </ul>
 
-      <h2>{l('Recordings')}</h2>
+        <h2>{l('Releases')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Recordings with earliest release relationships')}
-          reportName="RecordingsWithEarliestReleaseRelationships"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with titles containing featuring artists')}
-          reportName="FeaturingRecordings"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsRecordings"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with varying track times')}
-          reportName="RecordingsWithVaryingTrackLengths"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with deprecated relationships')}
-          reportName="DeprecatedRelationshipRecordings"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with annotations')}
-          reportName="AnnotationsRecordings"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Recordings not credited to "Various Artists"
-             but linked to VA`,
-          )}
-          reportName="RecordingsWithoutVACredit"
-        />
-        <ReportsIndexEntry
-          content={l(
-            `Recordings credited to "Various Artists"
-             but not linked to VA`,
-          )}
-          reportName="RecordingsWithoutVALink"
-        />
-        {/*
-          * MBS-10843: This report has been disabled since the upgrade
-          * to PG 12, because its query can no longer execute in under
-          * 5 minutes in production.
-          *
-          * <ReportsIndexEntry
-          *   content={l(
-          *     `Recordings with the same name
-          *      by different artists with the same name`,
-          *   )}
-          *   reportName="RecordingsSameNameDifferentArtistsSameName"
-          * />
-          */}
-        <ReportsIndexEntry
-          content={l(
-            'Recordings with a different name than their only track',
-          )}
-          reportName="RecordingTrackDifferentName"
-        />
-        <ReportsIndexEntry
-          content={l('Recordings with dates in the future')}
-          reportName="RecordingsWithFutureDates"
-        />
-        <ReportsIndexEntry
-          content={l('Video recordings in non-video mediums')}
-          reportName="VideosInNonVideoMediums"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l(
+              'Releases which might need converting to "multiple artists"',
+            )}
+            reportName="ReleasesToConvert"
+          />
+          <ReportsIndexEntry
+            content={l('Releases without language')}
+            reportName="NoLanguage"
+          />
+          <ReportsIndexEntry
+            content={l('Releases without script')}
+            reportName="NoScript"
+          />
+          <ReportsIndexEntry
+            content={l('Releases which have unexpected Amazon URLs')}
+            reportName="BadAmazonURLs"
+          />
+          <ReportsIndexEntry
+            content={l('Releases which have multiple ASINs')}
+            reportName="MultipleASINs"
+          />
+          <ReportsIndexEntry
+            content={l('Releases which have multiple Discogs links')}
+            reportName="MultipleDiscogsLinks"
+          />
+          <ReportsIndexEntry
+            content={l('Amazon URLs linked to multiple releases')}
+            reportName="ASINsWithMultipleReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Discogs URLs linked to multiple releases')}
+            reportName="DiscogsLinksWithMultipleReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Releases which have part of set relationships')}
+            reportName="PartOfSetRelationships"
+          />
+          <ReportsIndexEntry
+            content={l('Discs entered as separate releases')}
+            reportName="SeparateDiscs"
+          />
+          <ReportsIndexEntry
+            content={l('Tracks whose names include their sequence numbers')}
+            reportName="TracksNamedWithSequence"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with non-sequential track numbers')}
+            reportName="TracksWithSequenceIssues"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with superfluous data tracks')}
+            reportName="SuperfluousDataTracks"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with titles containing featuring artists')}
+            reportName="FeaturingReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Releases released too early')}
+            reportName="ReleasedTooEarly"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Releases where some (but not all) mediums
+               have no format set`,
+            )}
+            reportName="SomeFormatsUnset"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with catalog numbers that look like ASINs')}
+            reportName="CatNoLooksLikeASIN"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with catalog numbers that look like ISRCs')}
+            reportName="CatNoLooksLikeISRC"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases with catalog numbers that look like Label Codes',
+            )}
+            reportName="CatNoLooksLikeLabelCode"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Translated/Transliterated Pseudo-Releases
+               marked as the original version`,
+            )}
+            reportName="MislinkedPseudoReleases"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Translated/Transliterated Pseudo-Releases
+               not linked to an original version`,
+            )}
+            reportName="UnlinkedPseudoReleases"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Releases that have Amazon cover art
+               but no Cover Art Archive front cover`,
+            )}
+            reportName="ReleasesWithAmazonCoverArt"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Releases in the Cover Art Archive
+               where no cover art piece has types`,
+            )}
+            reportName="ReleasesWithCAANoTypes"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with mediums named after their position')}
+            reportName="MediumsWithOrderInTitle"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with non-sequential mediums')}
+            reportName="MediumsWithSequenceIssues"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with unlikely language/script pairs')}
+            reportName="ReleasesWithUnlikelyLanguageScript"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with unknown track times')}
+            reportName="TracksWithoutTimes"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with possible duplicate relationships')}
+            reportName="DuplicateRelationshipsReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with a single medium that has a name')}
+            reportName="SingleMediumReleasesWithMediumTitles"
+          />
+          <ReportsIndexEntry
+            content={l('Non-digital releases with digital relationships')}
+            reportName="ReleasesWithDownloadRelationships"
+          />
+          <ReportsIndexEntry
+            content={l('Digital releases with mail order relationships')}
+            reportName="ReleasesWithMailOrderRelationships"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with deprecated relationships')}
+            reportName="DeprecatedRelationshipReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with annotations')}
+            reportName="AnnotationsReleases"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with no mediums')}
+            reportName="ReleasesWithNoMediums"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with empty mediums')}
+            reportName="ReleasesWithEmptyMediums"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases not credited to "Various Artists" but linked to VA',
+            )}
+            reportName="ReleasesWithoutVACredit"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases credited to "Various Artists" but not linked to VA',
+            )}
+            reportName="ReleasesWithoutVALink"
+          />
+          <ReportsIndexEntry
+            content={l('Releases missing disc IDs')}
+            reportName="ReleasesMissingDiscIDs"
+          />
+          <ReportsIndexEntry
+            content={l('Releases with conflicting disc IDs')}
+            reportName="ReleasesConflictingDiscIDs"
+          />
+          <ReportsIndexEntry
+            content={l('Releases that have disc IDs, but shouldn’t')}
+            reportName="ShouldNotHaveDiscIDs"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases where artist name and label name are the same',
+            )}
+            reportName="ReleaseLabelSameArtist"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases with a different name than their release group',
+            )}
+            reportName="ReleaseRGDifferentName"
+          />
+          <ReportsIndexEntry
+            content={l(
+              'Releases with the same barcode in different release groups',
+            )}
+            reportName="ReleasesSameBarcode"
+          />
+        </ul>
 
-      <h2>{l('Places')}</h2>
+        <h2>{l('Recordings')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Places with deprecated relationships')}
-          reportName="DeprecatedRelationshipPlaces"
-        />
-        <ReportsIndexEntry
-          content={l('Places with annotations')}
-          reportName="AnnotationsPlaces"
-        />
-        <ReportsIndexEntry
-          content={l('Places without coordinates')}
-          reportName="PlacesWithoutCoordinates"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Recordings with earliest release relationships')}
+            reportName="RecordingsWithEarliestReleaseRelationships"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with titles containing featuring artists')}
+            reportName="FeaturingRecordings"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with possible duplicate relationships')}
+            reportName="DuplicateRelationshipsRecordings"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with varying track times')}
+            reportName="RecordingsWithVaryingTrackLengths"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with deprecated relationships')}
+            reportName="DeprecatedRelationshipRecordings"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with annotations')}
+            reportName="AnnotationsRecordings"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Recordings not credited to "Various Artists"
+               but linked to VA`,
+            )}
+            reportName="RecordingsWithoutVACredit"
+          />
+          <ReportsIndexEntry
+            content={l(
+              `Recordings credited to "Various Artists"
+               but not linked to VA`,
+            )}
+            reportName="RecordingsWithoutVALink"
+          />
+          {/*
+            * MBS-10843: This report has been disabled since the upgrade
+            * to PG 12, because its query can no longer execute in under
+            * 5 minutes in production.
+            *
+            * <ReportsIndexEntry
+            *   content={l(
+            *     `Recordings with the same name
+            *      by different artists with the same name`,
+            *   )}
+            *   reportName="RecordingsSameNameDifferentArtistsSameName"
+            * />
+            */}
+          <ReportsIndexEntry
+            content={l(
+              'Recordings with a different name than their only track',
+            )}
+            reportName="RecordingTrackDifferentName"
+          />
+          <ReportsIndexEntry
+            content={l('Recordings with dates in the future')}
+            reportName="RecordingsWithFutureDates"
+          />
+          <ReportsIndexEntry
+            content={l('Video recordings in non-video mediums')}
+            reportName="VideosInNonVideoMediums"
+          />
+        </ul>
 
-      <h2>{l('Series')}</h2>
+        <h2>{l('Places')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Series with annotations')}
-          reportName="AnnotationsSeries"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Places with deprecated relationships')}
+            reportName="DeprecatedRelationshipPlaces"
+          />
+          <ReportsIndexEntry
+            content={l('Places with annotations')}
+            reportName="AnnotationsPlaces"
+          />
+          <ReportsIndexEntry
+            content={l('Places without coordinates')}
+            reportName="PlacesWithoutCoordinates"
+          />
+        </ul>
 
-      <h2>{l('Works')}</h2>
+        <h2>{l('Series')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Works with possible duplicate relationships')}
-          reportName="DuplicateRelationshipsWorks"
-        />
-        <ReportsIndexEntry
-          content={l('Works with deprecated relationships')}
-          reportName="DeprecatedRelationshipWorks"
-        />
-        <ReportsIndexEntry
-          content={l('Works with annotations')}
-          reportName="AnnotationsWorks"
-        />
-        <ReportsIndexEntry
-          content={l('Works with the same type as their parent')}
-          reportName="WorkSameTypeAsParent"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Series with annotations')}
+            reportName="AnnotationsSeries"
+          />
+        </ul>
 
-      <h2>{l('URLs')}</h2>
+        <h2>{l('Works')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('URLs with deprecated relationships')}
-          reportName="DeprecatedRelationshipURLs"
-        />
-        <ReportsIndexEntry
-          content={l('URLs linked to multiple entities')}
-          reportName="LinksWithMultipleEntities"
-        />
-        <ReportsIndexEntry
-          content={l('Wikidata URLs linked to multiple entities')}
-          reportName="WikidataLinksWithMultipleEntities"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('Works with possible duplicate relationships')}
+            reportName="DuplicateRelationshipsWorks"
+          />
+          <ReportsIndexEntry
+            content={l('Works with deprecated relationships')}
+            reportName="DeprecatedRelationshipWorks"
+          />
+          <ReportsIndexEntry
+            content={l('Works with annotations')}
+            reportName="AnnotationsWorks"
+          />
+          <ReportsIndexEntry
+            content={l('Works with the same type as their parent')}
+            reportName="WorkSameTypeAsParent"
+          />
+        </ul>
 
-      <h2>{l('ISRCs')}</h2>
+        <h2>{l('URLs')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('ISRCs with multiple recordings')}
-          reportName="ISRCsWithManyRecordings"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('URLs with deprecated relationships')}
+            reportName="DeprecatedRelationshipURLs"
+          />
+          <ReportsIndexEntry
+            content={l('URLs linked to multiple entities')}
+            reportName="LinksWithMultipleEntities"
+          />
+          <ReportsIndexEntry
+            content={l('Wikidata URLs linked to multiple entities')}
+            reportName="WikidataLinksWithMultipleEntities"
+          />
+        </ul>
 
-      <h2>{l('ISWCs')}</h2>
+        <h2>{l('ISRCs')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('ISWCs with multiple works')}
-          reportName="ISWCsWithManyWorks"
-        />
-      </ul>
+        <ul>
+          <ReportsIndexEntry
+            content={l('ISRCs with multiple recordings')}
+            reportName="ISRCsWithManyRecordings"
+          />
+        </ul>
 
-      <h2>{l('Disc IDs')}</h2>
+        <h2>{l('ISWCs')}</h2>
 
-      <ul>
-        <ReportsIndexEntry
-          content={l('Disc IDs with dubious duration')}
-          reportName="CDTOCDubiousLength"
-        />
-        <ReportsIndexEntry
-          content={l('Disc IDs attached but not applied')}
-          reportName="CDTOCNotApplied"
-        />
-      </ul>
-    </div>
-  </Layout>
-);
+        <ul>
+          <ReportsIndexEntry
+            content={l('ISWCs with multiple works')}
+            reportName="ISWCsWithManyWorks"
+          />
+        </ul>
+
+        <h2>{l('Disc IDs')}</h2>
+
+        <ul>
+          <ReportsIndexEntry
+            content={l('Disc IDs with dubious duration')}
+            reportName="CDTOCDubiousLength"
+          />
+          <ReportsIndexEntry
+            content={l('Disc IDs attached but not applied')}
+            reportName="CDTOCNotApplied"
+          />
+        </ul>
+      </div>
+    </Layout>
+  );
+};
 
 export default ReportsIndex;

--- a/root/report/components/ReportLayout.js
+++ b/root/report/components/ReportLayout.js
@@ -86,7 +86,7 @@ const ReportLayout = ({
                   {date: formatUserDate($c, generated)})}
         </li>
 
-        {canBeFiltered ? <FilterLink $c={$c} filtered={filtered} /> : null}
+        {canBeFiltered ? <FilterLink filtered={filtered} /> : null}
       </ul>
 
       {children}

--- a/root/report/types.js
+++ b/root/report/types.js
@@ -80,7 +80,6 @@ export type ReportCollaborationT = {
 };
 
 export type ReportDataT<T> = {
-  +$c: CatalystContextT,
   +canBeFiltered: boolean,
   +filtered: boolean,
   +generated: string,

--- a/root/search/components/AnnotationResults.js
+++ b/root/search/components/AnnotationResults.js
@@ -47,8 +47,7 @@ const AnnotationResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<AnnotationT>):
-React.Element<typeof ResultsLayout> => (
+}: ResultsPropsT<AnnotationT>): React.Element<typeof ResultsLayout> => (
   <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import DescriptiveLink
   from '../../static/scripts/common/components/DescriptiveLink.js';
 import formatDate from '../../static/scripts/common/utility/formatDate.js';
@@ -19,7 +20,7 @@ import primaryAreaCode
 import {isLocationEditor}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -46,38 +47,40 @@ function buildResult(result: SearchResultT<AreaT>, index: number) {
 }
 
 const AreaResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<AreaT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Code')}</th>
-          <th>{l('Begin')}</th>
-          <th>{l('End')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isLocationEditor($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new area}.', {
-          uri: '/area/create?edit-area.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<AreaT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Code')}</th>
+            <th>{l('Begin')}</th>
+            <th>{l('End')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isLocationEditor($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new area}.', {
+            uri: '/area/create?edit-area.name=' + encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default AreaResults;

--- a/root/search/components/AreaResults.js
+++ b/root/search/components/AreaResults.js
@@ -52,8 +52,7 @@ const AreaResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<AreaT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<AreaT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -72,8 +72,7 @@ const ArtistResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<ArtistT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<ArtistT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/ArtistResults.js
+++ b/root/search/components/ArtistResults.js
@@ -9,13 +9,14 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import ArtistListEntry
   from '../../static/scripts/common/components/ArtistListEntry.js';
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import type {
-  InlineResultsPropsWithContextT,
-  ResultsPropsWithContextT,
+  InlineResultsPropsT,
+  ResultsPropsT,
   SearchResultT,
 } from '../types.js';
 
@@ -42,7 +43,7 @@ export const ArtistResultsInline = ({
   pager,
   query,
   results,
-}: InlineResultsPropsWithContextT<ArtistT>):
+}: InlineResultsPropsT<ArtistT>):
 React.Element<typeof PaginatedSearchResults> => (
   <PaginatedSearchResults
     buildResult={(result, index) => buildResult(result, index)}
@@ -66,28 +67,31 @@ React.Element<typeof PaginatedSearchResults> => (
 );
 
 const ArtistResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<ArtistT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <ArtistResultsInline
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new artist}.', {
-          uri: '/artist/create?edit-artist.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<ArtistT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <ArtistResultsInline
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new artist}.', {
+            uri: '/artist/create?edit-artist.name=' +
+              encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default ArtistResults;

--- a/root/search/components/CDStubResults.js
+++ b/root/search/components/CDStubResults.js
@@ -37,8 +37,7 @@ const CDStubResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<CDStubT>):
-React.Element<typeof ResultsLayout> => (
+}: ResultsPropsT<CDStubT>): React.Element<typeof ResultsLayout> => (
   <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}

--- a/root/search/components/EditorResults.js
+++ b/root/search/components/EditorResults.js
@@ -35,8 +35,7 @@ const EditorResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<EditorT>):
-React.Element<typeof ResultsLayout> => (
+}: ResultsPropsT<EditorT>): React.Element<typeof ResultsLayout> => (
   <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -62,8 +62,7 @@ const EventResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<EventT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<EventT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/EventResults.js
+++ b/root/search/components/EventResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import * as manifest from '../../static/manifest.mjs';
 import ArtistRoles
   from '../../static/scripts/common/components/ArtistRoles.js';
@@ -20,7 +21,7 @@ import formatDatePeriod
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -56,39 +57,41 @@ function buildResult(result: SearchResultT<EventT>, index: number) {
 }
 
 const EventResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<EventT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Date')}</th>
-          <th>{l('Time')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Artists')}</th>
-          <th>{l('Location')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new event}.', {
-          uri: '/event/create?edit-event.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<EventT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Date')}</th>
+            <th>{l('Time')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Artists')}</th>
+            <th>{l('Location')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new event}.', {
+            uri: '/event/create?edit-event.name=' + encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default EventResults;

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -9,17 +9,17 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../context.mjs';
 import InstrumentListEntry
   from '../../static/scripts/common/components/InstrumentListEntry.js';
 import {isRelationshipEditor}
   from '../../static/scripts/common/utility/privileges.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
 
 function buildResult(
-  $c: CatalystContextT,
   result: SearchResultT<InstrumentT>,
   index: number,
 ) {
@@ -28,7 +28,6 @@ function buildResult(
 
   return (
     <InstrumentListEntry
-      $c={$c}
       index={index}
       instrument={instrument}
       key={instrument.id}
@@ -38,37 +37,39 @@ function buildResult(
 }
 
 const InstrumentResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<InstrumentT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={(result, index) => buildResult($c, result, index)}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Description')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isRelationshipEditor($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new instrument}.', {
-          uri: '/instrument/create?edit-instrument.name=' +
-            encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<InstrumentT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={(result, index) => buildResult(result, index)}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Description')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isRelationshipEditor($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new instrument}.', {
+            uri: '/instrument/create?edit-instrument.name=' +
+              encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default InstrumentResults;

--- a/root/search/components/InstrumentResults.js
+++ b/root/search/components/InstrumentResults.js
@@ -42,8 +42,7 @@ const InstrumentResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<InstrumentT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<InstrumentT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(SanitizedCatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/LabelResults.js
+++ b/root/search/components/LabelResults.js
@@ -55,8 +55,7 @@ const LabelResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<LabelT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<LabelT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/LabelResults.js
+++ b/root/search/components/LabelResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import formatEndDate
@@ -17,7 +18,7 @@ import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import formatLabelCode from '../../utility/formatLabelCode.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -49,39 +50,41 @@ function buildResult(result: SearchResultT<LabelT>, index: number) {
 }
 
 const LabelResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<LabelT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Code')}</th>
-          <th>{l('Area')}</th>
-          <th>{l('Begin')}</th>
-          <th>{l('End')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new label}.', {
-          uri: '/label/create?edit-label.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<LabelT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Code')}</th>
+            <th>{l('Area')}</th>
+            <th>{l('Begin')}</th>
+            <th>{l('End')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new label}.', {
+            uri: '/label/create?edit-label.name=' + encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default LabelResults;

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import formatDate from '../../static/scripts/common/utility/formatDate.js';
 import formatEndDate
@@ -16,7 +17,7 @@ import formatEndDate
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -46,39 +47,41 @@ function buildResult(result: SearchResultT<PlaceT>, index: number) {
 }
 
 const PlaceResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<PlaceT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Address')}</th>
-          <th>{l('Area')}</th>
-          <th>{l('Begin')}</th>
-          <th>{l('End')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new place}.', {
-          uri: '/place/create?edit-place.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<PlaceT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Address')}</th>
+            <th>{l('Area')}</th>
+            <th>{l('Begin')}</th>
+            <th>{l('End')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new place}.', {
+            uri: '/place/create?edit-place.name=' + encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default PlaceResults;

--- a/root/search/components/PlaceResults.js
+++ b/root/search/components/PlaceResults.js
@@ -52,8 +52,7 @@ const PlaceResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<PlaceT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<PlaceT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/RecordingResults.js
+++ b/root/search/components/RecordingResults.js
@@ -20,8 +20,8 @@ import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
 import type {
-  InlineResultsPropsWithContextT,
-  ResultsPropsWithContextT,
+  InlineResultsPropsT,
+  ResultsPropsT,
   SearchResultT,
 } from '../types.js';
 import ArtistCreditLink
@@ -129,7 +129,7 @@ export const RecordingResultsInline = ({
   pager,
   query,
   results,
-}: InlineResultsPropsWithContextT<RecordingWithArtistCreditT>):
+}: InlineResultsPropsT<RecordingWithArtistCreditT>):
 React.Element<typeof PaginatedSearchResults> => {
   const $c = React.useContext(CatalystContext);
 
@@ -157,14 +157,14 @@ React.Element<typeof PaginatedSearchResults> => {
 };
 
 const RecordingResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<RecordingWithArtistCreditT>):
+}: ResultsPropsT<RecordingWithArtistCreditT>):
 React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
   linenum = 0;
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -9,13 +9,14 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import ArtistCreditLink
   from '../../static/scripts/common/components/ArtistCreditLink.js';
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -46,37 +47,39 @@ function buildResult(result: SearchResultT<ReleaseGroupT>, index: number) {
 }
 
 const ReleaseGroupResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<ReleaseGroupT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Release Group')}</th>
-          <th>{l('Artist')}</th>
-          <th>{l('Type')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new release group}.', {
-          uri: '/release-group/create?edit-release-group.name=' +
-            encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<ReleaseGroupT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Release Group')}</th>
+            <th>{l('Artist')}</th>
+            <th>{l('Type')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new release group}.', {
+            uri: '/release-group/create?edit-release-group.name=' +
+              encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default ReleaseGroupResults;

--- a/root/search/components/ReleaseGroupResults.js
+++ b/root/search/components/ReleaseGroupResults.js
@@ -52,8 +52,7 @@ const ReleaseGroupResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<ReleaseGroupT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<ReleaseGroupT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -26,8 +26,8 @@ import ReleaseCatnoList from '../../components/ReleaseCatnoList.js';
 import ReleaseLabelList from '../../components/ReleaseLabelList.js';
 import ReleaseLanguageScript from '../../components/ReleaseLanguageScript.js';
 import type {
-  InlineResultsPropsWithContextT,
-  ResultsPropsWithContextT,
+  InlineResultsPropsT,
+  ResultsPropsT,
   SearchResultT,
 } from '../types.js';
 
@@ -100,7 +100,7 @@ export const ReleaseResultsInline = ({
   pager,
   query,
   results,
-}: InlineResultsPropsWithContextT<ReleaseT>):
+}: InlineResultsPropsT<ReleaseT>):
 React.Element<typeof PaginatedSearchResults> => {
   const $c = React.useContext(CatalystContext);
 
@@ -133,29 +133,31 @@ React.Element<typeof PaginatedSearchResults> => {
 };
 
 const ReleaseResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<ReleaseT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <ReleaseResultsInline
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new release}.', {
-          uri: '/release/add',
-        })}
-      </p>
-    ) : null}
-    {manifest.js('common/components/TaggerIcon', {async: 'async'})}
-  </ResultsLayout>
-);
+}: ResultsPropsT<ReleaseT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <ReleaseResultsInline
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new release}.', {
+            uri: '/release/add',
+          })}
+        </p>
+      ) : null}
+      {manifest.js('common/components/TaggerIcon', {async: 'async'})}
+    </ResultsLayout>
+  );
+};
 
 export default ReleaseResults;

--- a/root/search/components/ReleaseResults.js
+++ b/root/search/components/ReleaseResults.js
@@ -138,8 +138,7 @@ const ReleaseResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<ReleaseT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<ReleaseT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -9,11 +9,12 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import EntityLink from '../../static/scripts/common/components/EntityLink.js';
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
 import loopParity from '../../utility/loopParity.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -40,35 +41,38 @@ function buildResult(
 }
 
 const SeriesResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<SeriesT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={buildResult}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Type')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new series}.', {
-          uri: '/series/create?edit-series.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<SeriesT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={buildResult}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Type')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new series}.', {
+            uri: '/series/create?edit-series.name=' +
+              encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default SeriesResults;

--- a/root/search/components/SeriesResults.js
+++ b/root/search/components/SeriesResults.js
@@ -46,8 +46,7 @@ const SeriesResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<SeriesT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<SeriesT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/TagResults.js
+++ b/root/search/components/TagResults.js
@@ -44,8 +44,7 @@ const TagResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<TagT>):
-React.Element<typeof ResultsLayout> => (
+}: ResultsPropsT<TagT>): React.Element<typeof ResultsLayout> => (
   <ResultsLayout form={form} lastUpdated={lastUpdated}>
     <PaginatedSearchResults
       buildResult={buildResult}

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -43,8 +43,7 @@ const WorkResults = ({
   pager,
   query,
   results,
-}: ResultsPropsT<WorkT>):
-React.Element<typeof ResultsLayout> => {
+}: ResultsPropsT<WorkT>): React.Element<typeof ResultsLayout> => {
   const $c = React.useContext(CatalystContext);
   return (
     <ResultsLayout form={form} lastUpdated={lastUpdated}>

--- a/root/search/components/WorkResults.js
+++ b/root/search/components/WorkResults.js
@@ -9,11 +9,12 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../../context.mjs';
 import WorkListEntry
   from '../../static/scripts/common/components/WorkListEntry.js';
 import {isEditingEnabled}
   from '../../static/scripts/common/utility/privileges.js';
-import type {ResultsPropsWithContextT, SearchResultT} from '../types.js';
+import type {ResultsPropsT, SearchResultT} from '../types.js';
 
 import PaginatedSearchResults from './PaginatedSearchResults.js';
 import ResultsLayout from './ResultsLayout.js';
@@ -37,39 +38,41 @@ function buildResult(
 }
 
 const WorkResults = ({
-  $c,
   form,
   lastUpdated,
   pager,
   query,
   results,
-}: ResultsPropsWithContextT<WorkT>):
-React.Element<typeof ResultsLayout> => (
-  <ResultsLayout form={form} lastUpdated={lastUpdated}>
-    <PaginatedSearchResults
-      buildResult={(result, index) => buildResult(result, index)}
-      columns={
-        <>
-          <th>{l('Name')}</th>
-          <th>{l('Writers')}</th>
-          <th>{l('Artists')}</th>
-          <th>{l('ISWC')}</th>
-          <th>{l('Type')}</th>
-          <th>{l('Lyrics Languages')}</th>
-        </>
-      }
-      pager={pager}
-      query={query}
-      results={results}
-    />
-    {isEditingEnabled($c.user) ? (
-      <p>
-        {exp.l('Alternatively, you may {uri|add a new work}.', {
-          uri: '/work/create?edit-work.name=' + encodeURIComponent(query),
-        })}
-      </p>
-    ) : null}
-  </ResultsLayout>
-);
+}: ResultsPropsT<WorkT>):
+React.Element<typeof ResultsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <ResultsLayout form={form} lastUpdated={lastUpdated}>
+      <PaginatedSearchResults
+        buildResult={(result, index) => buildResult(result, index)}
+        columns={
+          <>
+            <th>{l('Name')}</th>
+            <th>{l('Writers')}</th>
+            <th>{l('Artists')}</th>
+            <th>{l('ISWC')}</th>
+            <th>{l('Type')}</th>
+            <th>{l('Lyrics Languages')}</th>
+          </>
+        }
+        pager={pager}
+        query={query}
+        results={results}
+      />
+      {isEditingEnabled($c.user) ? (
+        <p>
+          {exp.l('Alternatively, you may {uri|add a new work}.', {
+            uri: '/work/create?edit-work.name=' + encodeURIComponent(query),
+          })}
+        </p>
+      ) : null}
+    </ResultsLayout>
+  );
+};
 
 export default WorkResults;

--- a/root/search/types.js
+++ b/root/search/types.js
@@ -8,13 +8,6 @@
  */
 
 export type InlineResultsPropsT<T> = {
-  +$c?: CatalystContextT,
-  +pager: PagerT,
-  +query: string,
-  +results: $ReadOnlyArray<SearchResultT<T>>,
-};
-
-export type InlineResultsPropsWithContextT<T> = {
   +pager: PagerT,
   +query: string,
   +results: $ReadOnlyArray<SearchResultT<T>>,
@@ -22,13 +15,6 @@ export type InlineResultsPropsWithContextT<T> = {
 
 export type ResultsPropsT<T> = {
   ...InlineResultsPropsT<T>,
-  +form: SearchFormT,
-  +lastUpdated?: string,
-};
-
-export type ResultsPropsWithContextT<T> = {
-  ...InlineResultsPropsT<T>,
-  +$c: CatalystContextT,
   +form: SearchFormT,
   +lastUpdated?: string,
 };

--- a/root/series/SeriesMerge.js
+++ b/root/series/SeriesMerge.js
@@ -18,13 +18,11 @@ import SeriesList from '../components/list/SeriesList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +toMerge: $ReadOnlyArray<SeriesT>,
 };
 
 const SeriesMerge = ({
-  $c,
   form,
   toMerge,
 }: Props): React.Element<typeof Layout> => (
@@ -35,7 +33,7 @@ const SeriesMerge = ({
         {l(`You are about to merge all these series into a single one.
             Please select the series all others should be merged into:`)}
       </p>
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <SeriesList
           mergeForm={form}
           series={sortByEntityName(toMerge)}

--- a/root/server/response.mjs
+++ b/root/server/response.mjs
@@ -72,8 +72,6 @@ export async function getResponse(requestBody, context) {
     if (props == null) {
       props = {};
     }
-    props.$c = context;
-
     response = ReactDOMServer.renderToString(
       React.createElement(
         CatalystContext.Provider,

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -49,7 +49,6 @@ import {
 } from '../../../utility/subfieldErrors.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +aliasTypes: SelectOptionsT,
   +entity: CoreEntityT,
   +form: AliasEditFormT,
@@ -196,7 +195,6 @@ function reducer(state: StateT, action: ActionT): StateT {
 }
 
 const AliasEditForm = ({
-  $c,
   aliasTypes,
   entity,
   form: initialForm,
@@ -279,7 +277,6 @@ const AliasEditForm = ({
       </p>
 
       <form
-        action={$c.req.uri}
         className="edit-alias"
         method="post"
         onKeyDown={handleKeyDown}

--- a/root/static/scripts/annotation/AnnotationHistoryTable.js
+++ b/root/static/scripts/annotation/AnnotationHistoryTable.js
@@ -9,12 +9,12 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../../context.mjs';
 import EditorLink from '../common/components/EditorLink.js';
 import bracketed from '../common/utility/bracketed.js';
 import formatUserDate from '../../../utility/formatUserDate.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +annotations: $ReadOnlyArray<AnnotationT>,
   +baseUrl: string,
 };
@@ -60,10 +60,11 @@ function reducer(state: StateT, action: ActionT): StateT {
 }
 
 const AnnotationHistoryTable = ({
-  $c,
   annotations,
   baseUrl,
 }: Props): React.Element<'table'> => {
+  const $c = React.useContext(SanitizedCatalystContext);
+
   const canCompare = annotations.length > 1;
 
   const [state, dispatch] = React.useReducer(

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -71,7 +71,7 @@ const CollectionEditForm = ({collectionTypes, form}: Props) => {
   return (
     <SanitizedCatalystContext.Consumer>
       {$c => (
-        <form action={$c.req.uri} method="post">
+        <form method="post">
           <fieldset>
             <legend>{l('Collection details')}</legend>
             <FormRowTextLong

--- a/root/static/scripts/common/components/ArtistListEntry.js
+++ b/root/static/scripts/common/components/ArtistListEntry.js
@@ -127,7 +127,6 @@ const ArtistListRow = ({
       ) : null}
       {mergeForm && artistList ? (
         <RemoveFromMergeTableCell
-          $c={$c}
           entity={artist}
           toMerge={artistList}
         />

--- a/root/static/scripts/common/components/InstrumentListEntry.js
+++ b/root/static/scripts/common/components/InstrumentListEntry.js
@@ -9,19 +9,18 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../../../context.mjs';
 import loopParity from '../../../../utility/loopParity.js';
 import expand2react from '../i18n/expand2react.js';
 
 import DescriptiveLink from './DescriptiveLink.js';
 
 type InstrumentListRowProps = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +instrument: InstrumentT,
 };
 
 type InstrumentListEntryProps = {
-  +$c: CatalystContextT,
   +checkboxes?: string,
   +index: number,
   +instrument: InstrumentT,
@@ -29,38 +28,39 @@ type InstrumentListEntryProps = {
 };
 
 const InstrumentListRow = ({
-  $c,
   checkboxes,
   instrument,
-}: InstrumentListRowProps) => (
-  <>
-    {$c.user && nonEmpty(checkboxes) ? (
+}: InstrumentListRowProps) => {
+  const $c = React.useContext(SanitizedCatalystContext);
+  return (
+    <>
+      {$c.user && nonEmpty(checkboxes) ? (
+        <td>
+          <input
+            name={checkboxes}
+            type="checkbox"
+            value={instrument.id}
+          />
+        </td>
+      ) : null}
       <td>
-        <input
-          name={checkboxes}
-          type="checkbox"
-          value={instrument.id}
-        />
+        <DescriptiveLink entity={instrument} />
       </td>
-    ) : null}
-    <td>
-      <DescriptiveLink entity={instrument} />
-    </td>
-    <td>
-      {nonEmpty(instrument.typeName)
-        ? lp_attributes(instrument.typeName, 'instrument_type')
-        : null}
-    </td>
-    <td>
-      {instrument.description
-        ? expand2react(l_instrument_descriptions(instrument.description))
-        : null}
-    </td>
-  </>
-);
+      <td>
+        {nonEmpty(instrument.typeName)
+          ? lp_attributes(instrument.typeName, 'instrument_type')
+          : null}
+      </td>
+      <td>
+        {instrument.description
+          ? expand2react(l_instrument_descriptions(instrument.description))
+          : null}
+      </td>
+    </>
+  );
+};
 
 const InstrumentListEntry = ({
-  $c,
   checkboxes,
   index,
   instrument,
@@ -68,7 +68,6 @@ const InstrumentListEntry = ({
 }: InstrumentListEntryProps): React.Element<'tr'> => (
   <tr className={loopParity(index)} data-score={score ?? null}>
     <InstrumentListRow
-      $c={$c}
       checkboxes={checkboxes}
       instrument={instrument}
     />

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -10,6 +10,7 @@
 import he from 'he';
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../../../../context.mjs';
 import {minimalEntity} from '../../../../utility/hydrate.js';
 import loopParity from '../../../../utility/loopParity.js';
 import {unwrapNl} from '../i18n.js';
@@ -142,20 +143,19 @@ const DownvoteButton = ({
 );
 
 type VoteButtonsPropsT = {
-  $c: CatalystContextT,
   callback: (VoteT) => void,
   count: number,
   currentVote: VoteT,
 };
 
 const VoteButtons = ({
-  $c,
   callback,
   count,
   currentVote,
 }: VoteButtonsPropsT): React.Element<'span'> => {
-  let className = '';
+  const $c = React.useContext(SanitizedCatalystContext);
 
+  let className = '';
   if (currentVote === 1) {
     className = ' tag-upvoted';
   } else if (currentVote === -1) {
@@ -176,7 +176,6 @@ const VoteButtons = ({
 };
 
 type TagRowPropsT = {
-  $c: CatalystContextT,
   callback: (VoteT) => void,
   count: number,
   currentVote: VoteT,
@@ -185,7 +184,6 @@ type TagRowPropsT = {
 };
 
 const TagRow = ({
-  $c,
   callback,
   count,
   currentVote,
@@ -195,7 +193,6 @@ const TagRow = ({
   <li className={loopParity(index)} key={tag.name}>
     <TagLink tag={tag.name} />
     <VoteButtons
-      $c={$c}
       callback={callback}
       count={count}
       currentVote={currentVote}
@@ -204,7 +201,6 @@ const TagRow = ({
 );
 
 type TagEditorProps = {
-  +$c: CatalystContextT,
   +aggregatedTags: $ReadOnlyArray<AggregatedTagT>,
   +entity: CoreEntityT | MinimalCoreEntityT,
   +genreMap: ?{+[genreName: string]: GenreT, ...},
@@ -337,7 +333,6 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
 
         const tagRow = (
           <TagRow
-            $c={this.props.$c}
             callback={callback}
             count={t.count}
             currentVote={t.vote}
@@ -556,78 +551,91 @@ export const MainTagEditor = (hydrate<TagEditorProps>(
             <p>{l('Nobody has tagged this yet.')}</p>
           )}
 
-          {(positiveTagsOnly && !tags.every(isAlwaysVisible)) ? (
-            <>
-              {this.props.$c.user?.has_confirmed_email_address ? (
-                <p>
-                  {l(
-                    `Tags with a score of zero or below,
-                     and tags that you’ve downvoted are hidden.`,
-                  )}
-                </p>
-              ) : (
-                <p>
-                  {l('Tags with a score of zero or below are hidden.')}
-                </p>
-              )}
-              <p>
-                <a href="#" onClick={(event) => this.showAllTags(event)}>
-                  {l('Show all tags.')}
-                </a>
-              </p>
-            </>
-          ) : null}
-
-          {positiveTagsOnly === false ? (
-            <>
-              <p>
-                {l('All tags are being shown.')}
-              </p>
-              {this.props.$c.user?.has_confirmed_email_address ? (
-                <p>
-                  <a
-                    href="#"
-                    onClick={(event) => this.hideNegativeTags(event)}
-                  >
-                    {l(
-                      `Hide tags with a score of zero or below,
-                       and tags that you’ve downvoted.`,
+          <SanitizedCatalystContext.Consumer>
+            {($c: SanitizedCatalystContextT) => (
+              <>
+                {(positiveTagsOnly && !tags.every(isAlwaysVisible)) ? (
+                  <>
+                    {$c.user?.has_confirmed_email_address ? (
+                      <p>
+                        {l(
+                          `Tags with a score of zero or below,
+                           and tags that you’ve downvoted are hidden.`,
+                        )}
+                      </p>
+                    ) : (
+                      <p>
+                        {l('Tags with a score of zero or below are hidden.')}
+                      </p>
                     )}
-                  </a>
-                </p>
-              ) : (
-                <p>
-                  <a
-                    href="#"
-                    onClick={(event) => this.hideNegativeTags(event)}
-                  >
-                    {l('Hide tags with a score of zero or below.')}
-                  </a>
-                </p>
-              )}
-            </>
-          ) : null}
+                    <p>
+                      <a
+                        href="#"
+                        onClick={(event) => this.showAllTags(event)}
+                      >
+                        {l('Show all tags.')}
+                      </a>
+                    </p>
+                  </>
+                ) : null}
 
-          {this.props.$c.user?.has_confirmed_email_address ? (
-            <>
-              <h2>{l('Add Tags')}</h2>
-              <p>
-                {exp.l(
-                  `You can add your own {tagdocs|tags} below.
-                   Use commas to separate multiple tags.`,
-                  {tagdocs: '/doc/Folksonomy_Tagging'},
-                )}
-              </p>
-              <form id="tag-form" onSubmit={this.handleSubmitBound}>
-                <p>
-                  <textarea cols="50" ref={this.setTagsInputBound} rows="5" />
-                </p>
-                <button className="styled-button" type="submit">
-                  {l('Submit tags')}
-                </button>
-              </form>
-            </>
-          ) : null}
+                {positiveTagsOnly === false ? (
+                  <>
+                    <p>
+                      {l('All tags are being shown.')}
+                    </p>
+                    {$c.user?.has_confirmed_email_address ? (
+                      <p>
+                        <a
+                          href="#"
+                          onClick={(event) => this.hideNegativeTags(event)}
+                        >
+                          {l(
+                            `Hide tags with a score of zero or below,
+                             and tags that you’ve downvoted.`,
+                          )}
+                        </a>
+                      </p>
+                    ) : (
+                      <p>
+                        <a
+                          href="#"
+                          onClick={(event) => this.hideNegativeTags(event)}
+                        >
+                          {l('Hide tags with a score of zero or below.')}
+                        </a>
+                      </p>
+                    )}
+                  </>
+                ) : null}
+
+                {$c.user?.has_confirmed_email_address ? (
+                  <>
+                    <h2>{l('Add Tags')}</h2>
+                    <p>
+                      {exp.l(
+                        `You can add your own {tagdocs|tags} below.
+                        Use commas to separate multiple tags.`,
+                        {tagdocs: '/doc/Folksonomy_Tagging'},
+                      )}
+                    </p>
+                    <form id="tag-form" onSubmit={this.handleSubmitBound}>
+                      <p>
+                        <textarea
+                          cols="50"
+                          ref={this.setTagsInputBound}
+                          rows="5"
+                        />
+                      </p>
+                      <button className="styled-button" type="submit">
+                        {l('Submit tags')}
+                      </button>
+                    </form>
+                  </>
+                ) : null}
+              </>
+            )}
+          </SanitizedCatalystContext.Consumer>
         </div>
       );
     }

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -20,7 +20,6 @@ import {exportTypeInfo} from '../../relationship-editor/common/viewModel.js';
 import {prepareSubmission} from '../../relationship-editor/generic.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +attrInfo: LinkAttrTypeOptionsT,
   +form: GenreFormT,
   +sourceEntity: GenreT | {entityType: 'genre'},
@@ -28,7 +27,6 @@ type Props = {
 };
 
 const GenreEditForm = ({
-  $c,
   attrInfo,
   form,
   sourceEntity,
@@ -83,7 +81,6 @@ const GenreEditForm = ({
 
   return (
     <form
-      action={$c.req.uri}
       className="edit-genre"
       method="post"
       onSubmit={handleSubmit}

--- a/root/static/scripts/release/components/MediumTable.js
+++ b/root/static/scripts/release/components/MediumTable.js
@@ -11,7 +11,6 @@ import * as React from 'react';
 import {captureException} from '@sentry/browser';
 
 import Paginator from '../../../../components/Paginator.js';
-import {CatalystContext} from '../../../../context.mjs';
 import mediumHasMultipleArtists
   from '../../../../utility/mediumHasMultipleArtists.js';
 import DataTrackIcon
@@ -72,8 +71,6 @@ const MediumTable = (React.memo<PropsT>(({
   release,
   tracks,
 }: PropsT) => {
-  const $c = React.useContext(CatalystContext);
-
   const [loadingMessage, setLoadingMessage] =
     React.useState('');
 
@@ -234,7 +231,6 @@ const MediumTable = (React.memo<PropsT>(({
                     )}
                   </p>
                   <Paginator
-                    $c={$c}
                     hash={'medium' + medium.position}
                     pager={tracksPager}
                   />

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -10,6 +10,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
@@ -19,7 +20,6 @@ import {formatCount, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type CountriesStatsT = {
-  +$c: CatalystContextT,
   +countryStats: $ReadOnlyArray<CountryStatT>,
   +dateCollected: string,
 };
@@ -32,127 +32,129 @@ type CountryStatT = {
 };
 
 const Countries = ({
-  $c,
   countryStats,
   dateCollected,
-}: CountriesStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout fullWidth page="countries" title={l('Countries')}>
-    <p>
-      {texp.l('Last updated: {date}',
-              {date: dateCollected})}
-    </p>
-    <table className="tbl" id="countries-table">
-      <thead>
-        <tr>
-          <th className="pos">{l('Rank')}</th>
-          <th>
-            {l('Country')}
-            <div className="arrow" />
-          </th>
-          <th>
-            {l('Artists')}
-            <div className="arrow" />
-          </th>
-          <th>
-            {l('Releases')}
-            <div className="arrow" />
-          </th>
-          <th>
-            {l('Labels')}
-            <div className="arrow" />
-          </th>
-          <th>
-            {l('Total')}
-            <div className="arrow" />
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {countryStats.map((countryStat, index) => {
-          const country = countryStat.entity;
-          const hasCountryCode = country && country.country_code;
-          return (
-            <tr
-              className={loopParity(index)}
-              key={
-                country
-                  ? country.gid
-                  : `missing-${index}`
-              }
-            >
-              <td className="t">{index + 1}</td>
-              <td>
-                {hasCountryCode
-                  ? <EntityLink entity={country} />
-                  : l('Unknown Country')}
-              </td>
-              <td className="t">
-                {hasCountryCode ? (
-                  <EntityLink
-                    content={formatCount($c, countryStat.artist_count)}
-                    entity={country}
-                    subPath="artists"
+}: CountriesStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout fullWidth page="countries" title={l('Countries')}>
+      <p>
+        {texp.l('Last updated: {date}',
+                {date: dateCollected})}
+      </p>
+      <table className="tbl" id="countries-table">
+        <thead>
+          <tr>
+            <th className="pos">{l('Rank')}</th>
+            <th>
+              {l('Country')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Artists')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Releases')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Labels')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Total')}
+              <div className="arrow" />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {countryStats.map((countryStat, index) => {
+            const country = countryStat.entity;
+            const hasCountryCode = country && country.country_code;
+            return (
+              <tr
+                className={loopParity(index)}
+                key={
+                  country
+                    ? country.gid
+                    : `missing-${index}`
+                }
+              >
+                <td className="t">{index + 1}</td>
+                <td>
+                  {hasCountryCode
+                    ? <EntityLink entity={country} />
+                    : l('Unknown Country')}
+                </td>
+                <td className="t">
+                  {hasCountryCode ? (
+                    <EntityLink
+                      content={formatCount($c, countryStat.artist_count)}
+                      entity={country}
+                      subPath="artists"
+                    />
+                  ) : formatCount($c, countryStat.artist_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.artist.country.' + (hasCountryCode
+                        ? country.country_code
+                        : 'null')
+                    }
                   />
-                ) : formatCount($c, countryStat.artist_count)}
-                {' '}
-                <TimelineLink
-                  statName={
-                    'count.artist.country.' + (hasCountryCode
-                      ? country.country_code
-                      : 'null')
-                  }
-                />
-              </td>
-              <td className="t">
-                {hasCountryCode ? (
-                  <EntityLink
-                    content={
-                      formatCount($c, countryStat.release_count)}
-                    entity={country}
-                    subPath="releases"
+                </td>
+                <td className="t">
+                  {hasCountryCode ? (
+                    <EntityLink
+                      content={
+                        formatCount($c, countryStat.release_count)}
+                      entity={country}
+                      subPath="releases"
+                    />
+                  ) : formatCount($c, countryStat.release_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.release.country.' + (hasCountryCode
+                        ? country.country_code
+                        : 'null')
+                    }
                   />
-                ) : formatCount($c, countryStat.release_count)}
-                {' '}
-                <TimelineLink
-                  statName={
-                    'count.release.country.' + (hasCountryCode
-                      ? country.country_code
-                      : 'null')
-                  }
-                />
-              </td>
-              <td className="t">
-                {hasCountryCode ? (
-                  <EntityLink
-                    content={formatCount($c, countryStat.label_count)}
-                    entity={country}
-                    subPath="labels"
+                </td>
+                <td className="t">
+                  {hasCountryCode ? (
+                    <EntityLink
+                      content={formatCount($c, countryStat.label_count)}
+                      entity={country}
+                      subPath="labels"
+                    />
+                  ) : formatCount($c, countryStat.label_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.label.country.' + (hasCountryCode
+                        ? country.country_code
+                        : 'null')
+                    }
                   />
-                ) : formatCount($c, countryStat.label_count)}
-                {' '}
-                <TimelineLink
-                  statName={
-                    'count.label.country.' + (hasCountryCode
-                      ? country.country_code
-                      : 'null')
-                  }
-                />
-              </td>
-              <td className="t">
-                {formatCount(
-                  $c,
-                  countryStat.artist_count +
-                  countryStat.release_count +
-                  countryStat.label_count,
-                )}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
-    {manifest.js('statistics')}
-  </StatisticsLayout>
-);
+                </td>
+                <td className="t">
+                  {formatCount(
+                    $c,
+                    countryStat.artist_count +
+                    countryStat.release_count +
+                    countryStat.label_count,
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {manifest.js('statistics')}
+    </StatisticsLayout>
+  );
+};
 
 export default Countries;

--- a/root/statistics/CoverArt.js
+++ b/root/statistics/CoverArt.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {l_statistics as l}
   from '../static/scripts/common/i18n/statistics.js';
 import mapRange from '../static/scripts/common/utility/mapRange.js';
@@ -17,7 +18,6 @@ import {formatCount, formatPercentage, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type CoverArtStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +releaseFormatStats: $ReadOnlyArray<CoverArtReleaseFormatStatT>,
   +releaseStatusStats: $ReadOnlyArray<CoverArtReleaseStatusStatT>,
@@ -55,57 +55,230 @@ const nameOrNull = (name: string, defaultName: string) => {
 };
 
 const CoverArt = ({
-  $c,
   dateCollected,
   releaseTypeStats,
   releaseStatusStats,
   releaseFormatStats,
   stats,
   typeStats,
-}: CoverArtStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout fullWidth page="coverart" title={l('Cover Art')}>
-    <p>
-      {texp.l('Last updated: {date}', {date: dateCollected})}
-    </p>
-    <h2>{l('Basics')}</h2>
-    {stats['count.release.has_caa'] < 1 ? (
+}: CoverArtStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout fullWidth page="coverart" title={l('Cover Art')}>
       <p>
-        {l('No cover art statistics available.')}
+        {texp.l('Last updated: {date}', {date: dateCollected})}
       </p>
-    ) : (
+      <h2>{l('Basics')}</h2>
+      {stats['count.release.has_caa'] < 1 ? (
+        <p>
+          {l('No cover art statistics available.')}
+        </p>
+      ) : (
+        <table className="database-statistics">
+          <tbody>
+            <tr>
+              <th>{l('Releases with cover art:')}</th>
+              <td>
+                {formatCount($c, stats['count.release.has_caa'])}
+                {' '}
+                <TimelineLink statName="count.release.has_caa" />
+              </td>
+              <td>
+                {formatPercentage(
+                  $c,
+                  stats['count.release.has_caa'] / stats['count.release'],
+                  1,
+                )}
+              </td>
+            </tr>
+            <tr>
+              <th>{l('Pieces of cover art:')}</th>
+              <td>
+                {formatCount($c, stats['count.coverart'])}
+                {' '}
+                <TimelineLink statName="count.coverart" />
+              </td>
+              <td />
+            </tr>
+          </tbody>
+        </table>
+      )}
+      <h2>{l('Releases')}</h2>
+      {(releaseTypeStats.length === 0 &&
+        releaseStatusStats.length === 0 &&
+        releaseFormatStats.length === 0) ? (
+          <p>
+            {l('No cover art statistics available.')}
+          </p>
+        ) : (
+          <table className="database-statistics">
+            <tbody>
+              <tr className="thead">
+                <th colSpan="4">{l('By Release Group Type')}</th>
+              </tr>
+              <tr>
+                <th colSpan="2">{l('Releases with cover art:')}</th>
+                <td>
+                  {formatCount($c, stats['count.release.has_caa'])}
+                  {' '}
+                  <TimelineLink statName="count.release.has_caa" />
+                </td>
+                <td />
+              </tr>
+              {releaseTypeStats.map((type, index) => (
+                <tr key={'type' + index}>
+                  <th />
+                  <th>
+                    {nameOrNull(
+                      lp_attributes(type.type, 'release_group_primary_type'),
+                      l('No type'),
+                    )}
+                  </th>
+                  <td>
+                    {formatCount($c, stats[type.stat_name])}
+                    {' '}
+                    <TimelineLink statName={type.stat_name} />
+                  </td>
+                  <td>
+                    {formatPercentage(
+                      $c,
+                      stats[type.stat_name] / stats['count.release.has_caa'],
+                      1,
+                    )}
+                  </td>
+                </tr>
+              ))}
+              <tr className="thead">
+                <th colSpan="4">{l('By Release Status')}</th>
+              </tr>
+              <tr>
+                <th colSpan="2">{l('Releases with cover art:')}</th>
+                <td>
+                  {formatCount($c, stats['count.release.has_caa'])}
+                  {' '}
+                  <TimelineLink statName="count.release.has_caa" />
+                </td>
+                <td />
+              </tr>
+              {releaseStatusStats.map((status, index) => (
+                <tr key={'status' + index}>
+                  <th />
+                  <th>
+                    {nameOrNull(
+                      lp_attributes(status.status, 'release_status'),
+                      l('No status'),
+                    )}
+                  </th>
+                  <td>
+                    {formatCount($c, stats[status.stat_name])}
+                    {' '}
+                    <TimelineLink statName={status.stat_name} />
+                  </td>
+                  <td>
+                    {formatPercentage(
+                      $c,
+                      stats[status.stat_name] /
+                        stats['count.release.has_caa'],
+                      1,
+                    )}
+                  </td>
+                </tr>
+              ))}
+              <tr className="thead">
+                <th colSpan="4">{l('By Release Format')}</th>
+              </tr>
+              <tr>
+                <th colSpan="2">{l('Releases with cover art:')}</th>
+                <td>
+                  {formatCount($c, stats['count.release.has_caa'])}
+                  {' '}
+                  <TimelineLink statName="count.release.has_caa" />
+                </td>
+                <td />
+              </tr>
+              {releaseFormatStats.map((format, index) => (
+                <tr key={'format' + index}>
+                  <th />
+                  <th>
+                    {nameOrNull(
+                      lp_attributes(format.format, 'medium_format'),
+                      l('No format'),
+                    )}
+                  </th>
+                  <td>
+                    {formatCount($c, stats[format.stat_name])}
+                    {' '}
+                    <TimelineLink statName={format.stat_name} />
+                  </td>
+                  <td>
+                    {formatPercentage(
+                      $c,
+                      stats[format.stat_name] /
+                        stats['count.release.has_caa'],
+                      1,
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>)
+      }
+      <h2>{l('Release groups')}</h2>
       <table className="database-statistics">
         <tbody>
           <tr>
-            <th>{l('Releases with cover art:')}</th>
+            <th colSpan="2">{l('Release groups with cover art:')}</th>
             <td>
-              {formatCount($c, stats['count.release.has_caa'])}
+              {formatCount($c, stats['count.releasegroup.caa'])}
               {' '}
-              <TimelineLink statName="count.release.has_caa" />
+              <TimelineLink statName="count.releasegroup.caa" />
+            </td>
+            <td />
+          </tr>
+          <tr>
+            <th />
+            <th>{l('manually selected:')}</th>
+            <td>
+              {formatCount(
+                $c,
+                stats['count.releasegroup.caa.manually_selected'],
+              )}
+              {' '}
+              <TimelineLink
+                statName="count.releasegroup.caa.manually_selected"
+              />
             </td>
             <td>
               {formatPercentage(
                 $c,
-                stats['count.release.has_caa'] / stats['count.release'],
+                stats['count.releasegroup.caa.manually_selected'] /
+                  stats['count.releasegroup.caa'],
                 1,
               )}
             </td>
           </tr>
           <tr>
-            <th>{l('Pieces of cover art:')}</th>
+            <th />
+            <th>{l('automatically inferred:')}</th>
             <td>
-              {formatCount($c, stats['count.coverart'])}
+              {formatCount($c, stats['count.releasegroup.caa.inferred'])}
               {' '}
-              <TimelineLink statName="count.coverart" />
+              <TimelineLink statName="count.releasegroup.caa.inferred" />
             </td>
-            <td />
+            <td>
+              {formatPercentage(
+                $c,
+                stats['count.releasegroup.caa.inferred'] /
+                  stats['count.releasegroup.caa'],
+                1,
+              )}
+            </td>
           </tr>
         </tbody>
       </table>
-    )}
-    <h2>{l('Releases')}</h2>
-    {(releaseTypeStats.length === 0 &&
-      releaseStatusStats.length === 0 &&
-      releaseFormatStats.length === 0) ? (
+
+      <h2>{l('Pieces of cover art')}</h2>
+      {stats['count.release.has_caa'] < 1 ? (
         <p>
           {l('No cover art statistics available.')}
         </p>
@@ -113,23 +286,23 @@ const CoverArt = ({
         <table className="database-statistics">
           <tbody>
             <tr className="thead">
-              <th colSpan="4">{l('By Release Group Type')}</th>
+              <th colSpan="4">{l('By Cover Art Type')}</th>
             </tr>
             <tr>
-              <th colSpan="2">{l('Releases with cover art:')}</th>
+              <th colSpan="2">{l('Pieces of cover art:')}</th>
               <td>
-                {formatCount($c, stats['count.release.has_caa'])}
+                {formatCount($c, stats['count.coverart'])}
                 {' '}
-                <TimelineLink statName="count.release.has_caa" />
+                <TimelineLink statName="count.coverart" />
               </td>
               <td />
             </tr>
-            {releaseTypeStats.map((type, index) => (
+            {typeStats.map((type, index) => (
               <tr key={'type' + index}>
                 <th />
                 <th>
                   {nameOrNull(
-                    lp_attributes(type.type, 'release_group_primary_type'),
+                    lp_attributes(type.type, 'cover_art_type'),
                     l('No type'),
                   )}
                 </th>
@@ -141,14 +314,14 @@ const CoverArt = ({
                 <td>
                   {formatPercentage(
                     $c,
-                    stats[type.stat_name] / stats['count.release.has_caa'],
+                    stats[type.stat_name] / stats['count.coverart'],
                     1,
                   )}
                 </td>
               </tr>
             ))}
             <tr className="thead">
-              <th colSpan="4">{l('By Release Status')}</th>
+              <th colSpan="4">{l('Per release')}</th>
             </tr>
             <tr>
               <th colSpan="2">{l('Releases with cover art:')}</th>
@@ -159,231 +332,66 @@ const CoverArt = ({
               </td>
               <td />
             </tr>
-            {releaseStatusStats.map((status, index) => (
-              <tr key={'status' + index}>
+            {mapRange(1, 29, (number) => (
+              <tr key={number}>
                 <th />
                 <th>
-                  {nameOrNull(
-                    lp_attributes(status.status, 'release_status'),
-                    l('No status'),
+                  {texp.ln(
+                    'with {num} piece of cover art:',
+                    'with {num} pieces of cover art:',
+                    number,
+                    {num: number},
                   )}
                 </th>
                 <td>
-                  {formatCount($c, stats[status.stat_name])}
+                  {formatCount(
+                    $c,
+                    stats['count.coverart.per_release.' + number + 'images'],
+                  )}
                   {' '}
-                  <TimelineLink statName={status.stat_name} />
+                  <TimelineLink
+                    statName={
+                      'count.coverart.per_release.' + number + 'images'
+                    }
+                  />
                 </td>
                 <td>
                   {formatPercentage(
                     $c,
-                    stats[status.stat_name] / stats['count.release.has_caa'],
+                    stats['count.coverart.per_release.' + number + 'images'] /
+                      stats['count.release.has_caa'],
                     1,
                   )}
                 </td>
               </tr>
             ))}
-            <tr className="thead">
-              <th colSpan="4">{l('By Release Format')}</th>
-            </tr>
             <tr>
-              <th colSpan="2">{l('Releases with cover art:')}</th>
-              <td>
-                {formatCount($c, stats['count.release.has_caa'])}
-                {' '}
-                <TimelineLink statName="count.release.has_caa" />
-              </td>
-              <td />
-            </tr>
-            {releaseFormatStats.map((format, index) => (
-              <tr key={'format' + index}>
-                <th />
-                <th>
-                  {nameOrNull(
-                    lp_attributes(format.format, 'medium_format'),
-                    l('No format'),
-                  )}
-                </th>
-                <td>
-                  {formatCount($c, stats[format.stat_name])}
-                  {' '}
-                  <TimelineLink statName={format.stat_name} />
-                </td>
-                <td>
-                  {formatPercentage(
-                    $c,
-                    stats[format.stat_name] / stats['count.release.has_caa'],
-                    1,
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>)
-    }
-    <h2>{l('Release groups')}</h2>
-    <table className="database-statistics">
-      <tbody>
-        <tr>
-          <th colSpan="2">{l('Release groups with cover art:')}</th>
-          <td>
-            {formatCount($c, stats['count.releasegroup.caa'])}
-            {' '}
-            <TimelineLink statName="count.releasegroup.caa" />
-          </td>
-          <td />
-        </tr>
-        <tr>
-          <th />
-          <th>{l('manually selected:')}</th>
-          <td>
-            {formatCount(
-              $c,
-              stats['count.releasegroup.caa.manually_selected'],
-            )}
-            {' '}
-            <TimelineLink
-              statName="count.releasegroup.caa.manually_selected"
-            />
-          </td>
-          <td>
-            {formatPercentage(
-              $c,
-              stats['count.releasegroup.caa.manually_selected'] /
-                stats['count.releasegroup.caa'],
-              1,
-            )}
-          </td>
-        </tr>
-        <tr>
-          <th />
-          <th>{l('automatically inferred:')}</th>
-          <td>
-            {formatCount($c, stats['count.releasegroup.caa.inferred'])}
-            {' '}
-            <TimelineLink statName="count.releasegroup.caa.inferred" />
-          </td>
-          <td>
-            {formatPercentage(
-              $c,
-              stats['count.releasegroup.caa.inferred'] /
-                stats['count.releasegroup.caa'],
-              1,
-            )}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h2>{l('Pieces of cover art')}</h2>
-    {stats['count.release.has_caa'] < 1 ? (
-      <p>
-        {l('No cover art statistics available.')}
-      </p>
-    ) : (
-      <table className="database-statistics">
-        <tbody>
-          <tr className="thead">
-            <th colSpan="4">{l('By Cover Art Type')}</th>
-          </tr>
-          <tr>
-            <th colSpan="2">{l('Pieces of cover art:')}</th>
-            <td>
-              {formatCount($c, stats['count.coverart'])}
-              {' '}
-              <TimelineLink statName="count.coverart" />
-            </td>
-            <td />
-          </tr>
-          {typeStats.map((type, index) => (
-            <tr key={'type' + index}>
               <th />
-              <th>
-                {nameOrNull(
-                  lp_attributes(type.type, 'cover_art_type'),
-                  l('No type'),
-                )}
-              </th>
-              <td>
-                {formatCount($c, stats[type.stat_name])}
-                {' '}
-                <TimelineLink statName={type.stat_name} />
-              </td>
-              <td>
-                {formatPercentage(
-                  $c,
-                  stats[type.stat_name] / stats['count.coverart'],
-                  1,
-                )}
-              </td>
-            </tr>
-          ))}
-          <tr className="thead">
-            <th colSpan="4">{l('Per release')}</th>
-          </tr>
-          <tr>
-            <th colSpan="2">{l('Releases with cover art:')}</th>
-            <td>
-              {formatCount($c, stats['count.release.has_caa'])}
-              {' '}
-              <TimelineLink statName="count.release.has_caa" />
-            </td>
-            <td />
-          </tr>
-          {mapRange(1, 29, (number) => (
-            <tr key={number}>
-              <th />
-              <th>
-                {texp.ln(
-                  'with {num} piece of cover art:',
-                  'with {num} pieces of cover art:',
-                  number,
-                  {num: number},
-                )}
-              </th>
+              <th>{l('with 30 or more pieces of cover art:')}</th>
               <td>
                 {formatCount(
                   $c,
-                  stats['count.coverart.per_release.' + number + 'images'],
+                  stats['count.coverart.per_release.30images'],
                 )}
                 {' '}
                 <TimelineLink
-                  statName={'count.coverart.per_release.' + number + 'images'}
+                  statName="count.coverart.per_release.30images"
                 />
               </td>
               <td>
                 {formatPercentage(
                   $c,
-                  stats['count.coverart.per_release.' + number + 'images'] /
+                  stats['count.coverart.per_release.30images'] /
                     stats['count.release.has_caa'],
                   1,
                 )}
               </td>
             </tr>
-          ))}
-          <tr>
-            <th />
-            <th>{l('with 30 or more pieces of cover art:')}</th>
-            <td>
-              {formatCount(
-                $c,
-                stats['count.coverart.per_release.30images'],
-              )}
-              {' '}
-              <TimelineLink statName="count.coverart.per_release.30images" />
-            </td>
-            <td>
-              {formatPercentage(
-                $c,
-                stats['count.coverart.per_release.30images'] /
-                  stats['count.release.has_caa'],
-                1,
-              )}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    )}
-  </StatisticsLayout>
-);
+          </tbody>
+        </table>
+      )}
+    </StatisticsLayout>
+  );
+};
 
 export default CoverArt;

--- a/root/statistics/Editors.js
+++ b/root/statistics/Editors.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import loopParity from '../utility/loopParity.js';
@@ -17,7 +18,6 @@ import {formatCount} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type EditorsStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +topEditors: $ReadOnlyArray<EditorStatT>,
   +topRecentlyActiveEditors: $ReadOnlyArray<EditorStatT>,
@@ -26,7 +26,6 @@ type EditorsStatsT = {
 };
 
 type EditorStatsTableProps = {
-  +$c: CatalystContextT,
   countLabel: string,
   dataPoints: $ReadOnlyArray<EditorStatT>,
   editorLabel: string,
@@ -39,56 +38,57 @@ type EditorStatT = {
 };
 
 const EditorStatsTable = ({
-  $c,
   countLabel,
   dataPoints,
   editorLabel,
   tableLabel,
-}: EditorStatsTableProps) => (
-  <>
-    <h3>{tableLabel}</h3>
-    <table className="tbl">
-      <thead>
-        <tr>
-          <th className="pos">{l('Rank')}</th>
-          <th>
-            {editorLabel}
-            <div className="arrow" />
-          </th>
-          <th>
-            {countLabel}
-            <div className="arrow" />
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {dataPoints.length > 0 ? (
-          dataPoints.map((editorStat, index) => (
-            <tr
-              className={loopParity(index)}
-              key={
-                editorStat.editor
-                  ? editorStat.editor.id
-                  : `missing-${index}`
-              }
-            >
-              <td className="t">{index + 1}</td>
-              <td><EditorLink editor={editorStat.editor} /></td>
-              <td className="t">{formatCount($c, editorStat.count)}</td>
-            </tr>
-          ))
-        ) : (
-          <tr className="even">
-            <td colSpan="3">{l('There is no data to display here.')}</td>
+}: EditorStatsTableProps) => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <>
+      <h3>{tableLabel}</h3>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th className="pos">{l('Rank')}</th>
+            <th>
+              {editorLabel}
+              <div className="arrow" />
+            </th>
+            <th>
+              {countLabel}
+              <div className="arrow" />
+            </th>
           </tr>
-        )}
-      </tbody>
-    </table>
-  </>
-);
+        </thead>
+        <tbody>
+          {dataPoints.length > 0 ? (
+            dataPoints.map((editorStat, index) => (
+              <tr
+                className={loopParity(index)}
+                key={
+                  editorStat.editor
+                    ? editorStat.editor.id
+                    : `missing-${index}`
+                }
+              >
+                <td className="t">{index + 1}</td>
+                <td><EditorLink editor={editorStat.editor} /></td>
+                <td className="t">{formatCount($c, editorStat.count)}</td>
+              </tr>
+            ))
+          ) : (
+            <tr className="even">
+              <td colSpan="3">{l('There is no data to display here.')}</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </>
+  );
+};
 
 const Editors = ({
-  $c,
   dateCollected,
   topEditors,
   topRecentlyActiveEditors,
@@ -108,14 +108,12 @@ const Editors = ({
     >
       <h2 style={{marginTop: 0}}>{l('Editors')}</h2>
       <EditorStatsTable
-        $c={$c}
         countLabel={l('Open and applied edits in past week')}
         dataPoints={topRecentlyActiveEditors}
         editorLabel={l('Editor')}
         tableLabel={l('Most active editors in the past week')}
       />
       <EditorStatsTable
-        $c={$c}
         countLabel={l('Total applied edits')}
         dataPoints={topEditors}
         editorLabel={l('Editor')}
@@ -127,14 +125,12 @@ const Editors = ({
     >
       <h2 style={{marginTop: 0}}>{l('Voters')}</h2>
       <EditorStatsTable
-        $c={$c}
         countLabel={l('Votes in past week')}
         dataPoints={topRecentlyActiveVoters}
         editorLabel={l('Voter')}
         tableLabel={l('Most active voters in the past week')}
       />
       <EditorStatsTable
-        $c={$c}
         countLabel={l('Total votes')}
         dataPoints={topVoters}
         editorLabel={l('Voter')}

--- a/root/statistics/Edits.js
+++ b/root/statistics/Edits.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 
 import LinkSearchableEditType from '../components/LinkSearchableEditType.js';
+import {CatalystContext} from '../context.mjs';
 import {l as lMbServer} from '../static/scripts/common/i18n.js';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 
@@ -22,83 +23,84 @@ type EditCategoryT = {
 };
 
 type EditsStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +stats: {[statName: string]: number},
   +statsByCategory: {[editCategory: string]: $ReadOnlyArray<EditCategoryT>},
 };
 
 const Edits = ({
-  $c,
   dateCollected,
   stats,
   statsByCategory,
-}: EditsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout fullWidth page="edits" title={l('Edits')}>
-    <p>
-      {texp.l('Last updated: {date}', {date: dateCollected})}
-    </p>
-    <h2>{l('Edits')}</h2>
-    {Object.keys(statsByCategory).length === 0 ? (
+}: EditsStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout fullWidth page="edits" title={l('Edits')}>
       <p>
-        {l('No edit statistics available.')}
+        {texp.l('Last updated: {date}', {date: dateCollected})}
       </p>
-    ) : (
-      <table className="database-statistics">
-        <tbody>
-          <tr>
-            <th colSpan="2">{addColonText(l('Edits'))}</th>
-            <td>
-              {formatCount($c, stats['count.edit'])}
-              {' '}
-              <TimelineLink statName="count.edit" />
-            </td>
+      <h2>{l('Edits')}</h2>
+      {Object.keys(statsByCategory).length === 0 ? (
+        <p>
+          {l('No edit statistics available.')}
+        </p>
+      ) : (
+        <table className="database-statistics">
+          <tbody>
+            <tr>
+              <th colSpan="2">{addColonText(l('Edits'))}</th>
+              <td>
+                {formatCount($c, stats['count.edit'])}
+                {' '}
+                <TimelineLink statName="count.edit" />
+              </td>
 
-            <td />
-          </tr>
-          {Object.keys(statsByCategory)
-            .sort()
-            .map((categoryKey) => {
-              const category = statsByCategory[categoryKey];
-              return (
-                <>
-                  <tr className="thead">
-                    <th colSpan="4">{categoryKey}</th>
-                  </tr>
-                  {category.map((type) => (
-                    <tr key={type.edit_type}>
-                      <th />
-                      <th>{lMbServer(type.edit_name)}</th>
-                      <td>
-                        <LinkSearchableEditType
-                          editTypeId={type.edit_type}
-                          text={formatCount(
-                            $c,
-                            stats['count.edit.type.' + type.edit_type],
-                          )}
-                        />
-                        {' '}
-                        <TimelineLink
-                          statName={'count.edit.type.' + type.edit_type}
-                        />
-                      </td>
-                      <td>
-                        {formatPercentage(
-                          $c,
-                          stats['count.edit.type.' + type.edit_type] /
-                            stats['count.edit'],
-                          2,
-                        )}
-                      </td>
+              <td />
+            </tr>
+            {Object.keys(statsByCategory)
+              .sort()
+              .map((categoryKey) => {
+                const category = statsByCategory[categoryKey];
+                return (
+                  <>
+                    <tr className="thead">
+                      <th colSpan="4">{categoryKey}</th>
                     </tr>
-                  ))}
-                </>
-              );
-            })}
-        </tbody>
-      </table>
-    )}
-  </StatisticsLayout>
-);
+                    {category.map((type) => (
+                      <tr key={type.edit_type}>
+                        <th />
+                        <th>{lMbServer(type.edit_name)}</th>
+                        <td>
+                          <LinkSearchableEditType
+                            editTypeId={type.edit_type}
+                            text={formatCount(
+                              $c,
+                              stats['count.edit.type.' + type.edit_type],
+                            )}
+                          />
+                          {' '}
+                          <TimelineLink
+                            statName={'count.edit.type.' + type.edit_type}
+                          />
+                        </td>
+                        <td>
+                          {formatPercentage(
+                            $c,
+                            stats['count.edit.type.' + type.edit_type] /
+                              stats['count.edit'],
+                            2,
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </>
+                );
+              })}
+          </tbody>
+        </table>
+      )}
+    </StatisticsLayout>
+  );
+};
 
 export default Edits;

--- a/root/statistics/Formats.js
+++ b/root/statistics/Formats.js
@@ -10,6 +10,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 import loopParity from '../utility/loopParity.js';
 import LinkSearchableProperty from '../components/LinkSearchableProperty.js';
@@ -18,7 +19,6 @@ import {formatCount, formatPercentage, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type FormatsStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +formatStats: $ReadOnlyArray<FormatStatT>,
   +stats: {[statName: string]: number},
@@ -33,103 +33,105 @@ type FormatStatT = {
 };
 
 const Formats = ({
-  $c,
   dateCollected,
   formatStats,
   stats,
-}: FormatsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout
-    fullWidth
-    page="formats"
-    title={l('Release/Medium Formats')}
-  >
-    <p>
-      {texp.l('Last updated: {date}',
-              {date: dateCollected})}
-    </p>
-    <h2>{l('Release/Medium Formats')}</h2>
-    <table className="tbl">
-      <thead>
-        <tr>
-          <th className="pos">{l('Rank')}</th>
-          <th>{l('Format')}</th>
-          <th>{l('Releases')}</th>
-          <th>{l('% of total releases')}</th>
-          <th>{l('Mediums')}</th>
-          <th>{l('% of total mediums')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td />
-          <td>{l('Total')}</td>
-          <td className="t">
-            {formatCount($c, stats['count.release'])}
-            {' '}
-            <TimelineLink statName="count.release" />
-          </td>
-          <td className="t">{formatPercentage($c, 1, 0)}</td>
-          <td className="t">
-            {formatCount($c, stats['count.medium'])}
-            {' '}
-            <TimelineLink statName="count.medium" />
-          </td>
-          <td className="t">{formatPercentage($c, 1, 0)}</td>
-        </tr>
-        {formatStats.map((formatStat, index) => {
-          const entity = formatStat.entity;
-          return (
-            <tr className={loopParity(index)} key={formatStat.medium_stat}>
-              <td className="t">{index + 1}</td>
-              <td>
-                {entity
-                  ? (
-                    <LinkSearchableProperty
-                      entityType="release"
-                      searchField="format"
-                      searchValue={entity.name}
-                      text={lp_attributes(entity.name, 'medium_format')}
-                    />
-                  ) : l('Unknown Format')}
-              </td>
-              <td className="t">
-                {formatCount($c, formatStat.release_count)}
-                {' '}
-                <TimelineLink
-                  statName={
-                    'count.release.format.' + (entity ? entity.id : 'null')
-                  }
-                />
-              </td>
-              <td className="t">
-                {formatPercentage(
-                  $c,
-                  formatStat.release_count / stats['count.release'],
-                  2,
-                )}
-              </td>
-              <td className="t">
-                {formatCount($c, formatStat.medium_count)}
-                {' '}
-                <TimelineLink
-                  statName={
-                    'count.medium.format.' + (entity ? entity.id : 'null')
-                  }
-                />
-              </td>
-              <td className="t">
-                {formatPercentage(
-                  $c,
-                  formatStat.medium_count / stats['count.medium'],
-                  2,
-                )}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
-  </StatisticsLayout>
-);
+}: FormatsStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout
+      fullWidth
+      page="formats"
+      title={l('Release/Medium Formats')}
+    >
+      <p>
+        {texp.l('Last updated: {date}',
+                {date: dateCollected})}
+      </p>
+      <h2>{l('Release/Medium Formats')}</h2>
+      <table className="tbl">
+        <thead>
+          <tr>
+            <th className="pos">{l('Rank')}</th>
+            <th>{l('Format')}</th>
+            <th>{l('Releases')}</th>
+            <th>{l('% of total releases')}</th>
+            <th>{l('Mediums')}</th>
+            <th>{l('% of total mediums')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td />
+            <td>{l('Total')}</td>
+            <td className="t">
+              {formatCount($c, stats['count.release'])}
+              {' '}
+              <TimelineLink statName="count.release" />
+            </td>
+            <td className="t">{formatPercentage($c, 1, 0)}</td>
+            <td className="t">
+              {formatCount($c, stats['count.medium'])}
+              {' '}
+              <TimelineLink statName="count.medium" />
+            </td>
+            <td className="t">{formatPercentage($c, 1, 0)}</td>
+          </tr>
+          {formatStats.map((formatStat, index) => {
+            const entity = formatStat.entity;
+            return (
+              <tr className={loopParity(index)} key={formatStat.medium_stat}>
+                <td className="t">{index + 1}</td>
+                <td>
+                  {entity
+                    ? (
+                      <LinkSearchableProperty
+                        entityType="release"
+                        searchField="format"
+                        searchValue={entity.name}
+                        text={lp_attributes(entity.name, 'medium_format')}
+                      />
+                    ) : l('Unknown Format')}
+                </td>
+                <td className="t">
+                  {formatCount($c, formatStat.release_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.release.format.' + (entity ? entity.id : 'null')
+                    }
+                  />
+                </td>
+                <td className="t">
+                  {formatPercentage(
+                    $c,
+                    formatStat.release_count / stats['count.release'],
+                    2,
+                  )}
+                </td>
+                <td className="t">
+                  {formatCount($c, formatStat.medium_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.medium.format.' + (entity ? entity.id : 'null')
+                    }
+                  />
+                </td>
+                <td className="t">
+                  {formatPercentage(
+                    $c,
+                    formatStat.medium_count / stats['count.medium'],
+                    2,
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </StatisticsLayout>
+  );
+};
 
 export default Formats;

--- a/root/statistics/Index.js
+++ b/root/statistics/Index.js
@@ -10,6 +10,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {l_statistics as l, lp_statistics as lp}
   from '../static/scripts/common/i18n/statistics.js';
 import mapRange from '../static/scripts/common/utility/mapRange.js';
@@ -18,7 +19,6 @@ import {formatCount, formatPercentage, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type MainStatsT = {
-  +$c: CatalystContextT,
   +areaTypes: $ReadOnlyArray<AreaTypeT>,
   +dateCollected: string,
   +eventTypes: $ReadOnlyArray<EventTypeT>,
@@ -36,7 +36,6 @@ type MainStatsT = {
 };
 
 const Index = ({
-  $c,
   areaTypes,
   dateCollected,
   eventTypes,
@@ -52,6 +51,8 @@ const Index = ({
   workAttributeTypes,
   workTypes,
 }: MainStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+
   const nonGroupCount = stats['count.artist.type.null'] +
     stats['count.artist.type.person'] +
     stats['count.artist.type.character'] +

--- a/root/statistics/LanguagesScripts.js
+++ b/root/statistics/LanguagesScripts.js
@@ -10,6 +10,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import * as manifest from '../static/manifest.mjs';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 import loopParity from '../utility/loopParity.js';
@@ -19,7 +20,6 @@ import {formatCount, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 type LanguagesScriptsStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +languageStats: $ReadOnlyArray<LanguageStatT>,
   +scriptStats: $ReadOnlyArray<ScriptStatT>,
@@ -38,160 +38,162 @@ type ScriptStatT = {
 };
 
 const LanguagesScripts = ({
-  $c,
   dateCollected,
   languageStats,
   scriptStats,
-}: LanguagesScriptsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout
-    fullWidth
-    page="languages-scripts"
-    title={l('Languages and Scripts')}
-  >
-    <p>
-      {texp.l('Last updated: {date}', {date: dateCollected})}
-    </p>
-    <p>
-      {l(`All other available languages and scripts
-          have 0 releases and works.`)}
-    </p>
-    <div
-      style={{display: 'inline-block', float: 'left', marginRight: '50px'}}
+}: LanguagesScriptsStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout
+      fullWidth
+      page="languages-scripts"
+      title={l('Languages and Scripts')}
     >
-      <h2 style={{marginTop: 0}}>{l('Languages')}</h2>
-      <table className="tbl" id="languages-table">
-        <thead>
-          <tr>
-            <th className="pos">{l('Rank')}</th>
-            <th>
-              {l('Languages')}
-              <div className="arrow" />
-            </th>
-            <th>
-              {l('Releases')}
-              <div className="arrow" />
-            </th>
-            <th>
-              {l('Works')}
-              <div className="arrow" />
-            </th>
-            <th>
-              {l('Total')}
-              <div className="arrow" />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {languageStats.map((languageStat, index) => (
-            languageStat.total > 0 ? (
-              <tr className={loopParity(index)} key={'language' + index}>
-                <td className="t">{index + 1}</td>
-                <td>
-                  {languageStat.entity
-                    ? l_languages(languageStat.entity.name)
-                    : l('Unknown language')}
-                </td>
-                <td className="t">
-                  {languageStat.entity && languageStat.entity.iso_code_3 ? (
-                    <LinkSearchableProperty
-                      entityType="release"
-                      searchField="lang"
-                      searchValue={languageStat.entity.iso_code_3}
-                      text={formatCount($c, languageStat.releases)}
+      <p>
+        {texp.l('Last updated: {date}', {date: dateCollected})}
+      </p>
+      <p>
+        {l(`All other available languages and scripts
+            have 0 releases and works.`)}
+      </p>
+      <div
+        style={{display: 'inline-block', float: 'left', marginRight: '50px'}}
+      >
+        <h2 style={{marginTop: 0}}>{l('Languages')}</h2>
+        <table className="tbl" id="languages-table">
+          <thead>
+            <tr>
+              <th className="pos">{l('Rank')}</th>
+              <th>
+                {l('Languages')}
+                <div className="arrow" />
+              </th>
+              <th>
+                {l('Releases')}
+                <div className="arrow" />
+              </th>
+              <th>
+                {l('Works')}
+                <div className="arrow" />
+              </th>
+              <th>
+                {l('Total')}
+                <div className="arrow" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {languageStats.map((languageStat, index) => (
+              languageStat.total > 0 ? (
+                <tr className={loopParity(index)} key={'language' + index}>
+                  <td className="t">{index + 1}</td>
+                  <td>
+                    {languageStat.entity
+                      ? l_languages(languageStat.entity.name)
+                      : l('Unknown language')}
+                  </td>
+                  <td className="t">
+                    {languageStat.entity && languageStat.entity.iso_code_3 ? (
+                      <LinkSearchableProperty
+                        entityType="release"
+                        searchField="lang"
+                        searchValue={languageStat.entity.iso_code_3}
+                        text={formatCount($c, languageStat.releases)}
+                      />
+                    ) : (
+                      formatCount($c, languageStat.releases)
+                    )}
+                    {' '}
+                    <TimelineLink
+                      statName={
+                        'count.release.language.' + (
+                          languageStat.entity?.iso_code_3 ?? 'null'
+                        )
+                      }
                     />
-                  ) : (
-                    formatCount($c, languageStat.releases)
-                  )}
-                  {' '}
-                  <TimelineLink
-                    statName={
-                      'count.release.language.' + (
-                        languageStat.entity?.iso_code_3 ?? 'null'
-                      )
-                    }
-                  />
-                </td>
-                <td className="t">
-                  {languageStat.entity && languageStat.entity.iso_code_3 ? (
-                    <LinkSearchableProperty
-                      entityType="work"
-                      searchField="lang"
-                      searchValue={languageStat.entity.iso_code_3}
-                      text={formatCount($c, languageStat.works)}
+                  </td>
+                  <td className="t">
+                    {languageStat.entity && languageStat.entity.iso_code_3 ? (
+                      <LinkSearchableProperty
+                        entityType="work"
+                        searchField="lang"
+                        searchValue={languageStat.entity.iso_code_3}
+                        text={formatCount($c, languageStat.works)}
+                      />
+                    ) : (
+                      formatCount($c, languageStat.works)
+                    )}
+                    {' '}
+                    <TimelineLink
+                      statName={
+                        'count.work.language.' + (
+                          languageStat.entity?.iso_code_3 ?? 'null'
+                        )
+                      }
                     />
-                  ) : (
-                    formatCount($c, languageStat.works)
-                  )}
-                  {' '}
-                  <TimelineLink
-                    statName={
-                      'count.work.language.' + (
-                        languageStat.entity?.iso_code_3 ?? 'null'
-                      )
-                    }
-                  />
-                </td>
-                <td className="t">{formatCount($c, languageStat.total)}</td>
-              </tr>
-            ) : null
-          ))}
-        </tbody>
-      </table>
-    </div>
-    <div style={{display: 'inline-block', float: 'left'}}>
-      <h2 style={{marginTop: 0}}>{l('Scripts')}</h2>
-      <table className="tbl" id="scripts-table">
-        <thead>
-          <tr>
-            <th className="pos">{l('Rank')}</th>
-            <th>
-              {l('Script')}
-              <div className="arrow" />
-            </th>
-            <th>
-              {l('Releases')}
-              <div className="arrow" />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {scriptStats.map((scriptStat, index) => (
-            scriptStat.count > 0 ? (
-              <tr className={loopParity(index)} key={'script' + index}>
-                <td className="t">{index + 1}</td>
-                <td>
-                  {scriptStat.entity
-                    ? l_scripts(scriptStat.entity.name)
-                    : l('Unknown script')}
-                </td>
-                <td className="t">
-                  {scriptStat.entity ? (
-                    <LinkSearchableProperty
-                      entityType="release"
-                      searchField="script"
-                      searchValue={scriptStat.entity.iso_code}
-                      text={formatCount($c, scriptStat.count)}
+                  </td>
+                  <td className="t">{formatCount($c, languageStat.total)}</td>
+                </tr>
+              ) : null
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div style={{display: 'inline-block', float: 'left'}}>
+        <h2 style={{marginTop: 0}}>{l('Scripts')}</h2>
+        <table className="tbl" id="scripts-table">
+          <thead>
+            <tr>
+              <th className="pos">{l('Rank')}</th>
+              <th>
+                {l('Script')}
+                <div className="arrow" />
+              </th>
+              <th>
+                {l('Releases')}
+                <div className="arrow" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {scriptStats.map((scriptStat, index) => (
+              scriptStat.count > 0 ? (
+                <tr className={loopParity(index)} key={'script' + index}>
+                  <td className="t">{index + 1}</td>
+                  <td>
+                    {scriptStat.entity
+                      ? l_scripts(scriptStat.entity.name)
+                      : l('Unknown script')}
+                  </td>
+                  <td className="t">
+                    {scriptStat.entity ? (
+                      <LinkSearchableProperty
+                        entityType="release"
+                        searchField="script"
+                        searchValue={scriptStat.entity.iso_code}
+                        text={formatCount($c, scriptStat.count)}
+                      />
+                    ) : (
+                      formatCount($c, scriptStat.count)
+                    )}
+                    {' '}
+                    <TimelineLink
+                      statName={
+                        'count.release.script.' + (
+                          scriptStat.entity?.iso_code ?? 'null'
+                        )
+                      }
                     />
-                  ) : (
-                    formatCount($c, scriptStat.count)
-                  )}
-                  {' '}
-                  <TimelineLink
-                    statName={
-                      'count.release.script.' + (
-                        scriptStat.entity?.iso_code ?? 'null'
-                      )
-                    }
-                  />
-                </td>
-              </tr>
-            ) : null
-          ))}
-        </tbody>
-      </table>
-    </div>
-    {manifest.js('statistics')}
-  </StatisticsLayout>
-);
+                  </td>
+                </tr>
+              ) : null
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {manifest.js('statistics')}
+    </StatisticsLayout>
+  );
+};
 
 export default LanguagesScripts;

--- a/root/statistics/Relationships.js
+++ b/root/statistics/Relationships.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import {compare} from '../static/scripts/common/i18n.js';
 import {l_statistics as l} from '../static/scripts/common/i18n/statistics.js';
 import formatEntityTypeName
@@ -18,7 +19,6 @@ import {formatCount, formatPercentage, TimelineLink} from './utilities.js';
 import StatisticsLayout from './StatisticsLayout.js';
 
 export type RelationshipsStatsT = {
-  +$c: CatalystContextT,
   +dateCollected: string,
   +stats: {[statName: string]: number},
   +types: {[relationshipTable: string]: RelationshipTypeT},
@@ -37,7 +37,6 @@ function comparePhrases(a: LinkTypeT, b: LinkTypeT) {
 }
 
 type TypeRowsPropsT = {
-  +$c: CatalystContextT,
   +base: string,
   +indent: number,
   +parent: string,
@@ -46,13 +45,13 @@ type TypeRowsPropsT = {
 };
 
 const TypeRows = ({
-  $c,
   base,
   indent,
   parent,
   stats,
   type,
 }: TypeRowsPropsT) => {
+  const $c = React.useContext(CatalystContext);
   return (
     <>
       <tr>
@@ -80,7 +79,6 @@ const TypeRows = ({
       {type.children ? (
         type.children.slice(0).sort(comparePhrases).map((child) => (
           <TypeRows
-            $c={$c}
             base={base}
             indent={indent + 1}
             key={child.id}
@@ -95,95 +93,99 @@ const TypeRows = ({
 };
 
 const Relationships = ({
-  $c,
   dateCollected,
   stats,
   types,
-}: RelationshipsStatsT): React.Element<typeof StatisticsLayout> => (
-  <StatisticsLayout
-    fullWidth
-    page="relationships"
-    title={l('Relationships')}
-  >
-    <p>
-      {texp.l('Last updated: {date}', {date: dateCollected})}
-    </p>
-    <h2>{l('Relationships')}</h2>
-    {stats['count.ar.links'] < 1 ? (
+}: RelationshipsStatsT): React.Element<typeof StatisticsLayout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <StatisticsLayout
+      fullWidth
+      page="relationships"
+      title={l('Relationships')}
+    >
       <p>
-        {l('No relationship statistics available.')}
+        {texp.l('Last updated: {date}', {date: dateCollected})}
       </p>
-    ) : (
-      <table className="database-statistics">
-        <tbody>
-          <tr className="thead">
-            <th />
-            <th>{lp('This type only', 'relationships')}</th>
-            <th>{lp('Including subtypes', 'relationships')}</th>
-            <th />
-          </tr>
-          <tr>
-            <th>{l('Relationships:')}</th>
-            <td />
-            <td>
-              {formatCount($c, stats['count.ar.links'])}
-              {' '}
-              <TimelineLink statName="count.ar.links" />
-            </td>
-            <td />
-          </tr>
-          {Object.keys(types).sort().map((typeKey) => {
-            const type = types[typeKey];
-            const type0 = formatEntityTypeName(type.entity_types[0]);
-            const type1 = formatEntityTypeName(type.entity_types[1]);
-            return (
-              <>
-                <tr className="thead">
-                  <th colSpan="4">
-                    {texp.l('{type0}-{type1}', {type0: type0, type1: type1})}
-                  </th>
-                </tr>
-                <tr>
-                  <th colSpan="2">
-                    {texp.l(
-                      '{type0}-{type1} relationships:',
-                      {type0: type0, type1: type1},
-                    )}
-                  </th>
-                  <td>
-                    {formatCount($c, stats['count.ar.links.' + typeKey])}
-                    {' '}
-                    <TimelineLink statName={'count.ar.links.' + typeKey} />
-                  </td>
-                  <td>
-                    {formatPercentage(
-                      $c,
-                      stats['count.ar.links.' + typeKey] /
-                        stats['count.ar.links'],
-                      1,
-                    )}
-                  </td>
-                </tr>
-                {Object.keys(type.tree).sort().map((child) => (
-                  type.tree[child].sort(comparePhrases).map((child2) => (
-                    <TypeRows
-                      $c={$c}
-                      base={'count.ar.links.' + typeKey}
-                      indent={2}
-                      key={child2.id}
-                      parent={'count.ar.links.' + typeKey}
-                      stats={stats}
-                      type={child2}
-                    />
-                  ))
-                ))}
-              </>
-            );
-          })}
-        </tbody>
-      </table>
-    )}
-  </StatisticsLayout>
-);
+      <h2>{l('Relationships')}</h2>
+      {stats['count.ar.links'] < 1 ? (
+        <p>
+          {l('No relationship statistics available.')}
+        </p>
+      ) : (
+        <table className="database-statistics">
+          <tbody>
+            <tr className="thead">
+              <th />
+              <th>{lp('This type only', 'relationships')}</th>
+              <th>{lp('Including subtypes', 'relationships')}</th>
+              <th />
+            </tr>
+            <tr>
+              <th>{l('Relationships:')}</th>
+              <td />
+              <td>
+                {formatCount($c, stats['count.ar.links'])}
+                {' '}
+                <TimelineLink statName="count.ar.links" />
+              </td>
+              <td />
+            </tr>
+            {Object.keys(types).sort().map((typeKey) => {
+              const type = types[typeKey];
+              const type0 = formatEntityTypeName(type.entity_types[0]);
+              const type1 = formatEntityTypeName(type.entity_types[1]);
+              return (
+                <>
+                  <tr className="thead">
+                    <th colSpan="4">
+                      {texp.l(
+                        '{type0}-{type1}',
+                        {type0: type0, type1: type1},
+                      )}
+                    </th>
+                  </tr>
+                  <tr>
+                    <th colSpan="2">
+                      {texp.l(
+                        '{type0}-{type1} relationships:',
+                        {type0: type0, type1: type1},
+                      )}
+                    </th>
+                    <td>
+                      {formatCount($c, stats['count.ar.links.' + typeKey])}
+                      {' '}
+                      <TimelineLink statName={'count.ar.links.' + typeKey} />
+                    </td>
+                    <td>
+                      {formatPercentage(
+                        $c,
+                        stats['count.ar.links.' + typeKey] /
+                          stats['count.ar.links'],
+                        1,
+                      )}
+                    </td>
+                  </tr>
+                  {Object.keys(type.tree).sort().map((child) => (
+                    type.tree[child].sort(comparePhrases).map((child2) => (
+                      <TypeRows
+                        base={'count.ar.links.' + typeKey}
+                        indent={2}
+                        key={child2.id}
+                        parent={'count.ar.links.' + typeKey}
+                        stats={stats}
+                        type={child2}
+                      />
+                    ))
+                  ))}
+                </>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </StatisticsLayout>
+  );
+};
 
 export default Relationships;

--- a/root/tag/EntityList.js
+++ b/root/tag/EntityList.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import PaginatedResults from '../components/PaginatedResults.js';
 import type {AccountLayoutUserT} from '../components/UserAccountLayout.js';
+import {CatalystContext} from '../context.mjs';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
 import TagLink from '../static/scripts/common/components/TagLink.js';
@@ -102,7 +103,6 @@ function getTagEntityListHeading(
 }
 
 type EntityListContentProps = {
-  +$c: CatalystContextT,
   +entityTags: $ReadOnlyArray<{
     +count?: number,
     +entity: CoreEntityT,
@@ -117,7 +117,6 @@ type EntityListContentProps = {
 };
 
 type EntityListProps = {
-  +$c: CatalystContextT,
   +entityTags: $ReadOnlyArray<{
     +count: number,
     +entity: CoreEntityT,
@@ -130,7 +129,6 @@ type EntityListProps = {
 };
 
 export const EntityListContent = ({
-  $c,
   entityTags,
   entityType,
   pager,
@@ -138,40 +136,42 @@ export const EntityListContent = ({
   showVotesSelect = false,
   tag,
   user,
-}: EntityListContentProps): React.Element<typeof React.Fragment> => (
-  <>
-    <h2>
-      {getTagEntityListHeading(user?.name, tag, showDownvoted, entityType)}
-    </h2>
-    {showVotesSelect ? (
-      <UserTagFilters
-        showDownvoted={showDownvoted}
-        showVotesSelect
-      />
-    ) : null}
-    <p>
-      {expand2text(
-        resultCountText[entityType](pager.total_entries),
-        {num: formatCount($c, pager.total_entries)},
-      )}
-    </p>
-    <PaginatedResults pager={pager}>
-      <ul>
-        {entityTags.map(tag => (
-          <li key={tag.entity_id}>
-            {tag.count == null
-              ? null
-              : String(tag.count) + ' - '}
-            <DescriptiveLink entity={tag.entity} />
-          </li>
-        ))}
-      </ul>
-    </PaginatedResults>
-  </>
-);
+}: EntityListContentProps): React.Element<typeof React.Fragment> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <>
+      <h2>
+        {getTagEntityListHeading(user?.name, tag, showDownvoted, entityType)}
+      </h2>
+      {showVotesSelect ? (
+        <UserTagFilters
+          showDownvoted={showDownvoted}
+          showVotesSelect
+        />
+      ) : null}
+      <p>
+        {expand2text(
+          resultCountText[entityType](pager.total_entries),
+          {num: formatCount($c, pager.total_entries)},
+        )}
+      </p>
+      <PaginatedResults pager={pager}>
+        <ul>
+          {entityTags.map(tag => (
+            <li key={tag.entity_id}>
+              {tag.count == null
+                ? null
+                : String(tag.count) + ' - '}
+              <DescriptiveLink entity={tag.entity} />
+            </li>
+          ))}
+        </ul>
+      </PaginatedResults>
+    </>
+  );
+};
 
 const EntityList = ({
-  $c,
   entityTags,
   entityType,
   page,
@@ -180,7 +180,6 @@ const EntityList = ({
 }: EntityListProps): React.Element<typeof TagLayout> => (
   <TagLayout page={page} tag={tag}>
     <EntityListContent
-      $c={$c}
       entityTags={entityTags}
       entityType={entityType}
       pager={pager}

--- a/root/tag/EntityList.js
+++ b/root/tag/EntityList.js
@@ -145,7 +145,6 @@ export const EntityListContent = ({
     </h2>
     {showVotesSelect ? (
       <UserTagFilters
-        $c={$c}
         showDownvoted={showDownvoted}
         showVotesSelect
       />

--- a/root/tag/TagCloud.js
+++ b/root/tag/TagCloud.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 
+import {CatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import TagLink from '../static/scripts/common/components/TagLink.js';
 import {sortByNumber} from '../static/scripts/common/utility/arrays.js';
@@ -16,7 +17,6 @@ import {formatCount} from '../statistics/utilities.js';
 import loopParity from '../utility/loopParity.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +genreMaxCount: number,
   +genres: $ReadOnlyArray<AggregatedTagT>,
   +showList?: boolean,
@@ -91,42 +91,46 @@ function generateTagList(
 }
 
 const TagCloud = ({
-  $c,
   genreMaxCount,
   genres,
   showList = false,
   tagMaxCount,
   tags,
-}: Props): React.Element<typeof Layout> => (
-  <Layout fullWidth title={l('Tags')}>
-    <div id="content">
-      <h1>{l('Tags')}</h1>
-      <p>
-        {l('These are the most used genres and other tags in the database.')}
-        {' '}
-        {showList ? (
-          <a href="/tags?show_list=0">{l('Show as a cloud instead.')}</a>
-        ) : (
-          <a href="/tags?show_list=1">{l('Show as a list instead.')}</a>
-        )}
-      </p>
+}: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <Layout fullWidth title={l('Tags')}>
+      <div id="content">
+        <h1>{l('Tags')}</h1>
+        <p>
+          {l(
+            'These are the most used genres and other tags in the database.',
+          )}
+          {' '}
+          {showList ? (
+            <a href="/tags?show_list=0">{l('Show as a cloud instead.')}</a>
+          ) : (
+            <a href="/tags?show_list=1">{l('Show as a list instead.')}</a>
+          )}
+        </p>
 
-      <h2>{l('Genres')}</h2>
-      {genres.length ? (
-        showList
-          ? generateTagList($c, genres)
-          : generateTagCloud($c, genres, genreMaxCount)
+        <h2>{l('Genres')}</h2>
+        {genres.length ? (
+          showList
+            ? generateTagList($c, genres)
+            : generateTagCloud($c, genres, genreMaxCount)
 
-      ) : l('No genre tags have been used yet.')}
+        ) : l('No genre tags have been used yet.')}
 
-      <h2>{l('Other tags')}</h2>
-      {tags.length ? (
-        showList
-          ? generateTagList($c, tags)
-          : generateTagCloud($c, tags, tagMaxCount)
-      ) : l('No non-genre tags have been used yet.')}
-    </div>
-  </Layout>
-);
+        <h2>{l('Other tags')}</h2>
+        {tags.length ? (
+          showList
+            ? generateTagList($c, tags)
+            : generateTagCloud($c, tags, tagMaxCount)
+        ) : l('No non-genre tags have been used yet.')}
+      </div>
+    </Layout>
+  );
+};
 
 export default TagCloud;

--- a/root/tag/TagIndex.js
+++ b/root/tag/TagIndex.js
@@ -16,7 +16,6 @@ import EntityLink
 import TagLayout from './TagLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +tag: TagT,
   +taggedEntities: {
     +[entityType: string]: {

--- a/root/types/catalyst.js
+++ b/root/types/catalyst.js
@@ -98,6 +98,7 @@ declare type SanitizedCatalystContextT = {
   +stash: {
     +current_language: string,
     +genre_map?: {+[genreName: string]: GenreT, ...},
+    +server_languages?: $ReadOnlyArray<ServerLanguageT>,
   },
   +user: ActiveEditorT | null,
 };

--- a/root/user/Login.js
+++ b/root/user/Login.js
@@ -7,10 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as React from 'react';
+
 import FormCsrfToken from '../components/FormCsrfToken.js';
 import FormRowCheckbox from '../components/FormRowCheckbox.js';
 import FormRowText from '../components/FormRowText.js';
 import FormSubmit from '../components/FormSubmit.js';
+import {CatalystContext} from '../context.mjs';
 import PostParameters, {
   type PostParametersT,
 } from '../static/scripts/common/components/PostParameters.js';
@@ -20,7 +23,6 @@ import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import returnUri from '../utility/returnUri.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +isLoginBad?: boolean,
   +isLoginRequired?: boolean,
   +isSpammer?: boolean,
@@ -35,107 +37,109 @@ type PropsT = {
 };
 
 const Login = ({
-  $c,
   isLoginBad = false,
   isLoginRequired = false,
   isSpammer = false,
   loginAction,
   loginForm,
   postParameters,
-}: PropsT): React$Element<typeof Layout> => (
-  <Layout fullWidth title={l('Log In')}>
-    <h1>{l('Log In')}</h1>
+}: PropsT): React$Element<typeof Layout> => {
+  const $c = React.useContext(CatalystContext);
+  return (
+    <Layout fullWidth title={l('Log In')}>
+      <h1>{l('Log In')}</h1>
 
-    {isLoginRequired ? (
+      {isLoginRequired ? (
+        <p>
+          <strong>{l('You need to be logged in to view this page.')}</strong>
+        </p>
+      ) : null}
+
       <p>
-        <strong>{l('You need to be logged in to view this page.')}</strong>
+        {exp.l(
+          `Don't have an account? {uri|Create one now}!`,
+          {uri: returnUri($c, '/register')},
+        )}
       </p>
-    ) : null}
 
-    <p>
-      {exp.l(
-        `Don't have an account? {uri|Create one now}!`,
-        {uri: returnUri($c, '/register')},
-      )}
-    </p>
+      <form action={loginAction} method="post">
+        <FormCsrfToken form={loginForm} />
 
-    <form action={loginAction} method="post">
-      <FormCsrfToken form={loginForm} />
+        {isLoginBad ? (
+          <div className="row no-label">
+            <span className="error">
+              <strong>{l('Incorrect username or password')}</strong>
+            </span>
+          </div>
+        ) : null}
 
-      {isLoginBad ? (
+        {isSpammer ? (
+          <div className="row no-label">
+            <span className="error">
+              <p>
+                <strong>
+                  {l(`You cannot log in because this account
+                      has been marked as a spam account.`)}
+                </strong>
+              </p>
+              <p>
+                {exp.l(
+                  `If you think this is a mistake, please contact
+                   <code>support@musicbrainz.org</code>
+                   with the name of your account.`,
+                )}
+              </p>
+            </span>
+          </div>
+        ) : null}
+
+        <FormRowText
+          field={loginForm.field.username}
+          label={l('Username:')}
+          required
+          uncontrolled
+        />
+
+        <FormRowText
+          field={loginForm.field.password}
+          label={l('Password:')}
+          required
+          type="password"
+          uncontrolled
+        />
+
+        {(DBDefs.DB_STAGING_SERVER && DBDefs.DB_STAGING_SERVER_SANITIZED) ? (
+          <div className="row no-label">
+            <span className="input-note sanitized-password-note">
+              {l(`This is a development server;
+                  all passwords have been reset to "mb".`)}
+            </span>
+          </div>
+        ) : null}
+
+        <FormRowCheckbox
+          field={loginForm.field.remember_me}
+          label={l('Keep me logged in')}
+          uncontrolled
+        />
+
+        {postParameters ? <PostParameters params={postParameters} /> : null}
+
         <div className="row no-label">
-          <span className="error">
-            <strong>{l('Incorrect username or password')}</strong>
-          </span>
+          <FormSubmit className="login" label={l('Log In')} />
         </div>
-      ) : null}
+      </form>
 
-      {isSpammer ? (
-        <div className="row no-label">
-          <span className="error">
-            <p>
-              <strong>
-                {l(`You cannot log in because this account
-                    has been marked as a spam account.`)}
-              </strong>
-            </p>
-            <p>
-              {exp.l(
-                `If you think this is a mistake, please contact
-                 <code>support@musicbrainz.org</code>
-                 with the name of your account.`,
-              )}
-            </p>
-          </span>
-        </div>
-      ) : null}
+      <p>
+        {exp.l('Forgot your {link1|username} or {link2|password}?', {
+          link1: '/lost-username',
+          link2: '/lost-password',
+        })}
+      </p>
 
-      <FormRowText
-        field={loginForm.field.username}
-        label={l('Username:')}
-        required
-        uncontrolled
-      />
-
-      <FormRowText
-        field={loginForm.field.password}
-        label={l('Password:')}
-        required
-        type="password"
-        uncontrolled
-      />
-
-      {(DBDefs.DB_STAGING_SERVER && DBDefs.DB_STAGING_SERVER_SANITIZED) ? (
-        <div className="row no-label">
-          <span className="input-note sanitized-password-note">
-            {l(`This is a development server;
-                all passwords have been reset to "mb".`)}
-          </span>
-        </div>
-      ) : null}
-
-      <FormRowCheckbox
-        field={loginForm.field.remember_me}
-        label={l('Keep me logged in')}
-        uncontrolled
-      />
-
-      {postParameters ? <PostParameters params={postParameters} /> : null}
-
-      <div className="row no-label">
-        <FormSubmit className="login" label={l('Log In')} />
-      </div>
-    </form>
-
-    <p>
-      {exp.l('Forgot your {link1|username} or {link2|password}?', {
-        link1: '/lost-username',
-        link2: '/lost-password',
-      })}
-    </p>
-
-    {manifest.js('user/login', {async: 'async'})}
-  </Layout>
-);
+      {manifest.js('user/login', {async: 'async'})}
+    </Layout>
+  );
+};
 
 export default Login;

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -29,7 +29,6 @@ type ReportReasonT =
   | 'voting';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: FormT<{
     +csrf_token: FieldT<string>,
     +message: FieldT<string>,
@@ -73,7 +72,6 @@ const reportReasonOptions = {
 };
 
 const ReportUser = ({
-  $c,
   form,
   user,
 }: Props): React.Element<typeof UserAccountLayout> => (
@@ -131,7 +129,7 @@ const ReportUser = ({
           )}
         </p>
 
-        <form action={$c.req.uri} className="report-form" method="post">
+        <form className="report-form" method="post">
           <FormCsrfToken form={form} />
 
           <FormRowSelect

--- a/root/user/ReportUser.js
+++ b/root/user/ReportUser.js
@@ -105,7 +105,7 @@ const ReportUser = ({
         <p>
           {exp.l(
             `Your report will be sent to our {uri|account administrators},
-             who will decide what action to take.`,
+              who will decide what action to take.`,
             {uri: {href: '/privileged', target: '_blank'}},
           )}
         </p>
@@ -153,7 +153,8 @@ const ReportUser = ({
               <p>
                 {exp.l(
                   `If you don’t want our admins to contact you further
-                   regarding this report, you can uncheck the checkbox above.
+                   regarding this report, you can uncheck the checkbox
+                   above.
                    <br />
                    We recommend leaving it checked, so that you can be
                    contacted if the report is resolved or the admins

--- a/root/user/UserCollections.js
+++ b/root/user/UserCollections.js
@@ -13,6 +13,7 @@ import type {ColumnOptions} from 'react-table';
 import Table from '../components/Table.js';
 import UserAccountLayout, {type AccountLayoutUserT}
   from '../components/UserAccountLayout.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import {formatPluralEntityTypeName}
   from '../static/scripts/common/utility/formatEntityTypeName.js';
 import {
@@ -23,7 +24,6 @@ import {
 } from '../utility/tableColumns.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +collaborativeCollections: CollectionListT,
   +ownCollections: CollectionListT,
   +user: AccountLayoutUserT,
@@ -158,11 +158,11 @@ const CollectionsEntityTypeSection = ({
 };
 
 const UserCollections = ({
-  $c,
   ownCollections,
   collaborativeCollections,
   user,
 }: Props): React.Element<typeof UserAccountLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const activeUser = $c.user;
   const viewingOwnProfile = !!(activeUser && activeUser.id === user.id);
   const ownCollectionTypes = Object.keys(ownCollections);

--- a/root/user/UserEdits.js
+++ b/root/user/UserEdits.js
@@ -9,12 +9,12 @@
 
 import * as React from 'react';
 
+import {SanitizedCatalystContext} from '../context.mjs';
 import Layout from '../layout/index.js';
 import EditList from '../edit/components/EditList.js';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +editCountLimit: number,
   +edits: $ReadOnlyArray<$ReadOnly<{...EditT, +id: number}>>,
   +pager: PagerT,
@@ -24,7 +24,6 @@ type Props = {
 };
 
 const UserEdits = ({
-  $c,
   editCountLimit,
   edits,
   pager,
@@ -32,6 +31,7 @@ const UserEdits = ({
   user,
   voter,
 }: Props): React.Element<typeof Layout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const titleParam = {name: user.name};
   const headingParam = {name: <EditorLink editor={user} />};
   let pageTitle = '';
@@ -81,7 +81,6 @@ const UserEdits = ({
       <div id="content">
         <h2>{pageHeading}</h2>
         <EditList
-          $c={$c}
           editCountLimit={editCountLimit}
           edits={edits}
           guessSearch

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import UserAccountLayout, {
   sanitizedAccountLayoutUser,
 } from '../components/UserAccountLayout.js';
+import {CatalystContext, SanitizedCatalystContext} from '../context.mjs';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
 import Warning from '../static/scripts/common/components/Warning.js';
@@ -127,7 +128,6 @@ const UserProfileProperty = ({
 );
 
 type UserProfileInformationProps = {
-  +$c: CatalystContextT,
   +applicationCount: number,
   +ipHashes: $ReadOnlyArray<string>,
   +subscribed: boolean,
@@ -138,7 +138,6 @@ type UserProfileInformationProps = {
 };
 
 const UserProfileInformation = ({
-  $c,
   applicationCount,
   ipHashes,
   subscribed,
@@ -147,6 +146,7 @@ const UserProfileInformation = ({
   user,
   viewingOwnProfile,
 }: UserProfileInformationProps) => {
+  const $c = React.useContext(CatalystContext);
   const showBioAndURL = !!(!user.is_limited || $c.user);
   let memberSince;
   if (user.name === 'rob') {
@@ -428,7 +428,6 @@ const UserProfileInformation = ({
 };
 
 type UserEditsPropertyProps = {
-  +$c: CatalystContextT,
   +addedEntities: number,
   +entityType: string,
   +name: string,
@@ -436,12 +435,12 @@ type UserEditsPropertyProps = {
 };
 
 const UserEditsProperty = ({
-  $c,
   addedEntities,
   entityType,
   name,
   user,
 }: UserEditsPropertyProps) => {
+  const $c = React.useContext(CatalystContext);
   const encodedName = encodeURIComponent(user.name);
   const createEditTypes: string = entityType === 'cover_art'
     ? String(TYPES.EDIT_RELEASE_ADD_COVER_ART)
@@ -523,7 +522,6 @@ type EntitiesStatsT = {
 };
 
 type UserProfileStatisticsProps = {
-  +$c: CatalystContextT,
   +addedEntities: EntitiesStatsT,
   +editStats: EditStatsT,
   +secondaryStats: SecondaryStatsT,
@@ -532,13 +530,13 @@ type UserProfileStatisticsProps = {
 };
 
 const UserProfileStatistics = ({
-  $c,
   editStats,
   user,
   votes,
   secondaryStats,
   addedEntities,
 }: UserProfileStatisticsProps) => {
+  const $c = React.useContext(CatalystContext);
   const voteTotals = votes.pop();
   const encodedName = encodeURIComponent(user.name);
   const allAppliedCount = editStats.accepted_count +
@@ -760,7 +758,6 @@ const UserProfileStatistics = ({
               .sort((a, b) => compare(a[1], b[1]))
               .map(([entityType, entityTypeName]) => (
                 <UserEditsProperty
-                  $c={$c}
                   addedEntities={addedEntities[entityType]}
                   entityType={entityType}
                   key={entityType}
@@ -834,7 +831,6 @@ const UserProfileStatistics = ({
 };
 
 type UserProfileProps = {
-  +$c: CatalystContextT,
   +addedEntities: EntitiesStatsT,
   +applicationCount: number,
   +editStats: EditStatsT,
@@ -848,7 +844,6 @@ type UserProfileProps = {
 };
 
 const UserProfile = ({
-  $c,
   applicationCount,
   editStats,
   ipHashes,
@@ -860,6 +855,7 @@ const UserProfile = ({
   votes,
   addedEntities,
 }: UserProfileProps): React.Element<typeof UserAccountLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const viewingOwnProfile = $c.user != null && $c.user.id === user.id;
   const adminViewing = $c.user != null && isAccountAdmin($c.user);
   const encodedName = encodeURIComponent(user.name);
@@ -891,7 +887,6 @@ const UserProfile = ({
           ) : null}
 
           <UserProfileInformation
-            $c={$c}
             applicationCount={applicationCount}
             ipHashes={ipHashes}
             subscribed={subscribed}
@@ -902,7 +897,6 @@ const UserProfile = ({
           />
 
           <UserProfileStatistics
-            $c={$c}
             addedEntities={addedEntities}
             editStats={editStats}
             secondaryStats={secondaryStats}

--- a/root/user/UserSubscriptions.js
+++ b/root/user/UserSubscriptions.js
@@ -14,6 +14,7 @@ import PaginatedResults from '../components/PaginatedResults.js';
 import UserAccountLayout, {
   type AccountLayoutUserT,
 } from '../components/UserAccountLayout.js';
+import {SanitizedCatalystContext} from '../context.mjs';
 import EditorLink from '../static/scripts/common/components/EditorLink.js';
 import EntityLink from '../static/scripts/common/components/EntityLink.js';
 import loopParity from '../utility/loopParity.js';
@@ -100,7 +101,6 @@ const UserSubscriptionsSection = ({
 );
 
 type UserSubscriptionsProps = {
-  +$c: CatalystContextT,
   +entities: $ReadOnlyArray<
     ArtistT | CollectionT | EditorT | LabelT | SeriesT>,
   +hiddenPrivateCollectionCount?: number,
@@ -118,7 +118,6 @@ type UserSubscriptionsProps = {
 };
 
 const UserSubscriptions = ({
-  $c,
   entities,
   hiddenPrivateCollectionCount,
   pager,
@@ -127,6 +126,7 @@ const UserSubscriptions = ({
   user,
   visiblePrivateCollections,
 }: UserSubscriptionsProps): React.Element<typeof UserAccountLayout> => {
+  const $c = React.useContext(SanitizedCatalystContext);
   const viewingOwnProfile = Boolean($c.user && $c.user.id === user.id);
   const isAdminViewingPrivate = Boolean(
     $c.user && !viewingOwnProfile && !user.preferences.public_subscriptions,

--- a/root/user/UserTag.js
+++ b/root/user/UserTag.js
@@ -16,7 +16,6 @@ import TagEntitiesList from '../components/TagEntitiesList.js';
 import {getTagListHeading, getTagListUrl} from './UserTagList.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +showDownvoted?: boolean,
   +tag: TagT,
   +taggedEntities: {
@@ -33,7 +32,6 @@ type Props = {
 };
 
 const UserTag = ({
-  $c,
   showDownvoted = false,
   tag,
   taggedEntities,
@@ -53,7 +51,6 @@ const UserTag = ({
       </ol>
     </nav>
     <TagEntitiesList
-      $c={$c}
       showDownvoted={showDownvoted}
       showLink
       showVotesSelect

--- a/root/user/UserTagEntity.js
+++ b/root/user/UserTagEntity.js
@@ -19,7 +19,6 @@ import {EntityListContent} from '../tag/EntityList.js';
 import {getTagListHeading, getTagListUrl} from './UserTagList.js';
 
 type UserTagEntityProps = {
-  +$c: CatalystContextT,
   +entityTags: $ReadOnlyArray<{
     +entity: CoreEntityT,
     +entity_id: number,
@@ -44,7 +43,6 @@ function getAllEntitiesTagUrl(
 }
 
 const UserTagEntity = ({
-  $c,
   entityTags,
   entityType,
   pager,
@@ -77,7 +75,6 @@ const UserTagEntity = ({
       </ol>
     </nav>
     <EntityListContent
-      $c={$c}
       entityTags={entityTags}
       entityType={entityType}
       pager={pager}

--- a/root/user/UserTagList.js
+++ b/root/user/UserTagList.js
@@ -46,7 +46,6 @@ export function getTagListUrl(
 }
 
 type Props = {
-  +$c: CatalystContextT,
   +genres: $ReadOnlyArray<UserTagT>,
   +showDownvoted?: boolean,
   +sortBy?: 'count' | 'countdesc' | 'name',
@@ -55,7 +54,6 @@ type Props = {
 };
 
 const UserTagList = ({
-  $c,
   genres,
   showDownvoted = false,
   sortBy,
@@ -68,7 +66,6 @@ const UserTagList = ({
     </h2>
 
     <UserTagFilters
-      $c={$c}
       showDownvoted={showDownvoted}
       showSortSelect
       showVotesSelect

--- a/root/user/components/UserTagFilters.js
+++ b/root/user/components/UserTagFilters.js
@@ -12,7 +12,6 @@ import * as React from 'react';
 import FormRow from '../../components/FormRow.js';
 
 type PropsT = {
-  +$c: CatalystContextT,
   +showDownvoted: boolean,
   +showSortSelect?: boolean,
   +showVotesSelect?: boolean,
@@ -29,14 +28,13 @@ const InlineSubmitButton = (): React.Element<typeof React.Fragment> => (
 );
 
 const UserTagFilters = ({
-  $c,
   showDownvoted,
   showSortSelect = false,
   showVotesSelect = false,
   sortBy,
 }: PropsT): Expand2ReactOutput | null => (
   (showSortSelect || showVotesSelect) ? (
-    <form action={$c.req.uri} style={{marginTop: '1em'}}>
+    <form style={{marginTop: '1em'}}>
       {showVotesSelect ? (
         <FormRow>
           <label>

--- a/root/utility/sanitizedContext.mjs
+++ b/root/utility/sanitizedContext.mjs
@@ -32,6 +32,7 @@ export default function sanitizedContext(
     } : null,
     stash: {
       current_language: stash.current_language,
+      server_languages: stash.server_languages,
     },
     user: user ? activeSanitizedEditor(user) : null,
   };

--- a/root/vars.js
+++ b/root/vars.js
@@ -28,7 +28,7 @@ declare var hasOwnProp: (
 ) => boolean;
 declare var hydrate: (
   <
-    Config: {+$c?: CatalystContextT, ...},
+    Config: {...},
     SanitizedConfig = Config,
   >(
     containerSelector: string,

--- a/root/work/WorkIndex.js
+++ b/root/work/WorkIndex.js
@@ -21,7 +21,6 @@ import * as manifest from '../static/manifest.mjs';
 import WorkLayout from './WorkLayout.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +eligibleForCleanup: boolean,
   +numberOfRevisions: number,
   +pagedLinkTypeGroup: ?PagedLinkTypeGroupT,
@@ -31,7 +30,6 @@ type Props = {
 };
 
 const WorkIndex = ({
-  $c,
   eligibleForCleanup,
   numberOfRevisions,
   pagedLinkTypeGroup,
@@ -55,7 +53,6 @@ const WorkIndex = ({
     />
     <Relationships source={work} />
     <RelationshipsTable
-      $c={$c}
       entity={work}
       heading={l('Recordings')}
       pagedLinkTypeGroup={pagedLinkTypeGroup}

--- a/root/work/WorkMerge.js
+++ b/root/work/WorkMerge.js
@@ -18,14 +18,12 @@ import WorkList from '../components/list/WorkList.js';
 import Layout from '../layout/index.js';
 
 type Props = {
-  +$c: CatalystContextT,
   +form: MergeFormT,
   +iswcsDiffer?: boolean,
   +toMerge: $ReadOnlyArray<WorkT>,
 };
 
 const WorkMerge = ({
-  $c,
   form,
   iswcsDiffer = false,
   toMerge,
@@ -49,7 +47,7 @@ const WorkMerge = ({
           </p>
         </div>
       ) : null}
-      <form action={$c.req.uri} method="post">
+      <form method="post">
         <WorkList
           mergeForm={form}
           works={sortByEntityName(toMerge)}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-11303

When I updated root/utility/hydrate.js in
9ef8b79b8e5e4f3c41fb8087b744f8ed90f3ff2d, I forgot to also update its
global type signature in root/vars.js.  When I got around to doing that,
it caused a ton of errors.

Trying to express a proper type that accounts for the component
receiving an unsanitized `$c` on the server and a sanitized one on the
client is pretty hard.  I'd rather components only access `$c` via the
React context APIs, which allows us to keep the `hydrate` type simple.
Server components always being passed `$c` through props wasn't very
obvious or documented, anyway.