### PR TITLE
MBS-12623: Editor icon is too large

### DIFF
--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -66,7 +66,7 @@ const UserAccountLayout = ({
     {...layoutProps}
   >
     <h1>
-      <EditorLink avatarSize={31} editor={user} />
+      <EditorLink avatarSize={32} editor={user} />
     </h1>
     <UserAccountTabs page={page} user={user} />
     {children}

--- a/root/components/UserAccountLayout.js
+++ b/root/components/UserAccountLayout.js
@@ -66,7 +66,7 @@ const UserAccountLayout = ({
     {...layoutProps}
   >
     <h1>
-      <EditorLink avatarSize={54} editor={user} />
+      <EditorLink avatarSize={31} editor={user} />
     </h1>
     <UserAccountTabs page={page} user={user} />
     {children}


### PR DESCRIPTION
Making the editor icon match the size of the other entity icons, at least until we get avatar support.