### PR TITLE
Avoid using multiple with in Edit:: files

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Alias/Add.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Add.pm
@@ -19,10 +19,10 @@ role {
     my $entity_type = model_to_type($model);
     my $entity_id = "${entity_type}_id";
 
-    with 'MusicBrainz::Server::Edit::Alias';
-    with "MusicBrainz::Server::Edit::$model";
-    with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-    with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+    with 'MusicBrainz::Server::Edit::Alias',
+         "MusicBrainz::Server::Edit::$model",
+         'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+         'MusicBrainz::Server::Edit::Role::DatePeriod';
 
     has data => (
         is => 'rw',

--- a/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Delete.pm
@@ -8,8 +8,8 @@ use MusicBrainz::Server::Edit::Types qw( Nullable PartialDateHash );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Alias';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Alias',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub _alias_model { die 'Not implemented' }
 

--- a/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Alias/Edit.pm
@@ -18,10 +18,10 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Alias';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Alias',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub _alias_model { die 'Not implemented' }
 

--- a/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Annotation/Edit.pm
@@ -23,9 +23,9 @@ role {
     my $entity_type = model_to_type($model);
     my $entity_id = "${entity_type}_id";
 
-    with "MusicBrainz::Server::Edit::$model";
-    with 'MusicBrainz::Server::Edit::Role::Preview';
-    with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+    with "MusicBrainz::Server::Edit::$model",
+         'MusicBrainz::Server::Edit::Role::Preview',
+         'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
     has data => (
         is => 'rw',

--- a/lib/MusicBrainz/Server/Edit/Area/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Create.pm
@@ -15,10 +15,10 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Area';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Area';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Area',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Add area') }
 sub edit_type { $EDIT_AREA_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Area/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Area/Edit.pm
@@ -23,10 +23,10 @@ use aliased 'MusicBrainz::Server::Entity::Area';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Area';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Area',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Edit area') }
 sub edit_type { $EDIT_AREA_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Artist/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Create.pm
@@ -16,15 +16,17 @@ use aliased 'MusicBrainz::Server::Entity::Artist';
 use aliased 'MusicBrainz::Server::Entity::Area';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Artist';
-with 'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
-    editor_subscription_preference => sub { shift->subscribe_to_created_artists },
-};
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Artist',
+     'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
+        editor_subscription_preference => sub {
+            shift->subscribe_to_created_artists;
+        },
+     },
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Add artist') }
 sub edit_type { $EDIT_ARTIST_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Artist/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_ARTIST_DELETE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::Role::DeleteSubscription';
-with 'MusicBrainz::Server::Edit::Artist';
+with 'MusicBrainz::Server::Edit::Role::DeleteSubscription',
+     'MusicBrainz::Server::Edit::Artist';
 
 sub edit_name { N_l('Remove artist') }
 sub edit_type { $EDIT_ARTIST_DELETE }

--- a/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Edit.pm
@@ -28,16 +28,16 @@ use aliased 'MusicBrainz::Server::Entity::Area';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::Artist';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::IPI';
-with 'MusicBrainz::Server::Edit::Role::ISNI';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_ARTIST_CREATE,
-    entity_type => 'artist',
-};
+with 'MusicBrainz::Server::Edit::Artist',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::IPI',
+     'MusicBrainz::Server::Edit::Role::ISNI',
+     'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_ARTIST_CREATE,
+        entity_type => 'artist',
+     };
 
 sub edit_name { N_l('Edit artist') }
 sub edit_type { $EDIT_ARTIST_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Artist/EditArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/EditArtistCredit.pm
@@ -20,8 +20,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Artist';
-with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+with 'MusicBrainz::Server::Edit::Artist',
+     'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
 
 sub edit_name { N_l('Edit artist credit') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Artist/Merge.pm
@@ -10,8 +10,8 @@ use MusicBrainz::Server::Translation qw( N_l );
 use Hash::Merge qw( merge );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
-with 'MusicBrainz::Server::Edit::Role::MergeSubscription';
-with 'MusicBrainz::Server::Edit::Artist';
+with 'MusicBrainz::Server::Edit::Role::MergeSubscription',
+     'MusicBrainz::Server::Edit::Artist';
 
 sub edit_name { N_l('Merge artists') }
 sub edit_type { $EDIT_ARTIST_MERGE }

--- a/lib/MusicBrainz/Server/Edit/Event/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Create.pm
@@ -15,10 +15,10 @@ use MooseX::Types::Structured qw( Dict );
 use aliased 'MusicBrainz::Server::Entity::Event';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Event';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Event',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Add event') }
 sub edit_type { $EDIT_EVENT_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Event/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Event/Edit.pm
@@ -29,13 +29,13 @@ use aliased 'MusicBrainz::Server::Entity::Event';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Event';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_EVENT_CREATE,
-    entity_type => 'event',
-};
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Event',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_EVENT_CREATE,
+        entity_type => 'event',
+     },
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_name { N_l('Edit event') }
 sub edit_type { $EDIT_EVENT_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Genre/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Create.pm
@@ -14,9 +14,9 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Genre';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Genre';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Genre',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add genre') }
 sub edit_type { $EDIT_GENRE_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Genre/Edit.pm
@@ -15,9 +15,9 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Genre';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Genre';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Genre',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit genre') }
 sub edit_type { $EDIT_GENRE_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Create.pm
@@ -13,9 +13,9 @@ use MooseX::Types::Structured qw( Dict );
 use aliased 'MusicBrainz::Server::Entity::Instrument';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Instrument';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Instrument',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add instrument') }
 sub edit_type { $EDIT_INSTRUMENT_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Instrument/Edit.pm
@@ -19,9 +19,9 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Instrument';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Instrument';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Instrument',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit instrument') }
 sub edit_type { $EDIT_INSTRUMENT_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Label/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Create.pm
@@ -12,15 +12,17 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Label';
-with 'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
-    editor_subscription_preference => sub { shift->subscribe_to_created_labels },
-};
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Label',
+     'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
+        editor_subscription_preference => sub {
+            shift->subscribe_to_created_labels;
+        },
+     },
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 use aliased 'MusicBrainz::Server::Entity::Label';
 use aliased 'MusicBrainz::Server::Entity::Area';

