### PR TITLE
MBS-12852 / MBS-12893: Add events and places to country stats page

### DIFF
--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -162,6 +162,7 @@ sub countries : Local
     my $artist_country_prefix = 'count.artist.country';
     my $release_country_prefix = 'count.release.country';
     my $label_country_prefix = 'count.label.country';
+    my $event_country_prefix = 'count.event.country';
     my @countries = $c->model('CountryArea')->get_all();
     my %countries = map { $_->country_code => $_ } grep { defined $_->country_code } @countries;
     foreach my $stat_name
@@ -169,11 +170,13 @@ sub countries : Local
         if (my ($iso_code) = $stat_name =~ /^$artist_country_prefix\.(.*)$/) {
             my $release_stat = $stat_name =~ s/$artist_country_prefix/$release_country_prefix/r;
             my $label_stat = $stat_name =~ s/$artist_country_prefix/$label_country_prefix/r;
+            my $event_stat = $stat_name =~ s/$artist_country_prefix/$event_country_prefix/r;
             push(@$country_stats, ({
                 'entity' => to_json_object($countries{$iso_code}),
                 'artist_count' => $stats->statistic($stat_name),
                 'release_count' => $stats->statistic($release_stat),
-                'label_count' => $stats->statistic($label_stat)
+                'label_count' => $stats->statistic($label_stat),
+                'event_count' => $stats->statistic($event_stat)
             }));
         }
     }

--- a/lib/MusicBrainz/Server/Controller/Statistics.pm
+++ b/lib/MusicBrainz/Server/Controller/Statistics.pm
@@ -163,6 +163,7 @@ sub countries : Local
     my $release_country_prefix = 'count.release.country';
     my $label_country_prefix = 'count.label.country';
     my $event_country_prefix = 'count.event.country';
+    my $place_country_prefix = 'count.place.country';
     my @countries = $c->model('CountryArea')->get_all();
     my %countries = map { $_->country_code => $_ } grep { defined $_->country_code } @countries;
     foreach my $stat_name
@@ -171,12 +172,14 @@ sub countries : Local
             my $release_stat = $stat_name =~ s/$artist_country_prefix/$release_country_prefix/r;
             my $label_stat = $stat_name =~ s/$artist_country_prefix/$label_country_prefix/r;
             my $event_stat = $stat_name =~ s/$artist_country_prefix/$event_country_prefix/r;
+            my $place_stat = $stat_name =~ s/$artist_country_prefix/$place_country_prefix/r;
             push(@$country_stats, ({
                 'entity' => to_json_object($countries{$iso_code}),
                 'artist_count' => $stats->statistic($stat_name),
                 'release_count' => $stats->statistic($release_stat),
                 'label_count' => $stats->statistic($label_stat),
-                'event_count' => $stats->statistic($event_stat)
+                'event_count' => $stats->statistic($event_stat),
+                'place_count' => $stats->statistic($place_stat)
             }));
         }
     }

--- a/lib/MusicBrainz/Server/Data/Statistics.pm
+++ b/lib/MusicBrainz/Server/Data/Statistics.pm
@@ -941,7 +941,7 @@ my %stats = (
                 FROM release r
                 LEFT JOIN release_country rc ON r.id = rc.release
                 FULL OUTER JOIN country_area c ON rc.country = c.area
-                LEFT JOIN iso_3166_1 iso ON c.area = iso.area
+                FULL OUTER JOIN iso_3166_1 iso ON c.area = iso.area
                 GROUP BY iso.code},
             );
 

--- a/root/static/scripts/statistics.js
+++ b/root/static/scripts/statistics.js
@@ -53,9 +53,10 @@ $('#countries-table').tablesorter({
     [3]: {sorter: 'fancyNumber'},
     [4]: {sorter: 'fancyNumber'},
     [5]: {sorter: 'fancyNumber'},
+    [6]: {sorter: 'fancyNumber'},
   },
   // order by descending number of entities, then name
-  sortList: [[5, 1], [1, 0]],
+  sortList: [[6, 1], [1, 0]],
   widgets: ['indexFirstColumn', 'loopParity'],
 });
 

--- a/root/static/scripts/statistics.js
+++ b/root/static/scripts/statistics.js
@@ -54,9 +54,10 @@ $('#countries-table').tablesorter({
     [4]: {sorter: 'fancyNumber'},
     [5]: {sorter: 'fancyNumber'},
     [6]: {sorter: 'fancyNumber'},
+    [7]: {sorter: 'fancyNumber'},
   },
   // order by descending number of entities, then name
-  sortList: [[6, 1], [1, 0]],
+  sortList: [[7, 1], [1, 0]],
   widgets: ['indexFirstColumn', 'loopParity'],
 });
 

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -29,6 +29,7 @@ type CountryStatT = {
   +entity: AreaT,
   +event_count: number,
   +label_count: number,
+  +place_count: number,
   +release_count: number,
 };
 
