### PR TITLE
MBS-10861: Change time before auto-deletion to 48 hours

### DIFF
--- a/lib/MusicBrainz/Script/RemoveEmpty.pm
+++ b/lib/MusicBrainz/Script/RemoveEmpty.pm
@@ -84,7 +84,7 @@ sub run {
         "SELECT id
          FROM $entity T
          WHERE edits_pending = 0
-           AND (last_updated < now() - '1 day'::interval OR last_updated IS NULL)
+           AND (last_updated < now() - '2 day'::interval OR last_updated IS NULL)
            AND NOT (
                EXISTS (
                    SELECT 1

--- a/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -4,10 +4,10 @@ use Moose;
 =head1 DESCRIPTION
 
 This script process the rows of the table 'unreferenced_row_log' that have been
-inserted more than 7 days ago.
+inserted more than 2 days ago.
 
 This table weakly references rows (of other tables) that have been temporarily
-unreferenced but might be referenced again by an edit, hence the 7 days delay.
+unreferenced but might be referenced again by an edit, hence the 2 days delay.
 
 When processing an 'unreferenced_row_log' row, the script removes the weakly
 referenced row if it is still unreferenced by checking 'ref_count', and removes
@@ -51,7 +51,7 @@ sub run {
               SELECT table_name,
                      array_agg(row_id) AS row_ids
                 FROM unreferenced_row_log
-               WHERE inserted < now() - '7 day'::interval
+               WHERE inserted < now() - '2 day'::interval
             GROUP BY table_name
             SQL
     };
@@ -67,7 +67,7 @@ sub run {
         my $removed = 0;
 
         log_info {
-            sprintf 'Found %d %s row%s unreferenced for 7 or more days.',
+            sprintf 'Found %d %s row%s unreferenced for 2 or more days.',
                 $count, $table_name, ($count==1 ? '' : 's');
         };
 


### PR DESCRIPTION
### Implement MBS-10861

# Problem
Most entities get autoremoved in 24 hours, but merging them keeps them around for a minimum of 48 hours. As such, if you want to get rid of something as an autoeditor, it's very tempting to empty it and let it be autoremoved, while a merge would be preferable.

Additionally, it's not uncommon for people to add artists for their release or whatnot, get sidetracked, and find out they've been autoremoved by the time they try to finish the whole thing the next day. Or a relationship gets removed, and suddenly the entity is empty, and gets autoremoved before the editor can react (even if the editor who removed the relationship is nice and leaves a note!).

Relatedly, but on the other direction, we have had reports that incorrect artists are buggy because they do not get autoremoved. The reason is that the artist credits they were used in take 7 days to get removed, a lot longer than the 24 hours the artist itself will need once the AC is gone.

# Solution
This sets the `RemoveEmpty` time to 48 hours / 2 days, up from 1 day, giving users a bit more time to react to edits that would lead to autoremoval.
It also sets the `RemoveUnreferencedRows` time to 48 hours / 2 days, down from 7 days, which makes it more consistent and hopefully less confusing to users.

48 hours was chosen as this is the minimum time an open merge/remove edit needs to apply, so manual and automatic removals will be consistent.

# Testing
No specific testing done but the changes are trivial.