### PR TITLE
MBS-12636: Do not remove unreferenced ACs with pending edits

### DIFF
--- a/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -105,8 +105,7 @@ sub run {
                         # skip it. Log a message in case the info is useful
                         # for debugging purposes later.
                         log_info {
-                            sprintf "Did not find id=%s in $table_name, skipping.",
-                            $id,
+                            "Did not find id=$id in $table_name, skipping.",
                         };
                     } else {
 
@@ -118,8 +117,7 @@ sub run {
 
                         if (defined $edits_pending && $edits_pending > 0) {
                             log_info {
-                                sprintf "id=%s from $table_name has pending edits, skipping.",
-                                $id,
+                                "id=$id from $table_name has pending edits, skipping.",
                             };
                             return;
                         }
@@ -128,10 +126,7 @@ sub run {
                         my $ref_count = $row->{ref_count};
 
                         if ($ref_count == 0) {
-                            log_info {
-                                sprintf "Will remove id=%s from $table_name.",
-                                $id,
-                            };
+                            log_info {"Will remove id=$id from $table_name."};
 
                             unless ($self->dry_run) {
                                 if ($table_name eq 'artist_credit') {
@@ -150,8 +145,7 @@ sub run {
                             }
                         } else {
                             log_info {
-                                sprintf "Found references for id=%s from $table_name.",
-                                $id,
+                                "Found references for id=$id from $table_name.",
                             };
                         }
                     }

--- a/t/sql/artistcredit.sql
+++ b/t/sql/artistcredit.sql
@@ -23,3 +23,6 @@ INSERT INTO recording (id, gid, name, artist_credit)
 
 INSERT INTO release_group (id, gid, name, artist_credit, type)
     VALUES (1, 'bdaeec2d-94f1-46b5-91f3-340ec6939c66', 'Under Pressure', 1, 2);
+
+INSERT INTO editor (id, name, password, email, privs, ha1, email_confirm_date)
+VALUES (1, 'boring_editor', '{CLEARTEXT}pass', 'boring_editor@example.com', 0, 'c88bfbed8b931a64c5feb069fe03c0c2', now());


### PR DESCRIPTION
### Fix MBS-12636

# Problem
We do not want an unreferenced artist credit to be removed if there's any pending edits editing them - that will fail the edit and go against the intent of letting people reuse credits.

# Solution
For `artist_credit` table ids, we also check `edits_pending` and skip the id, without removing it from the table, if it has open edits. Whenever it no longer has open edits, it will either be deleted as empty, or dropped from the table if it now has a `ref_count`.

# Notes
There's a second issue which probably cannot be solved in a trivial way, of artist credits not being edited themselves but being used in open edits. Is there even a way to check this without looking through all the `edit_data` for any edits which might use ACs? We could of course use `edits_pending` here too if we made these edits affect the AC's `edits_pending` in the first place, but that'd mean almost all popular ACs would be highlighted all the time and it sounds less than ideal. We could add a *second* temporary table for ACs being used in edits? Seems like a hack, but... I'm out of ideas otherwise. I guess we could also just let those be removed and not worry about it that much.

# Testing
Test added for this case.