### PR TITLE
MBS-12932: Always show [No lyrics] in work languages

### DIFF
--- a/root/static/scripts/common/components/Autocomplete2/recentItems.js
+++ b/root/static/scripts/common/components/Autocomplete2/recentItems.js
@@ -10,6 +10,7 @@
 import * as Sentry from '@sentry/browser';
 
 import {MAX_RECENT_ENTITIES} from '../../constants.js';
+import localizeLanguageName from '../../i18n/localizeLanguageName.js';
 import linkedEntities from '../../linkedEntities.mjs';
 import isDatabaseRowId from '../../utility/isDatabaseRowId.js';
 import isGuid from '../../utility/isGuid.js';
@@ -162,8 +163,14 @@ export function getRecentItems<+T: EntityItemT>(
   return _recentItemsCache.get(key) ?? [];
 }
 
-function getEntityName(entity: EntityItemT): string {
+function getEntityName(
+  entity: EntityItemT,
+  isLanguageForWorks?: boolean,
+): string {
   switch (entity.entityType) {
+    case 'language': {
+      return localizeLanguageName(entity, isLanguageForWorks);
+    }
     case 'link_type': {
       return formatLinkTypePhrases(entity);
     }
@@ -190,6 +197,8 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
   }
 
   if (ids.size) {
+    const isLanguageForWorks = key === 'language-lyrics';
+
     // Convert ids to an array since we delete in the loop.
     for (const id of Array.from(ids)) {
       const entity: ?T = linkedEntities[entityType]?.[id];
@@ -197,7 +206,7 @@ export async function getOrFetchRecentItems<+T: EntityItemT>(
         cachedList.push({
           entity: entity,
           id: String(entity.id) + '-recent',
-          name: getEntityName(entity),
+          name: getEntityName(entity, isLanguageForWorks),
           type: 'option',
         });
         ids.delete(id);


### PR DESCRIPTION
### Fix MBS-12932

# Problem
Work language `[No lyrics]` shows correctly on the main list, but it regresses to `No linguistic content` for recent entities on reload.

# Solution
This uses `localizeLanguageName` when formatting recent items for `Autocomplete2`. Luckily, we know when something is set to the key `language-lyrics` so we don't need to work too hard to figure it out.

Using `localizeLanguageName` here also means languages in the dropdown are actually translated also when they're in recent entities after a reload, which AFAICT they were not before.

# Testing
Manually, by picking the `[No lyrics]` language on the batch-create works dialog, reloading, and making sure it still shows the right name (and also when using the French translation).