### PR TITLE
MBS-12640: Preview always on for instrument relationships

### DIFF
--- a/root/static/scripts/common/utility/groupRelationships.js
+++ b/root/static/scripts/common/utility/groupRelationships.js
@@ -122,8 +122,8 @@ const cmpRelationshipTargetGroups = (
 
 export const areLinkAttrsEqual = (a: LinkAttrT, b: LinkAttrT): boolean => (
   a.typeID === b.typeID &&
-  a.text_value === b.text_value &&
-  a.credited_as === b.credited_as
+  (a.text_value ?? '') === (b.text_value ?? '') &&
+  (a.credited_as ?? '') === (b.credited_as ?? '')
 );
 
 const areDatedExtraAttributesEqual = (


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MBS-12640

The `LinkAttrT` type has optional `credited_as` and `text_value` fields.  In some cases, empty values will be undefined, and in other cases they'll be an empty string.  In the first case, fall back to an empty string before performing a comparison when calculating changes for previews.