### PR TITLE
MBS-12709: Do not copy series part number with "Add another [entity]"

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -101,9 +101,19 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
       if (canBeOrdered) {
         maxLinkOrder = Math.max(maxLinkOrder, relationship.linkOrder);
       }
+      // Drop number attribute for part of series - useless to reuse
+      const relationshipAttributesForReuse = tree.removeIfExists(
+        relationship.attributes,
+        {
+          type: {gid: 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a'},
+          typeID: 788,
+          typeName: 'number',
+        },
+        compareLinkAttributeIds,
+      );
       newAttributesData = tree.union(
         newAttributesData,
-        relationship.attributes,
+        relationshipAttributesForReuse,
         compareLinkAttributeIds,
       );
     }


### PR DESCRIPTION
### Implement MBS-12709

While it's generally fairly useful to preload a new relationship with the attributes of the existing one, this is never the case with series part numbers - you almost always want each relationship to have a different number. As such, this stops them from being preloaded.

Tested manually.