### PR TITLE
MBS-12926: Remove indents from Autocomplete search results

### DIFF
--- a/lib/MusicBrainz/Server/Data/Artist.pm
+++ b/lib/MusicBrainz/Server/Data/Artist.pm
@@ -105,7 +105,10 @@ sub find_by_instrument {
 
     my $query =
         'SELECT ' . $self->_columns . q(,
-                array_agg(json_build_object('typeName', link_type.name, 'credit', lac.credited_as)) AS instrument_credits_and_rel_types
+                array_agg(
+                    json_build_object('typeName', link_type.name, 'credit', lac.credited_as)
+                    ORDER BY link_type.name, lac.credited_as, link_type.entity_type1, rels.id
+                ) AS instrument_credits_and_rel_types
             FROM ) . $self->_table . '
                 JOIN (
                     SELECT * FROM l_artist_artist

--- a/root/static/scripts/common/components/Autocomplete2/searchItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/searchItems.js
@@ -103,7 +103,14 @@ export function indexItems<+T: EntityItemT>(
 function getItem<+T: EntityItemT>(
   itemAndRank: [OptionItemT<T>, number],
 ): OptionItemT<T> {
-  return itemAndRank[0];
+  const itemCopy = {...itemAndRank[0]};
+  /*
+   * The searched items are displayed as a flat list. If there's a tree
+   * hierarchy, it wouldn't make sense here, so we should remove any
+   * `level`.
+   */
+  delete itemCopy.level;
+  return itemCopy;
 }
 
 function compareItemRanks<+T: EntityItemT>(

--- a/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Instrument/Artists.pm
@@ -43,7 +43,7 @@ test 'Instrument artists page contains the expected data' => sub {
     );
     $tx->is(
         '//table[@class="tbl"]/tbody/tr/td[6]',
-        'teacher, instrument (as “violino”), instrument',
+        'instrument (as “violino”), instrument, teacher',
         'The entry lists both relevant roles, "instrument" and "teacher", with one credit too',
     );
 };


### PR DESCRIPTION
### Fix MBS-12926

# Problem
When searching for relationship types in the new relationship editor, the search results display indented based on the level of that specific result in the relationships tree. Level indents make sense when displaying the whole set of results as a static list (since then you can see that, say, "instrument" is a child of "performer"). But when filtering the list, if "instrument" is still indented, it will look like it's a child of whatever happened to be on top of it, which is at best useless and at worst makes the user think it's really connected to the previous result in the list.

# Solution
I made `getItem` always drop `item.level`, since I am fairly sure there's no case where we could want a search result to be indented. We already remove `item.level` for recent items for the same reason.

# Testing
I checked that the filtered list no longer has indentations, but the static list when the field is empty still does.