### PR TITLE
MBS-12911, MBS-12928: Can't link two new works together

### DIFF
--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -182,7 +182,7 @@ export function createInitialState(
   };
 }
 
-const NEW_WORK_HASH = /#new-work-(-[0-9]+)$/;
+const NEW_WORK_HASH = /#new-work-(-[0-9]+)\s*$/;
 
 function selectNewWork(
   newInputValue: string,

--- a/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
+++ b/root/static/scripts/relationship-editor/components/DialogTargetEntity.js
@@ -89,7 +89,10 @@ export function getTargetError(
     return '';
   }
 
-  if (source.gid === target.gid) {
+  if (
+    source.entityType === target.entityType &&
+    source.id === target.id
+  ) {
     return l('Entities in a relationship cannot be the same.');
   }
 

--- a/root/static/scripts/relationship-editor/utility/updateWorkStates.js
+++ b/root/static/scripts/relationship-editor/utility/updateWorkStates.js
@@ -12,6 +12,7 @@ import {
   onNotFoundDoNothing,
 } from 'weight-balanced-tree/update';
 
+import {compare} from '../../common/i18n.js';
 import type {
   MediumWorkStateT,
   ReleaseRelationshipEditorStateT,
@@ -31,7 +32,10 @@ export function compareWorkWithWorkState(
   work: WorkT,
   workState: MediumWorkStateT,
 ): number {
-  return work.id - workState.work.id;
+  return (
+    compare(work.name, workState.work.name) ||
+    (work.id - workState.work.id)
+  );
 }
 
 export function* findWorkRecordings(

--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -1204,20 +1204,30 @@ const reducer = reducerWithErrorHandling<
         );
       }
 
+      const updatedRelationshipsByKey =
+        new Map<string, RelationshipStateT>();
+
       const updateRelationshipState = function (
         relationship: RelationshipStateT,
         callback: ({...RelationshipStateT}) => void,
       ) {
+        const currentRelationship = updatedRelationshipsByKey.get(
+          getRelationshipKey(relationship),
+        ) ?? relationship;
         const newRelationship =
-          cloneRelationshipState(relationship);
+          cloneRelationshipState(currentRelationship);
         newRelationship._lineage = [
           ...newRelationship._lineage,
           'submitted',
         ];
         callback(newRelationship);
+        updatedRelationshipsByKey.set(
+          getRelationshipKey(newRelationship),
+          newRelationship,
+        );
         updates.push(
           {
-            relationship,
+            relationship: currentRelationship,
             throwIfNotExists: false,
             type: REMOVE_RELATIONSHIP,
           },
@@ -1319,6 +1329,10 @@ const reducer = reducerWithErrorHandling<
                 relationships.length === 1,
               );
               const relationship = relationships[0];
+              /*
+               * `relationship` is always recording-work here
+               * (see `getWorkEditsForEntity`).
+               */
               const oldWork = relationship.entity1;
               const newWork = response.entity;
               updateRelationshipState(
@@ -1339,10 +1353,30 @@ const reducer = reducerWithErrorHandling<
                 if (workRelationship.id === relationship.id) {
                   continue;
                 }
+                /*
+                 * Iterate through all other relationships associated with
+                 * the pending work, and update them to point to the created
+                 * work.
+                 */
                 updateRelationshipState(
                   workRelationship,
                   (newWorkRelationship) => {
-                    newWorkRelationship.entity1 = newWork;
+                    const {entity0, entity1} = newWorkRelationship;
+                    /*
+                     * The old work is not necessarily entity1, e.g. for
+                     * work-work relationships.
+                     */
+                    if (
+                      entity0.entityType === 'work' &&
+                      entity0.id === oldWork.id
+                    ) {
+                      newWorkRelationship.entity0 = newWork;
+                    } else if (
+                      entity1.entityType === 'work' &&
+                      entity1.id === oldWork.id
+                    ) {
+                      newWorkRelationship.entity1 = newWork;
+                    }
                   },
                 );
               }

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -635,6 +635,11 @@ const seleniumTests = [
   {name: 'MBS-12874.json5', login: true},
   {name: 'MBS-12885.json5', login: true},
   {name: 'MBS-12904.json5', login: true},
+  {
+    name: 'MBS-12911.json5',
+    login: true,
+    sql: 'vision_creation_newsun.sql',
+  },
   {name: 'MBS-12921.json5', login: true},
   {name: 'MBS-12922.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},

--- a/t/selenium/MBS-12911.json5
+++ b/t/selenium/MBS-12911.json5
@@ -1,0 +1,200 @@
+{
+  title: 'MBS-12911',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/868cc741-e3bc-31bc-9dac-756e35c8f152/edit-relationships',
+      value: '',
+    },
+    {
+      command: 'check',
+      target: 'xpath=(//tr[contains(@class, "track")])[1]//input[contains(@class, "recording")]',
+      value: '',
+    },
+    {
+      command: 'check',
+      target: 'xpath=(//tr[contains(@class, "track")])[2]//input[contains(@class, "recording")]',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=button.batch-create-works',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#batch-create-works-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'xpath=(//tr[contains(@class, "track")])[2]/td[contains(@class, "works")]//button[contains(@class, "add-relationship")]',
+      value: '',
+    },
+    // Copy the first new work link into the relationship target field.
+    {
+      command: 'runScript',
+      target: '\
+        const workInput = document.querySelector("#add-relationship-dialog input.relationship-target");\
+        /* XXX Allows React to see the input value change. */\
+        Object.getOwnPropertyDescriptor(\
+          window.HTMLInputElement.prototype,\
+          "value",\
+        ).set.call(\
+          workInput,\
+          document.querySelector("tr.track:nth-child(1) td.works a[href^=\\"#new-work\\"]").href,\
+        );\
+        workInput.dispatchEvent(new Event("input", {bubbles: true}));\
+      ',
+      value: '',
+    },
+    {
+      command: 'pause',
+      target: '500',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-type',
+      value: 'version${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog div.buttons button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=#relationship-editor-form button.positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 41,
+        status: 2,
+        data: {
+          comment: '',
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 1,
+          languages: [],
+          name: '○',
+          type_id: null,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 2,
+      value: {
+        type: 41,
+        status: 2,
+        data: {
+          comment: '',
+          entity_gid: '$$__IGNORE__$$',
+          entity_id: 2,
+          languages: [],
+          name: '☆',
+          type_id: null,
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 3,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: 'f66857fb-bb59-444e-97dc-62c73e5eddae',
+            id: 636551,
+            name: '○',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: '○',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 278,
+            link_phrase: '{live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            long_link_phrase: 'is a {live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            name: 'performance',
+            reverse_link_phrase: '{live} {medley:medleys including} {partial} {instrumental} {cover} recordings',
+          },
+          type0: 'recording',
+          type1: 'work',
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 4,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '$$__IGNORE__$$',
+            id: 2,
+            name: '☆',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 1,
+            name: '○',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 241,
+            link_phrase: 'later {translated} {parody} versions',
+            long_link_phrase: 'is the earliest version of {translated} {parody}',
+            name: 'other version',
+            reverse_link_phrase: '{translated} {parody} version of',
+          },
+          type0: 'work',
+          type1: 'work'
+        },
+      },
+    },
+    {
+      command: 'assertEditData',
+      target: 5,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '6c97b1d7-aa12-480e-8376-fa435235f164',
+            id: 636552,
+            name: '☆',
+          },
+          entity1: {
+            gid: '$$__IGNORE__$$',
+            id: 2,
+            name: '☆',
+          },
+          entity_id: 2,
+          link_type: {
+            id: 278,
+            link_phrase: '{live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            long_link_phrase: 'is a {live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            name: 'performance',
+            reverse_link_phrase: '{live} {medley:medleys including} {partial} {instrumental} {cover} recordings',
+          },
+          type0: 'recording',
+          type1: 'work',
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
# Fix MBS-12911 & MBS-12928

## Problem

See the description of MBS-12911.

## Solution

Newly-created works don't have gids, so we have to compare by id instead in order to avoid "entities in a relationship cannot be the same."

Fixing this also revealed another situation where the "two relationships with the same key" error can be triggered; in order to resolve that, we have to keep track of the new relationship states as they are updated in the update-submitted-relationships action, so that subsequent updates to the same relationship are operating on the latest version of its state.

## Testing

Added a Selenium test that links two newly-created works together with the "later version" AR, and checks that all edits are submitted successfully.