--- a/lib/MusicBrainz/Server/Edit/Label/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_LABEL_DELETE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::Role::DeleteSubscription';
-with 'MusicBrainz::Server::Edit::Label';
+with 'MusicBrainz::Server::Edit::Role::DeleteSubscription',
+     'MusicBrainz::Server::Edit::Label';
 
 sub edit_type { $EDIT_LABEL_DELETE }
 sub edit_name { N_l('Remove label') }

--- a/lib/MusicBrainz/Server/Edit/Label/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Edit.pm
@@ -27,16 +27,16 @@ use aliased 'MusicBrainz::Server::Entity::Label';
 use aliased 'MusicBrainz::Server::Entity::Area';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::Label';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::IPI';
-with 'MusicBrainz::Server::Edit::Role::ISNI';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_LABEL_CREATE,
-    entity_type => 'label',
-};
+with 'MusicBrainz::Server::Edit::Label',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::IPI',
+     'MusicBrainz::Server::Edit::Role::ISNI',
+     'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_LABEL_CREATE,
+        entity_type => 'label',
+     };
 
 sub edit_type { $EDIT_LABEL_EDIT }
 sub edit_name { N_l('Edit label') }

--- a/lib/MusicBrainz/Server/Edit/Label/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Label/Merge.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_LABEL_MERGE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
-with 'MusicBrainz::Server::Edit::Role::MergeSubscription';
-with 'MusicBrainz::Server::Edit::Label';
+with 'MusicBrainz::Server::Edit::Role::MergeSubscription',
+     'MusicBrainz::Server::Edit::Label';
 
 sub edit_type { $EDIT_LABEL_MERGE }
 sub edit_name { N_l('Merge labels') }

--- a/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/AddDiscID.pm
@@ -21,11 +21,11 @@ use aliased 'MusicBrainz::Server::Entity::MediumCDTOC';
 use aliased 'MusicBrainz::Server::Entity::Release';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Medium::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 has '+data' => (
     isa => Dict[

--- a/lib/MusicBrainz/Server/Edit/Medium/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Create.pm
@@ -17,13 +17,13 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASE_CREATE,
-    entity_type => 'release',
-};
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Medium::RelatedEntities',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASE_CREATE,
+        entity_type => 'release',
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 

--- a/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Delete.pm
@@ -11,10 +11,10 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Medium::RelatedEntities',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Medium';

--- a/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/Edit.pm
@@ -36,13 +36,13 @@ use JSON::XS;
 use Try::Tiny;
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASE_CREATE,
-    entity_type => 'release',
-};
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Medium::RelatedEntities',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASE_CREATE,
+        entity_type => 'release',
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Medium';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/MoveDiscID.pm
@@ -10,8 +10,8 @@ use MooseX::Types::Moose qw( Int Str );
 use MooseX::Types::Structured qw( Dict );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 use aliased 'MusicBrainz::Server::Entity::MediumCDTOC';

