### PR TITLE
MBS-12720: Set the remember_login cookie to HttpOnly

### DIFF
--- a/lib/MusicBrainz/Server/Controller/User.pm
+++ b/lib/MusicBrainz/Server/Controller/User.pm
@@ -269,6 +269,7 @@ sub _renew_login_cookie
             : '',
         samesite => 'Lax',
         $c->req->secure ? (secure => 1) : (),
+        httponly => 1,
     };
 }
 


### PR DESCRIPTION
This should not be accessible to JavaScript and is prone to XSS attacks otherwise.

Note: Once this is deployed, existing `remember_login` cookies will be overridden once the current session expires (which I believe only lasts 3 hours), so no other action needs to be taken on those.