### PR TITLE
MBS-12918: Reset credit string when updating target type

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipDialogContent.js
@@ -419,6 +419,8 @@ export function reducer(
         });
       }
 
+      newTargetState.creditedAs = '';
+
       newState.targetEntity = newTargetState;
       break;
     }

--- a/root/static/scripts/tests/relationship-editor/dialog.js
+++ b/root/static/scripts/tests/relationship-editor/dialog.js
@@ -43,7 +43,7 @@ const commonInitialState = {
 };
 
 test('action: set-credit', function (t) {
-  t.plan(4);
+  t.plan(5);
 
   let initialState = createInitialState({
     ...commonInitialState,
@@ -105,5 +105,19 @@ test('action: set-credit', function (t) {
     newState.targetEntity.creditedAs,
     'newtargetcredit',
     'target entity credit is updated (entity1)',
+  );
+
+  const targetTypeAction = {
+    source: recording,
+    targetType: 'work',
+    type: 'update-target-type',
+  };
+
+  newState = reducer(newState, targetTypeAction);
+
+  t.equals(
+    newState.targetEntity.creditedAs,
+    '',
+    'target entity credit is reset after selecting a different target type',
   );
 });

--- a/root/static/scripts/tests/relationship-editor/dialog.js
+++ b/root/static/scripts/tests/relationship-editor/dialog.js
@@ -43,7 +43,7 @@ const commonInitialState = {
 };
 
 test('action: set-credit', function (t) {
-  t.plan(5);
+  t.plan(4);
 
   let initialState = createInitialState({
     ...commonInitialState,
@@ -105,6 +105,35 @@ test('action: set-credit', function (t) {
     newState.targetEntity.creditedAs,
     'newtargetcredit',
     'target entity credit is updated (entity1)',
+  );
+});
+
+test('action: update-target-type', function (t) {
+  t.plan(2);
+
+  let initialState = createInitialState({
+    ...commonInitialState,
+    initialRelationship: newArtistRecordingRelationship,
+    source: recording,
+  });
+
+  const targetAction = {
+    action: {
+      action: {
+        creditedAs: 'newtargetcredit',
+        type: 'set-credit',
+      },
+      type: 'update-credit',
+    },
+    type: 'update-target-entity',
+  };
+
+  let newState = reducer(initialState, {...targetAction, source: recording});
+
+  t.equals(
+    newState.targetEntity.creditedAs,
+    'newtargetcredit',
+    'target entity credit is updated (entity0)',
   );
 
   const targetTypeAction = {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-12918
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In the React relationship editor, when selecting a new type of target entity, the previous credit string was wrongly used for relationship preview in the case where the target entity does not support credit.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Reset the credit string when updating target type.

# Testing

Tested manually by following the steps provided in the ticket.

Added a CI test on dialog state.