### PR TITLE
MBS-12924: Fix page freeze after selecting a link type on Android

### DIFF
--- a/docker/musicbrainz-tests/run_selenium_tests.sh
+++ b/docker/musicbrainz-tests/run_selenium_tests.sh
@@ -51,7 +51,10 @@ sv start artwork-indexer artwork-redirect ssssss
 # Compile static resources.
 sudo -E -H -u musicbrainz yarn
 sudo -E -H -u musicbrainz make -C po all_quiet deploy
-NODE_ENV=test WEBPACK_MODE=development NO_PROGRESS=1 \
+NODE_ENV=test \
+     WEBPACK_MODE=development \
+     MUSICBRAINZ_RUNNING_TESTS=1 \
+     NO_PROGRESS=1 \
      sudo -E -H -u musicbrainz carton exec -- ./script/compile_resources.sh default tests
 
 # Add mbtest host alias to work around NO_PROXY restriction.

--- a/lib/MusicBrainz/Server.pm
+++ b/lib/MusicBrainz/Server.pm
@@ -428,6 +428,9 @@ before dispatch => sub {
         my $cache_namespace = DBDefs->CACHE_NAMESPACE;
         *DBDefs::CACHE_NAMESPACE = sub { $cache_namespace . $database . ':' };
         *DBDefs::ENTITY_CACHE_TTL = sub { 1 };
+        # CSP script-src directives conflict with `Function` constructor calls
+        # injected by babel-plugin-instanbul (unsafe-eval).
+        $self->res->header('Content-Security-Policy', '');
     } else {
         # Use a fresh database connection for every request, and
         # remember to disconnect at the end.

--- a/lib/MusicBrainz/Server/Entity.pm
+++ b/lib/MusicBrainz/Server/Entity.pm
@@ -18,10 +18,11 @@ sub TO_JSON {
     my ($self) = @_;
 
     my $entity_type = ref_to_type($self);
+    my $id = $self->id;
 
     return {
         entityType => $entity_type,
-        id => $self->id,
+        id => defined $id ? (0 + $id) : undef,
     };
 }
 

--- a/root/layout/components/Head.js
+++ b/root/layout/components/Head.js
@@ -150,6 +150,8 @@ const Head = ({
         }),
       })}
 
