### PR TITLE
Fix MBS-11529 / MBS-12903: "Guess feat. artists" issues

### DIFF
--- a/root/static/scripts/common/entity.js
+++ b/root/static/scripts/common/entity.js
@@ -10,6 +10,9 @@ import ko from 'knockout';
 import * as ReactDOMServer from 'react-dom/server';
 
 import formatLabelCode from '../../../utility/formatLabelCode.js';
+import getRelatedArtists from '../edit/utility/getRelatedArtists.js';
+import isEntityProbablyClassical
+  from '../edit/utility/isEntityProbablyClassical.js';
 
 import ArtistCreditLink from './components/ArtistCreditLink.js';
 import DescriptiveLink from './components/DescriptiveLink.js';
@@ -24,7 +27,6 @@ import formatTrackLength from './utility/formatTrackLength.js';
 import {
   ENTITY_NAMES,
   PART_OF_SERIES_LINK_TYPES,
-  PROBABLY_CLASSICAL_LINK_TYPES,
 } from './constants.js';
 import {
   artistCreditsAreEqual,
@@ -317,8 +319,8 @@ import MB from './MB.js';
         this.artistCredit = {names: []};
       }
 
-      this.relatedArtists = relatedArtists(data.relationships);
-      this.isProbablyClassical = isProbablyClassical(data);
+      this.relatedArtists = getRelatedArtists(data.relationships);
+      this.isProbablyClassical = isEntityProbablyClassical(data);
 
       if (this._afterRecordingCtor) {
         this._afterRecordingCtor(data);
@@ -347,8 +349,8 @@ import MB from './MB.js';
         this.mediums = data.mediums.map(x => new Medium(x));
       }
 
