### PR TITLE
Update the ways to access $c from JavaScript

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -482,13 +482,9 @@ Common instructions for porting:
         ```
 
  3. You can access most of the [Catalyst Context](http://search.cpan.org/~ether/Catalyst-Manual-5.9009/lib/Catalyst/Manual/Intro.pod#Context) in JavaScript
-    via the variable `$c`. This is passed as a prop automatically if the
-    component is top-level or used from `React.embed`. If you need to access
-    `$c` from a deeply-nested component, you can either pass it down from
-    a parent component, or import the `CatalystContext`
-    [React context](https://reactjs.org/docs/context.html) from
-    root/context.mjs and either use the `CatalystContext.Consumer` component
-    or use `React.useContext(CatalystContext)`.
+    by importing the `CatalystContext` [React context](https://reactjs.org/docs/context.html)
+    from root/context.mjs and either using the `CatalystContext.Consumer` component
+    or using `React.useContext(CatalystContext)` (assigned by convention to the constant `$c`).
 
  4. To communicate between the Perl and Node servers (the latter renders React
     components for us), you need to appropriately serialize the props passed


### PR DESCRIPTION
We no longer pass `$c` to every top component, as HACKING still claimed, so reworded that a bit in a way that I think is correct.