### PR TITLE
MBS-12612: Default showDisambiguation to false in ArtistCreditLink

### DIFF
--- a/root/static/scripts/common/components/ArtistCreditLink.js
+++ b/root/static/scripts/common/components/ArtistCreditLink.js
@@ -72,7 +72,7 @@ export const MpIcon = (hydrate<MpIconProps>('span.ac-mp', (
 const ArtistCreditLink = ({
   artistCredit,
   showDeleted = true,
-  showDisambiguation = true,
+  showDisambiguation = false,
   showEditsPending = true,
   showIcon = false,
   ...props


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12612

As far as I can tell, this was the behavior prior to 536a5e89c47f494a48e33eb0ecfede5797240300