### PR TITLE
Refactor: Fix role’s name for pending edits

### DIFF
--- a/lib/MusicBrainz/Server/Data/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Alias.pm
@@ -12,7 +12,7 @@ use MusicBrainz::Server::Entity::PartialDate;
 
 extends 'MusicBrainz::Server::Data::Entity';
 
-# with MusicBrainz::Server::Data::Role::Editable -- see AliasRole for when this is applied
+# with MusicBrainz::Server::Data::Role::PendingEdits -- see AliasRole for when this is applied
 
 has 'parent' => (
     does => 'MusicBrainz::Server::Data::Role::Alias',

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -27,7 +27,7 @@ with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'area' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'area' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'area' };
 with 'MusicBrainz::Server::Data::Role::Merge';
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'area' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'area' };

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -33,7 +33,7 @@ with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::IPI' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::ISNI' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'artist' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Subscription' => {

--- a/lib/MusicBrainz/Server/Data/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Data/ArtistCredit.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Constants qw( entities_with );
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::EntityCache';
-with 'MusicBrainz::Server::Data::Role::Editable' => {
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => {
     table => 'artist_credit',
 };
 with 'MusicBrainz::Server::Data::Role::GetByGID';

--- a/lib/MusicBrainz/Server/Data/Artwork.pm
+++ b/lib/MusicBrainz/Server/Data/Artwork.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Data::Utils qw(
 use MusicBrainz::Server::Validation qw( is_database_bigint_id );
 
 extends 'MusicBrainz::Server::Data::Entity';
-with 'MusicBrainz::Server::Data::Role::Editable' => {
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => {
     table => 'cover_art_archive.cover_art'
 };
 

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -28,7 +28,7 @@ with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Area';
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'event' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'event' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'event' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'event' };

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -13,7 +13,7 @@ with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'genre' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'genre' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'genre' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'genre' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'genre' };
 with 'MusicBrainz::Server::Data::Role::SelectAll';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'genre' };

--- a/lib/MusicBrainz/Server/Data/ISRC.pm
+++ b/lib/MusicBrainz/Server/Data/ISRC.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 
 extends 'MusicBrainz::Server::Data::Entity';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'isrc' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'isrc' };
 
 sub _table
 {

--- a/lib/MusicBrainz/Server/Data/ISWC.pm
+++ b/lib/MusicBrainz/Server/Data/ISWC.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 
 extends 'MusicBrainz::Server::Data::Entity';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'iswc' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'iswc' };
 
 sub _table
 {

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -17,7 +17,7 @@ with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'instrument' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'instrument' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::Merge';
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'instrument' };

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -30,7 +30,7 @@ with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::IPI' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::ISNI' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'label' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'label' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::Subscription' => {

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -11,7 +11,7 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 
 extends 'MusicBrainz::Server::Data::Entity';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'medium' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'medium' };
 
 use Scalar::Util qw( weaken );
 

--- a/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Data/MediumCDTOC.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Constants qw(
 );
 
 extends 'MusicBrainz::Server::Data::Entity';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'medium_cdtoc' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'medium_cdtoc' };
 
 sub _table
 {

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -26,7 +26,7 @@ with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'place' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'place' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'place' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'place' };

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -23,7 +23,7 @@ with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'recording' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'recording' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'recording' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'recording' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'recording' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'recording' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'recording' };

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -37,7 +37,7 @@ with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'release' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'release' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'release' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'release' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'release' };

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -24,7 +24,7 @@ with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release_group' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'release_group' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'release_group' };

--- a/lib/MusicBrainz/Server/Data/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Alias.pm
@@ -44,7 +44,7 @@ role
             entity => $self->_entity_class . 'Alias',
             parent => $self
         );
-        ensure_all_roles($alias, 'MusicBrainz::Server::Data::Role::Editable' => { table => $params->table });
+        ensure_all_roles($alias, 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => $params->table });
     };
 
     method '_build_alias_type' => sub

--- a/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
+++ b/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
@@ -1,4 +1,4 @@
-package MusicBrainz::Server::Data::Role::Editable;
+package MusicBrainz::Server::Data::Role::PendingEdits;
 use MooseX::Role::Parameterized;
 
 use MusicBrainz::Server::Data::Utils qw( placeholders );

