### PR TITLE
Add another missing Types module import for Genre

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Tag.pm
+++ b/lib/MusicBrainz/Server/Entity/Tag.pm
@@ -1,6 +1,7 @@
 package MusicBrainz::Server::Entity::Tag;
 
 use Moose;
+use MusicBrainz::Server::Entity::Types;
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Entity';


### PR DESCRIPTION
Follow-up to a case that was missed in a7d71920e6723be81b04abfb3551f026a4120078.

The PruneCache error is triggered randomly, but it's possible to reproduce by running the script in a loop.  I confirmed that this commit fixes the error, because the script will loop indefinitely, whereas normally it will fail in under a minute.