### PR TITLE
MBS-12666: Better edit display for stream for free external links

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1216,26 +1216,6 @@ const ExternalLinkRelationship =
                     ) : null
                   )
               }
-              {linkType &&
-                hasOwnProp(
-                  linkType.attributes,
-                  String(VIDEO_ATTRIBUTE_ID),
-                ) ? (
-                  <div className="attribute-container">
-                    <label>
-                      <input
-                        checked={link.video}
-                        onChange={
-                          (event) => props.onVideoChange(link.index, event)
-                        }
-                        style={{verticalAlign: 'text-top'}}
-                        type="checkbox"
-                      />
-                      {' '}
-                      {l('video')}
-                    </label>
-                  </div>
-                ) : null}
               {link.url && !link.error && !hasUrlError
                 ? <TypeDescription type={link.type} url={link.url} />
                 : null}
@@ -1247,6 +1227,26 @@ const ExternalLinkRelationship =
               ) : null}
             </label>
           </div>
+          {linkType &&
+            hasOwnProp(
+              linkType.attributes,
+              String(VIDEO_ATTRIBUTE_ID),
+            ) ? (
+              <div className="attribute-container">
+                <label>
+                  <input
+                    checked={link.video}
+                    onChange={
+                      (event) => props.onVideoChange(link.index, event)
+                    }
+                    style={{verticalAlign: 'text-top'}}
+                    type="checkbox"
+                  />
+                  {' '}
+                  {l('video')}
+                </label>
+              </div>
+            ) : null}
           {link.error ? (
             <div className="error field-error" data-visible="1">
               {link.error.message}

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -33,6 +33,7 @@ import formatDatePeriod from '../common/utility/formatDatePeriod.js';
 import isDateEmpty from '../common/utility/isDateEmpty.js';
 import {hasSessionStorage} from '../common/utility/storage.js';
 import {uniqueId} from '../common/utility/strings.js';
+import {stripAttributes} from '../edit/utility/linkPhrase.js';
 import {
   appendHiddenRelationshipInputs,
 } from '../relationship-editor/utility/prepareHtmlFormSubmission.js';
@@ -1201,9 +1202,17 @@ const ExternalLinkRelationship =
                     />
                   ) : (
                     linkType ? (
-                      backward
-                        ? l_relationships(linkType.reverse_link_phrase)
-                        : l_relationships(linkType.link_phrase)
+                      backward ? (
+                        stripAttributes(
+                          linkType,
+                          linkType.l_reverse_link_phrase ?? '',
+                        )
+                      ) : (
+                        stripAttributes(
+                          linkType,
+                          linkType.l_link_phrase ?? '',
+                        )
+                      )
                     ) : null
                   )
               }
@@ -1470,21 +1479,25 @@ export class ExternalLink extends React.Component<LinkProps> {
             />
         ))}
         {firstLink.pendingTypes &&
-          firstLink.pendingTypes.map((type) => (
-            <tr className="relationship-item" key={type}>
-              <td />
-              <td>
-                <div className="relationship-content">
-                  <label>{addColonText(l('Type'))}</label>
-                  <label className="relationship-name">
-                    {l_relationships(
-                      linkedEntities.link_type[type].link_phrase,
-                    )}
-                  </label>
-                </div>
-              </td>
-            </tr>
-        ))}
+          firstLink.pendingTypes.map((type) => {
+            const relType = linkedEntities.link_type[type];
+            return (
+              <tr className="relationship-item" key={type}>
+                <td />
+                <td>
+                  <div className="relationship-content">
+                    <label>{addColonText(l('Type'))}</label>
+                    <label className="relationship-name">
+                      {stripAttributes(
+                        relType,
+                        relType.l_link_phrase ?? '',
+                      )}
+                    </label>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
         {/*
           * Hide the button when link is not submitted
           * or link type is auto-selected.

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -901,7 +901,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor label.relationship-name')).map(x => x.innerText).sort().toString()",
-      value: 'download for free,stream for free video',
+      value: 'download for free,stream for free',
     },
     {
       command: 'open',

--- a/t/selenium/External_Links_Editor.json5
+++ b/t/selenium/External_Links_Editor.json5
@@ -901,7 +901,7 @@
     {
       command: 'assertEval',
       target: "Array.from(document.querySelectorAll('#external-links-editor label.relationship-name')).map(x => x.innerText).sort().toString()",
-      value: 'download for free,stream {video} for free video',
+      value: 'download for free,stream for free video',
     },
     {
       command: 'open',


### PR DESCRIPTION
### Implement MBS-12666

See commit messages.

Talked with @Aerozol, he thought these seem like reasonable improvements.

Proposed change:
![Screenshot from 2022-10-13 08-59-24](https://user-images.githubusercontent.com/1069224/195514455-bf13a399-2d7a-47d0-9e32-5a8e97f47784.png)

Current:
![Screenshot from 2022-10-13 09-02-56](https://user-images.githubusercontent.com/1069224/195514708-69ac9544-9edc-4232-833e-47fe7b3035a7.png)

I decided against changing the label of the checkbox to "has video" or "contains video" because we just show the attribute name elsewhere AFAICT, but I'm happy to change that if we decide it's worth it.