--- a/lib/MusicBrainz/Server/Edit/Medium/RemoveDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/RemoveDiscID.pm
@@ -13,9 +13,9 @@ sub edit_kind { 'remove' }
 sub edit_template { 'RemoveDiscId' }
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Medium::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+with 'MusicBrainz::Server::Edit::Medium::RelatedEntities',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::CDTOC';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
+++ b/lib/MusicBrainz/Server/Edit/Medium/SetTrackLengths.pm
@@ -16,9 +16,9 @@ use aliased 'MusicBrainz::Server::Entity::MediumCDTOC';
 use aliased 'MusicBrainz::Server::Entity::Release';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Medium';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Medium',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Set track lengths') }
 sub edit_type { $EDIT_SET_TRACK_LENGTHS }

--- a/lib/MusicBrainz/Server/Edit/Place/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Create.pm
@@ -17,11 +17,11 @@ use aliased 'MusicBrainz::Server::Entity::Place';
 use aliased 'MusicBrainz::Server::Entity::Area';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Place';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Place',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
 
 sub edit_name { N_l('Add place') }
 sub edit_type { $EDIT_PLACE_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Place/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Place/Edit.pm
@@ -31,14 +31,14 @@ use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use aliased 'MusicBrainz::Server::Entity::Coordinates';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Place';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_PLACE_CREATE,
-    entity_type => 'place',
-};
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+with 'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Place',
+     'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_PLACE_CREATE,
+        entity_type => 'place',
+     },
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
 
 sub edit_name { N_l('Edit place') }
 sub edit_type { $EDIT_PLACE_EDIT }

--- a/lib/MusicBrainz/Server/Edit/Recording/AddAnnotation.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/AddAnnotation.pm
@@ -5,13 +5,12 @@ use MusicBrainz::Server::Constants qw( $EDIT_RECORDING_ADD_ANNOTATION );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
-
-with 'MusicBrainz::Server::Edit::Annotation::Edit' => {
-    model => 'Recording',
-    edit_name => N_l('Add recording annotation'),
-    edit_type => $EDIT_RECORDING_ADD_ANNOTATION,
-};
+with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
+     'MusicBrainz::Server::Edit::Annotation::Edit' => {
+        model => 'Recording',
+        edit_name => N_l('Add recording annotation'),
+        edit_type => $EDIT_RECORDING_ADD_ANNOTATION,
+     };
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Recording/AddISRCs.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/AddISRCs.pm
@@ -11,10 +11,10 @@ use MusicBrainz::Server::Edit::Exceptions;
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Recording::RelatedEntities' => {
-    -excludes => 'recording_ids',
-};
-with 'MusicBrainz::Server::Edit::Recording';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+        -excludes => 'recording_ids',
+     },
+     'MusicBrainz::Server::Edit::Recording',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::Recording';
 use aliased 'MusicBrainz::Server::Entity::ISRC';

--- a/lib/MusicBrainz/Server/Edit/Recording/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Create.pm
@@ -18,9 +18,9 @@ use MusicBrainz::Server::Translation qw( N_l );
 use aliased 'MusicBrainz::Server::Entity::Recording';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Recording';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
+     'MusicBrainz::Server::Edit::Recording',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_type { $EDIT_RECORDING_CREATE }
 sub edit_name { N_l('Add standalone recording') }

--- a/lib/MusicBrainz/Server/Edit/Recording/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_RECORDING_DELETE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::Recording';
-with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
+with 'MusicBrainz::Server::Edit::Recording',
+     'MusicBrainz::Server::Edit::Recording::RelatedEntities';
 
 sub edit_type { $EDIT_RECORDING_DELETE }
 sub edit_name { N_l('Remove recording') }

