### PR TITLE
MBS-12586: Adapt Brahms/IRCAM cleanup to new link style

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1319,7 +1319,7 @@ const CLEANUPS: CleanupEntries = {
     match: [new RegExp('^(https?://)?brahms\\.ircam\\.fr/', 'i')],
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
-      return url.replace(/^(?:https?:\/\/)?brahms\.ircam\.fr\/((works\/work)(?:\/)([0-9]+)|(?!works)[^?\/#]+).*$/, 'http://brahms.ircam.fr/$1');
+      return url.replace(/^(?:https?:\/\/)?brahms\.ircam\.fr\/(?:(?:en|fr)\/)?((works\/work)(?:\/)([0-9]+)|(?!works)[^?\/#]+).*$/, 'http://brahms.ircam.fr/$1');
     },
     validate: function (url, id) {
       const m = /^(?:https?:\/\/)?brahms\.ircam\.fr\/(works\/work|(?!works)[^?\/#]+).*$/.exec(url);

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1169,6 +1169,13 @@ limited_link_type_combinations: [
        only_valid_entity_types: ['artist'],
   },
   {
+                     input_url: 'https://brahms.ircam.fr/fr/anders-hillborg',
+             input_entity_type: 'artist',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://brahms.ircam.fr/anders-hillborg',
+       only_valid_entity_types: ['artist'],
+  },
+  {
                      input_url: 'http://brahms.ircam.fr/works/work/6385/',
              input_entity_type: 'work',
     expected_relationship_type: 'otherdatabases',


### PR DESCRIPTION
### Implement MBS-12586

These now include a language code in the subpath (en/ or fr/). The previous version without the code redirects, and seems preferable to me, so I'm just adapting the clean up to accept and strip the code.