### PR TITLE
MBS-12829: Use link type phrases in autocomplete input value

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/formatters.js
+++ b/root/static/scripts/common/components/Autocomplete2/formatters.js
@@ -315,14 +315,8 @@ function formatLinkAttributeType(
   );
 }
 
-function formatLinkType(
-  linkType: LinkTypeT,
-  showDescriptions: ?boolean,
-) {
-  const description = stripHtml(linkType.l_description);
-  const isGroupingType = empty(description);
-
-  let nameDisplay = linkType.l_name;
+export function formatLinkTypePhrases(linkType: LinkTypeT): string {
+  const isGroupingType = empty(linkType.description);
   if (!isGroupingType) {
     let linkPhrase = linkType.l_link_phrase;
     let reverseLinkPhrase = linkType.l_reverse_link_phrase;
@@ -330,16 +324,24 @@ function formatLinkType(
       linkPhrase = stripAttributes(linkType, linkPhrase);
       reverseLinkPhrase = stripAttributes(linkType, reverseLinkPhrase);
       if (linkPhrase === reverseLinkPhrase) {
-        nameDisplay = linkPhrase;
-      } else {
-        nameDisplay =
-          texp.l('{forward_link_phrase} / {backward_link_phrase}', {
-            backward_link_phrase: reverseLinkPhrase,
-            forward_link_phrase: linkPhrase,
-          });
+        return linkPhrase;
       }
+      return texp.l('{forward_link_phrase} / {backward_link_phrase}', {
+        backward_link_phrase: reverseLinkPhrase,
+        forward_link_phrase: linkPhrase,
+      });
     }
   }
+  return linkType.l_name ?? linkType.name;
+}
+
+function formatLinkType(
+  linkType: LinkTypeT,
+  showDescriptions: ?boolean,
+) {
+  const description = stripHtml(linkType.l_description);
+  const isGroupingType = empty(description);
+  const nameDisplay = formatLinkTypePhrases(linkType);
 
   return (
     <>

--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -15,6 +15,7 @@ import isDatabaseRowId from '../../utility/isDatabaseRowId.js';
 import isGuid from '../../utility/isGuid.js';
 import {localStorage} from '../../utility/storage.js';
 
+import {formatLinkTypePhrases} from './formatters.js';
 import type {
   EntityItemT,
   OptionItemT,
@@ -161,6 +162,17 @@ export function getRecentItems<+T: EntityItemT>(
   return _recentItemsCache.get(key) ?? [];
 }
 
+function getEntityName(entity: EntityItemT): string {
+  switch (entity.entityType) {
+    case 'link_type': {
+      return formatLinkTypePhrases(entity);
+    }
+    default: {
+      return entity.name;
+    }
+  }
+}
+
 export async function getOrFetchRecentItems<+T: EntityItemT>(
   entityType: string,
   key?: string = entityType,
@@ -185,7 +197,7 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
         cachedList.push({
           entity: entity,
           id: String(entity.id) + '-recent',
-          name: entity.name,
+          name: getEntityName(entity),
           type: 'option',
         });
         ids.delete(id);
@@ -220,7 +232,7 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
               // $FlowIgnore[incompatible-return]
               entity,
               id: String(entity.id) + '-recent',
-              name: entity.name,
+              name: getEntityName(entity),
               type: 'option',
             });
           }

--- a/root/static/scripts/relationship-editor/components/DialogLinkType.js
+++ b/root/static/scripts/relationship-editor/components/DialogLinkType.js
@@ -13,6 +13,9 @@ import Autocomplete2, {
   createInitialState as createInitialAutocompleteState,
 } from '../../common/components/Autocomplete2.js';
 import {
+  formatLinkTypePhrases,
+} from '../../common/components/Autocomplete2/formatters.js';
+import {
   default as autocompleteReducer,
 } from '../../common/components/Autocomplete2/reducer.js';
 import type {
@@ -115,7 +118,7 @@ export function createInitialState(
       id: 'relationship-type-' + id,
       inputClass: 'relationship-type' +
         (linkType == null ? ' focus-first' : ''),
-      inputValue: (linkType?.name) ?? '',
+      inputValue: linkType == null ? '' : formatLinkTypePhrases(linkType),
       placeholder: l('Type or click to search'),
       recentItemsKey: 'link_type-' + source.entityType + '-' + targetType,
       required: true,

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -12,6 +12,9 @@ import * as tree from 'weight-balanced-tree';
 
 import invariant from '../../../../utility/invariant.js';
 import {
+  formatLinkTypePhrases,
+} from '../../common/components/Autocomplete2/formatters.js';
+import {
   filterStaticItems,
   resetPage as resetAutocompletePage,
 } from '../../common/components/Autocomplete2/reducer.js';
@@ -268,7 +271,7 @@ function updateDialogStateForTargetTypeChange(
   const newLinkTypeAutocompleteState = {
     ...oldLinkTypeAutocompleteState,
     inputValue: onlyLinkType
-      ? onlyLinkType.name
+      ? formatLinkTypePhrases(onlyLinkType)
       : (
         oldLinkTypeAutocompleteState.selectedItem
           ? ''

--- a/root/static/scripts/relationship-editor/utility/getDialogLinkTypeOptions.js
+++ b/root/static/scripts/relationship-editor/utility/getDialogLinkTypeOptions.js
@@ -7,6 +7,9 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import {
+  formatLinkTypePhrases,
+} from '../../common/components/Autocomplete2/formatters.js';
 import {type OptionItemT}
   from '../../common/components/Autocomplete2/types.js';
 import {
@@ -38,7 +41,7 @@ function buildOption(
     entity: linkType,
     id: linkType.id,
     level,
-    name: l_relationships(linkType.name),
+    name: formatLinkTypePhrases(linkType),
     type: 'option',
   };
 }


### PR DESCRIPTION
# Fix MBS-12829

## Problem

When you select a link type in the relationship dialog, we set the autocomplete input value to the link type name rather than the phrases we showed in the menu. For example, if you select "recording engineer for / recording engineer," we set the input value to just "recording."

## Solution

When a selection is made, the input value is now the same "forward phrase / reverse phrase" text we showed in the menu.

I decided not to change the input value based on the direction of the relationship, because the forward/reverse link phrases aren't meant to be read in sentence order like the long link phrases are, so I don't think it makes the selection easier to understand. It's also harder to implement.

## Testing

Tested manually both by searching for a link type and selecting it from the results, and selecting a link type from the recent items list (which use different code paths to generate the item names). There is one other code path where we set the input value: when switching the target type and only one link type is available (e.g. clicking "Add relationship"  on a recording and changing the target type to "work"; the one available link type will be automatically selected). The input value correctly shows the phrases in this case, too.