### PR TITLE
MBS-12802: Use localize_error for artist credit errors

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
@@ -39,7 +39,7 @@ around 'validate_field' => sub {
 
         my $artist_id = Text::Trim::trim $_->{'artist'}->{'id'};
         my $artist_name = Text::Trim::trim $_->{'artist'}->{'name'};
-        my $name = Text::Trim::trim $_->{'name'} || Text::Trim::trim $_->{'artist'}->{'name'};
+        my $name = Text::Trim::trim $_->{'name'} || $artist_name;
 
         if ($artist_id && $name)
         {
@@ -51,13 +51,13 @@ around 'validate_field' => sub {
                 l('Please add an artist name for {credit}',
                   { credit => $name }));
         }
-        elsif (! $artist_id && ( $name || $artist_name ))
+        elsif (! $artist_id && $name )
         {
             # FIXME: better error message.
             $self->add_error(
                 l('Artist "{artist}" is unlinked, please select an existing artist. ' .
                   'You may need to add a new artist to MusicBrainz first.',
-                  { artist => ($name || $artist_name) }));
+                  { artist => $name }));
         }
         elsif (!$artist_id)
         {

--- a/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
+++ b/lib/MusicBrainz/Server/Form/Field/ArtistCredit.pm
@@ -11,6 +11,7 @@ extends 'HTML::FormHandler::Field::Compound';
 use MusicBrainz::Server::Edit::Utils qw( clean_submitted_artist_credits );
 use MusicBrainz::Server::Entity::ArtistCredit;
 use MusicBrainz::Server::Entity::ArtistCreditName;
+use MusicBrainz::Server::Form::Utils qw( localize_error );
 use MusicBrainz::Server::Translation qw( l );
 
 has_field 'names'             => ( type => 'Repeatable', num_when_empty => 1 );
@@ -132,6 +133,10 @@ sub json {
     }
 
     return to_json({names => $names});
+}
+
+sub build_localize_meth {
+    return \&localize_error;
 }
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/MusicBrainz/Server/Form/Merge.pm
+++ b/lib/MusicBrainz/Server/Form/Merge.pm
@@ -4,7 +4,8 @@ use warnings;
 
 use HTML::FormHandler::Moose;
 use namespace::autoclean;
-use MusicBrainz::Server::Translation qw( l N_l );
+use MusicBrainz::Server::Form::Utils qw( localize_error );
+use MusicBrainz::Server::Translation qw( N_l );
 
 extends 'MusicBrainz::Server::Form';
 with 'MusicBrainz::Server::Form::Role::Edit';
