### PR TITLE
MBS-12809: Pass minimal existing data for Historic/RemoveDiscID

### DIFF
--- a/lib/MusicBrainz/Server/Edit/Historic/RemoveDiscID.pm
+++ b/lib/MusicBrainz/Server/Edit/Historic/RemoveDiscID.pm
@@ -38,9 +38,10 @@ sub build_display_data
         releases => [ map {
             to_json_object($loaded->{Release}{$_})
         } @{ $self->data->{release_ids} } ],
-        cdtoc => to_json_object(CDTOC->new(
-            discid => $self->data->{disc_id}
-        )),
+        cdtoc => {
+            entityType => 'cdtoc',
+            discid => $self->data->{disc_id},
+        },
     };
 }
 

--- a/root/static/scripts/common/components/CDTocLink.js
+++ b/root/static/scripts/common/components/CDTocLink.js
@@ -13,7 +13,11 @@ import entityHref from '../utility/entityHref.js';
 
 type Props = {
   +anchorPath?: string,
-  +cdToc: CDTocT,
+  +cdToc: {
+    +discid: string,
+    +entityType: 'cdtoc',
+    ...
+  },
   +content?: string,
   +subPath?: string,
 };

--- a/root/types/edit_types_historic.js
+++ b/root/types/edit_types_historic.js
@@ -305,7 +305,10 @@ declare type MoveReleaseToReleaseGroupHistoricEditT = $ReadOnly<{
 declare type RemoveDiscIdHistoricEditT = $ReadOnly<{
   ...GenericEditT,
   +display_data: {
-    +cdtoc: CDTocT,
+    +cdtoc: {
+      +discid: string,
+      +entityType: 'cdtoc',
+    },
     +releases: $ReadOnlyArray<ReleaseT | null>,
   },
   +edit_type: EDIT_HISTORIC_REMOVE_DISCID_T,


### PR DESCRIPTION
### Fix MBS-12809

We were trying to build a new CDTOC from the discid alone, which actually goes against our definition of a `CDTOC` entity. This was now breaking in `TO_JSON` since it now expects a `track_offset`.

Rather than making that optional everywhere, I'm just passing a "minimal-cdtoc" JSON object with the data we have and allowing `CDTocLink` to use it - it does not need anything else, in any case.