### PR TITLE
MBS-12548: Handle conflicting tag names and avoid updating current_replication_sequence in MBS-12508 script

### DIFF
--- a/admin/sql/updates/20220720-mbs-12508.sh
+++ b/admin/sql/updates/20220720-mbs-12508.sh
@@ -144,8 +144,9 @@ INSERT INTO work_tag (SELECT * FROM tmp_work_tag_mbs_12508)
     ON CONFLICT (work, tag) DO UPDATE SET count = excluded.count, last_updated = excluded.last_updated;
 DROP TABLE tmp_work_tag_mbs_12508;
 
+DELETE FROM tag WHERE id IN (SELECT id FROM tmp_tag_mbs_12508);
 INSERT INTO tag (SELECT * FROM tmp_tag_mbs_12508)
-    ON CONFLICT (id) DO UPDATE SET ref_count = excluded.ref_count;
+    ON CONFLICT (name) DO UPDATE SET id = excluded.id, ref_count = excluded.ref_count;
 DROP TABLE tmp_tag_mbs_12508;
 SQL
 ) || ( echo "$OUTPUT" && exit 1 )

--- a/admin/sql/updates/20220720-mbs-12508.sh
+++ b/admin/sql/updates/20220720-mbs-12508.sh
@@ -93,6 +93,7 @@ echo `date`: Importing tag data from latest dump
     --table release_group_tag \
     --table series_tag \
     --table work_tag \
+    --noupdate-replication-control \
     "$DUMP_FILE"
 
 echo `date`: Restoring saved tag data from tmp tables


### PR DESCRIPTION
# Address MBS-12548

The script for MBS-12508 didn't take into account that a tag's ID may change if the last usage is removed and then re-added.  To handle this, the `ON CONFLICT` specifier is changed to `(name)` rather than `(id)`, and if there's a conflict we take the ID associated with that name in the temporary table (which is assumed to be up-to-date from replication).  To avoid any ID conflicts as before, a separate `DELETE` is performed first.

Second issue: MBImport.pl by default will update `replication_control.current_replication_sequence` with the value stored in the dump, but in this case that value will be older than the existing replication sequence.  Pass the appropriate flag to disable this behavior and avoid already-applied packets from being processed again, thereby causing uniqueness errors.