### PR TITLE
MBS-12628: Hide phrases for unselectable reltypes in inline search

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -264,19 +264,20 @@ function formatLinkType(linkType: LinkTypeT) {
   const description = stripHtml(linkType.l_description);
   const linkPhrase = linkType.l_link_phrase;
   const reverseLinkPhrase = linkType.l_reverse_link_phrase;
+  const isGroupingType = !nonEmpty(description);
 
   return (
     <>
       {linkType.l_name}
-      {nonEmpty(linkPhrase) ? showExtraInfoLine(
+      {nonEmpty(linkPhrase) && !isGroupingType ? showExtraInfoLine(
         l('Forward link phrase:') + ' ' + linkPhrase,
         'comment',
       ) : null}
-      {nonEmpty(reverseLinkPhrase) ? showExtraInfoLine(
+      {nonEmpty(reverseLinkPhrase) && !isGroupingType ? showExtraInfoLine(
         l('Reverse link phrase:') + ' ' + reverseLinkPhrase,
         'comment',
       ) : null}
-      {nonEmpty(description) ? showExtraInfoLine(description) : null}
+      {isGroupingType ? null : showExtraInfoLine(description)}
     </>
   );
 }


### PR DESCRIPTION
### Implement MBS-12628

No description means a relationship type is a grouping one that cannot be selected and only helps organize the tree. As such, it's useless to display the link phrases for these, since they're not meant to be selected. The phrases are also usually effectively placeholders since they never get used anyway.