### PR TITLE
MBS-12580 / MBS-12581 / MBS-12582: Convert cdstub/index to React

### DIFF
--- a/lib/MusicBrainz/Server/Controller/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/CDStub.pm
@@ -5,6 +5,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller'; }
 
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 
+use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::ControllerUtils::CDTOC qw( add_dash );
 
@@ -99,7 +100,18 @@ sub show : Chained('load') PathPart('')
 {
     my ($self, $c) = @_;
 
-    $c->stash( template => 'cdstub/index.tt' );
+    my $cdstub = $c->stash->{cdstub};
+
+    my %props = (
+        cdstub      => $cdstub->TO_JSON,
+        showArtists => boolean_to_json($c->stash->{show_artists}),
+    );
+
+    $c->stash(
+        current_view => 'Node',
+        component_path => 'cdstub/CDStubIndex.js',
+        component_props => \%props,
+    );
 }
 
 sub browse : Path('browse')

--- a/lib/MusicBrainz/Server/Entity/CDStub.pm
+++ b/lib/MusicBrainz/Server/Entity/CDStub.pm
@@ -125,11 +125,13 @@ around TO_JSON => sub {
     $json->{date_added} = datetime_to_iso8601($self->date_added);
     $json->{discid} = $self->discid;
     $json->{last_modified} = datetime_to_iso8601($self->last_modified);
+    $json->{leadout_offset} = 0 + $self->leadout_offset;
     $json->{lookup_count} = $self->lookup_count;
     $json->{modify_count} = $self->modify_count;
     $json->{title} = $self->title;
     $json->{toc} = $self->track_offset ? $self->toc : undef;
     $json->{track_count} = $self->track_count;
+    $json->{track_offset} = [map { 0 + $_ } @{ $self->track_offset }];
     $json->{tracks} = to_json_array($self->tracks);
 
     return $json;

--- a/lib/MusicBrainz/Server/Entity/CDStub.pm
+++ b/lib/MusicBrainz/Server/Entity/CDStub.pm
@@ -4,6 +4,7 @@ use Moose;
 use MusicBrainz::Server::Data::Utils qw( datetime_to_iso8601 );
 use MusicBrainz::Server::Entity::Barcode;
 use MusicBrainz::Server::Entity::Types;
+use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Types qw( DateTime );
 
 use namespace::autoclean;
@@ -129,6 +130,7 @@ around TO_JSON => sub {
     $json->{title} = $self->title;
     $json->{toc} = $self->track_offset ? $self->toc : undef;
     $json->{track_count} = $self->track_count;
+    $json->{tracks} = to_json_array($self->tracks);
 
     return $json;
 };

--- a/lib/MusicBrainz/Server/Entity/CDStubTrack.pm
+++ b/lib/MusicBrainz/Server/Entity/CDStubTrack.pm
@@ -35,6 +35,20 @@ has 'length' => (
     isa => 'Int'
 );
 
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $output = {
+        %{ $self->$orig },
+        artist          => $self->artist,
+        length          => 0 + $self->length,
+        sequence        => 0 + $self->sequence,
+        title           => $self->title,
+    };
+
+    return $output;
+};
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;

--- a/root/cdstub/CDStubHeader.js
+++ b/root/cdstub/CDStubHeader.js
@@ -1,0 +1,57 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Tabs from '../components/Tabs.js';
+import CDStubLink from '../static/scripts/common/components/CDStubLink.js';
+import SubHeader from '../components/SubHeader.js';
+
+type Props = {
+  +cdstub: CDStubT,
+  +page: string,
+};
+
+const CDStubHeader = ({
+  cdstub,
+  page,
+}: Props): React.Element<typeof React.Fragment> => {
+  const subHeading = exp.l(
+    'CD stub by {artist}',
+    {artist: cdstub.artist || l('Various Artists')},
+  );
+
+  return (
+    <>
+      <div className="blankheader">
+        <h1>
+          {cdstub.title}
+        </h1>
+        <SubHeader subHeading={subHeading} />
+      </div>
+      <Tabs>
+        <li className={page === 'index' ? 'sel' : ''} key="index">
+          <CDStubLink
+            cdstub={cdstub}
+            content={l('Overview')}
+          />
+        </li>
+        <li className={page === 'edit' ? 'sel' : ''} key="edit">
+          <CDStubLink
+            cdstub={cdstub}
+            content={l('Edit')}
+            subPath="edit"
+          />
+        </li>
+      </Tabs>
+    </>
+  );
+};
+
+export default CDStubHeader;

