### PR TITLE
MBS-12820: Add default label for attribute multiselects

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
+++ b/root/static/scripts/relationship-editor/components/DialogAttribute/MultiselectAttribute.js
@@ -224,7 +224,9 @@ const MultiselectAttribute = (React.memo<PropsT>(({
       {addColonText(localizeLinkAttributeTypeName(state.type))}
       <br />
       <LinkAttrTypeMultiselect
-        addLabel={addLabel ? addLabel() : ''}
+        addLabel={addLabel
+          ? addLabel()
+          : lp('Add another', 'relationship attribute')}
         buildExtraValueChildren={buildExtraValueChildren}
         dispatch={multiselectDispatch}
         state={state}


### PR DESCRIPTION
### Fix MBS-12820

Having no label in some cases is breaking the display of the + icon. Even without that, having a generic label is a lot easier to understand than having none.