### PR TITLE
Use Perl::Critic::Moose::RequireCleanNamespace 

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -16,6 +16,7 @@ allow_includes=1
 [Modules::RequireFilenameMatchesPackage]
 
 [Moose::ProhibitNewMethod]
+[Moose::RequireCleanNamespace]
 
 [Subroutines::ProhibitReturnSort]
 

--- a/lib/Catalyst/Plugin/Session/Store/MusicBrainz.pm
+++ b/lib/Catalyst/Plugin/Session/Store/MusicBrainz.pm
@@ -1,5 +1,6 @@
 package Catalyst::Plugin::Session::Store::MusicBrainz;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::DataStore::RedisMulti;
 use MIME::Base64 qw(encode_base64 decode_base64);
 use Storable qw/nfreeze thaw/;

--- a/lib/MusicBrainz/DataStore.pm
+++ b/lib/MusicBrainz/DataStore.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::DataStore;
 use Moose::Role;
+use namespace::autoclean;
 
 requires 'clear';
 requires 'delete_multi';

--- a/lib/MusicBrainz/DataStore/Redis.pm
+++ b/lib/MusicBrainz/DataStore/Redis.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::DataStore::Redis;
 
 use Moose;
+use namespace::autoclean;
 use DBDefs;
 use Encode;
 use Redis;

--- a/lib/MusicBrainz/DataStore/RedisMulti.pm
+++ b/lib/MusicBrainz/DataStore/RedisMulti.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::DataStore::RedisMulti;
 
 use Moose;
+use namespace::autoclean;
 use DBDefs;
 use MusicBrainz::DataStore::Redis;
 

--- a/lib/MusicBrainz/Script/FixLinkDuplicates.pm
+++ b/lib/MusicBrainz/Script/FixLinkDuplicates.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Script::FixLinkDuplicates;
 use Moose;
+use namespace::autoclean;
 use DBDefs;
 use MusicBrainz::Server::Context;
 use MusicBrainz::Server::Log qw( log_info );

--- a/lib/MusicBrainz/Script/PruneCache.pm
+++ b/lib/MusicBrainz/Script/PruneCache.pm
@@ -21,6 +21,7 @@ use DateTime::Duration;
 use DateTime::Format::Pg;
 use DBDefs;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );
 
 with 'MooseX::Runnable';

--- a/lib/MusicBrainz/Script/RemoveEmpty.pm
+++ b/lib/MusicBrainz/Script/RemoveEmpty.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Script::RemoveEmpty;
 use Moose;
+use namespace::autoclean;
 
 use DBDefs;
 use List::AllUtils qw( any );

--- a/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
+++ b/lib/MusicBrainz/Script/RemoveUnreferencedRows.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Script::RemoveUnreferencedRows;
 use Moose;
+use namespace::autoclean;
 
 =head1 DESCRIPTION
 

--- a/lib/MusicBrainz/Script/SampleDataDump.pm
+++ b/lib/MusicBrainz/Script/SampleDataDump.pm
@@ -15,6 +15,7 @@ use English;
 use File::Copy qw( copy );
 use List::AllUtils qw( natatime );
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Script::DatabaseDump;
 use MusicBrainz::Script::EntityDump qw(
     get_core_entities

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server;
 
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'Catalyst' }
 
 use Class::Load qw( load_class );

--- a/lib/MusicBrainz/Server/CacheManager.pm
+++ b/lib/MusicBrainz/Server/CacheManager.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::CacheManager;
 
 use Moose;
+use namespace::autoclean;
+
 use MusicBrainz::Server::CacheWrapper;
 use Class::Load qw( load_class );
 

--- a/lib/MusicBrainz/Server/CacheWrapper.pm
+++ b/lib/MusicBrainz/Server/CacheWrapper.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::CacheWrapper;
 
 use Moose;
+use namespace::autoclean;
 use Moose::Util::TypeConstraints;
 use Storable;
 
@@ -57,7 +58,6 @@ sub disconnect {}
 sub clear {}
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/CatalystLogger.pm
+++ b/lib/MusicBrainz/Server/CatalystLogger.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::CatalystLogger;
 use Moose;
+use namespace::autoclean;
 
 has dispatch => (
     is => 'ro',

--- a/lib/MusicBrainz/Server/Context.pm
+++ b/lib/MusicBrainz/Server/Context.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Context;
 use Moose;
+use namespace::autoclean;
 
 use DBDefs;
 use MusicBrainz::DataStore::RedisMulti;

--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'Catalyst::Controller'; }
 
 use Carp;

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Artist.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Account::Subscriptions::Artist;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Collection.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Account::Subscriptions::Collection;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Editor.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Editor.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Account::Subscriptions::Editor;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Label.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Account::Subscriptions::Label;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Series.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Account::Subscriptions::Series;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Admin;
 use Moose;
+use namespace::autoclean;
 use Try::Tiny;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };

--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Admin::Attributes;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 use MusicBrainz::Server::Translation qw( l );

--- a/lib/MusicBrainz/Server/Controller/Admin/StatisticsEvent.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/StatisticsEvent.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Admin::StatisticsEvent;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };

--- a/lib/MusicBrainz/Server/Controller/Ajax.pm
+++ b/lib/MusicBrainz/Server/Controller/Ajax.pm
@@ -4,6 +4,7 @@ use Moose;
 BEGIN { extends 'Catalyst::Controller' };
 
 use JSON qw( encode_json );
+use namespace::autoclean;
 use MusicBrainz::Server::FilterUtils qw(
     create_artist_events_form
     create_artist_release_groups_form

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Area;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -3,6 +3,7 @@ package MusicBrainz::Server::Controller::Artist;
 use utf8;
 
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Controller/ArtistCredit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::ArtistCredit;
 use Moose;
+use namespace::autoclean;
 use Moose::Util qw( find_meta );
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }

--- a/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
+++ b/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
@@ -5,6 +5,7 @@ BEGIN { extends 'MusicBrainz::Server::Controller' };
 
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
+use namespace::autoclean;
 use Try::Tiny;
 
 __PACKAGE__->config( namespace => 'elections' );

--- a/lib/MusicBrainz/Server/Controller/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/CDStub.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::CDStub;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_valid_discid );
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Collection;
 use Moose;
