### PR TITLE
MBS-12872: Autocomplete2: Don't focus the first item unless searching

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -551,11 +551,9 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
 
       case 'Enter':
       case 'Tab': {
-        if (isOpen) {
+        if (isOpen && highlightedItem) {
           event.preventDefault();
-          if (highlightedItem) {
-            selectItem(highlightedItem);
-          }
+          selectItem(highlightedItem);
         }
         break;
       }
@@ -822,6 +820,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
             ? 'visible'
             : 'hidden',
         }}
+        tabIndex="-1"
       >
         {disabled ? null : menuItemElements}
       </ul>

--- a/root/static/scripts/common/components/Autocomplete2/actions.js
+++ b/root/static/scripts/common/components/Autocomplete2/actions.js
@@ -20,10 +20,6 @@ export const HIGHLIGHT_PREVIOUS_ITEM = {
   type: 'highlight-previous-item',
 };
 
-export const NOOP = {
-  type: 'noop',
-};
-
 export const SHOW_MENU = {
   type: 'set-menu-visibility',
   value: true,

--- a/root/static/scripts/common/components/Autocomplete2/constants.js
+++ b/root/static/scripts/common/components/Autocomplete2/constants.js
@@ -10,7 +10,7 @@
 import {bracketedText} from '../../utility/bracketed.js';
 
 import {
-  NOOP,
+  HIDE_MENU,
   SEARCH_AGAIN,
   SHOW_MORE_RESULTS,
   TOGGLE_INDEXED_SEARCH,
@@ -71,19 +71,19 @@ export const MENU_ITEMS: {+[name: string]: ActionItemT<empty>, ...} = {
   },
   LOOKUP_ERROR: {
     type: 'action',
-    action: NOOP,
+    action: HIDE_MENU,
     id: 'lookup-error',
     name: N_l('An error occurred while looking up the MBID you entered.'),
   },
   LOOKUP_TYPE_ERROR: {
     type: 'action',
-    action: NOOP,
+    action: HIDE_MENU,
     id: 'lookup-type-error',
     name: N_l('The type of entity you pasted isn’t supported here.'),
   },
   NO_RESULTS: {
     type: 'action',
-    action: NOOP,
+    action: HIDE_MENU,
     id: 'no-results',
     name: () => bracketedText(l('No results')),
   },

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -418,9 +418,6 @@ export function runReducer<+T: EntityItemT>(
       break;
     }
 
-    case 'noop':
-      break;
-
     case 'toggle-add-entity-dialog': {
       state.isAddEntityDialogOpen = action.isOpen;
       break;
@@ -609,10 +606,6 @@ export default function reducer<+T: EntityItemT>(
   state: StateT<T>,
   action: ActionT<T>,
 ): StateT<T> {
-  if (action.type === 'noop') {
-    return state;
-  }
-
   const nextState = {...state};
   runReducer<T>(nextState, action);
   return nextState;

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -372,6 +372,7 @@ export function runReducer<+T: EntityItemT>(
   const wasOpen = state.isOpen;
   let updateItems = false;
   let updateStatusMessage = false;
+  let highlightFirstIndex = false;
 
   switch (action.type) {
     case 'change-entity-type': {
@@ -477,7 +478,7 @@ export function runReducer<+T: EntityItemT>(
          * where "Show more" was clicked).
          */
       } else {
-        state.highlightedIndex = 0;
+        highlightFirstIndex = true;
       }
 
       state.results = newResults;
@@ -563,6 +564,7 @@ export function runReducer<+T: EntityItemT>(
         if (nonEmpty(newInputValue)) {
           // We'll display "(No results)" even if `results` is null.
           state.isOpen = true;
+          highlightFirstIndex = true;
         }
       } else {
         state.results = null;
@@ -595,9 +597,8 @@ export function runReducer<+T: EntityItemT>(
     state.statusMessage = generateStatusMessage(state);
   }
 
-  // Highlight the first item by default.
   const isOpen = state.isOpen;
-  if (isOpen && (!wasOpen || state.highlightedIndex < 0)) {
+  if (isOpen && highlightFirstIndex) {
     state.highlightedIndex = getFirstHighlightableIndex(state);
   } else if (wasOpen && !isOpen) {
     state.highlightedIndex = -1;

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -69,7 +69,6 @@ export type ActionT<+T: EntityItemT> =
   | { +type: 'highlight-index', +index: number }
   | { +type: 'highlight-next-item' }
   | { +type: 'highlight-previous-item' }
-  | { +type: 'noop' }
   | { +type: 'reset-menu' }
   | { +type: 'select-item', +item: ItemT<T> }
   | { +type: 'set-menu-visibility', +value: boolean }


### PR DESCRIPTION
# Fix MBS-12872

## Problem

Trying to tab through the relationship dialog will automatically select the first item from every "Recent items" menu.

Relatedly, I found it annoying that if you get "(No results)," then you can't tab out of the menu when it's highlighted.

## Solution

Only highlight the first item if a search is performed.

Change "noop" actions like "(No results)" so that they close the menu instead.

## Testing

Tested manually, both with core entity lookups and static item lookups (link type, instrument, vocal).