### PR TITLE
MBS-12694: Fix error submitting a recording artist relationship

### DIFF
--- a/root/static/scripts/common/MB/Control/Autocomplete.js
+++ b/root/static/scripts/common/MB/Control/Autocomplete.js
@@ -339,7 +339,7 @@ $.widget('mb.entitylookup', $.ui.autocomplete, {
     if (hasID) {
       // Add/move to the top of the recent entities menu.
       pushRecentItem({
-        entity: data,
+        entity: typeof data.toJSON === 'function' ? data.toJSON() : data,
         id: data.id,
         name: data.name,
         type: 'option',

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -688,6 +688,10 @@ const seleniumTests = [
     name: 'Genre_Edit_Form.json5',
     login: true,
   },
+  {
+    name: 'Recording_Edit_Form.json5',
+    login: true,
+  },
 ];
 /* eslint-enable sort-keys */
 

--- a/t/selenium/Recording_Edit_Form.json5
+++ b/t/selenium/Recording_Edit_Form.json5
@@ -1,0 +1,160 @@
+{
+  title: 'Recording Edit Form',
+  commands: [
+    {
+      command: 'open',
+      target: '/recording/96f64611-49df-4e54-84e7-0f9a30f01766/edit',
+      value: '',
+    },
+    // MBS-12694: In the recording edit form, adding a relationship to an
+    // artist that appears in the recording AC, by selecting it from the
+    // recent entities list, triggers a JavaScript error which prevents
+    // submission of the relationship.
+    {
+      command: 'click',
+      target: 'css=#artist-credit-editor button.open-ac',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-bubble button.add-item',
+      value: '',
+    },
+    // Ensure the artist we select for the relationship target is in the
+    // recent entities list.
+    {
+      command: 'type',
+      target: 'id=ac-source-artist-1',
+      value: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-bubble div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'select',
+      target: 'css=#add-relationship-dialog select.entity-type',
+      value: 'label=Artist',
+    },
+    {
+      command: 'focus',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//div[@id = "add-relationship-dialog"]//div[contains(@class, "relationship-target")]//li[contains(descendant::text(), "Bing Crosby")]',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'performer${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-recording button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 72,
+        status: 1,
+        data: {
+          entity: {
+            gid: "96f64611-49df-4e54-84e7-0f9a30f01766",
+            id: 164872,
+            name: "mr self destruct",
+          },
+          new: {
+            artist_credit: {
+              names: [
+                {
+                  artist: {
+                    id: 347,
+                    name: "Nine Inch Nails",
+                  },
+                  join_phrase: " & ",
+                  name: "Nine Inch Nails",
+                },
+                {
+                  artist: {
+                    id: 99,
+                    name: "Bing Crosby",
+                  },
+                  join_phrase: "",
+                  name: "Bing Crosby",
+                },
+              ],
+            },
+          },
+          old: {
+            artist_credit: {
+              names: [
+                {
+                  artist: {
+                    id: 347,
+                    name: "Nine Inch Nails",
+                  },
+                  join_phrase: "",
+                  name: "Nine Inch Nails",
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+            id: 99,
+            name: 'Bing Crosby',
+          },
+          entity1: {
+            gid: '96f64611-49df-4e54-84e7-0f9a30f01766',
+            id: 164872,
+            name: 'mr self destruct',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 156,
+            link_phrase: '{additional:additionally} {guest} {solo} performed',
+            long_link_phrase: '{additional:additionally} {guest} {solo} performed',
+            name: 'performer',
+            reverse_link_phrase: '{additional} {guest} {solo} performer',
+          },
+          type0: 'artist',
+          type1: 'recording',
+        },
+      },
+    },
+    // End of test for MBS-12694.
+  ],
+}

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -125,9 +125,9 @@ INSERT INTO place_gid_redirect (gid, new_id, created) VALUES
     ('bcdf4f88-7a7c-3fd4-d7db-23a2bc8a20b9', 1161, '2012-04-09 20:07:05.161415+00');
 
 INSERT INTO recording (id, gid, name, artist_credit, length, comment, edits_pending, last_updated, video) VALUES
-    (164872, '96f64611-49df-4e54-84e7-0f9a30f01766', 'mr self destruct', 347, 270573, '', 0, '2017-09-29 09:00:51.064128+00', 'f'),
-    (164873, '429f0b1a-0293-4793-993b-0bb5f73567f2', 'Piggy', 347, 264426, '', 0, '2017-01-16 21:00:48.187704+00', 'f'),
-    (20937085, '0f42ab32-22cd-4dcf-927b-a8d9a183d68b', 'Travelling Man', 347, 270573, '', 0, '2017-05-15 20:36:38.082509+00', 'f');
+    (164872, '96f64611-49df-4e54-84e7-0f9a30f01766', 'mr self destruct', 347, NULL, '', 0, '2017-09-29 09:00:51.064128+00', 'f'),
+    (164873, '429f0b1a-0293-4793-993b-0bb5f73567f2', 'Piggy', 347, NULL, '', 0, '2017-01-16 21:00:48.187704+00', 'f'),
+    (20937085, '0f42ab32-22cd-4dcf-927b-a8d9a183d68b', 'Travelling Man', 347, NULL, '', 0, '2017-05-15 20:36:38.082509+00', 'f');
 
 INSERT INTO recording_gid_redirect (gid, new_id, created) VALUES
     ('23ba24f0-dc22-fcd4-b729-b86d381a9d8a', 20937085, '2012-04-09 20:07:05.161415+00');


### PR DESCRIPTION
The issue stems from the recording AC still using the old Autocomplete component, which pushes a class instance (Artist, from root/static/scripts/common/entity.js) onto the recent items cache (which is shared with Autocomplete2).

Selecting this recent item causes the class instance to wind up in the relationship editor state, which is expected to only contain plain objects.  Later, when the state is serialized to sessionStorage before submission, `compactEntityJson` throws an error upon seeing the class instance, which it doesn't know how to convert to JSON.