### PR TITLE
MBS-12646: Can't change time on artist-event relationship

### DIFF
--- a/root/static/scripts/relationship-editor/utility/prepareHtmlFormSubmission.js
+++ b/root/static/scripts/relationship-editor/utility/prepareHtmlFormSubmission.js
@@ -74,23 +74,16 @@ function pushRelationshipHiddenInputs(
     }
   };
 
+  const newAttributes = relationship.attributes;
+  let attributeIndex = 0;
+  for (const attribute of tree.iterate(newAttributes)) {
+    pushAttributeInputs(attributeIndex, attribute);
+    attributeIndex++;
+  }
+
   const origRelationship = relationship._original;
   if (origRelationship) {
     const origAttributes = origRelationship.attributes;
-    const newAttributes = relationship.attributes;
-
-    let index = 0;
-    for (const attribute of tree.iterate(newAttributes)) {
-      const origAttribute = tree.find(
-        origAttributes,
-        attribute,
-        compareLinkAttributeIds,
-      );
-      if (!origAttribute) {
-        pushAttributeInputs(index, attribute);
-      }
-      index++;
-    }
 
     for (const attribute of tree.iterate(origAttributes)) {
       const newAttribute = tree.find(
@@ -99,17 +92,9 @@ function pushRelationshipHiddenInputs(
         compareLinkAttributeIds,
       );
       if (!newAttribute) {
-        pushAttributeInputs(index++, attribute, true /* removed */);
+        pushAttributeInputs(attributeIndex++, attribute, true /* removed */);
       }
-      index++;
-    }
-  } else {
-    const newAttributes = relationship.attributes;
-
-    let index = 0;
-    for (const attribute of tree.iterate(newAttributes)) {
-      pushAttributeInputs(index, attribute);
-      index++;
+      attributeIndex++;
     }
   }
 

--- a/root/static/scripts/relationship-editor/utility/splitRelationshipByAttributes.js
+++ b/root/static/scripts/relationship-editor/utility/splitRelationshipByAttributes.js
@@ -16,7 +16,10 @@ import {INSTRUMENT_ROOT_ID, VOCAL_ROOT_ID} from '../../common/constants.js';
 import linkedEntities from '../../common/linkedEntities.mjs';
 import isDatabaseRowId from '../../common/utility/isDatabaseRowId.js';
 import {uniqueNegativeId} from '../../common/utility/numbers.js';
-import {REL_STATUS_ADD} from '../constants.js';
+import {
+  REL_STATUS_ADD,
+  REL_STATUS_NOOP,
+} from '../constants.js';
 import type {
   RelationshipStateT,
 } from '../types.js';
@@ -94,7 +97,6 @@ export default function splitRelationshipByAttributes(
 
   if (isExistingRelationship) {
     const newRelationship = cloneRelationshipState(relationship);
-    newRelationship.id = uniqueNegativeId();
     newRelationship.attributes = tree.union(
       preservedInstrumentsAndVocals,
       otherLinkAttributes,
@@ -102,7 +104,12 @@ export default function splitRelationshipByAttributes(
       onConflictThrowError,
     );
     newRelationship._status = getRelationshipEditStatus(newRelationship);
-    splitRelationships.push(newRelationship);
+    if (newRelationship._status === REL_STATUS_NOOP) {
+      /*:: invariant(relationship._original); */
+      splitRelationships.push(relationship._original);
+    } else {
+      splitRelationships.push(newRelationship);
+    }
   }
 
   for (const linkAttribute of addedInstrumentsAndVocals) {

--- a/root/static/scripts/tests/relationship-editor/constants.js
+++ b/root/static/scripts/tests/relationship-editor/constants.js
@@ -9,6 +9,7 @@
 
 import {
   createArtistObject,
+  createEventObject,
   createRecordingObject,
   createReleaseObject,
 } from '../../common/entity2.js';
@@ -19,6 +20,10 @@ import type {
 
 export const artist: ArtistT = createArtistObject({
   name: 'Artist',
+});
+
+export const event: EventT = createEventObject({
+  name: 'Event',
 });
 
 export const recording: RecordingT = createRecordingObject({

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -670,6 +670,10 @@ const seleniumTests = [
     login: true,
   },
   {
+    name: 'Event_Edit_Form.json5',
+    login: true,
+  },
+  {
     name: 'Genre_Edit_Form.json5',
     login: true,
   },

--- a/t/selenium/Event_Edit_Form.json5
+++ b/t/selenium/Event_Edit_Form.json5
@@ -1,0 +1,248 @@
+{
+  title: 'Event Edit Form',
+  commands: [
+    {
+      command: 'open',
+      target: '/event/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-event.name',
+      value: 'newevent',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'main performer${KEY_ENTER}',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog .attribute-container.text.time input[type=text]',
+      value: '6:00',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-event button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 150,
+        status: 2,
+        data: {
+          begin_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          cancelled: '0',
+          comment: '',
+          end_date: {
+            day: null,
+            month: null,
+            year: null,
+          },
+          ended: 0,
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 1,
+          name: 'newevent',
+          setlist: '',
+          time: null,
+          type_id: null,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          attributes: [
+            {
+              text_value: '6:00',
+              type: {
+                gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                id: 830,
+                name: 'time',
+                root: {
+                  gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                  id: 830,
+                  name: 'time',
+                },
+              },
+            },
+          ],
+          edit_version: 2,
+          ended: '0',
+          entity0: {
+            gid: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+            id: 99,
+            name: 'Bing Crosby',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: 'newevent',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 798,
+            link_phrase: 'main performer at',
+            long_link_phrase: 'was a main performer at',
+            name: 'main performer',
+            reverse_link_phrase: 'main performers',
+          },
+          type0: 'artist',
+          type1: 'event',
+        },
+      },
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=.tabs a[href$="/edit"]',
+      value: '',
+    },
+    // MBS-12646: Change the time of an artist-event relationship.
+    {
+      command: 'click',
+      target: 'xpath=(//tr[contains(@class, "main-performers")])[1]//button[contains(@class, "edit-item")]',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#edit-relationship-dialog .attribute-container.text.time input[type=text]',
+      value: '7:00',
+    },
+    {
+      command: 'click',
+      target: 'css=#edit-relationship-dialog button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-event button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 3,
+      value: {
+        type: 91,
+        status: 2,
+        data: {
+          edit_version: 2,
+          entity0_credit: '',
+          entity1_credit: '',
+          link: {
+            attributes: [
+              {
+                text_value: '6:00',
+                type: {
+                  gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                  id: 830,
+                  name: 'time',
+                  root: {
+                    gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                    id: 830,
+                    name: 'time',
+                  },
+                },
+              },
+            ],
+            begin_date: {
+              day: null,
+              month: null,
+              year: null,
+            },
+            end_date: {
+              day: null,
+              month: null,
+              year: null,
+            },
+            ended: 0,
+            entity0: {
+              gid: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+              id: 99,
+              name: 'Bing Crosby',
+            },
+            entity1: {
+              gid: '$$__IGNORE__$$',
+              id: 1,
+              name: 'newevent',
+            },
+            link_type: {
+              id: 798,
+              link_phrase: 'main performer at',
+              long_link_phrase: 'was a main performer at',
+              name: 'main performer',
+              reverse_link_phrase: 'main performers',
+            },
+          },
+          new: {
+            attributes: [
+              {
+                text_value: '7:00',
+                type: {
+                  gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                  id: 830,
+                  name: 'time',
+                  root: {
+                    gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                    id: 830,
+                    name: 'time',
+                  },
+                },
+              },
+            ],
+          },
+          old: {
+            attributes: [
+              {
+                text_value: '6:00',
+                type: {
+                  gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                  id: 830,
+                  name: 'time',
+                  root: {
+                    gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d',
+                    id: 830,
+                    name: 'time',
+                  },
+                },
+              },
+            ],
+          },
+          relationship_id: 1,
+          type0: 'artist',
+          type1: 'event',
+        },
+      },
+    },
+    // End of test for MBS-12646.
+  ],
+}


### PR DESCRIPTION
The first issue here was that in `pushRelationshipHiddenInputs`, we weren't outputting attribute data for existing attributes that had changed text values.  Now we output all new attributes unconditionally. (Attributes are only removed by specifying a 'removed' flag.)

The second issue was that in `splitRelationshipByAttributes`, we were resetting the ID on existing relationships, which actually caused it to submit a new relationship instead of editing the existing one.

Test cases have been added for both issues.