+use namespace::autoclean;
 use utf8;
 use Scalar::Util qw( looks_like_number );
 use List::AllUtils qw( first uniq );

--- a/lib/MusicBrainz/Server/Controller/Dialog.pm
+++ b/lib/MusicBrainz/Server/Controller/Dialog.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Dialog;
 use Encode qw( decode_utf8 );
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Discourse.pm
+++ b/lib/MusicBrainz/Server/Controller/Discourse.pm
@@ -8,6 +8,7 @@ use LWP::UserAgent;
 use MIME::Base64 qw( decode_base64 encode_base64 );
 use Moose;
 use MusicBrainz::Server::Data::Utils qw( non_empty );
+use namespace::autoclean;
 use URI;
 use URI::Escape qw( uri_escape_utf8 );
 use URI::QueryParam;

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Edit;
 use Moose;
+use namespace::autoclean;
 use Moose::Util qw( does_role );
 use Try::Tiny;
 

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Event;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Genre;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/ISRC.pm
+++ b/lib/MusicBrainz/Server/Controller/ISRC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::ISRC;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/ISWC.pm
+++ b/lib/MusicBrainz/Server/Controller/ISWC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::ISWC;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Validation qw( format_iswc is_valid_iswc );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Instrument;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Label;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/MBID.pm
+++ b/lib/MusicBrainz/Server/Controller/MBID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::MBID;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( entities_with );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Controller/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/OtherLookup.pm
@@ -1,5 +1,7 @@
 package MusicBrainz::Server::Controller::OtherLookup;
 use Moose;
+use namespace::autoclean;
+
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use Moose::Util qw( find_meta );

--- a/lib/MusicBrainz/Server/Controller/Partners.pm
+++ b/lib/MusicBrainz/Server/Controller/Partners.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Partners;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 sub amazon : Local Args(2)

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Place;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Rating;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );

--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Recording;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Relationship::LinkAttributeType;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Constants qw(
     $EDIT_RELATIONSHIP_ADD_ATTRIBUTE
     $EDIT_RELATIONSHIP_REMOVE_LINK_ATTRIBUTE

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Relationship::LinkType;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };
 

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::ReleaseGroup;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 
 use MusicBrainz::Server::Constants qw(

--- a/lib/MusicBrainz/Server/Controller/Role/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Collection.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Collection;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 parameter 'entity_name' => (

--- a/lib/MusicBrainz/Server/Controller/Role/Create.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Create.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Create;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 use aliased 'MusicBrainz::Server::WebService::JSONSerializer';
 

--- a/lib/MusicBrainz/Server/Controller/Role/Delete.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Delete.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Delete;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::ControllerUtils::Delete qw( cancel_or_action );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json model_to_type );
 

--- a/lib/MusicBrainz/Server/Controller/Role/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Edit.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Edit;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 
 parameter 'form' => (

--- a/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/EditRelationships.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::EditRelationships;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Constants qw(
     $DIRECTION_BACKWARD
     $DIRECTION_FORWARD

--- a/lib/MusicBrainz/Server/Controller/Role/IdentifierSet.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/IdentifierSet.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::IdentifierSet;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 
 parameter 'entity_type' => (

--- a/lib/MusicBrainz/Server/Controller/Role/JSONLD.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/JSONLD.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Controller::Role::JSONLD;
 use JSON qw( encode_json );
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_entity );
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 

--- a/lib/MusicBrainz/Server/Controller/Role/Load.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Load.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Controller::Role::Load;
 
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 use MusicBrainz::Server::Validation qw( is_guid is_positive_integer );
 use MusicBrainz::Server::Constants qw( :direction %ENTITIES );

--- a/lib/MusicBrainz/Server/Controller/Role/LoadWithRowID.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/LoadWithRowID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Role::LoadWithRowID;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_positive_integer );
 
 around _load => sub

--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Merge;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use List::AllUtils qw( any nsort_by uniq );
 use MusicBrainz::Server::Data::Utils qw( type_to_model );

--- a/lib/MusicBrainz/Server/Controller/Role/Profile.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Profile.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::Profile;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter 'threshold' => (
     required => 1,

--- a/lib/MusicBrainz/Server/Controller/Role/RelationshipEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/RelationshipEditor.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Role::RelationshipEditor;
 use List::AllUtils qw( uniq_by );
 use Moose::Role;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_RELATIONSHIP_EDIT

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Controller::Root;
 use DateTime::Locale;
 use Digest::MD5 qw( md5_hex );
 use Moose;
+use namespace::autoclean;
 use Try::Tiny;
 use List::AllUtils qw( max );
 use Readonly;

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Search;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use List::AllUtils qw( min max );

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Series;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Constants qw(
     $EDIT_SERIES_CREATE
     $EDIT_SERIES_EDIT

--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Statistics;
 use Digest::MD5 qw( md5_hex );
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Statistics::ByDate;
 use MusicBrainz::Server::Data::Statistics::ByName;
 use MusicBrainz::Server::Data::CountryArea;

--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::TagLookup;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 use List::AllUtils qw( any );

--- a/lib/MusicBrainz/Server/Controller/Track.pm
+++ b/lib/MusicBrainz/Server/Controller/Track.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::Track;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_guid );
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }

--- a/lib/MusicBrainz/Server/Controller/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/URL.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::URL;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' }
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::User;
 use Moose;
+use namespace::autoclean;
 use Moose::Util qw( find_meta );
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };

--- a/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::User::Subscriptions;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller' };
 

--- a/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
+++ b/lib/MusicBrainz/Server/Controller/User/SubscriptionsRole.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::User::SubscriptionsRole;
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Annotation.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Annotation.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Annotation;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Area;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Artist;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/CDStub.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::CDStub;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use MusicBrainz::Server::WebService::XML::XPath;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Collection;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/DiscID.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/DiscID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::DiscID;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' };
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Event;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Genre;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/ISRC.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ISRC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::ISRC;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/ISWC.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ISWC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::ISWC;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Instrument;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_guid );
 
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }

