### PR TITLE
MBS-12611: Fix medium table heading alignment

### DIFF
--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -696,7 +696,8 @@ table.tbl {
         background: data-uri('../images/layout/table-header.gif') repeat-x 0 50%;
     }
 
-    > thead th {
+    /* Should not apply to nested tables. */
+    > thead th, > tbody > tr > th {
         font-size: @small-text;
         padding: 0.2em 0.4em;
         text-align: left;


### PR DESCRIPTION
88a1a97b0709233f1919a217fc33a7fa381a98dc changed the medium table header styling to not apply to sub-tables (like `.rel-editor-table`).  However it ignored that there may be `<th>` elements under `<tbody>`, not just `<thead>`. While I don't like using the `>` selector liberally, this might be the simplest way to get the previous behavior.