### PR TITLE
Use Perl::Critic::Moose::ProhibitNewMethod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   musicbrainz-tests:
     docker:
-      - image: metabrainz/musicbrainz-tests:v-2022-08.2
+      - image: metabrainz/musicbrainz-tests:v-2022-10
         user: root
     working_directory: /home/musicbrainz/musicbrainz-server
 

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -15,6 +15,8 @@ allow_includes=1
 
 [Modules::RequireFilenameMatchesPackage]
 
+[Moose::ProhibitNewMethod]
+
 [Subroutines::ProhibitReturnSort]
 
 [TestingAndDebugging::ProhibitNoStrict]

--- a/HACKING-PROD.md
+++ b/HACKING-PROD.md
@@ -19,6 +19,13 @@ you have a Docker service running, run:
 Generating the snapshot will take quite a while. Once it is done, commit it
 and push it.
 
+Generating this new snapshot will often install the latest version of Chrome,
+which will require updating the version of ChromeDriver installed through
+[docker/Dockerfile.tests](docker/Dockerfile.tests). Check the appropriate
+version of ChromeDriver for the new version of Chrome from
+https://chromedriver.chromium.org/downloads and modify the Dockerfile
+accordingly.
+
 Then you will need to create a Docker `musicbrainz-tests` image. This step
 also takes quite a while, so you might want to consider running it inside a
 MetaBrainz server to make it faster. In any case, inside a musicbrainz-server

--- a/cpanfile
+++ b/cpanfile
@@ -124,6 +124,7 @@ test_requires 'HTML::HTML5::Parser';
 test_requires 'HTML::Selector::XPath';
 test_requires 'LWP::UserAgent::Mockable';
 test_requires 'Perl::Critic';
+test_requires 'Perl::Critic::Moose';
 test_requires 'Perl::Critic::TooMuchCode';
 test_requires 'Perl::Critic::Policy::Variables::ProhibitUnusedVarsStricter';
 test_requires 'TAP::Harness::JUnit';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -7,87 +7,88 @@ DISTRIBUTIONS
       Algorithm::Diff::_impl 1.201
     requirements:
       ExtUtils::MakeMaker 0
-  Alien-Build-2.59
-    pathname: P/PL/PLICEASE/Alien-Build-2.59.tar.gz
+  Alien-Build-2.71
+    pathname: P/PL/PLICEASE/Alien-Build-2.71.tar.gz
     provides:
-      Alien::Base 2.59
-      Alien::Base::PkgConfig 2.59
-      Alien::Base::Wrapper 2.59
-      Alien::Build 2.59
-      Alien::Build::CommandSequence 2.59
-      Alien::Build::Helper 2.59
-      Alien::Build::Interpolate 2.59
-      Alien::Build::Interpolate::Default 2.59
-      Alien::Build::Interpolate::Helper 2.59
-      Alien::Build::Log 2.59
-      Alien::Build::Log::Abbreviate 2.59
-      Alien::Build::Log::Default 2.59
-      Alien::Build::MM 2.59
-      Alien::Build::Meta 2.59
-      Alien::Build::Plugin 2.59
-      Alien::Build::Plugin::Build::Autoconf 2.59
-      Alien::Build::Plugin::Build::CMake 2.59
-      Alien::Build::Plugin::Build::Copy 2.59
-      Alien::Build::Plugin::Build::MSYS 2.59
-      Alien::Build::Plugin::Build::Make 2.59
-      Alien::Build::Plugin::Build::SearchDep 2.59
-      Alien::Build::Plugin::Core::CleanInstall 2.59
-      Alien::Build::Plugin::Core::Download 2.59
-      Alien::Build::Plugin::Core::FFI 2.59
-      Alien::Build::Plugin::Core::Gather 2.59
-      Alien::Build::Plugin::Core::Legacy 2.59
-      Alien::Build::Plugin::Core::Override 2.59
-      Alien::Build::Plugin::Core::Setup 2.59
-      Alien::Build::Plugin::Core::Tail 2.59
-      Alien::Build::Plugin::Decode::DirListing 2.59
-      Alien::Build::Plugin::Decode::DirListingFtpcopy 2.59
-      Alien::Build::Plugin::Decode::HTML 2.59
-      Alien::Build::Plugin::Decode::Mojo 2.59
-      Alien::Build::Plugin::Digest::Negotiate 2.59
-      Alien::Build::Plugin::Digest::SHA 2.59
-      Alien::Build::Plugin::Digest::SHAPP 2.59
-      Alien::Build::Plugin::Download::Negotiate 2.59
-      Alien::Build::Plugin::Extract::ArchiveTar 2.59
-      Alien::Build::Plugin::Extract::ArchiveZip 2.59
-      Alien::Build::Plugin::Extract::CommandLine 2.59
-      Alien::Build::Plugin::Extract::Directory 2.59
-      Alien::Build::Plugin::Extract::Negotiate 2.59
-      Alien::Build::Plugin::Fetch::CurlCommand 2.59
-      Alien::Build::Plugin::Fetch::HTTPTiny 2.59
-      Alien::Build::Plugin::Fetch::LWP 2.59
-      Alien::Build::Plugin::Fetch::Local 2.59
-      Alien::Build::Plugin::Fetch::LocalDir 2.59
-      Alien::Build::Plugin::Fetch::NetFTP 2.59
-      Alien::Build::Plugin::Fetch::Wget 2.59
-      Alien::Build::Plugin::Gather::IsolateDynamic 2.59
-      Alien::Build::Plugin::PkgConfig::CommandLine 2.59
-      Alien::Build::Plugin::PkgConfig::LibPkgConf 2.59
-      Alien::Build::Plugin::PkgConfig::MakeStatic 2.59
-      Alien::Build::Plugin::PkgConfig::Negotiate 2.59
-      Alien::Build::Plugin::PkgConfig::PP 2.59
-      Alien::Build::Plugin::Prefer::BadVersion 2.59
-      Alien::Build::Plugin::Prefer::GoodVersion 2.59
-      Alien::Build::Plugin::Prefer::SortVersions 2.59
-      Alien::Build::Plugin::Probe::CBuilder 2.59
-      Alien::Build::Plugin::Probe::CommandLine 2.59
-      Alien::Build::Plugin::Probe::Vcpkg 2.59
-      Alien::Build::Plugin::Test::Mock 2.59
-      Alien::Build::PluginMeta 2.59
-      Alien::Build::Temp 2.59
-      Alien::Build::TempDir 2.59
-      Alien::Build::Util 2.59
-      Alien::Build::Version::Basic 2.59
-      Alien::Build::rc 2.59
-      Alien::Role 2.59
-      Alien::Util 2.59
-      Test::Alien 2.59
-      Test::Alien::Build 2.59
-      Test::Alien::CanCompile 2.59
-      Test::Alien::CanPlatypus 2.59
-      Test::Alien::Diag 2.59
-      Test::Alien::Run 2.59
-      Test::Alien::Synthetic 2.59
-      alienfile 2.59
+      Alien::Base 2.71
+      Alien::Base::PkgConfig 2.71
+      Alien::Base::Wrapper 2.71
+      Alien::Build 2.71
+      Alien::Build::CommandSequence 2.71
+      Alien::Build::Helper 2.71
+      Alien::Build::Interpolate 2.71
+      Alien::Build::Interpolate::Default 2.71
+      Alien::Build::Interpolate::Helper 2.71
+      Alien::Build::Log 2.71
+      Alien::Build::Log::Abbreviate 2.71
+      Alien::Build::Log::Default 2.71
+      Alien::Build::MM 2.71
+      Alien::Build::Meta 2.71
+      Alien::Build::Plugin 2.71
+      Alien::Build::Plugin::Build::Autoconf 2.71
+      Alien::Build::Plugin::Build::CMake 2.71
+      Alien::Build::Plugin::Build::Copy 2.71
+      Alien::Build::Plugin::Build::MSYS 2.71
+      Alien::Build::Plugin::Build::Make 2.71
+      Alien::Build::Plugin::Build::SearchDep 2.71
+      Alien::Build::Plugin::Core::CleanInstall 2.71
+      Alien::Build::Plugin::Core::Download 2.71
+      Alien::Build::Plugin::Core::FFI 2.71
+      Alien::Build::Plugin::Core::Gather 2.71
+      Alien::Build::Plugin::Core::Legacy 2.71
+      Alien::Build::Plugin::Core::Override 2.71
+      Alien::Build::Plugin::Core::Setup 2.71
+      Alien::Build::Plugin::Core::Tail 2.71
+      Alien::Build::Plugin::Decode::DirListing 2.71
+      Alien::Build::Plugin::Decode::DirListingFtpcopy 2.71
+      Alien::Build::Plugin::Decode::HTML 2.71
+      Alien::Build::Plugin::Decode::Mojo 2.71
+      Alien::Build::Plugin::Digest::Negotiate 2.71
+      Alien::Build::Plugin::Digest::SHA 2.71
+      Alien::Build::Plugin::Digest::SHAPP 2.71
+      Alien::Build::Plugin::Download::Negotiate 2.71
+      Alien::Build::Plugin::Extract::ArchiveTar 2.71
+      Alien::Build::Plugin::Extract::ArchiveZip 2.71
+      Alien::Build::Plugin::Extract::CommandLine 2.71
+      Alien::Build::Plugin::Extract::Directory 2.71
+      Alien::Build::Plugin::Extract::File 2.71
+      Alien::Build::Plugin::Extract::Negotiate 2.71
+      Alien::Build::Plugin::Fetch::CurlCommand 2.71
+      Alien::Build::Plugin::Fetch::HTTPTiny 2.71
+      Alien::Build::Plugin::Fetch::LWP 2.71
+      Alien::Build::Plugin::Fetch::Local 2.71
+      Alien::Build::Plugin::Fetch::LocalDir 2.71
+      Alien::Build::Plugin::Fetch::NetFTP 2.71
+      Alien::Build::Plugin::Fetch::Wget 2.71
+      Alien::Build::Plugin::Gather::IsolateDynamic 2.71
+      Alien::Build::Plugin::PkgConfig::CommandLine 2.71
+      Alien::Build::Plugin::PkgConfig::LibPkgConf 2.71
+      Alien::Build::Plugin::PkgConfig::MakeStatic 2.71
+      Alien::Build::Plugin::PkgConfig::Negotiate 2.71
+      Alien::Build::Plugin::PkgConfig::PP 2.71
+      Alien::Build::Plugin::Prefer::BadVersion 2.71
+      Alien::Build::Plugin::Prefer::GoodVersion 2.71
+      Alien::Build::Plugin::Prefer::SortVersions 2.71
+      Alien::Build::Plugin::Probe::CBuilder 2.71
+      Alien::Build::Plugin::Probe::CommandLine 2.71
+      Alien::Build::Plugin::Probe::Vcpkg 2.71
+      Alien::Build::Plugin::Test::Mock 2.71
+      Alien::Build::PluginMeta 2.71
+      Alien::Build::Temp 2.71
+      Alien::Build::TempDir 2.71
+      Alien::Build::Util 2.71
+      Alien::Build::Version::Basic 2.71
+      Alien::Build::rc 2.71
+      Alien::Role 2.71
+      Alien::Util 2.71
+      Test::Alien 2.71
+      Test::Alien::Build 2.71
+      Test::Alien::CanCompile 2.71
+      Test::Alien::CanPlatypus 2.71
+      Test::Alien::Diag 2.71
+      Test::Alien::Run 2.71
+      Test::Alien::Synthetic 2.71
+      alienfile 2.71
     requirements:
       Capture::Tiny 0.17
       Digest::SHA 0
