### PR TITLE
MBS-12615: Fix compactEntityJson for other-document data

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -16,6 +16,7 @@ import linkedEntities from '../../common/linkedEntities.mjs';
 import bracketed from '../../common/utility/bracketed.js';
 import clean from '../../common/utility/clean.js';
 import {uniqueId} from '../../common/utility/numbers.js';
+import {kebabCase} from '../../common/utility/strings.js';
 import type {
   DialogAttributesStateT,
   DialogAttributesT,
@@ -392,7 +393,11 @@ const DialogAttributes = (React.memo<PropsT>(({
 
           return (
             <div
-              className={'attribute-container ' + attribute.control}
+              className={
+                'attribute-container ' +
+                attribute.control + ' ' +
+                kebabCase(attribute.type.name)
+              }
               key={attribute.key}
             >
               {attributeElement}

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -666,6 +666,10 @@ const seleniumTests = [
     login: true,
   },
   {
+    name: 'Artist_Edit_Form.json5',
+    login: true,
+  },
+  {
     name: 'Genre_Edit_Form.json5',
     login: true,
   },

--- a/t/selenium/Artist_Edit_Form.json5
+++ b/t/selenium/Artist_Edit_Form.json5
@@ -1,0 +1,306 @@
+{
+  title: 'Artist Edit Form',
+  commands: [
+    {
+      command: 'open',
+      target: '/artist/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-artist.name',
+      value: 'new artist',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-artist.sort_name',
+      value: 'artist, new',
+    },
+    {
+      command: 'select',
+      target: 'id=id-edit-artist.type_id',
+      value: 'label=Group',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: 'group member',
+    },
+    {
+      command: 'pause',
+      target: '2000',
+      value: '',
+    },
+    {
+      command: 'mouseOver',
+      target: 'xpath=//div[@id="add-relationship-dialog"]//div[contains(@class, "relationship-target")]//ul/li[contains(@class, "action-item")][contains(., "Add a new artist")]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//div[@id="add-relationship-dialog"]//div[contains(@class, "relationship-target")]//ul/li[contains(@class, "action-item")][contains(., "Add a new artist")]',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '2000',
+      value: '',
+    },
+    // Can only access the iframe document through JavaScript.
+    {
+      command: 'runScript',
+      target: 'document.querySelector("#add-artist-dialog iframe").contentDocument.querySelector("button.sortname-copy").click();',
+      value: '',
+    },
+    {
+      command: 'runScript',
+      target: 'document.querySelector("#add-artist-dialog iframe").contentDocument.getElementById("id-edit-artist.type_id").value = 1;',
+      value: '',
+    },
+    {
+      command: 'runScript',
+      target: 'document.querySelector("#add-artist-dialog iframe").contentDocument.querySelector("form.edit-artist button.submit.positive").click();',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '3000',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 1,
+        status: 2,
+        data: {
+          area_id: null,
+          begin_area_id: null,
+          begin_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          comment: '',
+          end_area_id: null,
+          end_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          ended: 0,
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 3,
+          gender_id: null,
+          ipi_codes: [],
+          isni_codes: [],
+          name: 'group member',
+          sort_name: 'group member',
+          type_id: 1,
+        },
+      },
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'member${KEY_ENTER}',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog .attribute-container.multiselect.instrument > .multiselect-value:nth-child(1) input[aria-autocomplete]',
+      value: 'guitar${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog .attribute-container.multiselect.instrument button.add-item',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog .attribute-container.multiselect.instrument > .multiselect-value:nth-child(2) input[aria-autocomplete]',
+      value: 'lyre${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.change-direction',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.positive',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#external-link-0 input[type=url]',
+      value: 'https://newartist.bandcamp.com',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-artist button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 1,
+        status: 2,
+        data: {
+          area_id: null,
+          begin_area_id: null,
+          begin_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          comment: '',
+          end_area_id: null,
+          end_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          ended: 0,
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 4,
+          gender_id: null,
+          ipi_codes: [],
+          isni_codes: [],
+          name: 'new artist',
+          sort_name: 'artist, new',
+          type_id: 2,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 3,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '$$__IGNORE__$$',
+            id: 4,
+            name: 'new artist',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: 'https://newartist.bandcamp.com/',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 718,
+            link_phrase: 'Bandcamp',
+            long_link_phrase: 'has Bandcamp page at',
+            name: 'bandcamp',
+            reverse_link_phrase: 'Bandcamp page for',
+          },
+          type0: 'artist',
+          type1: 'url',
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 4,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          attributes: [
+            {
+              type: {
+                gid: 'f68936f2-194c-4bcd-94a9-81e1dd947b8d',
+                id: 75,
+                name: 'guitars',
+                root: {
+                  gid: '0abd7f04-5e28-425b-956f-94789d9bcbe2',
+                  id: 14,
+                  name: 'instrument',
+                },
+              },
+            },
+          ],
+          edit_version: 2,
+          ended: '0',
+          entity0: {
+            gid: '$$__IGNORE__$$',
+            id: 3,
+            name: 'group member',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 4,
+            name: 'new artist',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 103,
+            link_phrase: '{additional} {founder:founding} member of',
+            long_link_phrase: 'is/was {additional:an additional|a} member of {founder:and founded|}',
+            name: 'member of band',
+            reverse_link_phrase: '{additional} {founder:founding} members',
+          },
+          type0: 'artist',
+          type1: 'artist',
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 5,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          attributes: [
+            {
+              type: {
+                gid: '21bd4d63-a75a-4022-abd3-52ba7487c2de',
+                id: 109,
+                name: 'lyre',
+                root: {
+                  gid: '0abd7f04-5e28-425b-956f-94789d9bcbe2',
+                  id: 14,
+                  name: 'instrument',
+                },
+              },
+            },
+          ],
+          edit_version: 2,
+          ended: '0',
+          entity0: {
+            gid: '$$__IGNORE__$$',
+            id: 3,
+            name: 'group member',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 4,
+            name: 'new artist',
+          },
+          entity_id: 2,
+          link_type: {
+            id: 103,
+            link_phrase: '{additional} {founder:founding} member of',
+            long_link_phrase: 'is/was {additional:an additional|a} member of {founder:and founded|}',
+            name: 'member of band',
+            reverse_link_phrase: '{additional} {founder:founding} members',
+          },
+          type0: 'artist',
+          type1: 'artist',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12615

`compactEntityJson` is used to minify the relationship editor state before putting it into sessionStorage during submission.

If you create a new entity from an autocomplete search, the returned entity object's constructor will be from a different document (the iframe), so we can't compare it by reference to our `Object`.  To determine if something is a plain object, we need another way.  The simplest is to check if the constructor function converted to a string matches our `Object` converted to a string.