-      this.relatedArtists = relatedArtists(data.relationships);
-      this.isProbablyClassical = isProbablyClassical(data);
+      this.relatedArtists = getRelatedArtists(data.relationships);
+      this.isProbablyClassical = isEntityProbablyClassical(data);
     }
 
     toJSON() {
@@ -490,27 +492,6 @@ import MB from './MB.js';
   MB.entity.Track = Track;
   MB.entity.URL = URL;
   MB.entity.Work = Work;
-
-  function relatedArtists(relationships) {
-    if (!relationships) {
-      return [];
-    }
-    return relationships.reduce((accum, r) => {
-      if (r.target.entityType === 'artist') {
-        accum.push(r.target);
-      }
-      return accum;
-    }, []);
-  }
-
-  var classicalRoles = /\W(baritone|cello|conductor|gamba|guitar|orch|orchestra|organ|piano|soprano|tenor|trumpet|vocals?|viola|violin): /;
-
-  function isProbablyClassical(entity) {
-    return classicalRoles.test(entity.name) ||
-           entity.relationships?.some(function (r) {
-             return PROBABLY_CLASSICAL_LINK_TYPES.includes(r.linkTypeID);
-           });
-  }
 
   /*
    * Used by MB.entity() to look up classes. JSON from the web service

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -7,6 +7,7 @@
  */
 
 import ko from 'knockout';
+import {createRef} from 'react';
 import {flushSync} from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
 
@@ -18,7 +19,11 @@ import ArtistCreditEditor from './ArtistCreditEditor.js';
 import FieldErrors from './FieldErrors.js';
 import FormRow from './FormRow.js';
 
-export const FormRowArtistCredit = ({form, entity}) => (
+export const FormRowArtistCredit = ({
+  artistCreditEditorRef,
+  form,
+  entity,
+}) => (
   <FormRow>
     <label className="required" htmlFor="entity-artist">
       {l('Artist:')}
@@ -28,6 +33,9 @@ export const FormRowArtistCredit = ({form, entity}) => (
       forLabel="entity-artist"
       form={form}
       hiddenInputs
+      // eslint-disable-next-line react/jsx-handler-names
+      onChange={entity.artistCredit}
+      ref={artistCreditEditorRef}
     />
     {form ? <FieldErrors field={form.field.artist_credit} /> : null}
   </FormRow>
@@ -37,18 +45,17 @@ MB.initializeArtistCredit = function (form, initialArtistCredit) {
   const source = MB.getSourceEntityInstance() ?? {name: ''};
   source.uniqueID = 'source';
   source.artistCredit = ko.observable(initialArtistCredit);
+  source.artistCreditEditorInst = createRef();
 
   const container = document.getElementById('artist-credit-editor');
   const root = ReactDOMClient.createRoot(container);
   flushSync(() => {
     root.render(
-      <FormRowArtistCredit entity={source} form={form} />,
+      <FormRowArtistCredit
+        artistCreditEditorRef={source.artistCreditEditorInst}
+        entity={source}
+        form={form}
+      />,
     );
-  });
-
-  source.artistCredit.subscribe((artistCredit) => {
-    $('table.artist-credit-editor', container)
-      .data('componentInst')
-      .setState({artistCredit});
   });
 };

--- a/root/static/scripts/edit/components/forms.js
+++ b/root/static/scripts/edit/components/forms.js
@@ -34,7 +34,8 @@ export const FormRowArtistCredit = ({form, entity}) => (
 );
 
 MB.initializeArtistCredit = function (form, initialArtistCredit) {
-  const source = MB.sourceEntity || {name: ''};
+  const source = MB.getSourceEntityInstance() ?? {name: ''};
+  source.uniqueID = 'source';
   source.artistCredit = ko.observable(initialArtistCredit);
 
   const container = document.getElementById('artist-credit-editor');

--- a/root/static/scripts/edit/utility/getRelatedArtists.js
+++ b/root/static/scripts/edit/utility/getRelatedArtists.js
@@ -1,0 +1,29 @@
+/*
+ * @flow strict
+ * Copyright (C) 2015 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ko, {
+  type ObservableArray as KnockoutObservableArray,
+} from 'knockout';
+
+export default function getRelatedArtists(
+  relationships: ?(
+    | $ReadOnlyArray<RelationshipT>
+    | KnockoutObservableArray<RelationshipT>
+  ),
+): Array<ArtistT> {
+  if (!relationships) {
+    return [];
+  }
+  return ko.unwrap(relationships).reduce((accum, r) => {
+    if (r.target.entityType === 'artist') {
+      accum.push(r.target);
+    }
+    return accum;
+  }, []);
+}

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -22,6 +22,8 @@ import {
   hasFullwidthLatin,
   toFullwidthLatin,
 } from './fullwidthLatin.js';
+import getRelatedArtists from './getRelatedArtists.js';
+import isEntityProbablyClassical from './isEntityProbablyClassical.js';
 import getSimilarity from './similarity.js';
 
 /* eslint-disable sort-keys */
@@ -212,12 +214,16 @@ export default function guessFeat(entity) {
   }
 
   let relatedArtists = entity.relatedArtists;
-  if (typeof relatedArtists === 'function') {
+  if (relatedArtists == null) {
+    relatedArtists = getRelatedArtists(entity.relationships);
+  } else if (typeof relatedArtists === 'function') {
     relatedArtists = relatedArtists.call(entity);
   }
 
   let isProbablyClassical = entity.isProbablyClassical;
-  if (typeof isProbablyClassical === 'function') {
+  if (isProbablyClassical == null) {
+    isProbablyClassical = isEntityProbablyClassical(entity);
+  } else if (typeof isProbablyClassical === 'function') {
     isProbablyClassical = isProbablyClassical.call(entity);
   }
 

--- a/root/static/scripts/edit/utility/isEntityProbablyClassical.js
+++ b/root/static/scripts/edit/utility/isEntityProbablyClassical.js
@@ -1,0 +1,36 @@
+/*
+ * @flow strict
+ * Copyright (C) 2015 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import ko, {
+  type Observable as KnockoutObservable,
+  type ObservableArray as KnockoutObservableArray,
+} from 'knockout';
+
+import {
+  PROBABLY_CLASSICAL_LINK_TYPES,
+} from '../../common/constants.js';
+
+const classicalRoles = /\W(baritone|cello|conductor|gamba|guitar|orch|orchestra|organ|piano|soprano|tenor|trumpet|vocals?|viola|violin): /;
+
+const testRelationship = (r: RelationshipT) => {
+  return PROBABLY_CLASSICAL_LINK_TYPES.includes(r.linkTypeID);
+};
+
+export default function isEntityProbablyClassical(
+  entity: {
+    +name: string | KnockoutObservable<string>,
+    +relationships?:
+      | $ReadOnlyArray<RelationshipT>
+      | KnockoutObservableArray<RelationshipT>,
+    ...
+  },
+): boolean {
+  return classicalRoles.test(ko.unwrap(entity.name)) ||
+    (ko.unwrap(entity.relationships)?.some(testRelationship) ?? false);
+}

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -627,6 +627,7 @@ const seleniumTests = [
   {name: 'MBS-9941.json5', login: true},
   {name: 'MBS-10188.json5', login: true, sql: 'mbs-10188.sql'},
   {name: 'MBS-10510.json5', login: true, sql: 'mbs-10510.sql'},
+  {name: 'MBS-11529.json5', login: true},
   {name: 'MBS-11730.json5', login: true},
   {name: 'MBS-11735.json5', login: true},
   {name: 'MBS-12641.json5', login: true},

--- a/t/selenium/MBS-11529.json5
+++ b/t/selenium/MBS-11529.json5
@@ -1,0 +1,212 @@
+{
+  title: 'MBS-11529',
+  commands: [
+    {
+      command: 'open',
+      target: '/recording/create',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.name',
+      value: 'test feat. bing crosby',
+    },
+    {
+      command: 'type',
+      target: 'id=entity-artist',
+      value: 'david bowie',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=(//li[contains(@class, "ui-menu-item")][contains(descendant::text(), "David Bowie")])[1]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=div.recording-name button.guessfeat',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=button.open-ac',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'xpath=(//div[@id = "artist-credit-bubble"]//input[contains(@class, "name")])[2]',
+      value: '${KEY_DOWN}',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'xpath=(//div[@id = "artist-credit-bubble"]//input[contains(@class, "name")])[2]',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-bubble button.positive',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.edit_note',
+      value: 'ok',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-recording button[type=submit].positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 71,
+        status: 2,
+        data: {
+          artist_credit: {
+            names: [
+              {
+                artist: {
+                  id: 956,
+                  name: 'David Bowie',
+                },
+                join_phrase: ' feat. ',
+                name: 'David Bowie',
+              },
+              {
+                artist: {
+                  id: 99,
+                  name: 'Bing Crosby',
+                },
+                join_phrase: '',
+                name: 'Bing Crosby',
+              }
+            ]
+          },
+          comment: '',
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 1,
+          length: null,
+          name: 'test',
+          video: '0',
+        },
+      },
+    },
+    // Repeat the same test, but with a seeded artist that's replaced.
+    // (As reported in the comments to MBS-11529, changing the artist and
+    // hitting "guess feat." would incorrectly cause it to reset to the
+    // seeded artist.)
+    //
+    {
+      command: 'open',
+      target: '/recording/create?artist=4f74991f-0156-427a-88db-9b2ac293dd42',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.name',
+      value: 'test feat. bing crosby',
+    },
+    {
+      command: 'type',
+      target: 'id=entity-artist',
+      value: 'david bowie',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=(//li[contains(@class, "ui-menu-item")][contains(descendant::text(), "David Bowie")])[1]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=div.recording-name button.guessfeat',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=button.open-ac',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'xpath=(//div[@id = "artist-credit-bubble"]//input[contains(@class, "name")])[2]',
+      value: '${KEY_DOWN}',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'xpath=(//div[@id = "artist-credit-bubble"]//input[contains(@class, "name")])[2]',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#artist-credit-bubble button.positive',
+      value: '',
+    },
+    {
+      command: 'type',
+      target: 'id=id-edit-recording.edit_note',
+      value: 'ok',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=form.edit-recording button[type=submit].positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 71,
+        status: 2,
+        data: {
+          artist_credit: {
+            names: [
+              {
+                artist: {
+                  id: 956,
+                  name: 'David Bowie',
+                },
+                join_phrase: ' feat. ',
+                name: 'David Bowie',
+              },
+              {
+                artist: {
+                  id: 99,
+                  name: 'Bing Crosby',
+                },
+                join_phrase: '',
+                name: 'Bing Crosby',
+              }
+            ]
+          },
+          comment: '',
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 2,
+          length: null,
+          name: 'test',
+          video: '0',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Fix MBS-11529 / MBS-12903

## Problem

An exception is thrown on beta if you try to use the "Guess feat. artists" button outside of the release editor (MBS-12903).

Additionally, if we fix the exception then it has weird behavior (MBS-11529) where it removes the primary artist.

## Solution

The exception is fixed by making sure the `guessFeat` module is using the same source entity object as `initializeArtistCredit`.

The weird behavior is fixed by syncing the knockout and React state correctly.

## Testing

Tested manually on recording pages. A Selenium test has been added for MBS-11529 (which would have also failed due to MBS-12903 in either case).

Also quickly checked that the "guess feat." button still works in the release editor for the release title and track titles.