### PR TITLE
Validate invalid session ID cookies earlier

### DIFF
--- a/docker/musicbrainz-tests/DBDefs.pm
+++ b/docker/musicbrainz-tests/DBDefs.pm
@@ -148,6 +148,7 @@ sub DISABLE_LAST_LOGIN_UPDATE { 1 }
 # a different hostname alias.
 sub WEB_SERVER { 'mbtest:5000' }
 sub STATIC_RESOURCES_LOCATION { '//mbtest:5000/static/build' }
+sub BETA_REDIRECT_HOSTNAME { 'mbtest-beta:5000' }
 
 sub REPLICATION_USE_DBMIRROR2 { 1 }
 

--- a/docker/musicbrainz-tests/add_mbtest_alias.sh
+++ b/docker/musicbrainz-tests/add_mbtest_alias.sh
@@ -7,3 +7,6 @@
 # to /etc/hosts here and in the selenium job below.
 
 echo '127.0.0.1 mbtest' >> /etc/hosts
+
+# For BETA_REDIRECT_HOSTNAME
+echo '127.0.0.1 mbtest-beta' >> /etc/hosts

--- a/t/lib/t/MusicBrainz/Server/Controller/Errors.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Errors.pm
@@ -92,29 +92,34 @@ test 'Respond with Bad Request for "invalid session ID"' => sub {
     my $test = shift;
     my $mech = $test->mech;
 
-    local $MusicBrainz::Errors::_sentry_enabled = 1;
-
-    my $sentry_ua = bless {
-        ctx_request => \&ctx_request,
-        posted_error => undef,
-    }, 'SentryUserAgent';
-
-    local $MusicBrainz::Errors::sentry = Sentry::Raven->new(
-        ua_obj => $sentry_ua,
-        sentry_dsn => 'http://user:password@localhost/sentry-test/1',
-    );
-
     $mech->request(HTTP::Request->new('GET', '/', [
         'Cookie' => 'musicbrainz_server_session=heheh',
     ]));
-    is($mech->response->code, 400);
-
-    my $sentry_error = decode_json($sentry_ua->{posted_error});
-    my $exception_value = $sentry_error->{'sentry.interfaces.Exception'}{value};
-
     is(
-        $exception_value,
-        q(Tried to set invalid session ID 'heheh'),
+        $mech->response->code,
+        400,
+        'bad request is returned for an invalid session ID',
+    );
+    is(
+        $mech->response->content,
+        q(Invalid session ID 'heheh'),
+        'an error message is returned in the response',
+    );
+
+    # Try with beta=on, since that triggers a redirect before
+    # any action is dispatched.
+    $mech->request(HTTP::Request->new('GET', '/', [
+        'Cookie' => 'musicbrainz_server_session=hahah; beta=on',
+    ]));
+    is(
+        $mech->response->code,
+        400,
+        'bad request is returned for an invalid session ID with beta=on',
+    );
+    is(
+        $mech->response->content,
+        q(Invalid session ID 'hahah'),
+        'an error message is returned in the response',
     );
 };
 


### PR DESCRIPTION
If a request contains an invalid (as in malformed) session ID cookie paired with a `beta=on` cookie, the request will die before the beta redirect response is returned and result in a closed connection on the gateway.

In daf0647c3fdeebd1cc857c14678a619ebd04a3cf we started catching "invalid session ID" errors in `Controller::Root::begin` and logging them to Sentry.  The `beta=on` issue arises because a redirect is issued immediately instead of dispatching the request through `Controller::Root`.

The potential for an invalid ID to be returned is now handled at the source by wrapping `get_session_id`.  Since this is called very early in the dispatch process, we can't render an HTML bad-request page because there's no view available, so a text/plain error is returned instead. This is fine because 100% of requests with malformed session IDs are spam.

I no longer think we should log these errors to Sentry for the same reason, and because having them in the Docker logs is enough for forensics.