### PR TITLE
MBS-12891 / MBS-7971: Show more info for inline artist/label search 

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Artist.pm
@@ -30,4 +30,9 @@ sub search : Chained('root') PathPart('artist')
     $self->dispatch_search($c);
 }
 
+after _load_entities => sub {
+    my ($self, $c, @entities) = @_;
+    $c->model('ArtistType')->load(@entities);
+};
+
 1;

--- a/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js/Label.pm
@@ -30,4 +30,9 @@ sub search : Chained('root') PathPart('label')
     $self->dispatch_search($c);
 }
 
+after _load_entities => sub {
+    my ($self, $c, @entities) = @_;
+    $c->model('LabelType')->load(@entities);
+};
+
 1;

--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -24,6 +24,7 @@ import bracketed, {bracketedText} from '../../utility/bracketed.js';
 import formatDate from '../../utility/formatDate.js';
 import formatDatePeriod from '../../utility/formatDatePeriod.js';
 import formatTrackLength from '../../utility/formatTrackLength.js';
+import isDateEmpty from '../../utility/isDateEmpty.js';
 import CountryAbbr from '../CountryAbbr.js';
 
 import type {
@@ -107,6 +108,8 @@ function formatGeneric(
 function formatArtist(artist: ArtistT) {
   const sortName = artist.sort_name;
   let extraInfo;
+  const secondInfoLine = [];
+
   if (
     sortName &&
     sortName !== artist.name &&
@@ -117,7 +120,23 @@ function formatArtist(artist: ArtistT) {
       info.unshift(sortName);
     };
   }
-  return formatGeneric(artist, extraInfo);
+
+  if (nonEmpty(artist.typeName)) {
+    secondInfoLine.push(lp_attributes(artist.typeName, 'artist_type'));
+  }
+
+  if (!isDateEmpty(artist.begin_date) || !isDateEmpty(artist.end_date)) {
+    secondInfoLine.push(formatDatePeriod(artist));
+  }
+
+  return (
+    <>
+      {formatGeneric(artist, extraInfo)}
+      {secondInfoLine.length
+        ? showExtraInfoLine(commaOnlyListText(secondInfoLine))
+        : null}
+    </>
+  );
 }
 
 function showLabeledTextList(
@@ -238,6 +257,27 @@ function formatInstrument(
         info.push(...extraInfo);
       })}
       {nonEmpty(description) ? showExtraInfoLine(description) : null}
+    </>
+  );
+}
+
+function formatLabel(label: LabelT) {
+  const secondInfoLine = [];
+
+  if (nonEmpty(label.typeName)) {
+    secondInfoLine.push(lp_attributes(label.typeName, 'label_type'));
+  }
+
+  if (!isDateEmpty(label.begin_date) || !isDateEmpty(label.end_date)) {
+    secondInfoLine.push(formatDatePeriod(label));
+  }
+
+  return (
+    <>
+      {formatGeneric(label)}
+      {secondInfoLine.length
+        ? showExtraInfoLine(commaOnlyListText(secondInfoLine))
+        : null}
     </>
   );
 }
@@ -550,7 +590,7 @@ export default function formatItem<+T: EntityItemT>(
           );
 
         case 'label':
-          return formatGeneric(entity);
+          return formatLabel(entity);
 
         case 'link_attribute_type':
           return formatLinkAttributeType(

--- a/t/lib/t/MusicBrainz/Server/Controller/WS/js/Autocomplete.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/WS/js/Autocomplete.pm
@@ -62,6 +62,7 @@ test all => sub {
                 'name' => 'Warp Records',
                 'primaryAlias' => undef,
                 'typeID' => 4,
+                'typeName' => 'Original Production',
               }, { 'current' => 1, 'pages' => 1 } ];
 
 };


### PR DESCRIPTION
### Implement

# Problem
Inline search for labels and artists often offers frustratingly little info, especially when compared with something like a work search. Often knowing the type or the dates for an artist / label will automatically make it obvious it's the right choice or, at the very least, disqualify it from the possibilities, meaning there's one less entry the editor needs to check more carefully - but neither of these are present, while they are for other kinds of entities.

# Solution
This adds both artist/label dates and type, when present, in a new row for Autocomplete2.

![image_2023-02-13_200517643](https://user-images.githubusercontent.com/1069224/218537273-0fea3b27-1788-4ddb-a5e1-893b8d0561ac.png)

If all we know is an artist/label is ended, this currently doesn't indicate anything. If you think it should, we can make the change!

# Testing
By hand, with both direct and indexed search, searching artists and labels and making sure they show the info as expected.

# Notes
On top of https://github.com/metabrainz/musicbrainz-server/pull/2834 since that also touches label autocompletes.