### PR TITLE
MBS-12552 (II): Refactor CoreEntity in data layer

### DIFF
--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -21,7 +21,9 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -24,7 +24,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'area' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'area' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'area' };
 with 'MusicBrainz::Server::Data::Role::Merge';

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -23,7 +23,9 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 use MusicBrainz::Server::Data::Utils::Uniqueness qw( assert_uniqueness_conserved );
 use Scalar::Util qw( looks_like_number );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Area';

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -30,7 +30,7 @@ with 'MusicBrainz::Server::Data::Role::Area';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::IPI' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::ISNI' => { type => 'artist' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'artist' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'artist' };

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -13,7 +13,13 @@ use MusicBrainz::Server::Data::Utils qw(
 use List::AllUtils qw( any uniq uniq_by zip );
 use MusicBrainz::Server::Constants qw( entities_with );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::EntityModelClass';
+with 'MusicBrainz::Server::Data::Role::GetByGID';
+with 'MusicBrainz::Server::Data::Role::MainTable';
+with 'MusicBrainz::Server::Data::Role::GID';
+with 'MusicBrainz::Server::Data::Role::GIDRedirect';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Subscription' => {
     table => 'editor_subscribe_collection',
     column => 'collection',

--- a/lib/MusicBrainz/Server/Data/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Data/CoreEntity.pm
@@ -3,12 +3,12 @@ package MusicBrainz::Server::Data::CoreEntity;
 use Moose;
 use namespace::autoclean;
 use MusicBrainz::Server::Constants qw( %ENTITIES );
-use MusicBrainz::Server::Data::Utils qw( generate_gid placeholders object_to_ids );
-use MusicBrainz::Server::Validation qw( is_guid );
+use MusicBrainz::Server::Data::Utils qw( generate_gid );
 use Sql;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
+with 'MusicBrainz::Server::Data::Role::GIDRedirect';
 with 'MusicBrainz::Server::Data::Role::Name';
 
 sub _main_table {
@@ -20,64 +20,6 @@ sub _main_table {
 sub _table { shift->_main_table }
 
 sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{model} }
-
-sub _gid_redirect_table {
-    my $self = shift;
-
-    return $self->_main_table . '_gid_redirect'
-        if $ENTITIES{$self->_type}{mbid}{multiple};
-    return;
-}
-
-around get_by_gids => sub
-{
-    my ($orig, $self) = splice(@_, 0, 2);
-    my (@gids) = @_;
-    my %gid_map = %{ $self->$orig(@_) };
-    my $table = $self->_gid_redirect_table;
-    return \%gid_map
-        unless defined $table;
-    my @missing_gids;
-    for my $gid (grep { is_guid($_) } @gids) {
-        unless (exists $gid_map{$gid}) {
-            push @missing_gids, $gid;
-        }
-    }
-    if (@missing_gids) {
-        my $sql = "SELECT new_id, gid FROM $table
-            WHERE gid IN (" . placeholders(@missing_gids) . ')';
-        my $ids = $self->sql->select_list_of_lists($sql, @missing_gids);
-        my $id_map = $self->get_by_ids(map { $_->[0] } @$ids);
-        for my $row (@$ids) {
-            my $id = $row->[0];
-            if (exists $id_map->{$id}) {
-                my $obj = $id_map->{$id};
-                $gid_map{$row->[1]} = $obj;
-            }
-        }
-    }
-    return \%gid_map;
-};
-
-around get_by_gid => sub
-{
-    my ($orig, $self) = splice(@_, 0, 2);
-    my ($gid) = @_;
-    return unless is_guid($gid);
-    if (my $obj = $self->$orig(@_)) {
-        return $obj;
-    }
-    else {
-        my $table = $self->_gid_redirect_table;
-        if (defined($table)) {
-            my $id = $self->sql->select_single_value("SELECT new_id FROM $table WHERE gid=?", $gid);
-            if (defined($id)) {
-                return $self->get_by_id($id);
-            }
-        }
-        return undef;
-    }
-};
 
 sub insert {
     my ($self, @entities) = @_;
@@ -114,76 +56,6 @@ sub _insert_hook_after_each { }
 
 sub _insert_hook_after { }
 
-sub load_gid_redirects {
-    my ($self, @entities) = @_;
-    my $table = $self->_gid_redirect_table;
-
-    my %entities_by_id = object_to_ids(@entities);
-
-    my $query = "SELECT new_id, array_agg(gid) AS gid_redirects FROM $table WHERE new_id = any(?) GROUP BY new_id";
-    my $results = $self->c->sql->select_list_of_hashes($query, [map { $_->id } @entities]);
-
-    for my $row (@$results) {
-        for my $entity (@{ $entities_by_id{$row->{new_id}} }) {
-            $entity->gid_redirects($row->{gid_redirects});
-        }
-    }
-}
-
-sub remove_gid_redirects
-{
-    my ($self, @ids) = @_;
-    my $table = $self->_gid_redirect_table;
-    $self->sql->do("DELETE FROM $table WHERE new_id IN (" . placeholders(@ids) . ')', @ids);
-}
-
-sub add_gid_redirects
-{
-    my ($self, %redirects) = @_;
-    my $table = $self->_gid_redirect_table;
-    my $query = "INSERT INTO $table (gid, new_id) VALUES " .
-                (join q(, ), ('(?, ?)') x keys %redirects);
-    $self->sql->do($query, %redirects);
-}
-
-sub update_gid_redirects
-{
-    my ($self, $new_id, @old_ids) = @_;
-    my $table = $self->_gid_redirect_table;
-    $self->sql->do("
-        UPDATE $table SET new_id = ?
-        WHERE new_id IN (".placeholders(@old_ids).')', $new_id, @old_ids);
-}
-
-sub _delete_and_redirect_gids
-{
-    my ($self, $table, $new_id, @old_ids) = @_;
-
-    # Update all GID redirects from @old_ids to $new_id
-    $self->update_gid_redirects($new_id, @old_ids);
-
-    # Delete the recording and select current GIDs
-    my $old_gids = $self->delete_returning_gids(@old_ids);
-
-    # Add redirects from GIDs of the deleted recordings to $new_id
-    $self->add_gid_redirects(map { $_ => $new_id } @$old_gids);
-
-    if ($self->can('_delete_from_cache')) {
-        $self->_delete_from_cache(
-            $new_id, @old_ids,
-            @$old_gids
-        );
-    }
-}
-
-sub delete_returning_gids {
-    my ($self, @ids) = @_;
-    return $self->sql->select_single_column_array('
-        DELETE FROM ' . $self->_main_table . '
-        WHERE id IN ('.placeholders(@ids).')
-        RETURNING gid', @ids);
-}
-
 __PACKAGE__->meta->make_immutable;
 no Moose;
 1;
@@ -191,17 +63,6 @@ no Moose;
 =head1 NAME
 
 MusicBrainz::Server::Data::CoreEntity
-
-=head1 METHODS
-
-=head2 get_by_gid ($gid)
-
-Loads and returns a single CoreEntity instance for the specified $gid.
-
-=head2 get_by_gids (@gids)
-
-Loads and returns multiple CoreEntity instances for the specified @gids,
-the response is a GID-keyes HASH reference.
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/MusicBrainz/Server/Data/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Data/CoreEntity.pm
@@ -2,23 +2,15 @@ package MusicBrainz::Server::Data::CoreEntity;
 
 use Moose;
 use namespace::autoclean;
-use MusicBrainz::Server::Constants qw( %ENTITIES );
 use Sql;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::EntityModelClass';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
+with 'MusicBrainz::Server::Data::Role::MainTable';
 with 'MusicBrainz::Server::Data::Role::GID';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
 with 'MusicBrainz::Server::Data::Role::Name';
-
-sub _main_table {
-    my $type = shift->_type;
-    return $ENTITIES{$type}{table} // $type;
-}
-
-# Override this for joins etc. if necessary.
-sub _table { shift->_main_table }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Data/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Data/CoreEntity.pm
@@ -3,11 +3,11 @@ package MusicBrainz::Server::Data::CoreEntity;
 use Moose;
 use namespace::autoclean;
 use MusicBrainz::Server::Constants qw( %ENTITIES );
-use MusicBrainz::Server::Data::Utils qw( generate_gid );
 use Sql;
 
 extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
+with 'MusicBrainz::Server::Data::Role::GID';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
 with 'MusicBrainz::Server::Data::Role::Name';
 
@@ -20,41 +20,6 @@ sub _main_table {
 sub _table { shift->_main_table }
 
 sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{model} }
-
-sub insert {
-    my ($self, @entities) = @_;
-
-    my $extra_data = $self->_insert_hook_prepare(\@entities);
-
-    my @created;
-    for my $entity (@entities) {
-        my $row = $self->_insert_hook_make_row($entity, $extra_data);
-        $row->{gid} = $entity->{gid} || generate_gid();
-
-        my $created = {
-            id => $self->sql->insert_row($self->_main_table, $row, 'id'),
-            gid => $row->{gid},
-        };
-
-        $self->_insert_hook_after_each($created, $entity, $extra_data);
-
-        push @created, $created;
-    }
-
-    $self->_insert_hook_after(\@created, $extra_data);
-    return @entities > 1 ? @created : $created[0];
-}
-
-sub _insert_hook_prepare { {} }
-
-sub _insert_hook_make_row {
-    my ($self, $entity) = @_;
-    return $self->_hash_to_row($entity);
-}
-
-sub _insert_hook_after_each { }
-
-sub _insert_hook_after { }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Data/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Data/CoreEntity.pm
@@ -6,6 +6,7 @@ use MusicBrainz::Server::Constants qw( %ENTITIES );
 use Sql;
 
 extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::EntityModelClass';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
 with 'MusicBrainz::Server::Data::Role::GID';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
@@ -18,8 +19,6 @@ sub _main_table {
 
 # Override this for joins etc. if necessary.
 sub _table { shift->_main_table }
-
-sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{model} }
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -20,7 +20,9 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Area';

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -24,7 +24,7 @@ extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Area';
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'event' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'event' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'event' };

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -10,7 +10,7 @@ use MusicBrainz::Server::Entity::Genre;
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'genre' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'genre' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'genre' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'genre' };
 with 'MusicBrainz::Server::Data::Role::SelectAll';

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -7,7 +7,9 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Entity::Genre;
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'genre' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'genre' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -10,7 +10,9 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Entity::Instrument;
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -13,7 +13,7 @@ use MusicBrainz::Server::Entity::Instrument;
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'instrument' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'instrument' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'instrument' };

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -27,7 +27,7 @@ with 'MusicBrainz::Server::Data::Role::Area';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::IPI' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::ISNI' => { type => 'label' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'label' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'label' };

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -20,7 +20,9 @@ use MusicBrainz::Server::Data::Utils qw(
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 use MusicBrainz::Server::Data::Utils::Uniqueness qw( assert_uniqueness_conserved );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'label' };
 with 'MusicBrainz::Server::Data::Role::Area';

--- a/lib/MusicBrainz/Server/Data/Medium.pm
+++ b/lib/MusicBrainz/Server/Data/Medium.pm
@@ -119,7 +119,7 @@ sub update
     my ($self, $medium_id, $medium_hash) = @_;
     die 'update cannot update tracklist' if exists $medium_hash->{tracklist};
 
-    my $row = $self->_create_row($medium_hash);
+    my $row = $self->_hash_to_row($medium_hash);
     return unless %$row;
 
     $self->sql->update_row('medium', $row, { id => $medium_id });
@@ -137,7 +137,7 @@ sub insert
     my @created;
     for my $medium_hash (@medium_hashes) {
         my $tracklist = delete $medium_hash->{tracklist};
-        my $row = $self->_create_row($medium_hash);
+        my $row = $self->_hash_to_row($medium_hash);
 
         my $medium_created = {
             id => $self->sql->insert_row('medium', $row, 'id'),
@@ -176,7 +176,7 @@ sub delete
     $self->sql->do('DELETE FROM medium WHERE id IN (' . placeholders(@ids) . ')', @ids);
 }
 
-sub _create_row
+sub _hash_to_row
 {
     my ($self, $medium_hash) = @_;
     my %row;

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -19,7 +19,9 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -22,7 +22,7 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'place' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'place' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'place' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'place' };

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -19,7 +19,7 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'recording' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'recording' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'recording' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'recording' };

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -17,7 +17,9 @@ use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use MusicBrainz::Server::Entity::Recording;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'recording' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'recording' };

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -31,7 +31,9 @@ use MusicBrainz::Server::Translation qw( comma_list N_l );
 use MusicBrainz::Server::Validation qw( encode_entities );
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release' };

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -33,7 +33,7 @@ use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'release' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'release' };

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -18,7 +18,9 @@ use MusicBrainz::Server::Data::Utils::Cleanup qw( used_in_relationship );
 
 use MusicBrainz::Server::Constants qw( $STATUS_OPEN );
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release_group' };

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -20,7 +20,7 @@ use MusicBrainz::Server::Constants qw( $STATUS_OPEN );
 
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'release_group' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'release_group' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'release_group' };

--- a/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
@@ -5,7 +5,7 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 
-# '_type' is indirectly required.
+requires '_type';
 
 sub _entity_class { 'MusicBrainz::Server::Entity::' . type_to_model(shift->_type) }
 

--- a/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
@@ -12,6 +12,24 @@ sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{mo
 no Moose::Role;
 1;
 
+=head1 NAME
+
+MusicBrainz::Server::Data::Role::EntityModelClass
+
+=head1 DESCRIPTION
+
+Define C<_entity_class> method assuming that
+the value of C<_type> match the key of
+an object literal in C<entities.json> file
+with a C<model> subkey.
+
+=head1 METHODS
+
+=head2 _entity_class
+
+Return the full name of the corresponding
+C<MusicBrainz::Server::Entity> subclass.
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009,2011 Lukas Lalinsky

--- a/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
@@ -3,11 +3,11 @@ package MusicBrainz::Server::Data::Role::EntityModelClass;
 use Moose::Role;
 use namespace::autoclean;
 
-use MusicBrainz::Server::Constants qw( %ENTITIES );
+use MusicBrainz::Server::Data::Utils qw( type_to_model );
 
 # '_type' is indirectly required.
 
-sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{model} }
+sub _entity_class { 'MusicBrainz::Server::Entity::' . type_to_model(shift->_type) }
 
 no Moose::Role;
 1;

--- a/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
+++ b/lib/MusicBrainz/Server/Data/Role/EntityModelClass.pm
@@ -1,0 +1,24 @@
+package MusicBrainz::Server::Data::Role::EntityModelClass;
+
+use Moose::Role;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+
+# '_type' is indirectly required.
+
+sub _entity_class { 'MusicBrainz::Server::Entity::' . $ENTITIES{shift->_type}{model} }
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009,2011 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Role/GID.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GID.pm
@@ -5,8 +5,7 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( generate_gid );
 
-requires '_main_table';
-# '_hash_to_row' is indirectly required too.
+requires '_hash_to_row', '_main_table';
 requires 'sql';
 
 sub insert {

--- a/lib/MusicBrainz/Server/Data/Role/GID.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GID.pm
@@ -1,0 +1,59 @@
+package MusicBrainz::Server::Data::Role::GID;
+
+use Moose::Role;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Data::Utils qw( generate_gid );
+
+requires '_main_table';
+# '_hash_to_row' is indirectly required too.
+requires 'sql';
+
+sub insert {
+    my ($self, @entities) = @_;
+
+    my $extra_data = $self->_insert_hook_prepare(\@entities);
+
+    my @created;
+    for my $entity (@entities) {
+        my $row = $self->_insert_hook_make_row($entity, $extra_data);
+        $row->{gid} = $entity->{gid} || generate_gid();
+
+        my $created = {
+            id => $self->sql->insert_row($self->_main_table, $row, 'id'),
+            gid => $row->{gid},
+        };
+
+        $self->_insert_hook_after_each($created, $entity, $extra_data);
+
+        push @created, $created;
+    }
+
+    $self->_insert_hook_after(\@created, $extra_data);
+    return @entities > 1 ? @created : $created[0];
+}
+
+sub _insert_hook_prepare { {} }
+
+sub _insert_hook_make_row {
+    my ($self, $entity) = @_;
+    return $self->_hash_to_row($entity);
+}
+
+sub _insert_hook_after_each { }
+
+sub _insert_hook_after { }
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009,2011 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -1,4 +1,4 @@
-package MusicBrainz::Server::Data::Role::CoreEntityCache;
+package MusicBrainz::Server::Data::Role::GIDEntityCache;
 
 use Moose::Role;
 

--- a/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
@@ -150,11 +150,11 @@ MusicBrainz::Server::Data::Role::GIDRedirect
 
 =head2 get_by_gid ($gid)
 
-Loads and returns a single CoreEntity instance for the specified $gid.
+Loads and returns a single Entity instance for the specified $gid.
 
 =head2 get_by_gids (@gids)
 
-Loads and returns multiple CoreEntity instances for the specified @gids;
+Loads and returns multiple Entity instances for the specified @gids;
 The response is a GID-keyed HASH reference.
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
@@ -7,8 +7,7 @@ use MusicBrainz::Server::Constants qw( %ENTITIES );
 use MusicBrainz::Server::Data::Utils qw( placeholders object_to_ids );
 use MusicBrainz::Server::Validation qw( is_guid );
 
-requires '_main_table';
-# '_type' is indirectly required too.
+requires '_main_table', '_type';
 requires 'c', 'get_by_gid', 'get_by_gids', 'get_by_id', 'get_by_ids', 'sql';
 
 sub _delete_and_redirect_gids

--- a/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
+++ b/lib/MusicBrainz/Server/Data/Role/GIDRedirect.pm
@@ -1,0 +1,170 @@
+package MusicBrainz::Server::Data::Role::GIDRedirect;
+
+use Moose::Role;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+use MusicBrainz::Server::Data::Utils qw( placeholders object_to_ids );
+use MusicBrainz::Server::Validation qw( is_guid );
+
+requires '_main_table';
+# '_type' is indirectly required too.
+requires 'c', 'get_by_gid', 'get_by_gids', 'get_by_id', 'get_by_ids', 'sql';
+
+sub _delete_and_redirect_gids
+{
+    my ($self, $table, $new_id, @old_ids) = @_;
+
+    # Update all GID redirects from @old_ids to $new_id
+    $self->update_gid_redirects($new_id, @old_ids);
+
+    # Delete the recording and select current GIDs
+    my $old_gids = $self->delete_returning_gids(@old_ids);
+
+    # Add redirects from GIDs of the deleted recordings to $new_id
+    $self->add_gid_redirects(map { $_ => $new_id } @$old_gids);
+
+    if ($self->can('_delete_from_cache')) {
+        $self->_delete_from_cache(
+            $new_id, @old_ids,
+            @$old_gids
+        );
+    }
+}
+
+sub _gid_redirect_table {
+    my $self = shift;
+
+    return $self->_main_table . '_gid_redirect'
+        if $ENTITIES{$self->_type}{mbid}{multiple};
+    return;
+}
+
+sub add_gid_redirects
+{
+    my ($self, %redirects) = @_;
+    my $table = $self->_gid_redirect_table;
+    my $query = "INSERT INTO $table (gid, new_id) VALUES " .
+                (join q(, ), ('(?, ?)') x keys %redirects);
+    $self->sql->do($query, %redirects);
+}
+
+sub delete_returning_gids {
+    my ($self, @ids) = @_;
+    return $self->sql->select_single_column_array('
+        DELETE FROM ' . $self->_main_table . '
+        WHERE id IN (' . placeholders(@ids) . ')
+        RETURNING gid', @ids);
+}
+
+around get_by_gid => sub
+{
+    my ($orig, $self) = splice(@_, 0, 2);
+    my ($gid) = @_;
+    return unless is_guid($gid);
+    if (my $obj = $self->$orig(@_)) {
+        return $obj;
+    }
+    else {
+        my $table = $self->_gid_redirect_table;
+        if (defined($table)) {
+            my $id = $self->sql->select_single_value("SELECT new_id FROM $table WHERE gid=?", $gid);
+            if (defined($id)) {
+                return $self->get_by_id($id);
+            }
+        }
+        return undef;
+    }
+};
+
+around get_by_gids => sub
+{
+    my ($orig, $self) = splice(@_, 0, 2);
+    my (@gids) = @_;
+    my %gid_map = %{ $self->$orig(@_) };
+    my $table = $self->_gid_redirect_table;
+    return \%gid_map
+        unless defined $table;
+    my @missing_gids;
+    for my $gid (grep { is_guid($_) } @gids) {
+        unless (exists $gid_map{$gid}) {
+            push @missing_gids, $gid;
+        }
+    }
+    if (@missing_gids) {
+        my $sql = "SELECT new_id, gid FROM $table
+            WHERE gid IN (" . placeholders(@missing_gids) . ')';
+        my $ids = $self->sql->select_list_of_lists($sql, @missing_gids);
+        my $id_map = $self->get_by_ids(map { $_->[0] } @$ids);
+        for my $row (@$ids) {
+            my $id = $row->[0];
+            if (exists $id_map->{$id}) {
+                my $obj = $id_map->{$id};
+                $gid_map{$row->[1]} = $obj;
+            }
+        }
+    }
+    return \%gid_map;
+};
+
+sub load_gid_redirects {
+    my ($self, @entities) = @_;
+    my $table = $self->_gid_redirect_table;
+
+    my %entities_by_id = object_to_ids(@entities);
+
+    my $query = "SELECT new_id, array_agg(gid) AS gid_redirects FROM $table WHERE new_id = any(?) GROUP BY new_id";
+    my $results = $self->c->sql->select_list_of_hashes($query, [map { $_->id } @entities]);
+
+    for my $row (@$results) {
+        for my $entity (@{ $entities_by_id{$row->{new_id}} }) {
+            $entity->gid_redirects($row->{gid_redirects});
+        }
+    }
+}
+
+sub remove_gid_redirects
+{
+    my ($self, @ids) = @_;
+    my $table = $self->_gid_redirect_table;
+    $self->sql->do("DELETE FROM $table WHERE new_id IN (" . placeholders(@ids) . ')', @ids);
+}
+
+sub update_gid_redirects
+{
+    my ($self, $new_id, @old_ids) = @_;
+    my $table = $self->_gid_redirect_table;
+    $self->sql->do("
+        UPDATE $table SET new_id = ?
+        WHERE new_id IN (" . placeholders(@old_ids) . ')', $new_id, @old_ids);
+}
+
+
+no Moose::Role;
+1;
+
+=head1 NAME
+
+MusicBrainz::Server::Data::Role::GIDRedirect
+
+=head1 METHODS
+
+=head2 get_by_gid ($gid)
+
+Loads and returns a single CoreEntity instance for the specified $gid.
+
+=head2 get_by_gids (@gids)
+
+Loads and returns multiple CoreEntity instances for the specified @gids;
+The response is a GID-keyed HASH reference.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009,2011 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Role/MainTable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/MainTable.pm
@@ -5,7 +5,7 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( %ENTITIES );
 
-# '_type' is indirectly required.
+requires '_type';
 
 sub _main_table {
     my $type = shift->_type;

--- a/lib/MusicBrainz/Server/Data/Role/MainTable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/MainTable.pm
@@ -1,0 +1,29 @@
+package MusicBrainz::Server::Data::Role::MainTable;
+
+use Moose::Role;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Constants qw( %ENTITIES );
+
+# '_type' is indirectly required.
+
+sub _main_table {
+    my $type = shift->_type;
+    return $ENTITIES{$type}{table} // $type;
+};
+
+sub _table { shift->_main_table }
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009,2011 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Role/MainTable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/MainTable.pm
@@ -17,6 +17,25 @@ sub _table { shift->_main_table }
 no Moose::Role;
 1;
 
+=head1 NAME
+
+MusicBrainz::Server::Data::Role::MainTable
+
+=head1 DESCRIPTION
+
+Define C<_main_table> method using either
+the value of C<_type> match the key of
+an object literal in C<entities.json> file
+with a C<table> subkey, C<_type> otherwise.
+
+Also define C<_table> with the same value.
+
+=head1 METHODS
+
+=head2 _main_class
+
+Return the name of the main table of this entity type.
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009,2011 Lukas Lalinsky

--- a/lib/MusicBrainz/Server/Data/Role/Name.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Name.pm
@@ -5,8 +5,7 @@ use namespace::autoclean;
 
 use MusicBrainz::Server::Data::Utils qw( placeholders );
 
-requires '_columns', '_id_column', '_new_from_row', '_table';
-# '_type' is indirectly required too.
+requires '_columns', '_id_column', '_new_from_row', '_table', '_type';
 requires 'c', 'query_to_list', 'sql';
 
 sub find_by_name

--- a/lib/MusicBrainz/Server/Data/Role/Name.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Name.pm
@@ -1,0 +1,86 @@
+package MusicBrainz::Server::Data::Role::Name;
+
+use Moose::Role;
+use namespace::autoclean;
+
+use MusicBrainz::Server::Data::Utils qw( placeholders );
+
+requires '_columns', '_id_column', '_new_from_row', '_table';
+# '_type' is indirectly required too.
+requires 'c', 'query_to_list', 'sql';
+
+sub find_by_name
+{
+    my ($self, $name) = @_;
+    my $query = 'SELECT ' . $self->_columns . ' FROM ' . $self->_table . '
+                  WHERE lower(musicbrainz_unaccent(name)) = lower(musicbrainz_unaccent(?))';
+    $self->query_to_list($query, [$name]);
+}
+
+sub find_by_names
+{
+    my $self = shift;
+    my @names = @_;
+
+    return () unless scalar @names;
+
+    my $query = 'SELECT ' . $self->_columns . ', search_terms.term '
+        .'FROM ' . $self->_table
+        . ', (VALUES '
+        .     join (q(,), ('(?)') x scalar(@names))
+        .    ') search_terms (term)'
+        .' WHERE lower(musicbrainz_unaccent(name)) = '
+        .' lower(musicbrainz_unaccent(search_terms.term));';
+
+    my $results = $self->c->sql->select_list_of_hashes($query, @names);
+
+    my %mapped;
+    for my $row (@$results)
+    {
+        my $key = delete $row->{term};
+
+        $mapped{$key} //= [];
+
+        push @{ $mapped{$key} }, $self->_new_from_row($row);
+    }
+
+    return %mapped;
+}
+
+sub get_by_ids_sorted_by_name
+{
+    my ($self, @ids) = @_;
+    @ids = grep { defined && $_ } @ids;
+    return [] unless @ids;
+
+    my $ordering_condition = $self->_type eq 'artist'
+        ? 'sort_name COLLATE musicbrainz'
+        : 'name COLLATE musicbrainz';
+
+    my $key = $self->_id_column;
+    my $query = 'SELECT ' . $self->_columns .
+                ' FROM ' . $self->_table .
+                " WHERE $key IN (" . placeholders(@ids) . ') ' .
+                " ORDER BY $ordering_condition";
+
+    my @result;
+    for my $row (@{ $self->sql->select_list_of_hashes($query, @ids) }) {
+        my $obj = $self->_new_from_row($row);
+        push @result, $obj;
+    }
+    return \@result;
+}
+
+no Moose::Role;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2009,2011 Lukas Lalinsky
+Copyright (C) 2010 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/Data/Role/Name.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Name.pm
@@ -74,6 +74,27 @@ sub get_by_ids_sorted_by_name
 no Moose::Role;
 1;
 
+=head1 NAME
+
+MusicBrainz::Server::Data::Role::Name
+
+=head1 METHODS
+
+=head2 find_by_name ($name)
+
+Loads and returns the first instance for the specified $name.
+
+=head2 find_by_names (@names)
+
+Loads and returns all instances for the specified @names;
+The response is an array of instantiated entities.
+
+=head2 get_by_ids_sorted_by_name (@ids)
+
+Loads and returns all instances for the specified @ids,
+sorted by name or sorted by sort name for artist;
+The response is an array of instantiated entities.
+
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009,2011 Lukas Lalinsky

--- a/lib/MusicBrainz/Server/Data/Role/Relatable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Relatable.pm
@@ -6,7 +6,9 @@ use namespace::autoclean;
 with 'MusicBrainz::Server::Data::Role::EntityModelClass';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
 with 'MusicBrainz::Server::Data::Role::MainTable';
+# Follows MainTable as it requires '_main_table';
 with 'MusicBrainz::Server::Data::Role::GID';
+# Follows GetByGID and MainTable as it requires 'get_by_gid' and '_main_table';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
 
 no Moose::Role;

--- a/lib/MusicBrainz/Server/Data/Role/Relatable.pm
+++ b/lib/MusicBrainz/Server/Data/Role/Relatable.pm
@@ -1,29 +1,32 @@
-package MusicBrainz::Server::Data::CoreEntity;
+package MusicBrainz::Server::Data::Role::Relatable;
 
-use Moose;
+use Moose::Role;
 use namespace::autoclean;
-use Sql;
 
-extends 'MusicBrainz::Server::Data::Entity';
 with 'MusicBrainz::Server::Data::Role::EntityModelClass';
 with 'MusicBrainz::Server::Data::Role::GetByGID';
 with 'MusicBrainz::Server::Data::Role::MainTable';
 with 'MusicBrainz::Server::Data::Role::GID';
 with 'MusicBrainz::Server::Data::Role::GIDRedirect';
-with 'MusicBrainz::Server::Data::Role::Name';
 
-__PACKAGE__->meta->make_immutable;
-no Moose;
+no Moose::Role;
 1;
 
 =head1 NAME
 
-MusicBrainz::Server::Data::CoreEntity
+MusicBrainz::Server::Data::Role::Relatable
+
+=head1 DESCRIPTION
+
+One role to relate them all!
+
+Group roles associated to entity types supporting relationships,
+and by extension having main table, model, GID, and GID redirect.
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2009,2011 Lukas Lalinsky
-Copyright (C) 2010 MetaBrainz Foundation
+Copyright (C) 2010-2022 MetaBrainz Foundation
 
 This file is part of MusicBrainz, the open internet music database,
 and is licensed under the GPL version 2, or (at your option) any

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -18,7 +18,9 @@ use MusicBrainz::Server::Data::Utils::Uniqueness qw( assert_uniqueness_conserved
 use MusicBrainz::Server::Entity::Series;
 use MusicBrainz::Server::Entity::SeriesType;
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'series' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'series' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -21,7 +21,7 @@ use MusicBrainz::Server::Entity::SeriesType;
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'series' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'series' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'series' };
 with 'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'series' };
 with 'MusicBrainz::Server::Data::Role::Merge';

--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -15,7 +15,13 @@ use MusicBrainz::Server::Data::Utils qw(
 );
 use aliased 'MusicBrainz::Server::Entity::Work';
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::EntityModelClass';
+with 'MusicBrainz::Server::Data::Role::GetByGID';
+with 'MusicBrainz::Server::Data::Role::MainTable';
+with 'MusicBrainz::Server::Data::Role::GID';
+with 'MusicBrainz::Server::Data::Role::GIDRedirect';
+with 'MusicBrainz::Server::Data::Role::Name';
 
 with 'MusicBrainz::Server::Data::Role::Editable' => { table => 'track' };
 

--- a/lib/MusicBrainz/Server/Data/Track.pm
+++ b/lib/MusicBrainz/Server/Data/Track.pm
@@ -215,7 +215,7 @@ sub _insert_hook_make_row {
     delete $track_hash->{id};
     $track_hash->{number} //= '';
     $track_hash->{is_data_track} //= 0;
-    my $row = $self->_create_row($track_hash);
+    my $row = $self->_hash_to_row($track_hash);
 
     push @{ $extra_data->{recording_ids} }, $row->{recording};
 
@@ -239,7 +239,7 @@ sub update
     my ($self, $track_id, $update) = @_;
     my $old_recording = $self->sql->select_single_value('SELECT recording FROM track WHERE id = ? FOR UPDATE', $track_id);
 
-    my $row = $self->_create_row($update);
+    my $row = $self->_hash_to_row($update);
     $self->sql->update_row('track', $row, { id => $track_id });
 
     my $mediums = $self->_medium_ids($track_id);
@@ -295,7 +295,7 @@ sub merge_mediums
     }
 }
 
-sub _create_row {
+sub _hash_to_row {
     my ($self, $track_hash) = @_;
 
     my $row = hash_to_row($track_hash, { reverse %{ $self->_column_mapping } });

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -7,7 +7,8 @@ use MusicBrainz::Server::Data::Utils qw( generate_gid hash_to_row );
 use MusicBrainz::Server::Entity::URL;
 use URI;
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
 with
     'MusicBrainz::Server::Data::Role::Editable' => { table => 'url' },
     'MusicBrainz::Server::Data::Role::LinksToEdit' => { table => 'url' },

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -19,7 +19,7 @@ use MusicBrainz::Server::Entity::WorkAttributeType;
 extends 'MusicBrainz::Server::Data::CoreEntity';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'work' };
-with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
 with 'MusicBrainz::Server::Data::Role::DeleteAndLog' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Rating' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Tag' => { type => 'work' };

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -16,7 +16,9 @@ use MusicBrainz::Server::Entity::Work;
 use MusicBrainz::Server::Entity::WorkAttribute;
 use MusicBrainz::Server::Entity::WorkAttributeType;
 
-extends 'MusicBrainz::Server::Data::CoreEntity';
+extends 'MusicBrainz::Server::Data::Entity';
+with 'MusicBrainz::Server::Data::Role::Relatable';
+with 'MusicBrainz::Server::Data::Role::Name';
 with 'MusicBrainz::Server::Data::Role::Annotation' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::Alias' => { type => 'work' };
 with 'MusicBrainz::Server::Data::Role::GIDEntityCache';

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -1,4 +1,4 @@
-package t::MusicBrainz::Server::Data::CoreEntityCache;
+package t::MusicBrainz::Server::Data::Role::GIDEntityCache;
 use Test::Routine;
 use Test::Moose;
 use Test::More;
@@ -9,11 +9,11 @@ use MusicBrainz::Server::Context;
 with 't::Context' => { -excludes => '_build_context' };
 
 {
-    package t::CoreEntityCache::MyEntity;
+    package t::GIDEntityCache::MyEntity;
     use Moose;
     extends 'MusicBrainz::Server::Entity::CoreEntity';
 
-    package t::CoreEntityCache::MyEntityData;
+    package t::GIDEntityCache::MyEntityData;
     use Moose;
     extends 'MusicBrainz::Server::Data::CoreEntity';
     has 'get_by_id_called' => ( is => 'rw', isa => 'Bool', default => 0 );
@@ -22,23 +22,23 @@ with 't::Context' => { -excludes => '_build_context' };
     {
         my $self = shift;
         $self->get_by_id_called(1);
-        return { 1 => t::CoreEntityCache::MyEntity->new(id => 1, gid => 'abc') };
+        return { 1 => t::GIDEntityCache::MyEntity->new(id => 1, gid => 'abc') };
     }
     sub get_by_gid
     {
         my $self = shift;
         $self->get_by_gid_called(1);
-        return t::CoreEntityCache::MyEntity->new(id => 1, gid => 'abc');
+        return t::GIDEntityCache::MyEntity->new(id => 1, gid => 'abc');
     }
 
-    package t::CoreEntityCache::MyCachedEntityData;
+    package t::GIDEntityCache::MyCachedEntityData;
     use Moose;
-    extends 't::CoreEntityCache::MyEntityData';
-    with 'MusicBrainz::Server::Data::Role::CoreEntityCache';
+    extends 't::GIDEntityCache::MyEntityData';
+    with 'MusicBrainz::Server::Data::Role::GIDEntityCache';
     sub _type { 'my_cached_entity_data' }
     sub _cache_id { 1 }
 
-    package t::CoreEntityCache::MockCache;
+    package t::GIDEntityCache::MockCache;
     use Moose;
     has 'data' => ( is => 'rw', isa => 'HashRef', default => sub { +{} } );
     has 'get_called' => ( is => 'rw', isa => 'Int', default => 0 );
@@ -61,7 +61,7 @@ sub _build_context {
     my $cache_manager = MusicBrainz::Server::CacheManager->new(
         profiles => {
             test => {
-                class => 't::CoreEntityCache::MockCache',
+                class => 't::GIDEntityCache::MockCache',
                 wrapped => 1,
                 keys => ['my_cached_entity_data'],
             },
@@ -75,7 +75,7 @@ sub _build_context {
 test all => sub {
 
 my $test = shift;
-my $entity_data = t::CoreEntityCache::MyCachedEntityData->new(c => $test->c);
+my $entity_data = t::GIDEntityCache::MyCachedEntityData->new(c => $test->c);
 
 my $entity = $entity_data->get_by_gid('abc');
 is ( $entity->id, 1 );

--- a/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/GIDEntityCache.pm
@@ -15,7 +15,8 @@ with 't::Context' => { -excludes => '_build_context' };
 
     package t::GIDEntityCache::MyEntityData;
     use Moose;
-    extends 'MusicBrainz::Server::Data::CoreEntity';
+    extends 'MusicBrainz::Server::Data::Entity';
+    with 'MusicBrainz::Server::Data::Role::GetByGID';
     has 'get_by_id_called' => ( is => 'rw', isa => 'Bool', default => 0 );
     has 'get_by_gid_called' => ( is => 'rw', isa => 'Bool', default => 0 );
     sub get_by_ids

--- a/t/lib/t/MusicBrainz/Server/Data/Role/Name.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Role/Name.pm
@@ -1,4 +1,4 @@
-package t::MusicBrainz::Server::Data::CoreEntity;
+package t::MusicBrainz::Server::Data::Role::Name;
 use Test::Routine;
 use Test::Moose;
 use Test::More;
@@ -13,7 +13,7 @@ test find_by_names => sub {
 
     MusicBrainz::Server::Test->prepare_test_database($test->c, '+data_artist');
 
-    # Test Data::CoreEntity->find_by_names using Data::Artist.
+    # Test Data::Role::Name->find_by_names using Data::Artist.
     my $artist_data = MusicBrainz::Server::Data::Artist->new(c => $test->c);
 
     my %results = $artist_data->find_by_names('test artist', 'minimal Artist');


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

As part of MBS-12552, it appears that the current class `CoreEntity` in data layer isn’t about relationships, it is rather mostly about GID/MBID.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Split `CoreEntitty` class into roles, `GIDRedirect`, `MainTable`, `Name`, `Relatable` in the data layer
* Rename `CoreEntittyCache` role to `GIDEntityCache` in the data layer

# Notes

* Having moved from a class to a role makes mandatory to add explicit `requires`.

# Open questions

* Should the `CoreEntity` entity class be renamed as `PermanentEntity` too? It involves undoing some changes from <https://github.com/metabrainz/musicbrainz-server/pull/2681>.
  - Pros:
    * Restore a close mapping between Entity classes and Data classes.
    * Free the term “core” to keep its use for public domain data as in [MusicBrainz Database](https://musicbrainz.org/doc/MusicBrainz_Database) / [Download](https://musicbrainz.org/doc/MusicBrainz_Database/Download) and for table list in [`MusicBrainz::Server::Constants`](https://github.com/metabrainz/musicbrainz-server/blob/v-2022-09-06/lib/MusicBrainz/Server/Constants.pm#L509-L732).
  - Cons:
    * More refactoring (but there will be more anyway).
    * Break with NGS usage in code (but not in public documentation).