@@ -104,15 +105,28 @@ DISTRIBUTIONS
       Text::ParseWords 3.26
       parent 0
       perl 5.008004
-  Alien-Libxml2-0.17
-    pathname: P/PL/PLICEASE/Alien-Libxml2-0.17.tar.gz
+  Alien-Build-Plugin-Download-GitLab-0.01
+    pathname: P/PL/PLICEASE/Alien-Build-Plugin-Download-GitLab-0.01.tar.gz
     provides:
-      Alien::Libxml2 0.17
+      Alien::Build::Plugin::Download::GitLab 0.01
+    requirements:
+      Alien::Build::Plugin 0
+      ExtUtils::MakeMaker 0
+      JSON::PP 0
+      Path::Tiny 0
+      URI 0
+      URI::Escape 0
+      perl 5.008004
+  Alien-Libxml2-0.19
+    pathname: P/PL/PLICEASE/Alien-Libxml2-0.19.tar.gz
+    provides:
+      Alien::Libxml2 0.19
     requirements:
       Alien::Base 2.37
       Alien::Build 2.37
       Alien::Build::MM 2.37
       Alien::Build::Plugin::Build::SearchDep 0.35
+      Alien::Build::Plugin::Download::GitLab 0
       Alien::Build::Plugin::Prefer::BadVersion 1.05
       Alien::Build::Plugin::Probe::Vcpkg 0
       ExtUtils::CBuilder 0
@@ -505,7 +519,7 @@ DISTRIBUTIONS
     requirements:
       Catalyst::Runtime 0
       Class::Accessor::Fast 0
-      ExtUtils::MakeMaker 7.34
+      ExtUtils::MakeMaker 7.64
       HTTP::Headers::ETag 0
       HTTP::Status 0
       List::Util 0
@@ -1269,20 +1283,20 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.48
       Test::Simple 0.90
       perl 5.008001
-  DBIx-Connector-0.57
-    pathname: A/AR/ARISTOTLE/DBIx-Connector-0.57.tar.gz
+  DBIx-Connector-0.58
+    pathname: A/AR/ARISTOTLE/DBIx-Connector-0.58.tar.gz
     provides:
-      DBIx::Connector 0.57
-      DBIx::Connector::Driver 0.57
-      DBIx::Connector::Driver::Firebird 0.57
-      DBIx::Connector::Driver::MSSQL 0.57
-      DBIx::Connector::Driver::Oracle 0.57
-      DBIx::Connector::Driver::Pg 0.57
-      DBIx::Connector::Driver::SQLite 0.57
-      DBIx::Connector::Driver::mysql 0.57
-      DBIx::Connector::RollbackError 0.57
-      DBIx::Connector::SvpRollbackError 0.57
-      DBIx::Connector::TxnRollbackError 0.57
+      DBIx::Connector 0.58
+      DBIx::Connector::Driver 0.58
+      DBIx::Connector::Driver::Firebird 0.58
+      DBIx::Connector::Driver::MSSQL 0.58
+      DBIx::Connector::Driver::Oracle 0.58
+      DBIx::Connector::Driver::Pg 0.58
+      DBIx::Connector::Driver::SQLite 0.58
+      DBIx::Connector::Driver::mysql 0.58
+      DBIx::Connector::RollbackError 0.58
+      DBIx::Connector::SvpRollbackError 0.58
+      DBIx::Connector::TxnRollbackError 0.58
     requirements:
       DBI 1.605
       perl 5.008001
@@ -1669,351 +1683,349 @@ DISTRIBUTIONS
       perl 5.008004
       strict 0
       warnings 0
-  DateTime-TimeZone-2.53
-    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.53.tar.gz
+  DateTime-TimeZone-2.55
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.55.tar.gz
     provides:
