### PR TITLE
MBS-12870: Trap focus inside the Popover component

### DIFF
--- a/root/static/scripts/common/components/Popover.js
+++ b/root/static/scripts/common/components/Popover.js
@@ -76,7 +76,7 @@ const Popover = (props: PropsT): React.Portal => {
       dialogRef={dialogRef}
       onEscape={closeAndReturnFocus}
       siblings={<div data-popper-arrow />}
-      trapFocus={false}
+      trapFocus
     >
       {buildChildren(closeAndReturnFocus)}
     </Dialog>,


### PR DESCRIPTION
# Fix MBS-12870

## Problem

Pressing tab on the last element inside a Popover or shift-tab on the first element will close the dialog.

## Solution

Sets the Dialog trapFocus prop to true in the Popover component so that tab/shift-tab cycles.

## Testing

Tested manually only.

Note that unlike the Modal component, clicking outside the Popover will not return focus to it, so you can still click on links etc. outside of it if needed.