### PR TITLE
MBS-12888: Check ended when copying end date

### DIFF
--- a/root/static/scripts/common/utility/isDateEmpty.js
+++ b/root/static/scripts/common/utility/isDateEmpty.js
@@ -17,5 +17,5 @@ export default function isDateEmpty(
   date: ?PartialDateT | ?PartialDateStringsT,
 ): boolean %checks {
   return (date == null) ||
-    (date.year == null && date.month == null && date.day == null);
+         (empty(date.year) && empty(date.month) && empty(date.day));
 }

--- a/root/static/scripts/common/utility/isDateEmpty.js
+++ b/root/static/scripts/common/utility/isDateEmpty.js
@@ -7,12 +7,6 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-declare type PartialDateStringsT = {
-  +day?: string,
-  +month?: string,
-  +year?: string,
-};
-
 export default function isDateEmpty(
   date: ?PartialDateT | ?PartialDateStringsT,
 ): boolean %checks {

--- a/root/static/scripts/edit/components/DateRangeFieldset.js
+++ b/root/static/scripts/edit/components/DateRangeFieldset.js
@@ -137,13 +137,21 @@ export function runReducer(
       const year = String(beginDateFields.year.value ?? '');
       const month = String(beginDateFields.month.value ?? '');
       const day = String(beginDateFields.day.value ?? '');
+      const newEndDate: PartialDateStringsT =
+        {day: day, month: month, year: year};
       runFormRowPartialDateReducer(
         subfields.end_date,
         {
-          date: {day: day, month: month, year: year},
+          date: newEndDate,
           type: 'set-date',
         },
       );
+      if (!isDateEmpty(newEndDate)) {
+        runReducer(
+          state,
+          {enabled: true, type: 'set-ended'},
+        );
+      }
       validateDatePeriod(state);
       applyAllPendingErrors(state);
       break;

--- a/root/types/entity.js
+++ b/root/types/entity.js
@@ -96,6 +96,12 @@ declare type PartialDateT = {
   +year: number | null,
 };
 
+declare type PartialDateStringsT = {
+  +day?: string,
+  +month?: string,
+  +year?: string,
+};
+
 declare type TypeRoleT<T> = {
   +typeID: number | null,
   +typeName?: string,


### PR DESCRIPTION
### Implement MBS-12888

# Problem
Currently, when using the copy date button to copy a date (for example in the alias editor), the "Ended" checkbox is not checked.

This is mostly just a visual issue, since having an end date implies ended and the checkbox is actually checked when removing the new date (this last bit might be unintentional though). In any case, it'd still a lot more clear if the (automatically disabled) ended checkbox is shown as checked rather than unchecked while frozen.

# Solution
In the reducer, I added the same check and dispatch call for `set-ended` on `case 'copy-date'` that we already had in the manual change dispatch, `case 'update-end-date'`.

I noticed while doing this that the check was broken, in that `isDateEmpty` would still claim the date is not empty for a case such as `{year: ''}`. I improved the checking in another commit, although this currently does not affect anything much since we don't actually *unset* ended if the end date gets blanked.

# Testing
Manually, in the alias editor, by adding a start date and copying to the end date and making sure the frozen checkbox is shown as checked.

# Related discussion
Should we actually unset the ended checkbox when the user empties the end date? I have seen a fair amount of cases where the end date is removed but ended is kept by accident, but I don't know how common the use case "remove the date because this is not actually ended" is vs "remove the date because it's unclear, but we know it is ended". I *think* I'd prefer to make the user actively check ended again if they want to mark it after emptying the field, but what do you feel?