--- a/root/cdstub/CDStubIndex.js
+++ b/root/cdstub/CDStubIndex.js
@@ -1,0 +1,69 @@
+/*
+ * @flow
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import calculateFullToc
+  from '../static/scripts/common/utility/calculateFullToc.js';
+import formatTrackLength
+  from '../static/scripts/common/utility/formatTrackLength.js';
+
+import CDStubInfo from './CDStubInfo.js';
+import CDStubLayout from './CDStubLayout.js';
+
+type Props = {
+  +cdstub: CDStubT,
+  +showArtists: boolean,
+};
+
+const CDStubIndex = ({
+  cdstub,
+  showArtists,
+}: Props): React.Element<typeof CDStubLayout> => {
+  const totalLength = cdstub.tracks.reduce(
+    (length, track) => length + track.length,
+    0,
+  );
+
+  return (
+    <CDStubLayout entity={cdstub} page="index">
+      {nonEmpty(cdstub.comment) ? (
+        <>
+          <h2>{l('Comment')}</h2>
+          <p>{cdstub.comment}</p>
+        </>
+      ) : null}
+
+      <h2>{l('Tracklist')}</h2>
+      <CDStubInfo cdstub={cdstub} showArtists={showArtists} />
+
+      <h2>{l('Disc ID information')}</h2>
+      <table className="details">
+        <tr>
+          <th>{exp.l('{doc|Disc ID}:', {doc: '/doc/Disc_ID'})}</th>
+          <td><code>{cdstub.discid}</code></td>
+        </tr>
+        <tr>
+          <th>{l('Total tracks:')}</th>
+          <td>{cdstub.track_count}</td>
+        </tr>
+        <tr>
+          <th>{l('Total length:')}</th>
+          <td>{formatTrackLength(totalLength)}</td>
+        </tr>
+        <tr>
+          <th>{l('Full TOC:')}</th>
+          <td>{calculateFullToc(cdstub)}</td>
+        </tr>
+      </table>
+    </CDStubLayout>
+  );
+};
+
+export default CDStubIndex;

--- a/root/cdstub/CDStubInfo.js
+++ b/root/cdstub/CDStubInfo.js
@@ -1,0 +1,47 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import formatTrackLength
+  from '../static/scripts/common/utility/formatTrackLength.js';
+import loopParity from '../utility/loopParity.js';
+
+type Props = {
+  +cdstub: CDStubT,
+  +showArtists?: boolean,
+};
+
+const CDStubInfo = ({
+  cdstub,
+  showArtists = false,
+}: Props): React.Element<'table'> => (
+  <table className="tbl">
+    <thead>
+      <tr>
+        <th className="pos t">{l('#')}</th>
+        <th>{l('Title')}</th>
+        {showArtists ? <th>{l('Artist')}</th> : null}
+        <th className="treleases">{l('Length')}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {cdstub.tracks.map((track, index) => (
+        <tr className={loopParity(index)} key={index}>
+          <td>{track.sequence}</td>
+          <td>{track.title}</td>
+          {showArtists ? <td>{track.artist}</td> : null}
+          <td>{formatTrackLength(track.length)}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default CDStubInfo;

--- a/root/cdstub/CDStubLayout.js
+++ b/root/cdstub/CDStubLayout.js
@@ -1,0 +1,49 @@
+/*
+ * @flow strict-local
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import Layout from '../layout/index.js';
+import CDStubSidebar from '../layout/components/sidebar/CDStubSidebar.js';
+
+import CDStubHeader from './CDStubHeader.js';
+
+type Props = {
+  +children: React.Node,
+  +entity: CDStubT,
+  +fullWidth?: boolean,
+  +page: string,
+};
+
+const CDStubLayout = ({
+  children,
+  entity: cdstub,
+  fullWidth = false,
+  page,
+}: Props): React.Element<typeof Layout> => {
+  const title = texp.l(
+    'CD stub “{title}” by {artist}',
+    {
+      artist: cdstub.artist || l('Various Artists'),
+      title: cdstub.title,
+    },
+  );
+
+  return (
+    <Layout title={title}>
+      <div id="content">
+        <CDStubHeader cdstub={cdstub} page={page} />
+        {children}
+      </div>
+      {fullWidth ? null : <CDStubSidebar cdstub={cdstub} />}
+    </Layout>
+  );
+};
+
+export default CDStubLayout;

--- a/root/cdtoc/CDTocInfo.js
+++ b/root/cdtoc/CDTocInfo.js
@@ -9,17 +9,14 @@
 
 import * as React from 'react';
 
+import calculateFullToc
+  from '../static/scripts/common/utility/calculateFullToc.js';
 import formatTrackLength
   from '../static/scripts/common/utility/formatTrackLength.js';
 
 type Props = {
   +cdToc: CDTocT,
 };
-
-function calculateFullToc(cdtoc: CDTocT) {
-  const trackOffsets = cdtoc.track_offset.join(' ');
-  return `1 ${cdtoc.track_count} ${cdtoc.leadout_offset} ${trackOffsets}`;
-}
 
 const CDTocInfo = ({cdToc}: Props): React.Element<typeof React.Fragment> => (
   <>

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -81,6 +81,7 @@ export default {
   'artist/SpecialPurpose': (): Promise<mixed> => import('../artist/SpecialPurpose.js'),
   'artist_credit/ArtistCreditIndex': (): Promise<mixed> => import('../artist_credit/ArtistCreditIndex.js'),
   'artist_credit/EntityList': (): Promise<mixed> => import('../artist_credit/EntityList.js'),
+  'cdstub/CDStubIndex': (): Promise<mixed> => import('../cdstub/CDStubIndex.js'),
   'cdtoc/AttachCDTocConfirmation': (): Promise<mixed> => import('../cdtoc/AttachCDTocConfirmation.js'),
   'cdtoc/RemoveDiscId': (): Promise<mixed> => import('../cdtoc/RemoveDiscId.js'),
   'cdtoc/SetTracklistDurations': (): Promise<mixed> => import('../cdtoc/SetTracklistDurations.js'),

--- a/root/static/scripts/common/utility/calculateFullToc.js
+++ b/root/static/scripts/common/utility/calculateFullToc.js
@@ -1,0 +1,13 @@
+/*
+ * @flow strict
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function calculateFullToc(cdtoc: CDTocT): string {
+  const trackOffsets = cdtoc.track_offset.join(' ');
+  return `1 ${cdtoc.track_count} ${cdtoc.leadout_offset} ${trackOffsets}`;
+}

--- a/root/static/scripts/common/utility/calculateFullToc.js
+++ b/root/static/scripts/common/utility/calculateFullToc.js
@@ -7,7 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-export default function calculateFullToc(cdtoc: CDTocT): string {
+export default function calculateFullToc(cdtoc: CDStubT | CDTocT): string {
   const trackOffsets = cdtoc.track_offset.join(' ');
   return `1 ${cdtoc.track_count} ${cdtoc.leadout_offset} ${trackOffsets}`;
 }

--- a/root/types/cdstub.js
+++ b/root/types/cdstub.js
@@ -21,4 +21,12 @@ declare type CDStubT = $ReadOnly<{
   +title: string,
   +toc: string | null,
   +track_count: number,
+  +tracks: $ReadOnlyArray<CDStubTrackT>,
+}>;
+
+declare type CDStubTrackT = $ReadOnly<{
+  +artist: string,
+  +length: number,
+  +sequence: number,
+  +title: string,
 }>;

--- a/root/types/cdstub.js
+++ b/root/types/cdstub.js
@@ -12,15 +12,18 @@ declare type CDStubT = $ReadOnly<{
   ...EntityRoleT<'cdstub'>,
   +artist: string,
   +barcode: string,
+  +comment?: string,
   // null properties are not present in search indexes
   +date_added: string | null,
   +discid: string,
   +last_modified: string | null,
+  +leadout_offset: number,
   +lookup_count: number | null,
   +modify_count: number | null,
   +title: string,
   +toc: string | null,
   +track_count: number,
+  +track_offset: $ReadOnlyArray<number>,
   +tracks: $ReadOnlyArray<CDStubTrackT>,
 }>;
 


### PR DESCRIPTION
### Implement MBS-12580 / MBS-12581 / MBS-12582

On top of my CD TOC work from https://github.com/metabrainz/musicbrainz-server/pull/2627 since it uses a shared function.

Tested manually with /cdstub/BjDm_3hGVComa8hVLX_zXF6fWb0- (single artist) and /cdstub/90F2R5UAcfzzrD7u4TuEdvQU2SA- (VA)