-      DateTime::TimeZone 2.53
-      DateTime::TimeZone::Africa::Abidjan 2.53
-      DateTime::TimeZone::Africa::Algiers 2.53
-      DateTime::TimeZone::Africa::Bissau 2.53
-      DateTime::TimeZone::Africa::Cairo 2.53
-      DateTime::TimeZone::Africa::Casablanca 2.53
-      DateTime::TimeZone::Africa::Ceuta 2.53
-      DateTime::TimeZone::Africa::El_Aaiun 2.53
-      DateTime::TimeZone::Africa::Johannesburg 2.53
-      DateTime::TimeZone::Africa::Juba 2.53
-      DateTime::TimeZone::Africa::Khartoum 2.53
-      DateTime::TimeZone::Africa::Lagos 2.53
-      DateTime::TimeZone::Africa::Maputo 2.53
-      DateTime::TimeZone::Africa::Monrovia 2.53
-      DateTime::TimeZone::Africa::Nairobi 2.53
-      DateTime::TimeZone::Africa::Ndjamena 2.53
-      DateTime::TimeZone::Africa::Sao_Tome 2.53
-      DateTime::TimeZone::Africa::Tripoli 2.53
-      DateTime::TimeZone::Africa::Tunis 2.53
-      DateTime::TimeZone::Africa::Windhoek 2.53
-      DateTime::TimeZone::America::Adak 2.53
-      DateTime::TimeZone::America::Anchorage 2.53
-      DateTime::TimeZone::America::Araguaina 2.53
-      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.53
-      DateTime::TimeZone::America::Argentina::Catamarca 2.53
-      DateTime::TimeZone::America::Argentina::Cordoba 2.53
-      DateTime::TimeZone::America::Argentina::Jujuy 2.53
-      DateTime::TimeZone::America::Argentina::La_Rioja 2.53
-      DateTime::TimeZone::America::Argentina::Mendoza 2.53
-      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.53
-      DateTime::TimeZone::America::Argentina::Salta 2.53
-      DateTime::TimeZone::America::Argentina::San_Juan 2.53
-      DateTime::TimeZone::America::Argentina::San_Luis 2.53
-      DateTime::TimeZone::America::Argentina::Tucuman 2.53
-      DateTime::TimeZone::America::Argentina::Ushuaia 2.53
-      DateTime::TimeZone::America::Asuncion 2.53
-      DateTime::TimeZone::America::Bahia 2.53
-      DateTime::TimeZone::America::Bahia_Banderas 2.53
-      DateTime::TimeZone::America::Barbados 2.53
-      DateTime::TimeZone::America::Belem 2.53
-      DateTime::TimeZone::America::Belize 2.53
-      DateTime::TimeZone::America::Boa_Vista 2.53
-      DateTime::TimeZone::America::Bogota 2.53
-      DateTime::TimeZone::America::Boise 2.53
-      DateTime::TimeZone::America::Cambridge_Bay 2.53
-      DateTime::TimeZone::America::Campo_Grande 2.53
-      DateTime::TimeZone::America::Cancun 2.53
-      DateTime::TimeZone::America::Caracas 2.53
-      DateTime::TimeZone::America::Cayenne 2.53
-      DateTime::TimeZone::America::Chicago 2.53
-      DateTime::TimeZone::America::Chihuahua 2.53
-      DateTime::TimeZone::America::Costa_Rica 2.53
-      DateTime::TimeZone::America::Cuiaba 2.53
-      DateTime::TimeZone::America::Danmarkshavn 2.53
-      DateTime::TimeZone::America::Dawson 2.53
-      DateTime::TimeZone::America::Dawson_Creek 2.53
-      DateTime::TimeZone::America::Denver 2.53
-      DateTime::TimeZone::America::Detroit 2.53
-      DateTime::TimeZone::America::Edmonton 2.53
-      DateTime::TimeZone::America::Eirunepe 2.53
-      DateTime::TimeZone::America::El_Salvador 2.53
-      DateTime::TimeZone::America::Fort_Nelson 2.53
-      DateTime::TimeZone::America::Fortaleza 2.53
-      DateTime::TimeZone::America::Glace_Bay 2.53
-      DateTime::TimeZone::America::Goose_Bay 2.53
-      DateTime::TimeZone::America::Grand_Turk 2.53
-      DateTime::TimeZone::America::Guatemala 2.53
-      DateTime::TimeZone::America::Guayaquil 2.53
-      DateTime::TimeZone::America::Guyana 2.53
-      DateTime::TimeZone::America::Halifax 2.53
-      DateTime::TimeZone::America::Havana 2.53
-      DateTime::TimeZone::America::Hermosillo 2.53
-      DateTime::TimeZone::America::Indiana::Indianapolis 2.53
-      DateTime::TimeZone::America::Indiana::Knox 2.53
-      DateTime::TimeZone::America::Indiana::Marengo 2.53
-      DateTime::TimeZone::America::Indiana::Petersburg 2.53
-      DateTime::TimeZone::America::Indiana::Tell_City 2.53
-      DateTime::TimeZone::America::Indiana::Vevay 2.53
-      DateTime::TimeZone::America::Indiana::Vincennes 2.53
-      DateTime::TimeZone::America::Indiana::Winamac 2.53
-      DateTime::TimeZone::America::Inuvik 2.53
-      DateTime::TimeZone::America::Iqaluit 2.53
-      DateTime::TimeZone::America::Jamaica 2.53
-      DateTime::TimeZone::America::Juneau 2.53
-      DateTime::TimeZone::America::Kentucky::Louisville 2.53
-      DateTime::TimeZone::America::Kentucky::Monticello 2.53
-      DateTime::TimeZone::America::La_Paz 2.53
-      DateTime::TimeZone::America::Lima 2.53
-      DateTime::TimeZone::America::Los_Angeles 2.53
-      DateTime::TimeZone::America::Maceio 2.53
-      DateTime::TimeZone::America::Managua 2.53
-      DateTime::TimeZone::America::Manaus 2.53
-      DateTime::TimeZone::America::Martinique 2.53
-      DateTime::TimeZone::America::Matamoros 2.53
-      DateTime::TimeZone::America::Mazatlan 2.53
-      DateTime::TimeZone::America::Menominee 2.53
-      DateTime::TimeZone::America::Merida 2.53
-      DateTime::TimeZone::America::Metlakatla 2.53
-      DateTime::TimeZone::America::Mexico_City 2.53
-      DateTime::TimeZone::America::Miquelon 2.53
-      DateTime::TimeZone::America::Moncton 2.53
-      DateTime::TimeZone::America::Monterrey 2.53
-      DateTime::TimeZone::America::Montevideo 2.53
-      DateTime::TimeZone::America::New_York 2.53
-      DateTime::TimeZone::America::Nipigon 2.53
-      DateTime::TimeZone::America::Nome 2.53
-      DateTime::TimeZone::America::Noronha 2.53
-      DateTime::TimeZone::America::North_Dakota::Beulah 2.53
-      DateTime::TimeZone::America::North_Dakota::Center 2.53
-      DateTime::TimeZone::America::North_Dakota::New_Salem 2.53
-      DateTime::TimeZone::America::Nuuk 2.53
-      DateTime::TimeZone::America::Ojinaga 2.53
-      DateTime::TimeZone::America::Panama 2.53
-      DateTime::TimeZone::America::Pangnirtung 2.53
-      DateTime::TimeZone::America::Paramaribo 2.53
-      DateTime::TimeZone::America::Phoenix 2.53
-      DateTime::TimeZone::America::Port_au_Prince 2.53
-      DateTime::TimeZone::America::Porto_Velho 2.53
-      DateTime::TimeZone::America::Puerto_Rico 2.53
-      DateTime::TimeZone::America::Punta_Arenas 2.53
-      DateTime::TimeZone::America::Rainy_River 2.53
-      DateTime::TimeZone::America::Rankin_Inlet 2.53
-      DateTime::TimeZone::America::Recife 2.53
-      DateTime::TimeZone::America::Regina 2.53
-      DateTime::TimeZone::America::Resolute 2.53
-      DateTime::TimeZone::America::Rio_Branco 2.53
-      DateTime::TimeZone::America::Santarem 2.53
-      DateTime::TimeZone::America::Santiago 2.53
-      DateTime::TimeZone::America::Santo_Domingo 2.53
-      DateTime::TimeZone::America::Sao_Paulo 2.53
-      DateTime::TimeZone::America::Scoresbysund 2.53
-      DateTime::TimeZone::America::Sitka 2.53
-      DateTime::TimeZone::America::St_Johns 2.53
-      DateTime::TimeZone::America::Swift_Current 2.53
-      DateTime::TimeZone::America::Tegucigalpa 2.53
-      DateTime::TimeZone::America::Thule 2.53
-      DateTime::TimeZone::America::Thunder_Bay 2.53
-      DateTime::TimeZone::America::Tijuana 2.53
-      DateTime::TimeZone::America::Toronto 2.53
-      DateTime::TimeZone::America::Vancouver 2.53
-      DateTime::TimeZone::America::Whitehorse 2.53
-      DateTime::TimeZone::America::Winnipeg 2.53
-      DateTime::TimeZone::America::Yakutat 2.53
-      DateTime::TimeZone::America::Yellowknife 2.53
-      DateTime::TimeZone::Antarctica::Casey 2.53
-      DateTime::TimeZone::Antarctica::Davis 2.53
-      DateTime::TimeZone::Antarctica::Macquarie 2.53
-      DateTime::TimeZone::Antarctica::Mawson 2.53
-      DateTime::TimeZone::Antarctica::Palmer 2.53
-      DateTime::TimeZone::Antarctica::Rothera 2.53
-      DateTime::TimeZone::Antarctica::Troll 2.53
-      DateTime::TimeZone::Asia::Almaty 2.53
-      DateTime::TimeZone::Asia::Amman 2.53
-      DateTime::TimeZone::Asia::Anadyr 2.53
-      DateTime::TimeZone::Asia::Aqtau 2.53
-      DateTime::TimeZone::Asia::Aqtobe 2.53
-      DateTime::TimeZone::Asia::Ashgabat 2.53
-      DateTime::TimeZone::Asia::Atyrau 2.53
-      DateTime::TimeZone::Asia::Baghdad 2.53
-      DateTime::TimeZone::Asia::Baku 2.53
-      DateTime::TimeZone::Asia::Bangkok 2.53
-      DateTime::TimeZone::Asia::Barnaul 2.53
-      DateTime::TimeZone::Asia::Beirut 2.53
-      DateTime::TimeZone::Asia::Bishkek 2.53
-      DateTime::TimeZone::Asia::Chita 2.53
-      DateTime::TimeZone::Asia::Choibalsan 2.53
-      DateTime::TimeZone::Asia::Colombo 2.53
-      DateTime::TimeZone::Asia::Damascus 2.53
-      DateTime::TimeZone::Asia::Dhaka 2.53
-      DateTime::TimeZone::Asia::Dili 2.53
-      DateTime::TimeZone::Asia::Dubai 2.53
-      DateTime::TimeZone::Asia::Dushanbe 2.53
-      DateTime::TimeZone::Asia::Famagusta 2.53
-      DateTime::TimeZone::Asia::Gaza 2.53
-      DateTime::TimeZone::Asia::Hebron 2.53
-      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.53
-      DateTime::TimeZone::Asia::Hong_Kong 2.53
-      DateTime::TimeZone::Asia::Hovd 2.53
-      DateTime::TimeZone::Asia::Irkutsk 2.53
-      DateTime::TimeZone::Asia::Jakarta 2.53
-      DateTime::TimeZone::Asia::Jayapura 2.53
-      DateTime::TimeZone::Asia::Jerusalem 2.53
-      DateTime::TimeZone::Asia::Kabul 2.53
-      DateTime::TimeZone::Asia::Kamchatka 2.53
-      DateTime::TimeZone::Asia::Karachi 2.53
-      DateTime::TimeZone::Asia::Kathmandu 2.53
-      DateTime::TimeZone::Asia::Khandyga 2.53
-      DateTime::TimeZone::Asia::Kolkata 2.53
-      DateTime::TimeZone::Asia::Krasnoyarsk 2.53
-      DateTime::TimeZone::Asia::Kuching 2.53
-      DateTime::TimeZone::Asia::Macau 2.53
-      DateTime::TimeZone::Asia::Magadan 2.53
-      DateTime::TimeZone::Asia::Makassar 2.53
-      DateTime::TimeZone::Asia::Manila 2.53
-      DateTime::TimeZone::Asia::Nicosia 2.53
-      DateTime::TimeZone::Asia::Novokuznetsk 2.53
-      DateTime::TimeZone::Asia::Novosibirsk 2.53
-      DateTime::TimeZone::Asia::Omsk 2.53
-      DateTime::TimeZone::Asia::Oral 2.53
-      DateTime::TimeZone::Asia::Pontianak 2.53
-      DateTime::TimeZone::Asia::Pyongyang 2.53
-      DateTime::TimeZone::Asia::Qatar 2.53
-      DateTime::TimeZone::Asia::Qostanay 2.53
-      DateTime::TimeZone::Asia::Qyzylorda 2.53
-      DateTime::TimeZone::Asia::Riyadh 2.53
-      DateTime::TimeZone::Asia::Sakhalin 2.53
-      DateTime::TimeZone::Asia::Samarkand 2.53
-      DateTime::TimeZone::Asia::Seoul 2.53
-      DateTime::TimeZone::Asia::Shanghai 2.53
-      DateTime::TimeZone::Asia::Singapore 2.53
-      DateTime::TimeZone::Asia::Srednekolymsk 2.53
-      DateTime::TimeZone::Asia::Taipei 2.53
-      DateTime::TimeZone::Asia::Tashkent 2.53
-      DateTime::TimeZone::Asia::Tbilisi 2.53
-      DateTime::TimeZone::Asia::Tehran 2.53
-      DateTime::TimeZone::Asia::Thimphu 2.53
-      DateTime::TimeZone::Asia::Tokyo 2.53
-      DateTime::TimeZone::Asia::Tomsk 2.53
-      DateTime::TimeZone::Asia::Ulaanbaatar 2.53
-      DateTime::TimeZone::Asia::Urumqi 2.53
-      DateTime::TimeZone::Asia::Ust_Nera 2.53
-      DateTime::TimeZone::Asia::Vladivostok 2.53
-      DateTime::TimeZone::Asia::Yakutsk 2.53
-      DateTime::TimeZone::Asia::Yangon 2.53
-      DateTime::TimeZone::Asia::Yekaterinburg 2.53
-      DateTime::TimeZone::Asia::Yerevan 2.53
-      DateTime::TimeZone::Atlantic::Azores 2.53
-      DateTime::TimeZone::Atlantic::Bermuda 2.53
-      DateTime::TimeZone::Atlantic::Canary 2.53
-      DateTime::TimeZone::Atlantic::Cape_Verde 2.53
-      DateTime::TimeZone::Atlantic::Faroe 2.53
-      DateTime::TimeZone::Atlantic::Madeira 2.53
-      DateTime::TimeZone::Atlantic::South_Georgia 2.53
-      DateTime::TimeZone::Atlantic::Stanley 2.53
-      DateTime::TimeZone::Australia::Adelaide 2.53
-      DateTime::TimeZone::Australia::Brisbane 2.53
-      DateTime::TimeZone::Australia::Broken_Hill 2.53
-      DateTime::TimeZone::Australia::Darwin 2.53
-      DateTime::TimeZone::Australia::Eucla 2.53
-      DateTime::TimeZone::Australia::Hobart 2.53
-      DateTime::TimeZone::Australia::Lindeman 2.53
-      DateTime::TimeZone::Australia::Lord_Howe 2.53
-      DateTime::TimeZone::Australia::Melbourne 2.53
-      DateTime::TimeZone::Australia::Perth 2.53
-      DateTime::TimeZone::Australia::Sydney 2.53
-      DateTime::TimeZone::CET 2.53
-      DateTime::TimeZone::CST6CDT 2.53
-      DateTime::TimeZone::Catalog 2.53
-      DateTime::TimeZone::EET 2.53
-      DateTime::TimeZone::EST 2.53
-      DateTime::TimeZone::EST5EDT 2.53
-      DateTime::TimeZone::Europe::Andorra 2.53
-      DateTime::TimeZone::Europe::Astrakhan 2.53
-      DateTime::TimeZone::Europe::Athens 2.53
-      DateTime::TimeZone::Europe::Belgrade 2.53
-      DateTime::TimeZone::Europe::Berlin 2.53
-      DateTime::TimeZone::Europe::Brussels 2.53
-      DateTime::TimeZone::Europe::Bucharest 2.53
-      DateTime::TimeZone::Europe::Budapest 2.53
-      DateTime::TimeZone::Europe::Chisinau 2.53
-      DateTime::TimeZone::Europe::Dublin 2.53
-      DateTime::TimeZone::Europe::Gibraltar 2.53
-      DateTime::TimeZone::Europe::Helsinki 2.53
-      DateTime::TimeZone::Europe::Istanbul 2.53
-      DateTime::TimeZone::Europe::Kaliningrad 2.53
-      DateTime::TimeZone::Europe::Kirov 2.53
-      DateTime::TimeZone::Europe::Kyiv 2.53
-      DateTime::TimeZone::Europe::Lisbon 2.53
-      DateTime::TimeZone::Europe::London 2.53
-      DateTime::TimeZone::Europe::Madrid 2.53
-      DateTime::TimeZone::Europe::Malta 2.53
-      DateTime::TimeZone::Europe::Minsk 2.53
-      DateTime::TimeZone::Europe::Moscow 2.53
-      DateTime::TimeZone::Europe::Paris 2.53
-      DateTime::TimeZone::Europe::Prague 2.53
-      DateTime::TimeZone::Europe::Riga 2.53
-      DateTime::TimeZone::Europe::Rome 2.53
-      DateTime::TimeZone::Europe::Samara 2.53
-      DateTime::TimeZone::Europe::Saratov 2.53
-      DateTime::TimeZone::Europe::Simferopol 2.53
-      DateTime::TimeZone::Europe::Sofia 2.53
-      DateTime::TimeZone::Europe::Tallinn 2.53
-      DateTime::TimeZone::Europe::Tirane 2.53
-      DateTime::TimeZone::Europe::Ulyanovsk 2.53
-      DateTime::TimeZone::Europe::Uzhgorod 2.53
-      DateTime::TimeZone::Europe::Vienna 2.53
-      DateTime::TimeZone::Europe::Vilnius 2.53
-      DateTime::TimeZone::Europe::Volgograd 2.53
-      DateTime::TimeZone::Europe::Warsaw 2.53
-      DateTime::TimeZone::Europe::Zaporozhye 2.53
-      DateTime::TimeZone::Europe::Zurich 2.53
-      DateTime::TimeZone::Floating 2.53
-      DateTime::TimeZone::HST 2.53
-      DateTime::TimeZone::Indian::Chagos 2.53
-      DateTime::TimeZone::Indian::Maldives 2.53
-      DateTime::TimeZone::Indian::Mauritius 2.53
-      DateTime::TimeZone::Local 2.53
-      DateTime::TimeZone::Local::Android 2.53
-      DateTime::TimeZone::Local::Unix 2.53
-      DateTime::TimeZone::Local::VMS 2.53
-      DateTime::TimeZone::MET 2.53
-      DateTime::TimeZone::MST 2.53
-      DateTime::TimeZone::MST7MDT 2.53
-      DateTime::TimeZone::OffsetOnly 2.53
-      DateTime::TimeZone::OlsonDB 2.53
-      DateTime::TimeZone::OlsonDB::Change 2.53
-      DateTime::TimeZone::OlsonDB::Observance 2.53
-      DateTime::TimeZone::OlsonDB::Rule 2.53
-      DateTime::TimeZone::OlsonDB::Zone 2.53
-      DateTime::TimeZone::PST8PDT 2.53
-      DateTime::TimeZone::Pacific::Apia 2.53
-      DateTime::TimeZone::Pacific::Auckland 2.53
-      DateTime::TimeZone::Pacific::Bougainville 2.53
-      DateTime::TimeZone::Pacific::Chatham 2.53
-      DateTime::TimeZone::Pacific::Easter 2.53
-      DateTime::TimeZone::Pacific::Efate 2.53
-      DateTime::TimeZone::Pacific::Fakaofo 2.53
-      DateTime::TimeZone::Pacific::Fiji 2.53
-      DateTime::TimeZone::Pacific::Galapagos 2.53
-      DateTime::TimeZone::Pacific::Gambier 2.53
-      DateTime::TimeZone::Pacific::Guadalcanal 2.53
-      DateTime::TimeZone::Pacific::Guam 2.53
-      DateTime::TimeZone::Pacific::Honolulu 2.53
-      DateTime::TimeZone::Pacific::Kanton 2.53
-      DateTime::TimeZone::Pacific::Kiritimati 2.53
-      DateTime::TimeZone::Pacific::Kosrae 2.53
-      DateTime::TimeZone::Pacific::Kwajalein 2.53
-      DateTime::TimeZone::Pacific::Marquesas 2.53
-      DateTime::TimeZone::Pacific::Nauru 2.53
-      DateTime::TimeZone::Pacific::Niue 2.53
-      DateTime::TimeZone::Pacific::Norfolk 2.53
-      DateTime::TimeZone::Pacific::Noumea 2.53
-      DateTime::TimeZone::Pacific::Pago_Pago 2.53
-      DateTime::TimeZone::Pacific::Palau 2.53
-      DateTime::TimeZone::Pacific::Pitcairn 2.53
-      DateTime::TimeZone::Pacific::Port_Moresby 2.53
-      DateTime::TimeZone::Pacific::Rarotonga 2.53
-      DateTime::TimeZone::Pacific::Tahiti 2.53
-      DateTime::TimeZone::Pacific::Tarawa 2.53
-      DateTime::TimeZone::Pacific::Tongatapu 2.53
-      DateTime::TimeZone::UTC 2.53
-      DateTime::TimeZone::WET 2.53
+      DateTime::TimeZone 2.55
+      DateTime::TimeZone::Africa::Abidjan 2.55
+      DateTime::TimeZone::Africa::Algiers 2.55
+      DateTime::TimeZone::Africa::Bissau 2.55
+      DateTime::TimeZone::Africa::Cairo 2.55
+      DateTime::TimeZone::Africa::Casablanca 2.55
+      DateTime::TimeZone::Africa::Ceuta 2.55
+      DateTime::TimeZone::Africa::El_Aaiun 2.55
+      DateTime::TimeZone::Africa::Johannesburg 2.55
+      DateTime::TimeZone::Africa::Juba 2.55
+      DateTime::TimeZone::Africa::Khartoum 2.55
+      DateTime::TimeZone::Africa::Lagos 2.55
+      DateTime::TimeZone::Africa::Maputo 2.55
+      DateTime::TimeZone::Africa::Monrovia 2.55
+      DateTime::TimeZone::Africa::Nairobi 2.55
+      DateTime::TimeZone::Africa::Ndjamena 2.55
+      DateTime::TimeZone::Africa::Sao_Tome 2.55
+      DateTime::TimeZone::Africa::Tripoli 2.55
+      DateTime::TimeZone::Africa::Tunis 2.55
+      DateTime::TimeZone::Africa::Windhoek 2.55
+      DateTime::TimeZone::America::Adak 2.55
+      DateTime::TimeZone::America::Anchorage 2.55
+      DateTime::TimeZone::America::Araguaina 2.55
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.55
+      DateTime::TimeZone::America::Argentina::Catamarca 2.55
+      DateTime::TimeZone::America::Argentina::Cordoba 2.55
+      DateTime::TimeZone::America::Argentina::Jujuy 2.55
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.55
+      DateTime::TimeZone::America::Argentina::Mendoza 2.55
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.55
+      DateTime::TimeZone::America::Argentina::Salta 2.55
+      DateTime::TimeZone::America::Argentina::San_Juan 2.55
+      DateTime::TimeZone::America::Argentina::San_Luis 2.55
+      DateTime::TimeZone::America::Argentina::Tucuman 2.55
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.55
+      DateTime::TimeZone::America::Asuncion 2.55
+      DateTime::TimeZone::America::Bahia 2.55
+      DateTime::TimeZone::America::Bahia_Banderas 2.55
+      DateTime::TimeZone::America::Barbados 2.55
+      DateTime::TimeZone::America::Belem 2.55
+      DateTime::TimeZone::America::Belize 2.55
+      DateTime::TimeZone::America::Boa_Vista 2.55
+      DateTime::TimeZone::America::Bogota 2.55
+      DateTime::TimeZone::America::Boise 2.55
+      DateTime::TimeZone::America::Cambridge_Bay 2.55
+      DateTime::TimeZone::America::Campo_Grande 2.55
+      DateTime::TimeZone::America::Cancun 2.55
+      DateTime::TimeZone::America::Caracas 2.55
+      DateTime::TimeZone::America::Cayenne 2.55
+      DateTime::TimeZone::America::Chicago 2.55
+      DateTime::TimeZone::America::Chihuahua 2.55
+      DateTime::TimeZone::America::Costa_Rica 2.55
+      DateTime::TimeZone::America::Cuiaba 2.55
+      DateTime::TimeZone::America::Danmarkshavn 2.55
+      DateTime::TimeZone::America::Dawson 2.55
+      DateTime::TimeZone::America::Dawson_Creek 2.55
+      DateTime::TimeZone::America::Denver 2.55
+      DateTime::TimeZone::America::Detroit 2.55
+      DateTime::TimeZone::America::Edmonton 2.55
+      DateTime::TimeZone::America::Eirunepe 2.55
+      DateTime::TimeZone::America::El_Salvador 2.55
+      DateTime::TimeZone::America::Fort_Nelson 2.55
+      DateTime::TimeZone::America::Fortaleza 2.55
+      DateTime::TimeZone::America::Glace_Bay 2.55
+      DateTime::TimeZone::America::Goose_Bay 2.55
+      DateTime::TimeZone::America::Grand_Turk 2.55
+      DateTime::TimeZone::America::Guatemala 2.55
+      DateTime::TimeZone::America::Guayaquil 2.55
+      DateTime::TimeZone::America::Guyana 2.55
+      DateTime::TimeZone::America::Halifax 2.55
+      DateTime::TimeZone::America::Havana 2.55
+      DateTime::TimeZone::America::Hermosillo 2.55
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.55
+      DateTime::TimeZone::America::Indiana::Knox 2.55
+      DateTime::TimeZone::America::Indiana::Marengo 2.55
+      DateTime::TimeZone::America::Indiana::Petersburg 2.55
+      DateTime::TimeZone::America::Indiana::Tell_City 2.55
+      DateTime::TimeZone::America::Indiana::Vevay 2.55
+      DateTime::TimeZone::America::Indiana::Vincennes 2.55
+      DateTime::TimeZone::America::Indiana::Winamac 2.55
+      DateTime::TimeZone::America::Inuvik 2.55
+      DateTime::TimeZone::America::Iqaluit 2.55
+      DateTime::TimeZone::America::Jamaica 2.55
+      DateTime::TimeZone::America::Juneau 2.55
+      DateTime::TimeZone::America::Kentucky::Louisville 2.55
+      DateTime::TimeZone::America::Kentucky::Monticello 2.55
+      DateTime::TimeZone::America::La_Paz 2.55
+      DateTime::TimeZone::America::Lima 2.55
+      DateTime::TimeZone::America::Los_Angeles 2.55
+      DateTime::TimeZone::America::Maceio 2.55
+      DateTime::TimeZone::America::Managua 2.55
+      DateTime::TimeZone::America::Manaus 2.55
+      DateTime::TimeZone::America::Martinique 2.55
+      DateTime::TimeZone::America::Matamoros 2.55
+      DateTime::TimeZone::America::Mazatlan 2.55
+      DateTime::TimeZone::America::Menominee 2.55
+      DateTime::TimeZone::America::Merida 2.55
+      DateTime::TimeZone::America::Metlakatla 2.55
+      DateTime::TimeZone::America::Mexico_City 2.55
+      DateTime::TimeZone::America::Miquelon 2.55
+      DateTime::TimeZone::America::Moncton 2.55
+      DateTime::TimeZone::America::Monterrey 2.55
+      DateTime::TimeZone::America::Montevideo 2.55
+      DateTime::TimeZone::America::New_York 2.55
+      DateTime::TimeZone::America::Nipigon 2.55
+      DateTime::TimeZone::America::Nome 2.55
+      DateTime::TimeZone::America::Noronha 2.55
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.55
+      DateTime::TimeZone::America::North_Dakota::Center 2.55
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.55
+      DateTime::TimeZone::America::Nuuk 2.55
+      DateTime::TimeZone::America::Ojinaga 2.55
+      DateTime::TimeZone::America::Panama 2.55
+      DateTime::TimeZone::America::Pangnirtung 2.55
+      DateTime::TimeZone::America::Paramaribo 2.55
+      DateTime::TimeZone::America::Phoenix 2.55
+      DateTime::TimeZone::America::Port_au_Prince 2.55
+      DateTime::TimeZone::America::Porto_Velho 2.55
+      DateTime::TimeZone::America::Puerto_Rico 2.55
+      DateTime::TimeZone::America::Punta_Arenas 2.55
+      DateTime::TimeZone::America::Rainy_River 2.55
+      DateTime::TimeZone::America::Rankin_Inlet 2.55
+      DateTime::TimeZone::America::Recife 2.55
+      DateTime::TimeZone::America::Regina 2.55
+      DateTime::TimeZone::America::Resolute 2.55
+      DateTime::TimeZone::America::Rio_Branco 2.55
+      DateTime::TimeZone::America::Santarem 2.55
+      DateTime::TimeZone::America::Santiago 2.55
+      DateTime::TimeZone::America::Santo_Domingo 2.55
+      DateTime::TimeZone::America::Sao_Paulo 2.55
+      DateTime::TimeZone::America::Scoresbysund 2.55
+      DateTime::TimeZone::America::Sitka 2.55
+      DateTime::TimeZone::America::St_Johns 2.55
+      DateTime::TimeZone::America::Swift_Current 2.55
+      DateTime::TimeZone::America::Tegucigalpa 2.55
+      DateTime::TimeZone::America::Thule 2.55
+      DateTime::TimeZone::America::Thunder_Bay 2.55
+      DateTime::TimeZone::America::Tijuana 2.55
+      DateTime::TimeZone::America::Toronto 2.55
+      DateTime::TimeZone::America::Vancouver 2.55
+      DateTime::TimeZone::America::Whitehorse 2.55
+      DateTime::TimeZone::America::Winnipeg 2.55
+      DateTime::TimeZone::America::Yakutat 2.55
+      DateTime::TimeZone::America::Yellowknife 2.55
+      DateTime::TimeZone::Antarctica::Casey 2.55
+      DateTime::TimeZone::Antarctica::Davis 2.55
+      DateTime::TimeZone::Antarctica::Macquarie 2.55
+      DateTime::TimeZone::Antarctica::Mawson 2.55
+      DateTime::TimeZone::Antarctica::Palmer 2.55
+      DateTime::TimeZone::Antarctica::Rothera 2.55
+      DateTime::TimeZone::Antarctica::Troll 2.55
+      DateTime::TimeZone::Asia::Almaty 2.55
+      DateTime::TimeZone::Asia::Amman 2.55
+      DateTime::TimeZone::Asia::Anadyr 2.55
+      DateTime::TimeZone::Asia::Aqtau 2.55
+      DateTime::TimeZone::Asia::Aqtobe 2.55
+      DateTime::TimeZone::Asia::Ashgabat 2.55
+      DateTime::TimeZone::Asia::Atyrau 2.55
+      DateTime::TimeZone::Asia::Baghdad 2.55
+      DateTime::TimeZone::Asia::Baku 2.55
+      DateTime::TimeZone::Asia::Bangkok 2.55
+      DateTime::TimeZone::Asia::Barnaul 2.55
+      DateTime::TimeZone::Asia::Beirut 2.55
+      DateTime::TimeZone::Asia::Bishkek 2.55
+      DateTime::TimeZone::Asia::Chita 2.55
+      DateTime::TimeZone::Asia::Choibalsan 2.55
+      DateTime::TimeZone::Asia::Colombo 2.55
+      DateTime::TimeZone::Asia::Damascus 2.55
+      DateTime::TimeZone::Asia::Dhaka 2.55
+      DateTime::TimeZone::Asia::Dili 2.55
+      DateTime::TimeZone::Asia::Dubai 2.55
+      DateTime::TimeZone::Asia::Dushanbe 2.55
+      DateTime::TimeZone::Asia::Famagusta 2.55
+      DateTime::TimeZone::Asia::Gaza 2.55
+      DateTime::TimeZone::Asia::Hebron 2.55
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.55
+      DateTime::TimeZone::Asia::Hong_Kong 2.55
+      DateTime::TimeZone::Asia::Hovd 2.55
+      DateTime::TimeZone::Asia::Irkutsk 2.55
+      DateTime::TimeZone::Asia::Jakarta 2.55
+      DateTime::TimeZone::Asia::Jayapura 2.55
+      DateTime::TimeZone::Asia::Jerusalem 2.55
+      DateTime::TimeZone::Asia::Kabul 2.55
+      DateTime::TimeZone::Asia::Kamchatka 2.55
+      DateTime::TimeZone::Asia::Karachi 2.55
+      DateTime::TimeZone::Asia::Kathmandu 2.55
+      DateTime::TimeZone::Asia::Khandyga 2.55
+      DateTime::TimeZone::Asia::Kolkata 2.55
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.55
+      DateTime::TimeZone::Asia::Kuching 2.55
+      DateTime::TimeZone::Asia::Macau 2.55
+      DateTime::TimeZone::Asia::Magadan 2.55
+      DateTime::TimeZone::Asia::Makassar 2.55
+      DateTime::TimeZone::Asia::Manila 2.55
+      DateTime::TimeZone::Asia::Nicosia 2.55
+      DateTime::TimeZone::Asia::Novokuznetsk 2.55
+      DateTime::TimeZone::Asia::Novosibirsk 2.55
+      DateTime::TimeZone::Asia::Omsk 2.55
+      DateTime::TimeZone::Asia::Oral 2.55
+      DateTime::TimeZone::Asia::Pontianak 2.55
+      DateTime::TimeZone::Asia::Pyongyang 2.55
+      DateTime::TimeZone::Asia::Qatar 2.55
+      DateTime::TimeZone::Asia::Qostanay 2.55
+      DateTime::TimeZone::Asia::Qyzylorda 2.55
+      DateTime::TimeZone::Asia::Riyadh 2.55
+      DateTime::TimeZone::Asia::Sakhalin 2.55
+      DateTime::TimeZone::Asia::Samarkand 2.55
+      DateTime::TimeZone::Asia::Seoul 2.55
+      DateTime::TimeZone::Asia::Shanghai 2.55
+      DateTime::TimeZone::Asia::Singapore 2.55
+      DateTime::TimeZone::Asia::Srednekolymsk 2.55
+      DateTime::TimeZone::Asia::Taipei 2.55
+      DateTime::TimeZone::Asia::Tashkent 2.55
+      DateTime::TimeZone::Asia::Tbilisi 2.55
+      DateTime::TimeZone::Asia::Tehran 2.55
+      DateTime::TimeZone::Asia::Thimphu 2.55
+      DateTime::TimeZone::Asia::Tokyo 2.55
+      DateTime::TimeZone::Asia::Tomsk 2.55
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.55
+      DateTime::TimeZone::Asia::Urumqi 2.55
+      DateTime::TimeZone::Asia::Ust_Nera 2.55
+      DateTime::TimeZone::Asia::Vladivostok 2.55
+      DateTime::TimeZone::Asia::Yakutsk 2.55
+      DateTime::TimeZone::Asia::Yangon 2.55
+      DateTime::TimeZone::Asia::Yekaterinburg 2.55
+      DateTime::TimeZone::Asia::Yerevan 2.55
+      DateTime::TimeZone::Atlantic::Azores 2.55
+      DateTime::TimeZone::Atlantic::Bermuda 2.55
+      DateTime::TimeZone::Atlantic::Canary 2.55
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.55
+      DateTime::TimeZone::Atlantic::Faroe 2.55
+      DateTime::TimeZone::Atlantic::Madeira 2.55
+      DateTime::TimeZone::Atlantic::South_Georgia 2.55
+      DateTime::TimeZone::Atlantic::Stanley 2.55
+      DateTime::TimeZone::Australia::Adelaide 2.55
+      DateTime::TimeZone::Australia::Brisbane 2.55
+      DateTime::TimeZone::Australia::Broken_Hill 2.55
+      DateTime::TimeZone::Australia::Darwin 2.55
+      DateTime::TimeZone::Australia::Eucla 2.55
+      DateTime::TimeZone::Australia::Hobart 2.55
+      DateTime::TimeZone::Australia::Lindeman 2.55
+      DateTime::TimeZone::Australia::Lord_Howe 2.55
+      DateTime::TimeZone::Australia::Melbourne 2.55
+      DateTime::TimeZone::Australia::Perth 2.55
+      DateTime::TimeZone::Australia::Sydney 2.55
+      DateTime::TimeZone::CET 2.55
+      DateTime::TimeZone::CST6CDT 2.55
+      DateTime::TimeZone::Catalog 2.55
+      DateTime::TimeZone::EET 2.55
+      DateTime::TimeZone::EST 2.55
+      DateTime::TimeZone::EST5EDT 2.55
+      DateTime::TimeZone::Europe::Andorra 2.55
+      DateTime::TimeZone::Europe::Astrakhan 2.55
+      DateTime::TimeZone::Europe::Athens 2.55
+      DateTime::TimeZone::Europe::Belgrade 2.55
+      DateTime::TimeZone::Europe::Berlin 2.55
+      DateTime::TimeZone::Europe::Brussels 2.55
+      DateTime::TimeZone::Europe::Bucharest 2.55
+      DateTime::TimeZone::Europe::Budapest 2.55
+      DateTime::TimeZone::Europe::Chisinau 2.55
+      DateTime::TimeZone::Europe::Dublin 2.55
+      DateTime::TimeZone::Europe::Gibraltar 2.55
+      DateTime::TimeZone::Europe::Helsinki 2.55
+      DateTime::TimeZone::Europe::Istanbul 2.55
+      DateTime::TimeZone::Europe::Kaliningrad 2.55
+      DateTime::TimeZone::Europe::Kirov 2.55
+      DateTime::TimeZone::Europe::Kyiv 2.55
+      DateTime::TimeZone::Europe::Lisbon 2.55
+      DateTime::TimeZone::Europe::London 2.55
+      DateTime::TimeZone::Europe::Madrid 2.55
+      DateTime::TimeZone::Europe::Malta 2.55
+      DateTime::TimeZone::Europe::Minsk 2.55
+      DateTime::TimeZone::Europe::Moscow 2.55
+      DateTime::TimeZone::Europe::Paris 2.55
+      DateTime::TimeZone::Europe::Prague 2.55
+      DateTime::TimeZone::Europe::Riga 2.55
+      DateTime::TimeZone::Europe::Rome 2.55
+      DateTime::TimeZone::Europe::Samara 2.55
+      DateTime::TimeZone::Europe::Saratov 2.55
+      DateTime::TimeZone::Europe::Simferopol 2.55
+      DateTime::TimeZone::Europe::Sofia 2.55
+      DateTime::TimeZone::Europe::Tallinn 2.55
+      DateTime::TimeZone::Europe::Tirane 2.55
+      DateTime::TimeZone::Europe::Ulyanovsk 2.55
+      DateTime::TimeZone::Europe::Vienna 2.55
+      DateTime::TimeZone::Europe::Vilnius 2.55
+      DateTime::TimeZone::Europe::Volgograd 2.55
+      DateTime::TimeZone::Europe::Warsaw 2.55
+      DateTime::TimeZone::Europe::Zurich 2.55
+      DateTime::TimeZone::Floating 2.55
+      DateTime::TimeZone::HST 2.55
+      DateTime::TimeZone::Indian::Chagos 2.55
+      DateTime::TimeZone::Indian::Maldives 2.55
+      DateTime::TimeZone::Indian::Mauritius 2.55
+      DateTime::TimeZone::Local 2.55
+      DateTime::TimeZone::Local::Android 2.55
+      DateTime::TimeZone::Local::Unix 2.55
+      DateTime::TimeZone::Local::VMS 2.55
+      DateTime::TimeZone::MET 2.55
+      DateTime::TimeZone::MST 2.55
+      DateTime::TimeZone::MST7MDT 2.55
+      DateTime::TimeZone::OffsetOnly 2.55
+      DateTime::TimeZone::OlsonDB 2.55
+      DateTime::TimeZone::OlsonDB::Change 2.55
+      DateTime::TimeZone::OlsonDB::Observance 2.55
+      DateTime::TimeZone::OlsonDB::Rule 2.55
+      DateTime::TimeZone::OlsonDB::Zone 2.55
+      DateTime::TimeZone::PST8PDT 2.55
+      DateTime::TimeZone::Pacific::Apia 2.55
+      DateTime::TimeZone::Pacific::Auckland 2.55
+      DateTime::TimeZone::Pacific::Bougainville 2.55
+      DateTime::TimeZone::Pacific::Chatham 2.55
+      DateTime::TimeZone::Pacific::Easter 2.55
+      DateTime::TimeZone::Pacific::Efate 2.55
+      DateTime::TimeZone::Pacific::Fakaofo 2.55
+      DateTime::TimeZone::Pacific::Fiji 2.55
+      DateTime::TimeZone::Pacific::Galapagos 2.55
+      DateTime::TimeZone::Pacific::Gambier 2.55
+      DateTime::TimeZone::Pacific::Guadalcanal 2.55
+      DateTime::TimeZone::Pacific::Guam 2.55
+      DateTime::TimeZone::Pacific::Honolulu 2.55
+      DateTime::TimeZone::Pacific::Kanton 2.55
+      DateTime::TimeZone::Pacific::Kiritimati 2.55
+      DateTime::TimeZone::Pacific::Kosrae 2.55
+      DateTime::TimeZone::Pacific::Kwajalein 2.55
+      DateTime::TimeZone::Pacific::Marquesas 2.55
+      DateTime::TimeZone::Pacific::Nauru 2.55
+      DateTime::TimeZone::Pacific::Niue 2.55
+      DateTime::TimeZone::Pacific::Norfolk 2.55
+      DateTime::TimeZone::Pacific::Noumea 2.55
+      DateTime::TimeZone::Pacific::Pago_Pago 2.55
+      DateTime::TimeZone::Pacific::Palau 2.55
+      DateTime::TimeZone::Pacific::Pitcairn 2.55
+      DateTime::TimeZone::Pacific::Port_Moresby 2.55
+      DateTime::TimeZone::Pacific::Rarotonga 2.55
+      DateTime::TimeZone::Pacific::Tahiti 2.55
+      DateTime::TimeZone::Pacific::Tarawa 2.55
+      DateTime::TimeZone::Pacific::Tongatapu 2.55
+      DateTime::TimeZone::UTC 2.55
+      DateTime::TimeZone::WET 2.55
     requirements:
       Class::Singleton 1.03
       Cwd 3
