### PR TITLE
MBS-12782: Block adding CritiqueBrainz links

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -708,6 +708,15 @@ export class _ExternalLinksEditor
                     Did you mean to paste something else?`),
         target: URLCleanup.ERROR_TARGETS.URL,
       };
+    } else if (isNewOrChangedLink && isCritiqueBrainz(link.url)) {
+      error = {
+        message: texp.l(
+          `Please don’t enter CritiqueBrainz links — reviews
+           are automatically linked from the “{reviews_tab_name}” tab.`,
+          {reviews_tab_name: l('Reviews')},
+        ),
+        target: URLCleanup.ERROR_TARGETS.URL,
+      };
     } else if (isNewOrChangedLink && isMalware(link.url)) {
       error = {
         message: l(`Links to this website are not allowed
@@ -1726,6 +1735,10 @@ function isExample(url: string) {
 
 function isMusicBrainz(url: string) {
   return /^https?:\/\/([^/]+\.)?musicbrainz\.org/.test(url);
+}
+
+function isCritiqueBrainz(url: string) {
+  return /^https?:\/\/([^/]+\.)?critiquebrainz\.org/.test(url);
 }
 
 type InitialOptionsT = {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -697,7 +697,7 @@ export class _ExternalLinksEditor
       error = {
         message: exp.l(
           `“{example_url}” is just an example.
-          Please enter the actual link you want to add.`,
+           Please enter the actual link you want to add.`,
           {example_url: <span className="url-quote">{link.url}</span>},
         ),
         target: URLCleanup.ERROR_TARGETS.URL,


### PR DESCRIPTION
### Implement MBS-12782

Since we link to CB automatically from the Reviews tab, there's no point on letting users manually link to the reviews.

I expected that doing the string like that will ensure that the Reviews tab name uses whatever translation we already have, but I tried with Italian and it still showed "Reviews" despite us having a translation - is my understanding of how it should work wrong, or does it only work if the main string is translated? :) 