### PR TITLE
MBS-12620: Autocomplete2: "Show more" missing

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -71,12 +71,14 @@ function doSearch<T: EntityItemT>(
     }
 
     const entities = JSON.parse(searchXhr.responseText);
-    const pager = entities.pop();
+    const pager: {+current: StrOrNum, +pages: StrOrNum} = entities.pop();
     const newPage = parseInt(pager.current, 10);
+    const totalPages = parseInt(pager.pages, 10);
 
     dispatch({
       entities,
       page: newPage,
+      totalPages,
       type: 'show-ws-results',
     });
   });
@@ -198,6 +200,7 @@ export function createInitialState<+T: EntityItemT>(
     staticItems,
     staticItemsFilter,
     statusMessage: '',
+    totalPages: null,
     ...restProps,
   };
 

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -122,7 +122,8 @@ export function generateItems<+T: EntityItemT>(
 
     if (resultCount > 0) {
       const visibleResults = Math.min(resultCount, page * PAGE_SIZE);
-      const totalPages = Math.ceil(resultCount / PAGE_SIZE);
+      const totalPages = state.totalPages ??
+        Math.ceil(resultCount / PAGE_SIZE);
 
       if (showingRecentItems) {
         items.push({...results[0], separator: true});
@@ -284,6 +285,7 @@ export function resetPage<+T: EntityItemT>(
   state.highlightedIndex = -1;
   state.isOpen = false;
   state.page = 1;
+  state.totalPages = null;
   state.error = 0;
 }
 
@@ -460,7 +462,7 @@ export function runReducer<+T: EntityItemT>(
     }
 
     case 'show-ws-results': {
-      const {entities, page} = action;
+      const {entities, page, totalPages} = action;
 
       let newResults: Array<ItemT<T>> = entities.map((entity: T) => ({
         entity,
@@ -476,14 +478,20 @@ export function runReducer<+T: EntityItemT>(
         newResults = prevResults.concat(
           newResults.filter(x => !prevIds.has(x.id)),
         );
+        /*
+         * Keep the previous `highlightedIndex` position here (most likely
+         * where "Show more" was clicked).
+         */
+      } else {
+        state.highlightedIndex = 0;
       }
 
       state.results = newResults;
       state.isOpen = true;
       state.page = page;
+      state.totalPages = totalPages;
       state.pendingSearch = null;
       state.error = 0;
-      state.highlightedIndex = 0;
 
       updateItems = true;
       updateStatusMessage = true;

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -41,6 +41,7 @@ export type StateT<T: EntityItemT> = {
   +staticItems?: $ReadOnlyArray<ItemT<T>>,
   +staticItemsFilter?: (ItemT<T>, string) => boolean,
   +statusMessage: string,
+  +totalPages: ?number,
   +width?: string,
 };
 
@@ -74,6 +75,7 @@ export type ActionT<+T: EntityItemT> =
       +type: 'show-ws-results',
       +entities: $ReadOnlyArray<T>,
       +page: number,
+      +totalPages: number,
     }
   | { +type: 'show-lookup-error' }
   | { +type: 'show-lookup-type-error' }


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12620

Previously we weren't using the returned number of pages in the results. I also fixed a minor issue where the highlighted index isn't preserved after clicking "Show more."