### PR TITLE
MBS-12716: Output the right JSON-LD @context

### DIFF
--- a/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD.pm
+++ b/lib/MusicBrainz/Server/WebService/Serializer/JSON/LD.pm
@@ -3,7 +3,9 @@ use Moose;
 
 sub serialize {
     my ($self, $entity, $inc, $stash, $toplevel) = @_;
-    return $toplevel ? {'@context' => 'http://schema.org'} : {};
+    return $toplevel
+        ? {'@context' => 'https://schema.org/docs/jsonldcontext.json'}
+        : {};
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Aliases.pm
@@ -34,7 +34,7 @@ test 'Area alias appears on alias page content and on JSON-LD' => sub {
     page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/area/106e0bec-b638-3b37-b731-f53d507dc00e',
         'alternateName' => ["\x{30aa}\x{30fc}\x{30b9}\x{30c8}\x{30e9}\x{30ea}\x{30a2}"],
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'name' => 'Australia',
         '@type' => 'Country'
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Area/Show.pm
@@ -29,7 +29,7 @@ test 'Basic area data appears on JSON-LD' => sub {
 
     page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/area/3f179da4-83c6-4a28-a627-e46b4a8ff1ed',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'name' => 'Sydney',
         '@type' => 'City',
         'containedIn' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Aliases.pm
@@ -42,7 +42,7 @@ test 'Artist alias appears on alias page content and on JSON-LD' => sub {
     );
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
         '@type' => ['Person', 'MusicGroup'],
         'alternateName' => ['Test Alias'],

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Recordings.pm
@@ -58,7 +58,7 @@ test 'Artist recordings page contains the expected data and JSON-LD' => sub {
             '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed'
         },
         '@type' => ['Person', 'MusicGroup'],
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'birthDate' => '2008-01-02',
         'birthPlace' => {
             '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Relationships.pm
@@ -48,7 +48,7 @@ test 'Artist relationships page contains the expected data and JSON-LD' => sub {
             '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
             '@type' => 'Country'
         },
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@type' => ['Person', 'MusicGroup'],
         'birthDate' => '2008-01-02',
         'birthPlace' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Show.pm
@@ -122,7 +122,7 @@ test 'Basic artist data appears on JSON-LD' => sub {
         },
         'alternateName' => ['Seekrit Identity'],
         '@id' => 'http://musicbrainz.org/artist/745c079d-374e-4436-9448-da92dedef3ce',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'birthPlace' => {
             '@id' => 'http://musicbrainz.org/area/8a754a16-0027-3a29-b6d7-2b40ea0481ed',
             '@type' => 'Country',
@@ -232,7 +232,7 @@ test 'Embedded JSON-LD `member` property' => sub {
                 'roleName' => 'guitar'
             }
         ],
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 
     $mech->get_ok(
@@ -257,7 +257,7 @@ test 'Embedded JSON-LD `member` property' => sub {
                 }
             },
         ],
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 };
 
@@ -304,7 +304,7 @@ test 'Embedded JSON-LD `track` property (for artists with only recordings)' => s
                 '@type' => 'MusicRecording'
             }
         ],
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 };
 
@@ -338,7 +338,7 @@ test 'Embedded JSON-LD `genre` property' => sub {
         '@type' => 'MusicGroup',
         '@id' => 'http://musicbrainz.org/artist/dcb48a49-b17d-49b9-aee5-4f168d8004d9',
         'genre' => 'http://musicbrainz.org/genre/1b50083b-1afa-4778-82c8-548b309af783',
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 
     $c->sql->do(<<~'SQL');
@@ -358,7 +358,7 @@ test 'Embedded JSON-LD `genre` property' => sub {
             'http://musicbrainz.org/genre/1b50083b-1afa-4778-82c8-548b309af783',
             'http://musicbrainz.org/genre/2b50083b-1afa-4778-82c8-548b309af783',
         ],
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 };
 
@@ -375,7 +375,7 @@ test 'Embedded JSON-LD sameAs & performsAs' => sub {
     );
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/artist/960db060-0ba8-4f6c-9770-49b81dc6e5ea',
         '@type' => ['Person', 'MusicGroup'],
         'alternateName' => ['Calvin Broadus', 'Snoop Dogg'],
