### PR TITLE
Document React state management

### DIFF
--- a/root/static/scripts/tests/examples/todo-list/README
+++ b/root/static/scripts/tests/examples/todo-list/README
@@ -1,0 +1,2 @@
+The TodoList component is used in HACKING.md as a reference example
+for React state management.

--- a/root/static/scripts/tests/examples/todo-list/Todo.js
+++ b/root/static/scripts/tests/examples/todo-list/Todo.js
@@ -1,0 +1,101 @@
+// @flow
+
+import * as React from 'react';
+
+import {uniqueId} from '../../../common/utility/numbers.js';
+
+export type StateT = {
+  +description: string,
+  +key: number,
+};
+
+export type ActionT =
+  | {
+      +description: string,
+      +type: 'set-description',
+    }
+  | {+type: 'move-up'}
+  | {+type: 'move-down'}
+  | {+type: 'remove'};
+
+type PropsT = {
+  +dispatch: (key: number, action: ActionT) => void,
+  +state: StateT,
+};
+
+export function createInitialState(): StateT {
+  return {
+    description: '',
+    key: uniqueId(),
+  };
+}
+
+export function reducer(
+  state: StateT,
+  action: ActionT,
+): StateT {
+  switch (action.type) {
+    case 'set-description': {
+      const newState = {...state};
+      newState.description = action.description;
+      return newState;
+    }
+    default: {
+      /*
+       * The other actions are handled by the parent
+       * reducer.
+       */
+      throw new Error();
+    }
+  }
+}
+
+type TodoComponentT = React.AbstractComponent<PropsT, mixed>;
+
+const Todo: TodoComponentT = React.memo<PropsT>(({
+  dispatch,
+  state,
+}: PropsT) => {
+  const moveUp = React.useCallback(() => {
+    dispatch(state.key, {type: 'move-up'});
+  }, [state.key, dispatch]);
+
+  const moveDown = React.useCallback(() => {
+    dispatch(state.key, {type: 'move-down'});
+  }, [state.key, dispatch]);
+
+  const remove = React.useCallback(() => {
+    dispatch(state.key, {type: 'remove'});
+  }, [state.key, dispatch]);
+
+  const setDescription = React.useCallback((
+    event: SyntheticKeyboardEvent<HTMLInputElement>,
+  ) => {
+    dispatch(state.key, {
+      type: 'set-description',
+      description: event.currentTarget.value,
+    });
+  }, [state.key, dispatch]);
+
+  return (
+    <li>
+      <input
+        onChange={setDescription}
+        placeholder="Description"
+        type="text"
+        value={state.description}
+      />
+      <button onClick={moveUp} type="button">
+        {'Move up'}
+      </button>
+      <button onClick={moveDown} type="button">
+        {'Move down'}
+      </button>
+      <button onClick={remove} type="button">
+        {'Remove'}
+      </button>
+    </li>
+  );
+});
+
+export default Todo;

