### PR TITLE
MBS-12589: Return if direct search query times out

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -61,6 +61,10 @@ sub search : Path('')
             $c->forward($form->field('method')->value eq 'direct' ? 'direct' : 'external');
         }
 
+        # $c->error may be set if an Internal Server Error occurs within the
+        # direct/external search methods, e.g. a database query timeout.
+        return if @{ $c->error };
+
         if ($type ne 'doc') {
             my $stash = $c->stash;
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12589

Return early if an existing Internal Server Error occurs within the direct/external search methods, instead of attempting to render the results page with an undef pager, triggering another error.

This also ensures a "Request Timed Out" page is shown to the user instead of "Internal Server Error" in cases where a statement timeout occurs, since it doesn't get confused by multiple errors in `$c->error`.