--- a/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Edit.pm
@@ -27,15 +27,15 @@ use MusicBrainz::Server::Track;
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Recording';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RECORDING_CREATE,
-    entity_type => 'recording',
-};
-with 'MusicBrainz::Server::Edit::Role::EditArtistCredit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
+with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
+     'MusicBrainz::Server::Edit::Recording',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RECORDING_CREATE,
+        entity_type => 'recording',
+     },
+     'MusicBrainz::Server::Edit::Role::EditArtistCredit',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::CheckForConflicts';
 
 use aliased 'MusicBrainz::Server::Entity::Recording';
 

--- a/lib/MusicBrainz/Server/Edit/Recording/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/Merge.pm
@@ -8,9 +8,9 @@ use MusicBrainz::Server::Edit::Utils qw( large_spread );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
 with 'MusicBrainz::Server::Edit::Recording::RelatedEntities' => {
-    -excludes => 'recording_ids',
-};
-with 'MusicBrainz::Server::Edit::Recording';
+        -excludes => 'recording_ids',
+     },
+     'MusicBrainz::Server::Edit::Recording';
 
 sub edit_name { N_l('Merge recordings') }
 sub edit_type { $EDIT_RECORDING_MERGE }

--- a/lib/MusicBrainz/Server/Edit/Recording/RemoveISRC.pm
+++ b/lib/MusicBrainz/Server/Edit/Recording/RemoveISRC.pm
@@ -11,12 +11,12 @@ use aliased 'MusicBrainz::Server::Entity::Recording';
 use aliased 'MusicBrainz::Server::Entity::ISRC';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Recording::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Recording';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RECORDING_CREATE,
