### PR TITLE
Move extends out of BEGIN blocks

### DIFF
--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -2,7 +2,8 @@ package MusicBrainz::Server;
 
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'Catalyst' }
+
+extends 'Catalyst';
 
 use Class::Load qw( load_class );
 use DBDefs;

--- a/lib/MusicBrainz/Server/Controller.pm
+++ b/lib/MusicBrainz/Server/Controller.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'Catalyst::Controller'; }
+
+extends 'Catalyst::Controller';
 
 use Carp;
 use Data::Page;

--- a/lib/MusicBrainz/Server/Controller/Account.pm
+++ b/lib/MusicBrainz/Server/Controller/Account.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Controller::Account;
 use Moose;
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+use MooseX::MethodAttributes;
+
+extends 'MusicBrainz::Server::Controller';
 
 use namespace::autoclean;
 use Digest::SHA qw(sha1_base64);

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Artist.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Account::Subscriptions::Artist;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Account::SubscriptionsRole';
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Collection.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Account::Subscriptions::Collection;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Translation qw( l );
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Editor.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Editor.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Account::Subscriptions::Editor;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Account::SubscriptionsRole';
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Label.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Account::Subscriptions::Label;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Account::SubscriptionsRole';
 

--- a/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Account/Subscriptions/Series.pm
@@ -2,7 +2,7 @@ package MusicBrainz::Server::Controller::Account::Subscriptions::Series;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Account::SubscriptionsRole';
 

--- a/lib/MusicBrainz/Server/Controller/Admin.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin.pm
@@ -1,10 +1,11 @@
 package MusicBrainz::Server::Controller::Admin;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use HTTP::Status qw( :constants );
 use Try::Tiny;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw( :privileges );
 use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );

--- a/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/Attributes.pm
@@ -1,12 +1,13 @@
 package MusicBrainz::Server::Controller::Admin::Attributes;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use utf8;
 
 use MusicBrainz::Server::Data::Utils qw( contains_string );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 my @models = qw(
     AreaType

--- a/lib/MusicBrainz/Server/Controller/Admin/StatisticsEvent.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/StatisticsEvent.pm
@@ -1,9 +1,10 @@
 package MusicBrainz::Server::Controller::Admin::StatisticsEvent;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 sub _form_to_hash {
     my ($self, $form) = @_;

--- a/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
+++ b/lib/MusicBrainz/Server/Controller/Admin/WikiDoc.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Admin::WikiDoc;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw( $EDIT_WIKIDOC_CHANGE );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );

--- a/lib/MusicBrainz/Server/Controller/Ajax.pm
+++ b/lib/MusicBrainz/Server/Controller/Ajax.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Ajax;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'Catalyst::Controller' }
+extends 'Catalyst::Controller';
 
 use JSON qw( encode_json );
 use namespace::autoclean;

--- a/lib/MusicBrainz/Server/Controller/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/Area.pm
@@ -1,9 +1,9 @@
 package MusicBrainz::Server::Controller::Area;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
-
+extends 'MusicBrainz::Server::Controller';
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Area',
     relationships   => {

--- a/lib/MusicBrainz/Server/Controller/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/Artist.pm
@@ -3,10 +3,10 @@ package MusicBrainz::Server::Controller::Artist;
 use utf8;
 
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
-
+extends 'MusicBrainz::Server::Controller';
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Artist',
     relationships   => {

--- a/lib/MusicBrainz/Server/Controller/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Controller/ArtistCredit.pm
@@ -2,8 +2,9 @@ package MusicBrainz::Server::Controller::ArtistCredit;
 use Moose;
 use namespace::autoclean;
 use Moose::Util qw( find_meta );
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );

--- a/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
+++ b/lib/MusicBrainz/Server/Controller/AutoEditorElections.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::AutoEditorElections;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Translation qw( l );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );

--- a/lib/MusicBrainz/Server/Controller/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/CDStub.pm
@@ -1,8 +1,11 @@
 package MusicBrainz::Server::Controller::CDStub;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
