### PR TITLE
MBS-12904: Fix another error submitting a recording artist relationship

### DIFF
--- a/root/static/lib/jquery.ui/ui/jquery-ui.custom.js
+++ b/root/static/lib/jquery.ui/ui/jquery-ui.custom.js
@@ -5055,9 +5055,6 @@ $.widget( "ui.autocomplete", {
 	},
 
 	__response: function( content ) {
-		if ( content ) {
-			content = this._normalize( content );
-		}
 		this._trigger( "response", null, { content: content } );
 		if ( !this.options.disabled && content && content.length && !this.cancelSearch ) {
 			this._suggest( content );
@@ -5086,25 +5083,6 @@ $.widget( "ui.autocomplete", {
 		if ( this.previous !== this._value() ) {
 			this._trigger( "change", event, { item: this.selectedItem } );
 		}
-	},
-
-	_normalize: function( items ) {
-		// assume all items have the right format when the first item is complete
-		if ( items.length && items[0].label && items[0].value ) {
-			return items;
-		}
-		return $.map( items, function( item ) {
-			if ( typeof item === "string" ) {
-				return {
-					label: item,
-					value: item
-				};
-			}
-			return $.extend({
-				label: item.label || item.value,
-				value: item.value || item.label
-			}, item );
-		});
 	},
 
 	_suggest: function( items ) {

--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -553,11 +553,30 @@ const RelationshipEditor = (
 
   const submissionInProgress = React.useRef(false);
 
+  const [
+    prepareSubmissionError,
+    setPrepareSubmissionError,
+  ] = React.useState<Error | null>(null);
+
+  const error = reducerError ?? prepareSubmissionError;
+
   React.useEffect(() => {
-    const handleSubmission = () => {
+    const handleSubmission = (event: Event) => {
       if (!submissionInProgress.current) {
         submissionInProgress.current = true;
-        prepareHtmlFormSubmission(formName, state);
+        try {
+          prepareHtmlFormSubmission(formName, state);
+        } catch (error) {
+          event.preventDefault();
+
+          captureException(error);
+
+          setPrepareSubmissionError(
+            error instanceof Error
+              ? error
+              : new Error(String(error)),
+          );
+        }
       }
     };
 
@@ -593,8 +612,8 @@ const RelationshipEditor = (
 
   return (
     <fieldset id="relationship-editor">
-      {reducerError ? (
-        <ErrorMessage error={reducerError.stack} />
+      {error ? (
+        <ErrorMessage error={error.stack} />
       ) : null}
 
       <legend>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -632,6 +632,7 @@ const seleniumTests = [
   {name: 'MBS-12859.json5', login: true},
   {name: 'MBS-12874.json5', login: true},
   {name: 'MBS-12885.json5', login: true},
+  {name: 'MBS-12904.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium/MBS-12904.json5
+++ b/t/selenium/MBS-12904.json5
@@ -1,0 +1,144 @@
+{
+  title: 'MBS-12904',
+  // This issue is very similar to MBS-12694, but involves selecting the
+  // recording artist from a search first in order to push it onto the
+  // recent entities list.
+  //
+  // The issue was that, when displaying search results, jQuery UI would
+  // modify the entity JSON to add undefined `label` and `value` properties
+  // as part of its "normalization" process. These undefined properties
+  // would cause `compactEntityJson` to throw an error.
+  commands: [
+    {
+      command: 'open',
+      target: '/recording/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.name',
+      value: 'test',
+    },
+    {
+      command: 'type',
+      target: 'id=entity-artist',
+      value: 'david bowie',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=(//li[contains(@class, "ui-menu-item")][contains(descendant::text(), "David Bowie")])[1]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#relationship-editor button.add-relationship',
+      value: '',
+    },
+    {
+      command: 'select',
+      target: 'css=#add-relationship-dialog select.entity-type',
+      value: 'label=Artist',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'arrange${KEY_ENTER}',
+    },
+    {
+      command: 'focus',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '250',
+      value: '',
+    },
+    // "David Bowie" should be in the recent entities list.
+    {
+      command: 'click',
+      target: 'xpath=//div[@id = "add-relationship-dialog"]//div[contains(@class, "relationship-target")]//li[contains(descendant::text(), "David Bowie")]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.edit_note',
+      value: 'ok',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-recording button[type=submit].positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 71,
+        status: 2,
+        data: {
+          artist_credit: {
+            names: [
+              {
+                artist: {
+                  id: 956,
+                  name: 'David Bowie',
+                },
+                join_phrase: '',
+                name: 'David Bowie',
+              }
+            ]
+          },
+          comment: '',
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 1,
+          length: null,
+          name: 'test',
+          video: '0',
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: '0',
+          entity0: {
+            gid: '5441c29d-3602-4898-b1a1-b77fa23b8e50',
+            id: 956,
+            name: 'David Bowie',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: 'test',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 297,
+            link_phrase: '{additional:additionally} arranged',
+            long_link_phrase: '{additional:additionally} arranged',
+            name: 'arranger',
+            reverse_link_phrase: '{additional} arranger',
+          },
+          type0: 'artist',
+          type1: 'recording',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Fix MBS-12904

## Problem

You can reproduce MBS-12904 as follows:

1. Open /recording/create and enter a title.
2. Search for a recording artist that isn't already in the recent entities list, and select it.
3. Add a relationship to the same artist you selected, choosing it from the recent entities list.
4. Enter an edit note and submit the form.

The recording will be submitted, but the relationship you added won't.

## Solution

This issue is very similar to [MBS-12694](https://tickets.metabrainz.org/browse/MBS-12694), but involves selecting the recording artist from a search first in order to push it onto the recent entities list.

The issue was that, when displaying search results, jQuery UI would modify the entity JSON to add undefined `label` and `value` properties as part of its "normalization" process. These undefined properties would cause `compactEntityJson` to throw an error.

I removed the normalization code from jQuery UI because its behavior is gross and we don't appear to need it anywhere. We override `_renderItem` everywhere, and don't require `label` or `value` to display anything that I can see.

## Testing

Added a Selenium test case which fails without the fix applied.

Manually tested other components using the old autocomplete code, to make sure they still function: the artist credit editor, the tag editor, and the "edit note author" field in the edit search all have working autocompletes.