### PR TITLE
Don't use no longer existing merge.tt

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -122,10 +122,7 @@ role {
 
     method _merge_confirm => sub {
         my ($self, $c) = @_;
-        $c->stash(
-            template => $c->namespace . '/merge.tt',
-            hide_merge_helper => 1
-        );
+        $c->stash( hide_merge_helper => 1 );
 
         my $merger = $c->session->{merger}
             or $c->res->redirect('/'), $c->detach;


### PR DESCRIPTION
These are all gone - it wasn't being hit by users usually anyway, but this was being hit in the Collection::Merge test.

Letting it go through a PR to make sure this doesn't break other tests somehow.