+
 use MusicBrainz::Server::Validation qw( is_valid_discid );
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+
+extends 'MusicBrainz::Server::Controller';
 
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 

--- a/lib/MusicBrainz/Server/Controller/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Controller/CDTOC.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::CDTOC;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_MEDIUM_ADD_DISCID

--- a/lib/MusicBrainz/Server/Controller/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/Collection.pm
@@ -1,12 +1,13 @@
 package MusicBrainz::Server::Controller::Collection;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use utf8;
 use Scalar::Util qw( looks_like_number );
 use List::AllUtils qw( first uniq );
 use MusicBrainz::Server::Translation qw( l );
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name => 'collection',

--- a/lib/MusicBrainz/Server/Controller/Dialog.pm
+++ b/lib/MusicBrainz/Server/Controller/Dialog.pm
@@ -1,10 +1,11 @@
 package MusicBrainz::Server::Controller::Dialog;
 use Encode qw( decode_utf8 );
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use HTTP::Status qw( :constants );
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 sub dialog : Path('/dialog') Edit {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Controller/Discourse.pm
+++ b/lib/MusicBrainz/Server/Controller/Discourse.pm
@@ -7,13 +7,14 @@ use JSON qw( decode_json );
 use LWP::UserAgent;
 use MIME::Base64 qw( decode_base64 encode_base64 );
 use Moose;
+use MooseX::MethodAttributes;
 use MusicBrainz::Server::Data::Utils qw( non_empty );
 use namespace::autoclean;
 use URI;
 use URI::Escape qw( uri_escape_utf8 );
 use URI::QueryParam;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 has lwp => (
     is => 'ro',

--- a/lib/MusicBrainz/Server/Controller/Doc.pm
+++ b/lib/MusicBrainz/Server/Controller/Doc.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Doc;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use DBDefs;
 use HTTP::Status qw( :constants );

--- a/lib/MusicBrainz/Server/Controller/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/Edit.pm
@@ -2,9 +2,11 @@ package MusicBrainz::Server::Controller::Edit;
 use Moose;
 use namespace::autoclean;
 use Moose::Util qw( does_role );
+use MooseX::MethodAttributes;
+
 use Try::Tiny;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use Data::Page;
 use DBDefs;

--- a/lib/MusicBrainz/Server/Controller/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/Event.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Event;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model       => 'Event',

--- a/lib/MusicBrainz/Server/Controller/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/Genre.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Genre;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use List::AllUtils qw( sort_by );
 use MusicBrainz::Server::Entity::Util::JSON qw(

--- a/lib/MusicBrainz/Server/Controller/ISRC.pm
+++ b/lib/MusicBrainz/Server/Controller/ISRC.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::ISRC;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Validation qw( is_valid_isrc );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );

--- a/lib/MusicBrainz/Server/Controller/ISWC.pm
+++ b/lib/MusicBrainz/Server/Controller/ISWC.pm
@@ -1,12 +1,13 @@
 package MusicBrainz::Server::Controller::ISWC;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
 use MusicBrainz::Server::Validation qw( format_iswc is_valid_iswc );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use List::AllUtils qw( sort_by );
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'ISWC',

--- a/lib/MusicBrainz/Server/Controller/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/Instrument.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Instrument;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_INSTRUMENT_CREATE

--- a/lib/MusicBrainz/Server/Controller/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/Label.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Label;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Label',

--- a/lib/MusicBrainz/Server/Controller/MBID.pm
+++ b/lib/MusicBrainz/Server/Controller/MBID.pm
@@ -1,12 +1,13 @@
 package MusicBrainz::Server::Controller::MBID;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
 use MusicBrainz::Server::Constants qw( entities_with );
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json );
 use MusicBrainz::Server::Validation qw( is_guid );
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 sub base : Path('/mbid') CaptureArgs(0) { }
 

--- a/lib/MusicBrainz/Server/Controller/OAuth2.pm
+++ b/lib/MusicBrainz/Server/Controller/OAuth2.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::OAuth2;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use DBDefs;
 use DateTime;

--- a/lib/MusicBrainz/Server/Controller/OtherLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/OtherLookup.pm
@@ -2,9 +2,11 @@ package MusicBrainz::Server::Controller::OtherLookup;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
-
 use Moose::Util qw( find_meta );
+use MooseX::MethodAttributes;
+
+extends 'MusicBrainz::Server::Controller';
+
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 sub lookup_handler {

--- a/lib/MusicBrainz/Server/Controller/Partners.pm
+++ b/lib/MusicBrainz/Server/Controller/Partners.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::Partners;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+extends 'MusicBrainz::Server::Controller';
 
 sub amazon : Local Args(2)
 {

--- a/lib/MusicBrainz/Server/Controller/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/Place.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Place;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Place',

--- a/lib/MusicBrainz/Server/Controller/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Rating.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::Rating;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Data::Utils qw( type_to_model );
 use MusicBrainz::Server::Translation qw( l );

--- a/lib/MusicBrainz/Server/Controller/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/Recording.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Recording;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'recording',

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkAttributeType.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Controller::Relationship::LinkAttributeType;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
+
 use MusicBrainz::Server::Constants qw(
     $EDIT_RELATIONSHIP_ADD_ATTRIBUTE
     $EDIT_RELATIONSHIP_REMOVE_LINK_ATTRIBUTE
@@ -11,12 +13,11 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 
 use MusicBrainz::Server::Validation qw( is_guid );
 
+extends 'MusicBrainz::Server::Controller';
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model => 'LinkAttributeType',
     entity_name => 'link_attr_type',
 };
-
-BEGIN { extends 'MusicBrainz::Server::Controller' }
 
 sub _load_tree
 {

--- a/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
+++ b/lib/MusicBrainz/Server/Controller/Relationship/LinkType.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::Relationship::LinkType;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use Sql;
 use List::AllUtils qw( partition_by sort_by );

--- a/lib/MusicBrainz/Server/Controller/RelationshipEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/RelationshipEditor.pm
@@ -3,8 +3,9 @@ package MusicBrainz::Server::Controller::RelationshipEditor;
 use utf8;
 
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use Encode;
 use HTTP::Status qw( :constants );

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -1,9 +1,11 @@
 package MusicBrainz::Server::Controller::Release;
 use Moose;
+use MooseX::MethodAttributes;
+
 use MusicBrainz::Server::Track;
 use aliased 'MusicBrainz::Server::Entity::Recording';
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name     => 'release',

--- a/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseEditor.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::ReleaseEditor;
 use utf8;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 __PACKAGE__->config(
     namespace => 'release_editor',

--- a/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/ReleaseGroup.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::ReleaseGroup;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_RELEASEGROUP_EDIT

--- a/lib/MusicBrainz/Server/Controller/Report.pm
+++ b/lib/MusicBrainz/Server/Controller/Report.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Report;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use DateTime;
 use MusicBrainz::Server::Filters qw( format_wikitext );

--- a/lib/MusicBrainz/Server/Controller/Root.pm
+++ b/lib/MusicBrainz/Server/Controller/Root.pm
@@ -3,6 +3,7 @@ use DateTime::Locale;
 use Digest::MD5 qw( md5_hex );
 use HTTP::Status qw( :constants );
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use Try::Tiny;
 use List::AllUtils qw( max );
@@ -10,7 +11,7 @@ use Readonly;
 use URI::Escape qw( uri_escape_utf8 );
 use URI::QueryParam;
 
-BEGIN { extends 'Catalyst::Controller' }
+extends 'Catalyst::Controller';
 
 # Import MusicBrainz libraries
 use DBDefs;

--- a/lib/MusicBrainz/Server/Controller/Search.pm
+++ b/lib/MusicBrainz/Server/Controller/Search.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::Search;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+extends 'MusicBrainz::Server::Controller';
 
 use HTTP::Status qw( :constants );
 use List::AllUtils qw( min max );

--- a/lib/MusicBrainz/Server/Controller/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/Series.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::Controller::Series;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
+
 use MusicBrainz::Server::Constants qw(
     $EDIT_SERIES_CREATE
     $EDIT_SERIES_EDIT
@@ -10,7 +12,7 @@ use MusicBrainz::Server::ControllerUtils::JSON qw( serialize_pager );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( l );
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     model           => 'Series',

--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -2,7 +2,9 @@ package MusicBrainz::Server::Controller::Statistics;
 use Digest::MD5 qw( md5_hex );
 use HTTP::Status qw( :constants );
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
+
 use MusicBrainz::Server::Data::Statistics::ByDate;
 use MusicBrainz::Server::Data::Statistics::ByName;
 use MusicBrainz::Server::Data::CountryArea;
@@ -14,7 +16,7 @@ use Date::Calc qw( Today Add_Delta_Days Date_to_Time );
 
 use aliased 'MusicBrainz::Server::EditRegistry';
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 sub statistics : Path('')
 {

--- a/lib/MusicBrainz/Server/Controller/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/Tag.pm
@@ -1,9 +1,10 @@
 package MusicBrainz::Server::Controller::Tag;
 use Moose;
 use Moose::Util qw( find_meta );
+use MooseX::MethodAttributes;
 use HTTP::Status qw( :constants );
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Data::Utils qw( boolean_to_json type_to_model );
 use MusicBrainz::Server::Constants qw( %ENTITIES entities_with );

--- a/lib/MusicBrainz/Server/Controller/TagLookup.pm
+++ b/lib/MusicBrainz/Server/Controller/TagLookup.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::TagLookup;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+extends 'MusicBrainz::Server::Controller';
 
 use List::AllUtils qw( any );
 use MusicBrainz::Server::Form::TagLookup;

--- a/lib/MusicBrainz/Server/Controller/Test.pm
+++ b/lib/MusicBrainz/Server/Controller/Test.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Test;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'Catalyst::Controller' }
+extends 'Catalyst::Controller';
 
 use DBDefs;
 

--- a/lib/MusicBrainz/Server/Controller/Track.pm
+++ b/lib/MusicBrainz/Server/Controller/Track.pm
@@ -1,10 +1,11 @@
 package MusicBrainz::Server::Controller::Track;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use HTTP::Status qw( :constants );
 use MusicBrainz::Server::Validation qw( is_guid );
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 with 'MusicBrainz::Server::Controller::Role::Load' => {
     entity_name => 'track',
     model       => 'Track',

--- a/lib/MusicBrainz/Server/Controller/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/URL.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::URL;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw( $EDIT_URL_EDIT );
 

--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -2,8 +2,9 @@ package MusicBrainz::Server::Controller::User;
 use Moose;
 use namespace::autoclean;
 use Moose::Util qw( find_meta );
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use DateTime;
 use DBDefs;

--- a/lib/MusicBrainz/Server/Controller/User/Edits.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Edits.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::User::Edits;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Data::Utils qw( load_everything_for_edits );
 use MusicBrainz::Server::Constants qw( :edit_status :vote );

--- a/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
+++ b/lib/MusicBrainz/Server/Controller/User/Subscriptions.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::User::Subscriptions;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::Controller::User::SubscriptionsRole' => {
     type => 'artist',

--- a/lib/MusicBrainz/Server/Controller/Vote.pm
+++ b/lib/MusicBrainz/Server/Controller/Vote.pm
@@ -1,7 +1,8 @@
 package MusicBrainz::Server::Controller::Vote;
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 sub index : Path('/vote') Args(0)
 {

--- a/lib/MusicBrainz/Server/Controller/WS/2.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2;
 
 use Moose;
+use MooseX::MethodAttributes;
 
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 sub default : Path {
     my ($self, $c) = @_;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Annotation.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Annotation.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Annotation;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Area.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Area;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Artist;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use Readonly;

--- a/lib/MusicBrainz/Server/Controller/WS/2/CDStub.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/CDStub.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::CDStub;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use MusicBrainz::Server::WebService::XML::XPath;
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Collection.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Collection;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use List::AllUtils qw( all );

--- a/lib/MusicBrainz/Server/Controller/WS/2/DiscID.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/DiscID.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::DiscID;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_valid_discid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Event.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Event;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Genre.pm
@@ -1,8 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Genre;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use MusicBrainz::Server::WebService::TXTSerializer;
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/ISRC.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ISRC.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::ISRC;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_valid_isrc );

--- a/lib/MusicBrainz/Server/Controller/WS/2/ISWC.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ISWC.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::ISWC;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_valid_iswc );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Instrument.pm
@@ -1,9 +1,10 @@
 package MusicBrainz::Server::Controller::WS::2::Instrument;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use MusicBrainz::Server::Validation qw( is_guid );
 
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 

--- a/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Label.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Label;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Place.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Place;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Rating.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Rating;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Constants qw( entities_with );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Recording.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Recording;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::Buffer';
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';

--- a/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Release.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Release;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Constants qw(

--- a/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/ReleaseGroup.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::ReleaseGroup;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Series.pm
@@ -1,8 +1,11 @@
 package MusicBrainz::Server::Controller::WS::2::Series;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
+
 use MusicBrainz::Server::Validation qw( is_guid );
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use Readonly;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Tag.pm
@@ -1,10 +1,11 @@
 package MusicBrainz::Server::Controller::WS::2::Tag;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
 use English;
 
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Data::Utils qw( non_empty trim type_to_model );

--- a/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/URL.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::URL;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use Readonly;

--- a/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Work.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::2::Work;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::2' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::2';
 
 use aliased 'MusicBrainz::Server::WebService::WebServiceStash';
 use MusicBrainz::Server::Validation qw( is_guid );

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js;
 
 use Moose;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js'; }
+use MooseX::MethodAttributes;
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 use utf8;
 use Data::OptList;

--- a/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Area.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Area;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Artist;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/CheckDuplicates.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/CheckDuplicates.pm
@@ -1,5 +1,6 @@
 package MusicBrainz::Server::Controller::WS::js::CheckDuplicates;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use HTTP::Status qw( :constants );
 use JSON;
@@ -7,7 +8,7 @@ use Try::Tiny;
 use MusicBrainz::Server::Data::Utils qw(type_to_model);
 use aliased 'MusicBrainz::Server::WebService::JSONSerializer';
 
-BEGIN {extends 'MusicBrainz::Server::ControllerBase::WS::js'}
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 my $ws_defs = Data::OptList::mkopt([
     'check_duplicates' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -5,6 +5,7 @@ use HTML::Entities qw( encode_entities );
 use HTTP::Status qw( :constants );
 use JSON qw( encode_json );
 use Moose;
+use MooseX::MethodAttributes;
 use MusicBrainz::Server::Constants qw(
     $EDIT_RELEASE_CREATE
     $EDIT_RELEASE_EDIT
@@ -62,7 +63,8 @@ use URI;
 use aliased 'MusicBrainz::Server::Entity::ArtistCredit';
 use aliased 'MusicBrainz::Server::Entity::Track';
 use aliased 'MusicBrainz::Server::WebService::JSONSerializer';
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+
+extends 'MusicBrainz::Server::Controller';
 
 Readonly our $ERROR_NOT_LOGGED_IN => 1;
 Readonly our $ERROR_NON_EXISTENT_ENTITIES => 2;

--- a/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Editor.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Editor;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 use Text::Trim qw( trim );
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Event.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Event;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Genre.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Genre;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Instrument.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Instrument;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Label;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/ParseCoordinates.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ParseCoordinates.pm
@@ -1,9 +1,12 @@
 package MusicBrainz::Server::Controller::WS::js::ParseCoordinates;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use JSON;
 use utf8;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
+
 use MusicBrainz::Server::Data::Utils qw( trim );
 use MusicBrainz::Server::Validation qw( validate_coordinates );
 

--- a/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Place.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Place;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Recording.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Recording;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Release.pm
@@ -1,10 +1,12 @@
 package MusicBrainz::Server::Controller::WS::js::Release;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use JSON qw( encode_json );
 use aliased 'MusicBrainz::Server::Entity::Work';
 use MusicBrainz::Server::Validation qw( is_guid );
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/ReleaseGroup.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::ReleaseGroup;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::WithArtistCredits';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Series.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Series;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Work.pm
@@ -1,7 +1,9 @@
 package MusicBrainz::Server::Controller::WS::js::Work;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::ControllerBase::WS::js' }
+
+extends 'MusicBrainz::Server::ControllerBase::WS::js';
 
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion';
 with 'MusicBrainz::Server::Controller::WS::js::Role::Autocompletion::PrimaryAlias' => {

--- a/lib/MusicBrainz/Server/Controller/Work.pm
+++ b/lib/MusicBrainz/Server/Controller/Work.pm
@@ -1,9 +1,10 @@
 package MusicBrainz::Server::Controller::Work;
 use 5.10.0;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 
-BEGIN { extends 'MusicBrainz::Server::Controller'; }
+extends 'MusicBrainz::Server::Controller';
 
 use MusicBrainz::Server::Constants qw(
     $EDIT_WORK_CREATE

--- a/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/2.pm
@@ -1,6 +1,8 @@
 package MusicBrainz::Server::ControllerBase::WS::2;
 use Moose;
-BEGIN { extends 'Catalyst::Controller'; }
+use MooseX::MethodAttributes;
+
+extends 'Catalyst::Controller';
 
 use DBDefs;
 use HTTP::Status qw( :constants );

--- a/lib/MusicBrainz/Server/ControllerBase/WS/js.pm
+++ b/lib/MusicBrainz/Server/ControllerBase/WS/js.pm
@@ -1,11 +1,13 @@
 package MusicBrainz::Server::ControllerBase::WS::js;
 use Moose;
+use MooseX::MethodAttributes;
 use namespace::autoclean;
 use HTTP::Status qw( :constants );
+
 use MusicBrainz::Server::WebService::Format;
 use MusicBrainz::Server::WebService::JSONSerializer;
 
-BEGIN { extends 'MusicBrainz::Server::Controller' }
+extends 'MusicBrainz::Server::Controller';
 
 with 'MusicBrainz::Server::WebService::Format';
 

--- a/lib/MusicBrainz/Server/Translation/Attributes.pm
+++ b/lib/MusicBrainz/Server/Translation/Attributes.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Attributes;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'attributes' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Countries.pm
+++ b/lib/MusicBrainz/Server/Translation/Countries.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Countries;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'countries' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/InstrumentDescriptions.pm
+++ b/lib/MusicBrainz/Server/Translation/InstrumentDescriptions.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::InstrumentDescriptions;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'instrument_descriptions' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Instruments.pm
+++ b/lib/MusicBrainz/Server/Translation/Instruments.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Instruments;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'instruments' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Languages.pm
+++ b/lib/MusicBrainz/Server/Translation/Languages.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Languages;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'languages' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Relationships.pm
+++ b/lib/MusicBrainz/Server/Translation/Relationships.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Relationships;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'relationships' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Scripts.pm
+++ b/lib/MusicBrainz/Server/Translation/Scripts.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Scripts;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'scripts' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }

--- a/lib/MusicBrainz/Server/Translation/Statistics.pm
+++ b/lib/MusicBrainz/Server/Translation/Statistics.pm
@@ -1,8 +1,8 @@
 package MusicBrainz::Server::Translation::Statistics;
 use Moose;
 use namespace::autoclean;
-BEGIN { extends 'MusicBrainz::Server::Translation'; }
 
+extends 'MusicBrainz::Server::Translation';
 with 'MusicBrainz::Server::Role::Translation' => { domain => 'statistics' };
 
 sub l { __PACKAGE__->instance->gettext(@_) }


### PR DESCRIPTION
AFAICT this doesn't provide any particular benefit. The main reason we were probably doing this is because method attributes such as `Private`, `Path`, etc made Moose crash, but [`use MooseX::MethodAttributes;`](https://metacpan.org/pod/MooseX::MethodAttributes) seems to be all that is needed to avoid that.