### PR TITLE
MBS-12641: Relationship dialog initial focus improvements

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -332,6 +332,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
   const inputTimeout = React.useRef<TimeoutID | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const shouldUpdateScrollPositionRef = React.useRef<boolean>(false);
+  const recentItemsPromise =
+    React.useRef<Promise<$ReadOnlyArray<OptionItemT<T>>> | null>(null);
 
   const highlightedItem = highlightedIndex >= 0
     ? (items[highlightedIndex] ?? null)
@@ -501,8 +503,14 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     }
   }
 
-  function showAvailableItems() {
-    if (items.length && !isOpen) {
+  async function showAvailableItems() {
+    const recentItems = await recentItemsPromise.current;
+    /*
+     * Normally `items` should comprise `recentItems` after the
+     * `set-recent-items` action runs, but this event may trigger before that
+     * action is run and thus while `items` has yet to be updated.
+     */
+    if ((items.length || recentItems?.length) && !isOpen) {
       shouldUpdateScrollPositionRef.current = true;
       dispatch(SHOW_MENU);
       return true;
@@ -510,8 +518,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     return false;
   }
 
-  function showAvailableItemsOrBeginLookupOrSearch() {
-    if (showAvailableItems()) {
+  async function showAvailableItemsOrBeginLookupOrSearch() {
+    if (await showAvailableItems()) {
       return;
     }
     /*
@@ -627,7 +635,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
 
   React.useEffect(() => {
     if (!recentItems) {
-      getOrFetchRecentItems<T>(
+      recentItemsPromise.current = getOrFetchRecentItems<T>(
         entityType,
         state.recentItemsKey,
       ).then((loadedRecentItems) => {
@@ -635,6 +643,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           items: loadedRecentItems,
           type: 'set-recent-items',
         });
+        return loadedRecentItems;
       });
     }
 

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -113,7 +113,8 @@ export function createInitialState(
       entityType: 'link_type',
       extractSearchTerms: extractLinkTypeSearchTerms,
       id: 'relationship-type-' + id,
-      inputClass: 'relationship-type focus-first',
+      inputClass: 'relationship-type' +
+        (linkType == null ? ' focus-first' : ''),
       inputValue: (linkType?.name) ?? '',
       placeholder: l('Type or click to search'),
       recentItemsKey: 'link_type-' + source.entityType + '-' + targetType,

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -129,7 +129,7 @@ export function createInitialAutocompleteStateForTarget(
     entityType: target.entityType,
     id: 'relationship-target-' + String(relationshipId),
     inputChangeHook: selectNewWork,
-    inputClass: 'relationship-target',
+    inputClass: 'relationship-target focus-first',
     inputValue: target.name,
     required: true,
     selectedItem: selectedEntity ? {

--- a/root/static/scripts/relationship-editor/components/DialogTargetType.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetType.js
@@ -20,6 +20,7 @@ import type {
 
 type PropsT = {
   +dispatch: (DialogActionT) => void,
+  +hasPreselectedTargetType: boolean,
   +options: ?TargetTypeOptionsT,
   +source: CoreEntityT,
   +targetType: CoreEntityTypeT,
@@ -30,6 +31,7 @@ const DialogTargetType = (React.memo<PropsT>((
 ): React.MixedElement => {
   const {
     dispatch,
+    hasPreselectedTargetType,
     options,
     source,
     targetType,
@@ -54,7 +56,10 @@ const DialogTargetType = (React.memo<PropsT>((
           formatEntityTypeName(targetType)
         ) : (
           <select
-            className="entity-type focus-first"
+            className={
+              'entity-type' +
+              (hasPreselectedTargetType ? '' : ' focus-first')
+            }
             onChange={handleTargetTypeChange}
             value={targetType}
           >

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -100,6 +100,7 @@ import DialogTargetType from './DialogTargetType.js';
 export type PropsT = {
   +batchSelectionCount?: number,
   +closeDialog: () => void,
+  +hasPreselectedTargetType: boolean,
   +initialRelationship: RelationshipStateT,
   +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
@@ -581,6 +582,7 @@ const RelationshipDialogContent = (React.memo<PropsT>((
   const {
     batchSelectionCount,
     closeDialog,
+    hasPreselectedTargetType,
     initialRelationship,
     sourceDispatch,
     source,
@@ -931,6 +933,7 @@ const RelationshipDialogContent = (React.memo<PropsT>((
           />
           <DialogTargetType
             dispatch={dispatch}
+            hasPreselectedTargetType={hasPreselectedTargetType}
             options={targetTypeOptions}
             source={source}
             targetType={targetEntityState.targetType}

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -174,6 +174,7 @@ const RelationshipItem = (React.memo<PropsT>(({
 
   const buildPopoverContent = useRelationshipDialogContent({
     dispatch,
+    hasPreselectedTargetType: true,
     relationship,
     releaseHasUnloadedTracks,
     source,

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -136,8 +136,8 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
   const buildPopoverContent = useAddRelationshipDialogContent({
     backward,
     buildNewRelationshipData,
-    defaultTargetType: targetType,
     dispatch,
+    preselectedTargetType: targetType,
     releaseHasUnloadedTracks,
     source,
     targetTypeOptions: null,

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -47,8 +47,8 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
 
   const buildPopoverContent = useAddRelationshipDialogContent({
-    defaultTargetType: null,
     dispatch,
+    preselectedTargetType: null,
     releaseHasUnloadedTracks,
     source,
     title: l('Add Relationship'),

--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -53,6 +53,7 @@ type CommonOptionsT = {
 export default function useRelationshipDialogContent(
   options: $ReadOnly<{
     ...CommonOptionsT,
+    +hasPreselectedTargetType: boolean,
     +relationship: RelationshipStateT,
     +targetTypeOptions: TargetTypeOptionsT | null,
     +targetTypeRef: {-current: CoreEntityTypeT} | null,
@@ -64,6 +65,7 @@ export default function useRelationshipDialogContent(
   const {
     batchSelectionCount,
     dispatch,
+    hasPreselectedTargetType,
     relationship,
     releaseHasUnloadedTracks,
     source,
@@ -93,6 +95,7 @@ export default function useRelationshipDialogContent(
       <RelationshipDialogContent
         batchSelectionCount={batchSelectionCount}
         closeDialog={closeAndReturnFocus}
+        hasPreselectedTargetType={hasPreselectedTargetType}
         initialRelationship={relationship}
         releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={source}
@@ -106,6 +109,7 @@ export default function useRelationshipDialogContent(
   }, [
     batchSelectionCount,
     dispatch,
+    hasPreselectedTargetType,
     relationship,
     releaseHasUnloadedTracks,
     source,
@@ -122,7 +126,7 @@ export function useAddRelationshipDialogContent(
     +backward?: boolean,
     +buildNewRelationshipData?:
       () => $Partial<RelationshipStateT> | null,
-    +defaultTargetType: CoreEntityTypeT | null,
+    +preselectedTargetType: CoreEntityTypeT | null,
     +targetTypeOptions?: TargetTypeOptionsT | null,
   }>,
 ): (
@@ -130,8 +134,8 @@ export function useAddRelationshipDialogContent(
 ) => React.MixedElement {
   const {
     backward,
-    defaultTargetType,
     buildNewRelationshipData,
+    preselectedTargetType,
     releaseHasUnloadedTracks,
     source,
     targetTypeOptions: customTargetTypeOptions,
@@ -156,7 +160,7 @@ export function useAddRelationshipDialogContent(
   const targetTypeRef = React.useRef<CoreEntityTypeT | null>(null);
 
   const targetType = (
-    defaultTargetType ||
+    preselectedTargetType ||
     targetTypeRef.current ||
     (targetTypeOptions?.[0]?.value) ||
     /*
@@ -195,6 +199,7 @@ export function useAddRelationshipDialogContent(
 
   return useRelationshipDialogContent({
     ...otherOptions,
+    hasPreselectedTargetType: preselectedTargetType != null,
     relationship: newRelationshipState,
     releaseHasUnloadedTracks,
     source,

--- a/root/static/scripts/release/components/RelationshipEditorBatchTools.js
+++ b/root/static/scripts/release/components/RelationshipEditorBatchTools.js
@@ -63,8 +63,8 @@ const BatchAddRelationshipButtonPopover = ({
 
   const buildPopoverContent = useAddRelationshipDialogContent({
     batchSelectionCount,
-    defaultTargetType: null,
     dispatch,
+    preselectedTargetType: null,
     releaseHasUnloadedTracks,
     source: sourcePlaceholder,
     title: l('Add Relationship'),

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -375,8 +375,8 @@ const RelatedWorksRelationshipEditor = React.memo<
 
   const buildAddRelatedWorkPopoverContent = useAddRelationshipDialogContent({
     buildNewRelationshipData: buildNewRelatedWorkRelationshipData,
-    defaultTargetType: 'work',
     dispatch,
+    preselectedTargetType: 'work',
     releaseHasUnloadedTracks,
     source: recording,
     title: l('Add Relationship'),

--- a/root/static/scripts/tests/relationship-editor/dialog.js
+++ b/root/static/scripts/tests/relationship-editor/dialog.js
@@ -22,6 +22,7 @@ import {
 
 const commonInitialState = {
   closeDialog: () => undefined,
+  hasPreselectedTargetType: true,
   releaseHasUnloadedTracks: false,
   sourceDispatch: () => undefined,
   targetTypeOptions: null,

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -629,6 +629,7 @@ const seleniumTests = [
   {name: 'MBS-10510.json5', login: true, sql: 'mbs-10510.sql'},
   {name: 'MBS-11730.json5', login: true},
   {name: 'MBS-11735.json5', login: true},
+  {name: 'MBS-12641.json5', login: true},
   {name: 'MBS-12859.json5', login: true},
   {name: 'MBS-12874.json5', login: true},
   {name: 'MBS-12885.json5', login: true},

--- a/t/selenium/MBS-12641.json5
+++ b/t/selenium/MBS-12641.json5
@@ -1,0 +1,70 @@
+{
+  title: 'MBS-12641: Relationship editor dialog initial focus',
+  commands: [
+    {
+      command: 'open',
+      target: '/recording/96f64611-49df-4e54-84e7-0f9a30f01766/edit?rels.0.target=2437980f-513a-44fc-80f1-b90d9d7fcf8f',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//th[contains(@class, "link-phrase")][contains(descendant::text(), "no type:")]/following-sibling::td//button[contains(@class, "edit-item")]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelector("#edit-relationship-dialog input.relationship-type")',
+      value: 'true',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#edit-relationship-dialog input.relationship-type',
+      value: 'vocals${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#edit-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//th[contains(@class, "link-phrase")][contains(descendant::text(), "vocals:")]/following-sibling::td//button[contains(@class, "edit-item")]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelector("#edit-relationship-dialog input.relationship-target")',
+      value: 'true',
+    },
+    {
+      command: 'click',
+      target: 'css=#edit-relationship-dialog div.buttons button.negative',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=//th[contains(@class, "link-phrase")][contains(descendant::text(), "vocals:")]//button[contains(@class, "add-another-entity")]',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelector("#add-relationship-dialog input.relationship-target")',
+      value: 'true',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.negative',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor td.add-relationship button.add-item',
+      value: '',
+    },
+    {
+      command: 'assertEval',
+      target: 'document.activeElement === document.querySelector("#add-relationship-dialog select.entity-type")',
+      value: 'true',
+    },
+  ],
+}


### PR DESCRIPTION
# Fix MBS-12641

## Problem

When opening the relationship editor dialog (whether for a new or existing relationship), we sometimes focus fields that are pre-filled and unlikely to be changed.  (See MBS-12641 and also [salo.rock's comment on the forums](https://community.metabrainz.org/t/help-test-the-relationship-editor-on-beta-musicbrainz-org/621824/34).)

## Solution

We now choose which field to initially focus based on the following priorities:

 * If no target type is preselected, focus that.

   This is not the same as the field being empty, since you can't empty the target type field. It's about whether the target type is determined by the type of dialog being opened.

   I renamed `defaultTargetType` to `preselectedTargetType` in the code to make this clearer.

 * If no link type is preselected, focus that.

 * Otherwise, focus the target entity.

## Testing

Tested manually with each of the various types of "add" and "edit" buttons, and added a Selenium test which does the same (including for a seeded relationship).