### PR TITLE
MBS-12528 / MBS-12530: More user-friendly reviews UX

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -118,7 +118,7 @@ after 'load' => sub {
 
     if ($c->action->name ne 'edit') {
         # Only needed by pages showing the sidebar
-        $c->model('CritiqueBrainz')->load_display_reviews($release->release_group)
+        $c->model('CritiqueBrainz')->load_review_count($release->release_group)
             unless $returning_jsonld;
     }
 };

--- a/lib/MusicBrainz/Server/Controller/Role/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Rating.pm
@@ -6,6 +6,20 @@ use MusicBrainz::Server::Constants qw( %ENTITIES );
 
 requires 'load';
 
+after 'load' => sub {
+    my ($self, $c) = @_;
+
+    my $entity = $c->stash->{$self->{entity_name}};
+    my $entity_properties = $ENTITIES{ $entity->entity_type };
+    my $returning_jsonld = $self->should_return_jsonld($c);
+
+    if ($entity_properties->{reviews} && $c->action->name ne 'edit') {
+        # Only needed by pages showing the sidebar
+        $c->model('CritiqueBrainz')->load_review_count($entity)
+            unless $returning_jsonld;
+    }
+};
+
 sub ratings : Chained('load') PathPart('ratings')
 {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Controller/Role/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Rating.pm
@@ -13,8 +13,7 @@ after 'load' => sub {
     my $entity_properties = $ENTITIES{ $entity->entity_type };
     my $returning_jsonld = $self->should_return_jsonld($c);
 
-    if ($entity_properties->{reviews} && $c->action->name ne 'edit') {
-        # Only needed by pages showing the sidebar
+    if ($entity_properties->{reviews}) {
         $c->model('CritiqueBrainz')->load_review_count($entity)
             unless $returning_jsonld;
     }

--- a/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
+++ b/lib/MusicBrainz/Server/Data/CritiqueBrainz.pm
@@ -12,6 +12,30 @@ use aliased 'MusicBrainz::Server::Entity::CritiqueBrainz::User';
 
 with 'MusicBrainz::Server::Data::Role::Context';
 
+# TODO: improve this file to use an entity endpoint if CB-427 is merged
+
+sub load_review_count {
+    my ($self, $entity) = @_;
+
+    my $url = URI->new(DBDefs->CRITIQUEBRAINZ_SERVER . '/ws/1/review/');
+
+    my %params = (
+        entity_id => $entity->gid,
+        entity_type => $entity->entity_type,
+        offset => 0,
+        limit => 1,
+        review_type => 'review', # Get only text reviews, not bare ratings
+        sort => 'published_on'
+    );
+
+    $url->query_form(%params);
+
+    my $content = $self->_get_review($url->as_string);
+    return unless $content;
+
+    $entity->review_count($content->{count});
+}
+
 sub load_display_reviews {
     my ($self, $entity) = @_;
 

--- a/root/components/EntityTabs.js
+++ b/root/components/EntityTabs.js
@@ -139,7 +139,10 @@ function buildLinks(
     entityProperties.reviews
   ) {
     const ratingsTabTitle = entityProperties.reviews
-      ? l('Reviews')
+      ? texp.l(
+        'Reviews ({num})',
+        {num: entity.review_count || 0},
+      )
       : l('Ratings');
     links.push(buildLink(ratingsTabTitle, entity, 'ratings', page));
   }

--- a/root/layout/components/sidebar/ArtistSidebar.js
+++ b/root/layout/components/sidebar/ArtistSidebar.js
@@ -40,6 +40,7 @@ import SidebarIsnis from './SidebarIsnis.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 import SubscriptionLinks from './SubscriptionLinks.js';
@@ -128,6 +129,8 @@ const ArtistSidebar = ({artist}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={artist} />
+
+      <SidebarReviews entity={artist} />
 
       <SidebarTags entity={artist} />
 

--- a/root/layout/components/sidebar/EventSidebar.js
+++ b/root/layout/components/sidebar/EventSidebar.js
@@ -28,6 +28,7 @@ import SidebarEndDate from './SidebarEndDate.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
@@ -73,6 +74,8 @@ const EventSidebar = ({event}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={event} />
+
+      <SidebarReviews entity={event} />
 
       <SidebarTags entity={event} />
 

--- a/root/layout/components/sidebar/LabelSidebar.js
+++ b/root/layout/components/sidebar/LabelSidebar.js
@@ -32,6 +32,7 @@ import SidebarIsnis from './SidebarIsnis.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 import SubscriptionLinks from './SubscriptionLinks.js';
@@ -91,6 +92,8 @@ const LabelSidebar = ({label}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={label} />
+
+      <SidebarReviews entity={label} />
 
       <SidebarTags entity={label} />
 

--- a/root/layout/components/sidebar/PlaceSidebar.js
+++ b/root/layout/components/sidebar/PlaceSidebar.js
@@ -30,6 +30,7 @@ import SidebarEndDate from './SidebarEndDate.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
@@ -100,6 +101,8 @@ const PlaceSidebar = ({place}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={place} />
+
+      <SidebarReviews entity={place} />
 
       <SidebarTags entity={place} />
 

--- a/root/layout/components/sidebar/RecordingSidebar.js
+++ b/root/layout/components/sidebar/RecordingSidebar.js
@@ -26,6 +26,7 @@ import RemoveLink from './RemoveLink.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 
 type Props = {
@@ -74,6 +75,8 @@ const RecordingSidebar = ({recording}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={recording} />
+
+      <SidebarReviews entity={recording} />
 
       <SidebarTags entity={recording} />
 

--- a/root/layout/components/sidebar/ReleaseGroupSidebar.js
+++ b/root/layout/components/sidebar/ReleaseGroupSidebar.js
@@ -24,6 +24,7 @@ import MergeLink from './MergeLink.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 
 type Props = {
@@ -59,6 +60,8 @@ const ReleaseGroupSidebar = ({releaseGroup}: Props): React.Element<'div'> => {
       </SidebarProperties>
 
       <SidebarRating entity={releaseGroup} />
+
+      <SidebarReviews entity={releaseGroup} />
 
       <SidebarTags entity={releaseGroup} />
 

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -27,7 +27,6 @@ import formatTrackLength
 import releaseLabelKey
   from '../../../static/scripts/common/utility/releaseLabelKey.js';
 import {Artwork} from '../../../components/Artwork.js';
-import CritiqueBrainzLinks from '../../../components/CritiqueBrainzLinks.js';
 import LinkSearchableLanguage
   from '../../../components/LinkSearchableLanguage.js';
 import LinkSearchableProperty
@@ -44,6 +43,7 @@ import SidebarDataQuality from './SidebarDataQuality.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 
 type Props = {
@@ -231,16 +231,10 @@ const ReleaseSidebar = ({release}: Props): React.Element<'div'> | null => {
         heading={l('Release group rating')}
       />
 
-      {releaseGroup.review_count == null ? null : (
-        <>
-          <h2 className="reviews">
-            {l('Release group reviews')}
-          </h2>
-          <p>
-            <CritiqueBrainzLinks entity={releaseGroup} />
-          </p>
-        </>
-      )}
+      <SidebarReviews
+        entity={releaseGroup}
+        heading={l('Release group reviews')}
+      />
 
       <SidebarTags entity={release} />
 

--- a/root/layout/components/sidebar/SidebarReviews.js
+++ b/root/layout/components/sidebar/SidebarReviews.js
@@ -1,0 +1,31 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2017 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import CritiqueBrainzLinks from '../../../components/CritiqueBrainzLinks.js';
+
+type Props = {
+  +entity: ReviewableT,
+  +heading?: string,
+};
+
+const SidebarReviews = ({
+  entity,
+  heading,
+}: Props): React.Element<typeof React.Fragment> => (
+  <>
+    <h2 className="reviews">{nonEmpty(heading) ? heading : l('Reviews')}</h2>
+    <p>
+      <CritiqueBrainzLinks entity={entity} />
+    </p>
+  </>
+);
+
+export default SidebarReviews;

--- a/root/layout/components/sidebar/WorkSidebar.js
+++ b/root/layout/components/sidebar/WorkSidebar.js
@@ -30,6 +30,7 @@ import MergeLink from './MergeLink.js';
 import SidebarLicenses from './SidebarLicenses.js';
 import {SidebarProperty, SidebarProperties} from './SidebarProperties.js';
 import SidebarRating from './SidebarRating.js';
+import SidebarReviews from './SidebarReviews.js';
 import SidebarTags from './SidebarTags.js';
 import SidebarType from './SidebarType.js';
 
@@ -105,6 +106,8 @@ const WorkSidebar = ({work}: Props): React.Element<'div'> => {
       ) : null}
 
       <SidebarRating entity={work} />
+
+      <SidebarReviews entity={work} />
 
       <SidebarTags entity={work} />
 


### PR DESCRIPTION
### Implement MBS-12528 / MBS-12530

See commit messages for details.

This means every page load will currently hit CB, which might not be ideal. My understanding is that these API queries are actually cached in CB and as such it shouldn't be a huge issue, but we could add caching on our side too - the only problem is that it might be infuriating to be told "no releases, go add one?" and then do that, come back and still be told "no releases".