### PR TITLE
 MBS-10610: Search for edits made by non-beginners 

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
@@ -32,6 +32,7 @@ role {
             'me' => 0,
             'not_me' => 0,
             'limited' => 0,
+            'not_limited' => 0,
             'not_edit_author' => 0,
             'nobody' => 0,
         );
@@ -57,6 +58,16 @@ role {
 
             $sql = $template_clause =~
                 s/ROLE_CLAUSE\(([^)]*)\)/$1 IN ($beginner_sql)/r;
+            $query->add_where([ $sql, [ $BEGINNER_FLAG ] ]);
+        } elsif ($self->operator eq 'not_limited') {
+            my $nonbeginner_sql = <<~'SQL';
+                SELECT id
+                  FROM editor beginner
+                 WHERE (privs & ?) = 0
+                SQL
+
+            $sql = $template_clause =~
+                s/ROLE_CLAUSE\(([^)]*)\)/$1 IN ($nonbeginner_sql)/r;
             $query->add_where([ $sql, [ $BEGINNER_FLAG ] ]);
         } elsif ($self->operator eq 'not_edit_author') {
             $query->add_where([

--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
@@ -62,7 +62,7 @@ role {
         } elsif ($self->operator eq 'not_limited') {
             my $nonbeginner_sql = <<~'SQL';
                 SELECT id
-                  FROM editor beginner
+                  FROM editor non_beginner
                  WHERE (privs & ?) = 0
                 SQL
 

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -367,6 +367,7 @@
                    [ 'subscribed', l('is in my subscriptions') ]
                    [ 'not_subscribed', l('is not in my subscriptions') ]
                    [ 'limited', l('is a beginner') ]
+                   [ 'not_limited', l('is not a beginner') ]
                 ], field_contents) %]
   [% END %]  
   <span class="arg autocomplete editor">


### PR DESCRIPTION
### Implement MBS-10610

On top of https://github.com/metabrainz/musicbrainz-server/pull/2813 to limit conflicts.

# Problem
There is currently no way to explicitly look for edits by non-beginner editors, but some editors had requested this to be made possible. The main goal was to search for edits by non-beginners with notes by beginners, which is going to be possible again with MBS-10614 (in beta now).

# Solution
I added a `not_limited` equivalent to the existing `limited` check as part of the `User` predicate role, which is only made available for `predicate_user`s other than `edit_note_author` (so, effectively, only for `editor`).

This is our fourth different check for beginner status (fifth once the fix for MBS-10609 is merged). Ideally we would be having this check at the database level and just be able to query `editor.beginner`, but I'm not quite sure how that would look like (a trigger-updated column would probably mean the trigger would need to run on every edit, which seems problematic). If there's any suggestions that we can implement in the next schema change, I'd be happy to hear them.

# Testing

Tested manually only (by navigating through a bunch of pages of the edit search and making sure no edits by beginner editors appeared with the predicate on, but they did without).