### PR TITLE
MBS-11770: Always list autocomplete additional data for all entities

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -658,6 +658,12 @@ sub entities : Chained('root') PathPart('entities') Args(2)
         $appears_on = $c->model('Recording')->appears_on(\@entities, 3, 1);
     }
 
+    if ($type_name eq 'release') {
+        $c->model('Release')->load_release_events(@entities);
+        $c->model('ReleaseLabel')->load(@entities);
+        $c->model('Label')->load(map { $_->all_labels } @entities);
+    }
+
     my %artists;
     if ($type_name eq 'work') {
         %artists = $c->model('Work')->find_artists(\@entities, 3);

--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -544,6 +544,12 @@ sub entity : Chained('root') PathPart('entity') Args(1)
         $data->{relationships} = $relationships if @$relationships;
     };
 
+    if ($type eq 'Event') {
+        my %related_entities =
+            $c->model('Event')->find_related_entities([$entity], 3);
+        $data->{related_entities} = $related_entities{$entity->id};
+    }
+
     if ($type eq 'Recording') {
         $c->model('ISRC')->load_for_recordings($entity);
         my $appears_on = $c->model('Recording')->appears_on([$entity], 3, 1);
@@ -647,6 +653,11 @@ sub entities : Chained('root') PathPart('entities') Args(2)
         $c->model('Area')->load_containment(@entities);
     }
 
+    my %related_entities;
+    if ($type_name eq 'event') {
+        %related_entities = $c->model('Event')->find_related_entities(\@entities, 3);
+    }
+
     if ($type_name eq 'place') {
         $c->model('Area')->load(@entities);
         $c->model('Area')->load_containment(map { $_->area } @entities);
@@ -671,6 +682,9 @@ sub entities : Chained('root') PathPart('entities') Args(2)
 
     while (my ($id, $entity) = each %{$results}) {
         my $json_entity = $entity->TO_JSON;
+        if ($type_name eq 'event') {
+            $json_entity->{related_entities} = $related_entities{$entity->id};
+        }
         if ($type_name eq 'recording') {
             $json_entity->{appearsOn} = $appears_on->{$entity->id};
         }


### PR DESCRIPTION
### Fix MBS-11770

# Problem
Autocomplete2 loads useful additional data for works (related artists), recordings (ISRCs and RGs), releases (labels and release events) and events (related artists and places) when searching, but this data is missing from the recent entries when pasting an MBID and/or when reloading the page.

# Solution
This makes sure the data is also loaded on those two cases.

# Testing
By hand, with sample data, searching for "a" and picking some of the first results that have the extra data to be tested (since the data is always shown on first search, it's easy to find good testing cases).