### PR TITLE
MBS-12908: Do not reuse "cancelled"/"time" for artist-event rels

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -100,12 +100,32 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
         maxLinkOrder = Math.max(maxLinkOrder, relationship.linkOrder);
       }
       // Drop number attribute for part of series - useless to reuse
-      const relationshipAttributesForReuse = tree.removeIfExists(
+      let relationshipAttributesForReuse = tree.removeIfExists(
         relationship.attributes,
         {
           type: {gid: 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a'},
           typeID: 788,
           typeName: 'number',
+        },
+        compareLinkAttributeIds,
+      );
+      // Drop cancelled for event performers (often not applicable)
+      relationshipAttributesForReuse = tree.removeIfExists(
+        relationshipAttributesForReuse,
+        {
+          type: {gid: 'efd89258-fb07-48e9-acf9-0a54ce03606d'},
+          typeID: 921,
+          typeName: 'cancelled',
+        },
+        compareLinkAttributeIds,
+      );
+      // Drop time for event performers (often not applicable)
+      relationshipAttributesForReuse = tree.removeIfExists(
+        relationshipAttributesForReuse,
+        {
+          type: {gid: 'ebd303c3-7f57-452a-aa3b-d780ebad868d'},
+          typeID: 830,
+          typeName: 'time',
         },
         compareLinkAttributeIds,
       );

--- a/t/sql/initial.sql
+++ b/t/sql/initial.sql
@@ -161,6 +161,7 @@ INSERT INTO link_attribute_type VALUES (700, 14, 14, 0, '1da1ca18-9d70-4217-9e3c
 INSERT INTO link_attribute_type VALUES (750, NULL, 750, 0, '37da3398-5d1b-4acb-be25-df95e33e423c', 'medley', 'This indicates that the recording is of a medley, of which the work is one part.', '2014-01-01 10:32:01.979531+00');
 INSERT INTO link_attribute_type VALUES (788, NULL, 788, 0, 'a59c5830-5ec7-38fe-9a21-c7ea54f6650a', 'number', 'This attribute indicates the number of a work in a series.', '2014-05-14 16:39:54.654562+00');
 INSERT INTO link_attribute_type VALUES (830, NULL, 830, 0, 'ebd303c3-7f57-452a-aa3b-d780ebad868d', 'time', 'Local time a band''s performance is scheduled to start, formatted HH:MM.', '2014-11-18 14:34:00.964336+00');
+INSERT INTO link_attribute_type VALUES (921, NULL, 921, 0, 'efd89258-fb07-48e9-acf9-0a54ce03606d', 'cancelled', 'This indicates an artist cancelled their appearance at an event.', '2016-07-04 18:28:11.756249+00');
 
 INSERT INTO link_creditable_attribute_type VALUES (3);
 INSERT INTO link_creditable_attribute_type VALUES (14);


### PR DESCRIPTION
### Implement MBS-12908

# Problem
When adding events and creating a new artist relationship based on an existing one that has the attributes "cancelled" and/or "time", those get prefilled for the new relationship. This is usually a desired behaviour, but it's unlikely that most artists will be performing at the same time and one being cancelled doesn't mean others are likely to be, so these two are likely to mostly get in the way.

# Solution
When cloning the relationship data, drop these two attributes.

# Testing
Manually, from `/event/create`.