### PR TITLE
MBS-12785: Wrap things sensibly on release sidebar

### DIFF
--- a/root/components/CritiqueBrainzLinks.js
+++ b/root/components/CritiqueBrainzLinks.js
@@ -29,10 +29,15 @@ const writeReviewLink = (entity: ReviewableT) => (
 
 type Props = {
   +entity: ReviewableT,
+  +isSidebar?: boolean,
 };
 
-const CritiqueBrainzLinks = ({entity}: Props): null | Expand2ReactOutput => {
+const CritiqueBrainzLinks = ({
+  entity,
+  isSidebar = false,
+}: Props): null | Expand2ReactOutput => {
   const reviewCount = entity.review_count;
+  const linkClassName = isSidebar ? 'wrap-anywhere' : '';
 
   if (reviewCount == null) {
     return l('An error occurred when loading reviews.');
@@ -42,7 +47,7 @@ const CritiqueBrainzLinks = ({entity}: Props): null | Expand2ReactOutput => {
       `No one has reviewed {entity} yet.
        Be the first to {write_link|write a review}.`,
       {
-        entity: <EntityLink entity={entity} />,
+        entity: <EntityLink className={linkClassName} entity={entity} />,
         write_link: writeReviewLink(entity),
       },
     );

--- a/root/components/EntityHeader.js
+++ b/root/components/EntityHeader.js
@@ -35,7 +35,7 @@ const EntityHeader = ({
   subHeading,
 }: Props): React$Element<typeof React.Fragment> => (
   <>
-    <div className={'entityheader ' + headerClass}>
+    <div className={'wrap-anywhere ' + headerClass}>
       {nonEmpty(preHeader) ? preHeader : null}
       <h1>
         {nonEmpty(heading) ? heading : <EntityLink entity={entity} />}

--- a/root/edit/details/EditUrl.js
+++ b/root/edit/details/EditUrl.js
@@ -38,7 +38,7 @@ const EditUrl = ({edit}: Props): React$Element<typeof React.Fragment> => {
           <tr>
             <th>{addColonText(l('URL'))}</th>
             <td className="old">
-              <a className="url-entity-link" href={uri.old}>
+              <a className="wrap-anywhere" href={uri.old}>
                 <DiffSide
                   filter={DELETE}
                   newText={uri.new}
@@ -47,7 +47,7 @@ const EditUrl = ({edit}: Props): React$Element<typeof React.Fragment> => {
               </a>
             </td>
             <td className="new">
-              <a className="url-entity-link" href={uri.new}>
+              <a className="wrap-anywhere" href={uri.new}>
                 <DiffSide
                   filter={INSERT}
                   newText={uri.new}

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -207,6 +207,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
                 {releaseLabel.label ? (
                   <>
                     <EntityLink
+                      className="wrap-anywhere"
                       entity={releaseLabel.label}
                       showDisambiguation={false}
                     />
@@ -246,7 +247,7 @@ const ReleaseSidebar = ({release}: Props): React$Element<'div'> | null => {
             {l('Release group reviews')}
           </h2>
           <p>
-            <CritiqueBrainzLinks entity={releaseGroup} />
+            <CritiqueBrainzLinks entity={releaseGroup} isSidebar />
           </p>
         </>
       )}

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -134,7 +134,7 @@ const NoInfoURL = ({allowNew, url}: {+allowNew: boolean, +url: string}) => (
       >
         {isolateText(url)}
       </span>
-    ) : <a className="url-entity-link" href={url}>{url}</a>}
+    ) : <a className="wrap-anywhere" href={url}>{url}</a>}
     {' '}
     <DeletedLink
       allowNew={allowNew}
@@ -276,7 +276,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   }
 
   if (entity.entityType === 'url') {
-    anchorProps.className = 'url-entity-link';
+    anchorProps.className = 'wrap-anywhere';
   }
 
   content = disableLink

--- a/root/static/styles/layout.less
+++ b/root/static/styles/layout.less
@@ -1077,7 +1077,7 @@ div.artwork { position: relative; width: 250px; }
     max-height: 125px;
 }
 
-.entityheader, .url-entity-link {
+.wrap-anywhere {
     overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
### Implement MBS-12785

# Problem
The release sidebar has two places where an entity name in `EntityLink` can be huge and cause the sidebar to grow to fairly unreasonable sizes: the label name (under **Labels**) and the release group name (for the CritiqueBrainz **Release group reviews**).

Other entity links on the sidebar are controlled by us (language and script names, release countries) so probably do not risk being a problem with this, and tags already wrap.

# Solution
This makes sure sidebar label and CB release group name can always wrap as needed by setting an appropriate CSS class. Rather than adding a third class name that does the same as `entityheader` and `url-entity-link`, I just changed all of them to a very explicit "`wrap-anywhere`".

The implementation is fairly conservative in the spirit of https://github.com/metabrainz/musicbrainz-server/pull/2557

# Testing
Tested manually locally, by adding a label and release group called `﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽ 3` (as per the RG causing issues on the ticket) and making sure both wrap more sensibly now.