-    entity_type => 'recording',
-};
+with 'MusicBrainz::Server::Edit::Recording::RelatedEntities',
+     'MusicBrainz::Server::Edit::Recording',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RECORDING_CREATE,
+        entity_type => 'recording',
+     };
 
 sub edit_name { N_l('Remove ISRC') }
 sub edit_kind { 'remove' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/AddLinkAttribute.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/AddLinkAttribute.pm
@@ -9,9 +9,9 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add relationship attribute') }
 sub edit_kind { 'add' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/AddLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/AddLinkType.pm
@@ -8,9 +8,9 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add relationship type') }
 sub edit_kind { 'add' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -6,11 +6,11 @@ use MusicBrainz::Server::Edit::Types qw( LinkAttributesArray PartialDateHash Nul
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Role::DatePeriod',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use MooseX::Types::Moose qw( Bool Int Str );
 use MooseX::Types::Structured qw( Dict Optional );

--- a/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Delete.pm
@@ -28,9 +28,9 @@ use MusicBrainz::Server::Entity::PartialDate;
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::Preview';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::Preview';
 
 sub edit_type { $EDIT_RELATIONSHIP_DELETE }
 sub edit_name { N_l('Remove relationship') }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Edit.pm
@@ -31,10 +31,10 @@ use aliased 'MusicBrainz::Server::Entity::Relationship';
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Role::DatePeriod';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Relationship::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Role::DatePeriod';
 
 sub edit_type { $EDIT_RELATIONSHIP_EDIT }
 sub edit_name { N_l('Edit relationship') }

--- a/lib/MusicBrainz/Server/Edit/Relationship/EditLinkAttribute.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/EditLinkAttribute.pm
@@ -11,8 +11,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit relationship attribute') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/EditLinkType.pm
@@ -17,8 +17,8 @@ use Scalar::Util qw( looks_like_number );
 use aliased 'MusicBrainz::Server::Entity::LinkType';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit relationship type') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkAttribute.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkAttribute.pm
@@ -7,8 +7,8 @@ use MusicBrainz::Server::Edit::Types qw( Nullable );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Remove relationship attribute') }
 sub edit_kind { 'remove' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkType.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/RemoveLinkType.pm
@@ -8,8 +8,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( l N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Remove relationship type') }
 sub edit_kind { 'remove' }

--- a/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Reorder.pm
@@ -19,16 +19,15 @@ use aliased 'MusicBrainz::Server::Entity::LinkAttribute';
 use aliased 'MusicBrainz::Server::Entity::Relationship';
 
 extends 'MusicBrainz::Server::Edit';
+with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Relationship',
+     'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
 
 sub edit_name { N_l('Reorder relationships') }
 sub edit_kind { 'other' }
 sub edit_type { $EDIT_RELATIONSHIPS_REORDER }
 sub edit_template { 'ReorderRelationships' }
-
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Relationship';
-with 'MusicBrainz::Server::Edit::Relationship::RelatedEntities';
 
 subtype 'LinkTypeHash'
     => as Dict[

--- a/lib/MusicBrainz/Server/Edit/Release/AddAnnotation.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddAnnotation.pm
@@ -5,13 +5,12 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_ADD_ANNOTATION );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-
-with 'MusicBrainz::Server::Edit::Annotation::Edit' => {
-    model => 'Release',
-    edit_name => N_l('Add release annotation'),
-    edit_type => $EDIT_RELEASE_ADD_ANNOTATION,
-};
+with 'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Annotation::Edit' => {
+        model => 'Release',
+        edit_name => N_l('Add release annotation'),
+        edit_type => $EDIT_RELEASE_ADD_ANNOTATION,
+     };
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddCoverArt.pm
@@ -14,9 +14,9 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::CoverArt';
+with 'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::CoverArt';
 
 sub edit_name { N_l('Add cover art') }
 sub edit_kind { 'add' }

--- a/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/AddReleaseLabel.pm
@@ -10,11 +10,11 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Add release label') }
 sub edit_kind { 'add' }

--- a/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ChangeQuality.pm
@@ -14,12 +14,12 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASE_CREATE,
-    entity_type => 'release',
-};
+with 'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASE_CREATE,
+        entity_type => 'release',
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 

--- a/lib/MusicBrainz/Server/Edit/Release/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Create.pm
@@ -19,10 +19,10 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( l N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::PartialDate';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Release/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_DELETE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
+with 'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release';
 
 sub edit_type { $EDIT_RELEASE_DELETE }
 sub edit_name { N_l('Remove release') }

--- a/lib/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/DeleteReleaseLabel.pm
@@ -13,10 +13,10 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Label';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Remove release label') }
 sub edit_kind { 'remove' }

--- a/lib/MusicBrainz/Server/Edit/Release/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Edit.pm
@@ -31,15 +31,15 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::Role::EditArtistCredit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASE_CREATE,
-    entity_type => 'release',
-};
+with 'MusicBrainz::Server::Edit::Role::EditArtistCredit',
+     'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASE_CREATE,
+        entity_type => 'release',
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 

--- a/lib/MusicBrainz/Server/Edit/Release/EditArtist.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditArtist.pm
@@ -18,13 +18,13 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASE_CREATE,
-    entity_type => 'release',
-};
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASE_CREATE,
+        entity_type => 'release',
+     };
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 

--- a/lib/MusicBrainz/Server/Edit/Release/EditBarcodes.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditBarcodes.pm
@@ -10,9 +10,9 @@ use MooseX::Types::Moose qw( ArrayRef Int Str );
 use MooseX::Types::Structured qw( Dict );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+with 'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::Barcode';
 use aliased 'MusicBrainz::Server::Entity::Release';

--- a/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditCoverArt.pm
@@ -15,10 +15,10 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::CoverArt';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::CoverArt',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit cover art') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/EditReleaseLabel.pm
@@ -18,11 +18,11 @@ use MusicBrainz::Server::Entity::Util::MediumFormat qw( combined_medium_format_n
 use Scalar::Util qw( looks_like_number );
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Edit release label') }
 sub edit_kind { 'edit' }

--- a/lib/MusicBrainz/Server/Edit/Release/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/Merge.pm
@@ -21,9 +21,9 @@ use MooseX::Types::Structured qw( Dict Optional );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
 with 'MusicBrainz::Server::Edit::Release::RelatedEntities' => {
-    -excludes => 'release_ids',
-};
-with 'MusicBrainz::Server::Edit::Release';
+        -excludes => 'release_ids',
+     },
+     'MusicBrainz::Server::Edit::Release';
 
 use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Medium';

--- a/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/RemoveCoverArt.pm
@@ -13,10 +13,10 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::CoverArt';
-with 'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
+with 'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::CoverArt',
+     'MusicBrainz::Server::Edit::Role::NeverAutoEdit';
 
 sub edit_name { N_l('Remove cover art') }
 sub edit_kind { 'remove' }

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderCoverArt.pm
@@ -17,9 +17,9 @@ use aliased 'MusicBrainz::Server::Entity::Release';
 use aliased 'MusicBrainz::Server::Entity::Artwork';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Reorder cover art') }
 sub edit_kind { 'other' }

--- a/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
+++ b/lib/MusicBrainz/Server/Edit/Release/ReorderMediums.pm
@@ -10,18 +10,17 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASE_REORDER_MEDIUMS );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Release::RelatedEntities',
+     'MusicBrainz::Server::Edit::Release',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+
+use aliased 'MusicBrainz::Server::Entity::Release';
 
 sub edit_name { N_l('Reorder mediums') }
 sub edit_kind { 'other' }
 sub edit_type { $EDIT_RELEASE_REORDER_MEDIUMS }
 sub edit_template { 'ReorderMediums' }
