### PR TITLE
MBS-12665: Widen DNB regex

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1963,8 +1963,8 @@ const CLEANUPS: CleanupEntries = {
     restrict: [LINK_TYPES.otherdatabases],
     clean: function (url) {
       url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?d-nb\.info\//, 'http://d-nb.info/');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?dnb\.de\/opac(?:\.htm\?)?.*\bquery=nid%3D(1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X]).*$/, 'http://d-nb.info/gnd/$1');
-      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?dnb\.de\/opac(?:\.htm\?)?.*\bquery=idn%3D(1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X]).*$/, 'http://d-nb.info/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?dnb\.de\/opac(?:\.htm\?)?.*\bquery=nid%3D([0-9X-]{9,10}).*$/, 'http://d-nb.info/gnd/$1');
+      url = url.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?dnb\.de\/opac(?:\.htm\?)?.*\bquery=idn%3D([0-9X-]{9,10}).*$/, 'http://d-nb.info/$1');
       return url;
     },
     validate: function (url, id) {
@@ -1974,17 +1974,17 @@ const CLEANUPS: CleanupEntries = {
         case LINK_TYPES.otherdatabases.series:
         case LINK_TYPES.otherdatabases.work:
           return {
-            result: /^http:\/\/d-nb\.info\/(?:gnd\/)?(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
+            result: /^http:\/\/d-nb\.info\/(?:gnd\/)?[0-9X-]{9,10}$/.test(url),
             target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.otherdatabases.label:
           return {
-            result: /^http:\/\/d-nb\.info\/(?:(?:dnbn|gnd)\/)?(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
+            result: /^http:\/\/d-nb\.info\/(?:(?:dnbn|gnd)\/)?[0-9X-]{9,10}$/.test(url),
             target: ERROR_TARGETS.ENTITY,
           };
         case LINK_TYPES.otherdatabases.release:
           return {
-            result: /^http:\/\/d-nb\.info\/(?:1[012]?\d{7}[0-9X]|[47]\d{6}-\d|[1-9]\d{0,7}-[0-9X]|3\d{7}[0-9X])$/.test(url),
+            result: /^http:\/\/d-nb\.info\/[0-9X-]{9,10}$/.test(url),
             target: ERROR_TARGETS.ENTITY,
           };
       }

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -1849,6 +1849,13 @@ limited_link_type_combinations: [
             expected_clean_url: 'http://d-nb.info/1181136512',
        only_valid_entity_types: ['artist', 'label', 'place', 'release', 'series', 'work'],
   },
+  {
+                     input_url: 'http://d-nb.info/97248485X',
+             input_entity_type: 'release',
+    expected_relationship_type: 'otherdatabases',
+            expected_clean_url: 'http://d-nb.info/97248485X',
+       only_valid_entity_types: ['artist', 'label', 'place', 'release', 'series', 'work'],
+  },
   // Dogmazic
   {
                      input_url: 'https://play.dogmazic.net/artists.php?action=show_all_songs&artist=2283',


### PR DESCRIPTION
### Fix MBS-12665

# Problem
The DNB regex has been problematic for a while. It used to be too wide, and we tried to standardize it following the regex Wikidata uses, but it turns out that is instead too strict and is blocking some valid links, such as https://d-nb.info/97248485X

# Solution
outsidecontext got in touch with DNB and asked for better clarity on what the IDs can look like. The answer wasn't super clear, but the best we got from it is that it's probably safe to assume 9 or 10 character long IDs containing digits, hyphen or X, so that's what I'm implementing here. It could be possible to be more specific, maybe, but we've already been bitten by that, and honestly I think this is probably good enough for our needs.

# Testing
All the current tests pass, plus added a new one for the previously blocked URL.