### PR TITLE
MBS-12859: Allow relationship credit to be the same as name 

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -104,6 +104,7 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
   let changeCreditsSection;
   if (
     state.creditsToChange ||
+    state.creditedAs !== '' ||
     state.creditedAs !== origCredit.current
   ) {
     changeCreditsSection = (

--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -71,8 +71,7 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
   state,
   targetType,
 }: PropsT): React.MixedElement => {
-  const creditedAsOrName = state.creditedAs || entityName;
-  const origCredit = React.useRef(creditedAsOrName);
+  const origCredit = React.useRef(state.creditedAs || '');
   const inputRef = React.useRef(null);
   const inputId = React.useId();
 
@@ -105,8 +104,7 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
   let changeCreditsSection;
   if (
     state.creditsToChange ||
-    creditedAsOrName !== origCredit.current ||
-    creditedAsOrName !== entityName
+    state.creditedAs !== origCredit.current
   ) {
     changeCreditsSection = (
       <>

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -113,6 +113,7 @@ const DialogPreview = (React.memo<PropsT>(({
       }
       disableLink={isDisabledLink(relationship, entity)}
       entity={entity}
+      showDisambiguation
       target="_blank"
     />
   );

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -676,19 +676,12 @@ const RelationshipDialogContent = (React.memo<PropsT>((
     const targetCredit = clean(targetEntityState.creditedAs);
     let entity0Credit = '';
     let entity1Credit = '';
-    if (targetCredit !== selectedTargetEntity.name) {
-      if (backward) {
-        entity0Credit = targetCredit;
-      } else {
-        entity1Credit = targetCredit;
-      }
-    }
-    if (sourceCredit !== source.name) {
-      if (backward) {
-        entity1Credit = sourceCredit;
-      } else {
-        entity0Credit = sourceCredit;
-      }
+    if (backward) {
+      entity0Credit = targetCredit;
+      entity1Credit = sourceCredit;
+    } else {
+      entity1Credit = targetCredit;
+      entity0Credit = sourceCredit;
     }
 
     const newRelationship: {...RelationshipStateT} = {

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -629,6 +629,7 @@ const seleniumTests = [
   {name: 'MBS-10510.json5', login: true, sql: 'mbs-10510.sql'},
   {name: 'MBS-11730.json5', login: true},
   {name: 'MBS-11735.json5', login: true},
+  {name: 'MBS-12859.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium/MBS-12859.json5
+++ b/t/selenium/MBS-12859.json5
@@ -1,0 +1,73 @@
+{
+  title: 'MBS-12859: Allow relationship credits to be the same as the entity name',
+  commands: [
+    {
+      command: 'open',
+      target: '/recording/96f64611-49df-4e54-84e7-0f9a30f01766/edit',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-item',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'performer${KEY_ENTER}',
+    },
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog div.target-entity-credit input.entity-credit',
+      value: 'Bing Crosby',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-recording button[type=submit]',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+            id: 99,
+            name: 'Bing Crosby',
+          },
+          entity0_credit: 'Bing Crosby',
+          entity1: {
+            gid: '96f64611-49df-4e54-84e7-0f9a30f01766',
+            id: 164872,
+            name: 'mr self destruct',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 156,
+            link_phrase: '{additional:additionally} {guest} {solo} performed',
+            long_link_phrase: '{additional:additionally} {guest} {solo} performed',
+            name: 'performer',
+            reverse_link_phrase: '{additional} {guest} {solo} performer',
+          },
+          type0: 'artist',
+          type1: 'recording',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Problem MBS-12859
The new relationship editor ignores / silently drops entity credits for relationships when they match the name. This is a break with the way the previous relationship editor worked, and it was a feature, not a bug: it was being intentionally used before to ensure credits remained as printed even if the artist name itself changed (for example, a Russian orchestra credited by a Latin name, where we want the printed Latin credit to stay the same even if someone correctly improves the artist name to the original Russian later).

A minor secondary issue found while testing the change is that https://github.com/metabrainz/musicbrainz-server/pull/2805 only applied to entities without a credit, since `EntityLink` hides the disambiguation when custom content is passed unless explicitly told not to (probably so that it won't show disambiguations in things like tab titles).

# Solution
I removed the extra code that made it so that credits matching the name would be ignored. Now you can again intentionally enter a credit matching the entity name. I also made it so the checkbox for changing artist credits for other uses of the entity will always show if there's a credit, even if it's the same as the entity name; this way, it's trivial to blank all credits matching the entity name if the user decides that's the right thing to do.

I also explicitly told `EntityLink` to always show disambiguations for the relationship preview entities.

# Testing
Manually, by adding credits same as (and different from) the entity name and seeing whether they actually were retained.

# Comments
The preview now can be a bit confusing when removing or adding a credit that matches the entity name. In general, it might make sense to have a way to tell that an entity has a credit but it matches its name, so I added MBS-12862 for that. It seems outside the scope of this PR though, since we already have the issue elsewhere.