-
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Release::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Release';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-
-use aliased 'MusicBrainz::Server::Entity::Release';
 
 sub release_id { shift->data->{release}{id} }
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/AddAnnotation.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/AddAnnotation.pm
@@ -5,13 +5,12 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASEGROUP_ADD_ANNOTATION );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
-
-with 'MusicBrainz::Server::Edit::Annotation::Edit' => {
-    model => 'ReleaseGroup',
-    edit_name => N_l('Add release group annotation'),
-    edit_type => $EDIT_RELEASEGROUP_ADD_ANNOTATION,
-};
+with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
+     'MusicBrainz::Server::Edit::Annotation::Edit' => {
+        model => 'ReleaseGroup',
+        edit_name => N_l('Add release group annotation'),
+        edit_type => $EDIT_RELEASEGROUP_ADD_ANNOTATION,
+     };
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Create.pm
@@ -18,10 +18,10 @@ use MusicBrainz::Server::Translation qw( N_l );
 use Scalar::Util qw( looks_like_number );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
-with 'MusicBrainz::Server::Edit::ReleaseGroup';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
+     'MusicBrainz::Server::Edit::ReleaseGroup',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::ReleaseGroup';
 

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_RELEASEGROUP_DELETE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
-with 'MusicBrainz::Server::Edit::ReleaseGroup';
+with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
+     'MusicBrainz::Server::Edit::ReleaseGroup';
 
 sub edit_type { $EDIT_RELEASEGROUP_DELETE }
 sub edit_name { N_l('Remove release group') }

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Edit.pm
@@ -28,15 +28,15 @@ use Scalar::Util qw( looks_like_number );
 use aliased 'MusicBrainz::Server::Entity::ReleaseGroup';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
-with 'MusicBrainz::Server::Edit::ReleaseGroup';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_RELEASEGROUP_CREATE,
-    entity_type => 'release_group',
-};
-with 'MusicBrainz::Server::Edit::Role::EditArtistCredit';
-with 'MusicBrainz::Server::Edit::Role::Preview';
+with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
+     'MusicBrainz::Server::Edit::ReleaseGroup',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_RELEASEGROUP_CREATE,
+        entity_type => 'release_group',
+     },
+     'MusicBrainz::Server::Edit::Role::EditArtistCredit',
+     'MusicBrainz::Server::Edit::Role::Preview';
 
 sub edit_type { $EDIT_RELEASEGROUP_EDIT }
 sub edit_name { N_l('Edit release group') }

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/Merge.pm
@@ -6,9 +6,9 @@ use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
 with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities' => {
-    -excludes => 'release_group_ids',
-};
-with 'MusicBrainz::Server::Edit::ReleaseGroup';
+        -excludes => 'release_group_ids',
+     },
+     'MusicBrainz::Server::Edit::ReleaseGroup';
 
 sub edit_name { N_l('Merge release groups') }
 sub edit_type { $EDIT_RELEASEGROUP_MERGE }

--- a/lib/MusicBrainz/Server/Edit/ReleaseGroup/SetCoverArt.pm
+++ b/lib/MusicBrainz/Server/Edit/ReleaseGroup/SetCoverArt.pm
@@ -13,9 +13,9 @@ use MusicBrainz::Server::Translation qw( N_l );
 use aliased 'MusicBrainz::Server::Entity::ReleaseGroup';
 
 extends 'MusicBrainz::Server::Edit::WithDifferences';
-with 'MusicBrainz::Server::Edit::ReleaseGroup';
-with 'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::ReleaseGroup',
+     'MusicBrainz::Server::Edit::ReleaseGroup::RelatedEntities',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_name { N_l('Set cover art') }
 sub edit_kind { 'other' }

