### PR TITLE
Fix building CSS in production Docker images

### DIFF
--- a/docker/scripts/compile_resources_for_image.sh
+++ b/docker/scripts/compile_resources_for_image.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Explanatory production notes:
+#
+# Building webpack/server.config.mjs is necessary in order to generate
+# *.css files in the Docker image, which are extracted from the image
+# in a Jenkins job and synced to a static resources volume on our gateway
+# servers.
+#
+# Building the server-side JS requires a DBDefs file, though, and one isn't
+# available when building the image.  Our production DBDefs files are stored
+# in a private repository and copied into the containers at runtime.
+#
+# Since the .less files aren't affected by any specific DBDefs configuration,
+# and because the server JS is rebuilt anyway after the container starts, we
+# can temporarily use the sample DBDefs file in the repository to allow the
+# CSS to build into the image, and then remove the useless server JS files
+# which contain sample configuration.
+
+cp lib/DBDefs.pm.sample lib/DBDefs.pm
+
+carton exec -- ./script/compile_resources.sh
+
+rm -f \
+    lib/DBDefs.pm \
+    root/static/build/{jed-*.source.js,server.js}

--- a/docker/templates/macros.m4
+++ b/docker/templates/macros.m4
@@ -36,12 +36,13 @@ m4_define(
     `m4_dnl
 install_javascript(`$1')
 
+copy_mb(``docker/scripts/compile_resources_for_image.sh docker/scripts/'')
 copy_mb(``root/ root/'')
 copy_mb(``script/compile_resources.sh script/dbdefs_to_js.pl script/start_renderer.pl script/xgettext.js script/'')
 copy_mb(``webpack/ webpack/'')
 
 ENV NODE_ENV production
-RUN sudo_mb(``carton exec -- ./script/compile_resources.sh client'')
+RUN sudo_mb(``./docker/scripts/compile_resources_for_image.sh'')
 RUN chown_mb(``/tmp/ttc'')')
 
 m4_define(


### PR DESCRIPTION
 * CSS is generated via webpack/server.config.mjs.
 * 8ef906fb40b4d2b8edc20e026e99229a574fc5c6 changed our image build steps so that server resources are no longer built.  The consequence is that CSS is no longer synced to the gateways.
 * 8ef906fb40b4d2b8edc20e026e99229a574fc5c6 is reverted and a script is added to run the server build with lib/DBDefs.pm.sample instead.