### PR TITLE
MBS-10614: Remove edit note / vote restrictions for beginners

### DIFF
--- a/lib/MusicBrainz/Server/Data/Vote.pm
+++ b/lib/MusicBrainz/Server/Data/Vote.pm
@@ -51,7 +51,7 @@ sub enter_votes
     Sql::run_in_transaction(sub {
         $self->sql->do('LOCK vote IN SHARE ROW EXCLUSIVE MODE');
 
-        # Deal with votes on closed or own edits, by beginners/limited users, etc.
+        # Deal with votes on closed or own edits, by blocked users, etc.
         my @edit_ids = map { $_->{edit_id} } @votes;
         my $edits = $self->c->model('Edit')->get_by_ids(@edit_ids);
         @votes = grep { defined $edits->{ $_->{edit_id} } } @votes;

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -147,7 +147,6 @@ sub editor_may_vote {
         $self->is_open &&
         defined $editor &&
         $editor->id != $self->editor_id &&
-        !$editor->is_limited &&
         !$editor->is_bot &&
         !$editor->is_editing_disabled
     );
@@ -158,7 +157,6 @@ sub editor_may_add_note
     my ($self, $editor) = @_;
 
     return defined $editor && $editor->email_confirmation_date &&
-        ($editor->id == $self->editor_id || !$editor->is_limited) &&
         !$editor->is_adding_notes_disabled;
 }
 

--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -92,11 +92,7 @@ function generateUserTypesList(user: UnsanitizedEditorT) {
     typesList.push(
       <span
         className="tooltip"
-        title={l(
-          `User accounts must be more than 2 weeks old, have a verified
-           email address, and more than 10 accepted edits in order
-           to vote on others' edits.`,
-        )}
+        title={l('This user is new to MusicBrainz.')}
       >
         {l('Beginner')}
       </span>,

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -24,6 +24,7 @@ import {
   EDIT_SERIES_EDIT,
 } from '../static/scripts/common/constants/editTypes.js';
 import {
+  isAddingNotesDisabled,
   isAutoEditor,
   isBot,
   isEditingEnabled,
@@ -125,7 +126,8 @@ export function editorMayAddNote(
   edit: GenericEditWithIdT,
   editor: ?UnsanitizedEditorT,
 ): boolean {
-  return !!editor && nonEmpty(editor.email_confirmation_date);
+  return !!editor && nonEmpty(editor.email_confirmation_date) &&
+    !isAddingNotesDisabled(editor);
 }
 
 export function editorMayApprove(

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -125,8 +125,7 @@ export function editorMayAddNote(
   edit: GenericEditWithIdT,
   editor: ?UnsanitizedEditorT,
 ): boolean {
-  return !!editor && nonEmpty(editor.email_confirmation_date) &&
-    (editor.id === edit.editor_id || !editor.is_limited);
+  return !!editor && nonEmpty(editor.email_confirmation_date);
 }
 
 export function editorMayApprove(
@@ -189,7 +188,6 @@ export function editorMayVote(
     !!editor &&
     edit.status === EDIT_STATUS_OPEN &&
     editor.id !== edit.editor_id &&
-    !editor.is_limited &&
     !isBot(editor) &&
     isEditingEnabled(editor)
   );

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
@@ -78,33 +78,6 @@ test 'Check edit page differences for own edit' => sub {
     );
 };
 
-test 'Check edit page differences for beginner editor' => sub {
-    my $test = shift;
-    my $mech = $test->mech;
-    my $edit = prepare($test);
-
-    $mech->get_ok('/login');
-    $mech->submit_form( with_fields => {
-        username => 'editor5',
-        password => 'pass',
-    } );
-
-    $mech->get_ok(
-        '/edit/' . $edit->id,
-        'Fetched edit page as a beginner editor other than the edit author',
-    );
-    html_ok($mech->content);
-
-    $mech->content_contains(
-        'You are not currently able to vote on this edit',
-        'The message about not being able to vote is present',
-    );
-    $mech->content_contains(
-        'You are not currently able to add notes to this edit',
-        'The message about not being able to add notes is present',
-    );
-};
-
 test 'Check edit page differences when logged out' => sub {
     my $test = shift;
     my $mech = $test->mech;


### PR DESCRIPTION
### Implement MBS-10614

As agreed on the 2022-11-07 team meeting.
These restrictions were introduced before we had a proper reporting / moderation system, and hopefully they are not needed anymore. They also make life a lot harder as a good beginner editor.

The restrictions that still allow for beginner editors after this are the following:
a) They are not allowed to disable banner alerts when they receive new edit notes on their edits. This seems sensible, since we want to train beginners to be responsive to edit notes.
b) Their bio and URL are hidden from logged-out users to limit spam effectiveness.

In addition, edits can still be filtered by whether the editor is a beginner and the editor report for admins still works.

While doing this I also simplified the description for beginners in `generateUserTypesList` - the voting thing is no longer true so it seems fine to just reuse the string we have elsewhere.

Tested locally by creating a new account and making sure it could vote and leave notes, but their bio / website were still hidden when logged out.

A second commit brings the JS `editorMayAddNote` function to parity with the Perl `editor_may_add_note` method - we were not checking for the edit notes disabled flag until now.

Edited [the wiki registration how to](https://wiki.musicbrainz.org/index.php?title=How_to_Create_an_Account&type=revision&diff=76061&oldid=75760) to specify what the new restrictions are.