### PR TITLE
MBS-12692: Also consider artist empty if used in unused AC

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -518,9 +518,12 @@ sub is_empty {
         WHERE id = ?
         AND NOT (
             EXISTS (
-                SELECT TRUE FROM artist_credit_name
-                WHERE artist = artist_row.id
-                LIMIT 1
+                SELECT TRUE
+                  FROM artist_credit_name acn
+                  JOIN artist_credit ac ON ac.id = acn.artist_credit
+                 WHERE acn.artist = artist_row.id
+                   AND ac.ref_count > 0
+                 LIMIT 1
             ) OR
             $used_in_relationship
         )

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/EligibleForCleanup.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/EligibleForCleanup.pm
@@ -124,4 +124,26 @@ test 'Cleanup banner appears for empty artist with only creation edit open' => s
     );
 };
 
+test 'Cleanup banner appears for artist with only unused artist credits' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database(
+        $c,
+        '+artist_cleanup',
+    );
+
+    $mech->get_ok(
+        '/artist/aa8a22fd-c2de-46df-be6e-327da6fce73d',
+        'Fetched the index page for an artist with an unused artist credit',
+    );
+
+    html_ok($mech->content);
+    $mech->content_contains(
+      'will be removed automatically',
+      'The artist page shows a cleanup banner',
+    );
+};
+
 1;

--- a/t/sql/artist_cleanup.sql
+++ b/t/sql/artist_cleanup.sql
@@ -5,12 +5,16 @@ INSERT INTO artist (id, gid, name, sort_name, edits_pending) VALUES
     (4, '5cd50089-fd14-460c-ae72-e94277b15ae4', 'Relationship Artist', 'Relationship Artist', 0),
     (5, '74b265fe-aeaf-4f47-a619-98d70ff61ffa', 'Open Edit Artist', 'Open Edit Artist', 2),
     (6, '08d33da4-d011-4731-897a-3df1fcfc4ed5', 'Empty Artist', 'Empty Artist', 0),
-    (7, 'c1f4717d-32af-418c-abae-e85ded7bd420', 'Open Creation Edit Artist', 'Open Creation Edit Artist', 1);
+    (7, 'c1f4717d-32af-418c-abae-e85ded7bd420', 'Open Creation Edit Artist', 'Open Creation Edit Artist', 1),
+    (8, 'aa8a22fd-c2de-46df-be6e-327da6fce73d', 'Unused Artist Credit Artist', 'Unused Artist Credit Artist', 0);
 
 INSERT INTO artist_credit (id, name, artist_count, gid)
-  VALUES (1, 'Recording Artist', 1, '7511889a-0c25-4991-8799-2ee08c54d9a3');
+  VALUES (1, 'Recording Artist', 1, '7511889a-0c25-4991-8799-2ee08c54d9a3'),
+         (2, 'Unused Artist Credit Artist', 1, '87b038df-6fbd-483e-ba6f-7ac80efdc3cd');
+
 INSERT INTO artist_credit_name (artist_credit, position, artist, name, join_phrase)
-  VALUES (1, 1, 3, 'Recording Artist', '');
+  VALUES (1, 1, 3, 'Recording Artist', ''),
+         (2, 1, 8, 'Unused Artist Credit Artist', '');
 
 INSERT INTO recording (id, gid, name, artist_credit, length) VALUES
     (1, '4d463513-8744-45d5-b425-e6e55c724d2e', 'Test Recording', 1, 123456);


### PR DESCRIPTION
### Implement MBS-12692

Unused artist credits are no longer automatically removed, so an artist can be "in use" in an AC which is itself scheduled for autoremoval. In this case, we should consider the artist empty and in risk of cleanup.

On top of https://github.com/metabrainz/musicbrainz-server/pull/1538