### PR TITLE
MBS-12556: Don't enter annotation edits unless text changes

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -153,6 +153,10 @@ role {
             ? $annotation_model->get_latest($entity->id)
             : undef;
 
+        MusicBrainz::Server::Edit::Exceptions::NoChanges->throw
+            if $latest_annotation &&
+               $latest_annotation->text eq $opts{text};
+
         $self->data({
             %opts,
             editor_id => $self->editor_id,

--- a/t/lib/t/MusicBrainz/Server/Edit/Artist/AddAnnotation.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/Artist/AddAnnotation.pm
@@ -9,42 +9,47 @@ BEGIN { use MusicBrainz::Server::Edit::Artist::AddAnnotation }
 use MusicBrainz::Server::Constants qw( $EDIT_ARTIST_ADD_ANNOTATION );
 use MusicBrainz::Server::Test;
 
-test all => sub {
+test 'Entering add annotation edit works as expected' => sub {
 
-my $test = shift;
-my $c = $test->c;
+    my $test = shift;
+    my $c = $test->c;
 
-MusicBrainz::Server::Test->prepare_test_database($c, '+annotation');
+    MusicBrainz::Server::Test->prepare_test_database($c, '+annotation');
 
-my $edit = $c->model('Edit')->create(
-    edit_type => $EDIT_ARTIST_ADD_ANNOTATION,
-    editor_id => 1,
+    my $edit = create_edit($c, 'Test annotation', 'A changelog');
+    isa_ok($edit, 'MusicBrainz::Server::Edit::Artist::AddAnnotation');
 
-    entity => $c->model('Artist')->get_by_id(1),
-    text => 'Test annotation',
-    changelog => 'A changelog',
-);
-isa_ok($edit, 'MusicBrainz::Server::Edit::Artist::AddAnnotation');
+    my ($edits) = $c->model('Edit')->find({ artist => 1 }, 10, 0);
+    is($edits->[0]->id, $edit->id);
 
-my ($edits) = $c->model('Edit')->find({ artist => 1 }, 10, 0);
-is($edits->[0]->id, $edit->id);
+    $c->model('Edit')->load_all($edit);
+    is($edit->display_data->{artist}{id}, 1);
+    is($edit->display_data->{changelog}, 'A changelog');
 
-$c->model('Edit')->load_all($edit);
-is($edit->display_data->{artist}{id}, 1);
-is($edit->display_data->{changelog}, 'A changelog');
+    my $artist = $c->model('Artist')->get_by_id(1);
 
-my $artist = $c->model('Artist')->get_by_id(1);
+    $c->model('Artist')->annotation->load_latest($artist);
+    my $annotation = $artist->latest_annotation;
+    ok(defined $annotation);
+    is($annotation->editor_id, 1);
+    is($annotation->text, 'Test annotation');
+    is($annotation->changelog, 'A changelog');
 
-$c->model('Artist')->annotation->load_latest($artist);
-my $annotation = $artist->latest_annotation;
-ok(defined $annotation);
-is($annotation->editor_id, 1);
-is($annotation->text, 'Test annotation');
-is($annotation->changelog, 'A changelog');
-
-my $annotation2 = $c->model('Artist')->annotation->get_by_id($edit->annotation_id);
-is_deeply($annotation, $annotation2);
-
+    my $annotation2 = $c->model('Artist')->annotation->get_by_id($edit->annotation_id);
+    is_deeply($annotation, $annotation2);
 };
+
+
+sub create_edit {
+    my ($c, $text, $changelog) = @_;
+    $changelog //= '';
+    return $c->model('Edit')->create(
+        edit_type => $EDIT_ARTIST_ADD_ANNOTATION,
+        editor_id => 1,
+        entity => $c->model('Artist')->get_by_id(1),
+        text => $text,
+        changelog => $changelog,
+    );
+}
 
 1;


### PR DESCRIPTION
### Fix MBS-12556

Right now you can go to /edit_annotation and just re-enter the form as-is and it will create an edit. That doesn't match what we do elsewhere and it's also not useful in any way (even adding a changelog means nothing if nothing was changed).

As such, this blocks entering the edit if the text is the same as the text from the last annotation (regardless of whether a changelog or edit note is added).

Tested locally, plus added a test.