### PR TITLE
Log browser console after each Selenium test

### DIFF
--- a/t/selenium.mjs
+++ b/t/selenium.mjs
@@ -18,6 +18,7 @@ import webdriver from 'selenium-webdriver';
 import chrome from 'selenium-webdriver/chrome.js';
 import firefox from 'selenium-webdriver/firefox.js';
 import {Key} from 'selenium-webdriver/lib/input.js';
+import logging from 'selenium-webdriver/lib/logging.js';
 import until from 'selenium-webdriver/lib/until.js';
 import webdriverProxy from 'selenium-webdriver/proxy.js';
 import test from 'tape';
@@ -860,6 +861,16 @@ async function runCommands(commands, t) {
             );
             throw error;
           } finally {
+            await driver.manage().logs().get(logging.Type.BROWSER)
+              .then(function (entries) {
+                entries.forEach(function (entry) {
+                  t.comment(
+                    '[browser console log] ' +
+                    `[${entry.level.name}] ${entry.message}`,
+                  );
+                });
+              });
+
             const finishTime = new Date();
             const elapsedTime = (finishTime - startTime) / 1000;
             t.comment(timePrefix(


### PR DESCRIPTION
# Problem

It's not always clear whether a Selenium test failure is due to a legitimate exception (although they are much less flaky lately in my experience).

# Solution

Logging the browser console will help the pull request author determine if an actual exception occurred.

# Testing

Tested manually with the steps in https://github.com/metabrainz/musicbrainz-server/pull/2859#discussion_r1114643305

Here's an example of what is logged for that failure:

```log
# [17:05:52.452Z] check target="xpath=//input[@id = 'change-matching-artists']" value=""
not ok 3 caught exception: TimeoutError: Waiting for element to be located By(xpath, //input[@id = 'change-matching-artists']) Wait timed out after 30161ms at /home/michael/code/musicbrainz-server/node_modules/selenium-webdriver/lib/webdriver.js:841:17 at runMicrotasks (<anonymous>) at processTicksAndRejections (node:internal/process/task_queues:96:5)
  ---
    operator: fail
    at: processTicksAndRejections (node:internal/process/task_queues:96:5)
    stack: |-
      Error: caught exception: TimeoutError: Waiting for element to be located By(xpath, //input[@id = 'change-matching-artists'])
      Wait timed out after 30161ms
          at /home/michael/code/musicbrainz-server/node_modules/selenium-webdriver/lib/webdriver.js:841:17
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)
          at Test.assert [as _assert] (/home/michael/code/musicbrainz-server/node_modules/tape/lib/test.js:212:54)
          at Test.bound [as _assert] (/home/michael/code/musicbrainz-server/node_modules/tape/lib/test.js:64:32)
          at Test.fail (/home/michael/code/musicbrainz-server/node_modules/tape/lib/test.js:277:10)
          at Test.bound [as fail] (/home/michael/code/musicbrainz-server/node_modules/tape/lib/test.js:64:32)
          at file:///home/michael/code/musicbrainz-server/t/selenium.mjs:858:15
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)
  ...
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 22332:25 "Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.%s" "\n    at ArtistCreditEditor (http://192.168.1.2:5000/static/build/common-chunks.js:60441:5)"
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 78426:10 Uncaught Error: Content of type object cannot be compared as a string to entity name for name variation.
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 78426:10 Uncaught Error: Content of type object cannot be compared as a string to entity name for name variation.
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 25247:16 "The above error occurred in the \u003CEntityLink> component:\n\n    at EntityLink (http://192.168.1.2:5000/static/build/common-chunks.js:43847:5)\n    at DescriptiveLink (http://192.168.1.2:5000/static/build/common-chunks.js:43353:5)\n    at td\n    at tr\n    at thead\n    at table\n    at div\n    at ArtistCreditBubble (http://192.168.1.2:5000/static/build/common-chunks.js:60220:5)\n\nConsider adding an error boundary to your tree to customize error handling behavior.\nVisit https://reactjs.org/link/error-boundaries to learn more about error boundaries."
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 78426:10 Uncaught Error: Content of type object cannot be compared as a string to entity name for name variation.
# [browser console log] [SEVERE] http://192.168.1.2:5000/static/build/common-chunks.js 78426:10 Uncaught Error: Content of type object cannot be compared as a string to entity name for name variation.
# [17:06:22.624Z] The Downward Spiral: took 44.087 seconds
TimeoutError: Waiting for element to be located By(xpath, //input[@id = 'change-matching-artists'])
Wait timed out after 30161ms
    at /home/michael/code/musicbrainz-server/node_modules/selenium-webdriver/lib/webdriver.js:841:17
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  remoteStacktrace: ''
}
```