### PR TITLE
MBS-12598: In relationship editor, open track ACs in new tab

### DIFF
--- a/root/static/scripts/common/components/DescriptiveLink.js
+++ b/root/static/scripts/common/components/DescriptiveLink.js
@@ -47,6 +47,7 @@ const DescriptiveLink = ({
     showDisambiguation,
     showEditsPending,
     showIcon,
+    target,
   };
 
   const props = {

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -10,8 +10,8 @@
 import * as React from 'react';
 import * as tree from 'weight-balanced-tree';
 
-import ArtistCreditLink from '../../common/components/ArtistCreditLink.js';
 import ButtonPopover from '../../common/components/ButtonPopover.js';
+import DescriptiveLink from '../../common/components/DescriptiveLink.js';
 import EntityLink from '../../common/components/EntityLink.js';
 import {RECORDING_OF_LINK_TYPE_ID} from '../../common/constants.js';
 import {createWorkObject} from '../../common/entity2.js';
@@ -46,21 +46,25 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
   showArtists,
   track,
 }) => {
-  let trackLink: Expand2ReactOutput = (
-    <EntityLink
-      content={track.name}
-      entity={track.recording}
-      target="_blank"
-    />
-  );
-
+  let trackLink: Expand2ReactOutput;
   if (showArtists) {
-    trackLink = exp.l('{entity} by {artist}', {
-      artist: <ArtistCreditLink artistCredit={track.artistCredit} />,
-      entity: trackLink,
-    });
+    trackLink = (
+      <DescriptiveLink
+        content={track.name}
+        customArtistCredit={track.artistCredit}
+        entity={track.recording}
+        target="_blank"
+      />
+    );
+  } else {
+    trackLink = (
+      <EntityLink
+        content={track.name}
+        entity={track.recording}
+        target="_blank"
+      />
+    );
   }
-
   return (
     <>
       {trackLink}

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -53,6 +53,7 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
         content={track.name}
         customArtistCredit={track.artistCredit}
         entity={track.recording}
+        showDisambiguation={false}
         target="_blank"
       />
     );
@@ -61,6 +62,7 @@ const TrackLink = React.memo<TrackLinkPropsT>(({
       <EntityLink
         content={track.name}
         entity={track.recording}
+        showDisambiguation={false}
         target="_blank"
       />
     );


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12598

I added 'target' to the list of shared props in DescriptiveLink, so that setting target="_blank" also applies it to any artist credit links. Then I changed the relationship editor's TrackLink component to make use of DescriptiveLink instead of re-implementing the artist credit display on top of EntityLink.