### PR TITLE
MBS-2349: Allow merging RGs when merging releases

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -4,6 +4,7 @@ use MooseX::MethodAttributes;
 
 use MusicBrainz::Server::Constants qw(
     :edit_type
+    $EDITOR_MODBOT
     $MAX_INITIAL_MEDIUMS
     $MAX_INITIAL_TRACKS
 );
@@ -43,7 +44,7 @@ with 'MusicBrainz::Server::Controller::Role::Collection' => {
 };
 
 use List::AllUtils qw( first nsort_by uniq );
-use MusicBrainz::Server::Translation qw( l );
+use MusicBrainz::Server::Translation qw( l N_l );
 use MusicBrainz::Server::Validation qw(
     is_integer
     is_positive_integer
@@ -53,6 +54,7 @@ use POSIX qw( ceil );
 use MusicBrainz::Server::Data::Utils qw(
     artist_credit_to_ref
     boolean_to_json
+    localized_note
     partial_date_to_hash
 );
 
@@ -381,6 +383,61 @@ sub _merge_parameters {
                 }, keys %medium_changes,
             ],
         );
+    } else {
+        return ();
+    }
+}
+
+sub _merge_on_creation {
+    my ($self, $c, $edit, $form, $new, $old_ids, $entities_by_id) = @_;
+    if ($form->field('merge_rgs')->value) {
+        my $edit_id = $edit->id;
+
+        my $new_rg_id = $new->release_group->id;
+        # We want to make sure we're merging only different RGs!
+        my @old_entities = map +{ id => $_->id, name => $_->name },
+            grep { $_->id != $new_rg_id }
+            map { $entities_by_id->{$_}->release_group }
+            @$old_ids;
+        if (scalar @old_entities) {
+            my $rg_edit = $self->_insert_edit(
+                $c, $form,
+                edit_type => $EDIT_RELEASEGROUP_MERGE,
+                editor_id => $c->user->id,
+                old_entities => \@old_entities,
+                new_entity => {
+                    id => $new_rg_id,
+                    name => $new->release_group->name,
+                },
+            );
+            my $rg_edit_id = $rg_edit->id;
+            $c->model('EditNote')->add_note(
+                $rg_edit_id,
+                {
+                    text => localized_note(
+                        N_l('These release groups are being merged in connection with a release merge in {edit_link|edit #{edit_id}}.'),
+                        vars => {
+                            edit_id => $edit_id,
+                            edit_link => '' . $c->uri_for_action('/edit/show', [ $edit_id ]),
+                        },
+                    ),
+                    editor_id => $EDITOR_MODBOT,
+                },
+            );
+            $c->model('EditNote')->add_note(
+                $edit_id,
+                {
+                    text => localized_note(
+                        N_l('The associated release groups are being merged in {edit_link|edit #{edit_id}}.'),
+                        vars => {
+                            edit_id => $rg_edit_id,
+                            edit_link => '' . $c->uri_for_action('/edit/show', [ $rg_edit_id ]),
+                        },
+                    ),
+                    editor_id => $EDITOR_MODBOT,
+                },
+            );
+        }
     } else {
         return ();
     }

--- a/lib/MusicBrainz/Server/Controller/Release.pm
+++ b/lib/MusicBrainz/Server/Controller/Release.pm
@@ -494,6 +494,7 @@ sub _merge_load_entities {
     $c->model('ArtistCredit')->load(@releases);
     $c->model('Release')->load_aliases(@releases);
     $c->model('Release')->load_related_info(@releases);
+    $c->model('ReleaseGroup')->load(@releases);
 }
 
 with 'MusicBrainz::Server::Controller::Role::Delete' => {

--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -202,21 +202,23 @@ role {
 
         $c->model('MB')->with_transaction(sub {
             if ($params->edit_type) {
-                $self->_insert_edit(
-                    $c, $form,
-                    edit_type => $params->edit_type,
-                    new_entity => {
-                        id => $new->id,
-                        name => $new->name,
-                        $self->_extra_entity_data($c, $form, $new),
+                $self->edit_action($c,
+                    form        => $params->merge_form,
+                    type        => $params->edit_type,
+                    edit_args   => {
+                        new_entity => {
+                            id => $new->id,
+                            name => $new->name,
+                            $self->_extra_entity_data($c, $form, $new),
+                        },
+                        old_entities => [ map +{
+                            id => $entity_id{$_}->id,
+                            name => $entity_id{$_}->name,
+                            $self->_extra_entity_data($c, $form, $entity_id{$_}),
+                        }, @old_ids ],
+                        (map { $_->name => $_->value } $form->edit_fields),
+                        $self->_merge_parameters($c, $form, $entities),
                     },
-                    old_entities => [ map +{
-                        id => $entity_id{$_}->id,
-                        name => $entity_id{$_}->name,
-                        $self->_extra_entity_data($c, $form, $entity_id{$_}),
-                    }, @old_ids ],
-                    (map { $_->name => $_->value } $form->edit_fields),
-                    $self->_merge_parameters($c, $form, $entities),
                 );
             } elsif ($c->namespace eq 'collection') {
                 $c->model('Collection')->merge(

--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -194,7 +194,7 @@ role {
 
         my %entity_id = map { $_->id => $_ } @$entities;
 
-        my $new_id = $form->field('target')->value or die 'Coludnt figure out new_id';
+        my $new_id = $form->field('target')->value or die q{Couldn't figure out new_id};
         my $new = $entity_id{$new_id};
         my @old_ids = grep { $_ != $new_id } @{ $form->field('merging')->value };
 

--- a/lib/MusicBrainz/Server/Controller/Role/Merge.pm
+++ b/lib/MusicBrainz/Server/Controller/Role/Merge.pm
@@ -4,9 +4,14 @@ use MooseX::Role::Parameterized;
 use namespace::autoclean;
 
 use List::AllUtils qw( any nsort_by uniq );
-use MusicBrainz::Server::Data::Utils qw( type_to_model );
+use MusicBrainz::Server::Constants qw(
+    $EDIT_RELEASEGROUP_MERGE
+    $EDITOR_MODBOT
+);
+use MusicBrainz::Server::Data::Utils qw( localized_note type_to_model );
 use MusicBrainz::Server::Entity::Util::JSON qw( to_json_array );
 use MusicBrainz::Server::Log qw( log_assertion );
+use MusicBrainz::Server::Translation qw( N_l );
 use MusicBrainz::Server::Validation qw( is_positive_integer );
 
 parameter 'edit_type' => (
@@ -218,6 +223,61 @@ role {
                         }, @old_ids ],
                         (map { $_->name => $_->value } $form->edit_fields),
                         $self->_merge_parameters($c, $form, $entities),
+                    },
+                    on_creation => sub {
+                        my ($edit, $form) = @_;
+
+                        if ($c->namespace eq 'release' && $form->field('merge_rgs')->value) {
+                            my $edit_id = $edit->id;
+
+                            my $new_rg_id = $new->release_group->id;
+                            # We want to make sure we're merging only different RGs!
+                            my @old_entities = map +{
+                                id => $entity_id{$_}->release_group->id,
+                                name => $entity_id{$_}->release_group->name,
+                            },
+                            grep { $entity_id{$_}->release_group->id != $new_rg_id }
+                            @old_ids;
+                            if (scalar @old_entities) {
+                                my $rg_edit = $self->_insert_edit(
+                                    $c, $form,
+                                    edit_type => $EDIT_RELEASEGROUP_MERGE,
+                                    editor_id => $c->user->id,
+                                    old_entities => \@old_entities,
+                                    new_entity => {
+                                        id => $new_rg_id,
+                                        name => $new->release_group->name,
+                                    },
+                                );
+                                my $rg_edit_id = $rg_edit->id;
+                                $c->model('EditNote')->add_note(
+                                    $rg_edit_id,
+                                    {
+                                        text => localized_note(
+                                            N_l('These release groups are being merged in connection with a release merge in {edit_link|edit #{edit_id}}.'),
+                                            vars => {
+                                                edit_id => $edit_id,
+                                                edit_link => '' . $c->uri_for_action('/edit/show', [ $edit_id ]),
+                                            },
+                                        ),
+                                        editor_id => $EDITOR_MODBOT,
+                                    },
+                                );
+                                $c->model('EditNote')->add_note(
+                                    $edit_id,
+                                    {
+                                        text => localized_note(
+                                            N_l('The associated release groups are being merged in {edit_link|edit #{edit_id}}.'),
+                                            vars => {
+                                                edit_id => $rg_edit_id,
+                                                edit_link => '' . $c->uri_for_action('/edit/show', [ $rg_edit_id ]),
+                                            },
+                                        ),
+                                        editor_id => $EDITOR_MODBOT,
+                                    },
+                                );
+                            }
+                        }
                     },
                 );
             } elsif ($c->namespace eq 'collection') {

--- a/lib/MusicBrainz/Server/Form/Merge/Release.pm
+++ b/lib/MusicBrainz/Server/Form/Merge/Release.pm
@@ -47,6 +47,10 @@ has_field 'medium_positions.map.name' => (
     type => 'Text',
 );
 
+has_field 'merge_rgs' => (
+    type => 'Checkbox',
+);
+
 sub edit_field_names { qw(merge_strategy) }
 
 sub options_merge_strategy {

--- a/root/release/ReleaseMerge.js
+++ b/root/release/ReleaseMerge.js
@@ -17,6 +17,8 @@ import EnterEdit from '../static/scripts/edit/components/EnterEdit.js';
 import EnterEditNote
   from '../static/scripts/edit/components/EnterEditNote.js';
 import FieldErrors from '../static/scripts/edit/components/FieldErrors.js';
+import FormRowCheckbox
+  from '../static/scripts/edit/components/FormRowCheckbox.js';
 import ReleaseMergeStrategy
   from '../static/scripts/edit/components/ReleaseMergeStrategy.js';
 
@@ -50,6 +52,12 @@ component ReleaseMerge(
             form={form}
             mediums={mediums}
             releases={linkedEntities.release}
+          />
+
+          <FormRowCheckbox
+            field={form.field.merge_rgs}
+            label={l('Also merge the associated release groups')}
+            uncontrolled
           />
 
           <EnterEditNote field={form.field.edit_note} />

--- a/root/types/forms.js
+++ b/root/types/forms.js
@@ -44,6 +44,7 @@ declare type MergeReleasesFormT = FormT<{
   +medium_positions: CompoundFieldT<{
     +map: CompoundFieldT<$ReadOnlyArray<MediumFieldT | void>>,
   }>,
+  +merge_rgs: FieldT<boolean>,
   +merge_strategy: FieldT<StrOrNum>,
   +merging: RepeatableFieldT<FieldT<StrOrNum>>,
   +rename: FieldT<boolean>,

--- a/t/lib/t/MusicBrainz/Server/Controller/Release/Merge.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Release/Merge.pm
@@ -218,6 +218,154 @@ cmp_deeply($edit->data, {
 
 };
 
+test 'Can merge release groups with releases' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+release');
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
+
+    $mech->get_ok('/release/merge_queue?add-to-merge=6');
+    $mech->get_ok('/release/merge_queue?add-to-merge=100');
+
+    $mech->get_ok('/release/merge');
+    $mech->submit_form_ok({
+        with_fields => {
+            'merge.target' => '6',
+            'merge.medium_positions.map.0.position' => '1',
+            'merge.medium_positions.map.1.position' => '2',
+            'merge.merge_rgs' => '1',
+            'merge.merge_strategy' => '1',
+            'merge.edit_note' => 'This is an edit note',
+        },
+    });
+
+    my $rg_edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    isa_ok($rg_edit, 'MusicBrainz::Server::Edit::ReleaseGroup::Merge');
+
+    cmp_deeply($rg_edit->data, {
+        new_entity => {
+            id => 1,
+            name => 'Arrival',
+        },
+        old_entities => [{
+            id => 100,
+            name => 'Pregap?',
+        }],
+    });
+
+    my $release_edit = $test->c->model('Edit')->get_by_id($rg_edit->id - 1);
+    isa_ok($release_edit, 'MusicBrainz::Server::Edit::Release::Merge');
+};
+
+test 'Cannot merge RGs if all releases are in the same RG' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $c    = $test->c;
+
+    MusicBrainz::Server::Test->prepare_test_database($c, '+release');
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => { username => 'editor', password => 'pass' } );
+
+    $mech->get_ok('/release/merge_queue?add-to-merge=6');
+    $mech->get_ok('/release/merge_queue?add-to-merge=7');
+
+    $mech->get_ok('/release/merge');
+    $mech->submit_form_ok({
+        with_fields => {
+            'merge.target' => '6',
+            'merge.merge_rgs' => '1',
+            'merge.merge_strategy' => '1',
+            'merge.edit_note' => 'This is an edit note',
+        },
+    });
+
+    my $release_edit = MusicBrainz::Server::Test->get_latest_edit($c);
+    note('If the latest edit is a release merge, no RG merge was entered');
+    isa_ok($release_edit, 'MusicBrainz::Server::Edit::Release::Merge');
+
+    cmp_deeply($release_edit->data, {
+        new_entity => {
+            id => 6,
+            name => 'The Prologue (disc 1)',
+            labels => [],
+            artist_credit => {
+                names => [
+                    {
+                        artist => {
+                            id => 1,
+                            name => 'Name',
+                        },
+                        join_phrase => '',
+                        name => 'Name',
+                    },
+                ],
+            },
+            mediums => [{
+                format_name => undef,
+                track_count => 1,
+            }],
+            events => [],
+        },
+        old_entities => [{
+            id => 7,
+            name => 'The Prologue (disc 2)',
+            labels => [],
+            artist_credit => {
+                names => [
+                    {
+                        artist => {
+                            id => 1,
+                            name => 'Name',
+                        },
+                        join_phrase => '',
+                        name => 'Name',
+                    },
+                ],
+            },
+            mediums => [{
+                format_name => undef,
+                track_count => 1,
+            }],
+            events => [],
+        }],
+        merge_strategy => 1,
+        _edit_version => 3,
+        medium_changes => bag(
+            {
+                release => {
+                    id => 6,
+                    name => 'The Prologue (disc 1)',
+                },
+                mediums => [{
+                    id => 2,
+                    old_position => 1,
+                    new_position => 1,
+                    old_name => '',
+                    new_name => '',
+                }],
+            },
+            {
+                release => {
+                    id => 7,
+                    name => 'The Prologue (disc 2)',
+                },
+                mediums => [{
+                    id => 3,
+                    old_position => 1,
+                    new_position => 2,
+                    old_name => '',
+                    new_name => '',
+                }],
+            },
+        ),
+    }, 'The release merge edit was still entered and contains the expected data');
+};
+
 test 'Edit note is required' => sub {
     my $test = shift;
     my $mech = $test->mech;


### PR DESCRIPTION
### Implement MBS-2349

# Problem
We used to have a checkbox before NGS came which allowed editors to enter a merge for the associated release groups when merging releases, and I still don't know why it was removed. I *think* it's because ocharles thought it was better to just let orphaned RGs get autoremoved, but that goes against the whole merge rather than delete ethos.

Readding the checkbox would allow editors to stop leaving orphaned RGs behind, without them having to go merge them by hand separately (which is enough effort to often think "you know what, whatever, they'll be garbage-collected anyway").

# Solution
This (re-)adds a checkbox "Also merge the associated release groups" when merging releases. If selected, a second "Merge release groups" edit will be entered when submitting the "Merge releases edit" (under the original editor's account since it's entered by their choice). Both edits are linked to each other by ModBot edit notes.

# Testing
So far I've tested this manually and it does what we expect it to, so putting it up to see if the idea seems sensible to others.

# Actions
* [x] Write a test.
* [x] Make the ModBot notes translatable (I guess? Although the credit edit notes when editing an artist name are not translatable).
* [x] Figure out how to make these edits also appear on the "Thank you, your edit(s)" message, which they do not right now.