### PR TITLE
MBS-12853: Disallow IPI that is all zeros

### DIFF
--- a/lib/MusicBrainz/Server/Validation.pm
+++ b/lib/MusicBrainz/Server/Validation.pm
@@ -146,6 +146,7 @@ sub format_iswc
 sub is_valid_ipi
 {
     my $ipi = shift;
+    return 0 if $ipi =~ /^0{11}$/;
     return $ipi =~ /^[0-9]{11}$/;
 }
 

--- a/t/lib/t/MusicBrainz/Server/Validation.pm
+++ b/t/lib/t/MusicBrainz/Server/Validation.pm
@@ -141,6 +141,7 @@ test 'Test format_isrc' => sub {
 
 test 'Test is_valid_ipi' => sub {
     ok(is_valid_ipi('00014107338'));
+    ok(!is_valid_ipi('00000000000'), 'All-zeros IPI is not valid');
     ok(!is_valid_ipi(''));
     ok(!is_valid_ipi('MusicBrainz::Server::Entity::ArtistIPI=HASH(0x11c9a410)'),
        'Regression test #MBS-5066');


### PR DESCRIPTION
### Implement MBS-12853

# Problem
A user recently entered an all-zeros IPI in [edit #96404467](https://musicbrainz.org/edit/96404467), possibly in order to fill the field with *something*. I'm pretty sure it is not a valid IPI, so we should probably just block it in the future

# Solution
Add a check to `is_valid_ipi` to return false if the IPI is all zeros. Since `format_ipi` specifically zero-fills the IPI to 11 digits, we can be sure it should always be 11.

# Testing
Added a new check to the `is_valid_ipi` test.