--- a/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Label;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Place;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Rating;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Recording;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::Buffer';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Release;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::ReleaseGroup;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Role/BrowseByCollection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Role/BrowseByCollection.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::WS::2::Role::BrowseByCollection;
 
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Constants qw( $ACCESS_SCOPE_COLLECTION );
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Role/Lookup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Role/Lookup.pm
@@ -4,6 +4,7 @@ use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use Moose::Util qw( apply_all_roles );
 use MooseX::MethodAttributes::Role;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( model_to_type );
 
 parameter model => (

--- a/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Series;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_guid );
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Tag;
 use Moose;
+use namespace::autoclean;
 
 use English;
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::URL;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::2::Work;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Area;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Artist;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/CheckDuplicates.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/CheckDuplicates.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::CheckDuplicates;
 use Moose;
+use namespace::autoclean;
 use JSON;
 use Try::Tiny;
 use MusicBrainz::Server::Data::Utils qw(type_to_model);

--- a/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Editor;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 use Text::Trim qw( trim );

--- a/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Event;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Genre;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Instrument;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Label;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/ParseCoordinates.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ParseCoordinates.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::ParseCoordinates;
 use Moose;
+use namespace::autoclean;
 use JSON;
 use utf8;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }

--- a/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Place;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Recording;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Release;
 use Moose;
+use namespace::autoclean;
 use JSON qw( encode_json );
 use aliased 'MusicBrainz::Server::Entity::Work';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::ReleaseGroup;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/PrimaryAlias.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/PrimaryAlias.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter model => (
     isa => 'Str',

--- a/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/WithArtistCredits.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Role/Autocompletion/WithArtistCredits.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Series;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::Work;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Controller::Work;
 use 5.10.0;
 use Moose;
+use namespace::autoclean;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
 

--- a/lib/MusicBrainz/Server/ControllerBase/WS/js.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/js.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::ControllerBase::WS::js;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::WebService::Format;
 use MusicBrainz::Server::WebService::JSONSerializer;
 

--- a/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
+++ b/lib/MusicBrainz/Server/Data/CoverArtArchive.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::CoverArtArchive;
 use Moose;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Data::Role::Sql';
 use DBDefs;

--- a/lib/MusicBrainz/Server/Data/Role/Alias.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Alias.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Alias;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Alias;
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
@@ -83,7 +84,6 @@ role
 };
 
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/AliasType.pm
+++ b/lib/MusicBrainz/Server/Data/Role/AliasType.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Data::Role::AliasType;
 
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::AliasType;
 use MusicBrainz::Server::Data::Utils qw( load_subobjects );
 

--- a/lib/MusicBrainz/Server/Data/Role/Annotation.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Annotation.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Annotation;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::EntityAnnotation;
 

--- a/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityCache.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Data::Role::EntityCache;
 
 use DBDefs;
 use Moose::Role;
+use namespace::autoclean;
 use List::AllUtils qw( any natatime uniq );
 use MusicBrainz::Server::Constants qw( %ENTITIES );
 use MusicBrainz::Server::Log qw( log_debug );

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Data::Role::GIDEntityCache;
 
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Data::Role::EntityCache';
 

--- a/lib/MusicBrainz/Server/Data/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Data/Role/IPI.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::IPI;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 
 parameter 'type' => (
@@ -50,7 +51,6 @@ role
 
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ISNI.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::ISNI;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 
 parameter 'type' => (
@@ -50,7 +51,6 @@ role
 
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/LinksToEdit.pm
+++ b/lib/MusicBrainz/Server/Data/Role/LinksToEdit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::LinksToEdit;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter 'table' => (
     isa => 'Str',

--- a/lib/MusicBrainz/Server/Data/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Merge.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Merge;
 use Moose::Role;
+use namespace::autoclean;
 
 use Carp qw( croak );
 

--- a/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
+++ b/lib/MusicBrainz/Server/Data/Role/PendingEdits.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::PendingEdits;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( placeholders );
 use Sql;
@@ -27,7 +28,6 @@ role {
 
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/Rating.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Rating.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Rating;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Rating;
 
@@ -31,8 +32,6 @@ role
     }
 };
 
-
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/SelectAll.pm
+++ b/lib/MusicBrainz/Server/Data/Role/SelectAll.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::SelectAll;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter 'order_by' => (
     isa => 'ArrayRef',
@@ -55,7 +56,6 @@ role
     method 'sort_in_forms' => sub { 0 };
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/Sql.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Sql.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Sql;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Data::Role::Context';
 

--- a/lib/MusicBrainz/Server/Data/Role/Subscription.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Subscription.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Subscription;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Subscription;
 

--- a/lib/MusicBrainz/Server/Data/Role/Tag.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Tag.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Data::Role::Tag;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::EntityTag;
 

--- a/lib/MusicBrainz/Server/Data/Role/ValueSet.pm
+++ b/lib/MusicBrainz/Server/Data/Role/ValueSet.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Data::Role::ValueSet;
 
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use Moose::Util qw( ensure_all_roles );
 use MusicBrainz::Server::Data::ValueSet;
 

--- a/lib/MusicBrainz/Server/Data/Utils/Cleanup.pm
+++ b/lib/MusicBrainz/Server/Data/Utils/Cleanup.pm
@@ -22,4 +22,5 @@ sub used_in_relationship {
     );
 }
 
+no Moose;
 1;

--- a/lib/MusicBrainz/Server/Data/Utils/Uniqueness.pm
+++ b/lib/MusicBrainz/Server/Data/Utils/Uniqueness.pm
@@ -49,4 +49,5 @@ sub assert_uniqueness_conserved {
     }
 }
 
+no Moose;
 1;

--- a/lib/MusicBrainz/Server/Edit/Alias.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Alias;
 use Moose::Role;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( partial_date_to_hash non_empty );
 use MusicBrainz::Server::Constants qw( %ENTITIES );

--- a/lib/MusicBrainz/Server/Edit/Alias/Add.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Add.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Alias::Add;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Data::Utils qw( model_to_type boolean_to_json );

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Alias::Edit;
 use 5.10.0;
 use Moose;
+use namespace::autoclean;
 
 use Moose::Util::TypeConstraints qw( as subtype find_type_constraint );
 use MooseX::Types::Moose qw( Bool Int Str );
@@ -195,6 +196,5 @@ around TO_JSON => sub {
 };
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
 
 1;

--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Annotation::Edit;
 use strict;
 use Carp;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MooseX::Types::Moose qw( Int Str );
 use MooseX::Types::Structured qw( Dict Optional );
 use MusicBrainz::Server::Constants qw( %ENTITIES );

--- a/lib/MusicBrainz/Server/Edit/Area/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Area::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_AREA_CREATE );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Edit/Artist/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Artist::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_ARTIST_CREATE );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Edit/Artist/EditArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/EditArtistCredit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Artist::EditArtistCredit;
 use Moose;