@@ -2256,16 +2268,17 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  Email-MIME-ContentType-1.026
-    pathname: R/RJ/RJBS/Email-MIME-ContentType-1.026.tar.gz
+  Email-MIME-ContentType-1.027
+    pathname: R/RJ/RJBS/Email-MIME-ContentType-1.027.tar.gz
     provides:
-      Email::MIME::ContentType 1.026
+      Email::MIME::ContentType 1.027
     requirements:
       Carp 0
       Encode 2.87
       Exporter 5.57
-      ExtUtils::MakeMaker 0
+      ExtUtils::MakeMaker 6.78
       Text::Unidecode 0
+      perl 5.012
       strict 0
       warnings 0
   Email-MIME-Encodings-1.315
@@ -2443,11 +2456,11 @@ DISTRIBUTIONS
       Test::Unit::Lite 0.12
       parent 0
       perl 5.006
-  Exporter-Tiny-1.002002
-    pathname: T/TO/TOBYINK/Exporter-Tiny-1.002002.tar.gz
+  Exporter-Tiny-1.004004
+    pathname: T/TO/TOBYINK/Exporter-Tiny-1.004004.tar.gz
     provides:
-      Exporter::Shiny 1.002002
-      Exporter::Tiny 1.002002
+      Exporter::Shiny 1.004004
+      Exporter::Tiny 1.004004
     requirements:
       ExtUtils::MakeMaker 6.17
       perl 5.006001
