### PR TITLE
MBS-12832: Improve edit submission batching in the release relationship editor

### DIFF
--- a/root/static/scripts/common/utility/natatime.js
+++ b/root/static/scripts/common/utility/natatime.js
@@ -1,0 +1,26 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+export default function* natatime<T>(
+  n: number,
+  values: Iterable<T>,
+): Generator<Array<T>, void, void> {
+  invariant(n > 0);
+  let chunk: Array<T> = [];
+  for (const value of values) {
+    chunk.push(value);
+    if (chunk.length === n) {
+      yield chunk;
+      chunk = [];
+    }
+  }
+  if (chunk.length) {
+    yield chunk;
+  }
+}


### PR DESCRIPTION
# Fix MBS-12832

## Problem

Prior to this commit, the release relationship editor would group edit submission requests by entity, and submit them at a rate of one entity per second; so if you made 100 edits to one recording it would submit them all in one request, but if you made 1 edit each to 100 recordings it would take roughly 100 seconds to complete.

("Per second" is a rough estimate, since what it actually does is wait for each request to complete before starting the next one, and additionally wait 500 ms before each request.)

## Solution

The implementation in this commit is more consistent and much faster in the average case.  Requests are no longer grouped by entity; we simply submit 25 edits per request, for all requests.

## Testing

I made 100+ edits to a release locally and watched the network request log in the browser development tools, which showed each request submitting 25 edits (other than the last one, of course).  The Selenium tests which submit a smaller number of edits also pass.