### PR TITLE
MBS-12562: Redirect row id url to gid url for works too

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -35,6 +35,7 @@ with 'MusicBrainz::Server::Controller::Role::Load' => {
         },
     },
 };
+with 'MusicBrainz::Server::Controller::Role::LoadWithRowID';
 with 'MusicBrainz::Server::Controller::Role::Annotation';
 with 'MusicBrainz::Server::Controller::Role::Alias';
 with 'MusicBrainz::Server::Controller::Role::Details';


### PR DESCRIPTION
# Problem

[MBS-12562](https://tickets.metabrainz.org/browse/MBS-12562): Work row ID URL is not redirected to GID (MBID) URL

All entities are using `LoadWithRowID` except works.

https://github.com/metabrainz/musicbrainz-server/search?q=LoadWithRowID

[lib/MusicBrainz/Server/Controller/Role/LoadWithRowID.pm](https://github.com/metabrainz/musicbrainz-server/blob/master/lib/MusicBrainz/Server/Controller/Role/LoadWithRowID.pm) allows redirection from row ID entity URL to GID (MBID) entity URL.

So, before this commit, https://musicbrainz.org/work/12431696 did display Ricochet work but it did not change URL to https://musicbrainz.org/work/3ba92b70-ef66-48b5-9c14-18ed6aa8afcc as it does for all other entity types.

# Solution

I just link `LoadWithRowID` in `lib/MusicBrainz/Server/Controller/Work.pm` as is already done with other entity types:

```perl
with 'MusicBrainz::Server::Controller::Role::LoadWithRowID';
```