--- a/lib/MusicBrainz/Server/Data/Role/ValueSet.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ValueSet.pm
@@ -48,7 +48,7 @@ role {
         );
         ensure_all_roles(
             $cls,
-            'MusicBrainz::Server::Data::Role::Editable' => {
+            'MusicBrainz::Server::Data::Role::PendingEdits' => {
                 table => qq(${entity_type}_$value_type),
             },
         );

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -24,7 +24,7 @@ with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'series' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'series' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'series' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'series' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'series' };
 with 'MusicBrainz::Server::Data::Role::Merge';
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'series' };

--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -23,7 +23,7 @@ with 'MusicBrainz::Server::Data::Role::GID';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
 with 'MusicBrainz::Server::Data::Role::Name';
 
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'track' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'track' };
 
 sub _type { 'track' }
 

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -10,7 +10,7 @@ use URI;
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::Relatable';
 with
-    'MusicBrainz::Server::Data::Role::Editable' => { table => 'url' },
+    'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'url' },
     'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'url' },
     'MusicBrainz::Server::Data::Role::Merge';
 

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -25,7 +25,7 @@ with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'work' };
-with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'work' };
+with 'MusicBrainz::Server::Data::Role::PendingEdits' => { table => 'work' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'work' };
 with 'MusicBrainz::Server::Data::Role::Merge';
 with 'MusicBrainz::Server::Data::Role::Collection';

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -261,8 +261,8 @@ sub adjust_edit_pending
     my $to_inc = $self->alter_edit_pending;
     while ( my ($model_name, $ids) = each %$to_inc) {
         my $model = $self->c->model($model_name);
-        $model->does('MusicBrainz::Server::Data::Role::Editable')
-            or croak 'Model must do MusicBrainz::Server::Data::Role::Editable';
+        $model->does('MusicBrainz::Server::Data::Role::PendingEdits')
+            or croak 'Model must do MusicBrainz::Server::Data::Role::PendingEdits';
         $model->adjust_edit_pending($adjust, @$ids);
     }
 }

