### PR TITLE
Relationship editor required field style redux

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -744,6 +744,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
         aria-expanded={isOpen ? 'true' : 'false'}
         aria-haspopup="listbox"
         aria-owns={menuId}
+        className={state.required ? 'required' : undefined}
         role="combobox"
       >
         <input
@@ -751,6 +752,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           aria-autocomplete="list"
           aria-controls={menuId}
           aria-labelledby={labelId}
+          aria-required={state.required ? 'true' : 'false'}
           autoComplete="off"
           className={
             (

--- a/root/static/scripts/relationship-editor/components/DialogPreview.js
+++ b/root/static/scripts/relationship-editor/components/DialogPreview.js
@@ -219,7 +219,7 @@ const DialogPreview = (React.memo<PropsT>(({
       ) : newRelationship ? (
         relationshipPreview(newRelationship, 'add-relationship')
       ) : (
-        <p>
+        <p className="required-fields-note">
           {l('Please fill out all required fields.')}
         </p>
       )}

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -217,6 +217,18 @@ div.required {
     font-weight: bold;
 }
 
+/* Used to indicate required fields. */
+.asterisk {
+    content: "*";
+    left: -0.75em;
+    top: -0.25em;
+}
+
+div.required::before {
+    position: absolute;
+    .asterisk();
+}
+
 textarea {
     font-family: sans-serif;
     font-size: @medium-text;

--- a/root/static/styles/relationship-editor.less
+++ b/root/static/styles/relationship-editor.less
@@ -65,7 +65,7 @@ div.relationship-dialog, div.work-dialog {
             vertical-align: top;
             text-align: right;
             width: 25%;
-            padding-right: 0.5em;
+            padding-right: 0.75em;
             &.required {font-weight: bold;}
         }
         td.fields {
@@ -128,6 +128,7 @@ div.relationship-dialog {
     input[type="checkbox"] {
         vertical-align: middle;
     }
+    p.required-fields-note::before { .asterisk(); }
     div.buttons {
         width: 100%;
     }


### PR DESCRIPTION
# Problem

In https://community.metabrainz.org/t/help-test-the-relationship-editor-on-beta-musicbrainz-org/621824 the discussion about how required fields should be displayed seemed to settle around showing both a red highlight (already done) and an asterisk (implemented in this commit, for color blind users if nothing else).

# Solution

Before:
<img width="526" alt="Screen Shot 2023-02-08 at 8 36 41 PM" src="https://user-images.githubusercontent.com/1056556/217703377-3571d6a6-0971-457e-991a-81f198d7b9c6.png">

After:
<img width="526" alt="Screen Shot 2023-02-08 at 8 36 58 PM" src="https://user-images.githubusercontent.com/1056556/217703371-1eea8bbb-97e5-4d06-acac-5274f320c630.png">

## Testing

I checked the display in Firefox, Safari, and Chromium on macOS, and it seemed fine in all of them.