### PR TITLE
MBS-9417 / MBS-12680: Fix some multiselect attribute bugs in the relationship editor

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -146,24 +146,6 @@ export function reducer(
         action,
         () => createMultiselectAttributeValue(state.type, null),
       );
-      if (
-        action.type === 'add-value' ||
-        action.type === 'update-value-autocomplete'
-      ) {
-        // Don't allow more than one attribute of the same type.
-        const selectedAttributeIds = new Set();
-        for (const value of newState.values) {
-          const attributeId = value.autocomplete.selectedItem?.entity?.id;
-          if (attributeId != null) {
-            if (selectedAttributeIds.has(attributeId)) {
-              newState.values = state.values;
-              break;
-            } else {
-              selectedAttributeIds.add(attributeId);
-            }
-          }
-        }
-      }
     }
   }
 

--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -29,7 +29,7 @@ import type {
 } from '../types/actions.js';
 import {
   areLinkAttributesEqual,
-  compareLinkAttributeIds,
+  compareLinkAttributes,
 } from '../utility/compareRelationships.js';
 
 import BooleanAttribute, {
@@ -181,7 +181,7 @@ export function getLinkAttributesFromState(
                 typeID: linkAttributeType.id,
                 typeName: linkAttributeType.name,
               },
-              compareLinkAttributeIds,
+              compareLinkAttributes,
             );
           }
           break;
@@ -204,7 +204,7 @@ export function getLinkAttributesFromState(
                   typeID: linkAttributeType.id,
                   typeName: linkAttributeType.name,
                 },
-                compareLinkAttributeIds,
+                compareLinkAttributes,
               );
             }
           }
@@ -224,7 +224,7 @@ export function getLinkAttributesFromState(
                 typeID: linkAttributeType.id,
                 typeName: linkAttributeType.name,
               },
-              compareLinkAttributeIds,
+              compareLinkAttributes,
             );
           }
           break;


### PR DESCRIPTION
 * MBS-9417: It's now allowed to add the same instrument or vocal multiple times with different credits.  (These can't exist on the same relationship per our database schema, but they will be split into separate relationships by `splitRelationshipByAttributes`).

 * MBS-12680: A duplicate relationship is no longer added when changing an instrument or vocal attribute on an existing relationship.