### PR TITLE
MBS-12851: Hide ratings/tags stats for deleted users

### DIFF
--- a/root/user/UserProfile.js
+++ b/root/user/UserProfile.js
@@ -793,7 +793,13 @@ const UserProfileStatistics = ({
             {hasPublicTags ? (
               <>
                 <UserProfileProperty name={l('Tags upvoted')}>
-                  {$c.user && upvotedTagCount > 0 ? exp.l(
+                  {user.deleted ? (
+                    <abbr
+                      title={l('Tags are removed when an editor is deleted.')}
+                    >
+                      {lp('Deleted', 'tags')}
+                    </abbr>
+                  ) : $c.user && upvotedTagCount > 0 ? exp.l(
                     '{count} ({view_url|view})',
                     {
                       count: formatCount($c, upvotedTagCount),
@@ -803,7 +809,13 @@ const UserProfileStatistics = ({
                 </UserProfileProperty>
 
                 <UserProfileProperty name={l('Tags downvoted')}>
-                  {$c.user && downvotedTagCount > 0 ? exp.l(
+                  {user.deleted ? (
+                    <abbr
+                      title={l('Tags are removed when an editor is deleted.')}
+                    >
+                      {lp('Deleted', 'tags')}
+                    </abbr>
+                  ) : $c.user && downvotedTagCount > 0 ? exp.l(
                     '{count} ({view_url|view})',
                     {
                       count: formatCount($c, downvotedTagCount),
@@ -815,7 +827,16 @@ const UserProfileStatistics = ({
             ) : null}
             {hasPublicRatings ? (
               <UserProfileProperty name={l('Ratings')}>
-                {$c.user && ratingCount > 0 ? exp.l(
+                {user.deleted ? (
+                  <abbr
+                    title={
+                      l('Ratings are removed when an editor is deleted.')
+                    }
+                  >
+                    {lp('Deleted', 'ratings')}
+                  </abbr>
+
+                ) : $c.user && ratingCount > 0 ? exp.l(
                   '{count} ({view_url|view})',
                   {
                     count: formatCount($c, ratingCount),


### PR DESCRIPTION
### Implement MBS-12851

# Problem

We blank tags and ratings as part of the user deletion process, so showing stats for their ratings and tags is useless in any case. I'd argue it's also kind of misleading, since it might give the impression they had never tagged/rated before (since their added entity data for example still shows the correct numbers on the adjacent statistics table).

# Solution

As suggested by @Aerozol, rather than deleting the whole table, we specify that the data is deleted:
![Screenshot from 2023-02-21 16-51-09](https://user-images.githubusercontent.com/1069224/220379343-b1ed55a4-8b87-4e1a-9082-8a84e1935590.png)


# Testing

Tested manually: both that a deleted editor, `/user/Deleted%20Editor%20%23667117`, shows no stats and says "Deleted", and that a non-deleted editor, `/user/reosarevok`, does still show them.