### PR TITLE
MBS-12806: Do not show "Play on LB" button for empty releases

### DIFF
--- a/lib/MusicBrainz/Server/Entity/Release.pm
+++ b/lib/MusicBrainz/Server/Entity/Release.pm
@@ -198,6 +198,26 @@ has 'cover_art_presence' => (
     is => 'rw'
 );
 
+=head2 has_no_tracks
+
+Returns true if the release has no tracks at all, or false
+if at least one medium on the release has one track or more.
+
+=cut
+
+sub has_no_tracks
+{
+    my ($self) = @_;
+    my @mediums = $self->all_mediums;
+    return 1 if !@mediums;
+
+    if (any { $_->track_count > 0 } @mediums) {
+        return 0;
+    };
+
+    return 1;
+}
+
 sub may_have_cover_art {
     my $cover_art_presence = shift->cover_art_presence;
 
@@ -282,6 +302,7 @@ around TO_JSON => sub {
         statusID    => $self->status_id,
         status      => to_json_object($self->status),
         cover_art_presence => $self->cover_art_presence,
+        has_no_tracks => boolean_to_json($self->has_no_tracks),
         may_have_cover_art => boolean_to_json($self->may_have_cover_art),
         may_have_discids => boolean_to_json($self->may_have_discids),
     };

--- a/root/layout/components/sidebar/ReleaseSidebar.js
+++ b/root/layout/components/sidebar/ReleaseSidebar.js
@@ -78,6 +78,7 @@ const ReleaseSidebar = ({release}: Props): React.Element<'div'> | null => {
   const script = scriptId == null
     ? null
     : linkedEntities.script[scriptId];
+  const isEmpty = release.has_no_tracks;
 
   return (
     <div id="sidebar">
@@ -109,10 +110,12 @@ const ReleaseSidebar = ({release}: Props): React.Element<'div'> | null => {
         )}
       </div>
 
-      <PlayOnListenBrainzButton
-        entityType="release"
-        mbids={release.gid}
-      />
+      {isEmpty ? null : (
+        <PlayOnListenBrainzButton
+          entityType="release"
+          mbids={release.gid}
+        />
+      )}
 
       <h2 className="release-information">
         {l('Release information')}

--- a/root/static/scripts/common/entity2.js
+++ b/root/static/scripts/common/entity2.js
@@ -260,6 +260,7 @@ export function createReleaseObject(
     cover_art_presence: 'absent',
     entityType: 'release',
     gid: '',
+    has_no_tracks: true,
     id: 0,
     language: null,
     languageID: null,

--- a/root/types/release.js
+++ b/root/types/release.js
@@ -35,6 +35,7 @@ declare type ReleaseT = $ReadOnly<{
   +combined_track_count?: string,
   +cover_art_presence: 'absent' | 'present' | 'darkened' | null,
   +events?: $ReadOnlyArray<ReleaseEventT>,
+  +has_no_tracks: boolean,
   +labels?: $ReadOnlyArray<ReleaseLabelT>,
   +language: LanguageT | null,
   +languageID: number | null,

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Edit.pm
@@ -288,6 +288,7 @@ test 'previewing/creating/editing a release group and release' => sub {
             ],
             editsPending => JSON::false,
             cover_art_presence => undef,
+            has_no_tracks => JSON::true,
             may_have_cover_art => JSON::true,
             may_have_discids => JSON::false,
             quality => 1,


### PR DESCRIPTION
### Implement MBS-12806

# Problem
The new "Play on ListenBrainz" button is appearing on every MusicBrainz release, even those which have no tracks at all. This just wastes the user's time if they click it (plus LB returns an ISE at the moment, but even if they returned a better "this is empty" page it would still be useless).

# Solution
I couldn't find any good, straightforward way to check for emptiness with the current code, so I added a new `has_no_tracks` method that just checks whether mediums exist at all, and if they do, whether all have 0 tracks.

This still shows the button if at least one medium on the release has tracks, since that should still be playable (it currently isn't because of a LB-side error which hopefully will be resolved soon).

# Testing
Tested with `/release/8a5285e9-4ce6-4aef-b77b-458d8f25f00f`, `/release/a1960f31-a4b6-4371-8275-18834115f82b` and `/release/0ee90972-72e8-4ef4-872e-5f31f0df6944`