### PR TITLE
MBS-12780: Fix allowNew check for AddRelationship

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
+++ b/lib/MusicBrainz/Server/Edit/Relationship/Create.pm
@@ -181,14 +181,14 @@ sub build_display_data
     my $loaded_entity_0 = $loaded->{$model0}{$entity0_gid_or_id} if $entity0_gid_or_id;
     my $entity0 = $loaded_entity_0 ||
         $self->c->model($model0)->_entity_class->new(
-            id => 0,
+            id => $self->data->{entity0}{id} // 0,
             name => $self->data->{entity0}{name}
         );
     my $entity1_gid_or_id = gid_or_id($self->data->{entity1});
     my $loaded_entity_1 = $loaded->{$model1}{$entity1_gid_or_id} if $entity1_gid_or_id;
     my $entity1 = $loaded_entity_1 ||
         $self->c->model($model1)->_entity_class->new(
-            id => 0,
+            id => $self->data->{entity1}{id} // 0,
             name => $self->data->{entity1}{name}
         );
     my $entity0_credit = $self->data->{entity0_credit} // '';
@@ -238,10 +238,6 @@ sub build_display_data
             grep { !exists $loaded->{LinkAttributeType}{$_->{type}{id}} }
                 @{ $self->data->{attributes} // [] }
         )),
-        source_type => $type0,
-        target_type => $type1,
-        entity0 => defined $entity0->id ? undef : to_json_object($entity0),
-        entity1 => defined $entity1->id ? undef : to_json_object($entity1),
     }
 }
 

--- a/root/edit/details/AddRelationship.js
+++ b/root/edit/details/AddRelationship.js
@@ -17,19 +17,15 @@ type Props = {
 };
 
 const AddRelationship = ({edit}: Props): React.MixedElement => {
-  const relationship = {
-    ...edit.display_data.relationship,
-    entity0: edit.display_data.entity0,
-    entity1: edit.display_data.entity1,
-  };
+  const relationship = edit.display_data.relationship;
   return (
     <table className="details add-relationship">
       <tr>
         <th>{l('Relationship:')}</th>
         <td>
           <Relationship
-            allowNewEntity0={!edit.display_data.entity0?.id}
-            allowNewEntity1={!edit.display_data.entity1?.id}
+            allowNewEntity0={relationship.entity0_id === 0}
+            allowNewEntity1={relationship.entity1_id === 0}
             relationship={relationship}
           />
         </td>

--- a/root/types/edit_types.js
+++ b/root/types/edit_types.js
@@ -259,8 +259,6 @@ declare type AddPlaceEditT = $ReadOnly<{
 declare type AddRelationshipEditT = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
-    +entity0?: CoreEntityT,
-    +entity1?: CoreEntityT,
     +relationship: RelationshipT,
     +unknown_attributes: boolean,
   },


### PR DESCRIPTION
### Fix MBS-12780

This was checking for the `entity0` and `entity1` passed outside the `relationship` itself - which we were also adding to the relationship data for display. But we were only passing this if the ID was not defined in the first place, so this check was nonsensical AFAICT. In fact, I cannot find any reason to pass `entity0` and `entity1` outside the `relationship`, since we're already passing them inside it.

I'm also removing the `source_type` and `target_type` that I had added in 9b0eae3e837e848c5eecb71b574185a37a2e9387 since AFAICT we're again not using those, but the ones inside the `relationship` object.

I tested this with `/edit/92070356` (the one where both sides were removed that triggered the ticket), with a new URL being added to a new release (to make sure release preview *does* still say "will be created"), and with `/edit/15273082` (the edit that triggered https://github.com/metabrainz/musicbrainz-server/pull/1589) to make sure it still works for deleted reltypes. Please do have a quick think on whether there might be some other case I didn't think of that could break with this :) 