+use namespace::autoclean;
 
 use MooseX::Types::Structured qw( Dict );
 

--- a/lib/MusicBrainz/Server/Edit/Event/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Event::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_EVENT_CREATE );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Edit/Genre/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Genre::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_GENRE_CREATE );
 use MusicBrainz::Server::Edit::Types qw( Nullable );

--- a/lib/MusicBrainz/Server/Edit/Historic/AddLink.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/AddLink.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::AddLink;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Edit::Historic::Utils qw( upgrade_date );
 use MusicBrainz::Server::Constants qw( $EDIT_HISTORIC_ADD_LINK );

--- a/lib/MusicBrainz/Server/Edit/Historic/AddReleaseEvents.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/AddReleaseEvents.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::AddReleaseEvents;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_HISTORIC_ADD_RELEASE_EVENTS

--- a/lib/MusicBrainz/Server/Edit/Historic/Base.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Base.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Historic::Base;
 
 use Moose;
+use namespace::autoclean;
 use Moose::Exporter;
 use Class::Load qw( load_class );
 

--- a/lib/MusicBrainz/Server/Edit/Historic/EditLink.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/EditLink.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::EditLink;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Edit::Historic::Utils qw( upgrade_date );
 use MusicBrainz::Server::Constants qw( $EDIT_HISTORIC_EDIT_LINK );

--- a/lib/MusicBrainz/Server/Edit/Historic/EditReleaseEvents.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/EditReleaseEvents.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::EditReleaseEvents;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_HISTORIC_EDIT_RELEASE_EVENTS

--- a/lib/MusicBrainz/Server/Edit/Historic/Fast.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/Fast.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Historic::Fast;
 
 use Moose;
+use namespace::autoclean;
 
 extends 'Class::Accessor::Fast::XS';
 

--- a/lib/MusicBrainz/Server/Edit/Historic/MergeReleaseMAC.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/MergeReleaseMAC.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::MergeReleaseMAC;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_HISTORIC_MERGE_RELEASE_MAC );
 use MusicBrainz::Server::Translation qw( N_l );

--- a/lib/MusicBrainz/Server/Edit/Historic/RemoveLink.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/RemoveLink.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::RemoveLink;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_HISTORIC_REMOVE_LINK );
 use MusicBrainz::Server::Edit::Historic::Utils qw( upgrade_date );

--- a/lib/MusicBrainz/Server/Edit/Historic/RemoveReleaseEvents.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/RemoveReleaseEvents.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Historic::RemoveReleaseEvents;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_HISTORIC_REMOVE_RELEASE_EVENTS

--- a/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Instrument::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_INSTRUMENT_CREATE );
 use MusicBrainz::Server::Edit::Types qw( Nullable );

--- a/lib/MusicBrainz/Server/Edit/Place/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Create.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Place::Create;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( $EDIT_PLACE_CREATE );
 use MusicBrainz::Server::Edit::Types qw( CoordinateHash Nullable PartialDateHash );

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Relationship::Edit;
 use Moose;
+use namespace::autoclean;
 use Carp;
 use Clone qw( clone );
 use Data::Compare;

--- a/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Relationship::Reorder;
 use strict;
 use Moose;
+use namespace::autoclean;
 use Moose::Util::TypeConstraints qw( as subtype find_type_constraint );
 use MooseX::Types::Moose qw( ArrayRef Int Str Bool );
 use MooseX::Types::Structured qw( Dict Optional );

--- a/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Release::ChangeQuality;
 use Moose;
+use namespace::autoclean;
 use Method::Signatures::Simple;
 use MooseX::Types::Moose qw( Int Str );
 use MooseX::Types::Structured qw( Dict );
@@ -109,5 +110,4 @@ sub allow_auto_edit
     return $self->data->{new}{quality} != $QUALITY_HIGH && $self->can_amend($self->release_id);
 }
 
-no Moose;
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Release::EditReleaseLabel;
 use Moose;
+use namespace::autoclean;
 use 5.10.0;
 
 use Moose::Util::TypeConstraints qw( find_type_constraint subtype as );
@@ -408,7 +409,6 @@ sub restore {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Release::RemoveCoverArt;
 use Moose;
+use namespace::autoclean;
 
 use MooseX::Types::Moose qw( Str Int ArrayRef );
 use MooseX::Types::Structured qw( Dict Optional );

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Release::ReorderMediums;
 use utf8;
 use Moose;
+use namespace::autoclean;
 use MooseX::Types::Moose qw( ArrayRef Int Str );
 use MooseX::Types::Structured qw( Dict );
 use MusicBrainz::Server::Edit::Types qw( Nullable NullableOnPreview );

--- a/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/AllowAmending.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Role::AllowAmending;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter create_edit_type => ( isa => 'Int', required => 1);
 parameter entity_type => ( isa => 'Str', required => 1);

--- a/lib/MusicBrainz/Server/Edit/Role/CheckDuplicates.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/CheckDuplicates.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Role::CheckDuplicates;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( non_empty );
 
 requires '_is_disambiguation_needed';

--- a/lib/MusicBrainz/Server/Edit/Role/CoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/CoverArt.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Role::CoverArt;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 role
 {
@@ -15,7 +16,6 @@ role
     };
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Edit/Role/DatePeriod.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/DatePeriod.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Role::DatePeriod;
 use Moose::Role;
+use namespace::autoclean;
 use Hash::Merge qw( merge );
 use List::AllUtils qw( any );
 use MusicBrainz::Server::Data::Utils qw( non_empty partial_date_to_hash );

--- a/lib/MusicBrainz/Server/Edit/Role/EditArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/EditArtistCredit.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Role::EditArtistCredit;
 
 use Data::Compare;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw(
     artist_credit_to_ref
 );
@@ -27,7 +28,6 @@ around initialize => sub {
     $self->$orig(%opts);
 };
 
-no Moose;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Edit/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/IPI.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Role::IPI;
 use 5.10.0;
 use Moose::Role;
+use namespace::autoclean;
 use utf8;
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
@@ -100,7 +101,6 @@ after post_insert => sub {
     }
 };
 