+      {MUSICBRAINZ_RUNNING_TESTS ? manifest.js('selenium') : null}
+
       {$c.stash.jsonld_data ? (
         <script
           dangerouslySetInnerHTML={

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -5,7 +5,6 @@
 
 /* eslint-disable import/no-commonjs */
 
-import DBDefs from './common/DBDefs-client.mjs';
 import MB from './common/MB.js';
 
 /* Global polyfills not provided by core-js */
@@ -15,7 +14,7 @@ require('./common/focusin-focusout-polyfill');
 
 require('./public-path');
 
-if (DBDefs.DEVELOPMENT_SERVER) {
+if (MUSICBRAINZ_RUNNING_TESTS) {
   /*
    * Used by the Selenium tests under /t/selenium/ to make sure that no errors
    * occurred on the page.

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -5,26 +5,12 @@
 
 /* eslint-disable import/no-commonjs */
 
-import MB from './common/MB.js';
-
 /* Global polyfills not provided by core-js */
 require('whatwg-fetch');
 require('./common/focusin-focusout-polyfill');
 /* End of global polyfills */
 
 require('./public-path');
-
-if (MUSICBRAINZ_RUNNING_TESTS) {
-  /*
-   * Used by the Selenium tests under /t/selenium/ to make sure that no errors
-   * occurred on the page.
-   */
-  MB.js_errors = [];
-  window.onerror = function (message, source, lineno, colno, error) {
-    MB.js_errors.push(error && error.stack ? error.stack : message);
-  };
-}
-
 require('./common/sentry');
 
 window.ko = require('knockout');

--- a/root/static/scripts/common.js
+++ b/root/static/scripts/common.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable import/no-commonjs */
 
-import {DEVELOPMENT_SERVER} from './common/DBDefs-client.mjs';
+import DBDefs from './common/DBDefs-client.mjs';
 import MB from './common/MB.js';
 
 /* Global polyfills not provided by core-js */
@@ -15,7 +15,7 @@ require('./common/focusin-focusout-polyfill');
 
 require('./public-path');
 
-if (DEVELOPMENT_SERVER) {
+if (DBDefs.DEVELOPMENT_SERVER) {
   /*
    * Used by the Selenium tests under /t/selenium/ to make sure that no errors
    * occurred on the page.

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -651,10 +651,12 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
         entityType,
         state.recentItemsKey,
       ).then((loadedRecentItems) => {
-        dispatch({
-          items: loadedRecentItems,
-          type: 'set-recent-items',
-        });
+        setTimeout(() => {
+          dispatch({
+            items: loadedRecentItems,
+            type: 'set-recent-items',
+          });
+        }, 1);
         return loadedRecentItems;
       });
     }

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -122,12 +122,15 @@ function setScrollPosition(menuId: string) {
   if (!menu) {
     return;
   }
-  const selectedItem = menu.querySelector('li[aria-selected=true]');
-  if (!selectedItem) {
+  let highlightedItem =
+    menu.querySelector('li[aria-selected=true]') ??
+    // If there's no highlighted item, scroll to the top of the list.
+    menu.querySelector('li');
+  if (!highlightedItem) {
     return;
   }
   const position =
-    (selectedItem.offsetTop + (selectedItem.offsetHeight / 2)) -
+    (highlightedItem.offsetTop + (highlightedItem.offsetHeight / 2)) -
     menu.scrollTop;
   const middle = menu.offsetHeight / 2;
   if (position < middle) {
@@ -199,6 +202,7 @@ export function createInitialState<+T: EntityItemT>(
     highlightedIndex: -1,
     indexedSearch: true,
     inputValue,
+    isInputFocused: false,
     isOpen: false,
     items: EMPTY_ITEMS,
     page: 1,
@@ -332,9 +336,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
   const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const inputTimeout = React.useRef<TimeoutID | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
-  const shouldUpdateScrollPositionRef = React.useRef<boolean>(false);
-  const recentItemsPromise =
-    React.useRef<Promise<$ReadOnlyArray<OptionItemT<T>>> | null>(null);
+  const prevIsOpen = React.useRef<boolean>(false);
+  const prevHighlightedIndex = React.useRef<number>(-1);
 
   const highlightedItem = highlightedIndex >= 0
     ? (items[highlightedIndex] ?? null)
@@ -496,50 +499,23 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
   }
 
   function handleInputFocus() {
-    if (selectedItem == null) {
-      showAvailableItems();
-    }
+    dispatch({isFocused: true, type: 'set-input-focus'});
   }
 
-  async function showAvailableItems() {
-    const recentItems = await recentItemsPromise.current;
-    /*
-     * Normally `items` should comprise `recentItems` after the
-     * `set-recent-items` action runs, but this event may trigger before that
-     * action is run and thus while `items` has yet to be updated.
-     */
-    if (
-      (
-        items.length ||
-        (
-          /*
-           * Recent items are only shown if the input is empty.
-           * (See `generateItems` in ./reducer.js.)
-           */
-          empty(state.inputValue) &&
-          recentItems?.length
-        )
-      ) &&
-      !isOpen
-    ) {
-      shouldUpdateScrollPositionRef.current = true;
-      dispatch(SHOW_MENU);
-      return true;
-    }
-    return false;
+  function handleInputBlur() {
+    dispatch({isFocused: false, type: 'set-input-focus'});
   }
 
-  async function showAvailableItemsOrBeginLookupOrSearch() {
-    if (await showAvailableItems()) {
-      return;
-    }
+  function showAvailableItemsOrBeginLookupOrSearch() {
     /*
      * If there's an existing search term, there should be at least one
      * item even if there are no results (saying so). If there isn't,
      * the entity type probably changed; re-initiate the search with
      * the existing input value.
      */
-    if (!isBlank(inputValue)) {
+    if (items.length) {
+      dispatch(SHOW_MENU);
+    } else if (!isBlank(inputValue)) {
       beginLookupOrSearch('', inputValue);
     }
   }
@@ -552,7 +528,6 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
         event.preventDefault();
 
         if (isOpen) {
-          shouldUpdateScrollPositionRef.current = true;
           dispatch(HIGHLIGHT_NEXT_ITEM);
         } else {
           showAvailableItemsOrBeginLookupOrSearch();
@@ -562,7 +537,6 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
       case 'ArrowUp':
         if (isOpen) {
           event.preventDefault();
-          shouldUpdateScrollPositionRef.current = true;
           dispatch(HIGHLIGHT_PREVIOUS_ITEM);
         }
         break;
@@ -648,7 +622,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
   React.useEffect(() => {
     let cancelled = false;
     if (recentItemsNotLoaded) {
-      recentItemsPromise.current = getOrFetchRecentItems<T>(
+      getOrFetchRecentItems<T>(
         entityType,
         state.recentItemsKey,
       ).then((loadedRecentItems) => {
@@ -701,11 +675,23 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
   });
 
   React.useLayoutEffect(() => {
-    if (shouldUpdateScrollPositionRef.current) {
+    const shouldUpdateScrollPosition = (
+      isOpen &&
+      (
+        !prevIsOpen.current ||
+        highlightedIndex !== prevHighlightedIndex.current
+      )
+    );
+    prevIsOpen.current = isOpen;
+    prevHighlightedIndex.current = highlightedIndex;
+    if (shouldUpdateScrollPosition) {
       setScrollPosition(menuId);
-      shouldUpdateScrollPositionRef.current = false;
     }
-  });
+  }, [
+    isOpen,
+    highlightedIndex,
+    menuId,
+  ]);
 
   type AutocompleteItemComponent<T> =
     React$AbstractComponent<AutocompleteItemPropsT<T>, void>;
@@ -809,8 +795,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           }
           disabled={disabled}
           id={inputId}
+          onBlur={handleInputBlur}
           onChange={handleInputChange}
-          onClick={handleInputFocus}
           onFocus={handleInputFocus}
           onKeyDown={handleInputKeyDown}
           placeholder={
@@ -842,6 +828,7 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           data-toggle="true"
           disabled={disabled}
           onClick={handleButtonClick}
+          onKeyDown={handleInputKeyDown}
           ref={buttonRef}
           role="button"
           tabIndex="-1"

--- a/root/static/scripts/common/components/Autocomplete2.js
+++ b/root/static/scripts/common/components/Autocomplete2.js
@@ -385,10 +385,8 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
     dispatch,
   ]);
 
-  function handleButtonClick(
-    event: SyntheticMouseEvent<HTMLButtonElement>,
-  ) {
-    event.currentTarget.focus();
+  function handleButtonClick() {
+    inputRef.current?.focus();
 
     stopRequests();
 
@@ -844,7 +842,6 @@ const Autocomplete2 = (React.memo(<+T: EntityItemT>(
           data-toggle="true"
           disabled={disabled}
           onClick={handleButtonClick}
-          onKeyDown={handleInputKeyDown}
           ref={buttonRef}
           role="button"
           tabIndex="-1"

--- a/root/static/scripts/common/components/Autocomplete2/reducer.js
+++ b/root/static/scripts/common/components/Autocomplete2/reducer.js
@@ -373,6 +373,7 @@ export function runReducer<+T: EntityItemT>(
   let updateItems = false;
   let updateStatusMessage = false;
   let highlightFirstIndex = false;
+  let showAvailableItems = false;
 
   switch (action.type) {
     case 'change-entity-type': {
@@ -433,6 +434,14 @@ export function runReducer<+T: EntityItemT>(
       updateItems = true;
       updateStatusMessage = true;
       break;
+
+    case 'set-input-focus': {
+      state.isInputFocused = action.isFocused;
+      if (action.isFocused && state.selectedItem == null) {
+        showAvailableItems = true;
+      }
+      break;
+    }
 
     case 'set-menu-visibility':
       state.isOpen = action.value && state.items.length > 0;
@@ -503,6 +512,15 @@ export function runReducer<+T: EntityItemT>(
       }
 
       updateItems = true;
+
+      if (
+        state.isInputFocused &&
+        empty(state.inputValue) &&
+        state.recentItems?.length
+      ) {
+        showAvailableItems = true;
+      }
+
       break;
     }
 
@@ -574,6 +592,7 @@ export function runReducer<+T: EntityItemT>(
 
       updateItems = true;
       updateStatusMessage = true;
+      showAvailableItems = true;
       break;
     }
 
@@ -588,6 +607,10 @@ export function runReducer<+T: EntityItemT>(
     if (!state.items.length) {
       state.isOpen = false;
     }
+  }
+
+  if (showAvailableItems && state.items.length) {
+    state.isOpen = true;
   }
 
   if (updateStatusMessage) {

--- a/root/static/scripts/common/components/Autocomplete2/types.js
+++ b/root/static/scripts/common/components/Autocomplete2/types.js
@@ -26,6 +26,7 @@ export type StateT<T: EntityItemT> = {
   +inputClass?: string,
   +inputValue: string,
   +isAddEntityDialogOpen?: boolean,
+  +isInputFocused: boolean,
   +isLookupPerformed?: boolean,
   +isOpen: boolean,
   +items: $ReadOnlyArray<ItemT<T>>,
@@ -71,6 +72,7 @@ export type ActionT<+T: EntityItemT> =
   | { +type: 'highlight-previous-item' }
   | { +type: 'reset-menu' }
   | { +type: 'select-item', +item: ItemT<T> }
+  | { +type: 'set-input-focus', +isFocused: boolean }
   | { +type: 'set-menu-visibility', +value: boolean }
   | {
       +type: 'show-ws-results',

--- a/root/static/scripts/common/utility/setInputValueForReact.mjs
+++ b/root/static/scripts/common/utility/setInputValueForReact.mjs
@@ -1,0 +1,30 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/*
+ * React doesn't allow setting an input's `value` directly: it overrides the
+ * value setter, so we must call the original explicitly. We then trigger an
+ * input event to simulate typing.
+ *
+ * This function generally shouldn't be used outside of tests unless there's
+ * no good alternative.
+ */
+export default function setInputValueForReact(
+  input: HTMLInputElement,
+  value: string,
+): void {
+  const setInputValue = Object.getOwnPropertyDescriptor(
+    input.constructor.prototype,
+    'value',
+  )?.set;
+  if (setInputValue != null) {
+    setInputValue.call(input, value);
+    input.dispatchEvent(new Event('input', {bubbles: true}));
+  }
+}

--- a/root/static/scripts/edit/utility/guessFeat.js
+++ b/root/static/scripts/edit/utility/guessFeat.js
@@ -16,6 +16,8 @@ import MB from '../../common/MB.js';
 import {last} from '../../common/utility/arrays.js';
 import clean from '../../common/utility/clean.js';
 import {cloneArrayDeep} from '../../common/utility/cloneDeep.mjs';
+import setInputValueForReact
+  from '../../common/utility/setInputValueForReact.mjs';
 
 import {
   fromFullwidthLatin,
@@ -267,12 +269,7 @@ MB.Control.initGuessFeatButton = function (formName) {
       name: function () {
         const nameInput = document.getElementById('id-' + formName + '.name');
         if (arguments.length) {
-          // XXX Allows React to see the input value change.
-          Object.getOwnPropertyDescriptor(
-            window.HTMLInputElement.prototype,
-            'value',
-          ).set.call(nameInput, arguments[0]);
-          nameInput.dispatchEvent(new Event('input', {bubbles: true}));
+          setInputValueForReact(nameInput, arguments[0]);
           return undefined;
         }
         return nameInput.value;

--- a/root/static/scripts/selenium.js
+++ b/root/static/scripts/selenium.js
@@ -1,0 +1,15 @@
+import MB from './common/MB.js';
+
+/*
+ * Used by the Selenium tests under /t/selenium/ to make sure that no errors
+ * occurred on the page.
+ */
+MB.js_errors = [];
+window.onerror = function (message, source, lineno, colno, error) {
+  MB.js_errors.push(error && error.stack ? error.stack : message);
+};
+
+// Used by our implementation of the Selenium 'type' command.
+import('./common/utility/setInputValueForReact.mjs').then((module) => {
+  MB.setInputValueForReact = module.default;
+});

--- a/root/static/scripts/tests/autocomplete2.html
+++ b/root/static/scripts/tests/autocomplete2.html
@@ -6,6 +6,9 @@
     <link rel="stylesheet/less" type="text/css" href="../../../static/styles/autocomplete2.less" />
     <link rel="stylesheet/less" type="text/css" href="../../../static/styles/icons.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
+    <script src="../../build/runtime.js"></script>
+    <script src="../../build/common-chunks.js"></script>
+    <script src="../../build/selenium.js"></script>
   </head>
   <body>
     <script src="../../build/autocomplete2.js"></script>

--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -445,6 +445,15 @@ async function handleCommand({command, target, value}, t) {
     ' value=' + JSON.stringify(value),
   ));
 
+  if (
+    typeof value === 'string' &&
+    value.startsWith('$$_EVAL_$$')
+  ) {
+    const valueScript = value.slice(10);
+    // eslint-disable-next-line require-atomic-updates
+    value = await driver.executeScript(`return (${valueScript})`);
+  }
+
   let element;
   switch (command) {
     case 'assertArtworkJson':
@@ -577,6 +586,7 @@ async function handleCommand({command, target, value}, t) {
       break;
 
     case 'sendKeys':
+      // eslint-disable-next-line require-atomic-updates
       value = value.split(/(\$\{[A-Z_]+\})/)
         .filter(x => x)
         .map(x => KEY_CODES[x] || x);
@@ -598,7 +608,10 @@ async function handleCommand({command, target, value}, t) {
        * selenium-webdriver 3.6.0
        */
       await element.clear();
-      await driver.executeScript('arguments[0].value = ""', element);
+      await driver.executeScript(
+        'window.MB.setInputValueForReact(arguments[0], "")',
+        element,
+      );
       await element.sendKeys(value);
       break;
 

--- a/t/selenium/MBS-12911.json5
+++ b/t/selenium/MBS-12911.json5
@@ -33,20 +33,9 @@
     },
     // Copy the first new work link into the relationship target field.
     {
-      command: 'runScript',
-      target: '\
-        const workInput = document.querySelector("#add-relationship-dialog input.relationship-target");\
-        /* XXX Allows React to see the input value change. */\
-        Object.getOwnPropertyDescriptor(\
-          window.HTMLInputElement.prototype,\
-          "value",\
-        ).set.call(\
-          workInput,\
-          document.querySelector("tr.track:nth-child(1) td.works a[href^=\\"#new-work\\"]").href,\
-        );\
-        workInput.dispatchEvent(new Event("input", {bubbles: true}));\
-      ',
-      value: '',
+      command: 'type',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '$$_EVAL_$$ document.querySelector("tr.track:nth-child(1) td.works a[href^=\\"#new-work\\"]").href',
     },
     {
       command: 'pause',

--- a/t/selenium/Release_Relationship_Editor.json5
+++ b/t/selenium/Release_Relationship_Editor.json5
@@ -1908,17 +1908,6 @@
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '',
     },
-    // FIXME: Sometimes the recent-items list doesn't show up. Wait and click again.
-    {
-      command: 'pause',
-      target: '100',
-      value: '',
-    },
-    {
-      command: 'click',
-      target: 'css=#add-relationship-dialog input.relationship-target',
-      value: '',
-    },
     // "Boredoms" should be in the recent entities list.
     {
       command: 'click',
@@ -2060,17 +2049,6 @@
     },
     {
       command: 'focus',
-      target: 'css=#add-relationship-dialog input.relationship-target',
-      value: '',
-    },
-    // FIXME: Sometimes the recent-items list doesn't show up. Wait and click again.
-    {
-      command: 'pause',
-      target: '100',
-      value: '',
-    },
-    {
-      command: 'click',
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '',
     },

--- a/t/selenium/Release_Relationship_Editor.json5
+++ b/t/selenium/Release_Relationship_Editor.json5
@@ -1908,6 +1908,17 @@
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '',
     },
+    // FIXME: Sometimes the recent-items list doesn't show up. Wait and click again.
+    {
+      command: 'pause',
+      target: '100',
+      value: '',
+    },
+    {
+      command: 'click',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '',
+    },
     // "Boredoms" should be in the recent entities list.
     {
       command: 'click',
@@ -2049,6 +2060,17 @@
     },
     {
       command: 'focus',
+      target: 'css=#add-relationship-dialog input.relationship-target',
+      value: '',
+    },
+    // FIXME: Sometimes the recent-items list doesn't show up. Wait and click again.
+    {
+      command: 'pause',
+      target: '100',
+      value: '',
+    },
+    {
+      command: 'click',
       target: 'css=#add-relationship-dialog input.relationship-target',
       value: '',
     },

--- a/webpack/client.config.mjs
+++ b/webpack/client.config.mjs
@@ -258,7 +258,7 @@ export default {
 
   context: MB_SERVER_ROOT,
 
-  devtool: 'source-map',
+  devtool: process.env.WEBPACK_DEVTOOL ?? 'source-map',
 
   entry: entries,
 

--- a/webpack/client.config.mjs
+++ b/webpack/client.config.mjs
@@ -77,6 +77,7 @@ const entries = [
   'release/index',
   'release-editor',
   'release-group/index',
+  'selenium',
   'series/edit',
   'series/index',
   'statistics',


### PR DESCRIPTION
# Fix MBS-12924

## Problem

Selecting a link type in the relationship dialog on Android freezes the page.

## Solution

The `set-recent-items` dispatch causes an infinite loop of re-renders in Chrome on Android. Delaying the dispatch fixes it. I haven't determined why this doesn't occur on desktop, because the React internals are quite opaque to me.

The `cancelled` addition isn't strictly needed, but it's always a good idea to clean up your effects.

## Testing

Tested manually in the Android Emulator.
