### PR TITLE
MBS-12516: Block smart links: mez.ink

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1643,6 +1643,7 @@ const URL_SHORTENERS = [
   'lsnto.me',
   'many.link',
   'mcaf.ee',
+  'mez.ink',
   'moourl.com',
   'music.indiefy.net',
   'musics.link',


### PR DESCRIPTION
### Implement MBS-12516

https://mez.ink/ - doesn't seem needed as a host either.
