### PR TITLE
MBS-12630: Make the relationship type autocompletes more compact

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -18,6 +18,7 @@ import {
 import useOutsideClickEffect from '../hooks/useOutsideClickEffect.js';
 import {unwrapNl} from '../i18n.js';
 import clean from '../utility/clean.js';
+import getCookie from '../utility/getCookie.js';
 
 import {
   CLOSE_ADD_ENTITY_DIALOG,
@@ -34,7 +35,9 @@ import {
   ARIA_LIVE_STYLE,
   SEARCH_PLACEHOLDERS,
 } from './Autocomplete2/constants.js';
-import formatItem from './Autocomplete2/formatters.js';
+import formatItem, {
+  type FormatOptionsT,
+} from './Autocomplete2/formatters.js';
 import {getOrFetchRecentItems} from './Autocomplete2/recentItems.js';
 import {
   generateItems,
@@ -201,6 +204,8 @@ export function createInitialState<+T: EntityItemT>(
     recentItemsKey: recentItemsKey ?? entityType,
     results: staticResults,
     selectedItem: selectedItem ?? null,
+    showDescriptions:
+      getCookie('show_autocomplete_descriptions') !== 'false',
     staticItems,
     statusMessage: '',
     totalPages: null,
@@ -215,6 +220,7 @@ export function createInitialState<+T: EntityItemT>(
 
 type AutocompleteItemPropsT<T: EntityItemT> = {
   autocompleteId: string,
+  formatOptions?: ?FormatOptionsT,
   isHighlighted: boolean,
   isSelected: boolean,
   item: ItemT<T>,
@@ -223,6 +229,7 @@ type AutocompleteItemPropsT<T: EntityItemT> = {
 
 const AutocompleteItem = React.memo(<+T: EntityItemT>({
   autocompleteId,
+  formatOptions,
   isHighlighted,
   isSelected,
   item,
@@ -276,7 +283,7 @@ const AutocompleteItem = React.memo(<+T: EntityItemT>({
       role="option"
       style={style}
     >
-      {formatItem<T>(item)}
+      {formatItem<T>(item, formatOptions)}
     </li>
   );
 });
@@ -657,6 +664,14 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     () => items.map((item) => (
       <AutocompleteItemWithType
         autocompleteId={id}
+        formatOptions={
+          (
+            entityType === 'link_attribute_type' ||
+            entityType === 'link_type'
+          )
+            ? {showDescriptions: state.showDescriptions}
+            : undefined
+        }
         isHighlighted={!!(highlightedItem && item.id === highlightedItem.id)}
         isSelected={!!(
           selectedItem &&
@@ -669,11 +684,13 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
       />
     )),
     [
+      entityType,
       highlightedItem,
       id,
       items,
       selectItem,
       selectedItem,
+      state.showDescriptions,
     ],
   );
 

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -16,6 +16,7 @@ import {
   isLocationEditor,
   isRelationshipEditor,
 } from '../../utility/privileges.js';
+import setCookie from '../../utility/setCookie.js';
 
 import {
   OPEN_ADD_ENTITY_DIALOG,
@@ -94,9 +95,11 @@ export function generateItems<+T: EntityItemT>(
   }
 
   const {
+    entityType,
     page,
     recentItems,
     results,
+    showDescriptions = true,
   } = state;
 
   const isInputValueNonEmpty = nonEmpty(state.inputValue);
@@ -138,6 +141,25 @@ export function generateItems<+T: EntityItemT>(
 
       if (page < totalPages) {
         items.push(MENU_ITEMS.SHOW_MORE);
+      }
+
+      if (
+        entityType === 'link_attribute_type' ||
+        entityType === 'link_type'
+      ) {
+        items.push({
+          type: 'action',
+          action: {
+            showDescriptions: !showDescriptions,
+            type: 'toggle-descriptions',
+          },
+          id: 'toggle-descriptions',
+          name:
+            showDescriptions
+              ? l('Hide descriptions')
+              : l('Show descriptions'),
+          separator: true,
+        });
       }
     } else if (isInputValueNonEmpty && !hasSelection) {
       items.push(MENU_ITEMS.NO_RESULTS);
@@ -506,6 +528,12 @@ export function runReducer<+T: EntityItemT>(
     case 'stop-search':
       state.pendingSearch = null;
       break;
+
+    case 'toggle-descriptions': {
+      state.showDescriptions = action.showDescriptions;
+      setCookie('show_autocomplete_descriptions', state.showDescriptions);
+      break;
+    }
 
     case 'toggle-indexed-search':
       state.indexedSearch = !state.indexedSearch;

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -38,6 +38,7 @@ export type StateT<T: EntityItemT> = {
   +recentItemsKey: string,
   +results: $ReadOnlyArray<ItemT<T>> | null,
   +selectedItem: OptionItemT<T> | null,
+  +showDescriptions?: boolean,
   +staticItems?: $ReadOnlyArray<OptionItemT<T>>,
   +statusMessage: string,
   +totalPages: ?number,
@@ -84,6 +85,10 @@ export type ActionT<+T: EntityItemT> =
   | { +type: 'stop-search' }
   | { +type: 'toggle-add-entity-dialog', +isOpen: boolean }
   | { +type: 'toggle-indexed-search' }
+  | {
+      +type: 'toggle-descriptions',
+      +showDescriptions: boolean,
+    }
   | { +type: 'type-value', +value: string };
 
 export type ActionItemT<+T> = {

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -20,9 +20,7 @@ import type {
   PropsT as AutocompletePropsT,
 } from '../../common/components/Autocomplete2/types.js';
 import {PART_OF_SERIES_LINK_TYPE_IDS} from '../../common/constants.js';
-import expand2react from '../../common/i18n/expand2react.js';
 import linkedEntities from '../../common/linkedEntities.mjs';
-import bracketed from '../../common/utility/bracketed.js';
 import isBlank from '../../common/utility/isBlank.js';
 import {stripAttributes} from '../../edit/utility/linkPhrase.js';
 import type {
@@ -261,15 +259,6 @@ const DialogLinkType = (React.memo<PropsT>(({
     error,
   } = state;
 
-  const linkType = autocomplete.selectedItem?.entity;
-
-  const [isHelpVisible, setHelpVisible] = React.useState(false);
-
-  function toggleHelp(event: SyntheticEvent<HTMLAnchorElement>) {
-    event.preventDefault();
-    setHelpVisible(!isHelpVisible);
-  }
-
   const autocompleteDispatch = React.useCallback((action) => {
     dispatch({
       action,
@@ -282,12 +271,6 @@ const DialogLinkType = (React.memo<PropsT>(({
     <tr>
       <td className="required section">
         {addColonText(l('Relationship type'))}
-        <br />
-        {bracketed(
-          <a href="#" onClick={toggleHelp}>
-            {l('help')}
-          </a>,
-        )}
       </td>
       <td className="fields">
         <LinkTypeAutocomplete
@@ -297,15 +280,6 @@ const DialogLinkType = (React.memo<PropsT>(({
         <div aria-atomic="true" className="error" role="alert">
           {error}
         </div>
-        {isHelpVisible && (linkType?.description) ? (
-          <div className="ar-descr">
-            {exp.l('{description} ({url|more documentation})', {
-              description:
-                expand2react(l_relationships(linkType.description)),
-              url: {href: '/relationship/' + linkType.gid, target: '_blank'},
-            })}
-          </div>
-        ) : null}
       </td>
     </tr>
   );

--- a/root/static/styles/widgets.less
+++ b/root/static/styles/widgets.less
@@ -347,6 +347,9 @@ div.autocomplete2 {
             border-style: solid;
             cursor: pointer;
             padding: 4px;
+            &.action-item {
+                font-style: italic;
+            }
             &.disabled {
                 color: #666;
                 cursor: default;


### PR DESCRIPTION
This fixes MBS-12630 by adding a "Show/hide descriptions" action at the end of link type and link attribute type (including instrument) autocomplete menus.  This preference is stored as a cookie so that it doesn't need to be constantly toggled off (as it defaults to true).

The above change by itself makes the menus a lot more compact, but in addition, I've also changed how link type results are displayed based on feedback from Aerozol by just showing "Forward link phrase / reverse link phrase" (so, no longer showing the actual type name, and no longer showing the "Forward link phrase:" and "Backward link phrase:" labels). Additionally, if the reverse link phrase is identical to the forward one once translated and stripped of attributes, only the forward one is shown.