### PR TITLE
MBS-12693: Select relationship type before target

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -837,6 +837,11 @@ const RelationshipDialogContent = (React.memo<PropsT>((
             state={sourceEntityState}
             targetType={targetType}
           />
+          <DialogLinkType
+            dispatch={linkTypeDispatch}
+            source={source}
+            state={linkTypeState}
+          />
           <DialogTargetEntity
             allowedTypes={targetTypeOptions}
             backward={backward}
@@ -844,11 +849,6 @@ const RelationshipDialogContent = (React.memo<PropsT>((
             linkType={selectedLinkType}
             source={source}
             state={targetEntityState}
-          />
-          <DialogLinkType
-            dispatch={linkTypeDispatch}
-            source={source}
-            state={linkTypeState}
           />
           <DialogAttributes
             dispatch={attributesDispatch}


### PR DESCRIPTION
### Implement MBS-12693

This follows the most natural-language-y flow (at least for English): "Entity Type" "Source" "Rel Type" "Target"
(e.g. "Artist Foo studied at Bar")

This does mean the attributes do not immediately follow the rel type even though they depend on it; had a discussion with @mwiencek and @aerozol and we all agreed that having the target further up is more important for clarity.