### PR TITLE
MBS-12674: Don't assume offset data exists

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CDStub.pm
+++ b/lib/MusicBrainz/Server/Entity/CDStub.pm
@@ -125,13 +125,17 @@ around TO_JSON => sub {
     $json->{date_added} = datetime_to_iso8601($self->date_added);
     $json->{discid} = $self->discid;
     $json->{last_modified} = datetime_to_iso8601($self->last_modified);
-    $json->{leadout_offset} = 0 + $self->leadout_offset;
+    $json->{leadout_offset} = $self->leadout_offset
+        ? 0 + $self->leadout_offset
+        : undef;
     $json->{lookup_count} = $self->lookup_count;
     $json->{modify_count} = $self->modify_count;
     $json->{title} = $self->title;
     $json->{toc} = $self->track_offset ? $self->toc : undef;
     $json->{track_count} = $self->track_count;
-    $json->{track_offset} = [map { 0 + $_ } @{ $self->track_offset }];
+    $json->{track_offset} = $self->track_offset
+        ? [map { 0 + $_ } @{ $self->track_offset }]
+        : undef;
     $json->{tracks} = to_json_array($self->tracks);
 
     return $json;

--- a/root/static/scripts/common/utility/calculateFullToc.js
+++ b/root/static/scripts/common/utility/calculateFullToc.js
@@ -8,6 +8,13 @@
  */
 
 export default function calculateFullToc(cdtoc: CDStubT | CDTocT): string {
-  const trackOffsets = cdtoc.track_offset.join(' ');
-  return `1 ${cdtoc.track_count} ${cdtoc.leadout_offset} ${trackOffsets}`;
+  const trackOffset = cdtoc.track_offset;
+  invariant(trackOffset != null, 'Expected a defined track offset');
+
+  const leadoutOffset = cdtoc.leadout_offset;
+  invariant(leadoutOffset != null, 'Expected a defined leadout offset');
+
+  const trackOffsets = trackOffset.join(' ');
+
+  return `1 ${cdtoc.track_count} ${leadoutOffset} ${trackOffsets}`;
 }

--- a/root/types/cdstub.js
+++ b/root/types/cdstub.js
@@ -17,13 +17,13 @@ declare type CDStubT = $ReadOnly<{
   +date_added: string | null,
   +discid: string,
   +last_modified: string | null,
-  +leadout_offset: number,
+  +leadout_offset: number | null,
   +lookup_count: number | null,
   +modify_count: number | null,
   +title: string,
   +toc: string | null,
   +track_count: number,
-  +track_offset: $ReadOnlyArray<number>,
+  +track_offset: $ReadOnlyArray<number> | null,
   +tracks: $ReadOnlyArray<CDStubTrackT>,
 }>;
 

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -664,6 +664,7 @@ const seleniumTests = [
     sql: 'duplicate_checker.sql',
   },
   {name: 'CD_Lookup.json5', login: true},
+  {name: 'CD_Stub_Search.json5', sql: 'cdstub_raw.sql'},
   {name: 'FilterForm.json5', sql: 'filtering.sql'},
   {
     name: 'Release_Relationship_Editor.json5',

--- a/t/selenium/CD_Stub_Search.json5
+++ b/t/selenium/CD_Stub_Search.json5
@@ -1,0 +1,15 @@
+{
+  title: 'CD Stub Search',
+  commands: [
+    {
+      command: 'open',
+      target: '/search?query=Test&type=cdstub&method=indexed',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: "window.document.querySelector('table.tbl').innerText",
+      value: 'CD Stub\tArtist\tTracks\nTest Stub\tTest Artist\t2',
+    },
+  ],
+}


### PR DESCRIPTION
### Fix MBS-12674

Search results do not contain offset data, which was causing a warning for the `0 + leadout_offset` sum, and an ISE when trying to use a null `track_offset` as an array.