### PR TITLE
MBS-12873, MBS-12875: Avoid unloaded tracks when batch editing release relationships

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
+++ b/root/static/scripts/relationship-editor/components/DialogEntityCredit.js
@@ -31,10 +31,12 @@ type PropsT = {
 
 export function createInitialState(
   creditedAs: string,
+  releaseHasUnloadedTracks: boolean,
 ): DialogEntityCreditStateT {
   return {
     creditedAs,
     creditsToChange: '',
+    releaseHasUnloadedTracks,
   };
 }
 
@@ -113,6 +115,7 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
         <label className="change-credits-checkbox">
           <input
             checked={!!state.creditsToChange}
+            disabled={state.releaseHasUnloadedTracks}
             onChange={handleChangeCreditsChecked}
             type="checkbox"
           />
@@ -124,65 +127,75 @@ const DialogEntityCredit = (React.memo<PropsT, void>(({
             )}
           </span>
         </label>
-        {state.creditsToChange ? (
-          <div className="change-credits-radio-options">
-            <label>
-              <input
-                checked={state.creditsToChange === 'all'}
-                name="changed-credits"
-                onChange={handleChangedCreditsSelection}
-                type="radio"
-                value="all"
-              />
-              {l('All of these relationships.')}
-            </label>
-
-            <label>
-              <input
-                checked={state.creditsToChange === 'same-entity-types'}
-                name="changed-credits"
-                onChange={handleChangedCreditsSelection}
-                type="radio"
-                value="same-entity-types"
-              />
-              <span>
-                {texp.l('Only relationships to {entity_type} entities.', {
-                  entity_type: ENTITY_NAMES[targetType](),
-                })}
-              </span>
-            </label>
-
-            {linkType ? (
+        {state.releaseHasUnloadedTracks ? (
+          <div className="form-help">
+            <p>
+              {l(`Some tracks/mediums haven’t been loaded yet. If you want
+                  to use this option, please close this dialog and load all
+                  tracks/mediums beforehand.`)}
+            </p>
+          </div>
+        ) : (
+          state.creditsToChange ? (
+            <div className="change-credits-radio-options">
               <label>
                 <input
-                  checked={
-                    state.creditsToChange === 'same-relationship-type'}
+                  checked={state.creditsToChange === 'all'}
                   name="changed-credits"
                   onChange={handleChangedCreditsSelection}
                   type="radio"
-                  value="same-relationship-type"
+                  value="all"
+                />
+                {l('All of these relationships.')}
+              </label>
+
+              <label>
+                <input
+                  checked={state.creditsToChange === 'same-entity-types'}
+                  name="changed-credits"
+                  onChange={handleChangedCreditsSelection}
+                  type="radio"
+                  value="same-entity-types"
                 />
                 <span>
-                  {texp.l(
-                    `Only “{relationship_type}” relationships to
-                    {entity_type} entities.`,
-                    {
-                      entity_type: ENTITY_NAMES[targetType](),
-                      relationship_type: stripAttributes(
-                        linkType,
-                        l_relationships(
-                          backward
-                            ? linkType.reverse_link_phrase
-                            : linkType.link_phrase,
-                        ),
-                      ),
-                    },
-                  )}
+                  {texp.l('Only relationships to {entity_type} entities.', {
+                    entity_type: ENTITY_NAMES[targetType](),
+                  })}
                 </span>
               </label>
-            ) : null}
-          </div>
-        ) : null}
+
+              {linkType ? (
+                <label>
+                  <input
+                    checked={
+                      state.creditsToChange === 'same-relationship-type'}
+                    name="changed-credits"
+                    onChange={handleChangedCreditsSelection}
+                    type="radio"
+                    value="same-relationship-type"
+                  />
+                  <span>
+                    {texp.l(
+                      `Only “{relationship_type}” relationships to
+                      {entity_type} entities.`,
+                      {
+                        entity_type: ENTITY_NAMES[targetType](),
+                        relationship_type: stripAttributes(
+                          linkType,
+                          l_relationships(
+                            backward
+                              ? linkType.reverse_link_phrase
+                              : linkType.link_phrase,
+                          ),
+                        ),
+                      },
+                    )}
+                  </span>
+                </label>
+              ) : null}
+            </div>
+          ) : null
+        )}
       </>
     );
   }

--- a/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogSourceEntity.js
@@ -67,6 +67,7 @@ export function getSourceError(
 }
 
 export function createInitialState(
+  releaseHasUnloadedTracks: boolean,
   sourceType: CoreEntityTypeT,
   relationship: RelationshipStateT,
   source: CoreEntityT,
@@ -80,6 +81,7 @@ export function createInitialState(
       backward
         ? relationship.entity1_credit
         : relationship.entity0_credit,
+      releaseHasUnloadedTracks,
     ),
   };
 }

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -143,6 +143,7 @@ export function createInitialAutocompleteStateForTarget(
 
 export function createInitialState(
   user: ActiveEditorT,
+  releaseHasUnloadedTracks: boolean,
   source: CoreEntityT,
   initialRelationship: RelationshipStateT,
   allowedTypes: TargetTypeOptionsT | null,
@@ -166,6 +167,7 @@ export function createInitialState(
       backward
         ? initialRelationship.entity0_credit
         : initialRelationship.entity1_credit,
+      releaseHasUnloadedTracks,
     ),
     allowedTypes,
     autocomplete,

--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -101,6 +101,7 @@ export type PropsT = {
   +batchSelectionCount?: number,
   +closeDialog: () => void,
   +initialRelationship: RelationshipStateT,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +sourceDispatch: (UpdateRelationshipActionT) => void,
   +targetTypeOptions: TargetTypeOptionsT | null,
@@ -221,12 +222,14 @@ export function createInitialState(props: PropsT): RelationshipDialogStateT {
       ended: relationship.ended,
     },
     sourceEntity: createDialogSourceEntityState(
+      props.releaseHasUnloadedTracks,
       sourceType,
       relationship,
       source,
     ),
     targetEntity: createDialogTargetEntityState(
       props.user,
+      props.releaseHasUnloadedTracks,
       source,
       relationship,
       props.targetTypeOptions,

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -605,6 +605,7 @@ const RelationshipEditor = (
         <RelationshipTargetTypeGroups
           dialogLocation={state.dialogLocation}
           dispatch={dispatch}
+          releaseHasUnloadedTracks={false}
           source={state.entity}
           targetTypeGroups={findTargetTypeGroups(
             state.relationshipsBySource,

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -54,6 +54,7 @@ type PropsT = {
   +hasOrdering: boolean,
   +isDialogOpen: boolean,
   +relationship: RelationshipStateT,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +track: TrackWithRecordingT | null,
 };
@@ -64,6 +65,7 @@ const RelationshipItem = (React.memo<PropsT>(({
   isDialogOpen,
   hasOrdering,
   relationship,
+  releaseHasUnloadedTracks,
   source,
   track,
 }: PropsT): React.MixedElement => {
@@ -173,6 +175,7 @@ const RelationshipItem = (React.memo<PropsT>(({
   const buildPopoverContent = useRelationshipDialogContent({
     dispatch,
     relationship,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions: null,
     targetTypeRef: null,

--- a/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipLinkTypeGroup.js
@@ -22,6 +22,7 @@ type PropsT = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (RelationshipEditorActionT) => void,
   +linkTypeGroup: RelationshipLinkTypeGroupT,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +targetType: CoreEntityTypeT,
   +track: TrackWithRecordingT | null,
@@ -31,6 +32,7 @@ const RelationshipLinkTypeGroup = (React.memo<PropsT>(({
   dialogLocation,
   dispatch,
   linkTypeGroup,
+  releaseHasUnloadedTracks,
   source,
   targetType,
   track,
@@ -50,6 +52,7 @@ const RelationshipLinkTypeGroup = (React.memo<PropsT>(({
         key={linkPhraseGroup.textPhrase}
         linkPhraseGroup={linkPhraseGroup}
         linkTypeId={linkTypeGroup.typeId}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={source}
         targetType={targetType}
         track={track}

--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -51,6 +51,7 @@ type PropsT = {
   +dispatch: (RelationshipEditorActionT) => void,
   +linkPhraseGroup: RelationshipPhraseGroupT,
   +linkTypeId: number,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +targetType: CoreEntityTypeT,
   +track: TrackWithRecordingT | null,
@@ -73,6 +74,7 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
   dispatch,
   linkPhraseGroup,
   linkTypeId,
+  releaseHasUnloadedTracks,
   source,
   targetType,
   track,
@@ -136,6 +138,7 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
     buildNewRelationshipData,
     defaultTargetType: targetType,
     dispatch,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions: null,
     title: l('Add Relationship'),
@@ -194,6 +197,7 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
         }
         key={relationship.id}
         relationship={relationship}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={source}
         track={track}
       />,

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroup.js
@@ -23,6 +23,7 @@ type Props = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (RelationshipEditorActionT) => void,
   +linkTypeGroups: RelationshipLinkTypeGroupsT,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +targetType: CoreEntityTypeT,
   +track: TrackWithRecordingT | null,
@@ -32,6 +33,7 @@ const RelationshipTargetTypeGroup = (React.memo<Props>(({
   dialogLocation,
   dispatch,
   linkTypeGroups,
+  releaseHasUnloadedTracks,
   source,
   targetType,
   track,
@@ -53,6 +55,7 @@ const RelationshipTargetTypeGroup = (React.memo<Props>(({
           linkTypeGroup.backward,
         )}
         linkTypeGroup={linkTypeGroup}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={source}
         targetType={targetType}
         track={track}

--- a/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipTargetTypeGroups.js
@@ -29,6 +29,7 @@ type PropsT = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (RelationshipEditorActionT) => void,
   +filter?: (CoreEntityTypeT) => boolean,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +targetTypeGroups: RelationshipTargetTypeGroupsT,
   +track: TrackWithRecordingT | null,
@@ -38,6 +39,7 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
   dialogLocation,
   dispatch,
   filter,
+  releaseHasUnloadedTracks,
   source,
   targetTypeGroups,
   track,
@@ -47,6 +49,7 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
   const buildPopoverContent = useAddRelationshipDialogContent({
     defaultTargetType: null,
     dispatch,
+    releaseHasUnloadedTracks,
     source,
     title: l('Add Relationship'),
   });
@@ -72,6 +75,7 @@ const RelationshipTargetTypeGroups = (React.memo<PropsT>(({
           dispatch={dispatch}
           key={targetType}
           linkTypeGroups={linkTypeGroups}
+          releaseHasUnloadedTracks={releaseHasUnloadedTracks}
           source={source}
           targetType={targetType}
           track={track}

--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -45,6 +45,7 @@ const RELATIONSHIP_DEFAULTS = {
 type CommonOptionsT = {
   +batchSelectionCount?: number,
   +dispatch: (UpdateRelationshipActionT) => void,
+  +releaseHasUnloadedTracks: boolean,
   +source: CoreEntityT,
   +title: string,
 };
@@ -64,6 +65,7 @@ export default function useRelationshipDialogContent(
     batchSelectionCount,
     dispatch,
     relationship,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions,
     targetTypeRef,
@@ -92,6 +94,7 @@ export default function useRelationshipDialogContent(
         batchSelectionCount={batchSelectionCount}
         closeDialog={closeAndReturnFocus}
         initialRelationship={relationship}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={source}
         sourceDispatch={dispatch}
         targetTypeOptions={targetTypeOptions}
@@ -104,6 +107,7 @@ export default function useRelationshipDialogContent(
     batchSelectionCount,
     dispatch,
     relationship,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions,
     targetTypeRef,
@@ -128,6 +132,7 @@ export function useAddRelationshipDialogContent(
     backward,
     defaultTargetType,
     buildNewRelationshipData,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions: customTargetTypeOptions,
     ...otherOptions
@@ -191,6 +196,7 @@ export function useAddRelationshipDialogContent(
   return useRelationshipDialogContent({
     ...otherOptions,
     relationship: newRelationshipState,
+    releaseHasUnloadedTracks,
     source,
     targetTypeOptions,
     targetTypeRef,

--- a/root/static/scripts/relationship-editor/types.js
+++ b/root/static/scripts/relationship-editor/types.js
@@ -236,6 +236,7 @@ export type DialogTargetEntityStateT = $ReadOnly<{
 export type DialogEntityCreditStateT = {
   +creditedAs: string,
   +creditsToChange: CreditChangeOptionT,
+  +releaseHasUnloadedTracks: boolean,
 };
 
 export type LinkAttributeShapeT = {

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -35,6 +35,7 @@ type PropsT = {
   +medium: MediumWithRecordingsT,
   +recordingStates: MediumRecordingStateTreeT | null,
   +release: ReleaseWithMediumsT,
+  +releaseHasUnloadedTracks: boolean,
   +tracks: $ReadOnlyArray<TrackWithRecordingT> | null,
 };
 
@@ -78,6 +79,7 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
   medium,
   recordingStates,
   release,
+  releaseHasUnloadedTracks,
   tracks,
 }: PropsT) => {
   const tableVars = usePagedMediumTable({
@@ -175,6 +177,7 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
                 dispatch={dispatch}
                 key={track.id}
                 recordingState={recordingState}
+                releaseHasUnloadedTracks={releaseHasUnloadedTracks}
                 showArtists={tableVars.showArtists}
                 track={track}
               />

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -94,12 +94,14 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
   });
 
   const allMediumRecordingsChecked = React.useMemo(() => {
+    let hasRecordings = false;
     for (const recordingState of tree.iterate(recordingStates)) {
       if (!recordingState.isSelected) {
         return false;
       }
+      hasRecordings = true;
     }
-    return true;
+    return hasRecordings;
   }, [recordingStates]);
 
   const allMediumWorksChecked = React.useMemo(() => {

--- a/root/static/scripts/release/components/MediumRelationshipEditor.js
+++ b/root/static/scripts/release/components/MediumRelationshipEditor.js
@@ -142,6 +142,7 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
             <input
               checked={allMediumRecordingsChecked}
               className="medium-recordings"
+              disabled={hasUnloadedTracks}
               id={'medium-recordings-checkbox-' + String(medium.id)}
               onChange={selectMediumRecordings}
               type="checkbox"
@@ -153,6 +154,7 @@ const MediumRelationshipEditor = (React.memo<PropsT>(({
             <input
               checked={allMediumWorksChecked}
               className="medium-works"
+              disabled={hasUnloadedTracks}
               id={'medium-works-checkbox-' + String(medium.id)}
               onChange={selectMediumWorks}
               type="checkbox"

--- a/root/static/scripts/release/components/RelationshipEditorBatchTools.js
+++ b/root/static/scripts/release/components/RelationshipEditorBatchTools.js
@@ -28,6 +28,7 @@ type PropsT = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +recordingSelectionCount: number,
+  +releaseHasUnloadedTracks: boolean,
   +workSelectionCount: number,
 };
 
@@ -39,6 +40,7 @@ type BatchAddRelationshipButtonPopoverPropsT = {
   +entityPlaceholder: string,
   +isOpen: boolean,
   +popoverId: string,
+  +releaseHasUnloadedTracks: boolean,
   +sourceType: CoreEntityTypeT,
 };
 
@@ -50,6 +52,7 @@ const BatchAddRelationshipButtonPopover = ({
   entityPlaceholder,
   isOpen,
   popoverId,
+  releaseHasUnloadedTracks,
   sourceType,
 }: BatchAddRelationshipButtonPopoverPropsT) => {
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -62,6 +65,7 @@ const BatchAddRelationshipButtonPopover = ({
     batchSelectionCount,
     defaultTargetType: null,
     dispatch,
+    releaseHasUnloadedTracks,
     source: sourcePlaceholder,
     title: l('Add Relationship'),
   });
@@ -127,6 +131,7 @@ const RelationshipEditorBatchTools = (React.memo<PropsT>(({
   dialogLocation,
   dispatch,
   recordingSelectionCount,
+  releaseHasUnloadedTracks,
   workSelectionCount,
 }: PropsT): React.Element<'table'> => {
   return (
@@ -146,6 +151,7 @@ const RelationshipEditorBatchTools = (React.memo<PropsT>(({
                 dialogLocation.targetType == null
               }
               popoverId="batch-add-recording-relationship-dialog"
+              releaseHasUnloadedTracks={releaseHasUnloadedTracks}
               sourceType="recording"
             />
           </td>
@@ -172,6 +178,7 @@ const RelationshipEditorBatchTools = (React.memo<PropsT>(({
                 dialogLocation.source.entityType === 'work'
               }
               popoverId="batch-add-work-relationship-dialog"
+              releaseHasUnloadedTracks={releaseHasUnloadedTracks}
               sourceType="work"
             />
           </td>

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -137,6 +137,7 @@ import {
   getMediumTracks,
   isMediumExpanded,
   runLazyReleaseReducer,
+  useReleaseHasUnloadedTracks,
   useUnloadedTracksMap,
 } from './TracklistAndCredits.js';
 
@@ -1387,6 +1388,8 @@ const MediumRelationshipEditors = React.memo(({
 }: MediumRelationshipEditorsPropsT) => {
   const hasUnloadedTracksPerMedium =
     useUnloadedTracksMap(release.mediums, loadedTracks);
+  const hasUnloadedTracks =
+    useReleaseHasUnloadedTracks(hasUnloadedTracksPerMedium);
   const mediumElements = [];
   for (const [medium, recordingStates] of tree.iterate(mediums)) {
     mediumElements.push(
@@ -1405,6 +1408,7 @@ const MediumRelationshipEditors = React.memo(({
         medium={medium}
         recordingStates={recordingStates}
         release={release}
+        releaseHasUnloadedTracks={hasUnloadedTracks}
         tracks={getMediumTracks(loadedTracks, medium)}
       />,
     );
@@ -1419,6 +1423,7 @@ type TrackRelationshipsSectionPropsT = {
   +loadedTracks: LoadedTracksMapT,
   +mediums: MediumStateTreeT,
   +release: ReleaseWithMediumsT,
+  +releaseHasUnloadedTracks: boolean,
   +selectedRecordings: tree.ImmutableTree<RecordingT> | null,
   +selectedWorks: tree.ImmutableTree<WorkT> | null,
 };
@@ -1430,6 +1435,7 @@ const TrackRelationshipsSection = React.memo(({
   loadedTracks,
   mediums,
   release,
+  releaseHasUnloadedTracks,
   selectedRecordings,
   selectedWorks,
 }: TrackRelationshipsSectionPropsT) => {
@@ -1481,6 +1487,7 @@ const TrackRelationshipsSection = React.memo(({
             }
             dispatch={dispatch}
             recordingSelectionCount={recordingCount}
+            releaseHasUnloadedTracks={releaseHasUnloadedTracks}
             workSelectionCount={workCount}
           />
           <span id="medium-toolbox">
@@ -1555,6 +1562,7 @@ type ReleaseRelationshipSectionPropsT = {
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +relationshipsBySource: RelationshipSourceGroupsT,
   +release: ReleaseWithMediumsT,
+  +releaseHasUnloadedTracks: boolean,
 };
 
 const ReleaseRelationshipSection = React.memo(({
@@ -1562,6 +1570,7 @@ const ReleaseRelationshipSection = React.memo(({
   dispatch,
   relationshipsBySource,
   release,
+  releaseHasUnloadedTracks,
 }: ReleaseRelationshipSectionPropsT) => {
   if (dialogLocation != null) {
     invariant(dialogLocation.source.id === release.id);
@@ -1581,6 +1590,7 @@ const ReleaseRelationshipSection = React.memo(({
         <RelationshipTargetTypeGroups
           dialogLocation={dialogLocation}
           dispatch={dispatch}
+          releaseHasUnloadedTracks={releaseHasUnloadedTracks}
           source={release}
           targetTypeGroups={releaseCredits}
           track={null}
@@ -1595,6 +1605,7 @@ type ReleaseGroupRelationshipSectionPropsT = {
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +relationshipsBySource: RelationshipSourceGroupsT,
   +releaseGroup: ReleaseGroupT,
+  +releaseHasUnloadedTracks: boolean,
 };
 
 const ReleaseGroupRelationshipSection = React.memo(({
@@ -1602,6 +1613,7 @@ const ReleaseGroupRelationshipSection = React.memo(({
   dispatch,
   relationshipsBySource,
   releaseGroup,
+  releaseHasUnloadedTracks,
 }: ReleaseGroupRelationshipSectionPropsT) => {
   if (dialogLocation != null) {
     invariant(dialogLocation.source.id === releaseGroup.id);
@@ -1621,6 +1633,7 @@ const ReleaseGroupRelationshipSection = React.memo(({
         <RelationshipTargetTypeGroups
           dialogLocation={dialogLocation}
           dispatch={dispatch}
+          releaseHasUnloadedTracks={releaseHasUnloadedTracks}
           source={releaseGroup}
           targetTypeGroups={releaseGroupCredits}
           track={null}
@@ -1715,6 +1728,11 @@ let ReleaseRelationshipEditor: React.AbstractComponent<{}, void> = (
 
   const dialogLocation = state.dialogLocation;
 
+  const hasUnloadedTracksPerMedium =
+    useUnloadedTracksMap(state.entity.mediums, state.loadedTracks);
+  const hasUnloadedTracks =
+    useReleaseHasUnloadedTracks(hasUnloadedTracksPerMedium);
+
   return (
     <RelationshipSourceGroupsContext.Provider value={sourceGroupsContext}>
       <TrackRelationshipsSection
@@ -1732,6 +1750,7 @@ let ReleaseRelationshipEditor: React.AbstractComponent<{}, void> = (
         loadedTracks={state.loadedTracks}
         mediums={state.mediums}
         release={state.entity}
+        releaseHasUnloadedTracks={hasUnloadedTracks}
         selectedRecordings={state.selectedRecordings}
         selectedWorks={state.selectedWorks}
       />
@@ -1746,6 +1765,7 @@ let ReleaseRelationshipEditor: React.AbstractComponent<{}, void> = (
         dispatch={dispatch}
         relationshipsBySource={state.relationshipsBySource}
         release={state.entity}
+        releaseHasUnloadedTracks={hasUnloadedTracks}
       />
 
       <ReleaseGroupRelationshipSection
@@ -1758,6 +1778,7 @@ let ReleaseRelationshipEditor: React.AbstractComponent<{}, void> = (
         dispatch={dispatch}
         relationshipsBySource={state.relationshipsBySource}
         releaseGroup={state.entity.releaseGroup}
+        releaseHasUnloadedTracks={hasUnloadedTracks}
       />
 
       {state.submissionError == null ? null : (

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1490,6 +1490,17 @@ const TrackRelationshipsSection = React.memo(({
             releaseHasUnloadedTracks={releaseHasUnloadedTracks}
             workSelectionCount={workCount}
           />
+          {releaseHasUnloadedTracks ? (
+            <div className="form-help">
+              <p>
+                {l(
+                  `Some tracks/mediums haven’t been loaded yet.
+                   If you want to make batch operations on all tracks,
+                   please fully load all mediums beforehand.`,
+                )}
+              </p>
+            </div>
+          ) : null}
           <span id="medium-toolbox">
             <ToggleAllMediumsButtons
               dispatch={dispatch}
@@ -1508,6 +1519,7 @@ const TrackRelationshipsSection = React.memo(({
                   <input
                     className="all-recordings"
                     defaultChecked={false}
+                    disabled={releaseHasUnloadedTracks}
                     onChange={selectAllRecordings}
                     type="checkbox"
                   />
@@ -1520,6 +1532,7 @@ const TrackRelationshipsSection = React.memo(({
                   <input
                     className="all-works"
                     defaultChecked={false}
+                    disabled={releaseHasUnloadedTracks}
                     onChange={selectAllWorks}
                     type="checkbox"
                   />

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1495,8 +1495,8 @@ const TrackRelationshipsSection = React.memo(({
               <p>
                 {l(
                   `Some tracks/mediums haven’t been loaded yet.
-                   If you want to make batch operations on all tracks,
-                   please fully load all mediums beforehand.`,
+                   If you want to make batch operations on these,
+                   please fully load them first.`,
                 )}
               </p>
             </div>

--- a/root/static/scripts/release/components/TrackRelationshipEditor.js
+++ b/root/static/scripts/release/components/TrackRelationshipEditor.js
@@ -204,6 +204,7 @@ type RelatedWorkRelationshipEditorPropsT = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +relatedWork: MediumWorkStateT,
+  +releaseHasUnloadedTracks: boolean,
   +track: TrackWithRecordingT,
 };
 
@@ -217,6 +218,7 @@ const RelatedWorkRelationshipEditor = React.memo<
   dialogLocation,
   dispatch,
   relatedWork,
+  releaseHasUnloadedTracks,
   track,
 }) => {
   const work = relatedWork.work;
@@ -313,6 +315,7 @@ const RelatedWorkRelationshipEditor = React.memo<
         dialogLocation={dialogLocation}
         dispatch={dispatch}
         filter={filterRecordings}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         source={work}
         targetTypeGroups={relatedWork.targetTypeGroups}
         track={track}
@@ -326,6 +329,7 @@ type RelatedWorksRelationshipEditorPropsT = {
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +recording: RecordingT,
   +relatedWorks: MediumWorkStateTreeT | null,
+  +releaseHasUnloadedTracks: boolean,
   +track: TrackWithRecordingT,
 };
 
@@ -336,6 +340,7 @@ const RelatedWorksRelationshipEditor = React.memo<
   dispatch,
   recording,
   relatedWorks,
+  releaseHasUnloadedTracks,
   track,
 }) => {
   const relatedWorkElements = [];
@@ -352,6 +357,7 @@ const RelatedWorksRelationshipEditor = React.memo<
         dispatch={dispatch}
         key={relatedWork.work.id}
         relatedWork={relatedWork}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         track={track}
       />,
     );
@@ -371,6 +377,7 @@ const RelatedWorksRelationshipEditor = React.memo<
     buildNewRelationshipData: buildNewRelatedWorkRelationshipData,
     defaultTargetType: 'work',
     dispatch,
+    releaseHasUnloadedTracks,
     source: recording,
     title: l('Add Relationship'),
   });
@@ -414,6 +421,7 @@ type TrackRelationshipEditorPropsT = {
   +dialogLocation: RelationshipDialogLocationT | null,
   +dispatch: (ReleaseRelationshipEditorActionT) => void,
   +recordingState: MediumRecordingStateT,
+  +releaseHasUnloadedTracks: boolean,
   +showArtists: boolean,
   +track: TrackWithRecordingT,
 };
@@ -422,6 +430,7 @@ const TrackRelationshipEditor = (React.memo<TrackRelationshipEditorPropsT>(({
   dialogLocation,
   dispatch,
   recordingState,
+  releaseHasUnloadedTracks,
   showArtists,
   track,
 }: TrackRelationshipEditorPropsT) => {
@@ -467,6 +476,7 @@ const TrackRelationshipEditor = (React.memo<TrackRelationshipEditorPropsT>(({
             ) ? dialogLocation : null
           }
           dispatch={dispatch}
+          releaseHasUnloadedTracks={releaseHasUnloadedTracks}
           source={track.recording}
           targetTypeGroups={recordingState.targetTypeGroups}
           track={track}
@@ -489,6 +499,7 @@ const TrackRelationshipEditor = (React.memo<TrackRelationshipEditorPropsT>(({
         dispatch={dispatch}
         recording={recordingState.recording}
         relatedWorks={recordingState.relatedWorks}
+        releaseHasUnloadedTracks={releaseHasUnloadedTracks}
         track={track}
       />
     </tr>

--- a/root/static/scripts/release/components/TracklistAndCredits.js
+++ b/root/static/scripts/release/components/TracklistAndCredits.js
@@ -225,6 +225,22 @@ export function useUnloadedTracksMap(
   ), [loadedTracks, mediums]);
 }
 
+export function useReleaseHasUnloadedTracks(
+  hasUnloadedTracksPerMedium: $ReadOnlyMap<number, boolean>,
+): boolean {
+  return React.useMemo(() => {
+    for (
+      const mediumHasUnloadedTracks of
+      hasUnloadedTracksPerMedium.values()
+    ) {
+      if (mediumHasUnloadedTracks) {
+        return true;
+      }
+    }
+    return false;
+  }, [hasUnloadedTracksPerMedium]);
+}
+
 const TracklistAndCredits = React.memo<PropsT>((props: PropsT) => {
   const {
     noScript,
@@ -254,14 +270,8 @@ const TracklistAndCredits = React.memo<PropsT>((props: PropsT) => {
   const hasUnloadedTracksPerMedium =
     useUnloadedTracksMap(mediums, loadedTracks);
 
-  const hasUnloadedTracks = React.useMemo(() => {
-    for (const value of hasUnloadedTracksPerMedium.values()) {
-      if (value) {
-        return true;
-      }
-    }
-    return false;
-  }, [hasUnloadedTracksPerMedium]);
+  const hasUnloadedTracks =
+    useReleaseHasUnloadedTracks(hasUnloadedTracksPerMedium);
 
   const bottomMediumCredits = React.useMemo(() => (
     creditsMode === 'bottom'

--- a/root/static/scripts/tests/relationship-editor/dialog.js
+++ b/root/static/scripts/tests/relationship-editor/dialog.js
@@ -22,6 +22,7 @@ import {
 
 const commonInitialState = {
   closeDialog: () => undefined,
+  releaseHasUnloadedTracks: false,
   sourceDispatch: () => undefined,
   targetTypeOptions: null,
   targetTypeRef: null,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problems MBS-12873 & MBS-12875

Since the new React implementation of the release relationship editor avoid loading all the tracks for the big releases by default, the batch tools for changing credits in relationships (MBS-12873) and for linking to recordings and works (MBS-12875) don’t work nicely as described and as it used to be in the previous implementation of release relationship editor.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Disable every checkbox related to these tools until all the related tracks have been loaded. Accompany such disabled checkbox with an help message.

It just uses a computation of the loading status already used for the release overview page.

The release relationship editor is expected to re-render only one more time after having loaded all the missing tracks.

The longer-term solution is to load all tracks when ticking such checkbox instead of requiring the user to chase the mediums with missing tracks.

# Testing

* [x] Updated existing tests without testing the new behavior.
  _I don’t think that it is needed to have automated tests at this point since it is not a definitive behavior._
* [x] Tested MBS-12873 manually using sample data with:
  * two releases:
    * `/release/32a6fcc2-bd3c-467b-956c-d207fe5bc367/edit-relationships` which has one partially loaded medium,
    * `/release/b4d66536-cbf1-4540-81cf-60f3b64ba78e/edit-relationships` which has a last completely unloaded medium;
  * to verify:
    * batch-adding a relationship to recordings,
    * batch-adding a relationship to works,
    * adding a relationship with artist credits to a recording,
    * adding a relationship with artist credits to a work,
    * adding a relationship with artist credits to the release,
    * adding a relationship with artist credits to the release group.
* [x] Tested MBS-12875 manually using the same releases to verify every selection checkbox before/after loading all tracks.

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. <del>Create a new (non-beta) ticket for the definitive solution.</del> See MBS-12907