### PR TITLE
MBS-12930: Validate relationship fields on Perl level

### DIFF
--- a/lib/MusicBrainz/Server/Form/Field/Relationship.pm
+++ b/lib/MusicBrainz/Server/Form/Field/Relationship.pm
@@ -2,8 +2,8 @@ package MusicBrainz::Server::Form::Field::Relationship;
 use strict;
 use warnings;
 
-
 use HTML::FormHandler::Moose;
+use MusicBrainz::Server::Translation qw( l );
 extends 'HTML::FormHandler::Field::Compound';
 
 has_field 'relationship_id' => (
@@ -86,5 +86,16 @@ sub is_empty {
     );
     return 0;
 }
+
+after 'validate' => sub {
+    my $self = shift;
+    my $link_type = $self->field('link_type_id')->value;
+
+    if (!$link_type) {
+        return $self->add_error(l('You must select a relationship type and target entity for every relationship.'));
+    }
+
+    return 1;
+};
 
 1;


### PR DESCRIPTION
### Fix MBS-12930

# Problem
When seeding a relationship without a type (for example, by clicking Add work on an artist's sidebar), we were showing an error on the JS level saying that a type was missing, so the user would add it before submission. Because the submit button is a buggy knockout mess and does not get disabled properly, it is still possible to try to submit the form without selecting the type as long as all the mandatory fields are filled, which then causes an ISE. 

# Solution
This adds Perl-level validation to properly detect that the type is missing and blocks the form from submitting (reloads the page and form). I don't think the error here is currently being shown on the browser, but since it's the same string as for the JS one, it should be fine.

We generally want to have multi-level validation in forms anyway, so this is desired even if the buggy button gets fixed. That said, it's probably not worth the effort to fix it in its current knockout form: this validation should be enough until we have Reactified the whole page.

I originally was also checking if the target exists, but that seems to be intentionally missing for URL relationships, so I restricted this to type only, which still fixes the bug.

# Testing 
Manually, from `/work/create?rels.0.target=d3dd86df-2f57-4a97-8100-d09915343f60`