--- a/lib/MusicBrainz/Server/Edit/Series/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Create.pm
@@ -10,14 +10,16 @@ use MooseX::Types::Structured qw( Dict );
 use aliased 'MusicBrainz::Server::Entity::Series';
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Role::Preview';
-with 'MusicBrainz::Server::Edit::Series';
-with 'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
-    editor_subscription_preference => sub { shift->subscribe_to_created_series },
-};
-with 'MusicBrainz::Server::Edit::Role::Insert';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+with 'MusicBrainz::Server::Edit::Role::Preview',
+     'MusicBrainz::Server::Edit::Series',
+     'MusicBrainz::Server::Edit::Role::SubscribeOnCreation' => {
+        editor_subscription_preference => sub {
+            shift->subscribe_to_created_series;
+        },
+     },
+     'MusicBrainz::Server::Edit::Role::Insert',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit',
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
 
 sub edit_name { N_l('Add series') }
 sub edit_type { $EDIT_SERIES_CREATE }

--- a/lib/MusicBrainz/Server/Edit/Series/Delete.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Delete.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_SERIES_DELETE );
 use MusicBrainz::Server::Translation qw ( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Delete';
-with 'MusicBrainz::Server::Edit::Role::DeleteSubscription';
-with 'MusicBrainz::Server::Edit::Series';
+with 'MusicBrainz::Server::Edit::Role::DeleteSubscription',
+     'MusicBrainz::Server::Edit::Series';
 
 sub edit_type { $EDIT_SERIES_DELETE }
 sub edit_name { N_l('Remove series') }

--- a/lib/MusicBrainz/Server/Edit/Series/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Edit.pm
@@ -18,13 +18,13 @@ use MooseX::Types::Structured qw( Dict Optional );
 use aliased 'MusicBrainz::Server::Entity::Series';
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::Series';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_SERIES_CREATE,
-    entity_type => 'series',
-};
-with 'MusicBrainz::Server::Edit::Role::CheckDuplicates';
+with 'MusicBrainz::Server::Edit::Series',
+     'MusicBrainz::Server::Edit::CheckForConflicts',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_SERIES_CREATE,
+        entity_type => 'series',
+     },
+     'MusicBrainz::Server::Edit::Role::CheckDuplicates';
 
 sub edit_type { $EDIT_SERIES_EDIT }
 sub edit_name { N_l('Edit series') }

--- a/lib/MusicBrainz/Server/Edit/Series/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Series/Merge.pm
@@ -4,8 +4,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_SERIES_MERGE );
 use MusicBrainz::Server::Translation qw ( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
-with 'MusicBrainz::Server::Edit::Role::MergeSubscription';
-with 'MusicBrainz::Server::Edit::Series';
+with 'MusicBrainz::Server::Edit::Role::MergeSubscription',
+     'MusicBrainz::Server::Edit::Series';
 
 sub edit_type { $EDIT_SERIES_MERGE }
 sub edit_name { N_l('Merge series') }

--- a/lib/MusicBrainz/Server/Edit/URL/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit/URL/Edit.pm
@@ -17,9 +17,9 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Edit';
-with 'MusicBrainz::Server::Edit::URL';
-with 'MusicBrainz::Server::Edit::URL::RelatedEntities';
-with 'MusicBrainz::Server::Edit::CheckForConflicts';
+with 'MusicBrainz::Server::Edit::URL',
+     'MusicBrainz::Server::Edit::URL::RelatedEntities',
+     'MusicBrainz::Server::Edit::CheckForConflicts';
 
 use aliased 'MusicBrainz::Server::Entity::URL';
 

--- a/lib/MusicBrainz/Server/Edit/WikiDoc/Change.pm
+++ b/lib/MusicBrainz/Server/Edit/WikiDoc/Change.pm
@@ -9,8 +9,8 @@ use MooseX::Types::Moose qw( Int Str );
 use MooseX::Types::Structured qw( Dict );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::WikiDoc';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::WikiDoc',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 sub edit_type { $EDIT_WIKIDOC_CHANGE }
 sub edit_name { N_l('Change WikiDoc') }

--- a/lib/MusicBrainz/Server/Edit/Work/AddAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/AddAlias.pm
@@ -5,13 +5,12 @@ use MusicBrainz::Server::Constants qw( $EDIT_WORK_ADD_ALIAS );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-
-with 'MusicBrainz::Server::Edit::Alias::Add' => {
-    model => 'Work',
-    edit_name => N_l('Add work alias'),
-    edit_type => $EDIT_WORK_ADD_ALIAS,
-};
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Alias::Add' => {
+        model => 'Work',
+        edit_name => N_l('Add work alias'),
+        edit_type => $EDIT_WORK_ADD_ALIAS,
+     };
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Work/AddAnnotation.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/AddAnnotation.pm
@@ -5,13 +5,12 @@ use MusicBrainz::Server::Constants qw( $EDIT_WORK_ADD_ANNOTATION );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-
-with 'MusicBrainz::Server::Edit::Annotation::Edit' => {
-    model => 'Work',
-    edit_name => N_l('Add work annotation'),
-    edit_type => $EDIT_WORK_ADD_ANNOTATION,
-};
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Annotation::Edit' => {
+        model => 'Work',
+        edit_name => N_l('Add work annotation'),
+        edit_type => $EDIT_WORK_ADD_ANNOTATION,
+     };
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/MusicBrainz/Server/Edit/Work/AddISWCs.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/AddISWCs.pm
@@ -9,10 +9,10 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 
 extends 'MusicBrainz::Server::Edit';
 with 'MusicBrainz::Server::Edit::Work::RelatedEntities' => {
-    -excludes => 'work_ids',
-};
-with 'MusicBrainz::Server::Edit::Work';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+        -excludes => 'work_ids',
+     },
+     'MusicBrainz::Server::Edit::Work',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::Work';
 use aliased 'MusicBrainz::Server::Entity::ISWC';

