### PR TITLE
Allow compiling JS for modern browsers in development

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -11,19 +11,28 @@ const BROWSER_TARGETS = {
   safari: '9.0',
 };
 
+const MODERN_BROWSER_TARGETS = {
+  chrome: '106',
+  firefox: '105',
+  safari: '15.0',
+};
+
 const NODE_TARGETS = {
   node: process.versions.node,
 };
 
 module.exports = function (api) {
   api.cache.using(() => process.env.NODE_ENV);
+  api.cache.using(() => process.env.MODERN_BROWSERS === '1');
 
   const presets = [
     ['@babel/preset-env', {
       corejs: 3,
       targets: api.caller(caller => caller && caller.target === 'node')
         ? NODE_TARGETS
-        : BROWSER_TARGETS,
+        : (process.env.MODERN_BROWSERS === '1'
+          ? MODERN_BROWSER_TARGETS
+          : BROWSER_TARGETS),
       useBuiltIns: 'usage',
     }],
   ];

--- a/webpack/cacheConfig.mjs
+++ b/webpack/cacheConfig.mjs
@@ -20,6 +20,7 @@ export default {
   version: (
     WEBPACK_MODE + '-' +
     String(process.env.NODE_ENV) + '-' +
+    String(process.env.MODERN_BROWSERS === '1') + '-' +
     String(process.env.MUSICBRAINZ_RUNNING_TESTS)
   ),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,15 +2046,10 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
-
-caniuse-lite@^1.0.30001248:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001248:
+  version "1.0.30001420"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz"
+  integrity sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==
 
 canonical-json@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
When trying to use a debugger in development it's annoying to have to step through various Babel helpers (particularly for "for...of" loops). This patch allows compiling JS for modern browsers by setting an environment variable, `MODERN_BROWSERS=1`.