### PR TITLE
MBS-12890: Show disambiguation in label/genre autocompletes

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -71,7 +71,9 @@ function formatName<+T: EntityItemT>(entity: T) {
 function formatGeneric(
   entity: | ArtistT
           | EventT
+          | GenreT
           | InstrumentT
+          | LabelT
           | PlaceT
           | ReleaseT
           | WorkT,
@@ -538,11 +540,17 @@ export default function formatItem<+T: EntityItemT>(
         case 'event':
           return formatEvent(entity);
 
+        case 'genre':
+          return formatGeneric(entity);
+
         case 'instrument':
           return formatInstrument(
             entity,
             options?.showDescriptions,
           );
+
+        case 'label':
+          return formatGeneric(entity);
 
         case 'link_attribute_type':
           return formatLinkAttributeType(


### PR DESCRIPTION
### Fix MBS-12890

# Problem
Labels and genres with disambiguation comments do not show it when searching in an autocomplete2 inline search (for example to add relationships).

# Solution
Running the labels and genres through `formatGeneric` will give them the bare minimum that they should have: disambiguation and primary alias when relevant. We could also add types to labels (and artists) but that's not a regression so it can be done later.

# Testing
Manually, with **PMDC** for label search (easy from a release) and **bolero** for genre search (easy from an instrument).