--- a/lib/MusicBrainz/Server/Edit/Work/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Create.pm
@@ -9,9 +9,9 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Create';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Work';
-with 'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Work',
+     'MusicBrainz::Server::Edit::Role::AlwaysAutoEdit';
 
 use aliased 'MusicBrainz::Server::Entity::Work';
 

--- a/lib/MusicBrainz/Server/Edit/Work/DeleteAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/DeleteAlias.pm
@@ -6,8 +6,8 @@ use MusicBrainz::Server::Entity::Util::JSON qw( to_json_object );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Alias::Delete';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Work';
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Work';
 
 use aliased 'MusicBrainz::Server::Entity::Work';
 

--- a/lib/MusicBrainz/Server/Edit/Work/EditAlias.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/EditAlias.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_WORK_EDIT_ALIAS );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Alias::Edit';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Work';
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Work';
 
 sub _alias_model { shift->c->model('Work')->alias }
 

--- a/lib/MusicBrainz/Server/Edit/Work/Merge.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/Merge.pm
@@ -5,8 +5,8 @@ use MusicBrainz::Server::Constants qw( $EDIT_WORK_MERGE );
 use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Edit::Generic::Merge';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Work';
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Work';
 
 sub edit_type { $EDIT_WORK_MERGE }
 sub edit_name { N_l('Merge works') }

--- a/lib/MusicBrainz/Server/Edit/Work/RemoveISWC.pm
+++ b/lib/MusicBrainz/Server/Edit/Work/RemoveISWC.pm
@@ -13,12 +13,12 @@ use aliased 'MusicBrainz::Server::Entity::Work';
 use aliased 'MusicBrainz::Server::Entity::ISWC';
 
 extends 'MusicBrainz::Server::Edit';
-with 'MusicBrainz::Server::Edit::Work::RelatedEntities';
-with 'MusicBrainz::Server::Edit::Work';
-with 'MusicBrainz::Server::Edit::Role::AllowAmending' => {
-    create_edit_type => $EDIT_WORK_CREATE,
-    entity_type => 'work',
-};
+with 'MusicBrainz::Server::Edit::Work::RelatedEntities',
+     'MusicBrainz::Server::Edit::Work',
+     'MusicBrainz::Server::Edit::Role::AllowAmending' => {
+        create_edit_type => $EDIT_WORK_CREATE,
+        entity_type => 'work',
+     };
 
 sub edit_name { N_l('Remove ISWC') }
 sub edit_kind { 'remove' }


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::Moose::ProhibitMultipleWiths

Since this involves a lot of files, doing it in parts to ensure it's easier to find what broke if something does - this just for Edit::

On top of https://github.com/metabrainz/musicbrainz-server/pull/2751