### PR TITLE
MBS-12915: Default to 'artist' in the add-relationship dialog

### DIFF
--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -162,14 +162,25 @@ export function useAddRelationshipDialogContent(
   const targetType = (
     preselectedTargetType ||
     targetTypeRef.current ||
-    (targetTypeOptions?.[0]?.value) ||
-    /*
-     * targetType may be undefined if the current server doesn't have any
-     * available link types for the source entity type.  In that case
-     * `defaultTargetObject` won't be used, but a dummy 'artist' type is
-     * supplied to simplify type-checking.
-     */
-    'artist'
+    (
+      targetTypeOptions?.length
+        ? (
+          /*
+           * If artist is available, use that (MBS-12915). Otherwise select
+           * the first available type as they are sorted.
+           */
+          (targetTypeOptions.find(
+            (option) => option.value === 'artist',
+          )?.value) ?? targetTypeOptions[0].value
+        )
+        /*
+         * targetType may be undefined if the current server doesn't have any
+         * available link types for the source entity type.  In that case
+         * `defaultTargetObject` won't be used, but a dummy 'artist' type is
+         * supplied to simplify type-checking.
+         */
+        : 'artist'
+    )
   );
 
   if (backward != null) {

--- a/t/selenium/Release_Relationship_Editor.json5
+++ b/t/selenium/Release_Relationship_Editor.json5
@@ -278,6 +278,11 @@
       value: '',
     },
     {
+      command: 'select',
+      target: 'css=#add-relationship-dialog select.entity-type',
+      value: 'label=Area',
+    },
+    {
       command: 'type',
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: 'Osaka',
@@ -2136,11 +2141,6 @@
       value: '',
     },
     {
-      command: 'sendKeys',
-      target: 'css=#add-relationship-dialog input.relationship-type',
-      value: 'arrang${KEY_ENTER}',
-    },
-    {
       command: 'type',
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '30bcaa92-9870-4798-be1a-4e0036755316',
@@ -2149,6 +2149,11 @@
       command: 'pause',
       target: '500',
       value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'arrang${KEY_ENTER}',
     },
     {
       command: 'click',
@@ -2161,11 +2166,6 @@
       value: '',
     },
     {
-      command: 'sendKeys',
-      target: 'css=#add-relationship-dialog input.relationship-type',
-      value: 'prod${KEY_ENTER}',
-    },
-    {
       command: 'type',
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '30bcaa92-9870-4798-be1a-4e0036755316',
@@ -2174,6 +2174,11 @@
       command: 'pause',
       target: '500',
       value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'prod${KEY_ENTER}',
     },
     {
       command: 'click',


### PR DESCRIPTION
# Fix MBS-12915

## Problem

If you haven't previously added a relationship in the current editing session, the add-relationship dialog will default to selecting the first target entity type in the list, which can vary depending on the UI language. In production we default to "artist."

## Solution

If artist is available, default to that or otherwise use the first item.

## Testing

Tested manually in the release relationship editor.
