### PR TITLE
MBS-12552 (III): Move Entity::Role::Linkable to Relatable

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CoreEntity.pm
+++ b/lib/MusicBrainz/Server/Entity/CoreEntity.pm
@@ -6,7 +6,7 @@ extends 'MusicBrainz::Server::Entity';
 with 'MusicBrainz::Server::Entity::Role::Editable';
 with 'MusicBrainz::Server::Entity::Role::GID';
 with 'MusicBrainz::Server::Entity::Role::LastUpdate';
-with 'MusicBrainz::Server::Entity::Role::Linkable';
+with 'MusicBrainz::Server::Entity::Role::Relatable';
 with 'MusicBrainz::Server::Entity::Role::Name';
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Entity/Relationship.pm
+++ b/lib/MusicBrainz/Server/Entity/Relationship.pm
@@ -42,7 +42,7 @@ has 'entity0_id' => (
 
 has 'entity0' => (
     is => 'rw',
-    isa => 'Linkable',
+    isa => 'Relatable',
 );
 
 has 'entity0_credit' => (
@@ -57,7 +57,7 @@ has 'entity1_id' => (
 
 has 'entity1' => (
     is => 'rw',
-    isa => 'Linkable',
+    isa => 'Relatable',
 );
 
 has 'entity1_credit' => (
@@ -130,7 +130,7 @@ sub can_manually_reorder {
 
 has source => (
     is => 'rw',
-    isa => 'Linkable',
+    isa => 'Relatable',
 );
 
 has source_type => (
@@ -145,7 +145,7 @@ has source_credit => (
 
 has target => (
     is => 'rw',
-    isa => 'Linkable',
+    isa => 'Relatable',
 );
 
 has target_type => (

--- a/lib/MusicBrainz/Server/Entity/Role/Relatable.pm
+++ b/lib/MusicBrainz/Server/Entity/Role/Relatable.pm
@@ -1,4 +1,4 @@
-package MusicBrainz::Server::Entity::Role::Linkable;
+package MusicBrainz::Server::Entity::Role::Relatable;
 use Moose::Role;
 
 use List::AllUtils qw( partition_by sort_by );
@@ -132,7 +132,7 @@ around TO_JSON => sub {
 
 =head1 NAME
 
-MusicBrainz::Server::Entity::Role::Linkable
+MusicBrainz::Server::Entity::Role::Relatable
 
 =head1 ATTRIBUTES
 

--- a/lib/MusicBrainz/Server/Entity/Types.pm
+++ b/lib/MusicBrainz/Server/Entity/Types.pm
@@ -36,8 +36,8 @@ subtype 'Edit'
 subtype 'Entity'
     => as class_type 'MusicBrainz::Server::Entity';
 
-subtype 'Linkable'
-    => as role_type 'MusicBrainz::Server::Entity::Role::Linkable';
+subtype 'Relatable'
+    => as role_type 'MusicBrainz::Server::Entity::Role::Relatable';
 
 1;
 


### PR DESCRIPTION
# Problem: Part of MBS-12552
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Linkable is used in entityHref.js only and in a way broader meaning, whereas Relatable is used in a lot of files (including the very central Constants.pm and entities.mjs) and in the same meaning as in this role: “that can have relationships”.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Move Entity role Linkable to Relatable

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Check case-insensitive occurrences of linkable and relatable in the code base.
* [x] Rebase on master after #2706 has been merged.
