### PR TITLE
MBS-12597: Set min size for relationship editor works column

### DIFF
--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -156,3 +156,9 @@ div.relationship-editor, div.release-relationship-editor {
         border-bottom: 1px @dark-grey dotted;
     }
 }
+
+div.release-relationship-editor {
+    td.recording, td.works {
+        width: 50%;
+    }
+}


### PR DESCRIPTION
I couldn't find a way to allow the recording side to expand more if needed while defaulting to 50/50.  Setting them to 60/40 just made the recordings always use 60%, even if there were more work relationships. Making them always equal at least makes the positions of the UI elements more consistent.