### PR TITLE
Fix the spacing below ISRCs/ISWCs (show ... more)

### DIFF
--- a/root/static/scripts/common/components/CollapsibleList.js
+++ b/root/static/scripts/common/components/CollapsibleList.js
@@ -24,7 +24,7 @@ type Props<T> = {
   +buildRowProps?: BuildRowPropsT,
   +className: string,
   +ContainerElement?: 'dl' | 'ul',
-  +InnerElement?: 'p' | 'li',
+  +InnerElement?: 'p' | 'li' | 'div',
   +rows: ?$ReadOnlyArray<T>,
   +showAllTitle: string,
   +showLessTitle: string,

--- a/root/static/scripts/common/components/IsrcList.js
+++ b/root/static/scripts/common/components/IsrcList.js
@@ -42,7 +42,7 @@ const IsrcList = ({
 }: IsrcListProps) => (
   <CollapsibleList
     ContainerElement={isSidebar ? 'dl' : 'ul'}
-    InnerElement={isSidebar ? 'p' : 'li'}
+    InnerElement={isSidebar ? 'div' : 'li'}
     ariaLabel={l('ISRCs')}
     buildRow={isSidebar ? buildIsrcSidebarRow : buildIsrcListRow}
     className={isSidebar ? 'properties isrcs' : 'isrcs'}

--- a/root/static/scripts/common/components/IswcList.js
+++ b/root/static/scripts/common/components/IswcList.js
@@ -42,7 +42,7 @@ const IswcList = ({
 }: IswcListProps) => (
   <CollapsibleList
     ContainerElement={isSidebar ? 'dl' : 'ul'}
-    InnerElement={isSidebar ? 'p' : 'li'}
+    InnerElement={isSidebar ? 'div' : 'li'}
     ariaLabel={l('ISWCs')}
     buildRow={isSidebar ? buildIswcSidebarRow : buildIswcListRow}
     className={isSidebar ? 'properties iswcs' : 'iswcs'}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In previous implementation of MBS-12334 by pull request #2500, ISRCs/ISWCs “(show ... more)” - which is displayed to shorten a long list of ISRCs/ISWCs - was rendered as a `p` element in the sidebar causing unintentional extra space under it.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch uses `div` instead which better fits in a definition list.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested https://musicbrainz.org/recording/21bc4ba0-3b43-43b8-9702-f5f066c894e8