### PR TITLE
Bump Redux version to 4.2.0

### DIFF
--- a/flow-typed/npm/redux_v4.x.x.js
+++ b/flow-typed/npm/redux_v4.x.x.js
@@ -1,6 +1,3 @@
-// flow-typed signature: ed3e20936dd7b07b5487912b2d22f352
-// flow-typed version: 537401fe1b/redux_v3.x.x/flow_>=v0.89.x
-
 declare module 'redux' {
   /*
 
@@ -10,13 +7,16 @@ declare module 'redux' {
 
   */
 
+  declare export type Action<T> = { type: T, ... }
+
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+  declare export type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,
     getState(): S,
+    ...
   };
 
   declare export type Store<S, A, D = Dispatch<A>> = {
@@ -25,12 +25,13 @@ declare module 'redux' {
     getState(): S,
     subscribe(listener: () => void): () => void,
     replaceReducer(nextReducer: Reducer<S, A>): void,
+    ...
   };
 
-  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+  declare export type Reducer<S, A> = (state: S, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (
-    state: ($Shape<S> & {}) | void,
+    state: ($Shape<S> & {...}) | void,
     action: A
   ) => S;
 
@@ -45,6 +46,7 @@ declare module 'redux' {
       preloadedState: S,
       enhancer?: StoreEnhancer<S, A, D>
     ): Store<S, A, D>,
+    ...
   };
 
   declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
@@ -61,14 +63,22 @@ declare module 'redux' {
     enhancer?: StoreEnhancer<S, A, D>
   ): Store<S, A, D>;
 
+  declare export function legacy_createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function legacy_createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
   declare export function applyMiddleware<S, A, D>(
     ...middlewares: Array<Middleware<S, A, D>>
   ): StoreEnhancer<S, A, D>;
 
   declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
-  declare export type ActionCreators<K, A> = {
-    [key: K]: ActionCreator<A, any>,
-  };
+  declare export type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any>, ... };
 
   declare export function bindActionCreators<
     A,
@@ -88,7 +98,7 @@ declare module 'redux' {
     dispatch: D
   ): C;
 
-  declare export function combineReducers<O: {}, A>(
+  declare export function combineReducers<O: {...}, A>(
     reducers: O
   ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-table": "7.8.0",
-    "redux": "3.6.0",
+    "redux": "4.2.0",
     "shell-quote": "1.7.3",
     "shelljs": "0.8.5",
     "sliced": "1.0.1",

--- a/root/static/scripts/work/edit.js
+++ b/root/static/scripts/work/edit.js
@@ -13,7 +13,7 @@ import mutate from 'mutate-cow';
 // $FlowIgnore[missing-export]
 import {flushSync} from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
-import {createStore} from 'redux';
+import {legacy_createStore as createStore} from 'redux';
 
 import {LANGUAGE_MUL_ID, LANGUAGE_ZXX_ID} from '../common/constants.js';
 import {groupBy} from '../common/utility/arrays.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -3876,11 +3883,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.2.1:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -3891,7 +3893,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.1:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4929,15 +4931,12 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
-  integrity sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0=
+redux@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
   dependencies:
-    lodash "^4.2.1"
-    lodash-es "^4.2.1"
-    loose-envify "^1.1.0"
-    symbol-observable "^1.0.2"
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -5663,11 +5662,6 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
-
-symbol-observable@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The currently used `redux` 3.6.0 depends on vulnerable `lodash-es`: SEC-674, SEC-707, SEC-708

Note: It is very likely that none of these vulnerabilities actually affect MusicBrainz Server.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Update to the latest `redux` 4.2.0.

Note: The `createStore` API is now deprecated. Not sure whether it is worth moving to Redux Toolkit or if any Redux dependency should be dropped eventually.