### PR TITLE
Add an easy way to set dialog attributes from userscripts

### DIFF
--- a/root/static/scripts/relationship-editor/types.js
+++ b/root/static/scripts/relationship-editor/types.js
@@ -188,6 +188,16 @@ export type DialogLinkAttributeStateT = {
   type: LinkAttrTypeT,
 };
 
+/*
+ * Represents a LinkAttrT that may come from an external userscript.
+ * The primary difference is that typeID/typeName are not required.
+ */
+export type ExternalLinkAttrT = {
+  +credited_as?: string,
+  +text_value?: string,
+  +type: {+gid: string, ...},
+};
+
 export type DialogLinkTypeStateT = {
   +autocomplete: AutocompleteStateT<LinkTypeT>,
   +error: React$Node,

--- a/root/static/scripts/relationship-editor/types/actions.js
+++ b/root/static/scripts/relationship-editor/types/actions.js
@@ -24,6 +24,7 @@ import type {
 import type {LazyReleaseActionT} from '../../release/types.js';
 import type {
   CreditChangeOptionT,
+  ExternalLinkAttrT,
   MediumRecordingStateTreeT,
   MediumWorkStateT,
   RelationshipDialogLocationT,
@@ -49,6 +50,10 @@ export type DialogLinkOrderActionT = {
 export type DialogActionT =
   | {
       +type: 'change-direction',
+    }
+  | {
+      +attributes: $ReadOnlyArray<ExternalLinkAttrT>,
+      +type: 'set-attributes',
     }
   | {
       +action: DialogEntityCreditActionT,


### PR DESCRIPTION
This currently requires a lot of nested actions and is much more difficult than in the old relationship editor. (Based on feedback from @kellnerd.)

Example:

```JS
MB.relationshipEditor.relationshipDialogDispatch({
  type: 'set-attributes',
  attributes: [
    {
      type: {gid: 'd3a36e62-a7c4-4eb9-839f-adfebe87ac12'},
      credited_as: 'Narrator',
    },
  ],
});
```