### PR TITLE
MBS-12863: Tooltips too far to the left

### DIFF
--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -1,7 +1,15 @@
 #content.rel-editor #tracklist td {vertical-align: top;}
 #content.rel-editor #tracklist td.midcol {vertical-align: middle; font-size: @small-text;}
 #content.rel-editor #tracklist input[type="checkbox"] {vertical-align: middle;}
-#content.rel-editor #batch-tools {width: 100%; margin: 0.8em;}
+#content.rel-editor #batch-tools {
+    width: 100%;
+    margin: 0.8em;
+    /*
+     * Center the tooltips so that they're less likely to clip
+     * outside the viewport.
+     */
+    .tooltip-container { left: 50%; }
+}
 #content.rel-editor div.ars {padding: 0; margin: 0.5em 0; margin-left: 1.5em;}
 #content.rel-editor #release-rels {margin-top: 1em;}
 

--- a/root/static/styles/tooltip.less
+++ b/root/static/styles/tooltip.less
@@ -8,7 +8,7 @@
         visibility: hidden;
         position: absolute;
         top: -12px;
-        left: 50%;
+        left: 100%;
         z-index: 1000;
 
         .tooltip-triangle-mixin {


### PR DESCRIPTION
# Problem MBS-12863

# Solution

This fixes the tooltip positioning in the external links editor and relationship dialog. An override has been added for the batch tool buttons, to keep the existing 50% positioning, since 100% makes it possible for the last button's tooltip to clip outside the viewport.