### PR TITLE
MBS-12901: Show user website and bio on the admin user views

### DIFF
--- a/root/admin/components/UserList.js
+++ b/root/admin/components/UserList.js
@@ -28,9 +28,11 @@ const UserList = ({users}: Props): React.Element<'table'> => {
         <tr>
           <th>{l('Editor')}</th>
           <th>{l('Member since')}</th>
+          <th>{l('Website')}</th>
           <th>{l('Email')}</th>
           <th>{l('Verified on')}</th>
           <th>{l('Last login')}</th>
+          <th>{l('Bio')}</th>
         </tr>
       </thead>
       <tbody>
@@ -54,6 +56,9 @@ const UserList = ({users}: Props): React.Element<'table'> => {
               )}
             </td>
             <td>{formatUserDate($c, user.registration_date)}</td>
+            <td>
+              {nonEmpty(user.website) ? user.website : null}
+            </td>
             <td>{user.email}</td>
             <td>
               {nonEmpty(user.email_confirmation_date) ? (
@@ -64,6 +69,9 @@ const UserList = ({users}: Props): React.Element<'table'> => {
               {nonEmpty(user.last_login_date) ? (
                 formatUserDate($c, user.last_login_date)
               ) : null}
+            </td>
+            <td>
+              {nonEmpty(user.biography) ? user.biography : null}
             </td>
           </tr>
         ))}


### PR DESCRIPTION
### Implement MBS-12901

# Problem
It's trivial to find out (with the IP lookup) what users share an IP with a known spammer. But the information on that view is pretty useless to figure out if any of those accounts are themselves spammers. Compared with the (much more useful) beginner editor report, the main things missing there are the user bio and website.

# Solution
This adds the bio and website to the `UserList` component used by `IpLookup`, `EmailSearch` and `PrivilegeList`. While the info is probably less obviously useful in the last two, I don't think it ever hurts, and it can sometimes still help, so I am not restricting it to `IpLookup` only.

# Testing
Manually, from the `EmailSearch` component (since I don't have IPs stored locally) - since the code used is the same, it should work on the other two as well.