--- a/root/static/scripts/tests/examples/todo-list/TodoList.js
+++ b/root/static/scripts/tests/examples/todo-list/TodoList.js
@@ -1,0 +1,129 @@
+// @flow
+
+import * as React from 'react';
+
+import Todo, {
+  type ActionT as TodoActionT,
+  type StateT as TodoStateT,
+  createInitialState as createTodoState,
+  reducer as todoReducer,
+} from './Todo.js';
+
+type PropsT = {
+  +initialTodos: $ReadOnlyArray<TodoStateT>,
+};
+
+type StateT = {
+  +todos: $ReadOnlyArray<TodoStateT>,
+};
+
+type ActionT =
+  | {
+      +type: 'add-todo',
+    }
+  | {
+      +action: TodoActionT,
+      +key: number,
+      +type: 'update-todo',
+    };
+
+export function createInitialState(
+  initialTodos: $ReadOnlyArray<TodoStateT>,
+): StateT {
+  return {todos: initialTodos};
+}
+
+function reducer(state: StateT, action: ActionT): StateT {
+  const newState = {...state};
+  switch (action.type) {
+    case 'add-todo': {
+      newState.todos = [
+        ...newState.todos,
+        createTodoState(),
+      ];
+      break;
+    }
+    case 'update-todo': {
+      const index = newState.todos.findIndex(x => x.key === action.key);
+      const todoAction = action.action;
+      let newTodos = newState.todos;
+
+      switch (todoAction.type) {
+        case 'move-up': {
+          if (index > 0) {
+            newTodos = [...newState.todos];
+            // $FlowIssue[unsupported-syntax]
+            [newTodos[index - 1], newTodos[index]] =
+              [newTodos[index], newTodos[index - 1]];
+          }
+          break;
+        }
+        case 'move-down': {
+          if (index < (newState.todos.length - 1)) {
+            newTodos = [...newState.todos];
+            // $FlowIssue[unsupported-syntax]
+            [newTodos[index], newTodos[index + 1]] =
+              [newTodos[index + 1], newTodos[index]];
+          }
+          break;
+        }
+        case 'remove': {
+          newTodos = [...newState.todos];
+          newTodos.splice(index, 1);
+          if (newTodos.length === 0) {
+            newTodos.push(createTodoState());
+          }
+          break;
+        }
+        default: {
+          newTodos = [...newState.todos];
+          newTodos[index] = todoReducer(newTodos[index], todoAction);
+          break;
+        }
+      }
+      newState.todos = newTodos;
+      break;
+    }
+  }
+  return newState;
+}
+
+export default function TodoList(props: PropsT): React.MixedElement {
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    props.initialTodos,
+    createInitialState,
+  );
+
+  const addTodo = React.useCallback(() => {
+    dispatch({type: 'add-todo'});
+  }, [dispatch]);
+
+  const todoDispatch = React.useCallback((
+    key: number,
+    action: TodoActionT,
+  ) => {
+    dispatch({
+      action,
+      key,
+      type: 'update-todo',
+    });
+  }, [dispatch]);
+
+  return (
+    <>
+      <ul>
+        {state.todos.map((todo) => (
+          <Todo
+            dispatch={todoDispatch}
+            key={todo.key}
+            state={todo}
+          />
+        ))}
+      </ul>
+      <button onClick={addTodo} type="button">
+        {'Add todo'}
+      </button>
+    </>
+  );
+}

--- a/root/static/scripts/tests/examples/todo-list/index.html
+++ b/root/static/scripts/tests/examples/todo-list/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Todo List Example</title>
+  </head>
+  <body>
+    <div id="todo-list-container"></div>
+    <script src="../../../../build/todo-list.js"></script>
+  </body>
+</html>

--- a/root/static/scripts/tests/examples/todo-list/index.js
+++ b/root/static/scripts/tests/examples/todo-list/index.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as ReactDOMClient from 'react-dom/client';
+
+import {uniqueId} from '../../../common/utility/numbers.js';
+
+import TodoList from './TodoList.js';
+
+const container = document.getElementById('todo-list-container');
+if (container) {
+  const root = ReactDOMClient.createRoot(container);
+  root.render(
+    <TodoList
+      initialTodos={[
+        {description: 'todo1', key: uniqueId()},
+        {description: 'todo2', key: uniqueId()},
+      ]}
+    />,
+  );
+}

--- a/webpack/tests.config.mjs
+++ b/webpack/tests.config.mjs
@@ -29,6 +29,7 @@ const webTestsConfig = {
     'autocomplete2': path.resolve(SCRIPTS_DIR, 'tests', 'autocomplete2.js'),
     'dialog-test': path.resolve(SCRIPTS_DIR, 'tests', 'dialog.js'),
     'web-tests': path.resolve(SCRIPTS_DIR, 'tests', 'browser-runner.js'),
+    'todo-list': path.resolve(SCRIPTS_DIR, 'tests', 'examples', 'todo-list', 'index.js'),
   },
 
   mode: 'development',


### PR DESCRIPTION
# Problem

We are lacking developer documentation on how to best manage React state for complex pages.  This can also help in understanding how existing code, like the relationship editor, is structured.

# Solution

Adds a section about React state management to HACKING.md and an example component in root/static/scripts/tests/examples/todo-list/.  I'm not sure if the example is helpful or necessary -- if not we can just remove it.