@@ -2546,12 +2559,13 @@ DISTRIBUTIONS
       File::Spec 0.8
       Pod::Man 0
       perl 5.006
-  FFI-CheckLib-0.28
-    pathname: P/PL/PLICEASE/FFI-CheckLib-0.28.tar.gz
+  FFI-CheckLib-0.31
+    pathname: P/PL/PLICEASE/FFI-CheckLib-0.31.tar.gz
     provides:
-      FFI::CheckLib 0.28
+      FFI::CheckLib 0.31
     requirements:
       ExtUtils::MakeMaker 0
+      File::Which 0
       List::Util 1.33
       perl 5.006
   Fatal-Exception-0.05
@@ -2754,18 +2768,18 @@ DISTRIBUTIONS
       GnuPG::Tie::Sign undef
     requirements:
       ExtUtils::MakeMaker 0
-  HTML-Form-6.09
-    pathname: S/SI/SIMBABQUE/HTML-Form-6.09.tar.gz
+  HTML-Form-6.10
+    pathname: S/SI/SIMBABQUE/HTML-Form-6.10.tar.gz
     provides:
-      HTML::Form 6.09
-      HTML::Form::FileInput 6.09
-      HTML::Form::IgnoreInput 6.09
-      HTML::Form::ImageInput 6.09
-      HTML::Form::Input 6.09
-      HTML::Form::KeygenInput 6.09
-      HTML::Form::ListInput 6.09
-      HTML::Form::SubmitInput 6.09
-      HTML::Form::TextInput 6.09
+      HTML::Form 6.10
+      HTML::Form::FileInput 6.10
+      HTML::Form::IgnoreInput 6.10
+      HTML::Form::ImageInput 6.10
+      HTML::Form::Input 6.10
+      HTML::Form::KeygenInput 6.10
+      HTML::Form::ListInput 6.10
+      HTML::Form::SubmitInput 6.10
+      HTML::Form::TextInput 6.10
     requirements:
       Carp 0
       Encode 2