@@ -65,6 +66,10 @@ const Countries = ({
             </th>
             <th>
               {l('Events')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Places')}
               <div className="arrow" />
             </th>
             <th>
@@ -162,12 +167,30 @@ const Countries = ({
                   />
                 </td>
                 <td className="t">
+                  {hasCountryCode ? (
+                    <EntityLink
+                      content={formatCount($c, countryStat.place_count)}
+                      entity={country}
+                      subPath="places"
+                    />
+                  ) : formatCount($c, countryStat.place_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.event.country.' + (hasCountryCode
+                        ? country.country_code
+                        : 'null')
+                    }
+                  />
+                </td>
+                <td className="t">
                   {formatCount(
                     $c,
                     countryStat.artist_count +
                     countryStat.release_count +
                     countryStat.label_count +
-                    countryStat.event_count,
+                    countryStat.event_count +
+                    countryStat.place_count,
                   )}
                 </td>
               </tr>

--- a/root/statistics/Countries.js
+++ b/root/statistics/Countries.js
@@ -27,6 +27,7 @@ type CountriesStatsT = {
 type CountryStatT = {
   +artist_count: number,
   +entity: AreaT,
+  +event_count: number,
   +label_count: number,
   +release_count: number,
 };
@@ -60,6 +61,10 @@ const Countries = ({
             </th>
             <th>
               {l('Labels')}
+              <div className="arrow" />
+            </th>
+            <th>
+              {l('Events')}
               <div className="arrow" />
             </th>
             <th>
@@ -140,11 +145,29 @@ const Countries = ({
                   />
                 </td>
                 <td className="t">
+                  {hasCountryCode ? (
+                    <EntityLink
+                      content={formatCount($c, countryStat.event_count)}
+                      entity={country}
+                      subPath="events"
+                    />
+                  ) : formatCount($c, countryStat.event_count)}
+                  {' '}
+                  <TimelineLink
+                    statName={
+                      'count.event.country.' + (hasCountryCode
+                        ? country.country_code
+                        : 'null')
+                    }
+                  />
+                </td>
+                <td className="t">
                   {formatCount(
                     $c,
                     countryStat.artist_count +
                     countryStat.release_count +
-                    countryStat.label_count,
+                    countryStat.label_count +
+                    countryStat.event_count,
                   )}
                 </td>
               </tr>

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -433,6 +433,11 @@ const stats = {
     color: '#e8ab08',
     label: l('Events'),
   },
+  'count.event.country.null': {
+    category: 'event-countries',
+    color: '#ff0000',
+    label: l('Events with no country set'),
+  },
   'count.event.type.null': {
     category: 'event-types',
     color: '#ff0000',
@@ -1014,6 +1019,12 @@ export function buildTypeStats(typeData) {
       category: 'artist-countries',
       color: '#ff0000',
       label: texp.l('{country} artists', countryArg),
+    };
+
+    stats[`count.event.country.${key}`] = {
+      category: 'event-countries',
+      color: '#ff0000',
+      label: texp.l('{country} events', countryArg),
     };
 
     stats[`count.label.country.${key}`] = {

--- a/root/statistics/stats.js
+++ b/root/statistics/stats.js
@@ -548,6 +548,11 @@ const stats = {
     color: '#bc0a0a',
     label: l('Places'),
   },
+  'count.place.country.null': {
+    category: 'place-countries',
+    color: '#ff0000',
+    label: l('Places with no country set'),
+  },
   'count.place.type.null': {
     category: 'place-types',
     color: '#ff0000',
@@ -1031,6 +1036,12 @@ export function buildTypeStats(typeData) {
       category: 'label-countries',
       color: '#ff0000',
       label: texp.l('{country} labels', countryArg),
+    };
+
+    stats[`count.place.country.${key}`] = {
+      category: 'place-countries',
+      color: '#ff0000',
+      label: texp.l('{country} places', countryArg),
     };
 
     stats[`count.release.country.${key}`] = {


### PR DESCRIPTION
### Implement MBS-12852 / MBS-12893

# Problem
While events and places are very directly associated to the areas they happen in, our country stats page at [`/statistics/countries`](https://musicbrainz.org/statistics/countries) has no country level stats for them. This seems like it would be interesting data to see.

While testing the code, I found a bug with release counts for countries with 0 releases, where the country would be skipped in the results rather than return 0 like for other entity counts. This is probably only an issue with sample data, since I'm pretty sure the production database has releases for all countries.

# Solution
I added both of the entity types to the stats. Place is a trivial implementation since they work in the same way as artists and labels. For events I copied the relevant parts of the query we use to get events with `find_by_area`.

For the found issue with release counts, I just changed a `LEFT JOIN` to a `FULL OUTER JOIN` like on other similar queries to ensure all countries will get a result.

# Testing
Manually, with (fairly limited) sample data. I checked that the numbers matched the amount of entities under the appropriate area page for a few cases.