### PR TITLE
MBS-12799 / MBS-7028: Extra options for filters

### DIFF
--- a/lib/MusicBrainz/Server/Data/Event.pm
+++ b/lib/MusicBrainz/Server/Data/Event.pm
@@ -217,6 +217,10 @@ sub find_by_artist
             push @where_query, "(mb_simple_tsvector(event.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR event.name = ?)";
             push @where_args, ($filter{name}) x 2;
         }
+        if (exists $filter{disambiguation}) {
+            push @where_query, "(mb_simple_tsvector(event.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR event.comment = ?)";
+            push @where_args, ($filter{disambiguation}) x 2;
+        }
         if (exists $filter{type_id}) {
             if ($filter{type_id} eq '-1') {
                 push @where_query, 'event.type IS NULL';

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -90,6 +90,15 @@ sub find_by_artist
 
     if (exists $args{filter}) {
         my %filter = %{ $args{filter} };
+        if (exists $filter{video}) {
+            if ($filter{video} == 1) {
+                # Show only videos
+                push @where_query, 'video IS TRUE';
+            } elsif ($filter{video} == 2) {
+                # Show only non-video recordings
+                push @where_query, 'video IS FALSE';
+            }
+        }
         if (exists $filter{name}) {
             push @where_query, q{(mb_simple_tsvector(recording.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR recording.name = ?)};
             push @where_args, $filter{name}, $filter{name};

--- a/lib/MusicBrainz/Server/Data/Recording.pm
+++ b/lib/MusicBrainz/Server/Data/Recording.pm
@@ -103,6 +103,10 @@ sub find_by_artist
             push @where_query, q{(mb_simple_tsvector(recording.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR recording.name = ?)};
             push @where_args, $filter{name}, $filter{name};
         }
+        if (exists $filter{disambiguation}) {
+            push @where_query, "(mb_simple_tsvector(recording.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR recording.comment = ?)";
+            push @where_args, ($filter{disambiguation}) x 2;
+        }
         if (exists $filter{artist_credit_id}) {
             push @where_query, 'recording.artist_credit = ?';
             push @where_args, $filter{artist_credit_id};

--- a/lib/MusicBrainz/Server/Data/Release.pm
+++ b/lib/MusicBrainz/Server/Data/Release.pm
@@ -110,6 +110,10 @@ sub _where_filter
             push @query, q{(mb_simple_tsvector(release.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR release.name = ?)};
             push @params, $filter->{name}, $filter->{name};
         }
+        if (exists $filter->{disambiguation}) {
+            push @query, q{(mb_simple_tsvector(release.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR release.comment = ?)};
+            push @params, $filter->{disambiguation}, $filter->{disambiguation};
+        }
         if (exists $filter->{artist_credit_id}) {
             push @query, 'release.artist_credit = ?';
             push @params, $filter->{artist_credit_id};

--- a/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Data/ReleaseGroup.pm
@@ -91,6 +91,10 @@ sub _where_filter
             push @query, q{(mb_simple_tsvector(rg.name) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR rg.name = ?)};
             push @params, $filter->{name}, $filter->{name};
         }
+        if (exists $filter->{disambiguation}) {
+            push @query, q{(mb_simple_tsvector(rg.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR rg.comment = ?)};
+            push @params, ($filter->{disambiguation}) x 2;
+        }
         if (exists $filter->{artist_credit_id}) {
             $needs_rg_table = 1 if $using_artist_release_group_table;
             push @query, 'rg.artist_credit = ?';

--- a/lib/MusicBrainz/Server/Data/Work.pm
+++ b/lib/MusicBrainz/Server/Data/Work.pm
@@ -113,6 +113,11 @@ sub find_by_artist
             push @where_args, ($filter{name}) x 2;
         }
 
+        if (exists $filter{disambiguation}) {
+            push @where_query, "(mb_simple_tsvector(work.comment) @@ plainto_tsquery('mb_simple', mb_lower(?)) OR work.comment = ?)";
+            push @where_args, ($filter{disambiguation}) x 2;
+        }
+
         if (exists $filter{type_id}) {
             if ($filter{type_id} eq '-1') {
                 push @where_query, 'work.type IS NULL';

--- a/lib/MusicBrainz/Server/Form/Filter/Event.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Event.pm
@@ -22,7 +22,7 @@ has_field 'type_id' => (
 );
 
 sub filter_field_names {
-    return qw/ name setlist type_id /;
+    return qw/ disambiguation name setlist type_id /;
 }
 
 sub options_type_id {

--- a/lib/MusicBrainz/Server/Form/Filter/Generic.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Generic.pm
@@ -13,6 +13,11 @@ has 'entity_type' => (
     required => 1,
 );
 
+has_field 'disambiguation' => (
+    type => '+MusicBrainz::Server::Form::Field::Text',
+    default => '',
+);
+
 has_field 'name' => (
     type => '+MusicBrainz::Server::Form::Field::Text',
     default => '',
@@ -22,7 +27,7 @@ has_field 'cancel' => ( type => 'Submit' );
 has_field 'submit' => ( type => 'Submit' );
 
 sub filter_field_names {
-    return qw/ name /;
+    return qw/ disambiguation name /;
 }
 
 around TO_JSON => sub {

--- a/lib/MusicBrainz/Server/Form/Filter/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Recording.pm
@@ -22,7 +22,7 @@ has_field 'video' => (
 );
 
 sub filter_field_names {
-    return qw/ name artist_credit_id video /;
+    return qw/ disambiguation name artist_credit_id video /;
 }
 
 sub options_artist_credit_id {

--- a/lib/MusicBrainz/Server/Form/Filter/Recording.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Recording.pm
@@ -5,6 +5,8 @@ use warnings;
 use HTML::FormHandler::Moose;
 extends 'MusicBrainz::Server::Form::Filter::Generic';
 
+use MusicBrainz::Server::Translation qw( l );
+
 has 'artist_credits' => (
     isa => 'ArrayRef[ArtistCredit]',
     is => 'ro',
@@ -15,8 +17,12 @@ has_field 'artist_credit_id' => (
     type => 'Select',
 );
 
+has_field 'video' => (
+    type => 'Select',
+);
+
 sub filter_field_names {
-    return qw/ name artist_credit_id /;
+    return qw/ name artist_credit_id video /;
 }
 
 sub options_artist_credit_id {
@@ -27,11 +33,19 @@ sub options_artist_credit_id {
     ];
 }
 
+sub options_video {
+    return [
+        { value => 1, label => l('Videos only') },
+        { value => 2, label => l('Non-videos only') },
+    ];
+}
+
 around TO_JSON => sub {
     my ($orig, $self) = @_;
 
     my $json = $self->$orig;
     $json->{options_artist_credit_id} = $self->options_artist_credit_id;
+    $json->{options_video} = $self->options_video;
     return $json;
 };
 

--- a/lib/MusicBrainz/Server/Form/Filter/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Release.pm
@@ -54,7 +54,7 @@ has_field 'status_id' => (
 );
 
 sub filter_field_names {
-    return qw/ name artist_credit_id country_id date label_id status_id /;
+    return qw/ disambiguation name artist_credit_id country_id date label_id status_id /;
 }
 
 sub options_artist_credit_id {

--- a/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/ReleaseGroup.pm
@@ -37,7 +37,7 @@ has_field 'secondary_type_id' => (
 );
 
 sub filter_field_names {
-    return qw/ name artist_credit_id secondary_type_id type_id /;
+    return qw/ disambiguation name artist_credit_id secondary_type_id type_id /;
 }
 
 sub options_artist_credit_id {

--- a/lib/MusicBrainz/Server/Form/Filter/Work.pm
+++ b/lib/MusicBrainz/Server/Form/Filter/Work.pm
@@ -21,7 +21,7 @@ has_field 'type_id' => (
 );
 
 sub filter_field_names {
-    return qw/ name role_type type_id /;
+    return qw/ disambiguation name role_type type_id /;
 }
 
 sub options_role_type {

--- a/root/artist/ArtistEvents.js
+++ b/root/artist/ArtistEvents.js
@@ -13,7 +13,7 @@ import EventList from '../components/list/EventList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
-import {type FilterFormT}
+import {type EventFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
@@ -23,7 +23,7 @@ type Props = {
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
   +events: $ReadOnlyArray<EventT>,
-  +filterForm: ?FilterFormT,
+  +filterForm: ?EventFilterT,
   +hasFilter: boolean,
   +pager: PagerT,
 };

--- a/root/artist/ArtistIndex.js
+++ b/root/artist/ArtistIndex.js
@@ -20,7 +20,7 @@ import Annotation from '../static/scripts/common/components/Annotation.js';
 import DescriptiveLink
   from '../static/scripts/common/components/DescriptiveLink.js';
 import Filter from '../static/scripts/common/components/Filter.js';
-import {type FilterFormT}
+import {type ReleaseGroupFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import WikipediaExtract
   from '../static/scripts/common/components/WikipediaExtract.js';
@@ -49,7 +49,7 @@ type Props = {
   +baseName: ?ArtistT,
   +baseNameLegalNameAliases: ?$ReadOnlyArray<string>,
   +eligibleForCleanup: boolean,
-  +filterForm: ?FilterFormT,
+  +filterForm: ?ReleaseGroupFilterT,
   +hasDefault: boolean,
   +hasExtra: boolean,
   +hasFilter: boolean,

--- a/root/artist/ArtistRecordings.js
+++ b/root/artist/ArtistRecordings.js
@@ -13,7 +13,7 @@ import RecordingList from '../components/list/RecordingList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
-import {type FilterFormT}
+import {type RecordingFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import bracketed from '../static/scripts/common/utility/bracketed.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
@@ -33,7 +33,7 @@ type Props = {
   ...ReleaseGroupAppearancesRoleT,
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
-  +filterForm: ?FilterFormT,
+  +filterForm: ?RecordingFilterT,
   +hasFilter: boolean,
   +hasStandalone: boolean,
   +hasVideo: boolean,

--- a/root/artist/ArtistReleases.js
+++ b/root/artist/ArtistReleases.js
@@ -13,7 +13,7 @@ import ReleaseList from '../components/list/ReleaseList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
-import {type FilterFormT}
+import {type ReleaseFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
@@ -23,7 +23,7 @@ import ArtistLayout from './ArtistLayout.js';
 type Props = {
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
-  +filterForm: ?FilterFormT,
+  +filterForm: ?ReleaseFilterT,
   +hasFilter: boolean,
   +pager: PagerT,
   +releases: $ReadOnlyArray<ReleaseT>,

--- a/root/artist/ArtistWorks.js
+++ b/root/artist/ArtistWorks.js
@@ -13,7 +13,7 @@ import WorkList from '../components/list/WorkList.js';
 import PaginatedResults from '../components/PaginatedResults.js';
 import {SanitizedCatalystContext} from '../context.mjs';
 import Filter from '../static/scripts/common/components/Filter.js';
-import {type FilterFormT}
+import {type WorkFilterT}
   from '../static/scripts/common/components/FilterForm.js';
 import {returnToCurrentPage} from '../utility/returnUri.js';
 
@@ -22,7 +22,7 @@ import ArtistLayout from './ArtistLayout.js';
 type Props = {
   +ajaxFilterFormUrl: string,
   +artist: ArtistT,
-  +filterForm: ?FilterFormT,
+  +filterForm: ?WorkFilterT,
   +hasFilter: boolean,
   +pager: PagerT,
   +works: ?$ReadOnlyArray<WorkT>,

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -11,30 +11,83 @@ import SelectField from '../../common/components/SelectField.js';
 import FieldErrors from '../../edit/components/FieldErrors.js';
 import {addColonText} from '../i18n/addColon.js';
 
-export type FilterFormT = $ReadOnly<{
-  ...FormT<{
-    +artist_credit_id: FieldT<number>,
-    +country_id?: FieldT<number>,
-    +date?: FieldT<string>,
-    +label_id?: FieldT<number>,
-    +name: FieldT<string>,
-    +role_type?: FieldT<number>,
-    +secondary_type_id?: FieldT<number>,
-    +setlist?: FieldT<string>,
-    +status_id?: FieldT<number>,
-    +type_id?: FieldT<number>,
-    +video?: FieldT<number>,
-  }>,
-  entity_type: 'recording' | 'release' | 'release_group',
-  options_artist_credit_id: SelectOptionsT,
-  options_country_id: SelectOptionsT,
-  options_label_id?: SelectOptionsT,
-  options_role_type?: SelectOptionsT,
-  options_secondary_type_id?: SelectOptionsT,
-  options_status_id?: SelectOptionsT,
-  options_type_id?: SelectOptionsT,
-  options_video?: SelectOptionsT,
+type EventFilterFormT = FormT<{
+  +name: FieldT<string>,
+  +setlist: FieldT<string>,
+  +type_id: FieldT<number>,
 }>;
+
+export type EventFilterT = $ReadOnly<{
+  ...EventFilterFormT,
+  +entity_type: 'event',
+  +options_type_id: SelectOptionsT,
+}>;
+
+type RecordingFilterFormT = FormT<{
+  +artist_credit_id: FieldT<number>,
+  +name: FieldT<string>,
+  +video: FieldT<number>,
+}>;
+
+export type RecordingFilterT = $ReadOnly<{
+  ...RecordingFilterFormT,
+  +entity_type: 'recording',
+  +options_artist_credit_id: SelectOptionsT,
+  +options_video: SelectOptionsT,
+}>;
+
+type ReleaseFilterFormT = FormT<{
+  +artist_credit_id: FieldT<number>,
+  +country_id: FieldT<number>,
+  +date: FieldT<string>,
+  +label_id: FieldT<number>,
+  +name: FieldT<string>,
+  +status_id: FieldT<number>,
+}>;
+
+export type ReleaseFilterT = $ReadOnly<{
+  ...ReleaseFilterFormT,
+  +entity_type: 'release',
+  +options_artist_credit_id: SelectOptionsT,
+  +options_country_id: SelectOptionsT,
+  +options_label_id: SelectOptionsT,
+  +options_status_id: SelectOptionsT,
+}>;
+
+type ReleaseGroupFilterFormT = FormT<{
+  +artist_credit_id: FieldT<number>,
+  +name: FieldT<string>,
+  +secondary_type_id: FieldT<number>,
+  +type_id: FieldT<number>,
+}>;
+
+export type ReleaseGroupFilterT = $ReadOnly<{
+  ...ReleaseGroupFilterFormT,
+  +entity_type: 'release_group',
+  +options_artist_credit_id: SelectOptionsT,
+  +options_secondary_type_id: SelectOptionsT,
+  +options_type_id: SelectOptionsT,
+}>;
+
+type WorkFilterFormT = FormT<{
+  +name: FieldT<string>,
+  +role_type: FieldT<number>,
+  +type_id: FieldT<number>,
+}>;
+
+export type WorkFilterT = $ReadOnly<{
+  ...WorkFilterFormT,
+  +entity_type: 'work',
+  +options_role_type: SelectOptionsT,
+  +options_type_id: SelectOptionsT,
+}>;
+
+export type FilterFormT =
+  | EventFilterT
+  | RecordingFilterT
+  | ReleaseFilterT
+  | ReleaseGroupFilterT
+  | WorkFilterT;
 
 type Props = {
   +form: FilterFormT,
@@ -56,249 +109,264 @@ function getSubmitText(type: string) {
   return '';
 }
 
-const FilterForm = ({form}: Props): React$Element<'div'> => {
-  const typeIdField = form.field.type_id;
-  const typeIdOptions = form.options_type_id;
-  const secondaryTypeIdField = form.field.secondary_type_id;
-  const secondaryTypeIdOptions = form.options_secondary_type_id;
-  const artistCreditIdField = form.field.artist_credit_id;
-  const artistCreditIdOptions = form.options_artist_credit_id;
-  const countryIdOptions = form.options_country_id;
-  const countryIdField = form.field.country_id;
-  const labelIdOptions = form.options_label_id;
-  const labelIdField = form.field.label_id;
-  const dateField = form.field.date;
-  const roleTypeField = form.field.role_type;
-  const roleTypeOptions = form.options_role_type;
-  const statusIdOptions = form.options_status_id;
-  const statusIdField = form.field.status_id;
-  const setlistField = form.field.setlist;
-  const videoField = form.field.video;
-  const videoOptions = form.options_video;
+type FieldProps = {
+  field: FieldT<number>,
+  options: SelectOptionsT,
+};
 
-  return (
-    <div id="filter">
-      <form method="get">
-        <table>
-          <tbody>
-            {typeIdField && typeIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Type'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={typeIdField}
-                    options={{grouped: false, options: typeIdOptions}}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
+const ArtistCreditField = ({
+  field,
+  options,
+}: FieldProps): React$Element<'tr'> => (
+  <tr>
+    <td>
+      {addColonText(l('Artist credit'))}
+    </td>
+    <td>
+      <SelectField
+        field={field}
+        options={{
+          grouped: false,
+          options: options,
+        }}
+        style={{maxWidth: '40em'}}
+        uncontrolled
+      />
+    </td>
+  </tr>
+);
 
-            {secondaryTypeIdField && secondaryTypeIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Secondary type'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={secondaryTypeIdField}
-                    options={{
-                      grouped: false,
-                      options: secondaryTypeIdOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
+const TypeField = ({field, options}: FieldProps): React$Element<'tr'> => (
+  <tr>
+    <td>
+      {addColonText(l('Type'))}
+    </td>
+    <td>
+      <SelectField
+        field={field}
+        options={{
+          grouped: false,
+          options: options,
+        }}
+        style={{maxWidth: '40em'}}
+        uncontrolled
+      />
+    </td>
+  </tr>
+);
 
-            {artistCreditIdField && artistCreditIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Artist credit'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={artistCreditIdField}
-                    options={{
-                      grouped: false,
-                      options: artistCreditIdOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
+const FilterForm = ({form}: Props): React$Element<'div'> => (
+  <div id="filter">
+    <form method="get">
+      <table>
+        <tbody>
+          <tr>
+            <td>{addColonText(l('Name'))}</td>
+            <td>
+              <input
+                defaultValue={form.field.name.value}
+                name={form.field.name.html_name}
+                size="47"
+                type="text"
+              />
+            </td>
+          </tr>
 
-            <tr>
-              <td>{addColonText(l('Name'))}</td>
-              <td>
-                <input
-                  defaultValue={form.field.name.value}
-                  name={form.field.name.html_name}
-                  size="47"
-                  type="text"
-                />
-              </td>
-            </tr>
-
-            {roleTypeField && roleTypeOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Role'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={roleTypeField}
-                    options={{
-                      grouped: false,
-                      options: roleTypeOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
-
-            {labelIdField && labelIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Label'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={labelIdField}
-                    options={{
-                      grouped: false,
-                      options: labelIdOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
-
-            {countryIdField && countryIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(l('Country'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={countryIdField}
-                    options={{
-                      grouped: false,
-                      options: countryIdOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
-
-            {statusIdField && statusIdOptions ? (
-              <tr>
-                <td>
-                  {addColonText(lp('Status', 'release'))}
-                </td>
-                <td>
-                  <SelectField
-                    field={statusIdField}
-                    options={{
-                      grouped: false,
-                      options: statusIdOptions,
-                    }}
-                    style={{maxWidth: '40em'}}
-                    uncontrolled
-                  />
-                </td>
-              </tr>
-            ) : null}
-
-            {dateField ? (
-              <tr>
-                <td>
-                  {addColonText(l('Date'))}
-                </td>
-                <td>
-                  <input
-                    defaultValue={dateField.value ?? ''}
-                    name={dateField.html_name}
-                    size="47"
-                    type="text"
-                  />
-                  <FieldErrors field={dateField} />
-                </td>
-              </tr>
-            ) : null}
-
-            {setlistField ? (
+          {form.entity_type === 'event' ? (
+            <>
+              <TypeField
+                field={form.field.type_id}
+                options={form.options_type_id}
+              />
               <tr>
                 <td>
                   {addColonText(l('Setlist contains'))}
                 </td>
                 <td>
                   <input
-                    defaultValue={setlistField.value ?? ''}
-                    name={setlistField.html_name}
+                    defaultValue={form.field.setlist.value ?? ''}
+                    name={form.field.setlist.html_name}
                     size="47"
                     type="text"
                   />
-                  <FieldErrors field={setlistField} />
+                  <FieldErrors field={form.field.setlist} />
                 </td>
               </tr>
-            ) : null}
+            </>
+          ) : null}
 
-            {videoField && videoOptions ? (
+          {form.entity_type === 'recording' ? (
+            <>
+              <ArtistCreditField
+                field={form.field.artist_credit_id}
+                options={form.options_artist_credit_id}
+              />
               <tr>
                 <td>
                   {addColonText(l('Video'))}
                 </td>
                 <td>
                   <SelectField
-                    field={videoField}
+                    field={form.field.video}
                     options={{
                       grouped: false,
-                      options: videoOptions,
+                      options: form.options_video,
                     }}
                     style={{maxWidth: '40em'}}
                     uncontrolled
                   />
                 </td>
               </tr>
-            ) : null}
+            </>
+          ) : null}
 
-            <tr>
-              <td />
-              <td>
-                <span className="buttons">
-                  <button className="submit positive" type="submit">
-                    {getSubmitText(form.entity_type)}
-                  </button>
-                  <button
-                    className="submit negative"
-                    name="filter.cancel"
-                    type="submit"
-                    value="1"
-                  >
-                    {l('Cancel')}
-                  </button>
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </form>
-    </div>
-  );
-};
+          {form.entity_type === 'release' ? (
+            <>
+              <ArtistCreditField
+                field={form.field.artist_credit_id}
+                options={form.options_artist_credit_id}
+              />
+              <tr>
+                <td>
+                  {addColonText(l('Label'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={form.field.label_id}
+                    options={{
+                      grouped: false,
+                      options: form.options_label_id,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  {addColonText(l('Country'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={form.field.country_id}
+                    options={{
+                      grouped: false,
+                      options: form.options_country_id,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  {addColonText(lp('Status', 'release'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={form.field.status_id}
+                    options={{
+                      grouped: false,
+                      options: form.options_status_id,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  {addColonText(l('Date'))}
+                </td>
+                <td>
+                  <input
+                    defaultValue={form.field.date.value ?? ''}
+                    name={form.field.date.html_name}
+                    size="47"
+                    type="text"
+                  />
+                  <FieldErrors field={form.field.date} />
+                </td>
+              </tr>
+            </>
+          ) : null}
+
+          {form.entity_type === 'release_group' ? (
+            <>
+              <TypeField
+                field={form.field.type_id}
+                options={form.options_type_id}
+              />
+              <ArtistCreditField
+                field={form.field.artist_credit_id}
+                options={form.options_artist_credit_id}
+              />
+              <tr>
+                <td>
+                  {addColonText(l('Secondary type'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={form.field.secondary_type_id}
+                    options={{
+                      grouped: false,
+                      options: form.options_secondary_type_id,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+            </>
+          ) : null}
+
+          {form.entity_type === 'work' ? (
+            <>
+              <TypeField
+                field={form.field.type_id}
+                options={form.options_type_id}
+              />
+              <tr>
+                <td>
+                  {addColonText(l('Role'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={form.field.role_type}
+                    options={{
+                      grouped: false,
+                      options: form.options_role_type,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
+                </td>
+              </tr>
+            </>
+          ) : null}
+
+          <tr>
+            <td />
+            <td>
+              <span className="buttons">
+                <button className="submit positive" type="submit">
+                  {getSubmitText(form.entity_type)}
+                </button>
+                <button
+                  className="submit negative"
+                  name="filter.cancel"
+                  type="submit"
+                  value="1"
+                >
+                  {l('Cancel')}
+                </button>
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </form>
+  </div>
+);
 
 export default FilterForm;

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -11,8 +11,13 @@ import SelectField from '../../common/components/SelectField.js';
 import FieldErrors from '../../edit/components/FieldErrors.js';
 import {addColonText} from '../i18n/addColon.js';
 
-type EventFilterFormT = FormT<{
+type GenericFilterFormFieldsT = {
+  +disambiguation: FieldT<string>,
   +name: FieldT<string>,
+};
+
+type EventFilterFormT = FormT<{
+  ...GenericFilterFormFieldsT,
   +setlist: FieldT<string>,
   +type_id: FieldT<number>,
 }>;
@@ -24,8 +29,8 @@ export type EventFilterT = $ReadOnly<{
 }>;
 
 type RecordingFilterFormT = FormT<{
+  ...GenericFilterFormFieldsT,
   +artist_credit_id: FieldT<number>,
-  +name: FieldT<string>,
   +video: FieldT<number>,
 }>;
 
@@ -37,11 +42,11 @@ export type RecordingFilterT = $ReadOnly<{
 }>;
 
 type ReleaseFilterFormT = FormT<{
+  ...GenericFilterFormFieldsT,
   +artist_credit_id: FieldT<number>,
   +country_id: FieldT<number>,
   +date: FieldT<string>,
   +label_id: FieldT<number>,
-  +name: FieldT<string>,
   +status_id: FieldT<number>,
 }>;
 
@@ -55,8 +60,8 @@ export type ReleaseFilterT = $ReadOnly<{
 }>;
 
 type ReleaseGroupFilterFormT = FormT<{
+  ...GenericFilterFormFieldsT,
   +artist_credit_id: FieldT<number>,
-  +name: FieldT<string>,
   +secondary_type_id: FieldT<number>,
   +type_id: FieldT<number>,
 }>;
@@ -70,7 +75,7 @@ export type ReleaseGroupFilterT = $ReadOnly<{
 }>;
 
 type WorkFilterFormT = FormT<{
-  +name: FieldT<string>,
+  ...GenericFilterFormFieldsT,
   +role_type: FieldT<number>,
   +type_id: FieldT<number>,
 }>;
@@ -344,6 +349,18 @@ const FilterForm = ({form}: Props): React$Element<'div'> => (
               </tr>
             </>
           ) : null}
+
+          <tr>
+            <td>{addColonText(l('Disambiguation'))}</td>
+            <td>
+              <input
+                defaultValue={form.field.disambiguation.value}
+                name={form.field.disambiguation.html_name}
+                size="47"
+                type="text"
+              />
+            </td>
+          </tr>
 
           <tr>
             <td />

--- a/root/static/scripts/common/components/FilterForm.js
+++ b/root/static/scripts/common/components/FilterForm.js
@@ -23,6 +23,7 @@ export type FilterFormT = $ReadOnly<{
     +setlist?: FieldT<string>,
     +status_id?: FieldT<number>,
     +type_id?: FieldT<number>,
+    +video?: FieldT<number>,
   }>,
   entity_type: 'recording' | 'release' | 'release_group',
   options_artist_credit_id: SelectOptionsT,
@@ -32,6 +33,7 @@ export type FilterFormT = $ReadOnly<{
   options_secondary_type_id?: SelectOptionsT,
   options_status_id?: SelectOptionsT,
   options_type_id?: SelectOptionsT,
+  options_video?: SelectOptionsT,
 }>;
 
 type Props = {
@@ -71,6 +73,8 @@ const FilterForm = ({form}: Props): React$Element<'div'> => {
   const statusIdOptions = form.options_status_id;
   const statusIdField = form.field.status_id;
   const setlistField = form.field.setlist;
+  const videoField = form.field.video;
+  const videoOptions = form.options_video;
 
   return (
     <div id="filter">
@@ -249,6 +253,25 @@ const FilterForm = ({form}: Props): React$Element<'div'> => {
                     type="text"
                   />
                   <FieldErrors field={setlistField} />
+                </td>
+              </tr>
+            ) : null}
+
+            {videoField && videoOptions ? (
+              <tr>
+                <td>
+                  {addColonText(l('Video'))}
+                </td>
+                <td>
+                  <SelectField
+                    field={videoField}
+                    options={{
+                      grouped: false,
+                      options: videoOptions,
+                    }}
+                    style={{maxWidth: '40em'}}
+                    uncontrolled
+                  />
                 </td>
               </tr>
             ) : null}

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -433,6 +433,35 @@ test 'Recording page filtering' => sub {
         'Sinfonia Varsovia, Witold Lutosławski',
         'The first has the expected artist credit"',
     );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.video=1',
+        'Fetched artist recordings page with videos only option',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the recording table after filtering by videos only',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Interludium',
+        'The entry is named "Interludium"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.video=2',
+        'Fetched artist recordings page with non-videos only option',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '3',
+        'There are three entries in the recording table after filtering by non-videos only',
+    );
 };
 
 test 'Work page filtering' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Artist/Filtering.pm
@@ -413,7 +413,7 @@ test 'Recording page filtering' => sub {
     );
     $tx->is(
         '//table[@class="tbl"]/tbody/tr/td[1]',
-        'Symphony no. 3',
+        'Symphony no. 3 (Testy 2)',
         'The entry is named "Symphony no. 3"',
     );
 
@@ -447,7 +447,7 @@ test 'Recording page filtering' => sub {
     );
     $tx->is(
         '//table[@class="tbl"]/tbody/tr/td[1]',
-        'Interludium',
+        'Interludium (Testy)',
         'The entry is named "Interludium"',
     );
 
@@ -461,6 +461,18 @@ test 'Recording page filtering' => sub {
         'count(//table[@class="tbl"]/tbody/tr)',
         '3',
         'There are three entries in the recording table after filtering by non-videos only',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/recordings?filter.disambiguation=Testy',
+        'Fetched artist recordings page with disambiguation filter "Testy"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '2',
+        'There are two entries in the recording table after filtering by disambiguation',
     );
 };
 
@@ -551,6 +563,23 @@ test 'Work page filtering' => sub {
         'count(//table[@class="tbl"]/tbody/tr)',
         '1',
         'There is one entry in the work table after filtering by name "Interlude"',
+    );
+
+    $mech->get_ok(
+        '/artist/af4c43d3-c0e0-421e-ac64-000329af0435/works?filter.disambiguation=Testy',
+        'Fetched artist works page with disambiguation filter "Testy"',
+    );
+
+    $tx = test_xpath_html($mech->content);
+    $tx->is(
+        'count(//table[@class="tbl"]/tbody/tr)',
+        '1',
+        'There is one entry in the work table after filtering by disambiguation',
+    );
+    $tx->is(
+        '//table[@class="tbl"]/tbody/tr/td[1]',
+        'Mini Overture (Testy)',
+        'The entry is named "Mini Overture" and the disambiguation is indeed "Testy"',
     );
 };
 

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -84,11 +84,11 @@ INSERT INTO event (id, gid, name, type, setlist)
 
 -- Recordings
 
-INSERT INTO recording (id, gid, name, artist_credit)
-    VALUES (3400, 'ce82bfa1-733a-494a-aaa0-fc5de79bd54f', 'Interludium', 3402),
-           (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401),
-           (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401),
-           (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402);
+INSERT INTO recording (id, gid, name, artist_credit, video)
+    VALUES (3400, 'ce82bfa1-733a-494a-aaa0-fc5de79bd54f', 'Interludium', 3402, 't'),
+           (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401, 'f'),
+           (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401, 'f'),
+           (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402, 'f');
 
 -- Works
 

--- a/t/sql/filtering.sql
+++ b/t/sql/filtering.sql
@@ -84,20 +84,20 @@ INSERT INTO event (id, gid, name, type, setlist)
 
 -- Recordings
 
-INSERT INTO recording (id, gid, name, artist_credit, video)
-    VALUES (3400, 'ce82bfa1-733a-494a-aaa0-fc5de79bd54f', 'Interludium', 3402, 't'),
-           (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401, 'f'),
-           (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401, 'f'),
-           (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402, 'f');
+INSERT INTO recording (id, gid, name, artist_credit, video, comment)
+    VALUES (3400, 'ce82bfa1-733a-494a-aaa0-fc5de79bd54f', 'Interludium', 3402, 't', 'Testy'),
+           (3401, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c08', 'Symphony no. 3', 3401, 'f', 'Testy 2'),
+           (3402, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c01', 'Brandenburg Concerto no. 5', 3401, 'f', ''),
+           (3403, 'd9c7a74e-3c08-48b1-be2f-5d9a144f2c02', 'Brandenburg Concerto no. 5', 3402, 'f', '');
 
 -- Works
 
-INSERT INTO work (id, gid, name, type)
-    VALUES (3400, 'a0cd8685-0626-49e2-8722-aa8c726287db', 'Interlude', NULL),
-           (3401, '4d89910c-14ae-4d23-b7d4-9cbe111981b6', 'Symphony no. 3', 16),
-           (3402, '4ef6d273-4534-4b37-97f1-3e01d76b2fe5', 'Symphony no. 4', 16),
-           (3403, 'fcedfaf3-63ad-4ea2-949a-b16cdc2cd019', 'Mini Overture', 12),
-           (3404, 'dbb7157a-5dc3-41c4-aacc-4e3d4705e132', 'Brandenburgisches Konzert Nr. 5 D-Dur, BWV 1050', 4);
+INSERT INTO work (id, gid, name, type, comment)
+    VALUES (3400, 'a0cd8685-0626-49e2-8722-aa8c726287db', 'Interlude', NULL, ''),
+           (3401, '4d89910c-14ae-4d23-b7d4-9cbe111981b6', 'Symphony no. 3', 16, ''),
+           (3402, '4ef6d273-4534-4b37-97f1-3e01d76b2fe5', 'Symphony no. 4', 16, ''),
+           (3403, 'fcedfaf3-63ad-4ea2-949a-b16cdc2cd019', 'Mini Overture', 12, 'Testy'),
+           (3404, 'dbb7157a-5dc3-41c4-aacc-4e3d4705e132', 'Brandenburgisches Konzert Nr. 5 D-Dur, BWV 1050', 4, '');
 
 -- Relationships
 


### PR DESCRIPTION
### Implement MBS-12799 / MBS-7028

# Improvements
This adds two new filtering options: video/not video for recordings and disambiguation for all entities.

It also makes the flow typing more robust and organizes the code a bit more (I don't dare say simplifies it, but it's less spaghettish at least).

# Testing
By hand (mostly on Nine Inch Nails recordings), plus added tests.