### PR TITLE
MBS-12792: Hide ratings by spammer users

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Role/Rating.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Rating.pm
@@ -28,8 +28,17 @@ sub ratings : Chained('load') PathPart('ratings')
 
     my @public_ratings;
     my $private_rating_count = 0;
+    my $spammer_rating_count = 0;
 
     for my $rating (@ratings) {
+        # We don't want spammer ratings, but they're still
+        # part of the calculated rating.
+        # Once MBS-13861 is done we can just skip these silently
+        if ($rating->editor->is_spammer) {
+            $spammer_rating_count++;
+            next;
+        }
+
         if ($rating->editor->preferences->public_ratings) {
             push @public_ratings, $rating;
         } else {
@@ -43,6 +52,7 @@ sub ratings : Chained('load') PathPart('ratings')
         $entity_properties->{reviews} ? (mostRecentReview => to_json_object($entity->most_recent_review)) : (),
         publicRatings => to_json_array(\@public_ratings),
         privateRatingCount => $private_rating_count,
+        spammerRatingCount => $spammer_rating_count,
     );
 
     $c->stash(

--- a/root/entity/Ratings.js
+++ b/root/entity/Ratings.js
@@ -25,11 +25,14 @@ component Ratings(
   mostRecentReview: CritiqueBrainzReviewT,
   privateRatingCount: number,
   publicRatings: $ReadOnlyArray<RatingT>,
+  spammerRatingCount: number,
 ) {
   const entityType = entity.entityType;
   const entityProperties = ENTITIES[entity.entityType];
   const LayoutComponent = chooseLayoutComponent(entityType);
-  const hasRatings = publicRatings.length || privateRatingCount > 0;
+  const hasRatings = publicRatings.length ||
+                     privateRatingCount > 0 ||
+                     spammerRatingCount > 0;
 
   return (
     <LayoutComponent
@@ -64,9 +67,25 @@ component Ratings(
                   )}
                 </p>
               ) : null}
-              {l('Average rating:')}
-              {' '}
-              <StaticRatingStars rating={entity.rating} />
+              {/* Remove this once MBS-13861 skips spammers for averages */}
+              {spammerRatingCount > 0 ? (
+                <p>
+                  {exp.ln(
+                    '{count} hidden rating by a spammer user.',
+                    '{count} hidden ratings by spammer users.',
+                    spammerRatingCount,
+                    {count: spammerRatingCount},
+                  )}
+                </p>
+              ) : null}
+              {publicRatings.length === 0 && privateRatingCount === 0
+                ? null : (
+                  <>
+                    {l('Average rating:')}
+                    {' '}
+                    <StaticRatingStars rating={entity.rating} />
+                  </>
+                )}
             </>
           ) : (
             <p>


### PR DESCRIPTION
### Implement MBS-12792

# Problem
While we block seeing the profiles of spammer users, their ratings are still visible. For cases where the user was specifically spamming ratings, this makes marking them as spammers kinda useless.

We also use the spammer ratings in the calculation of the average community rating, which is not ideal.

# Solution
Sadly, it turns out we will need a schema change (MBS-12794) to stop using spammer ratings (and tags) when calculating community results.

For now, this at least hides links to spammer profiles from the ratings page and makes it clear to users viewing from that page that the ratings might be dodgy. There's no indication of that on the sidebar, sadly, but it's something, and it probably doesn't make sense to write code to check for spammer ratings on all pages with sidebars if we plan to stop using them in calculations later on anyway.

# Testing
Tested manually. To test, you can use `/artist/9a694506-85b4-4610-ae05-f20934b9aabc/ratings` - to test with "legit" ratings too, when using pink, just temporarily add your own rating from mb.org.

I didn't add a more formal test since this is meant as a temporary hack.