### PR TITLE
MBS-12616: Fix crash in relationship dialog searching for release

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -147,7 +147,10 @@ export function generateItems<+T: EntityItemT>(
       } else {
         items.push(MENU_ITEMS.TRY_AGAIN_INDEXED);
       }
-      if (determineIfUserCanAddEntities(state)) {
+      if (
+        determineIfUserCanAddEntities(state) &&
+        typeof ADD_NEW_ENTITY_TITLES[state.entityType] === 'function'
+      ) {
         items.push({
           action: OPEN_ADD_ENTITY_DIALOG,
           id: 'add-new-entity',
@@ -176,6 +179,7 @@ export function determineIfUserCanAddEntities<+T: EntityItemT>(
     case 'genre':
     case 'link_type':
     case 'link_attribute_type':
+    case 'release':
       return false;
     case 'instrument':
       return isRelationshipEditor(user);

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -275,7 +275,7 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
             buildChildren={buildPopoverContent}
             buttonContent={addAnotherEntityLabels[targetType]()}
             buttonProps={{
-              className: 'add-item with-label',
+              className: 'add-item with-label add-another-entity',
             }}
             buttonRef={addButtonRef}
             className="relationship-dialog"

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -92,7 +92,7 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
               buildChildren={buildPopoverContent}
               buttonContent={l('Add relationship')}
               buttonProps={{
-                className: 'add-item with-label',
+                className: 'add-item with-label add-relationship',
               }}
               buttonRef={addButtonRef}
               className="relationship-dialog"

--- a/t/selenium/Release_Relationship_Editor.json5
+++ b/t/selenium/Release_Relationship_Editor.json5
@@ -1739,5 +1739,84 @@
       },
     },
     // End of test for MBS-12606.
+    // MBS-12616: Searching for a release crashes the relationship dialog.
+    {
+      command: 'open',
+      target: '/release/868cc741-e3bc-31bc-9dac-756e35c8f152/edit-relationships',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#release-rels .rel-editor-table button.add-relationship',
+      value: '',
+    },
+    {
+      command: 'select',
+      target: 'css=#add-relationship-dialog select.entity-type',
+      value: 'label=Release',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: 'Demons',
+    },
+    {
+      command: 'pause',
+      target: '1500',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//div[contains(@class, "relationship-target")]/ul/li[contains(descendant::text(), "Demons")]',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'supporting${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=#relationship-editor-form button.positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 28,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '868cc741-e3bc-31bc-9dac-756e35c8f152',
+            id: 249113,
+            name: 'Vision Creation Newsun',
+          },
+          entity1: {
+            gid: 'dd245091-b21e-48a3-b59a-f9b8ed8a0469',
+            id: 26,
+            name: 'Demons',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 3,
+            link_phrase: 'released in support of',
+            long_link_phrase: 'was released in support of',
+            name: 'supporting release',
+            reverse_link_phrase: 'supporting releases',
+          },
+          type0: 'release',
+          type1: 'release',
+        },
+      },
+    },
+    // End of test for MBS-12616.
   ],
 }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12616

The issue here was it trying to execute `ADD_NEW_ENTITY_TITLES.release()`, which doesn't exist.  I've made it check that that's a function first, and additionally changed `determineIfUserCanAddEntities` to always return `false` for releases.