### PR TITLE
MBS-12435: Block smart links: linkfly.to

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1634,6 +1634,7 @@ const URL_SHORTENERS = [
   'li.sten.to',
   'linkco.re',
   'lnkfi.re',
+  'linkfly.to',
   'linktr.ee',
   'listen.lt',
   'lnk.bio',


### PR DESCRIPTION
### Implement MBS-12435

https://linkfly.to/ - doesn't seem needed as a host either.
