### PR TITLE
MBS-12917: Fix title of credited entity’s link

### DIFF
--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as Sentry from '@sentry/browser';
 import ko from 'knockout';
 import * as React from 'react';
 
@@ -195,6 +196,17 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
   let nameVariation = passedNameVariation;
   let showDisambiguation = passedShowDisambiguation;
   let showIcon = passedShowIcon;
+
+  if (nameVariation === undefined &&
+    nonEmpty(content) && typeof content !== 'string'
+  ) {
+    const errorMessage = 'Content of type ' + typeof content +
+      ' cannot be compared as a string to entity name for name variation.';
+    if (__DEV__) {
+      invariant(false, errorMessage);
+    }
+    Sentry.captureMessage(errorMessage);
+  }
 
   if (showDisambiguation === undefined) {
     showDisambiguation = !hasCustomContent;

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -174,7 +174,7 @@ const EntityLink = ({
   disableLink = false,
   entity,
   hover: passedHover,
-  nameVariation: passedNameVariation = false,
+  nameVariation: passedNameVariation,
   showCaaPresence = false,
   showDeleted = true,
   showDisambiguation: passedShowDisambiguation,
@@ -245,7 +245,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
       nameVariation = content !== entity.name;
     }
 
-    if (nameVariation) {
+    if (nameVariation === true) {
       if (nonEmpty(hover)) {
         hover = texp.l('{name} – {additional_info}', {
           additional_info: hover,
@@ -280,7 +280,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
       </span>
     ) : <a key="link" {...anchorProps}>{isolateText(content)}</a>;
 
-  if (nameVariation) {
+  if (nameVariation === true) {
     content = (
       <span className="name-variation" key="namevar">
         {content}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-12917
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since the refactoring commit a252f37bd1de585cf3f87660cc5bee44eaea80e0 in beta only, the title shown on hover every link to any entity credited under a different name and rendered with React is broken, wrongly showing sort name for artist and nothing for entity of other type.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

- Improve test conditions instead of setting a default value to `nameVariation`
- Report any misuse of `nameVariation` depending on `content`’s type

# Testing

Tested reproducing the bug in a work relationship editor
Noticed that React links to credited entities have been fixed in many other parts of the website
Agreed on not adding further test for this specific issue as it would be reported in development or through Sentry at least.