### PR TITLE
MBS-12610: Discard selected link type name when changing entity type

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -241,7 +241,11 @@ function updateDialogStateForTargetTypeChange(
     ...oldLinkTypeAutocompleteState,
     inputValue: onlyLinkType
       ? onlyLinkType.name
-      : oldLinkTypeAutocompleteState.inputValue,
+      : (
+        oldLinkTypeAutocompleteState.selectedItem
+          ? ''
+          : oldLinkTypeAutocompleteState.inputValue
+      ),
     recentItems: null,
     recentItemsKey: 'link_type-' + sourceType + '-' + newTargetType,
     results: newLinkTypeOptions,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12610

When changing the target entity type in the relationship editor dialog, discard the link type name if it belonged to a selection.  If there wasn't a selection, assume it may have been user-entered and preserve it.