### PR TITLE
MBS-12560: Stop using track ID for recording ID URL

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -83,14 +83,6 @@ after 'load' => sub
     $c->model('ArtistCredit')->load($recording);
 };
 
-sub _row_id_to_gid
-{
-    my ($self, $c, $track_id) = @_;
-    my $track = $c->model('Track')->get_by_id($track_id) or return;
-    $c->model('Recording')->load($track);
-    return $track->recording->gid;
-}
-
 sub show : Chained('load') PathPart('') {
     my ($self, $c) = @_;
     my $recording = $c->stash->{recording};


### PR DESCRIPTION
# Problem

[MBS-12560](https://tickets.metabrainz.org/browse/MBS-12560): Stop using track ID for recording ID URL

In MB, if you call the `/entity/id` URL, it will redirect to the matching `/entity/gid` URL.

But it is broken for recording:

NGS has now separate track and recording ID, but pre-NGS, there was some
redirection necessary or something: 7acea69a042a4f50f759199fe661e736cee208a4

Example: https://musicbrainz.org/recording/272811 should lead to [recording with ID 272811](https://musicbrainz.org/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and&conditions.0.field=recording&conditions.0.operator=%3D&conditions.0.name=with+ID+272811&conditions.0.args.0=272811&conditions.1.field=type&conditions.1.operator=%3D&conditions.1.args=72%2C204%2C245).
Not to unrelated recording with ID 316322 via track with ID 272811.

https://musicbrainz.org/recording/272811 should not lead to same recording as unrelated https://musicbrainz.org/track/272811


# Solution

Remove the pre-NGS redirection from /recording/id that is looking up for track with id instead of recording with id.

Let MBS use/inherit the genetic _row_id_to_gid function for recording, by removing the recording-level specific function.
