### PR TITLE
MBS-12679: Refresh dialog attributes when entity type changes

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogAttributes.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttributes.js
@@ -54,7 +54,7 @@ const DIALOG_ATTRIBUTE_ORDER = {
   text: 2,
 };
 
-export function createDialogAttributesList(
+function createDialogAttributesList(
   linkType: ?LinkTypeT,
   existingAttributesByRootId: LinkAttributesByRootIdT | null,
 ): DialogAttributesT {
@@ -164,7 +164,7 @@ export function createInitialState(
   };
 }
 
-export function getLinkAttributesFromState(
+function getLinkAttributesFromState(
   attributesList: DialogAttributesT,
 ): tree.ImmutableTree<LinkAttrT> | null {
   return attributesList.reduce(

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -37,6 +37,7 @@ import type {
 
 import {
   createDialogAttributesList,
+  createInitialState as createDialogAttributesState,
   getLinkAttributesFromState,
 } from './DialogAttributes.js';
 
@@ -104,11 +105,6 @@ export function createInitialState(
   id: string,
   disabled?: boolean = false,
 ): DialogLinkTypeStateT {
-  const selectedLinkType = linkType ?? (
-    linkTypeOptions.length === 1
-      ? linkTypeOptions[0].entity
-      : null
-  ) ?? null;
   return {
     autocomplete: createInitialAutocompleteState<LinkTypeT>({
       containerClass: 'relationship-type',
@@ -117,17 +113,17 @@ export function createInitialState(
       extractSearchTerms: extractLinkTypeSearchTerms,
       id: 'relationship-type-' + id,
       inputClass: 'relationship-type',
-      inputValue: (selectedLinkType?.name) ?? '',
+      inputValue: (linkType?.name) ?? '',
       recentItemsKey: 'link_type-' + source.entityType + '-' + targetType,
-      selectedItem: selectedLinkType ? {
-        entity: selectedLinkType,
-        id: selectedLinkType.id,
-        name: l_relationships(selectedLinkType.name),
+      selectedItem: linkType ? {
+        entity: linkType,
+        id: linkType.id,
+        name: l_relationships(linkType.name),
         type: 'option',
       } : null,
       staticItems: linkTypeOptions,
     }),
-    error: getLinkTypeError(selectedLinkType, source),
+    error: getLinkTypeError(linkType, source),
   };
 }
 
@@ -180,25 +176,25 @@ export function updateDialogState(
   const newLinkType = newState.linkType.autocomplete.selectedItem?.entity;
 
   if (oldLinkType !== newLinkType) {
-    const newAttributesList = createDialogAttributesList(
-      newLinkType,
-      newState.attributes.attributesList
-        .reduce<LinkAttributesByRootIdT>(
-          accumulateDialogAttributeByRootId,
-          new Map(),
-        ),
-    );
-    newState.attributes = {
-      ...newState.attributes,
-      attributesList: newAttributesList,
-      resultingLinkAttributes: getLinkAttributesFromState(
-        newAttributesList,
-      ),
-    };
+    updateDialogAttributesStateForLinkType(newState, newLinkType ?? null);
     return true;
   }
 
   return false;
+}
+
+export function updateDialogAttributesStateForLinkType(
+  newState: {...PartialDialogStateT, ...},
+  newLinkType: LinkTypeT | null,
+): void {
+  newState.attributes = createDialogAttributesState(
+    newLinkType ?? null,
+    newState.attributes.attributesList
+      .reduce<LinkAttributesByRootIdT>(
+        accumulateDialogAttributeByRootId,
+        new Map(),
+      ),
+  );
 }
 
 function accumulateDialogAttributeByRootId(

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -36,9 +36,7 @@ import type {
 } from '../types/actions.js';
 
 import {
-  createDialogAttributesList,
   createInitialState as createDialogAttributesState,
-  getLinkAttributesFromState,
 } from './DialogAttributes.js';
 
 type PropsT = {


### PR DESCRIPTION
This commit ensures that attributes in the relationship editor dialog are properly updated when:

 * The dialog opens and a link type is pre-selected (for cases where it's the only link type available).

 * The target entity type is changed.