### PR TITLE
MBS-11758: Use current_language instead of lang cookie in Node.js

### DIFF
--- a/root/server/response.mjs
+++ b/root/server/response.mjs
@@ -14,7 +14,6 @@ import {
   CatalystContext,
   SanitizedCatalystContext,
 } from '../context.mjs';
-import getRequestCookie from '../utility/getRequestCookie.mjs';
 import sanitizedContext from '../utility/sanitizedContext.mjs';
 
 import components from './components.mjs';
@@ -41,10 +40,9 @@ export async function getResponse(requestBody, context) {
 
   /*
    * Set the current translations to be used for this request based on the
-   * given 'lang' cookie.
+   * given 'current_language' in the stash.
    */
-  const bcp47Locale = getRequestCookie(context.req, 'lang') || 'en';
-  gettext.setLocale(bcp47Locale.replace('-', '_'));
+  gettext.setLocale(context.stash.current_language || 'en');
 
   const componentPath = String(requestBody.component).replace(jsExt, '');
   const componentModule = components[componentPath];


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-11758

The Node template renderer currently sets its locale from the lang
cookie.  This may conflict with the locale set by Perl, which would not
be based on the lang cookie if it's not set, but rather the
Accept-Language header.  We should respect the locale determined and set
by Perl, which it stores in current_language in the stash.

This fixes an issue where certain strings (anything rendered by Node)
would be displayed in English even if the browser locale was not
English.