### PR TITLE
MBS-12563: Block smart links: strm.to

### DIFF
--- a/root/static/scripts/edit/utility/isShortenedUrl.js
+++ b/root/static/scripts/edit/utility/isShortenedUrl.js
@@ -92,6 +92,7 @@ const URL_SHORTENERS = [
   'spread.link',
   'streamerlinks.com',
   'streamlink.to',
+  'strm.to',
   'su.pr',
   't.co',
   'tiny.cc',


### PR DESCRIPTION
### Implement MBS-12563

Another Linkfire domain