### PR TITLE
MBS-12847: Allow searching for edits without any notes 

### DIFF
--- a/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
+++ b/lib/MusicBrainz/Server/EditSearch/Predicate/Role/User.pm
@@ -33,6 +33,7 @@ role {
             'not_me' => 0,
             'limited' => 0,
             'not_edit_author' => 0,
+            'nobody' => 0,
         );
     };
 
@@ -66,6 +67,15 @@ role {
                 )',
                 [ ],
             ]);
+        } elsif ($self->operator eq 'nobody') {
+            $sql = <<~'SQL';
+                NOT EXISTS (
+                    SELECT TRUE
+                      FROM edit_note
+                     WHERE edit_note.edit = edit.id
+                )
+                SQL
+            $query->add_where([ $sql, [ ] ]);
         } else {
             $query->add_where([ $sql, [ $self->arguments ] ]);
         }

--- a/root/edit/search_macros.tt
+++ b/root/edit/search_macros.tt
@@ -357,6 +357,7 @@
                    [ 'not_subscribed', l('do not include editors in my subscriptions') ]
                    [ 'limited', l('include a beginner editor') ]
                    [ 'not_edit_author', l('include someone other than the edit author') ]
+                   [ 'nobody', l('do not exist (edit has no notes)') ]
                 ], field_contents) %]
   [% ELSE %]
     [% operators([ [ '=', l('is') ]

--- a/root/vote/VotingIndex.js
+++ b/root/vote/VotingIndex.js
@@ -67,9 +67,9 @@ component VotingIndex() {
         <p>
           {l(
             `By default, these searches skip your own edits and edits you have
-            already voted on (when relevant). To change that, load the search
-            and then remove the conditions “Editor is not me” and “Voter is me
-            and voted No vote”, respectively.`,
+             already voted on (when relevant). To change that, load the search
+             and then remove the conditions “Editor is not me” and “Voter is
+             me and voted No vote”, respectively.`,
           )}
         </p>
 
@@ -82,12 +82,14 @@ component VotingIndex() {
              guaranteed to remain open for at least two full days even if they
              get three “Yes” votes, to avoid them closing too quickly, but
              it’s always good to get more eyes on them. Below you can find
-             four different searches: one for all destructive edits (which
-             might be overwhelming sometimes), one for entity merges and
-             removals only (the edits more likely to cause a mess if they
-             incorrectly go through), one for relationship removals only, and
-             one for destructive changes to releases (track, medium and
-             release label removals).`,
+             five different searches: one for all destructive edits (which
+             might be overwhelming sometimes), one only for those destructive
+             edits that have no edit notes (so no reasoning has been provided
+             for them at all), one for entity merges and removals only
+             (the edits more likely to cause a mess if they incorrectly go
+             through), one for relationship removals only, and one for
+             destructive changes to releases (track, medium and release label
+             removals).`,
           )}
         </p>
         <ul>
@@ -99,6 +101,16 @@ component VotingIndex() {
               'conditions.1.field=status&conditions.1.operator=%3D&conditions.1.args=1&' +
               'conditions.2.field=editor&conditions.2.operator=not_me&conditions.2.name=&conditions.2.args.0=&' +
               'conditions.3.field=voter&conditions.3.operator=me&conditions.3.name=&conditions.3.voter_id=&conditions.3.args=no'}
+            showSubscribedArtistsUrl
+          />
+          <VotingGuideRow
+            guideName={l('All open destructive edits without edit notes')}
+            mainUrl={'/search/edits?' +
+              'conditions.0.field=type&conditions.0.operator=%3D&conditions.0.args=9&conditions.0.args=84&conditions.0.args=4&conditions.0.args=153&conditions.0.args=134&conditions.0.args=14&conditions.0.args=64&conditions.0.args=74&conditions.0.args=24&conditions.0.args=225%2C223%2C311&conditions.0.args=143&conditions.0.args=44&conditions.0.args=83&conditions.0.args=3&conditions.0.args=315&conditions.0.args=152&conditions.0.args=133&conditions.0.args=78&conditions.0.args=410&conditions.0.args=13&conditions.0.args=53&conditions.0.args=63&conditions.0.args=73&conditions.0.args=23&conditions.0.args=36&conditions.0.args=224&conditions.0.args=142&conditions.0.args=211&conditions.0.args=43&conditions.0.args=47&' +
+              'conditions.1.field=status&conditions.1.operator=%3D&conditions.1.args=1&' +
+              'conditions.2.field=editor&conditions.2.operator=not_me&conditions.2.name=&conditions.2.args.0=&' +
+              'conditions.3.field=voter&conditions.3.operator=me&conditions.3.name=&conditions.3.voter_id=&conditions.3.args=no&' +
+              'conditions.4.field=edit_note_author&conditions.4.operator=nobody&conditions.4.name=&conditions.4.args.0='}
             showSubscribedArtistsUrl
           />
           <VotingGuideRow
@@ -189,12 +201,12 @@ component VotingIndex() {
         <p>
           {l(
             `Edits that have already received “No” votes are also ones likely
-            to benefit from more eyes on them, to either confirm the edit is 
-            indeed incorrect or to add a dissenting opinion to the current
-            “No” vote. Similarly, edits with both “Yes” and “No” votes are
-            likely to benefit from more opinions to push them to one side or
-            the other. As always, remember to be polite, even if you disagree
-            with a voter!`,
+             to benefit from more eyes on them, to either confirm the edit is 
+             indeed incorrect or to add a dissenting opinion to the current
+             “No” vote. Similarly, edits with both “Yes” and “No” votes are
+             likely to benefit from more opinions to push them to one side or
+             the other. As always, remember to be polite, even if you disagree
+             with a voter!`,
           )}
         </p>
         <ul>
@@ -286,6 +298,16 @@ component VotingIndex() {
               'conditions.1.field=open_time&conditions.1.operator=>&conditions.1.args.0=2+weeks+ago&conditions.1.args.1=&' +
               'conditions.2.field=status&conditions.2.operator=%3D&conditions.2.args=1&' +
               'conditions.3.field=voter&conditions.3.operator=me&conditions.3.name=&conditions.3.voter_id=&conditions.3.args=no'}
+            showSubscribedArtistsUrl
+          />
+          <VotingGuideRow
+            guideName={l('All edits from beginner editors without edit notes made less than 2 weeks ago')}
+            mainUrl={'/search/edits?' +
+              'conditions.0.field=editor&conditions.0.operator=limited&conditions.0.name=&conditions.0.args.0=&' +
+              'conditions.1.field=open_time&conditions.1.operator=>&conditions.1.args.0=2+weeks+ago&conditions.1.args.1=&' +
+              'conditions.2.field=status&conditions.2.operator=%3D&conditions.2.args=1&' +
+              'conditions.3.field=voter&conditions.3.operator=me&conditions.3.name=&conditions.3.voter_id=&conditions.3.args=no&' +
+              'conditions.4.field=edit_note_author&conditions.4.operator=nobody&conditions.4.name=&conditions.4.args.0='}
             showSubscribedArtistsUrl
           />
           <VotingGuideRow


### PR DESCRIPTION
### Implement MBS-12847

On top of https://github.com/metabrainz/musicbrainz-server/pull/2808 to avoid possible conflicts.

# Problem
Edits without notes are a common mark of either beginners not quite sure of what they are doing (common risk of human error) or expert editors a bit too sure of what they are doing (also a common risk of human error). Despite that, we do not currently have any way to search for them specifically, AFAICT.

# Solution
This adds an option under "Edit Note Authors" (seemed the best fit) with the wording "do not exist (edit has no notes)". It might read a bit strangely, but it's the best I could think of - improvement suggestions welcome.

It also adds a new vote suggestion for beginner edits without notes, and another for destructive edits without notes. These seem like the most obvious use cases where a careful voter could be of use.

# Testing
Tested by hand (checked the results and they indeed had no edit notes) - it's also a very straightforward condition check.
Tested the new vote suggestion searches from `/vote`.