### PR TITLE
MBS-12925: Allow submitting work dialogs with Enter

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -47,6 +47,7 @@ import {
 import {
   RelationshipSourceGroupsContext,
 } from '../constants.js';
+import useDialogEnterKeyHandler from '../hooks/useDialogEnterKeyHandler.js';
 import useRangeSelectionHandler from '../hooks/useRangeSelectionHandler.js';
 import type {
   DialogAttributesStateT,
@@ -874,22 +875,7 @@ const RelationshipDialogContent = (React.memo<PropsT>((
     initialRelationship?.editsPending
   ) ? getOpenEditsLink(initialRelationship._original) : null;
 
-  const handleKeyDown = React.useCallback((event) => {
-    if (
-      event.keyCode === 13 &&
-      !event.isDefaultPrevented() &&
-      /*
-       * MBS-12619: Hitting <Enter> on a button should click the button
-       * rather than accept the dialog.
-       */
-      !(event.target instanceof HTMLButtonElement)
-    ) {
-      // Prevent a click event on the ButtonPopover.
-      event.preventDefault();
-      // This will return focus to the button.
-      acceptDialog();
-    }
-  }, [acceptDialog]);
+  const handleKeyDown = useDialogEnterKeyHandler(acceptDialog);
 
   const canEditDates = selectedLinkType != null &&
     selectedLinkType.has_dates;

--- a/root/static/scripts/relationship-editor/hooks/useDialogEnterKeyHandler.js
+++ b/root/static/scripts/relationship-editor/hooks/useDialogEnterKeyHandler.js
@@ -1,0 +1,31 @@
+/*
+ * @flow strict
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+export default function useDialogEnterKeyHandler(
+  acceptDialog: () => void,
+): (event: SyntheticKeyboardEvent<HTMLElement>) => void {
+  return React.useCallback((event) => {
+    if (
+      event.keyCode === 13 &&
+      !event.isDefaultPrevented() &&
+      /*
+       * MBS-12619: Hitting <Enter> on a button should click the button
+       * rather than accept the dialog.
+       */
+      !(event.target instanceof HTMLButtonElement)
+    ) {
+      // Prevent a click event on the ButtonPopover.
+      event.preventDefault();
+      // This will return focus to the button.
+      acceptDialog();
+    }
+  }, [acceptDialog]);
+}

--- a/root/static/scripts/release/components/BatchCreateWorksDialog.js
+++ b/root/static/scripts/release/components/BatchCreateWorksDialog.js
@@ -29,6 +29,8 @@ import DialogLinkType, {
   createInitialState as createDialogLinkTypeState,
   updateDialogState as updateDialogLinkTypeState,
 } from '../../relationship-editor/components/DialogLinkType.js';
+import useDialogEnterKeyHandler
+  from '../../relationship-editor/hooks/useDialogEnterKeyHandler.js';
 import type {
   BatchCreateWorksDialogStateT,
 } from '../../relationship-editor/types.js';
@@ -123,7 +125,7 @@ const BatchCreateWorksDialogContent = React.memo<
 >(({
   closeDialog,
   sourceDispatch,
-}: BatchCreateWorksDialogContentPropsT): React.MixedElement => {
+}: BatchCreateWorksDialogContentPropsT): React.Element<'div'> => {
   const [state, dispatch] = React.useReducer(
     reducer,
     null,
@@ -182,8 +184,10 @@ const BatchCreateWorksDialogContent = React.memo<
     sourceDispatch,
   ]);
 
+  const handleKeyDown = useDialogEnterKeyHandler(acceptDialog);
+
   return (
-    <>
+    <div className="form" onKeyDown={handleKeyDown}>
       <p className="msg">
         {l(`This will create a new work for each checked recording that has no
             work already. The work names will be the same as their respective
@@ -221,7 +225,7 @@ const BatchCreateWorksDialogContent = React.memo<
         onCancel={closeDialog}
         onDone={acceptDialog}
       />
-    </>
+    </div>
   );
 });
 

--- a/root/static/scripts/release/components/EditWorkDialog.js
+++ b/root/static/scripts/release/components/EditWorkDialog.js
@@ -16,6 +16,8 @@ import {
 } from '../../edit/components/Multiselect.js';
 import DialogButtons
   from '../../relationship-editor/components/DialogButtons.js';
+import useDialogEnterKeyHandler
+  from '../../relationship-editor/hooks/useDialogEnterKeyHandler.js';
 import type {
   EditWorkDialogStateT,
 } from '../../relationship-editor/types.js';
@@ -151,8 +153,10 @@ const EditWorkDialog: React.AbstractComponent<
     closeDialog,
   ]);
 
+  const handleKeyDown = useDialogEnterKeyHandler(acceptDialog);
+
   return (
-    <div className="form">
+    <div className="form" onKeyDown={handleKeyDown}>
       <h1>{l('Edit Work')}</h1>
       <table className="work-details">
         <tbody>


### PR DESCRIPTION
### Fix MBS-12925

# Problem
Most pop-up dialogs in the release relationship editor can be submitted with Enter without issues, but that is not the case for the work dialogs (batch-create and edit), where pressing Enter does nothing.

# Solution
This follows the example of `RelationshipDialogContent` by submitting on pressing Enter unless it is pressed while on a button (to avoid an Enter press on "Cancel" submitting the form).

I turned the batch-create fragment into a `div` to support `onKeyDown`; I added the `"form"` class because it seemed sensible for parity.

This means Enter no longer opens the dropdowns for work types, but that's already the case for the target type dropdowns in the other dialogs, so it does not seem problematic to me (if anything, it's more consistent). Space still opens them fine.

# Testing
Tested manually, while pressing Enter on (AFAICT) every part of each form, and especially making sure pressing Enter on Cancel did not actually apply the changes.