### PR TITLE
MBS-12784: Mark more tracklist errors as such

### DIFF
--- a/root/release/edit/tracklist.tt
+++ b/root/release/edit/tracklist.tt
@@ -18,7 +18,7 @@
   <textarea class="tracklist" data-bind="value: toBeParsed"></textarea>
 
   <!-- ko if: error -->
-    <p>[% l('Unable to parse the tracklist you entered.') %]</p>
+    <p class="error">[% l('Unable to parse the tracklist you entered.') %]</p>
   <!-- /ko -->
 
   <h3 class="track-parser-options">[% l('Options') %]</h3>
@@ -141,7 +141,7 @@
   <!-- /ko -->
 
   <!-- ko if: error -->
-    <p>[% l('An error occurred: ') %] <span data-bind="text: error"></span></p>
+    <p class="error">[% l('An error occurred: ') %] <span data-bind="text: error"></span></p>
   <!-- /ko -->
 
   <!-- ko foreach: { data: searchResults, if: searchResults } -->


### PR DESCRIPTION
### Fix MBS-12784

For some reason we were missing the "`error`" class on these, meaning they just showed as a normal black text line that was very easy to miss.

Tested the parse error manually - not sure how to trigger the search one, but it should work in the same way.