### PR TITLE
Fix an ISE when displaying Audiomack link in the sidebar

### DIFF
--- a/lib/MusicBrainz/Server/Entity/URL/Audiomack.pm
+++ b/lib/MusicBrainz/Server/Entity/URL/Audiomack.pm
@@ -2,6 +2,8 @@ package MusicBrainz::Server::Entity::URL::Audiomack;
 
 use Moose;
 
+use MusicBrainz::Server::Translation qw( l );
+
 extends 'MusicBrainz::Server::Entity::URL';
 with 'MusicBrainz::Server::Entity::URL::Sidebar';
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

ISE when displaying a page with Audiomack URL in the sidebar

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Amend #2743 by importing the missing `l` sub from `Translation` package.


# Checklist for author

* [x] Tested locally by adding such link to a random artist and visiting its page