### PR TITLE
MBS-12588: Escape user-provided disc ID in regex

### DIFF
--- a/lib/MusicBrainz/Server/ControllerUtils/CDTOC.pm
+++ b/lib/MusicBrainz/Server/ControllerUtils/CDTOC.pm
@@ -11,7 +11,7 @@ sub add_dash
    my ($c, $discid) = @_;
 
    if (substr($discid,length($discid)-1,1) ne '-') {
-       my $redir = $c->relative_uri =~ s/$discid/$discid-/r;
+       my $redir = $c->relative_uri =~ s/\Q$discid\E/$discid-/r;
        $c->response->redirect($redir);
        $c->detach;
    }


### PR DESCRIPTION
### Fix MBS-12588

Solution suggested by @mwiencek. See the docs: https://perldoc.perl.org/perlrebackslash#All-the-sequences-and-escapes
