### PR TITLE
MBS-12614: Better placement for Add collaborator button

### DIFF
--- a/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
+++ b/lib/MusicBrainz/Server/WebService/JSONSerializer.pm
@@ -129,10 +129,7 @@ sub autocomplete_editor {
     my ($self, $output, $pager) = @_;
 
     return encode_json([
-        (map +{
-            name => $_->name,
-            id => $_->id,
-        }, @$output),
+        (map { $_->TO_JSON } @$output),
         {
             pages => $pager->last_page,
             current => $pager->current_page

--- a/root/collection/types.js
+++ b/root/collection/types.js
@@ -7,19 +7,40 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import type {
+  StateT as AutocompleteStateT,
+} from '../static/scripts/common/components/Autocomplete2/types.js';
+
+export type CollaboratorFieldT = ReadOnlyCompoundFieldT<{
+  +id: ReadOnlyFieldT<?number>,
+  +name: ReadOnlyFieldT<string>,
+}>;
+
+export type WritableCollaboratorFieldT = CompoundFieldT<{
+  +id: FieldT<?number>,
+  +name: FieldT<string>,
+}>;
+
+export type CollaboratorStateT = $ReadOnly<{
+  ...CollaboratorFieldT,
+  +autocomplete: AutocompleteStateT<EditorT>,
+}>;
+
+export type WritableCollaboratorStateT = {
+  ...WritableCollaboratorFieldT,
+  autocomplete: AutocompleteStateT<EditorT>,
+};
+
+export type CollaboratorsStateT =
+  ReadOnlyRepeatableFieldT<CollaboratorStateT>;
+
+export type WritableCollaboratorsStateT =
+  RepeatableFieldT<WritableCollaboratorStateT>;
+
 export type CollectionEditFormT = FormT<{
-  +collaborators: ReadOnlyRepeatableFieldT<ReadOnlyCompoundFieldT<{
-    +id: ReadOnlyFieldT<number>,
-    +name: ReadOnlyFieldT<string>,
-  }>>,
+  +collaborators: ReadOnlyRepeatableFieldT<CollaboratorFieldT>,
   +description: ReadOnlyFieldT<string>,
   +name: ReadOnlyFieldT<string>,
   +public: ReadOnlyFieldT<boolean>,
   +type_id: ReadOnlyFieldT<number>,
 }>;
-
-export type CollaboratorStateT =
-  RepeatableFieldT<CompoundFieldT<{
-    +id: FieldT<number | null>,
-    +name: FieldT<string>,
-  }>>;

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -136,7 +136,7 @@ const CollectionEditForm = ({collectionTypes, form}: Props) => {
                     <FieldErrors field={collaborator.field.name} />
                   </div>
                 ))}
-                <div className="form-row-add">
+                <div className="form-row-add short">
                   <button
                     className="with-label add-item"
                     onClick={handleCollaboratorAdd}

--- a/root/static/scripts/collection/components/CollectionEditForm.js
+++ b/root/static/scripts/collection/components/CollectionEditForm.js
@@ -10,10 +10,24 @@
 import mutate from 'mutate-cow';
 import * as React from 'react';
 
-import type {CollaboratorStateT, CollectionEditFormT}
-  from '../../../../collection/types.js';
+import type {
+  CollaboratorFieldT,
+  CollaboratorsStateT,
+  CollaboratorStateT,
+  CollectionEditFormT,
+  WritableCollaboratorsStateT,
+} from '../../../../collection/types.js';
 import {SanitizedCatalystContext} from '../../../../context.mjs';
-import Autocomplete from '../../common/components/Autocomplete.js';
+import Autocomplete2, {
+  createInitialState as createInitialAutocompleteState,
+} from '../../common/components/Autocomplete2.js';
+import {
+  default as autocompleteReducer,
+} from '../../common/components/Autocomplete2/reducer.js';
+import type {
+  ActionT as AutocompleteActionT,
+  StateT as AutocompleteStateT,
+} from '../../common/components/Autocomplete2/types.js';
 import FieldErrors from '../../edit/components/FieldErrors.js';
 import FormLabel from '../../edit/components/FormLabel.js';
 import FormRow from '../../edit/components/FormRow.js';
@@ -22,50 +36,152 @@ import FormRowSelect from '../../edit/components/FormRowSelect.js';
 import FormRowTextArea from '../../edit/components/FormRowTextArea.js';
 import FormRowTextLong from '../../edit/components/FormRowTextLong.js';
 import FormSubmit from '../../edit/components/FormSubmit.js';
-import {pushCompoundField} from '../../edit/utility/pushField.js';
+import {
+  createCompoundFieldFromObject,
+} from '../../edit/utility/createField.js';
 
 type Props = {
   +collectionTypes: SelectOptionsT,
   +form: CollectionEditFormT,
 };
 
-const CollectionEditForm = ({collectionTypes, form}: Props) => {
-  const [collaborators, setCollaborators] =
-    React.useState(form.field.collaborators);
+type StateT = {
+  +collaborators: CollaboratorsStateT,
+};
 
-  function removeCollaborator(collaboratorIndex: number) {
-    setCollaborators(mutate<CollaboratorStateT, _>(collaborators, copy => {
-      copy.field.splice(collaboratorIndex, 1);
-    }));
-  }
+type ActionT =
+  | {+type: 'add-collaborator'}
+  | {+fieldId: number, +type: 'remove-collaborator'}
+  | {
+      +action: AutocompleteActionT<EditorT>,
+      +fieldId: number,
+      +type: 'update-collaborator',
+    };
 
-  function handleCollaboratorAdd() {
-    setCollaborators(mutate<CollaboratorStateT, _>(collaborators, copy => {
-      pushCompoundField(copy, {
+function createCollaboratorAutocompleteState(
+  collaborator: CollaboratorFieldT,
+): AutocompleteStateT<EditorT> {
+  const field = collaborator.field;
+  const name = field.name.value;
+  const id = field.id.value;
+
+  return createInitialAutocompleteState({
+    entityType: 'editor',
+    id: 'id-' + collaborator.html_name,
+    inputValue: name,
+    selectedItem: nonEmpty(id) ? {
+      entity: {
+        avatar: '',
+        deleted: false,
+        entityType: 'editor',
+        id,
+        is_limited: false,
+        name,
+        privileges: -1,
+      },
+      id,
+      name,
+      type: 'option',
+    } : null,
+  });
+}
+
+function addCollaborator(
+  collaborators: CollaboratorsStateT,
+): CollaboratorsStateT {
+  return mutate(
+    collaborators,
+    (copy: WritableCollaboratorsStateT) => {
+      const name = copy.html_name + '.' + String(++copy.last_index);
+      const field = createCompoundFieldFromObject(name, {
         id: null,
         name: '',
       });
-    }));
-  }
+      copy.field.push({
+        ...field,
+        autocomplete: createCollaboratorAutocompleteState(field),
+      });
+    },
+  );
+}
 
-  function handleCollaboratorChange(
-    newCollaborator: EditorT,
-    index: number,
-  ) {
-    setCollaborators(mutate<CollaboratorStateT, _>(collaborators, copy => {
-      copy.field[index].field.id.value = newCollaborator.id;
-      copy.field[index].field.name.value = newCollaborator.name;
-    }));
+function createInitialState(form: CollectionEditFormT): StateT {
+  const initialCollaborators = form.field.collaborators;
+  let collaborators: CollaboratorsStateT = {
+    ...initialCollaborators,
+    field: initialCollaborators.field.map((collaborator) => ({
+      ...collaborator,
+      autocomplete: createCollaboratorAutocompleteState(collaborator),
+    })),
+  };
+  if (collaborators.last_index === -1) {
+    collaborators = addCollaborator(collaborators);
   }
+  return {collaborators};
+}
 
+function reducer(state: StateT, action: ActionT): StateT {
+  let collaborators = state.collaborators;
+  switch (action.type) {
+    case 'add-collaborator': {
+      collaborators = addCollaborator(collaborators);
+      break;
+    }
+    case 'remove-collaborator': {
+      const index = collaborators.field.findIndex(
+        (collaborator) => collaborator.id === action.fieldId,
+      );
+      invariant(index >= 0);
+      collaborators = mutate(
+        collaborators,
+        (copy: WritableCollaboratorsStateT) => {
+          copy.field.splice(index, 1);
+        },
+      );
+      break;
+    }
+    case 'update-collaborator': {
+      const index = state.collaborators.field.findIndex(
+        (collaborator) => collaborator.id === action.fieldId,
+      );
+      invariant(index >= 0);
+      const oldAutocompleteState = collaborators.field[index].autocomplete;
+      const oldEditor = oldAutocompleteState.selectedItem?.entity;
+      collaborators = mutate(
+        collaborators,
+        (copy: WritableCollaboratorsStateT) => {
+          const newAutocompleteState = autocompleteReducer(
+            oldAutocompleteState,
+            action.action,
+          );
+          copy.field[index].autocomplete = newAutocompleteState;
+          const newEditor = newAutocompleteState.selectedItem?.entity;
+          if (newEditor !== oldEditor) {
+            let id = null;
+            let name = '';
+            if (newEditor) {
+              id = newEditor.id;
+              name = newEditor.name;
+            }
+            copy.field[index].field.id.value = id;
+            copy.field[index].field.name.value = name;
+          }
+        },
+      );
+      break;
+    }
+  }
+  return {collaborators};
+}
+
+const CollectionEditForm = ({
+  collectionTypes,
+  form,
+}: Props): React$MixedElement => {
   const typeOptions = {
     grouped: false,
     options: collectionTypes,
   };
-
-  if (collaborators.last_index === -1) {
-    handleCollaboratorAdd();
-  }
 
   return (
     <SanitizedCatalystContext.Consumer>
@@ -97,55 +213,10 @@ const CollectionEditForm = ({collectionTypes, form}: Props) => {
 
             <FormRow>
               <FormLabel
-                forField={collaborators}
+                forField={form.field.collaborators}
                 label={addColonText(l('Collaborators'))}
               />
-              <div className="form-row-text-list">
-                {collaborators.field.map((collaborator, index) => (
-                  <div
-                    className="text-list-row"
-                    id="collaborators-form-list"
-                    key={collaborator.html_name}
-                  >
-                    <Autocomplete
-                      currentSelection={{
-                        id: collaborator.field.id.value,
-                        name: collaborator.field.name.value,
-                      }}
-                      entity="editor"
-                      inputID={'id-' + collaborator.html_name}
-                      inputName={collaborator.field.name.html_name}
-                      onChange={(
-                        collaborator: EditorT,
-                      ) => handleCollaboratorChange(collaborator, index)}
-                    >
-                      <input
-                        name={collaborator.field.id.html_name}
-                        type="hidden"
-                        value={collaborator.field.id.value || ''}
-                      />
-                    </Autocomplete>
-                    <button
-                      className="nobutton icon remove-item"
-                      onClick={() => (removeCollaborator(index))}
-                      title={l('Remove collaborator')}
-                      type="button"
-                    />
-
-                    <FieldErrors field={collaborator.field.id} />
-                    <FieldErrors field={collaborator.field.name} />
-                  </div>
-                ))}
-                <div className="form-row-add short">
-                  <button
-                    className="with-label add-item"
-                    onClick={handleCollaboratorAdd}
-                    type="button"
-                  >
-                    {l('Add collaborator')}
-                  </button>
-                </div>
-              </div>
+              <CollaboratorsFormList form={form} />
             </FormRow>
           </fieldset>
 
@@ -162,7 +233,115 @@ const CollectionEditForm = ({collectionTypes, form}: Props) => {
   );
 };
 
-export default (hydrate<Props>(
-  'div.collection-edit-form',
-  CollectionEditForm,
-): React$AbstractComponent<Props, void>);
+type CollaboratorsFormListPropsT = {
+  +form: CollectionEditFormT,
+};
+
+const CollaboratorsFormList = (hydrate<CollaboratorsFormListPropsT>(
+  'div.collaborators-form-list',
+  React.memo(({
+    form,
+  }: CollaboratorsFormListPropsT) => {
+    const [state, dispatch] =
+      React.useReducer<StateT, ActionT, CollectionEditFormT>(
+        reducer,
+        form,
+        createInitialState,
+      );
+
+    const removeCollaborator = React.useCallback((
+      fieldId: number,
+    ): void => {
+      dispatch({fieldId, type: 'remove-collaborator'});
+    }, [dispatch]);
+
+    const addCollaborator = React.useCallback(() => {
+      dispatch({type: 'add-collaborator'});
+    }, [dispatch]);
+
+    const updateCollaborator = React.useCallback((
+      fieldId: number,
+      action: AutocompleteActionT<EditorT>,
+    ) => {
+      dispatch({action, fieldId, type: 'update-collaborator'});
+    }, [dispatch]);
+
+    return (
+      <div className="form-row-text-list">
+        {state.collaborators.field.map((collaborator) => (
+          <CollaboratorRow
+            collaborator={collaborator}
+            key={collaborator.id}
+            removeCollaborator={removeCollaborator}
+            updateCollaborator={updateCollaborator}
+          />
+        ))}
+        <div className="form-row-add short">
+          <button
+            className="with-label add-item"
+            onClick={addCollaborator}
+            type="button"
+          >
+            {l('Add collaborator')}
+          </button>
+        </div>
+      </div>
+    );
+  }),
+): React$AbstractComponent<CollaboratorsFormListPropsT, void>);
+
+type CollaboratorRowPropsT = {
+  +collaborator: CollaboratorStateT,
+  +removeCollaborator: (fieldId: number) => void,
+  +updateCollaborator: (
+    fieldId: number,
+    action: AutocompleteActionT<EditorT>,
+  ) => void,
+};
+
+const CollaboratorRow = React.memo(({
+  collaborator,
+  removeCollaborator,
+  updateCollaborator,
+}: CollaboratorRowPropsT) => {
+  const autocompleteDispatch = React.useCallback((
+    action: AutocompleteActionT<EditorT>,
+  ) => {
+    updateCollaborator(collaborator.id, action);
+  }, [updateCollaborator, collaborator.id]);
+
+  const field = collaborator.field;
+  const idField = field.id;
+  const nameField = field.name;
+
+  return (
+    <div className="text-list-row">
+      <Autocomplete2
+        dispatch={autocompleteDispatch}
+        state={collaborator.autocomplete}
+      >
+        <button
+          className="nobutton icon remove-item"
+          onClick={() => removeCollaborator(collaborator.id)}
+          style={{alignSelf: 'center'}}
+          title={l('Remove collaborator')}
+          type="button"
+        />
+        <input
+          name={idField.html_name}
+          type="hidden"
+          value={idField.value ?? ''}
+        />
+        <input
+          name={nameField.html_name}
+          type="hidden"
+          value={nameField.value}
+        />
+      </Autocomplete2>
+      <FieldErrors field={idField} />
+      <FieldErrors field={nameField} />
+    </div>
+  );
+});
+
+export default CollectionEditForm;

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -681,7 +681,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     };
   });
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const shouldUpdateScrollPosition = (
       (isOpen && !prevIsOpen.current) ||
       shouldUpdateScrollPositionRef.current

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -95,6 +95,8 @@ div.form-row-add {
     margin: (@form-margin / 2) 0;
 }
 
+div.form-row-add.short { width: @form-input-width-short; }
+
 /* these rows are missing a <label> on the left and use a margin instead. */
 div.form-row-add.nolabel { margin-left: @form-label-width + @form-margin; }
 

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -2,7 +2,7 @@
 @form-margin: 12px;
 @form-label-width: 150px;
 @form-input-width: @form-half-width - @form-label-width - (@form-margin * 3);
-@form-input-width-short: 220px;
+@form-input-width-short: 260px;
 @form-icon-size: 16px;
 @form-bubble-label-width: @form-label-width;
 @form-bubble-input-width: 176px;
@@ -173,7 +173,10 @@ form div.no-margin {
     margin-left: 0;
 }
 
-#collaborators-form-list ul.errors { margin-left: 0; }
+.collaborators-form-list {
+    div.autocomplete2 { width: @form-input-width-short; }
+    ul.errors { margin-left: 0; }
+}
 
 .select-list-row ul.errors {
     margin-left: 0;

--- a/t/lib/t/MusicBrainz/Server/Data/Collection.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Collection.pm
@@ -166,9 +166,12 @@ is($hits, 2, 'Editor #1 is still subscribed to now private collection they colla
 
 # Checking for subscription changes when collaborator is removed
 $mech->get_ok('/collection/f34c079d-374e-4436-9448-da92dedef3cb/own_collection/edit');
-$mech->form_number(2);
-$mech->field('edit-list.collaborators.0.id', '');
-$mech->click();
+$mech->submit_form_ok({
+   with_fields => {
+      'edit-list.collaborators.0.id' => '',
+      'edit-list.collaborators.0.name' => '',
+   },
+}, 'The form returned a 2xx response code');
 
 my $tx = test_xpath_html($mech->content);
 $tx->is('//div[@id="content"]/div[@class="collaborators"]/p/a', '',


### PR DESCRIPTION
### Implement MBS-12614

The autocomplete input is very short, so it doesn't make sense for `form-row-add` to use a full standard `form-input-width` here. Since we already have `form-input-width-short` which fits better, I'm just adding a `form-row-add.short` combo to match.

![image](https://user-images.githubusercontent.com/1056556/197204221-b25bba36-8222-4e42-97ca-6be78fe01977.png)