@@ -2983,16 +2997,16 @@ DISTRIBUTIONS
       XML::LibXML 1.94
       XML::LibXML::Devel 0
       perl 5.008001
-  HTML-Parser-3.78
-    pathname: O/OA/OALDERS/HTML-Parser-3.78.tar.gz
+  HTML-Parser-3.79
+    pathname: O/OA/OALDERS/HTML-Parser-3.79.tar.gz
     provides:
-      HTML::Entities 3.78
-      HTML::Filter 3.78
-      HTML::HeadParser 3.78
-      HTML::LinkExtor 3.78
-      HTML::Parser 3.78
-      HTML::PullParser 3.78
-      HTML::TokeParser 3.78
+      HTML::Entities 3.79
+      HTML::Filter 3.79
+      HTML::HeadParser 3.79
+      HTML::LinkExtor 3.79
+      HTML::Parser 3.79
+      HTML::PullParser 3.79
+      HTML::TokeParser 3.79
     requirements:
       Carp 0
       Exporter 0
@@ -3020,13 +3034,12 @@ DISTRIBUTIONS
       HTML::Tagset 3.20
     requirements:
       ExtUtils::MakeMaker 0
-  HTML-Tiny-1.05
-    pathname: A/AN/ANDYA/HTML-Tiny-1.05.tar.gz
+  HTML-Tiny-1.08
+    pathname: A/AR/ARISTOTLE/HTML-Tiny-1.08.tar.gz
     provides:
-      HTML::Tiny 1.05
+      HTML::Tiny 1.08
     requirements:
-      ExtUtils::MakeMaker 0
-      Test::More 0
+      perl 5.006
   HTML-Tree-5.07
     pathname: K/KE/KENTNL/HTML-Tree-5.07.tar.gz
     provides:
@@ -3144,21 +3157,22 @@ DISTRIBUTIONS
       perl 5.005
       strict 0
       warnings 0
-  HTTP-Message-6.37
-    pathname: O/OA/OALDERS/HTTP-Message-6.37.tar.gz
+  HTTP-Message-6.41
+    pathname: O/OA/OALDERS/HTTP-Message-6.41.tar.gz
     provides:
-      HTTP::Config 6.37
-      HTTP::Headers 6.37
-      HTTP::Headers::Auth 6.37
-      HTTP::Headers::ETag 6.37
-      HTTP::Headers::Util 6.37
-      HTTP::Message 6.37
-      HTTP::Request 6.37
-      HTTP::Request::Common 6.37
-      HTTP::Response 6.37
-      HTTP::Status 6.37
+      HTTP::Config 6.41
+      HTTP::Headers 6.41
+      HTTP::Headers::Auth 6.41
+      HTTP::Headers::ETag 6.41
+      HTTP::Headers::Util 6.41
+      HTTP::Message 6.41
+      HTTP::Request 6.41
+      HTTP::Request::Common 6.41
+      HTTP::Response 6.41
+      HTTP::Status 6.41
     requirements:
       Carp 0
+      Compress::Raw::Bzip2 0
       Compress::Raw::Zlib 0
       Encode 3.01
       Encode::Locale 1
@@ -3178,7 +3192,7 @@ DISTRIBUTIONS
       MIME::Base64 2.1
       MIME::QuotedPrint 0
       URI 1.10
-      base 0
+      parent 0
       perl 5.008001
       strict 0
       warnings 0
@@ -3292,17 +3306,17 @@ DISTRIBUTIONS
       Exporter 5.57
       ExtUtils::MakeMaker 0
       perl 5.008
-  IO-Socket-SSL-2.074
-    pathname: S/SU/SULLR/IO-Socket-SSL-2.074.tar.gz
+  IO-Socket-SSL-2.075
+    pathname: S/SU/SULLR/IO-Socket-SSL-2.075.tar.gz
     provides:
-      IO::Socket::SSL 2.074
+      IO::Socket::SSL 2.075
       IO::Socket::SSL::Intercept 2.056
-      IO::Socket::SSL::OCSP_Cache 2.074
-      IO::Socket::SSL::OCSP_Resolver 2.074
+      IO::Socket::SSL::OCSP_Cache 2.075
+      IO::Socket::SSL::OCSP_Resolver 2.075
       IO::Socket::SSL::PublicSuffix undef
-      IO::Socket::SSL::SSL_Context 2.074
-      IO::Socket::SSL::SSL_HANDLE 2.074
-      IO::Socket::SSL::Session_Cache 2.074
+      IO::Socket::SSL::SSL_Context 2.075
+      IO::Socket::SSL::SSL_HANDLE 2.075
+      IO::Socket::SSL::Session_Cache 2.075
       IO::Socket::SSL::Utils 2.015
     requirements:
       ExtUtils::MakeMaker 0
@@ -3336,11 +3350,11 @@ DISTRIBUTIONS
       IPC::Signal 1.00
     requirements:
       ExtUtils::MakeMaker 0
-  JSON-4.09
-    pathname: I/IS/ISHIGAKI/JSON-4.09.tar.gz
+  JSON-4.10
+    pathname: I/IS/ISHIGAKI/JSON-4.10.tar.gz
     provides:
-      JSON 4.09
-      JSON::Backend::PP 4.09
+      JSON 4.10
+      JSON::Backend::PP 4.10
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
@@ -3355,10 +3369,10 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
-  JSON-MaybeXS-1.004003
-    pathname: E/ET/ETHER/JSON-MaybeXS-1.004003.tar.gz
+  JSON-MaybeXS-1.004004
+    pathname: E/ET/ETHER/JSON-MaybeXS-1.004004.tar.gz
     provides:
-      JSON::MaybeXS 1.004003
+      JSON::MaybeXS 1.004004
     requirements:
       Carp 0
       Cpanel::JSON::XS 2.3310
@@ -4668,15 +4682,15 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  Net-DNS-1.34
-    pathname: N/NL/NLNETLABS/Net-DNS-1.34.tar.gz
+  Net-DNS-1.35
+    pathname: N/NL/NLNETLABS/Net-DNS-1.35.tar.gz
     provides:
-      Net::DNS 1.34
+      Net::DNS 1.35
       Net::DNS::Domain 1855
       Net::DNS::DomainName 1855
       Net::DNS::DomainName1035 1855
       Net::DNS::DomainName2535 1855
-      Net::DNS::Header 1855
+      Net::DNS::Header 1875
       Net::DNS::Mailbox 1855
       Net::DNS::Mailbox1035 1855
       Net::DNS::Mailbox2535 1855
@@ -4747,11 +4761,11 @@ DISTRIBUTIONS
       Net::DNS::RR::RT 1857
       Net::DNS::RR::SIG 1856
       Net::DNS::RR::SMIMEA 1857
