### PR TITLE
MBS-11770 (erratum): Load work languages for recently used works

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/js.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/js.pm
@@ -678,6 +678,7 @@ sub entities : Chained('root') PathPart('entities') Args(2)
     my %artists;
     if ($type_name eq 'work') {
         %artists = $c->model('Work')->find_artists(\@entities, 3);
+        $c->model('Language')->load_for_works(@entities);
     }
 
     while (my ($id, $entity) = each %{$results}) {


### PR DESCRIPTION
### Fix MBS-11770 (redux)

# Problem
I missed work languages in https://github.com/metabrainz/musicbrainz-server/pull/2843. We show these for direct search results and when pasting an MBID, but we were not loading them for recent entries on reload.

# Solution
Also load work languages in the `/entities` endpoint.

# Testing
Manually by searching, selecting a work with a language, and then reloading to make sure the language still shows.