### PR TITLE
MBS-12831: Don't hide disambiguations in relationship previews

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -113,7 +113,6 @@ const DialogPreview = (React.memo<PropsT>(({
       }
       disableLink={isDisabledLink(relationship, entity)}
       entity={entity}
-      showDisambiguation={false}
       target="_blank"
     />
   );


### PR DESCRIPTION
### Implement MBS-12831

# Problem
Showing disambiguation comments is disabled when previewing relationships in the relationship editor. 

I'm not sure why this was actively disabled here (the commit history shows nothing about it) but it certainly seems useful to see the disambiguations in the preview. There's at least two cases where this can be very useful:
1) When the two entities have the same or a very similar name, so the disambiguation is the main way to understand the selected order.
2) When the editor misclicked and picked another entity with the same name as the intended one, having the disambiguation here makes it easier to notice and fix immediately.

# Solution
Just remove the parameter disabling disambiguations.

# Testing
Tested manually. Since this is the default mechanism for `EntityLink`, I understand there's no need to create a separate test for it here.