### PR TITLE
MBS-12552 (I),MBS-12661: Refactor Moose CoreEntity and fix URL last updated display

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Alias.pm
+++ b/lib/MusicBrainz/Server/Entity/Alias.pm
@@ -6,12 +6,8 @@ use Moose;
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
+with 'MusicBrainz::Server::Entity::Role::Name';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'AliasType' };
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
 
 has 'sort_name' => (
     is => 'rw',
@@ -33,7 +29,6 @@ around TO_JSON => sub {
 
     return {
         %{ $self->$orig },
-        name => $self->name,
         locale => $self->locale,
         primary_for_locale => boolean_to_json($self->primary_for_locale),
         sort_name => $self->sort_name,

--- a/lib/MusicBrainz/Server/Entity/Application.pm
+++ b/lib/MusicBrainz/Server/Entity/Application.pm
@@ -7,6 +7,7 @@ use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 has 'owner' => (
     isa => 'Editor',
@@ -15,11 +16,6 @@ has 'owner' => (
 
 has 'owner_id' => (
     isa => 'Int',
-    is  => 'rw',
-);
-
-has 'name' => (
-    isa => 'Str',
     is  => 'rw',
 );
 
@@ -59,7 +55,6 @@ around TO_JSON => sub {
     return {
         %{ $self->$orig },
         is_server           => boolean_to_json($self->is_server),
-        name                => $self->name,
         oauth_id            => $self->oauth_id,
         oauth_redirect_uri  => $self->oauth_redirect_uri,
         oauth_secret        => $self->oauth_secret,

--- a/lib/MusicBrainz/Server/Entity/Area.pm
+++ b/lib/MusicBrainz/Server/Entity/Area.pm
@@ -9,7 +9,6 @@ use List::AllUtils qw( first );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';

--- a/lib/MusicBrainz/Server/Entity/Area.pm
+++ b/lib/MusicBrainz/Server/Entity/Area.pm
@@ -10,7 +10,6 @@ use List::AllUtils qw( first );
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
 with 'MusicBrainz::Server::Entity::Role::Comment';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'AreaType' };

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -8,7 +8,6 @@ use MusicBrainz::Server::Entity::Types;
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';

--- a/lib/MusicBrainz/Server/Entity/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Artist.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';

--- a/lib/MusicBrainz/Server/Entity/Collection.pm
+++ b/lib/MusicBrainz/Server/Entity/Collection.pm
@@ -6,7 +6,11 @@ use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Filters qw( format_wikitext );
 
-extends 'MusicBrainz::Server::Entity::CoreEntity';
+extends 'MusicBrainz::Server::Entity';
+with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::GID';
+with 'MusicBrainz::Server::Entity::Role::Name';
+
 
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'CollectionType' };
 

--- a/lib/MusicBrainz/Server/Entity/Collection.pm
+++ b/lib/MusicBrainz/Server/Entity/Collection.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Filters qw( format_wikitext );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
 with 'MusicBrainz::Server::Entity::Role::Name';
 

--- a/lib/MusicBrainz/Server/Entity/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Entity/CoreEntity.pm
@@ -5,6 +5,7 @@ use Moose;
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
+with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Name';
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Entity/CoreEntity.pm
@@ -5,6 +5,7 @@ use Moose;
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
+with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Name';
 

--- a/lib/MusicBrainz/Server/Entity/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Entity/CoreEntity.pm
@@ -5,19 +5,7 @@ use Moose;
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
-
-around TO_JSON => sub {
-    my ($orig, $self) = @_;
-
-    my $json = $self->$orig;
-    $json->{name} = $self->name;
-    return $json;
-};
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -8,7 +8,6 @@ extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Event.pm
+++ b/lib/MusicBrainz/Server/Entity/Event.pm
@@ -6,7 +6,6 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';

--- a/lib/MusicBrainz/Server/Entity/Genre.pm
+++ b/lib/MusicBrainz/Server/Entity/Genre.pm
@@ -7,7 +7,6 @@ extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::Comment';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 
 sub entity_type { 'genre' }
 

--- a/lib/MusicBrainz/Server/Entity/Genre.pm
+++ b/lib/MusicBrainz/Server/Entity/Genre.pm
@@ -6,7 +6,6 @@ use MusicBrainz::Server::Entity::Types;
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::Comment';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 
 sub entity_type { 'genre' }
 

--- a/lib/MusicBrainz/Server/Entity/Instrument.pm
+++ b/lib/MusicBrainz/Server/Entity/Instrument.pm
@@ -8,7 +8,6 @@ use MusicBrainz::Server::Translation::InstrumentDescriptions;
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Comment';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'InstrumentType' };
 

--- a/lib/MusicBrainz/Server/Entity/Instrument.pm
+++ b/lib/MusicBrainz/Server/Entity/Instrument.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Translation::InstrumentDescriptions;
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Label.pm
+++ b/lib/MusicBrainz/Server/Entity/Label.pm
@@ -8,7 +8,6 @@ use MusicBrainz::Server::Entity::Types;
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';

--- a/lib/MusicBrainz/Server/Entity/Label.pm
+++ b/lib/MusicBrainz/Server/Entity/Label.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';

--- a/lib/MusicBrainz/Server/Entity/Language.pm
+++ b/lib/MusicBrainz/Server/Entity/Language.pm
@@ -4,11 +4,7 @@ use Moose;
 use MusicBrainz::Server::Translation::Languages qw( l );
 
 extends 'MusicBrainz::Server::Entity';
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 sub l_name {
     my $self = shift;
@@ -62,7 +58,6 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
-    $json->{name} = $self->name;
     $json->{iso_code_1} = $self->iso_code_1;
     $json->{iso_code_2b} = $self->iso_code_2b;
     $json->{iso_code_2t} = $self->iso_code_2t;

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -8,6 +8,7 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 sub entity_type { 'medium' }
 
@@ -53,11 +54,6 @@ has 'release_id' => (
 has 'release' => (
     is => 'rw',
     isa => 'Release'
-);
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
 );
 
 has 'format_id' => (
@@ -181,7 +177,6 @@ around TO_JSON => sub {
         cdtocs      => [map { $_->cdtoc->toc } $self->all_cdtocs],
         format      => $self->format ? $self->format->TO_JSON : undef,
         format_id   => $self->format_id,
-        name        => $self->name,
         position    => $self->position,
         release_id  => $self->release_id,
         track_count => defined $track_count ? (0 + $track_count) : undef,

--- a/lib/MusicBrainz/Server/Entity/Place.pm
+++ b/lib/MusicBrainz/Server/Entity/Place.pm
@@ -6,7 +6,6 @@ use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';

--- a/lib/MusicBrainz/Server/Entity/Place.pm
+++ b/lib/MusicBrainz/Server/Entity/Place.pm
@@ -7,7 +7,6 @@ use MusicBrainz::Server::Entity::Types;
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';

--- a/lib/MusicBrainz/Server/Entity/Recording.pm
+++ b/lib/MusicBrainz/Server/Entity/Recording.pm
@@ -13,7 +13,6 @@ use List::AllUtils qw( uniq_by );
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Recording.pm
+++ b/lib/MusicBrainz/Server/Entity/Recording.pm
@@ -12,7 +12,6 @@ use List::AllUtils qw( uniq_by );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -13,7 +13,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Quality';
 with 'MusicBrainz::Server::Entity::Role::Comment';
 with 'MusicBrainz::Server::Entity::Role::ArtistCredit';

--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -12,7 +12,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Quality';

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
@@ -11,7 +11,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';

--- a/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseGroup.pm
@@ -12,7 +12,6 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Role/Name.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Name.pm
@@ -1,0 +1,29 @@
+package MusicBrainz::Server::Entity::Role::Name;
+
+use Moose::Role;
+
+has 'name' => (
+    is => 'rw',
+    isa => 'Str'
+);
+
+around TO_JSON => sub {
+    my ($orig, $self) = @_;
+
+    my $json = $self->$orig;
+    $json->{name} = $self->name;
+    return $json;
+};
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009 Lukas Lalinsky
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Entity/Script.pm
+++ b/lib/MusicBrainz/Server/Entity/Script.pm
@@ -4,11 +4,7 @@ use Moose;
 use MusicBrainz::Server::Translation::Scripts qw( l );
 
 extends 'MusicBrainz::Server::Entity';
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 sub l_name {
     my $self = shift;
@@ -34,7 +30,6 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
-    $json->{name} = $self->name;
     $json->{iso_code} = $self->iso_code;
     $json->{iso_number} = $self->iso_number;
     $json->{frequency} = $self->frequency;

--- a/lib/MusicBrainz/Server/Entity/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Series.pm
@@ -8,7 +8,6 @@ no if $] >= 5.018, warnings => 'experimental::smartmatch';
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Comment';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'SeriesType' };
 

--- a/lib/MusicBrainz/Server/Entity/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Series.pm
@@ -7,7 +7,6 @@ no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Tag.pm
+++ b/lib/MusicBrainz/Server/Entity/Tag.pm
@@ -4,11 +4,7 @@ use Moose;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Entity';
-
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 has 'genre_id' => (
     is => 'rw',
@@ -24,8 +20,6 @@ around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
-
-    $json->{name} = $self->name;
 
     if ($self->genre) {
         $json->{genre} = to_json_object($self->genre);

--- a/lib/MusicBrainz/Server/Entity/Track.pm
+++ b/lib/MusicBrainz/Server/Entity/Track.pm
@@ -43,11 +43,6 @@ has 'number' => (
     isa => 'Str'
 );
 
-has 'name' => (
-    is => 'rw',
-    isa => 'Str'
-);
-
 has 'length' => (
     is => 'rw',
     isa => 'Maybe[Int]',

--- a/lib/MusicBrainz/Server/Entity/Track.pm
+++ b/lib/MusicBrainz/Server/Entity/Track.pm
@@ -5,9 +5,11 @@ use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Track qw( format_track_length );
 
-extends 'MusicBrainz::Server::Entity::CoreEntity';
+extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::ArtistCredit';
+with 'MusicBrainz::Server::Entity::Role::GID';
+with 'MusicBrainz::Server::Entity::Role::Name';
 
 has 'recording_id' => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/URL.pm
+++ b/lib/MusicBrainz/Server/Entity/URL.pm
@@ -5,7 +5,6 @@ use MooseX::Types::URI qw( Uri );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 
 sub entity_type { 'url' }
 

--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -9,7 +9,6 @@ use aliased 'MusicBrainz::Server::Entity::WorkAttribute';
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
-with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';
 with 'MusicBrainz::Server::Entity::Role::Review';
 with 'MusicBrainz::Server::Entity::Role::Comment';

--- a/lib/MusicBrainz/Server/Entity/Work.pm
+++ b/lib/MusicBrainz/Server/Entity/Work.pm
@@ -8,7 +8,6 @@ use aliased 'MusicBrainz::Server::Entity::WorkAttribute';
 
 extends 'MusicBrainz::Server::Entity::CoreEntity';
 with 'MusicBrainz::Server::Entity::Role::Taggable';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
 with 'MusicBrainz::Server::Entity::Role::Annotation';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Rating';


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

As part of MBS-12552, it has been decided to uniformize “core” (entity type) to “relatable” = “linkable”. The current Moose class `CoreEntity` doesn’t follow this meaning thus needing some refactoring.

Note: There still are other occurrences of “core”, only the ones in Moose classes are examined in this part I.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Move `name` Moose attribute from `CoreEntity` class to `Name` role;
* Also fix the name of the Moose role for pending edits by renaming it from `Editable` to `PendingEdits`;
* Remove collection and track from core entities in Moose as these are not relatable;
* Add the role `Linkable` to `CoreEntity` class as core entities are relatable;
* Add the role `LastUpdated` to `CoreEntity` as core entities are editable;
  Incidentally fix the bug MBS-12661 in URL’s sidebar.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Check the impact of reordering roles into the JSON output.
      (Possibly update tests or revert changes.)