### PR TITLE
MBS-12737: Properly check backwardness with isRelationshipBackward

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -44,6 +44,7 @@ import type {
 import getLinkPhrase from '../utility/getLinkPhrase.js';
 import getRelationshipKey from '../utility/getRelationshipKey.js';
 import getRelationshipLinkType from '../utility/getRelationshipLinkType.js';
+import isRelationshipBackward from '../utility/isRelationshipBackward.js';
 
 import NewWorkLink from './NewWorkLink.js';
 
@@ -66,7 +67,7 @@ const RelationshipItem = (React.memo<PropsT>(({
   source,
   track,
 }: PropsT): React.MixedElement => {
-  const backward = relationship.entity1.id === source.id;
+  const backward = isRelationshipBackward(relationship, source);
   const target: CoreEntityT = backward
     ? relationship.entity0
     : relationship.entity1;

--- a/root/static/scripts/relationship-editor/utility/prepareHtmlFormSubmission.js
+++ b/root/static/scripts/relationship-editor/utility/prepareHtmlFormSubmission.js
@@ -28,6 +28,7 @@ import {
   findTargetTypeGroups,
   iterateRelationshipsInTargetTypeGroups,
 } from '../utility/findState.js';
+import isRelationshipBackward from '../utility/isRelationshipBackward.js';
 
 function pushRelationshipHiddenInputs(
   formName: string,
@@ -46,7 +47,7 @@ function pushRelationshipHiddenInputs(
     pushInput(relPrefix, 'removed', '1');
   }
 
-  const backward = relationship.entity1.id === source.id;
+  const backward = isRelationshipBackward(relationship, source);
   const target = backward ? relationship.entity0 : relationship.entity1;
 
   if (target.gid) {


### PR DESCRIPTION
### Fix MBS-12737

The overconfident check we had was hitting issues for recordings creating during the NGS migration which had the same rowid as the associated works.

We have a perfectly working `isRelationshipBackward` check, so this just changes the code to use it.

Tested manually with the examples on the ticket.