### PR TITLE
MBS-12558: Block linking to Wikipedia User: pages

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5038,6 +5038,16 @@ const CLEANUPS: CleanupEntries = {
           target: ERROR_TARGETS.URL,
         };
       }
+      if (/^(https?:\/\/)?([^.\/]+\.)?wikipedia\.org\/wiki\/User:.*/.test(url)) {
+        return {
+          error: l(
+            `Links to Wikipedia user pages are not allowed. Please link only
+             to actual Wikipedia articles.`,
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       return {
         result: /^https:\/\/[a-z]+\.wikipedia\.org\/wiki\//.test(url),
         target: ERROR_TARGETS.URL,

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -5267,6 +5267,17 @@ limited_link_type_combinations: [
                                   target: 'entity',
                                 },
   },
+  {
+                     input_url: 'https://en.wikipedia.org/wiki/User:JackDormantPress/By_The_Rivers_(band)',
+             input_entity_type: 'artist',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'wikipedia',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'Wikipedia user pages are not allowed',
+                                  target: 'url',
+                                },
+  },
   // Wikisource
   {
                      input_url: 'https://pt.wikisource.org/wiki/A_Portuguesa',


### PR DESCRIPTION
### Implement MBS-12558

User: pages are not really articles. Since the namespace is language-dependent, this will only block enwiki user pages, but that's probably most of them anyway.
