### PR TITLE
MBS-10609: Actually check for edit notes by beginners

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -411,7 +411,13 @@ sub update_privileges {
                 + ($values->{spammer}               // 0) * $SPAMMER_FLAG;
 
     Sql::run_in_transaction(sub {
-        $self->sql->do('UPDATE editor SET privs = ? WHERE id = ?', $privs, $editor->id);
+        $self->sql->do(
+            'UPDATE editor SET privs = ? | (privs & ?) WHERE id = ?',
+            $privs,
+            # Preserve the value of the beginner flag.
+            $BEGINNER_FLAG,
+            $editor->id,
+        );
     }, $self->sql);
 }
 


### PR DESCRIPTION
### Fix MBS-10609

# Problem
The edit search filter for edit notes by a beginner editor was returning edits which did not have an edit note at all.

On inspection of the code, I found that we were completely replacing the search condition in `Predicate::Role::User` when the operator was `limited`, so this search was becoming simply "Editor is a beginner".

# Solution

Originally I just added a new operator `beginner_note_author` and added a new `elsif` to handle it, but @mwiencek suggested in a comment a way we'd be able to use the passed template clauses, which seems to work nicely, so I ended up using that.

# Testing

Tested by hand only.

We don't seem to currently have any decent tests for edit search ensuring the correct results are returned (only some tests that check validation of fields). Ideally we'd change that, although a proper set of edit search tests would probably require putting together a dataset with a fair amount of edits to test on.