### PR TITLE
MBS-12604: Autocomplete2: Show '[No lyrics]' for work language

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -533,7 +533,7 @@ export default function formatItem<+T: EntityItemT>(
           return formatWork(entity);
 
         default:
-          return formatName(entity);
+          return unwrapNl<string>(item.name);
       }
     }
   }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12604

It seems in the relationship editor at least we already set the autocomplete's work language item name appropriately, but we aren't using the item name for the generic formatter (skipping it for the non-customized entity name -- `item.entity.name`, where `item.entity` is the `LanguageT`, vs. `item.name`).  Since the item name should be set to the entity name anyway if it has no other changes, I can't see any reason to not always use the item name here.