### PR TITLE
MBS-12879: Block Bandcamp /videoframe links 

### DIFF
--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -1120,12 +1120,34 @@ const CLEANUPS: CleanupEntries = {
       },
     ],
     clean: function (url) {
+      // To reject /videoframe links without breaking the ?video_id parameter
+      if (/^https?:\/\/bandcamp.com\/videoframe/.test(url)) {
+        return url;
+      }
       url = url.replace(/^(?:https?:\/\/)?([^\/]+\.)?bandcamp\.com(?:\/([^?#]*))?.*$/, 'https://$1bandcamp.com/$2');
       url = url.replace(/^https:\/\/([^\/]+)\.bandcamp\.com\/(?:((?:album|track)\/[^\/]+))?.*$/, 'https://$1.bandcamp.com/$2');
       url = url.replace(/^https:\/\/bandcamp\.com\/(?:discover|tag)\/([^\/]+).*$/, 'https://bandcamp.com/discover/$1');
       return url;
     },
     validate: function (url, id) {
+      if (/^https:\/\/(?:[^\/]+\.)?bandcamp\.com\/videoframe/.test(url)) {
+        return {
+          error: exp.l(
+            `Please do not add “{blocked_url_pattern}” links,
+             link to the appropriate “{wanted_url_pattern}” page instead.`,
+            {
+              blocked_url_pattern: (
+                <span className="url-quote">{'/videoframe'}</span>
+              ),
+              wanted_url_pattern: (
+                <span className="url-quote">{'/track'}</span>
+              ),
+            },
+          ),
+          result: false,
+          target: ERROR_TARGETS.URL,
+        };
+      }
       switch (id) {
         case LINK_TYPES.bandcamp.artist:
           if (/^https:\/\/[^\/]+\.bandcamp\.com\/(album|track)/.test(url)) {

--- a/root/static/scripts/tests/Control/URLCleanup.js
+++ b/root/static/scripts/tests/Control/URLCleanup.js
@@ -924,6 +924,17 @@ limited_link_type_combinations: [
             expected_clean_url: 'https://gamechops.bandcamp.com/campaign/samus-chill',
        only_valid_entity_types: ['release'],
   },
+  {
+                     input_url: 'https://bandcamp.com/videoframe?video_id=188124/',
+             input_entity_type: 'recording',
+    expected_relationship_type: undefined,
+       input_relationship_type: 'streamingfree',
+       only_valid_entity_types: [],
+                expected_error: {
+                                  error: 'Please do not add',
+                                  target: 'url',
+                                },
+  },
   // Bandsintown
   {
                      input_url: "https://m.bandsintown.com/MattDobberteen's50thBirthday?came_from=178",


### PR DESCRIPTION
### Fix MBS-12879

# Problem
We got a report that we were mangling Bandcamp `/videoframe` links, since the cleanup was removing the video ID from them.

On researching it, yvanzo found that these seem to be intended as Bandcamp's inner working links, as they are, as far as we have found, meant to be shown in an `iframe` in `/track` pages (notice that the links are not even listed under the appropriate artist.bandcamp.com subpage).

# Solution
Since linking to the `/track` page seems a lot better, this blocks adding `/videoframe` pages and suggests using the `/track` link instead.

I shortcut the cleanup code when these links are found so that we don't run it and remove the query parameter needed for accessing it, since that's quite confusing. I considered cleaning them up to HTTPS but since we're blocking them anyway, I guess it doesn't matter :)

# Testing
Manually, plus added a test.

# Notes
On top of https://github.com/metabrainz/musicbrainz-server/pull/2825 since the implementation depends on us actually validating Bandcamp links for recordings and releases.