### PR TITLE
MBS-12801: Warn users about "Disc n" titles on release merge

### DIFF
--- a/root/static/scripts/edit/utility/isUselessMediumTitle.js
+++ b/root/static/scripts/edit/utility/isUselessMediumTitle.js
@@ -1,0 +1,12 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function isUselessMediumTitle(title: string): boolean {
+  return /^(Cassette|CD|Dis[ck]|DVD|SACD|Vinyl)\s*\d+/i.test(title);
+}

--- a/root/static/scripts/release-editor/fields.js
+++ b/root/static/scripts/release-editor/fields.js
@@ -29,6 +29,7 @@ import request from '../common/utility/request.js';
 import {fixedWidthInteger, uniqueId} from '../common/utility/strings.js';
 import mbEdit from '../edit/MB/edit.js';
 import * as dates from '../edit/utility/dates.js';
+import isUselessMediumTitle from '../edit/utility/isUselessMediumTitle.js';
 import * as validation from '../edit/validation.js';
 
 import recordingAssociation from './recordingAssociation.js';
@@ -466,7 +467,7 @@ class Medium {
       this.hasStrangeDigitalPackaging(),
     );
     this.hasUselessMediumTitle = ko.computed(function () {
-      return /^(Cassette|CD|Dis[ck]|DVD|SACD|Vinyl)\s*\d+/i.test(self.name());
+      return isUselessMediumTitle(self.name());
     });
     this.confirmedMediumTitle = ko.observable(this.hasUselessMediumTitle());
     this.needsTrackArtists = ko.computed(function () {

--- a/root/static/scripts/tests/edit/utility/isUselessMediumTitle.js
+++ b/root/static/scripts/tests/edit/utility/isUselessMediumTitle.js
@@ -1,0 +1,32 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import test from 'tape';
+
+import isUselessMediumTitle
+  from '../../../edit/utility/isUselessMediumTitle.js';
+
+test('isUselessMediumTitle', function (t) {
+  t.plan(3);
+
+  t.ok(
+    !isUselessMediumTitle('The Happy Disc'),
+    'A normal title is not useless',
+  );
+
+  t.ok(
+    isUselessMediumTitle('DVD 42'),
+    'A "format plus number" title is useless',
+  );
+
+  t.ok(
+    isUselessMediumTitle('Disk1'),
+    'A "format plus number" title is still useless if not space-separated',
+  );
+});

--- a/root/static/scripts/tests/index-web.js
+++ b/root/static/scripts/tests/index-web.js
@@ -5,6 +5,7 @@ require('./common/immutable-entities.js');
 require('./Control/URLCleanup.js');
 require('./CoverArt.js');
 require('./edit.js');
+require('./edit/utility/isUselessMediumTitle.js');
 require('./edit/utility/linkPhrase.js');
 require('./entity.js');
 require('./GuessCase.js');


### PR DESCRIPTION
### Implement MBS-12801

# Problem
MBS-12034 made it mandatory to provide a confirmation when adding a "Disc 1" style medium name when editing a release. I did not remember, when implementing it, that there is a second place where you can set medium names: the release merge page. Right now, nothing blocks adding those from that page nor warns the user it might be a bad idea.

# Solution
I just implemented a basic warning, which is probably enough. We could also disable submission unless they confirm, by erroring at the Perl level, but this is less intrusive and hopefully does the trick still, since it appears just below the name row as soon as the user enters the triggering name.

![image_2022-12-28_100817159](https://user-images.githubusercontent.com/1069224/209779912-b2969b96-0306-422c-9e38-b40927237cd7.png)

# Testing
Tested manually when merging two random releases, since the testing is only dependent on the entered medium name.