### PR TITLE
MBS-12857 / MBS-12858: Details for recent entities in autocompletes

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -755,7 +755,7 @@
         "model": "Tag"
     },
     "track": {
-        "artist_credits": 1,
+        "artist_credits": true,
         "last_updated_column": true,
         "mbid": {
             "multiple": true,

--- a/entities.mjs
+++ b/entities.mjs
@@ -781,7 +781,7 @@ const ENTITIES = {
     model: 'Tag',
   },
   track: {
-    artist_credits: 1,
+    artist_credits: true,
     last_updated_column: true,
     mbid: {
       multiple: true,

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -622,8 +622,14 @@ sub entities : Chained('root') PathPart('entities') Args(2)
         }
     }
 
+    my @entities = values %{$results};
+
     if ($ENTITIES{$type_name}{artist_credits}) {
-        $c->model('ArtistCredit')->load(values %{$results});
+        $c->model('ArtistCredit')->load(@entities);
+    }
+
+    if ($ENTITIES{$type_name}{type}) {
+        $c->model(type_to_model($type_name) . 'Type')->load(@entities);
     }
 
     while (my ($id, $entity) = each %{$results}) {

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -632,6 +632,15 @@ sub entities : Chained('root') PathPart('entities') Args(2)
         $c->model(type_to_model($type_name) . 'Type')->load(@entities);
     }
 
+    if ($type_name eq 'area') {
+        $c->model('Area')->load_containment(@entities);
+    }
+
+    if ($type_name eq 'place') {
+        $c->model('Area')->load(@entities);
+        $c->model('Area')->load_containment(map { $_->area } @entities);
+    }
+
     while (my ($id, $entity) = each %{$results}) {
         $results->{$id} = $entity->TO_JSON;
     }


### PR DESCRIPTION
### Fix MBS-12857 / Implement MBS-12858

# Problem
When using recent entities in an autocomplete search, the data returned is sometimes not enough to be sure of which entities they actually are. This is specially true of areas and places, which have containment info when you search for them, but no longer have it when loaded as part of the list of recent entities.

Additionally, in beta, a regression has been added where the entity type is also not saved (or rather, not loaded) in the recent entities list.

# Solution
Since beta uses the `WS::js` `/entities` endpoint to load all the recent items from their ID, I added a few extra conditional loads there, for entity types on all entities with them and for area and containment for areas/places.

# Testing
Manually, by searching for items in Add relationship popups and then reloading the page and checking what data the recent entities have. Almost any search should do the trick for types; I tested release groups separately since those have more complex types. For area containment you obviously will want to search for places and areas (you can do all of these from `/artist/create` if you use the artist area search for areas).