-no Moose;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/ISNI.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Role::ISNI;
 use 5.10.0;
 use Moose::Role;
+use namespace::autoclean;
 use utf8;
 
 use MusicBrainz::Server::Constants qw( $EDITOR_MODBOT );
@@ -100,7 +101,6 @@ after post_insert => sub {
     }
 };
 
-no Moose;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Edit/Role/SubscribeOnCreation.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/SubscribeOnCreation.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::Role::SubscribeOnCreation;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 parameter editor_subscription_preference => (
     isa => 'CodeRef',

--- a/lib/MusicBrainz/Server/Edit/Role/ValueSet.pm
+++ b/lib/MusicBrainz/Server/Edit/Role/ValueSet.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Edit::Role::ValueSet;
 use 5.10.0;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use Clone qw( clone );
 use List::AllUtils qw( nsort_by uniq );

--- a/lib/MusicBrainz/Server/Edit/WithDifferences.pm
+++ b/lib/MusicBrainz/Server/Edit/WithDifferences.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Edit::WithDifferences;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Edit::Exceptions;
 use MusicBrainz::Server::Data::Utils qw( remove_equal );

--- a/lib/MusicBrainz/Server/EditSearch/Exceptions.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Exceptions.pm
@@ -1,5 +1,6 @@
 ## no critic (RequireFilenameMatchesPackage)
 package MusicBrainz::Server::EditSearch::Exceptions::UnsupportOperator;
 use Moose;
+use namespace::autoclean;
 extends 'Throwable::Error';
 1;

--- a/lib/MusicBrainz/Server/EditSearch/Predicate.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::EditSearch::Predicate;
 use Moose::Role;
+use namespace::autoclean;
 
 use MooseX::Types::Moose qw( Any ArrayRef Str );
 use MusicBrainz::Server::EditSearch::Exceptions;

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditNoteContent.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::EditSearch::Predicate::EditNoteContent;
 use Moose;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/EditSubscription.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/EditSubscription.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::EditSearch::Predicate::EditSubscription;
 use Moose;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
 

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/RelationshipType.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::EditSearch::Predicate::RelationshipType;
 use Moose;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::EditSearch::Predicate';
 

--- a/lib/MusicBrainz/Server/EditSearch/Query.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Query.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::EditSearch::Query;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::CGI::Expand qw( expand_hash );
 use MooseX::Types::Moose qw( Any ArrayRef Bool Maybe Str );

--- a/lib/MusicBrainz/Server/Entity/ExampleRelationship.pm
+++ b/lib/MusicBrainz/Server/Entity/ExampleRelationship.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::ExampleRelationship;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );

--- a/lib/MusicBrainz/Server/Entity/ReleaseEvent.pm
+++ b/lib/MusicBrainz/Server/Entity/ReleaseEvent.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::ReleaseEvent;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Entity::Types;
 

