### PR TITLE
Fix Perl type constraint issues in Selenium tests

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Event/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/DeleteAlias.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Event::DeleteAlias;
 use Moose;
 
 use MusicBrainz::Server::Constants qw( $EDIT_EVENT_DELETE_ALIAS );
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 

--- a/lib/MusicBrainz/Server/Edit/Genre/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/DeleteAlias.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Genre::DeleteAlias;
 use Moose;
 
 use MusicBrainz::Server::Constants qw( $EDIT_GENRE_DELETE_ALIAS );
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 

--- a/lib/MusicBrainz/Server/Edit/Instrument/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/DeleteAlias.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Instrument::DeleteAlias;
 use Moose;
 
 use MusicBrainz::Server::Constants qw( $EDIT_INSTRUMENT_DELETE_ALIAS );
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 

--- a/lib/MusicBrainz/Server/Edit/Label/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/DeleteAlias.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Label::DeleteAlias;
 use Moose;
 
 use MusicBrainz::Server::Constants qw( $EDIT_LABEL_DELETE_ALIAS );
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 

--- a/lib/MusicBrainz/Server/Edit/Series/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/DeleteAlias.pm
@@ -2,6 +2,7 @@ package MusicBrainz::Server::Edit::Series::DeleteAlias;
 use Moose;
 
 use MusicBrainz::Server::Constants qw( $EDIT_SERIES_DELETE_ALIAS );
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw ( N_l );
 

--- a/lib/MusicBrainz/Server/Entity/Subscription/Artist.pm
+++ b/lib/MusicBrainz/Server/Entity/Subscription/Artist.pm
@@ -2,6 +2,8 @@ package MusicBrainz::Server::Entity::Subscription::Artist;
 use Moose;
 use namespace::autoclean;
 
+use MusicBrainz::Server::Entity::Types;
+
 with 'MusicBrainz::Server::Entity::Subscription::Active';
 
 has 'artist_id' => (

--- a/lib/MusicBrainz/Server/Entity/Subscription/Label.pm
+++ b/lib/MusicBrainz/Server/Entity/Subscription/Label.pm
@@ -2,6 +2,8 @@ package MusicBrainz::Server::Entity::Subscription::Label;
 use Moose;
 use namespace::autoclean;
 
+use MusicBrainz::Server::Entity::Types;
+
 with 'MusicBrainz::Server::Entity::Subscription::Active';
 
 has 'label_id' => (

--- a/lib/MusicBrainz/Server/Entity/Subscription/Series.pm
+++ b/lib/MusicBrainz/Server/Entity/Subscription/Series.pm
@@ -2,6 +2,8 @@ package MusicBrainz::Server::Entity::Subscription::Series;
 use Moose;
 use namespace::autoclean;
 
+use MusicBrainz::Server::Entity::Types;
+
 with 'MusicBrainz::Server::Entity::Subscription::Active';
 
 has 'series_id' => (


### PR DESCRIPTION
I think the lack of a `use MusicBrainz::Server::Entity::Types` call on `Genre::DeleteAlias` is what was causing an error when running Selenium tests: `The type constraint 'Genre' has already been created`.

Moose seems to generate a constraint based on `isa => 'Genre'` calls, which then clashes with the one in `Types`, or at least that is my understanding from https://stackoverflow.com/questions/41550691/the-type-constraint-xyz-has-already-been-created
