### PR TITLE
MBS-12673: Make it clearer that genres are added as tags

### DIFF
--- a/root/layout/components/sidebar/SidebarTags.js
+++ b/root/layout/components/sidebar/SidebarTags.js
@@ -67,7 +67,9 @@ const SidebarTags = ({
             />
           ) : (
             <div id="sidebar-tags">
-              <h2>{l('Genres')}</h2>
+              <h2>{l('Tags')}</h2>
+
+              <h3>{l('Genres')}</h3>
               <div className="genre-list">
                 <p>
                   <TagList
@@ -78,7 +80,7 @@ const SidebarTags = ({
                 </p>
               </div>
 
-              <h2>{l('Other tags')}</h2>
+              <h3>{l('Other tags')}</h3>
               <div id="sidebar-tag-list">
                 <p>
                   <TagList

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -650,8 +650,9 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
       const tagRows = this.createTagRows();
       return (
         <>
-          <h2>{l('Genres')}</h2>
+          <h2>{l('Tags')}</h2>
 
+          <h3>{l('Genres')}</h3>
           {tagRows.genres.length ? (
             <ul className="genre-list">
               {tagRows.genres}
@@ -660,8 +661,7 @@ export const SidebarTagEditor = (hydrate<TagEditorProps>(
             <p>{lp('(none)', 'genre')}</p>
           )}
 
-          <h2>{l('Other tags')}</h2>
-
+          <h3>{l('Other tags')}</h3>
           {tagRows.tags.length ? (
             <ul className="tag-list">
               {tagRows.tags}

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -92,7 +92,6 @@ h3 {
 
 #sidebar h3, .sidebar h3 {
     font-size: @small-text;
-    color: @text-orange;
 }
 
 ul {


### PR DESCRIPTION
### Implement MBS-12673

Some people were confused because Genres and Other tags were both top level headings on the sidebar, but only Other tags had a field to enter tags. This makes it so that the sidebar tag component has a Tags header, under which smaller Genres and Other tags subheaders appear.

When logged out:
![Screenshot from 2022-10-19 10-15-08](https://user-images.githubusercontent.com/1069224/196622625-8d0cd3b8-698c-4244-84c8-58ddf8753044.png)

When logged in:
![Screenshot from 2022-10-19 10-14-57](https://user-images.githubusercontent.com/1069224/196622627-1cad1d87-b3bf-46bd-9fae-1139ff434ea1.png)

I used `h3` as it's the obvious next step from `h2` - ~~that's currently orange, while the mockup was black. We can change the color of these if that seems helpful~~ and made it black so that it's more clearly different from the top headers.