### PR TITLE
MBS-12816: Highlight doc header when linking to fragment

### DIFF
--- a/root/static/styles/extra/wikidocs.less
+++ b/root/static/styles/extra/wikidocs.less
@@ -180,6 +180,9 @@
         }
     }
 
+    *:target {
+        background-color: @highlight-table-row;
+    }
 }
 
 // For pages that have no content between the h1 and the TOC


### PR DESCRIPTION
### Implement MBS-12816

# Problem
It's often unclear where a direct link to a fragment is pointing when opening a doc page, especially when the page
is short enough the browser does not load the linked section at the top of the window. For example, following https://musicbrainz.org/doc/Style/Relationships/URLs#When_to_remove in my computer shows the following, which does not suggest at all the user should be looking at "When to remove":
![image_2023-01-26_164540553](https://user-images.githubusercontent.com/1069224/214865777-c455fb41-c6d6-42a8-8d55-ed44325ac50f.png)

# Solution
I added a CSS highlight in `wikidocs.less` so that the target element will be highlighted in `@highlight-table-row` yellow (like highlighted edit notes with direct links).

This at least highlights the header for that section; sadly, in order to highlight more than that we'd probably need to either change the HTML to have the fragment ids on a `<section>` surrounding the heading + paragraphs, or add a class directly to all paragraphs after getting the HTML from the wiki. It's probably already better than nothing for direct the user's focus, I hope:

![Screenshot from 2023-01-05 11-47-20](https://user-images.githubusercontent.com/1069224/210790814-68402c4e-da49-4773-9595-44ce0c264b76.png)

# Testing
By hand, just by navigating to the appropriate URL (`/doc/Style/Relationships/URLs#When_to_remove`).