-      Net::DNS::RR::SOA 1857
+      Net::DNS::RR::SOA 1875
       Net::DNS::RR::SPF 1857
       Net::DNS::RR::SRV 1857
       Net::DNS::RR::SSHFP 1857
-      Net::DNS::RR::SVCB 1857
+      Net::DNS::RR::SVCB 1875
       Net::DNS::RR::TKEY 1857
       Net::DNS::RR::TLSA 1857
       Net::DNS::RR::TSIG 1856
@@ -4779,17 +4793,17 @@ DISTRIBUTIONS
       Digest::MD5 2.13
       Digest::SHA 5.23
       Encode 2.26
-      Exporter 5.56
-      ExtUtils::MakeMaker 6.66
-      File::Spec 0.86
+      Exporter 5.63
+      ExtUtils::MakeMaker 6.48
+      File::Spec 3.29
       Getopt::Long 2.43
-      IO::File 1.08
-      IO::Select 1.14
-      IO::Socket 1.26
+      IO::File 1.14
+      IO::Select 1.17
+      IO::Socket 1.3
       IO::Socket::IP 0.38
       MIME::Base64 2.13
       PerlIO 1.05
-      Scalar::Util 1.25
+      Scalar::Util 1.19
       Time::Local 1.19
       perl 5.008009
   Net-HTTP-6.22
@@ -4997,21 +5011,21 @@ DISTRIBUTIONS
       overload 0
       perl 5.006
       strict 0
-  PPIx-QuoteLike-0.022
-    pathname: W/WY/WYANT/PPIx-QuoteLike-0.022.tar.gz
+  PPIx-QuoteLike-0.023
+    pathname: W/WY/WYANT/PPIx-QuoteLike-0.023.tar.gz
     provides:
-      PPIx::QuoteLike 0.022
-      PPIx::QuoteLike::Constant 0.022
-      PPIx::QuoteLike::Dumper 0.022
-      PPIx::QuoteLike::Token 0.022
-      PPIx::QuoteLike::Token::Control 0.022
-      PPIx::QuoteLike::Token::Delimiter 0.022
-      PPIx::QuoteLike::Token::Interpolation 0.022
-      PPIx::QuoteLike::Token::String 0.022
-      PPIx::QuoteLike::Token::Structure 0.022
-      PPIx::QuoteLike::Token::Unknown 0.022
-      PPIx::QuoteLike::Token::Whitespace 0.022
-      PPIx::QuoteLike::Utils 0.022
+      PPIx::QuoteLike 0.023
+      PPIx::QuoteLike::Constant 0.023
+      PPIx::QuoteLike::Dumper 0.023
+      PPIx::QuoteLike::Token 0.023
+      PPIx::QuoteLike::Token::Control 0.023
+      PPIx::QuoteLike::Token::Delimiter 0.023
+      PPIx::QuoteLike::Token::Interpolation 0.023
+      PPIx::QuoteLike::Token::String 0.023
+      PPIx::QuoteLike::Token::Structure 0.023
+      PPIx::QuoteLike::Token::Unknown 0.023
+      PPIx::QuoteLike::Token::Whitespace 0.023
+      PPIx::QuoteLike::Utils 0.023
     requirements:
       Carp 0
       Encode 0
@@ -5328,11 +5342,11 @@ DISTRIBUTIONS
       overload 0
       parent 0
       strict 0
-  Path-Tiny-0.122
-    pathname: D/DA/DAGOLDEN/Path-Tiny-0.122.tar.gz
+  Path-Tiny-0.124
+    pathname: D/DA/DAGOLDEN/Path-Tiny-0.124.tar.gz
     provides:
-      Path::Tiny 0.122
-      Path::Tiny::Error 0.122
+      Path::Tiny 0.124
+      Path::Tiny::Error 0.124
     requirements:
       Carp 0
       Cwd 0
@@ -5608,6 +5622,27 @@ DISTRIBUTIONS
       strict 0
       version 0.77
       warnings 0
+  Perl-Critic-Moose-1.05
+    pathname: D/DR/DROLSKY/Perl-Critic-Moose-1.05.tar.gz
+    provides:
+      Perl::Critic::Moose 1.05
+      Perl::Critic::Policy::Moose::ProhibitDESTROYMethod 1.05
+      Perl::Critic::Policy::Moose::ProhibitLazyBuild 1.05
+      Perl::Critic::Policy::Moose::ProhibitMultipleWiths 1.05
+      Perl::Critic::Policy::Moose::ProhibitNewMethod 1.05
+      Perl::Critic::Policy::Moose::RequireCleanNamespace 1.05
+      Perl::Critic::Policy::Moose::RequireMakeImmutable 1.05
+    requirements:
+      ExtUtils::MakeMaker 0
+      Perl::Critic::Policy 0
+      Perl::Critic::Utils 0
+      Perl::Critic::Utils::PPI 0
+      Readonly 0
+      base 0
+      namespace::autoclean 0
+      perl 5.008
+      strict 0
+      warnings 0
   Perl-Critic-Policy-Variables-ProhibitUnusedVarsStricter-0.114
     pathname: W/WY/WYANT/Perl-Critic-Policy-Variables-ProhibitUnusedVarsStricter-0.114.tar.gz
     provides:
@@ -5705,12 +5740,12 @@ DISTRIBUTIONS
       Test::More 0
       Test::TCP 0
       Time::HiRes 0
-  Plack-1.0048
-    pathname: M/MI/MIYAGAWA/Plack-1.0048.tar.gz
+  Plack-1.0050
+    pathname: M/MI/MIYAGAWA/Plack-1.0050.tar.gz
     provides:
       HTTP::Message::PSGI undef
       HTTP::Server::PSGI undef
-      Plack 1.0048
+      Plack 1.0050
       Plack::App::CGIBin undef
       Plack::App::Cascade undef
       Plack::App::Directory undef
@@ -5769,9 +5804,9 @@ DISTRIBUTIONS
       Plack::Middleware::XFramework undef
       Plack::Middleware::XSendfile undef
       Plack::Recursive::ForwardRequest undef
-      Plack::Request 1.0048
+      Plack::Request 1.0050
       Plack::Request::Upload undef
-      Plack::Response 1.0048
+      Plack::Response 1.0050
       Plack::Runner undef
       Plack::TempBuffer undef
       Plack::Test undef
@@ -5893,11 +5928,11 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Pod-Spell-1.20
-    pathname: D/DO/DOLMEN/Pod-Spell-1.20.tar.gz
+  Pod-Spell-1.25
+    pathname: H/HA/HAARG/Pod-Spell-1.25.tar.gz
     provides:
-      Pod::Spell 1.20
-      Pod::Wordlist 1.20
+      Pod::Spell 1.25
+      Pod::Wordlist 1.25
     requirements:
       Carp 0
       Class::Tiny 0
@@ -5906,16 +5941,13 @@ DISTRIBUTIONS
       File::ShareDir::Install 0.06
       Lingua::EN::Inflect 0
       POSIX 0
-      Path::Tiny 0
       Pod::Escapes 0
-      Pod::Parser 0
+      Pod::Simple 3.27
       Text::Wrap 0
       constant 0
       locale 0
       parent 0
       perl 5.008
-      strict 0
-      warnings 0
   Proc-Wait3-0.05
     pathname: C/CT/CTILMES/Proc-Wait3-0.05.tar.gz
     provides:
@@ -6678,11 +6710,11 @@ DISTRIBUTIONS
       Test::More 0
       Time::Local 0
       Time::Piece 1.08
-  Test-Most-0.37
-    pathname: O/OV/OVID/Test-Most-0.37.tar.gz
+  Test-Most-0.38
+    pathname: O/OV/OVID/Test-Most-0.38.tar.gz
     provides:
-      Test::Most 0.37
-      Test::Most::Exception 0.37
+      Test::Most 0.38
+      Test::Most::Exception 0.38
     requirements:
       Exception::Class 1.14
       ExtUtils::MakeMaker 0
@@ -6852,7 +6884,7 @@ DISTRIBUTIONS
       URI::file 0
       WWW::Mechanize 1.68
       parent 0
-      perl 5.01
+      perl 5.010
   Test-WWW-Mechanize-CGI-0.1
     pathname: M/MR/MRAMBERG/Test-WWW-Mechanize-CGI-0.1.tar.gz
     provides:
@@ -6947,7 +6979,7 @@ DISTRIBUTIONS
       Exporter 0
       ExtUtils::MakeMaker 0
       constant 0
-      perl 5.00503
+      perl 5.005030
   Text-Markdown-1.000031
     pathname: B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz
     provides:
@@ -6972,7 +7004,7 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.59
       File::Temp 0
       Test::More 0
-      perl 5.00800
+      perl 5.008000
   Text-SimpleTable-2.07
     pathname: M/MR/MRAMBERG/Text-SimpleTable-2.07.tar.gz
     provides:
@@ -7137,57 +7169,63 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Type-Tiny-1.016008
-    pathname: T/TO/TOBYINK/Type-Tiny-1.016008.tar.gz
+  Type-Tiny-2.000001
+    pathname: T/TO/TOBYINK/Type-Tiny-2.000001.tar.gz
     provides:
-      Devel::TypeTiny::Perl56Compat 1.016008
-      Devel::TypeTiny::Perl58Compat 1.016008
-      Error::TypeTiny 1.016008
-      Error::TypeTiny::Assertion 1.016008
-      Error::TypeTiny::Compilation 1.016008
-      Error::TypeTiny::WrongNumberOfParameters 1.016008
-      Eval::TypeTiny 1.016008
-      Eval::TypeTiny::CodeAccumulator 1.016008
-      Reply::Plugin::TypeTiny 1.016008
-      Test::TypeTiny 1.016008
-      Type::Coercion 1.016008
-      Type::Coercion::FromMoose 1.016008
-      Type::Coercion::Union 1.016008
-      Type::Library 1.016008
-      Type::Params 1.016008
-      Type::Params::Parameter 1.016008
-      Type::Params::Signature 1.016008
-      Type::Parser 1.016008
-      Type::Parser::AstBuilder undef
-      Type::Parser::Token undef
-      Type::Parser::TokenStream undef
-      Type::Registry 1.016008
-      Type::Tiny 1.016008
-      Type::Tiny::Class 1.016008
-      Type::Tiny::ConstrainedObject 1.016008
-      Type::Tiny::Duck 1.016008
-      Type::Tiny::Enum 1.016008
-      Type::Tiny::Intersection 1.016008
-      Type::Tiny::Role 1.016008
-      Type::Tiny::Union 1.016008
-      Type::Utils 1.016008
-      Types::Common::Numeric 1.016008
-      Types::Common::String 1.016008
-      Types::Standard 1.016008
-      Types::Standard::ArrayRef 1.016008
-      Types::Standard::CycleTuple 1.016008
-      Types::Standard::Dict 1.016008
-      Types::Standard::HashRef 1.016008
-      Types::Standard::Map 1.016008
-      Types::Standard::ScalarRef 1.016008
-      Types::Standard::StrMatch 1.016008
-      Types::Standard::Tied 1.016008
-      Types::Standard::Tuple 1.016008
-      Types::TypeTiny 1.016008
+      Devel::TypeTiny::Perl58Compat 2.000001
+      Error::TypeTiny 2.000001
+      Error::TypeTiny::Assertion 2.000001
+      Error::TypeTiny::Compilation 2.000001
+      Error::TypeTiny::WrongNumberOfParameters 2.000001
+      Eval::TypeTiny 2.000001
+      Eval::TypeTiny::CodeAccumulator 2.000001
+      Reply::Plugin::TypeTiny 2.000001
+      Test::TypeTiny 2.000001
+      Type::Coercion 2.000001
+      Type::Coercion::FromMoose 2.000001
+      Type::Coercion::Union 2.000001
+      Type::Library 2.000001
+      Type::Params 2.000001
+      Type::Params::Alternatives 2.000001
+      Type::Params::Parameter 2.000001
+      Type::Params::Signature 2.000001
+      Type::Parser 2.000001
+      Type::Parser::AstBuilder 2.000001
+      Type::Parser::Token 2.000001
+      Type::Parser::TokenStream 2.000001
+      Type::Registry 2.000001
+      Type::Tie 2.000001
+      Type::Tie::ARRAY 2.000001
+      Type::Tie::BASE 2.000001
+      Type::Tie::HASH 2.000001
+      Type::Tie::SCALAR 2.000001
+      Type::Tiny 2.000001
+      Type::Tiny::Class 2.000001
+      Type::Tiny::ConstrainedObject 2.000001
+      Type::Tiny::Duck 2.000001
+      Type::Tiny::Enum 2.000001
+      Type::Tiny::Intersection 2.000001
+      Type::Tiny::Role 2.000001
+      Type::Tiny::Union 2.000001
+      Type::Utils 2.000001
+      Types::Common 2.000001
+      Types::Common::Numeric 2.000001
+      Types::Common::String 2.000001
+      Types::Standard 2.000001
+      Types::Standard::ArrayRef 2.000001
+      Types::Standard::CycleTuple 2.000001
+      Types::Standard::Dict 2.000001
+      Types::Standard::HashRef 2.000001
+      Types::Standard::Map 2.000001
+      Types::Standard::ScalarRef 2.000001
+      Types::Standard::StrMatch 2.000001
+      Types::Standard::Tied 2.000001
+      Types::Standard::Tuple 2.000001
+      Types::TypeTiny 2.000001
     requirements:
