### PR TITLE
MBS-12882: Adding & removing a relationship date shows pending edits

### DIFF
--- a/root/static/scripts/common/utility/areDatesEqual.js
+++ b/root/static/scripts/common/utility/areDatesEqual.js
@@ -7,11 +7,13 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import isDateEmpty from './isDateEmpty.js';
+
 export default function areDatesEqual(
   a: PartialDateT | null,
   b: PartialDateT | null,
 ): boolean %checks {
-  return (a === null && b === null) || (
+  return (isDateEmpty(a) && isDateEmpty(b)) || (
     a !== null && b !== null &&
     a.year === b.year && a.month === b.month && a.day === b.day
   );

--- a/root/static/scripts/tests/utility.js
+++ b/root/static/scripts/tests/utility.js
@@ -11,6 +11,10 @@ import test from 'tape';
 
 import * as age from '../../../utility/age.js';
 import formatUserDate from '../../../utility/formatUserDate.js';
+import {
+  EMPTY_PARTIAL_DATE,
+} from '../common/constants.js';
+import areDatesEqual from '../common/utility/areDatesEqual.js';
 import compareDates, {
   compareDatePeriods,
 } from '../common/utility/compareDates.js';
@@ -95,6 +99,21 @@ test('age', function (t) {
     end_date: {year: 2012, month: 1, day: null},
     ended: true,
   }), [1, 0, 1], 'age with partial dates is 1 year, 1 day');
+});
+
+test('areDatesEqual', function (t) {
+  t.plan(7);
+
+  const date1 = {year: 2000, month: 1, day: 1};
+  const date2 = {year: 2000, month: 11, day: 1};
+
+  t.ok(areDatesEqual(null, null));
+  t.ok(areDatesEqual(EMPTY_PARTIAL_DATE, null));
+  t.ok(areDatesEqual(null, EMPTY_PARTIAL_DATE));
+  t.ok(areDatesEqual(EMPTY_PARTIAL_DATE, EMPTY_PARTIAL_DATE));
+  t.ok(areDatesEqual(date1, date1));
+  t.ok(areDatesEqual(date2, date2));
+  t.ok(!areDatesEqual(date1, date2));
 });
 
 test('compareDates', function (t) {


### PR DESCRIPTION
# Fix MBS-12882

## Problem

See the attached gif in MBS-12882.

## Solution

This was due to `areDatesEqual` not treating `null` and `{year: null, month: null, day: null}` as both being empty partial dates.

Modify `areDatesEqual` to use `isDateEmpty`, which fixes the issue.

## Testing

Tested manually by repeating the same action as in the referenced gif.  Added some basic unit tests for `areDatesEqual` which cover the failure.