--- a/lib/MusicBrainz/Server/Entity/Role/Area.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Area.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::Area;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Types;
 
 has area_id => (

--- a/lib/MusicBrainz/Server/Entity/Role/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/ArtistCredit.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::ArtistCredit;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Types;
 
 has 'artist_credit_id' => (

--- a/lib/MusicBrainz/Server/Entity/Role/Comment.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Comment.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::Comment;
 use Moose::Role;
+use namespace::autoclean;
 
 has comment => (
     is => 'rw',

--- a/lib/MusicBrainz/Server/Entity/Role/IPI.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/IPI.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::IPI;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 has ipi_codes => (

--- a/lib/MusicBrainz/Server/Entity/Role/ISNI.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/ISNI.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::ISNI;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 has isni_codes => (

--- a/lib/MusicBrainz/Server/Entity/Role/OptionsTree.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/OptionsTree.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::OptionsTree;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Entity::Types;
 

--- a/lib/MusicBrainz/Server/Entity/Role/PendingEdits.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/PendingEdits.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Entity::Role::PendingEdits;
 
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 
 has 'edits_pending' => (

--- a/lib/MusicBrainz/Server/Entity/Role/Relatable.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Relatable.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::Relatable;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Entity::Role::GID';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';

--- a/lib/MusicBrainz/Server/Entity/Role/Taggable.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Taggable.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::Taggable;
 use Moose::Role;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Entity::Types;
 

--- a/lib/MusicBrainz/Server/Entity/Role/Type.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Type.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::Role::Type;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( add_linked_entity );
 
 parameter model => (

--- a/lib/MusicBrainz/Server/Entity/Types.pm
+++ b/lib/MusicBrainz/Server/Entity/Types.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Entity::Types;
 
 use Moose::Util::TypeConstraints;
+use namespace::autoclean;
 
 for my $cls (qw(AggregatedTag AggregatedGenre Annotation Application
                 Area AreaAlias AreaAliasType AreaType

--- a/lib/MusicBrainz/Server/Entity/URL/License.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/License.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::URL::License;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 
 requires 'sidebar_name';

--- a/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/MediaWiki.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::URL::MediaWiki;
 use Moose::Role;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Filters;
 

--- a/lib/MusicBrainz/Server/Entity/URL/Sidebar.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Sidebar.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::URL::Sidebar;
 use Moose::Role;
+use namespace::autoclean;
 
 requires 'sidebar_name';
 

--- a/lib/MusicBrainz/Server/Entity/WorkAttribute.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAttribute.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::WorkAttribute;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Translation::Attributes qw( lp );
 

--- a/lib/MusicBrainz/Server/Entity/WorkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAttributeType.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::WorkAttributeType;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Translation::Attributes qw( lp );

--- a/lib/MusicBrainz/Server/Entity/WorkAttributeTypeAllowedValue.pm
+++ b/lib/MusicBrainz/Server/Entity/WorkAttributeTypeAllowedValue.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Entity::WorkAttributeTypeAllowedValue;
 use Moose;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Translation::Attributes qw( lp );
 

--- a/lib/MusicBrainz/Server/Exceptions.pm
+++ b/lib/MusicBrainz/Server/Exceptions.pm
@@ -1,31 +1,37 @@
 ## no critic (RequireFilenameMatchesPackage)
 package MusicBrainz::Server::Exceptions::InvalidInput;
 use Moose;
+use namespace::autoclean;
 extends 'Throwable::Error';
 
 package MusicBrainz::Server::Exceptions::BadData;
 use Moose;
+use namespace::autoclean;
 extends 'MusicBrainz::Server::Exceptions::InvalidInput';
 
 package MusicBrainz::Server::Exceptions::Duplicate;
 use Moose;
+use namespace::autoclean;
 extends 'MusicBrainz::Server::Exceptions::InvalidInput';
 
 has 'duplicates' => ( is => 'ro', isa => 'ArrayRef' );
 
 package MusicBrainz::Server::Exceptions::DuplicateViolation;
 use Moose;
+use namespace::autoclean;
 with 'Throwable';
 
 has 'conflict' => ( is => 'ro', required => 1 );
 
 package MusicBrainz::Server::Exceptions::GenericTimeout;
 use Moose;
+use namespace::autoclean;
 extends 'Throwable::Error';
 with 'MusicBrainz::Server::Exceptions::Role::Timeout';
 
 package MusicBrainz::Server::Exceptions::DatabaseError;
 use Moose;
+use namespace::autoclean;
 extends 'Throwable::Error';
 
 use overload q{""} => 'as_string', fallback => 1;
@@ -37,6 +43,7 @@ sub as_string { my $self = shift; $self->sqlstate . ' ' . $self->message }
 
 package MusicBrainz::Server::Exceptions::DatabaseError::StatementTimedOut;
 use Moose;
+use namespace::autoclean;
 extends 'MusicBrainz::Server::Exceptions::DatabaseError';
 with 'MusicBrainz::Server::Exceptions::Role::Timeout';
 

--- a/lib/MusicBrainz/Server/Exceptions/Role/Timeout.pm
+++ b/lib/MusicBrainz/Server/Exceptions/Role/Timeout.pm
@@ -1,4 +1,5 @@
 package MusicBrainz::Server::Exceptions::Role::Timeout;
 use Moose::Role;
+use namespace::autoclean;
 
 1;

--- a/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
+++ b/lib/MusicBrainz/Server/Form/Field/OAuthRedirectURI.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Field::OAuthRedirectURI;
 use URI;
 use Moose;
+use namespace::autoclean;
 
 extends 'HTML::FormHandler::Field::Text';
 

--- a/lib/MusicBrainz/Server/Form/Field/URL.pm
+++ b/lib/MusicBrainz/Server/Form/Field/URL.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Form::Field::URL;
 use URI;
 use Moose;
+use namespace::autoclean;
 
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Validation qw( is_valid_url );

--- a/lib/MusicBrainz/Server/Model/MB.pm
+++ b/lib/MusicBrainz/Server/Model/MB.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Model::MB;
 use Moose;
+use namespace::autoclean;
 
 extends 'Catalyst::Model';
 

--- a/lib/MusicBrainz/Server/Report.pm
+++ b/lib/MusicBrainz/Server/Report.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Data::Role::Sql';
 with 'MusicBrainz::Server::Data::Role::QueryToList';

--- a/lib/MusicBrainz/Server/Report/AnnotationReport.pm
+++ b/lib/MusicBrainz/Server/Report/AnnotationReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::AnnotationReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Data::Relationship;
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/ArtistCreditReport.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistCreditReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::ArtistCreditReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/ArtistReport.pm
+++ b/lib/MusicBrainz/Server/Report/ArtistReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::ArtistReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/CDTOCReport.pm
+++ b/lib/MusicBrainz/Server/Report/CDTOCReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::CDTOCReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/DeprecatedRelationshipReport.pm
+++ b/lib/MusicBrainz/Server/Report/DeprecatedRelationshipReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::DeprecatedRelationshipReport;
 use Moose::Role;
+use namespace::autoclean;
 use List::AllUtils qw( any );
 use MusicBrainz::Server::Data::Relationship;
 

--- a/lib/MusicBrainz/Server/Report/EditorReport.pm
+++ b/lib/MusicBrainz/Server/Report/EditorReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::EditorReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/EventReport.pm
+++ b/lib/MusicBrainz/Server/Report/EventReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::EventReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/FilterForEditor.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor;
 use Moose::Role;
+use namespace::autoclean;
 
 requires 'filter_sql';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/ArtistCreditID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/ArtistCreditID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::ArtistCreditID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/ArtistID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/ArtistID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::ArtistID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/EventID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/EventID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::EventID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/LabelID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/LabelID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::LabelID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/RecordingID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/RecordingID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::RecordingID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseGroupID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseGroupID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::ReleaseGroupID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/ReleaseID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::ReleaseID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/SeriesID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/SeriesID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::SeriesID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/FilterForEditor/WorkID.pm
+++ b/lib/MusicBrainz/Server/Report/FilterForEditor/WorkID.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::FilterForEditor::WorkID;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report::FilterForEditor';
 

--- a/lib/MusicBrainz/Server/Report/InstrumentReport.pm
+++ b/lib/MusicBrainz/Server/Report/InstrumentReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::InstrumentReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/LabelReport.pm
+++ b/lib/MusicBrainz/Server/Report/LabelReport.pm
@@ -3,6 +3,7 @@ package MusicBrainz::Server::Report::LabelReport;
 use utf8;
 
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/PlaceReport.pm
+++ b/lib/MusicBrainz/Server/Report/PlaceReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::PlaceReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/QueryReport.pm
+++ b/lib/MusicBrainz/Server/Report/QueryReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::QueryReport;
 use Moose::Role;
+use namespace::autoclean;
 
 with 'MusicBrainz::Server::Report';
 

--- a/lib/MusicBrainz/Server/Report/RecordingReport.pm
+++ b/lib/MusicBrainz/Server/Report/RecordingReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::RecordingReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/ReleaseGroupReport.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseGroupReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::ReleaseGroupReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/ReleaseReport.pm
+++ b/lib/MusicBrainz/Server/Report/ReleaseReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::ReleaseReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/SeriesReport.pm
+++ b/lib/MusicBrainz/Server/Report/SeriesReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::SeriesReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/URLReport.pm
+++ b/lib/MusicBrainz/Server/Report/URLReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::URLReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Report/WorkReport.pm
+++ b/lib/MusicBrainz/Server/Report/WorkReport.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Report::WorkReport;
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 with 'MusicBrainz::Server::Report::QueryReport';

--- a/lib/MusicBrainz/Server/Role/FollowForeignKeys.pm
+++ b/lib/MusicBrainz/Server/Role/FollowForeignKeys.pm
@@ -4,6 +4,7 @@ use Data::Compare qw( Compare );
 use Data::Dumper;
 use List::AllUtils qw( any );
 use Moose::Role;
+use namespace::autoclean;
 use MusicBrainz::Script::Utils qw( retry );
 
 requires qw( follow_primary_key );

--- a/lib/MusicBrainz/Server/Role/Translation.pm
+++ b/lib/MusicBrainz/Server/Role/Translation.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Role::Translation;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use Locale::Messages qw( dgettext dpgettext dngettext );
 use Encode;
 

--- a/lib/MusicBrainz/Server/Translation/Attributes.pm
+++ b/lib/MusicBrainz/Server/Translation/Attributes.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Attributes;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'attributes' };

--- a/lib/MusicBrainz/Server/Translation/Countries.pm
+++ b/lib/MusicBrainz/Server/Translation/Countries.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Countries;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'countries' };

--- a/lib/MusicBrainz/Server/Translation/InstrumentDescriptions.pm
+++ b/lib/MusicBrainz/Server/Translation/InstrumentDescriptions.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::InstrumentDescriptions;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'instrument_descriptions' };

--- a/lib/MusicBrainz/Server/Translation/Instruments.pm
+++ b/lib/MusicBrainz/Server/Translation/Instruments.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Instruments;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'instruments' };

--- a/lib/MusicBrainz/Server/Translation/Languages.pm
+++ b/lib/MusicBrainz/Server/Translation/Languages.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Languages;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'languages' };

--- a/lib/MusicBrainz/Server/Translation/Relationships.pm
+++ b/lib/MusicBrainz/Server/Translation/Relationships.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Relationships;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'relationships' };

--- a/lib/MusicBrainz/Server/Translation/Scripts.pm
+++ b/lib/MusicBrainz/Server/Translation/Scripts.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Scripts;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'scripts' };

--- a/lib/MusicBrainz/Server/Translation/Statistics.pm
+++ b/lib/MusicBrainz/Server/Translation/Statistics.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Translation::Statistics;
 use Moose;
+use namespace::autoclean;
 BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'statistics' };

--- a/lib/MusicBrainz/Server/WebService/Exceptions.pm
+++ b/lib/MusicBrainz/Server/WebService/Exceptions.pm
@@ -1,6 +1,7 @@
 ## no critic (RequireFilenameMatchesPackage)
 package MusicBrainz::Server::WebService::Exceptions::UnknownIncParameter;
 use Moose;
+use namespace::autoclean;
 with 'Throwable';
 
 has parameter => ( is => 'ro', required => 1, isa => 'Str' );

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Area.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/Area.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::Area;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( serialize_entity );
 
@@ -35,7 +36,6 @@ role {
     };
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/LifeSpan.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD/Role/LifeSpan.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::WebService::Serializer::JSON::LD::Role::LifeSpan;
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use DateTime::Format::ISO8601;
 use MusicBrainz::Server::WebService::Serializer::JSON::LD::Utils qw( format_date );
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
@@ -48,7 +49,6 @@ role {
     };
 };
 
