### PR TITLE
MBS-12645: Add guess case to genre edit form

### DIFF
--- a/root/genre/types.js
+++ b/root/genre/types.js
@@ -16,5 +16,12 @@ export type GenreFormT = FormT<{
   +comment: ReadOnlyFieldT<string>,
   +edit_note: ReadOnlyFieldT<string>,
   +make_votable: ReadOnlyFieldT<boolean>,
-  +name: ReadOnlyFieldT<string>,
+  +name: ReadOnlyFieldT<string | null>,
+}>;
+
+export type WritableGenreFormT = FormT<{
+  +comment: FieldT<string>,
+  +edit_note: FieldT<string>,
+  +make_votable: FieldT<boolean>,
+  +name: FieldT<string | null>,
 }>;

--- a/root/static/scripts/alias/AliasEditForm.js
+++ b/root/static/scripts/alias/AliasEditForm.js
@@ -1,5 +1,5 @@
 /*
- * @flow
+ * @flow strict-local
  * Copyright (C) 2020 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -1,5 +1,5 @@
 /*
- * @flow
+ * @flow strict-local
  * Copyright (C) 2019 MetaBrainz Foundation
  *
  * This file is part of MusicBrainz, the open internet music database,

--- a/root/static/scripts/genre/components/GenreEditForm.js
+++ b/root/static/scripts/genre/components/GenreEditForm.js
@@ -7,13 +7,27 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import mutate from 'mutate-cow';
 import * as React from 'react';
 
 import {SanitizedCatalystContext} from '../../../../context.mjs';
-import type {GenreFormT} from '../../../../genre/types.js';
+import type {
+  GenreFormT,
+  WritableGenreFormT,
+} from '../../../../genre/types.js';
+import isBlank from '../../common/utility/isBlank.js';
 import EnterEdit from '../../edit/components/EnterEdit.js';
 import EnterEditNote from '../../edit/components/EnterEditNote.js';
+import FormRowNameWithGuessCase, {
+  type ActionT as NameActionT,
+  runReducer as runNameReducer,
+} from '../../edit/components/FormRowNameWithGuessCase.js';
 import FormRowTextLong from '../../edit/components/FormRowTextLong.js';
+import {
+  type StateT as GuessCaseOptionsStateT,
+  type WritableStateT as WritableGuessCaseOptionsStateT,
+  createInitialState as createGuessCaseOptionsState,
+} from '../../edit/components/GuessCaseOptions.js';
 import {
   ExternalLinksEditor,
   prepareExternalLinksHtmlFormSubmission,
@@ -26,17 +40,86 @@ type Props = {
   +form: GenreFormT,
 };
 
+/* eslint-disable flowtype/sort-keys */
+type ActionT =
+  | {+type: 'update-name', +action: NameActionT};
+/* eslint-enable flowtype/sort-keys */
+
+type StateT = {
+  +form: GenreFormT,
+  +guessCaseOptions: GuessCaseOptionsStateT,
+  +isGuessCaseOptionsOpen: boolean,
+};
+
+type WritableStateT = {
+  ...StateT,
+  form: WritableGenreFormT,
+  guessCaseOptions: WritableGuessCaseOptionsStateT,
+};
+
+function createInitialState(form: GenreFormT) {
+  return {
+    form,
+    guessCaseOptions: createGuessCaseOptionsState(),
+    isGuessCaseOptionsOpen: false,
+  };
+}
+
+function reducer(state: StateT, action: ActionT): StateT {
+  return mutate<WritableStateT, StateT>(state, newState => {
+    switch (action.type) {
+      case 'update-name': {
+        const nameState = {
+          field: newState.form.field.name,
+          guessCaseOptions: newState.guessCaseOptions,
+          isGuessCaseOptionsOpen: newState.isGuessCaseOptionsOpen,
+        };
+        runNameReducer(nameState, action.action);
+        newState.guessCaseOptions = nameState.guessCaseOptions;
+        newState.isGuessCaseOptionsOpen = nameState.isGuessCaseOptionsOpen;
+        break;
+      }
+      default: {
+        /*:: exhaustive(action); */
+      }
+    }
+  });
+}
+
 const GenreEditForm = ({
-  form,
+  form: initialForm,
 }: Props): React.Element<'form'> => {
   const $c = React.useContext(SanitizedCatalystContext);
+
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    createInitialState(initialForm),
+  );
+
+  const nameDispatch = React.useCallback((action: NameActionT) => {
+    dispatch({action, type: 'update-name'});
+  }, [dispatch]);
+
+  const missingRequired = isBlank(state.form.field.name.value);
+
+  const hasErrors = missingRequired;
+
+  // Ensure errors are shown if the user tries to submit with Enter
+  const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLFormElement>) => {
+    if (event.key === 'Enter' && hasErrors) {
+      event.preventDefault();
+    }
+  };
 
   const genre = $c.stash.source_entity;
   invariant(genre && genre.entityType === 'genre');
 
   const externalLinksEditorRef = React.createRef();
 
-  const handleSubmit = () => {
+  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
+    if (hasErrors) {
+      event.preventDefault();
+    }
     invariant(externalLinksEditorRef.current);
     prepareExternalLinksHtmlFormSubmission(
       'edit-genre',
@@ -48,25 +131,28 @@ const GenreEditForm = ({
     <form
       className="edit-genre"
       method="post"
+      onKeyDown={handleKeyDown}
       onSubmit={handleSubmit}
     >
       <div className="half-width">
         <fieldset>
           <legend>{l('Genre details')}</legend>
-          <FormRowTextLong
-            field={form.field.name}
+          <FormRowNameWithGuessCase
+            dispatch={nameDispatch}
+            entity={genre}
+            field={state.form.field.name}
+            guessCaseOptions={state.guessCaseOptions}
+            isGuessCaseOptionsOpen={state.isGuessCaseOptionsOpen}
             label={addColonText(l('Name'))}
-            required
-            uncontrolled
           />
           <FormRowTextLong
-            field={form.field.comment}
+            field={state.form.field.comment}
             label={addColonText(l('Disambiguation'))}
             uncontrolled
           />
         </fieldset>
         <RelationshipEditorWrapper
-          formName={form.name}
+          formName={state.form.name}
           seededRelationships={$c.stash.seeded_relationships}
         />
         <fieldset>
@@ -78,8 +164,8 @@ const GenreEditForm = ({
           />
         </fieldset>
 
-        <EnterEditNote field={form.field.edit_note} />
-        <EnterEdit form={form} />
+        <EnterEditNote field={state.form.field.edit_note} />
+        <EnterEdit disabled={hasErrors} form={state.form} />
       </div>
     </form>
   );


### PR DESCRIPTION
### Implement MBS-12645

Genre names should always be lowercased, so it'd be nice to have a guess case button to click rather than fiddling with the name by hand.