-      Exporter::Tiny 1.000000
+      Exporter::Tiny 1.004001
       ExtUtils::MakeMaker 6.17
-      perl 5.006001
+      perl 5.008001
   Types-Serialiser-1.01
     pathname: M/ML/MLEHMANN/Types-Serialiser-1.01.tar.gz
     provides:
@@ -7198,53 +7236,53 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       common::sense 0
-  URI-5.12
-    pathname: O/OA/OALDERS/URI-5.12.tar.gz
+  URI-5.16
+    pathname: O/OA/OALDERS/URI-5.16.tar.gz
     provides:
-      URI 5.12
-      URI::Escape 5.12
-      URI::Heuristic 5.12
-      URI::IRI 5.12
-      URI::QueryParam 5.12
-      URI::Split 5.12
-      URI::URL 5.12
-      URI::WithBase 5.12
-      URI::data 5.12
-      URI::file 5.12
-      URI::file::Base 5.12
-      URI::file::FAT 5.12
-      URI::file::Mac 5.12
-      URI::file::OS2 5.12
-      URI::file::QNX 5.12
-      URI::file::Unix 5.12
-      URI::file::Win32 5.12
-      URI::ftp 5.12
-      URI::gopher 5.12
-      URI::http 5.12
-      URI::https 5.12
-      URI::ldap 5.12
-      URI::ldapi 5.12
-      URI::ldaps 5.12
-      URI::mailto 5.12
-      URI::mms 5.12
-      URI::news 5.12
-      URI::nntp 5.12
-      URI::nntps 5.12
-      URI::pop 5.12
-      URI::rlogin 5.12
-      URI::rsync 5.12
-      URI::rtsp 5.12
-      URI::rtspu 5.12
-      URI::sftp 5.12
-      URI::sip 5.12
-      URI::sips 5.12
-      URI::snews 5.12
-      URI::ssh 5.12
-      URI::telnet 5.12
-      URI::tn3270 5.12
-      URI::urn 5.12
-      URI::urn::isbn 5.12
-      URI::urn::oid 5.12
+      URI 5.16
+      URI::Escape 5.16
+      URI::Heuristic 5.16
+      URI::IRI 5.16
+      URI::QueryParam 5.16
+      URI::Split 5.16
+      URI::URL 5.16
+      URI::WithBase 5.16
+      URI::data 5.16
+      URI::file 5.16
+      URI::file::Base 5.16
+      URI::file::FAT 5.16
+      URI::file::Mac 5.16
+      URI::file::OS2 5.16
+      URI::file::QNX 5.16
+      URI::file::Unix 5.16
+      URI::file::Win32 5.16
+      URI::ftp 5.16
+      URI::gopher 5.16
+      URI::http 5.16
+      URI::https 5.16
+      URI::ldap 5.16
+      URI::ldapi 5.16
+      URI::ldaps 5.16
+      URI::mailto 5.16
+      URI::mms 5.16
+      URI::news 5.16
+      URI::nntp 5.16
+      URI::nntps 5.16
+      URI::pop 5.16
+      URI::rlogin 5.16
+      URI::rsync 5.16
+      URI::rtsp 5.16
+      URI::rtspu 5.16
+      URI::sftp 5.16
+      URI::sip 5.16
+      URI::sips 5.16
+      URI::snews 5.16
+      URI::ssh 5.16
+      URI::telnet 5.16
+      URI::tn3270 5.16
+      URI::urn 5.16
+      URI::urn::isbn 5.16
+      URI::urn::oid 5.16
     requirements:
       Carp 0
       Cwd 0
@@ -7304,10 +7342,10 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0.47
       XSLoader 0
-  Variable-Magic-0.62
-    pathname: V/VP/VPIT/Variable-Magic-0.62.tar.gz
+  Variable-Magic-0.63
+    pathname: V/VP/VPIT/Variable-Magic-0.63.tar.gz
     provides:
-      Variable::Magic 0.62
+      Variable::Magic 0.63
     requirements:
       Carp 0
       Config 0
@@ -7413,45 +7451,45 @@ DISTRIBUTIONS
       XML::LibXML 1.70
       strict 0
       warnings 0
-  XML-LibXML-2.0207
-    pathname: S/SH/SHLOMIF/XML-LibXML-2.0207.tar.gz
+  XML-LibXML-2.0208
+    pathname: S/SH/SHLOMIF/XML-LibXML-2.0208.tar.gz
     provides:
-      XML::LibXML 2.0207
-      XML::LibXML::Attr 2.0207
-      XML::LibXML::AttributeHash 2.0207
-      XML::LibXML::Boolean 2.0207
-      XML::LibXML::CDATASection 2.0207
-      XML::LibXML::Comment 2.0207
-      XML::LibXML::Common 2.0207
-      XML::LibXML::Devel 2.0207
-      XML::LibXML::Document 2.0207
-      XML::LibXML::DocumentFragment 2.0207
-      XML::LibXML::Dtd 2.0207
-      XML::LibXML::Element 2.0207
-      XML::LibXML::ErrNo 2.0207
-      XML::LibXML::Error 2.0207
-      XML::LibXML::InputCallback 2.0207
-      XML::LibXML::Literal 2.0207
-      XML::LibXML::NamedNodeMap 2.0207
-      XML::LibXML::Namespace 2.0207
-      XML::LibXML::Node 2.0207
-      XML::LibXML::NodeList 2.0207
-      XML::LibXML::Number 2.0207
-      XML::LibXML::PI 2.0207
-      XML::LibXML::Pattern 2.0207
-      XML::LibXML::Reader 2.0207
-      XML::LibXML::RegExp 2.0207
-      XML::LibXML::RelaxNG 2.0207
-      XML::LibXML::SAX 2.0207
-      XML::LibXML::SAX::AttributeNode 2.0207
-      XML::LibXML::SAX::Builder 2.0207
-      XML::LibXML::SAX::Generator 2.0207
-      XML::LibXML::SAX::Parser 2.0207
-      XML::LibXML::Schema 2.0207
-      XML::LibXML::Text 2.0207
-      XML::LibXML::XPathContext 2.0207
-      XML::LibXML::XPathExpression 2.0207
-      XML::LibXML::_SAXParser 2.0207
+      XML::LibXML 2.0208
+      XML::LibXML::Attr 2.0208
+      XML::LibXML::AttributeHash 2.0208
+      XML::LibXML::Boolean 2.0208
+      XML::LibXML::CDATASection 2.0208
+      XML::LibXML::Comment 2.0208
+      XML::LibXML::Common 2.0208
+      XML::LibXML::Devel 2.0208
+      XML::LibXML::Document 2.0208
+      XML::LibXML::DocumentFragment 2.0208
+      XML::LibXML::Dtd 2.0208
+      XML::LibXML::Element 2.0208
+      XML::LibXML::ErrNo 2.0208
+      XML::LibXML::Error 2.0208
+      XML::LibXML::InputCallback 2.0208
+      XML::LibXML::Literal 2.0208
+      XML::LibXML::NamedNodeMap 2.0208
+      XML::LibXML::Namespace 2.0208
+      XML::LibXML::Node 2.0208
+      XML::LibXML::NodeList 2.0208
+      XML::LibXML::Number 2.0208
+      XML::LibXML::PI 2.0208
+      XML::LibXML::Pattern 2.0208
+      XML::LibXML::Reader 2.0208
+      XML::LibXML::RegExp 2.0208
+      XML::LibXML::RelaxNG 2.0208
+      XML::LibXML::SAX 2.0208
+      XML::LibXML::SAX::AttributeNode 2.0208
+      XML::LibXML::SAX::Builder 2.0208
+      XML::LibXML::SAX::Generator 2.0208
+      XML::LibXML::SAX::Parser 2.0208
+      XML::LibXML::Schema 2.0208
+      XML::LibXML::Text 2.0208
+      XML::LibXML::XPathContext 2.0208
+      XML::LibXML::XPathExpression 2.0208
+      XML::LibXML::_SAXParser 2.0208
     requirements:
       Alien::Base::Wrapper 0
       Alien::Libxml2 0.14
@@ -7501,7 +7539,7 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       LWP::UserAgent 0
-      perl 5.00405
+      perl 5.004050
   XML-Parser-Lite-0.722
     pathname: P/PH/PHRED/XML-Parser-Lite-0.722.tar.gz
     provides:
@@ -7910,7 +7948,7 @@ DISTRIBUTIONS
       HTTP::Request 6
       HTTP::Request::Common 6
       HTTP::Response 6
-      HTTP::Status 6.07
+      HTTP::Status 6.18
       IO::Select 0
       IO::Socket 0
       LWP::MediaTypes 6

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -167,7 +167,7 @@ RUN sudo -E -H -u musicbrainz git clone https://github.com/metabrainz/artwork-re
     sudo -E -H -u musicbrainz sh -c 'python3.9 -m venv venv; . venv/bin/activate; pip install -r requirements.txt' && \
     cd /home/musicbrainz
 
-RUN curl -sLO https://chromedriver.storage.googleapis.com/103.0.5060.53/chromedriver_linux64.zip && \
+RUN curl -sLO https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/chromedriver && \
     rm chromedriver_linux64.zip


### PR DESCRIPTION
We don't have anything hitting this now, but it seems like a good thing to keep in mind and a good introduction for Critic::Moose.

Eventually we'll probably want to look into https://metacpan.org/pod/Perl::Critic::Policy::Moose::ProhibitMultipleWiths and possibly some other rules in https://metacpan.org/pod/Perl::Critic::Moose