### PR TITLE
MBS-12880: Support fieldset.row legend styling again

### DIFF
--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -65,7 +65,8 @@ form, div.form {
     }
 
     div.row label,
-    div.row div.label {
+    div.row div.label,
+    fieldset.row legend {
         float: left;
         text-align: right;
         min-width: @form-label-width;


### PR DESCRIPTION
### Fix MBS-12880

# Problem
Cover art checkboxes are now left-aligned, while they used to be aligned centrally like "comment" below them.

# Solution
I found out that the styling for `form fieldset.row legend` was dropped with 165f7c7f727969d796ae73ec0b30d83dccd363f9 - this seems to only be used in one place (here) so that's probably why it was overlooked.

I could use `label` instead of `legend` rather than restoring this extra option, but `legend` is AFAIK more correct for `fieldset`s.

# Testing
Manually, on `/release/25a5a840-37bc-4c7c-800b-babca39d71cb/edit-cover-art/34816166820` (`pink` data)
