### PR TITLE
Fix warnings in DAOLogger

### DIFF
--- a/lib/Plack/Middleware/Debug/DAOLogger.pm
+++ b/lib/Plack/Middleware/Debug/DAOLogger.pm
@@ -19,7 +19,7 @@ sub run {
     $i = 0;
 
     return sub {
-        my $sum = sum(map { $_->[1] } @call_stack);
+        my $sum = sum(map { $_->[1] } @call_stack) // 0;
 
         $panel->content(
             '<p>This panel shows time spent within the data access layer. Rows '.
@@ -39,7 +39,7 @@ sub run {
 
 sub render_stack {
     my ($indent, @stack) = @_;
-    return unless @stack;
+    return '' unless @stack;
 
     my @times = map { $_->[1] } @stack;
     my $mean = mean(@times);


### PR DESCRIPTION
We had a bunch of uninitialized values here, and they were triggering warnings I did not see earlier because I don't usually run `CATALYST_DEBUG`.