--- a/lib/MusicBrainz/Server/Edit/Generic/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Create.pm
@@ -19,7 +19,7 @@ sub alter_edit_pending
 {
     my $self = shift;
     my $model = $self->c->model( $self->_create_model);
-    if ($model->does('MusicBrainz::Server::Data::Role::Editable')) {
+    if ($model->does('MusicBrainz::Server::Data::Role::PendingEdits')) {
         return {
             $self->_create_model => [ $self->entity_id ]
         }

--- a/lib/MusicBrainz/Server/Edit/Generic/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Delete.pm
@@ -26,7 +26,7 @@ sub alter_edit_pending
 {
     my $self = shift;
     my $model = $self->c->model( $self->_delete_model);
-    if ($model->does('MusicBrainz::Server::Data::Role::Editable')) {
+    if ($model->does('MusicBrainz::Server::Data::Role::PendingEdits')) {
         return {
             $self->_delete_model => [ $self->entity_id ]
         }

--- a/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Generic/Edit.pm
@@ -32,7 +32,7 @@ sub alter_edit_pending
 {
     my $self = shift;
     my $model = $self->c->model( $self->_edit_model);
-    if ($model->does('MusicBrainz::Server::Data::Role::Editable')) {
+    if ($model->does('MusicBrainz::Server::Data::Role::PendingEdits')) {
         return {
             $self->_edit_model => [ $self->entity_id ]
         }

--- a/lib/MusicBrainz/Server/Entity/Alias.pm
+++ b/lib/MusicBrainz/Server/Entity/Alias.pm
@@ -4,9 +4,9 @@ use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use Moose;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::DatePeriod';
 with 'MusicBrainz::Server::Entity::Role::Name';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 with 'MusicBrainz::Server::Entity::Role::Type' => { model => 'AliasType' };
 
 has 'sort_name' => (

--- a/lib/MusicBrainz/Server/Entity/Annotation.pm
+++ b/lib/MusicBrainz/Server/Entity/Annotation.pm
@@ -9,7 +9,7 @@ use MusicBrainz::Server::Filters qw( format_wikitext );
 use namespace::autoclean;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'annotation' }
 

--- a/lib/MusicBrainz/Server/Entity/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Entity/ArtistCredit.pm
@@ -13,8 +13,8 @@ use overload
     fallback => 1;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'artist_credit' }
 

--- a/lib/MusicBrainz/Server/Entity/Artwork.pm
+++ b/lib/MusicBrainz/Server/Entity/Artwork.pm
@@ -5,7 +5,7 @@ use DBDefs;
 use MusicBrainz::Server::Entity::CoverArtType;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 has comment => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Entity/CoreEntity.pm
@@ -3,11 +3,11 @@ package MusicBrainz::Server::Entity::CoreEntity;
 use Moose;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
 with 'MusicBrainz::Server::Entity::Role::Relatable';
 with 'MusicBrainz::Server::Entity::Role::Name';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Entity/IPI.pm
+++ b/lib/MusicBrainz/Server/Entity/IPI.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Entity::IPI;
 
 use Moose;
 
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 has 'ipi' => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/ISNI.pm
+++ b/lib/MusicBrainz/Server/Entity/ISNI.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Entity::ISNI;
 
 use Moose;
 
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 has 'isni' => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/ISRC.pm
+++ b/lib/MusicBrainz/Server/Entity/ISRC.pm
@@ -5,7 +5,7 @@ use Readonly;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'isrc' }
 

--- a/lib/MusicBrainz/Server/Entity/ISWC.pm
+++ b/lib/MusicBrainz/Server/Entity/ISWC.pm
@@ -5,7 +5,7 @@ use Readonly;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 has 'iswc' => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/Medium.pm
+++ b/lib/MusicBrainz/Server/Entity/Medium.pm
@@ -7,8 +7,8 @@ use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::Name';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'medium' }
 

--- a/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
+++ b/lib/MusicBrainz/Server/Entity/MediumCDTOC.pm
@@ -5,7 +5,7 @@ use Moose;
 use MusicBrainz::Server::Entity::Types;
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'medium_cdtoc' }
 

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -14,8 +14,8 @@ use MusicBrainz::Server::Data::Utils qw( boolean_to_json partial_date_to_hash );
 use overload '<=>' => \&_cmp, fallback => 1;
 
 extends 'MusicBrainz::Server::Entity';
-with  'MusicBrainz::Server::Entity::Role::Editable';
 with  'MusicBrainz::Server::Entity::Role::LastUpdate';
+with  'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 sub entity_type { 'relationship' }
 

--- a/lib/MusicBrainz/Server/Entity/Role/PendingEdits.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/PendingEdits.pm
@@ -1,4 +1,4 @@
-package MusicBrainz::Server::Entity::Role::Editable;
+package MusicBrainz::Server::Entity::Role::PendingEdits;
 
 use Moose::Role;
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Entity/Track.pm
+++ b/lib/MusicBrainz/Server/Entity/Track.pm
@@ -6,10 +6,10 @@ use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Track qw( format_track_length );
 
 extends 'MusicBrainz::Server::Entity';
-with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::ArtistCredit';
 with 'MusicBrainz::Server::Entity::Role::GID';
 with 'MusicBrainz::Server::Entity::Role::Name';
+with 'MusicBrainz::Server::Entity::Role::PendingEdits';
 
 has 'recording_id' => (
     is => 'rw',

--- a/root/types/alias.js
+++ b/root/types/alias.js
@@ -10,8 +10,8 @@
 // MusicBrainz::Server::Entity::Alias::TO_JSON
 declare type AliasT = {
   ...DatePeriodRoleT,
-  ...EditableRoleT,
   ...EntityRoleT<'alias'>,
+  ...PendingEditsRoleT,
   ...TypeRoleT<AliasTypeT>,
   +locale: string | null,
   +name: string,

--- a/root/types/artwork.js
+++ b/root/types/artwork.js
@@ -9,7 +9,7 @@
 
 // MusicBrainz::Server::Entity::Artwork::TO_JSON
 declare type ArtworkT = {
-  ...EditableRoleT,
+  ...PendingEditsRoleT,
   +comment: string,
   +filename: string | null,
   +huge_ia_thumbnail: string,

--- a/root/types/codes.js
+++ b/root/types/codes.js
@@ -12,7 +12,7 @@ declare type IpiCodesRoleT = {
 };
 
 declare type IpiCodeT = {
-  ...EditableRoleT,
+  ...PendingEditsRoleT,
   +ipi: string,
 };
 
@@ -21,20 +21,20 @@ declare type IsniCodesRoleT = {
 };
 
 declare type IsniCodeT = {
-  ...EditableRoleT,
+  ...PendingEditsRoleT,
   +isni: string,
 };
 
 declare type IsrcT = {
-  ...EditableRoleT,
   ...EntityRoleT<'isrc'>,
+  ...PendingEditsRoleT,
   +isrc: string,
   +recording_id: number,
 };
 
 declare type IswcT = {
-  ...EditableRoleT,
   ...EntityRoleT<'iswc'>,
+  ...PendingEditsRoleT,
   +iswc: string,
   +work_id: number,
 };

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -92,7 +92,7 @@ declare type DatePeriodRoleT = {
   +ended: boolean,
 };
 
-declare type EditableRoleT = {
+declare type PendingEditsRoleT = {
   +editsPending: boolean,
 };
 

--- a/root/types/relationship.js
+++ b/root/types/relationship.js
@@ -82,7 +82,7 @@ declare type PagedTargetTypeGroupT = {
 
 declare type RelationshipT = $ReadOnly<{
   ...DatePeriodRoleT,
-  ...EditableRoleT,
+  ...PendingEditsRoleT,
   +attributes: $ReadOnlyArray<LinkAttrT>,
   +backward: boolean,
   +entity0?: ?CoreEntityT,

--- a/root/types/url.js
+++ b/root/types/url.js
@@ -10,7 +10,7 @@
 // MusicBrainz::Server::Entity::URL::TO_JSON
 declare type UrlT = {
   ...CoreEntityRoleT<'url'>,
-  ...EditableRoleT,
+  ...PendingEditsRoleT,
   +decoded: string,
   +href_url: string,
   +pretty_name: string,

--- a/t/lib/t/MusicBrainz/Server/Data/Alias.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Alias.pm
@@ -53,7 +53,7 @@ test all => sub {
     # Artist data should do the alias role
     my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
     does_ok($artist_data, 'MusicBrainz::Server::Data::Role::Alias');
-    does_ok($artist_data->alias, 'MusicBrainz::Server::Data::Role::Editable');
+    does_ok($artist_data->alias, 'MusicBrainz::Server::Data::Role::PendingEdits');
 
     # Make sure we can load specific aliases
     my $alias = $artist_data->alias->get_by_id(1);

--- a/t/lib/t/MusicBrainz/Server/Data/Artist.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Artist.pm
@@ -62,7 +62,7 @@ my $sql = $test->c->sql;
 $sql->begin;
 
 my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
-does_ok($artist_data, 'MusicBrainz::Server::Data::Role::Editable');
+does_ok($artist_data, 'MusicBrainz::Server::Data::Role::PendingEdits');
 
 # ----
 # Test fetching artists:

--- a/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Instrument.pm
@@ -23,7 +23,7 @@ test 'Load basic data' => sub {
     MusicBrainz::Server::Test->prepare_test_database($test->c, '+data_instrument');
 
     my $instrument_data = $test->c->model('Instrument');
-    does_ok($instrument_data, 'MusicBrainz::Server::Data::Role::Editable');
+    does_ok($instrument_data, 'MusicBrainz::Server::Data::Role::PendingEdits');
 
     # ----
     # Test fetching instruments:

--- a/t/lib/t/MusicBrainz/Server/Data/Place.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Place.pm
@@ -94,7 +94,7 @@ my $sql = $test->c->sql;
 $sql->begin;
 
 my $place_data = MusicBrainz::Server::Data::Place->new(c => $test->c);
-does_ok($place_data, 'MusicBrainz::Server::Data::Role::Editable');
+does_ok($place_data, 'MusicBrainz::Server::Data::Role::PendingEdits');
 
 # A place with the minimal set of required attributes
 my $place = $place_data->get_by_id(1);


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Role’s name `Editable` wrongly suggested that entity could be directly edited, whereas it just brings pending edits which can be made to a connected editable entity instead.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Thus renaming as `PendingEdits`.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Fix Moose code (`MusicBrainz::Server::Entity`)
* [x] Locate and fix other inappropriate occurrences of `Editable`