### PR TITLE
MBS-12817: Fix selector for relationship dialog warnings

### DIFF
--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -28,7 +28,7 @@ fieldset#relationship-editor {
 #content.rel-editor .btn.disabled {cursor: default; color: @button-text;}
 
 #content.rel-editor .warning,
-div.rel-editor-dialog .warning {
+div.relationship-dialog .warning {
     border: 2px red dotted;
     background: @negative-light-bg;
     padding: 0.5em;


### PR DESCRIPTION
### Fix MBS-12817

It seems `.rel-editor-dialog` is now `.relationship-dialog`, but we forgot to update the CSS accordingly.

Tested manually.