### PR TITLE
MBS-12923: Stop submission when no changes made

### DIFF
--- a/root/static/scripts/release/components/ReleaseRelationshipEditor.js
+++ b/root/static/scripts/release/components/ReleaseRelationshipEditor.js
@@ -794,6 +794,7 @@ async function submitEdits(
     syncDispatch,
     submitRelationshipEdits(syncDispatch, currentStateRef.current),
   );
+  dispatch({type: 'stop-submission'});
 }
 
 function setRecordingsAsSelected(


### PR DESCRIPTION
### Fix MBS-12923

# Problem
If the editor accidentally submits the release relationship editor without actually changing anything, it correctly disables the submit button and shows "Submitting edits..." while it deals with the submission, then it shows an alert that the user changed nothing. It never actually re-enables the submit button so we can actually make changes, though.

# Solution
This just sends a `stop-submission` dispatch at the end of the edit submission process, to clear the `submissionInProgress` state and re-enable the submission controls.

# Testing
Manually, with a random release relationship editor instance: first I clicked Submit, checked that after dismissing the alert that I added nothing the site enabled submission again. Then I actually made a change and submitted it to make sure the subsequent submission still worked (which it did).