### PR TITLE
MBS-12566: Fix incorrect URL shortener detection

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -33,6 +33,7 @@ import {compareDatePeriods} from '../common/utility/compareDates.js';
 import {isMalware} from '../url/utility/isGreyedOut.js';
 
 import isPositiveInteger from './utility/isPositiveInteger.js';
+import isShortenedUrl from './utility/isShortenedUrl.js';
 import HelpIcon from './components/HelpIcon.js';
 import RemoveButton from './components/RemoveButton.js';
 import URLInputPopover from './components/URLInputPopover.js';
@@ -607,7 +608,7 @@ export class ExternalLinksEditor
                     because it is known to host malware.`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
-    } else if (isNewOrChangedLink && isShortened(link.url)) {
+    } else if (isNewOrChangedLink && isShortenedUrl(link.url)) {
       error = {
         message: l(`Please don’t enter bundled/shortened URLs,
                     enter the destination URL(s) instead.`),
@@ -1586,113 +1587,6 @@ function isValidURL(url: string) {
   }
 
   return true;
-}
-
-// For shortener pages which should still be allowed as a host-only link
-const SHORTENER_ALLOWED_HOSTS = [
-  'bruit.app',
-  'distrokid.com',
-  'trac.co',
-];
-
-const URL_SHORTENERS = [
-  'adf.ly',
-  'album.link',
-  'ampl.ink',
-  'amu.se',
-  'artist.link',
-  'band.link',
-  'bfan.link',
-  'biglink.to',
-  'bio.link',
-  'bit.ly',
-  'bitly.com',
-  'backl.ink',
-  'bruit.app',
-  'bstlnk.to',
-  'cli.gs',
-  'deck.ly',
-  'distrokid.com',
-  'ditto.fm',
-  'eventlink.to',
-  'fanlink.to',
-  'ffm.to',
-  'found.ee',
-  'fty.li',
-  'fur.ly',
-  'g.co',
-  'gate.fm',
-  'geni.us',
-  'goo.gl',
-  'hypeddit.com',
-  'hypel.ink',
-  'hyperfollow.com',
-  'hyperurl.co',
-  'is.gd',
-  'kl.am',
-  'laburbain.com',
-  'li.sten.to',
-  'linkco.re',
-  'lnkfi.re',
-  'linkfly.to',
-  'linktr.ee',
-  'listen.lt',
-  'lnk.bio',
-  'lnk.co',
-  'lnk.site',
-  'lnk.to',
-  'lsnto.me',
-  'many.link',
-  'mcaf.ee',
-  'mez.ink',
-  'moourl.com',
-  'music.indiefy.net',
-  'musics.link',
-  'mylink.page',
-  'myurls.bio',
-  'odesli.co',
-  'orcd.co',
-  'owl.ly',
-  'page.link',
-  'pandora.app.link',
-  'podlink.to',
-  'pods.link',
-  'push.fm',
-  'rb.gy',
-  'rubyurl.com',
-  'share.amuse.io',
-  'smarturl.it',
-  'snd.click',
-  'song.link',
-  'songwhip.com',
-  'spinnup.link',
-  'spoti.fi',
-  'sptfy.com',
-  'spread.link',
-  'streamerlinks.com',
-  'streamlink.to',
-  'su.pr',
-  't.co',
-  'tiny.cc',
-  'tinyurl.com',
-  'tourlink.to',
-  'trac.co',
-  'u.nu',
-  'unitedmasters.com',
-  'untd.io',
-  'vyd.co',
-  'yep.it',
-].map(shortener => new RegExp(
-  '^https?://([^/]+\\.)?' +
-  shortener +
-  (SHORTENER_ALLOWED_HOSTS.includes(shortener) ? '/.+' : ''),
-  'i',
-));
-
-function isShortened(url: string) {
-  return URL_SHORTENERS.some(function (shortenerRegex) {
-    return url.match(shortenerRegex) !== null;
-  });
 }
 
 function isGoogleAmp(url: string) {

--- a/root/static/scripts/edit/utility/isShortenedUrl.js
+++ b/root/static/scripts/edit/utility/isShortenedUrl.js
@@ -1,0 +1,115 @@
+/*
+ * @flow strict
+ * Copyright (C) 2015 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+// For shortener pages which should still be allowed as a host-only link
+const SHORTENER_ALLOWED_HOSTS = [
+  'bruit.app',
+  'distrokid.com',
+  'trac.co',
+];
+
+const URL_SHORTENERS = [
+  'adf.ly',
+  'album.link',
+  'ampl.ink',
+  'amu.se',
+  'artist.link',
+  'band.link',
+  'bfan.link',
+  'biglink.to',
+  'bio.link',
+  'bit.ly',
+  'bitly.com',
+  'backl.ink',
+  'bruit.app',
+  'bstlnk.to',
+  'cli.gs',
+  'deck.ly',
+  'distrokid.com',
+  'ditto.fm',
+  'eventlink.to',
+  'fanlink.to',
+  'ffm.to',
+  'found.ee',
+  'fty.li',
+  'fur.ly',
+  'g.co',
+  'gate.fm',
+  'geni.us',
+  'goo.gl',
+  'hypeddit.com',
+  'hypel.ink',
+  'hyperfollow.com',
+  'hyperurl.co',
+  'is.gd',
+  'kl.am',
+  'laburbain.com',
+  'li.sten.to',
+  'linkco.re',
+  'lnkfi.re',
+  'linkfly.to',
+  'linktr.ee',
+  'listen.lt',
+  'lnk.bio',
+  'lnk.co',
+  'lnk.site',
+  'lnk.to',
+  'lsnto.me',
+  'many.link',
+  'mcaf.ee',
+  'mez.ink',
+  'moourl.com',
+  'music.indiefy.net',
+  'musics.link',
+  'mylink.page',
+  'myurls.bio',
+  'odesli.co',
+  'orcd.co',
+  'owl.ly',
+  'page.link',
+  'pandora.app.link',
+  'podlink.to',
+  'pods.link',
+  'push.fm',
+  'rb.gy',
+  'rubyurl.com',
+  'share.amuse.io',
+  'smarturl.it',
+  'snd.click',
+  'song.link',
+  'songwhip.com',
+  'spinnup.link',
+  'spoti.fi',
+  'sptfy.com',
+  'spread.link',
+  'streamerlinks.com',
+  'streamlink.to',
+  'su.pr',
+  't.co',
+  'tiny.cc',
+  'tinyurl.com',
+  'tourlink.to',
+  'trac.co',
+  'u.nu',
+  'unitedmasters.com',
+  'untd.io',
+  'vyd.co',
+  'yep.it',
+].map(shortener => new RegExp(
+  '^https?://([^/]+\\.)?' +
+  shortener +
+  (SHORTENER_ALLOWED_HOSTS.includes(shortener) ? '/.+' : ''),
+  'i',
+));
+
+export default function isShortenedUrl(url: string): boolean {
+  return URL_SHORTENERS.some(function (shortenerRegex) {
+    return url.match(shortenerRegex) !== null;
+  });
+}

--- a/root/static/scripts/edit/utility/isShortenedUrl.js
+++ b/root/static/scripts/edit/utility/isShortenedUrl.js
@@ -7,6 +7,8 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import escapeRegExp from '../../common/utility/escapeRegExp.mjs';
+
 // For shortener pages which should still be allowed as a host-only link
 const SHORTENER_ALLOWED_HOSTS = [
   'bruit.app',
@@ -103,8 +105,8 @@ const URL_SHORTENERS = [
   'yep.it',
 ].map(shortener => new RegExp(
   '^https?://([^/]+\\.)?' +
-  shortener +
-  (SHORTENER_ALLOWED_HOSTS.includes(shortener) ? '/.+' : ''),
+  escapeRegExp(shortener) +
+  (SHORTENER_ALLOWED_HOSTS.includes(shortener) ? '/.+' : '(?:/.*)?$'),
   'i',
 ));
 

--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -21,6 +21,7 @@ import formatTrackLength from '../common/utility/formatTrackLength.js';
 import parseDate from '../common/utility/parseDate.js';
 import * as dates from '../edit/utility/dates.js';
 import * as fullwidthLatin from '../edit/utility/fullwidthLatin.js';
+import isShortenedUrl from '../edit/utility/isShortenedUrl.js';
 
 test('age', function (t) {
   t.plan(11);
@@ -606,4 +607,32 @@ test('formatSetlist', function (t) {
     '</strong><br/>' +
     'plain text work<br/><br/><br/>',
   );
+});
+
+test('isShortenedUrl', function (t) {
+  t.plan(17);
+
+  t.ok(isShortenedUrl('https://su.pr/example'));
+  t.ok(isShortenedUrl('https://t.co/example'));
+  t.ok(isShortenedUrl('https://bit.ly/example'));
+  t.ok(isShortenedUrl('http://example.su.pr'));
+  t.ok(isShortenedUrl('http://example.t.co'));
+  t.ok(isShortenedUrl('http://example.bit.ly'));
+
+  // Allowed host-only shorteners
+  t.ok(!isShortenedUrl('https://example.bruit.app/'));
+  t.ok(!isShortenedUrl('https://example.distrokid.com'));
+  t.ok(!isShortenedUrl('https://example.trac.co'));
+
+  t.ok(isShortenedUrl('https://bruit.app/abc'));
+  t.ok(isShortenedUrl('https://example.distrokid.com/abc'));
+  t.ok(isShortenedUrl('https://example.trac.co/abc'));
+
+  // MBS-12566
+  t.ok(!isShortenedUrl('https://surprisechef.bandcamp.com' +
+                       '/album/velodrome-b-w-springs-theme'));
+  t.ok(!isShortenedUrl('https://t.co.example'));
+  t.ok(!isShortenedUrl('https://taco.example'));
+  t.ok(!isShortenedUrl('https://bit.ly.example'));
+  t.ok(!isShortenedUrl('https://bitaly.example'));
 });


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12566

As the ticket explains, our RegExps should escape their dots (t.co
should not match taco), and also match the hostname correctly (t.co
should not match t.co.example).