### PR TITLE
Make _hash_to_row methods more consistent

### DIFF
--- a/lib/MusicBrainz/Server/Data/Area.pm
+++ b/lib/MusicBrainz/Server/Data/Area.pm
@@ -280,11 +280,10 @@ sub merge_codes
 sub _hash_to_row
 {
     my ($self, $area) = @_;
+
     my $row = hash_to_row($area, {
         type => 'type_id',
-        ended => 'ended',
-        name => 'name',
-        map { $_ => $_ } qw( comment )
+        map { $_ => $_ } qw( comment ended name )
     });
 
     add_partial_date_to_row($row, $area->{begin_date}, 'begin_date');

--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -443,26 +443,23 @@ sub merge
 
 sub _hash_to_row
 {
-    my ($self, $values) = @_;
+    my ($self, $artist) = @_;
 
-    my $row = hash_to_row($values, {
+    my $row = hash_to_row($artist, {
         area => 'area_id',
         begin_area => 'begin_area_id',
         end_area => 'end_area_id',
-        type    => 'type_id',
         gender  => 'gender_id',
-        comment => 'comment',
-        ended => 'ended',
-        name => 'name',
-        sort_name => 'sort_name',
+        type    => 'type_id',
+        map { $_ => $_ } qw( comment ended name sort_name )
     });
 
-    if (exists $values->{begin_date}) {
-        add_partial_date_to_row($row, $values->{begin_date}, 'begin_date');
+    if (exists $artist->{begin_date}) {
+        add_partial_date_to_row($row, $artist->{begin_date}, 'begin_date');
     }
 
-    if (exists $values->{end_date}) {
-        add_partial_date_to_row($row, $values->{end_date}, 'end_date');
+    if (exists $artist->{end_date}) {
+        add_partial_date_to_row($row, $artist->{end_date}, 'end_date');
     }
 
     return $row;

--- a/lib/MusicBrainz/Server/Data/Collection.pm
+++ b/lib/MusicBrainz/Server/Data/Collection.pm
@@ -7,6 +7,7 @@ use Carp;
 use Sql;
 use MusicBrainz::Server::Entity::Collection;
 use MusicBrainz::Server::Data::Utils qw(
+    hash_to_row
     load_subobjects
     placeholders
 );
@@ -480,16 +481,14 @@ sub set_collaborators {
 }
 
 sub _hash_to_row {
-    my ($self, $values) = @_;
+    my ($self, $collection) = @_;
 
-    my %row = (
-        name => $values->{name},
-        public => $values->{public},
-        description => $values->{description},
-        type => $values->{type_id},
-    );
+    my $row = hash_to_row($collection, {
+        type    => 'type_id',
+        map { $_ => $_ } qw( description name public )
+    });
 
-    return \%row;
+    return $row;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -347,17 +347,13 @@ sub update_profile
         _die_if_username_invalid($update->{username});
     }
 
-    my $row = hash_to_row(
-        $update,
-        {
-            name => 'username',
-            bio => 'biography',
-            area => 'area_id',
-            gender => 'gender_id',
-            website => 'website',
-            birth_date => 'birth_date',
-        }
-    );
+    my $row = hash_to_row($update, {
+        area => 'area_id',
+        bio => 'biography',
+        gender => 'gender_id',
+        name => 'username',
+        map { $_ => $_ } qw( birth_date website )
+    });
 
     if (my $date = delete $row->{birth_date}) {
         if (%$date) { # if date is given but all NULL, it will be an empty hash.

--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -57,9 +57,9 @@ sub _id_column
 sub _column_mapping
 {
     return {
-        type_id => 'type',
         begin_date => sub { MusicBrainz::Server::Entity::PartialDate->new_from_row(shift, shift() . 'begin_date_') },
         end_date => sub { MusicBrainz::Server::Entity::PartialDate->new_from_row(shift, shift() . 'end_date_') },
+        type_id => 'type',
         map { $_ => $_ } qw( id gid comment setlist time ended name cancelled edits_pending last_updated)
     };
 }
@@ -130,14 +130,16 @@ sub _merge_impl
 
 sub _hash_to_row
 {
-    my ($self, $event, $names) = @_;
+    my ($self, $event) = @_;
+
     my $row = hash_to_row($event, {
         type => 'type_id',
-        map { $_ => $_ } qw( comment setlist time ended name cancelled )
+        map { $_ => $_ } qw( cancelled comment ended name setlist time )
     });
 
     add_partial_date_to_row($row, $event->{begin_date}, 'begin_date');
     add_partial_date_to_row($row, $event->{end_date}, 'end_date');
+
     return $row;
 }
 

--- a/lib/MusicBrainz/Server/Data/Genre.pm
+++ b/lib/MusicBrainz/Server/Data/Genre.pm
@@ -66,6 +66,7 @@ sub delete {
 
 sub _hash_to_row {
     my ($self, $genre) = @_;
+
     my $row = hash_to_row($genre, {
         map { $_ => $_ } qw( comment name )
     });

--- a/lib/MusicBrainz/Server/Data/Instrument.pm
+++ b/lib/MusicBrainz/Server/Data/Instrument.pm
@@ -117,9 +117,10 @@ sub _merge_impl {
 
 sub _hash_to_row {
     my ($self, $instrument) = @_;
+
     my $row = hash_to_row($instrument, {
         type => 'type_id',
-        map { $_ => $_ } qw( comment name description )
+        map { $_ => $_ } qw( comment description name )
     });
 
     return $row;

--- a/lib/MusicBrainz/Server/Data/Label.pm
+++ b/lib/MusicBrainz/Server/Data/Label.pm
@@ -230,11 +230,11 @@ sub _merge_impl
 sub _hash_to_row
 {
     my ($self, $label) = @_;
+
     my $row = hash_to_row($label, {
         area => 'area_id',
         type => 'type_id',
-        ended => 'ended',
-        map { $_ => $_ } qw( label_code comment name )
+        map { $_ => $_ } qw( comment ended label_code name )
     });
 
     add_partial_date_to_row($row, $label->{begin_date}, 'begin_date');

--- a/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkAttributeType.pm
@@ -216,14 +216,14 @@ sub delete
 
 sub _hash_to_row
 {
-    my ($self, $values) = @_;
+    my ($self, $link_attribute_type) = @_;
 
-    return hash_to_row($values, {
-        parent          => 'parent_id',
-        child_order      => 'child_order',
-        name            => 'name',
-        description     => 'description',
+    my $row = hash_to_row($link_attribute_type, {
+        parent  => 'parent_id',
+        map { $_ => $_ } qw( child_order description name )
     });
+
+    return $row;
 }
 
 sub get_by_gid

--- a/lib/MusicBrainz/Server/Data/LinkType.pm
+++ b/lib/MusicBrainz/Server/Data/LinkType.pm
@@ -405,24 +405,28 @@ sub delete
 
 sub _hash_to_row
 {
-    my ($self, $values) = @_;
+    my ($self, $link_type) = @_;
 
-    return hash_to_row($values, {
+    my $row = hash_to_row($link_type, {
+        entity_type0    => 'entity0_type',
+        entity_type1    => 'entity1_type',
         parent          => 'parent_id',
-        entity_type0     => 'entity0_type',
-        entity_type1     => 'entity1_type',
-        child_order      => 'child_order',
-        name            => 'name',
-        description     => 'description',
-        link_phrase      => 'link_phrase',
-        reverse_link_phrase     => 'reverse_link_phrase',
-        long_link_phrase => 'long_link_phrase',
-        priority        => 'priority',
-        is_deprecated => 'is_deprecated',
-        has_dates        => 'has_dates',
-        entity0_cardinality => 'entity0_cardinality',
-        entity1_cardinality => 'entity1_cardinality',
+        map { $_ => $_ } qw(
+            child_order
+            description
+            entity0_cardinality
+            entity1_cardinality
+            has_dates
+            is_deprecated
+            link_phrase
+            long_link_phrase
+            name
+            priority
+            reverse_link_phrase
+        )
     });
+
+    return $row;
 }
 
 sub in_use {

--- a/lib/MusicBrainz/Server/Data/Place.pm
+++ b/lib/MusicBrainz/Server/Data/Place.pm
@@ -133,19 +133,19 @@ sub _merge_impl
 
 sub _hash_to_row
 {
-    my ($self, $place, $names) = @_;
+    my ($self, $place) = @_;
+
     my $row = hash_to_row($place, {
-        type => 'type_id',
-        ended => 'ended',
-        name => 'name',
         area => 'area_id',
-        map { $_ => $_ } qw( comment address )
+        type => 'type_id',
+        map { $_ => $_ } qw( address comment ended name )
     });
 
     add_partial_date_to_row($row, $place->{begin_date}, 'begin_date');
     add_partial_date_to_row($row, $place->{end_date}, 'end_date');
     add_coordinates_to_row($row, $place->{coordinates}, 'coordinates')
         if exists $place->{coordinates};
+
     return $row;
 }
 

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -265,8 +265,7 @@ sub _hash_to_row
 {
     my ($self, $recording) = @_;
     my $row = hash_to_row($recording, {
-        video => 'video',
-        map { $_ => $_ } qw( artist_credit length comment name )
+        map { $_ => $_ } qw( artist_credit comment length name video )
     });
 
     return $row;

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -1431,13 +1431,12 @@ sub _hash_to_row
 {
     my ($self, $release) = @_;
     my $row = hash_to_row($release, {
-        artist_credit => 'artist_credit',
-        release_group => 'release_group_id',
-        status => 'status_id',
-        packaging => 'packaging_id',
-        script => 'script_id',
         language => 'language_id',
-        map { $_ => $_ } qw( barcode comment quality name )
+        packaging => 'packaging_id',
+        release_group => 'release_group_id',
+        script => 'script_id',
+        status => 'status_id',
+        map { $_ => $_ } qw( artist_credit barcode comment name quality )
     });
 
     return $row;

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -764,8 +764,9 @@ sub _merge_impl
 
 sub _hash_to_row
 {
-    my ($self, $group) = @_;
-    my $row = hash_to_row($group, {
+    my ($self, $release_group) = @_;
+
+    my $row = hash_to_row($release_group, {
         type => 'primary_type_id',
         map { $_ => $_ } qw( artist_credit comment edits_pending name )
     });

--- a/lib/MusicBrainz/Server/Data/Series.pm
+++ b/lib/MusicBrainz/Server/Data/Series.pm
@@ -65,10 +65,9 @@ sub _hash_to_row {
     my ($self, $series) = @_;
 
     my $row = hash_to_row($series, {
-        type => 'type_id',
         ordering_type => 'ordering_type_id',
-        name => 'name',
-        comment => 'comment',
+        type => 'type_id',
+        map { $_ => $_ } qw( comment name )
     });
 
     return $row;

--- a/lib/MusicBrainz/Server/Data/URL.pm
+++ b/lib/MusicBrainz/Server/Data/URL.pm
@@ -321,10 +321,13 @@ sub delete {
 
 sub _hash_to_row
 {
-    my ($self, $values) = @_;
-    return hash_to_row($values, {
+    my ($self, $url) = @_;
+
+    my $row = hash_to_row($url, {
         url => 'url',
     });
+
+    return $row;
 }
 
 sub insert { confess 'Should not be used for URLs' }

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -252,6 +252,7 @@ sub _merge_impl
 sub _hash_to_row
 {
     my ($self, $work) = @_;
+
     my $row = hash_to_row($work, {
         type => 'type_id',
         map { $_ => $_ } qw( comment name )


### PR DESCRIPTION
Some of these were just stupid (having a map for same-name keys, then having some other same-name keys outside the map). Some were mostly fine but inconsistent - I though I would just make it so that the ones that already followed a mostly equal pattern would actually be equivalent.

FWIW, a lot of this seems kinda redundant with `_column_mapping` - it might be possible to just make it simpler using that.