### PR TITLE
MBS-12695: Fix encoding issue in "Add a new entity" dialog

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Dialog.pm
+++ b/lib/MusicBrainz/Server/Controller/Dialog.pm
@@ -1,4 +1,5 @@
 package MusicBrainz::Server::Controller::Dialog;
+use Encode qw( decode_utf8 );
 use Moose;
 
 BEGIN { extends 'MusicBrainz::Server::Controller'; }
@@ -16,8 +17,12 @@ sub dialog : Path('/dialog') Edit {
     $path = $path_uri->path;
 
     if ($c->dispatcher->get_action_by_path($path)) {
-        %{ $c->req->query_params } = $path_uri->query_form;
-        %{ $c->req->params } = $path_uri->query_form;
+        my %query_form = $path_uri->query_form;
+        my %decoded_query_form = map {
+            $_ => decode_utf8($query_form{$_})
+        } keys %query_form;
+        %{ $c->req->query_params } = %decoded_query_form;
+        %{ $c->req->params } = %decoded_query_form;
         $c->stash( template => 'forms/dialog.tt' );
         $c->forward($path, [ within_dialog => 1 ]);
     }

--- a/t/selenium/Artist_Edit_Form.json5
+++ b/t/selenium/Artist_Edit_Form.json5
@@ -29,7 +29,7 @@
     {
       command: 'type',
       target: 'css=#add-relationship-dialog input.relationship-target',
-      value: 'group member',
+      value: 'gröup member',
     },
     {
       command: 'pause',
@@ -99,8 +99,8 @@
           gender_id: null,
           ipi_codes: [],
           isni_codes: [],
-          name: 'group member',
-          sort_name: 'group member',
+          name: 'gröup member',
+          sort_name: 'gröup member',
           type_id: 1,
         },
       },
@@ -236,7 +236,7 @@
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 3,
-            name: 'group member',
+            name: 'gröup member',
           },
           entity1: {
             gid: '$$__IGNORE__$$',
@@ -282,7 +282,7 @@
           entity0: {
             gid: '$$__IGNORE__$$',
             id: 3,
-            name: 'group member',
+            name: 'gröup member',
           },
           entity1: {
             gid: '$$__IGNORE__$$',


### PR DESCRIPTION
This was a regression introduced by 1786909dd2aa2a082a63b5dd6704eb21e8c71d69.  Fix it by decoding the path's query_form before forwarding it to the dialog action.