### PR TITLE
MBS-12919: Show warning icon when rel has pending edits

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -65,6 +65,7 @@ import {
   findTargetTypeGroups,
 } from '../utility/findState.js';
 import getDialogLinkTypeOptions from '../utility/getDialogLinkTypeOptions.js';
+import getOpenEditsLink from '../utility/getOpenEditsLink.js';
 import getRelationshipEditStatus
   from '../utility/getRelationshipEditStatus.js';
 import getRelationshipKey from '../utility/getRelationshipKey.js';
@@ -1021,32 +1022,6 @@ function getBatchSelectionMessage(sourceType: CoreEntityTypeT) {
     }
   }
   return '';
-}
-
-function getOpenEditsLink(relationship: RelationshipStateT) {
-  const entity0 = relationship.entity0;
-  const entity1 = relationship.entity1;
-
-  if (!isDatabaseRowId(entity0.id) || !isDatabaseRowId(entity1.id)) {
-    return null;
-  }
-
-  return (
-    '/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and' +
-    `&conditions.0.field=${encodeURIComponent(entity0.entityType)}` +
-    '&conditions.0.operator=%3D' +
-    `&conditions.0.name=${encodeURIComponent(entity0.name)}` +
-    `&conditions.0.args.0=${encodeURIComponent(String(entity0.id))}` +
-    `&conditions.1.field=${encodeURIComponent(entity1.entityType)}` +
-    '&conditions.1.operator=%3D' +
-    `&conditions.1.name=${encodeURIComponent(entity1.name)}` +
-    `&conditions.1.args.0=${encodeURIComponent(String(entity1.id))}` +
-    '&conditions.2.field=type' +
-    '&conditions.2.operator=%3D&conditions.2.args=90%2C233' +
-    '&conditions.2.args=91&conditions.2.args=92' +
-    '&conditions.3.field=status&conditions.3.operator=%3D' +
-    '&conditions.3.args=1&field=Please+choose+a+condition'
-  );
 }
 
 export default RelationshipDialogContent;

--- a/root/static/scripts/relationship-editor/components/RelationshipItem.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipItem.js
@@ -10,6 +10,7 @@
 import * as React from 'react';
 import * as tree from 'weight-balanced-tree';
 
+import warningIconUrl from '../../../images/icons/warning.png';
 import ButtonPopover from '../../common/components/ButtonPopover.js';
 import DescriptiveLink from '../../common/components/DescriptiveLink.js';
 import {bracketedText} from '../../common/utility/bracketed.js';
@@ -24,6 +25,7 @@ import {
 } from '../../common/utility/isLinkTypeDirectionOrderable.js';
 import relationshipDateText
   from '../../common/utility/relationshipDateText.js';
+import Tooltip from '../../edit/components/Tooltip.js';
 import {
   getPhraseAndExtraAttributesText,
 } from '../../edit/utility/linkPhrase.js';
@@ -40,6 +42,7 @@ import type {
   RelationshipEditorActionT,
 } from '../types/actions.js';
 import getLinkPhrase from '../utility/getLinkPhrase.js';
+import getOpenEditsLink from '../utility/getOpenEditsLink.js';
 import getRelationshipKey from '../utility/getRelationshipKey.js';
 import getRelationshipLinkType from '../utility/getRelationshipLinkType.js';
 import getRelationshipStatusName
@@ -76,6 +79,8 @@ const RelationshipItem = (React.memo<PropsT>(({
   const [sourceCredit, targetCredit] = backward
     ? [relationship.entity1_credit, relationship.entity0_credit]
     : [relationship.entity0_credit, relationship.entity1_credit];
+  const hasPendingEdits = relationship.editsPending;
+  const openEditsLink = getOpenEditsLink(relationship);
   const isRemoved = relationship._status === REL_STATUS_REMOVE;
   const removeButtonId =
     'remove-relationship-' + getRelationshipKey(relationship);
@@ -272,6 +277,26 @@ const RelationshipItem = (React.memo<PropsT>(({
               })
             )
             : targetDisplay}
+          {hasPendingEdits && nonEmpty(openEditsLink) ? (
+            <>
+              {' '}
+              <Tooltip
+                content={exp.l(
+                  'This relationship has {edit_search|pending edits}.',
+                  {edit_search: openEditsLink},
+                )}
+                target={
+                  <img
+                    alt={l('This relationship has pending edits.')}
+                    className="info"
+                    src={warningIconUrl}
+                    style={{verticalAlign: 'middle'}}
+                    width={14}
+                  />
+                }
+              />
+            </>
+          ) : null}
           {datesAndAttributes}
         </span>
       </div>

--- a/root/static/scripts/relationship-editor/utility/getOpenEditsLink.js
+++ b/root/static/scripts/relationship-editor/utility/getOpenEditsLink.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict
+ * Copyright (C) 2022 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import isDatabaseRowId from '../../common/utility/isDatabaseRowId.js';
+import type {
+  RelationshipStateT,
+} from '../types.js';
+
+export default function getOpenEditsLink(
+  relationship: RelationshipStateT,
+): string | null {
+  const entity0 = relationship.entity0;
+  const entity1 = relationship.entity1;
+
+  if (!isDatabaseRowId(entity0.id) || !isDatabaseRowId(entity1.id)) {
+    return null;
+  }
+
+  return (
+    '/search/edits?auto_edit_filter=&order=desc&negation=0&combinator=and' +
+    `&conditions.0.field=${encodeURIComponent(entity0.entityType)}` +
+    '&conditions.0.operator=%3D' +
+    `&conditions.0.name=${encodeURIComponent(entity0.name)}` +
+    `&conditions.0.args.0=${encodeURIComponent(String(entity0.id))}` +
+    `&conditions.1.field=${encodeURIComponent(entity1.entityType)}` +
+    '&conditions.1.operator=%3D' +
+    `&conditions.1.name=${encodeURIComponent(entity1.name)}` +
+    `&conditions.1.args.0=${encodeURIComponent(String(entity1.id))}` +
+    '&conditions.2.field=type' +
+    '&conditions.2.operator=%3D&conditions.2.args=90%2C233' +
+    '&conditions.2.args=91&conditions.2.args=92' +
+    '&conditions.3.field=status&conditions.3.operator=%3D' +
+    '&conditions.3.args=1&field=Please+choose+a+condition'
+  );
+}


### PR DESCRIPTION
### Fix MBS-12919

# Problem
In the previous relationship editor, we used to show (previous) pending edits by highlighting the entity in orange, but that's now how changes made during the active editor session are shown so that doesn't work anymore. We should still have some way of showing the users that edits are pending for the rel, so they can check them before they accidentally delete it, for example (right now they will get notified of pending changes if they open the edit relationship popup, but not if they just enter a removal).

# Solution
I decided to show a small warning sign, with the same pending edits link on hover as we use once you in the relationship editing popup:

![Peek 2023-02-21 17-48](https://user-images.githubusercontent.com/1069224/220395981-9a95405a-0f62-4192-9387-09b68415b6b2.gif)


# Testing
Manually, as per above example.