@@ -421,7 +421,7 @@ test 'Embedded JSON-LD dates & origins for people' => sub {
     );
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/artist/b972f589-fb0e-474e-b64a-803b0364fa75',
         '@type' => ['Person', 'MusicGroup'],
         'birthDate' => '1756-01-27',
@@ -473,7 +473,7 @@ test 'Embedded JSON-LD for groups' => sub {
     );
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/artist/b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d',
         '@type' => 'MusicGroup',
         'dissolutionDate' => '1970-04-10',
@@ -591,7 +591,7 @@ test 'Embedded JSON-LD for an empty artist' => sub {
     );
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@type' => 'MusicGroup',
         '@id' => 'http://musicbrainz.org/artist/60e5d080-c964-11de-8a39-0800200c9a66',
         'name' => 'Empty Artist'

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Aliases.pm
@@ -42,7 +42,7 @@ test 'Label alias appears on alias page content and on JSON-LD' => sub {
         },
         '@id' => 'http://musicbrainz.org/label/46f0f4cd-8aab-4b33-b698-f459faf64190',
         '@type' => 'MusicLabel',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'alternateName' => ['Test Label Alias']
     };
 };

--- a/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Label/Show.pm
@@ -35,7 +35,7 @@ $mech->content_like(qr{GB}, 'has country in release list');
 $mech->content_like(qr{/release/f34c079d-374e-4436-9448-da92dedef3ce}, 'links to correct release');
 
 page_test_jsonld $mech => {
-    '@context' => 'http://schema.org',
+    '@context' => 'https://schema.org/docs/jsonldcontext.json',
     'releasePublished' => [
         {
             'name' => 'Aerial',

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Aliases.pm
@@ -45,7 +45,7 @@ test 'Place alias appears on alias page content and on JSON-LD' => sub {
             '@type' => 'GeoCoordinates'
         },
         'name' => 'A Test Place',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@type' => 'Place',
         '@id' => 'http://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Place/Show.pm
@@ -31,7 +31,7 @@ test all => sub {
             'latitude' => '0.323'
         },
         '@type' => 'Place',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'foundingDate' => '2013',
         '@id' => 'http://musicbrainz.org/place/df9269dd-0470-4ea2-97e8-c11e46080edd'
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Aliases.pm
@@ -35,7 +35,7 @@ test 'Recording alias appears on alias page content and on JSON-LD' => sub {
         'alternateName' => ['King of the Mt.'],
         'isrcCode' => 'DEE250800230',
         '@type' => 'MusicRecording',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'duration' => 'PT04M54S',
         'name' => 'King of the Mountain'
     };

--- a/t/lib/t/MusicBrainz/Server/Controller/Recording/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Recording/Show.pm
@@ -38,7 +38,7 @@ $mech->content_contains('Test annotation 3', 'has annotation');
 page_test_jsonld $mech => {
     'isrcCode' => 'DEE250800231',
     '@id' => 'http://musicbrainz.org/recording/123c079d-374e-4436-9448-da92dedef3ce',
-    '@context' => 'http://schema.org',
+    '@context' => 'https://schema.org/docs/jsonldcontext.json',
     '@type' => 'MusicRecording',
     'sameAs' => 'http://musicbrainz.org/recording/0986e67c-6b7a-40b7-b4ba-c9d7583d6426',
     'name' => 'Dancing Queen',
@@ -57,7 +57,7 @@ test 'Embedded JSON-LD' => sub {
     $mech->get_ok('/recording/6b517117-8b98-463b-9457-f8e3a08d1f49', 'fetch dancing queen recording');
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/recording/6b517117-8b98-463b-9457-f8e3a08d1f49',
         '@type' => 'MusicRecording',
         'contributor' => [

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Aliases.pm
@@ -70,7 +70,7 @@ test 'Release alias appears on alias page content and on JSON-LD' => sub {
         '@id' => 'http://musicbrainz.org/release/f205627f-b70a-409d-adbe-66289b614e80',
         'name' => 'Aerial',
         'musicReleaseFormat' => 'http://schema.org/CDFormat',
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/CoverArt.pm
@@ -19,7 +19,7 @@ test all => sub {
     html_ok($mech->content);
 
     page_test_jsonld $mech => {
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'releaseOf' => {
             '@type' => 'MusicAlbum',
             'albumProductionType' => 'http://schema.org/StudioAlbum',

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Show.pm
@@ -198,7 +198,7 @@ page_test_jsonld $mech => {
             'duration' => 'PT07M53S'
         }
     ],
-    '@context' => 'http://schema.org',
+    '@context' => 'https://schema.org/docs/jsonldcontext.json',
     'hasReleaseRegion' => [
         {
             'releaseCountry' => {

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Aliases.pm
@@ -59,7 +59,7 @@ test 'Release group alias appears on alias page content and on JSON-LD' => sub {
         'albumProductionType' => 'http://schema.org/StudioAlbum',
         'name' => 'Test RG 1',
         '@type' => 'MusicAlbum',
-        '@context' => 'http://schema.org'
+        '@context' => 'https://schema.org/docs/jsonldcontext.json'
     };
 };
 

--- a/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/ReleaseGroup/Show.pm
@@ -27,7 +27,7 @@ $mech->content_like(qr{/artist/a45c079d-374e-4436-9448-da92dedef3cf}, 'link to a
 $mech->content_like(qr/Test annotation 5/, 'has annotation');
 
 page_test_jsonld $mech => {
-    '@context' => 'http://schema.org',
+    '@context' => 'https://schema.org/docs/jsonldcontext.json',
     'albumProductionType' => 'http://schema.org/StudioAlbum',
     'byArtist' => {
         'name' => 'ABBA',
@@ -90,7 +90,7 @@ page_test_jsonld $mech => {
         '@id' => 'http://musicbrainz.org/artist/4b585938-f271-45e2-b19a-91c634b5e396',
         'name' => 'Kate Bush'
     },
-    '@context' => 'http://schema.org',
+    '@context' => 'https://schema.org/docs/jsonldcontext.json',
     'name' => 'Aerial',
     '@id' => 'http://musicbrainz.org/release-group/7c3218d7-75e0-4e8c-971f-f097b6c308c5',
     'albumReleaseType' => 'http://schema.org/AlbumRelease',

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Aliases.pm
@@ -33,7 +33,7 @@ test 'Work alias appears on alias page content and on JSON-LD' => sub {
 
     page_test_jsonld $mech => {
         'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         '@id' => 'http://musicbrainz.org/work/559be0c1-2c87-45d6-ba43-1b1feb8f831e',
         'iswcCode' => ['T-000.000.001-0', 'T-000.000.002-0'],
         'alternateName' => ['WA1', 'WA2'],

--- a/t/lib/t/MusicBrainz/Server/Controller/Work/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Work/Show.pm
@@ -27,7 +27,7 @@ test all => sub {
         '@type' => 'MusicComposition',
         'iswcCode' => 'T-000.000.001-0',
         'sameAs' => 'http://musicbrainz.org/work/28e73402-5666-4d74-80ab-c3734dc699ea',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'name' => 'Dancing Queen',
         '@id' => 'http://musicbrainz.org/work/745c079d-374e-4436-9448-da92dedef3ce'
     };
@@ -61,7 +61,7 @@ test 'Embedded JSON-LD' => sub {
             'duration' => 'PT05M00S'
         },
         'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'musicArrangement' => [
             {
                 '@id' => 'http://musicbrainz.org/work/a72c9be6-5ef9-4bdf-afa1-6a3db697ff62',
@@ -126,7 +126,7 @@ test 'Embedded JSON-LD' => sub {
             'duration' => 'PT05M00S'
         },
         'sameAs' => 'http://musicbrainz.org/work/a30a4245-a7ec-4979-8b1e-b549f2782239',
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org/docs/jsonldcontext.json',
         'iswcCode' => ['T-000.000.001-0', 'T-000.000.002-0'],
         'inLanguage' => 'en'
     };


### PR DESCRIPTION
### Fix MBS-12716

In order to make `@context` properly machine-readable, we should be pointing at the actual JSON-LD context file, as per https://schema.org/docs/developers.html

I'm keeping the link as HTTP because that's what we do all over our JSON-LD and schema.org say it's fine.