### PR TITLE
MBS-12708: Report for lonely pseudo-releases

### DIFF
--- a/lib/MusicBrainz/Server/Report/LonelyPseudoReleases.pm
+++ b/lib/MusicBrainz/Server/Report/LonelyPseudoReleases.pm
@@ -1,0 +1,36 @@
+package MusicBrainz::Server::Report::LonelyPseudoReleases;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~'SQL'}
+            SELECT r.id AS release_id,
+                   row_number() OVER (
+                       ORDER BY ac.name COLLATE musicbrainz,
+                                r.name COLLATE musicbrainz
+                   )
+              FROM release r
+              JOIN artist_credit ac ON r.artist_credit = ac.id
+             WHERE r.status = 4 --pseudo-release
+    AND NOT EXISTS (
+                       SELECT 1
+                         FROM release r2
+                        WHERE r2.release_group = r.release_group
+                          AND r2.status != 4
+                   )
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2022 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -64,6 +64,7 @@ my @all = qw(
     LabelsDisambiguationSameName
     LimitedEditors
     LinksWithMultipleEntities
+    LonelyPseudoReleases
     LowDataQualityReleases
     MediumsWithOrderInTitle
     MediumsWithSequenceIssues
@@ -168,6 +169,7 @@ use MusicBrainz::Server::Report::ISWCsWithManyWorks;
 use MusicBrainz::Server::Report::LabelsDisambiguationSameName;
 use MusicBrainz::Server::Report::LimitedEditors;
 use MusicBrainz::Server::Report::LinksWithMultipleEntities;
+use MusicBrainz::Server::Report::LonelyPseudoReleases;
 use MusicBrainz::Server::Report::LowDataQualityReleases;
 use MusicBrainz::Server::Report::MediumsWithOrderInTitle;
 use MusicBrainz::Server::Report::MediumsWithSequenceIssues;

--- a/root/report/LonelyPseudoReleases.js
+++ b/root/report/LonelyPseudoReleases.js
@@ -1,0 +1,44 @@
+/*
+ * @flow strict
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+component LonelyPseudoReleases(...{
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>) {
+  return (
+    <ReportLayout
+      canBeFiltered={canBeFiltered}
+      description={l(
+        `This report shows releases with status “Pseudo-Release” that are
+         in release groups that contain only pseudo-releases.
+         This should never be fully correct; either the release is not really
+         a pseudo-release (being, for example, a badly indicated bootleg),
+         or the official release is missing and needs to be added.`,
+      )}
+      entityType="release"
+      filtered={filtered}
+      generated={generated}
+      title={l(
+        'Pseudo-releases in release groups that contain only pseudo-releases',
+      )}
+      totalEntries={pager.total_entries}
+    >
+      <ReleaseList items={items} pager={pager} />
+    </ReportLayout>
+  );
+}
+
+export default LonelyPseudoReleases;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -332,6 +332,13 @@ component ReportsIndex() {
           />
           <ReportsIndexEntry
             content={l(
+              `Pseudo-releases in release groups that contain
+               only pseudo-releases`,
+            )}
+            reportName="LonelyPseudoReleases"
+          />
+          <ReportsIndexEntry
+            content={l(
               `Translated/Transliterated Pseudo-Releases
               marked as the original version`,
             )}

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -269,6 +269,7 @@ export default {
   'report/LabelsDisambiguationSameName': (): Promise<mixed> => import('../report/LabelsDisambiguationSameName.js'),
   'report/LimitedEditors': (): Promise<mixed> => import('../report/LimitedEditors.js'),
   'report/LinksWithMultipleEntities': (): Promise<mixed> => import('../report/LinksWithMultipleEntities.js'),
+  'report/LonelyPseudoReleases': (): Promise<mixed> => import('../report/LonelyPseudoReleases.js'),
   'report/LowDataQualityReleases': (): Promise<mixed> => import('../report/LowDataQualityReleases.js'),
   'report/MediumsWithOrderInTitle': (): Promise<mixed> => import('../report/MediumsWithOrderInTitle.js'),
   'report/MediumsWithSequenceIssues': (): Promise<mixed> => import('../report/MediumsWithSequenceIssues.js'),


### PR DESCRIPTION
### Implement MBS-12708

A pseudo-release should never be in a release group by itself or only with other pseudos.

Made this a release report, rather than RG, to allow it to be filtered by subscriptions.