### PR TITLE
MBS-12827: Run our sanitize function on new usernames

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -18,6 +18,7 @@ use MusicBrainz::Server::Data::Utils qw(
     hash_to_row
     load_subobjects
     placeholders
+    sanitize
     type_to_model
 );
 use MusicBrainz::Server::Constants qw( :edit_status :privileges );
@@ -246,11 +247,22 @@ sub find_subscribers
     $self->query_to_list_limited($query, [$editor_id], $limit, $offset);
 }
 
+sub _die_if_username_invalid {
+    my $name = shift;
+    my $sanitized_name = sanitize($name);
+
+    die 'Invalid user name' if (
+        $name ne $sanitized_name ||
+        $sanitized_name =~ qr{^deleted editor \#\d+$}i
+    );
+}
+
 sub insert
 {
     my ($self, $data) = @_;
 
-    die 'Invalid user name' if $data->{name} =~ qr{^deleted editor \#\d+$}i;
+    _die_if_username_invalid($data->{name});
+
     my $plaintext = $data->{password};
     $data->{password} = hash_password($plaintext);
     $data->{ha1} = ha1_password($data->{name}, $plaintext);
@@ -321,6 +333,10 @@ sub update_password
 sub update_profile
 {
     my ($self, $editor, $update) = @_;
+
+    if (defined $update->{username}) {
+        _die_if_username_invalid($update->{username});
+    }
 
     my $row = hash_to_row(
         $update,

--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -253,7 +253,8 @@ sub _die_if_username_invalid {
 
     die 'Invalid user name' if (
         $name ne $sanitized_name ||
-        $sanitized_name =~ qr{^deleted editor \#\d+$}i
+        $sanitized_name =~ qr{^deleted editor \#\d+$}i ||
+        $sanitized_name =~ qr{://}
     );
 }
 

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -207,7 +207,10 @@ sub validate_username {
     if (defined $username) {
         unless (defined $previous_username && $editor_model->are_names_equivalent($previous_username, $username)) {
             my $sanitized_name = sanitize($username);
-            if ($username ne $sanitized_name) {
+            if (
+                $username ne $sanitized_name ||
+                $sanitized_name =~ qr{://}
+            ) {
                 $self->add_error(l('This username contains invalid characters. (Check for consecutive spaces.)'));
             }
             if ($username =~ qr{^deleted editor \#\d+$}i) {

--- a/lib/MusicBrainz/Server/Form/Utils.pm
+++ b/lib/MusicBrainz/Server/Form/Utils.pm
@@ -3,6 +3,7 @@ package MusicBrainz::Server::Form::Utils;
 use strict;
 use warnings;
 
+use MusicBrainz::Server::Data::Utils qw( sanitize );
 use MusicBrainz::Server::Translation qw( l lp );
 use List::AllUtils qw( sort_by );
 
@@ -205,6 +206,10 @@ sub validate_username {
 
     if (defined $username) {
         unless (defined $previous_username && $editor_model->are_names_equivalent($previous_username, $username)) {
+            my $sanitized_name = sanitize($username);
+            if ($username ne $sanitized_name) {
+                $self->add_error(l('This username contains invalid characters. (Check for consecutive spaces.)'));
+            }
             if ($username =~ qr{^deleted editor \#\d+$}i) {
                 $self->add_error(l('This username is reserved for internal use.'));
             }

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -74,6 +74,24 @@ test 'Trying to register with an invalid name' => sub {
 
     like($mech->uri, qr{/register}, 'stays on registration page');
     $mech->content_contains('username is reserved', 'form has error message');
+
+    $mech->submit_form( with_fields => {
+        'register.username' => "very\rnew\nlines",
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('username contains invalid characters', 'form has error message for newlines in username');
+
+    $mech->submit_form( with_fields => {
+        'register.username' => 'consecutive  spaces',
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('username contains invalid characters', 'form has error message for consecutive spaces in username');
 };
 
 test 'Trying to register with an existing name' => sub {

--- a/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/User/Register.pm
@@ -92,6 +92,15 @@ test 'Trying to register with an invalid name' => sub {
     });
     like($mech->uri, qr{/register}, 'stays on registration page');
     $mech->content_contains('username contains invalid characters', 'form has error message for consecutive spaces in username');
+
+    $mech->submit_form( with_fields => {
+        'register.username' => 'looks://like_a_url_to_me',
+        'register.password' => 'foo',
+        'register.confirm_password' => 'foo',
+        'register.email' => 'foobar@example.org',
+    });
+    like($mech->uri, qr{/register}, 'stays on registration page');
+    $mech->content_contains('username contains invalid characters', 'form has error message for :// in username');
 };
 
 test 'Trying to register with an existing name' => sub {


### PR DESCRIPTION
Fixes https://tickets.metabrainz.org/browse/MBS-12827

This shows an error on the registration form (and should also show one on the admin edit user form) if the name doesn't match the sanitized version of the name.  I imagine this will mostly be accidentally triggered by people adding extraneous whitespace characters. Suggestions for how to best word the error message are appreciated.

If an unsanitized username somehow makes it past our form validation, the editor data layer performs the same check and possibly dies.