### PR TITLE
MBS-8876: Fix the banner message on UI language switch

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -92,10 +92,12 @@ sub set_language : Path('set-language') Args(1)
                 prev_lang_name => ucfirst DateTime::Locale->load($prev_lang)->native_name,
                 url => {href => '/set-language/' . $prev_lang . '?returnto=' . uri_escape_utf8($c->req->query_params->{returnto} || '/')},
             });
-        Translation->instance->set_language($lang);
-        $flash .= '<br/>' . l(
-            'If you find any problems with the translation, please {url|help us improve it}!',
-            {url => {href => 'https://www.transifex.com/musicbrainz/musicbrainz/', target => '_blank'}});
+        if ($lang ne 'en') {
+            Translation->instance->set_language($lang);
+            $flash .= '<br/>' . l(
+                'If you find any problems with the translation, please {url|help us improve it}!',
+                {url => {href => 'https://www.transifex.com/musicbrainz/musicbrainz/', target => '_blank'}});
+        }
         $c->flash->{message} = $flash;
     }
     $c->redirect_back;

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -82,9 +82,12 @@ sub set_language : Path('set-language') Args(1)
     } else {
         # set the cookie to expire in a year
         $c->set_language_cookie($lang);
-        $c->flash->{message} =
-            l('Language set. If you find any problems with the translation, please {url|help us improve it}!',
-              {url => {href => 'https://www.transifex.com/musicbrainz/musicbrainz/', target => '_blank'}});
+        my $flash = l('Language set.');
+        Translation->instance->set_language($lang);
+        $flash .= '<br/>' . l(
+            'If you find any problems with the translation, please {url|help us improve it}!',
+            {url => {href => 'https://www.transifex.com/musicbrainz/musicbrainz/', target => '_blank'}});
+        $c->flash->{message} = $flash;
     }
     $c->redirect_back;
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

MBS-8876: The translation hint in the banner message was not shown in the newly selected UI language.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Split the banner message into two parts:
- The language change notice, still shown in the previously used language
  * Additionally add a direct link for the user to revert the change in case of mistake
- The translation hint, in the newly selected UI language
  * Additionally hide this message when the selected UI language is English (since it is also the source language for translations).

Note: Changes are easier to read with hidden whitespace.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested by
  * updating source messages in `po/mb_server.pot`
  * translating messages in `po/mb_server.*.po`
  * installing translations with `cd po && make install`
  * Switching UI language from the front page and from the editor profile