@@ -19,7 +20,7 @@ has_field 'target' => (
     type => '+MusicBrainz::Server::Form::Field::Integer',
     required => 1,
     required_message => N_l('Please pick the entity you want the others merged into.'),
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth => \&localize_error,
 );
 
 has_field 'merging' => (

--- a/lib/MusicBrainz/Server/Form/Role/CSRFToken.pm
+++ b/lib/MusicBrainz/Server/Form/Role/CSRFToken.pm
@@ -4,17 +4,13 @@ use strict;
 use warnings;
 
 use HTML::FormHandler::Moose::Role;
+use MusicBrainz::Server::Form::Utils qw( localize_error );
 use MusicBrainz::Server::Translation qw( l N_l );
 
 my $error_message = N_l(
     'The form you’ve submitted has expired. ' .
     'Please resubmit your request.',
 );
-
-sub localize_error {
-    my ($self, @message) = @_;
-    return l(@message);
-}
 
 has_field 'csrf_token' => (
     type => 'Hidden',

--- a/lib/MusicBrainz/Server/Form/User/Login.pm
+++ b/lib/MusicBrainz/Server/Form/User/Login.pm
@@ -3,7 +3,8 @@ use strict;
 use warnings;
 
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Translation qw( l N_l );
+use MusicBrainz::Server::Form::Utils qw( localize_error );
+use MusicBrainz::Server::Translation qw( N_l );
 extends 'HTML::FormHandler';
 
 with 'MusicBrainz::Server::Form::Role::ToJSON';
@@ -13,7 +14,7 @@ has_field 'username' => (
     type => 'Text',
     required => 1,
     messages => { required => N_l('Username field is required') },
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth => \&localize_error,
 );
 
 has_field 'password' => (
@@ -21,7 +22,7 @@ has_field 'password' => (
     required => 1,
     min_length => 1,
     messages => { required => N_l('Password field is required') },
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth => \&localize_error,
 );
 
 has_field 'remember_me' => (

--- a/lib/MusicBrainz/Server/Form/User/Register.pm
+++ b/lib/MusicBrainz/Server/Form/User/Register.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use HTML::FormHandler::Moose;
-use MusicBrainz::Server::Form::Utils qw( validate_username );
+use MusicBrainz::Server::Form::Utils qw( localize_error validate_username );
 use MusicBrainz::Server::Translation qw( l N_l );
 
 extends 'MusicBrainz::Server::Form';
@@ -53,7 +53,7 @@ has_field 'confirm_password' => (
     required       => 1,
     minlength      => 1,
     messages       => { pass_conf_not_matched => N_l('The password confirmation does not match the password') },
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth  => \&localize_error,
 );
 
 has_field 'email' => (

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -18,6 +18,7 @@ use Sub::Exporter -setup => {
                       build_type_info
                       build_options_tree
                       indentation
+                      localize_error
                       validate_username
               )],
 };
@@ -195,6 +196,11 @@ sub build_child_info {
 sub indentation {
     my $level = shift;
     return "\N{NO-BREAK SPACE}" x (3 * $level);
+}
+
+sub localize_error {
+    my ($self, @message) = @_;
+    return l(@message);
 }
 
 sub validate_username {

--- a/lib/MusicBrainz/Server/Form/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Work.pm
@@ -4,7 +4,11 @@ use warnings;
 
 use HTML::FormHandler::Moose;
 use MusicBrainz::Server::Translation qw( l N_l );
-use MusicBrainz::Server::Form::Utils qw( language_options select_options_tree );
+use MusicBrainz::Server::Form::Utils qw(
+    language_options
+    localize_error
+    select_options_tree
+);
 use List::AllUtils qw( any uniq );
 
 extends 'MusicBrainz::Server::Form';
@@ -58,14 +62,14 @@ has_field 'attributes.type_id' => (
     type => 'Integer',
     required => 1,
     required_message => N_l('Please select a work attribute type.'),
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth => \&localize_error,
 );
 
 has_field 'attributes.value' => (
     type => '+MusicBrainz::Server::Form::Field::Text',
     required => 1,
     required_message => N_l('Please enter a work attribute value.'),
-    localize_meth => sub { my ($self, @message) = @_; return l(@message); },
+    localize_meth => \&localize_error,
 );
 
 sub is_empty_attribute {


### PR DESCRIPTION
### Fix MBS-12802

# Problem
Trying to submit (or seed, reportedly, haven't tested that directly) an artist credit field where there's a string with brackets as either the artist credit (with the artist field empty) or the artist (unlinked) raises an error telling the user that's wrong, as expected (e.g. `Artist "[whatever]" is unlinked, please select an existing artist.`) . FormHandler passes that to maketext, which chokes on the brackets (a restricted notation for it, see https://perldoc.perl.org/Locale::Maketext#BRACKET-NOTATION) and ISEs.

# Solution
I generalized the override we used elsewhere to skip `maketext` as `localize_error`, and then used it for artist credits as well.

While I was here, I simplified the check that raises the errors, since `$name` always exists if `$artist_name` does.

# Testing
Manually. You can try to add a standalone recording with a `[whatever]` unlinked artist, and/or with a `[whatever]` artist credit and an empty artist field.