-no Moose::Role;
 1;
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::WebService::Validator;
 use List::AllUtils qw( uniq );
 use MooseX::Role::Parameterized;
+use namespace::autoclean;
 use aliased 'MusicBrainz::Server::WebService::WebServiceInc';
 use MusicBrainz::Server::Constants qw(
     $ACCESS_SCOPE_TAG

--- a/lib/MusicBrainz/WWW/Mechanize.pm
+++ b/lib/MusicBrainz/WWW/Mechanize.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::WWW::Mechanize;
 
 use Moose;
+use namespace::autoclean;
 use LWP::Authen::Digest;
 
 extends 'Test::WWW::Mechanize::Catalyst';

--- a/lib/Sql.pm
+++ b/lib/Sql.pm
@@ -3,6 +3,7 @@ package Sql;
 use feature 'state';
 
 use Moose;
+use namespace::autoclean;
 use DBDefs;
 use English;
 use Carp qw( cluck croak );

--- a/script/dump-entities-sql.pl
+++ b/script/dump-entities-sql.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature 'switch';
 
 use Moose;
+use namespace::autoclean;
 use FindBin;
 use Getopt::Long;
 use lib "$FindBin::Bin/../lib";

--- a/t/lib/t/MusicBrainz/Server/CacheManager.pm
+++ b/t/lib/t/MusicBrainz/Server/CacheManager.pm
@@ -8,11 +8,13 @@ use Test::More;
 {
     package t::MusicBrainz::Server::CacheManager::TestCache1;
     use Moose;
+    use namespace::autoclean;
     sub get { '1' }
     sub set {}
     1;
     package t::MusicBrainz::Server::CacheManager::TestCache2;
     use Moose;
+    use namespace::autoclean;
     has 'value' => ( is => 'ro' );
     sub get { shift->value }
     sub set {}

--- a/t/lib/t/MusicBrainz/Server/Context.pm
+++ b/t/lib/t/MusicBrainz/Server/Context.pm
@@ -9,10 +9,12 @@ use Test::More;
 {
     package t::MusicBrainz::Server::Context::TestCache1;
     use Moose;
+    use namespace::autoclean;
     sub get { Storable::freeze(\'1') }
     sub set {}
     package t::MusicBrainz::Server::Context::TestCache2;
     use Moose;
+    use namespace::autoclean;
     sub get { Storable::freeze(\'2') }
     sub set {}
 }

--- a/t/lib/t/MusicBrainz/Server/Data/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Edit.pm
@@ -14,6 +14,7 @@ BEGIN { use MusicBrainz::Server::Data::Edit };
 {
     package t::Edit::MockEdit;
     use Moose;
+    use namespace::autoclean;
     extends 'MusicBrainz::Server::Edit';
     sub edit_type { 123 }
     sub edit_name { 'mock edit' }

--- a/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EditNote.pm
@@ -18,6 +18,8 @@ use MusicBrainz::Server::Test;
 BEGIN {
     package MockEdit;
     use Moose;
+    use namespace::autoclean;
+
     extends 'MusicBrainz::Server::Edit';
 
     sub edit_type { 111; }

--- a/t/lib/t/MusicBrainz/Server/Data/EntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/EntityCache.pm
@@ -9,6 +9,8 @@ use Test::More;
 {
     package MyEntityData;
     use Moose;
+    use namespace::autoclean;
+
     extends 'MusicBrainz::Server::Data::Entity';
     sub _type { 'my_entity_data' }
     sub get_by_ids
@@ -20,6 +22,8 @@ use Test::More;
 
     package MyCachedEntityData;
     use Moose;
+    use namespace::autoclean;
+
     extends 'MyEntityData';
     with 'MusicBrainz::Server::Data::Role::EntityCache';
     has 'get_called' => ( is => 'rw', isa => 'Bool', default => 0 );
@@ -27,6 +31,8 @@ use Test::More;
 
     package MockCache;
     use Moose;
+    use namespace::autoclean;
+
     has 'data' => ( is => 'rw', isa => 'HashRef', default => sub { +{} } );
     has 'get_called' => ( is => 'rw', isa => 'Bool', default => 0 );
     has 'set_called' => ( is => 'rw', isa => 'Bool', default => 0 );

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -15,11 +15,13 @@ with 't::Context' => { -excludes => '_build_context' };
 {
     package t::GIDEntityCache::MyEntity;
     use Moose;
+    use namespace::autoclean;
     extends 'MusicBrainz::Server::Entity';
     with 'MusicBrainz::Server::Entity::Role::Relatable';
 
     package t::GIDEntityCache::MyEntityData;
     use Moose;
+    use namespace::autoclean;
     extends 'MusicBrainz::Server::Data::Entity';
     with 'MusicBrainz::Server::Data::Role::GetByGID';
     has 'get_by_id_called' => ( is => 'rw', isa => 'Bool', default => 0 );
@@ -39,6 +41,7 @@ with 't::Context' => { -excludes => '_build_context' };
 
     package t::GIDEntityCache::MyCachedEntityData;
     use Moose;
+    use namespace::autoclean;
     extends 't::GIDEntityCache::MyEntityData';
     with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
     sub _type { 'my_cached_entity_data' }
@@ -46,6 +49,7 @@ with 't::Context' => { -excludes => '_build_context' };
 
     package t::GIDEntityCache::MockCache;
     use Moose;
+    use namespace::autoclean;
     has 'data' => ( is => 'rw', isa => 'HashRef', default => sub { +{} } );
     has 'get_called' => ( is => 'rw', isa => 'Int', default => 0 );
     has 'set_called' => ( is => 'rw', isa => 'Int', default => 0 );

--- a/t/lib/t/MusicBrainz/Server/Data/Role/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/Merge.pm
@@ -9,6 +9,8 @@ use Test::Fatal;
 {
     package t::MusicBrainz::Server::Data::Role::Merge::Impl;
     use Moose;
+    use namespace::autoclean;
+
     with 'MusicBrainz::Server::Data::Role::Merge';
 
     sub _merge_impl {

--- a/t/lib/t/MusicBrainz/Server/Data/Vote.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Vote.pm
@@ -18,6 +18,7 @@ with 't::Context';
 {
     package t::Vote::MockEdit;
     use Moose;
+    use namespace::autoclean;
     extends 'MusicBrainz::Server::Edit';
     sub edit_type { 4242 }
     sub edit_name { 'mock edit' }

--- a/t/lib/t/MusicBrainz/Server/Edit/WithDifferences.pm
+++ b/t/lib/t/MusicBrainz/Server/Edit/WithDifferences.pm
@@ -8,6 +8,7 @@ use Test::More;
 {
     package t::MusicBrainz::Server::Edit::WithDifferences::Entity;
     use Moose;
+    use namespace::autoclean;
 
     has 'foo_id' => (
         is => 'ro',
@@ -20,6 +21,8 @@ use Test::More;
 {
     package t::MusicBrainz::Server::Edit::WithDifferences::TestEdit;
     use Moose;
+    use namespace::autoclean;
+
     extends 'MusicBrainz::Server::Edit::WithDifferences';
 
     sub edit_name { 'Test Edit' }

--- a/t/lib/t/MusicBrainz/Server/EditQueue.pm
+++ b/t/lib/t/MusicBrainz/Server/EditQueue.pm
@@ -18,6 +18,8 @@ my $mock_class = 1000 + int(rand(1000));
 {
     package t::MusicBrainz::Server::EditQueue::MockEditSimple;
     use Moose;
+    use namespace::autoclean;
+
     extends 'MusicBrainz::Server::Edit';
     with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
     sub edit_name { 'Mock edit with database votes' }

--- a/t/lib/t/MusicBrainz/Server/Form/Area.pm
+++ b/t/lib/t/MusicBrainz/Server/Form/Area.pm
@@ -75,6 +75,8 @@ sub form_context {
 
 package t::FormContext;
 use Moose;
+use namespace::autoclean;
+
 use MusicBrainz::Server::Translation;
 extends 'MusicBrainz::Server::Context';
 


### PR DESCRIPTION
See https://metacpan.org/pod/Perl::Critic::Policy::Moose::RequireCleanNamespace

I used `namespace::autoclean` rather than `no Moose` wherever possible, as per https://metacpan.org/pod/Moose::Manual::BestPractices