### PR TITLE
MBS-12727: Show genre alias connections for tags

### DIFF
--- a/lib/MusicBrainz/Server/Data/Search.pm
+++ b/lib/MusicBrainz/Server/Data/Search.pm
@@ -319,11 +319,17 @@ sub search
             SQL
 
         $use_hard_search_limit = 0;
-    } elsif ($type eq 'tag') {
+    }
+
+    elsif ($type eq 'tag') {
         $query = <<~'SQL';
-            SELECT tag.id, tag.name, genre.id AS genre_id,
+            SELECT tag.id,
+                   tag.name,
+                   coalesce(genre.id, genre_alias.genre) AS genre_id,
                    ts_rank_cd(mb_simple_tsvector(tag.name), query, 2) AS rank
-            FROM tag LEFT JOIN genre USING (name), plainto_tsquery('mb_simple', mb_lower(?)) AS query
+            FROM tag
+            LEFT JOIN genre USING (name)
+            LEFT JOIN genre_alias USING (name), plainto_tsquery('mb_simple', mb_lower(?)) AS query
             WHERE mb_simple_tsvector(tag.name) @@ query
             ORDER BY rank DESC, tag.name
             OFFSET ?

--- a/lib/MusicBrainz/Server/Data/Tag.pm
+++ b/lib/MusicBrainz/Server/Data/Tag.pm
@@ -16,7 +16,9 @@ sub _type { 'tag' }
 
 sub _table
 {
-    return 'tag LEFT JOIN genre USING (name)';
+    return 'tag
+            LEFT JOIN genre USING (name)
+            LEFT JOIN genre_alias USING (name)';
 }
 
 sub _id_column
@@ -26,7 +28,9 @@ sub _id_column
 
 sub _columns
 {
-    return 'tag.id, tag.name, genre.id as genre_id';
+    return 'tag.id,
+            tag.name,
+            coalesce(genre.id, genre_alias.genre) as genre_id';
 }
 
 sub _column_mapping


### PR DESCRIPTION
### Implement MBS-12727

While using genre aliases for actual genre tagging requires quite a bit of effort, mostly to come up with a sensible UI, there's no reason I can see why we shouldn't be showing the tag/genre associations from aliases on search results and the `/tag` page.

### Testing
`/search?query=rap&type=tag` shows "hip hop" as the genre, `/tag/rap` shows "This tag is associated with the genre [hip hop](http://reolappy:5000/genre/52faa157-6bad-4d86-a0ab-d4dec7d2513c)."