### PR TITLE
MBS-12921: Can't search for works in the "Add related work" dialog

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -19,6 +19,7 @@ import useOutsideClickEffect from '../hooks/useOutsideClickEffect.js';
 import {unwrapNl} from '../i18n.js';
 import clean from '../utility/clean.js';
 import getCookie from '../utility/getCookie.js';
+import isBlank from '../utility/isBlank.js';
 
 import {
   CLOSE_ADD_ENTITY_DIALOG,
@@ -414,11 +415,10 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     event: SyntheticKeyboardEvent<HTMLInputElement>,
   ) {
     const newInputValue = event.currentTarget.value;
-    const newCleanInputValue = clean(newInputValue);
 
     dispatch({type: 'type-value', value: newInputValue});
 
-    if (!newCleanInputValue) {
+    if (isBlank(newInputValue)) {
       stopRequests();
       return;
     }
@@ -426,7 +426,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     if (
       inputChangeHook != null &&
       inputChangeHook(
-        newCleanInputValue,
+        newInputValue,
         state,
         selectItem,
       )
@@ -434,14 +434,14 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
       return;
     }
 
-    beginLookupOrSearch(inputValue, newCleanInputValue);
+    beginLookupOrSearch(inputValue, newInputValue);
   }
 
   function beginLookupOrSearch(
     oldInputValue: string,
-    newCleanInputValue: string,
+    newInputValue: string,
   ) {
-    const mbidMatch = newCleanInputValue.match(MBID_REGEXP);
+    const mbidMatch = newInputValue.match(MBID_REGEXP);
     if (mbidMatch) {
       /*
        * The user pasted an MBID (or a URL containing one). Perform a
@@ -488,10 +488,10 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
 
       lookupXhr.open('GET', '/ws/js/entity/' + mbidMatch[0]);
       lookupXhr.send();
-    } else if (clean(oldInputValue) !== newCleanInputValue) {
+    } else if (oldInputValue !== newInputValue) {
       stopRequests();
       dispatch({
-        searchTerm: newCleanInputValue,
+        searchTerm: clean(newInputValue),
         type: 'search-after-timeout',
       });
     }
@@ -541,9 +541,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
      * the entity type probably changed; re-initiate the search with
      * the existing input value.
      */
-    const cleanInputValue = clean(inputValue);
-    if (cleanInputValue) {
-      beginLookupOrSearch('', cleanInputValue);
+    if (!isBlank(inputValue)) {
+      beginLookupOrSearch('', inputValue);
     }
   }
 

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -510,7 +510,20 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
      * `set-recent-items` action runs, but this event may trigger before that
      * action is run and thus while `items` has yet to be updated.
      */
-    if ((items.length || recentItems?.length) && !isOpen) {
+    if (
+      (
+        items.length ||
+        (
+          /*
+           * Recent items are only shown if the input is empty.
+           * (See `generateItems` in ./reducer.js.)
+           */
+          empty(state.inputValue) &&
+          recentItems?.length
+        )
+      ) &&
+      !isOpen
+    ) {
       shouldUpdateScrollPositionRef.current = true;
       dispatch(SHOW_MENU);
       return true;

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -435,7 +435,7 @@ export function runReducer<+T: EntityItemT>(
       break;
 
     case 'set-menu-visibility':
-      state.isOpen = action.value;
+      state.isOpen = action.value && state.items.length > 0;
       updateStatusMessage = true;
       break;
 

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -636,6 +636,7 @@ const seleniumTests = [
   {name: 'MBS-12885.json5', login: true},
   {name: 'MBS-12904.json5', login: true},
   {name: 'MBS-12921.json5', login: true},
+  {name: 'MBS-12922.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -635,6 +635,7 @@ const seleniumTests = [
   {name: 'MBS-12874.json5', login: true},
   {name: 'MBS-12885.json5', login: true},
   {name: 'MBS-12904.json5', login: true},
+  {name: 'MBS-12921.json5', login: true},
   {name: 'Artist_Credit_Editor.json5', login: true},
   {name: 'Autocomplete2.json5'},
   {name: 'CAA.json5', login: true},

--- a/t/selenium/MBS-12921.json5
+++ b/t/selenium/MBS-12921.json5
@@ -1,0 +1,105 @@
+{
+  title: 'MBS-12921',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit-relationships',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=td.works button.add-item',
+      value: '',
+    },
+    // Seems we need to wait for works to show up in the index.
+    {
+      command: 'pause',
+      target: '2500',
+      value: '',
+    },
+    // Make sure there's a work in the recent entities list, which is a
+    // prerequisite for triggering the bug.
+    {
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: 'starman',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.negative',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=td.works button.add-item',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '${KEY_DOWN}',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=#relationship-editor-form button.positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '0f42ab32-22cd-4dcf-927b-a8d9a183d68b',
+            id: 20937085,
+            name: 'Travelling Man',
+          },
+          entity1: {
+            gid: 'bba52ea6-ed91-4be8-91b1-9acb10f57093',
+            id: 14042436,
+            name: 'Travelling Man',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 278,
+            link_phrase: '{live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            long_link_phrase: 'is a {live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            name: 'performance',
+            reverse_link_phrase: '{live} {medley:medleys including} {partial} {instrumental} {cover} recordings',
+          },
+          type0: 'recording',
+          type1: 'work',
+        },
+      },
+    },
+  ],
+}

--- a/t/selenium/MBS-12922.json5
+++ b/t/selenium/MBS-12922.json5
@@ -1,0 +1,79 @@
+{
+  title: 'MBS-12922',
+  commands: [
+    {
+      command: 'open',
+      target: '/release/24d4159a-99d9-425d-a7b8-1b9ec0261a33/edit-relationships',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=td.works button.add-item',
+      value: '',
+    },
+    // Wait for works to show up in the index...
+    {
+      command: 'pause',
+      target: '2500',
+      value: '',
+    },
+    // Check that adding a space can trigger a search.
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: ' ',
+    },
+    {
+      command: 'pause',
+      target: '1000',
+      value: '',
+    },
+    {
+      command: 'sendKeys',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '${KEY_ENTER}',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog button.positive',
+      value: '',
+    },
+    {
+      command: 'clickAndWait',
+      target: 'css=#relationship-editor-form button.positive',
+      value: '',
+    },
+    {
+      command: 'assertEditData',
+      target: 1,
+      value: {
+        type: 90,
+        status: 2,
+        data: {
+          edit_version: 2,
+          ended: 0,
+          entity0: {
+            gid: '0f42ab32-22cd-4dcf-927b-a8d9a183d68b',
+            id: 20937085,
+            name: 'Travelling Man',
+          },
+          entity1: {
+            gid: 'bba52ea6-ed91-4be8-91b1-9acb10f57093',
+            id: 14042436,
+            name: 'Travelling Man',
+          },
+          entity_id: 1,
+          link_type: {
+            id: 278,
+            link_phrase: '{live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            long_link_phrase: 'is a {live} {medley:medley including a} {partial} {instrumental} {cover} recording of',
+            name: 'performance',
+            reverse_link_phrase: '{live} {medley:medleys including} {partial} {instrumental} {cover} recordings',
+          },
+          type0: 'recording',
+          type1: 'work',
+        },
+      },
+    },
+  ],
+}

--- a/t/sql/selenium.sql
+++ b/t/sql/selenium.sql
@@ -176,7 +176,8 @@ INSERT INTO l_release_url (id, link, entity0, entity1, edits_pending, last_updat
 
 INSERT INTO work (id, gid, name, type, comment, edits_pending, last_updated) VALUES
     (346907, '4491f749-d06a-348c-aa58-a288d2eafa5f', 'Starman', 17, '', 0, '2017-04-01 20:00:18.388559+00'),
-    (12610030, '69cd3461-089e-4138-adc2-f3a1907a5013', 'The Night Is Over', 17, '', 0, '2013-04-17 11:06:22.012835+00');
+    (12610030, '69cd3461-089e-4138-adc2-f3a1907a5013', 'The Night Is Over', 17, '', 0, '2013-04-17 11:06:22.012835+00'),
+    (14042436, 'bba52ea6-ed91-4be8-91b1-9acb10f57093', 'Travelling Man', 17, '', 0, '2022-11-14 22:15:02.357535+00');
 
 INSERT INTO work_gid_redirect (gid, new_id, created) VALUES
     ('1643dc96-e980-8314-2cda-3105a7091a3f', 12610030, '2013-04-17 11:06:22.012835+00');


### PR DESCRIPTION
# Fix MBS-12921

## Problem

Clicking "Add related work" and attempting to search for the pre-filled work name does not work in most cases.

## Solution

The Autocomplete2 component was attempting to show recent items instead of performing a search, because of an incorrect check where it assumed recent items would show even if the input was non-empty (they won't).

The reason the issue only manifests in the "Add related work" dialog is because we pre-fill the input value with the recording name there.

I've also changed the set-menu-visibility action to only open the menu if there are actually items; prior to this commit you could see an empty "menu" open (i.e. a gray line) beneath the input, and hitting arrow-down to move the item position would throw an exception because there are no items to highlight.

## Testing

Added a Selenium test which fails without the fix applied.