### PR TITLE
MBS-12902: Add pagination to admin email/IP search

### DIFF
--- a/lib/MusicBrainz/Server/Data/Editor.pm
+++ b/lib/MusicBrainz/Server/Data/Editor.pm
@@ -183,25 +183,25 @@ sub find_by_email
 }
 
 sub find_by_ip {
-    my ($self, $ip) = @_;
+    my ($self, $ip, $limit, $offset) = @_;
 
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table . ' WHERE id = any(?)' .
-        ' ORDER BY member_since LIMIT 100';
+        ' ORDER BY member_since';
 
     my @ids = $self->store->set_members("ipusers:$ip");
-    $self->query_to_list($query, [\@ids]);
+    $self->query_to_list_limited($query, [\@ids], $limit, $offset);
 }
 
 sub search_by_email {
-    my ($self, $email_regexp) = @_;
+    my ($self, $email_regexp, $limit, $offset) = @_;
 
     my $query = 'SELECT ' . $self->_columns .
         ' FROM ' . $self->_table .
         q" WHERE (regexp_replace(regexp_replace(email, '[@+].*', ''), '\.', '', 'g') || regexp_replace(email, '.*@', '@')) ~* ?" .
-        ' ORDER BY member_since DESC LIMIT 100';
+        ' ORDER BY member_since DESC';
 
-    $self->query_to_list($query, [$email_regexp]);
+    $self->query_to_list_limited($query, [$email_regexp], $limit, $offset);
 }
 
 sub find_by_privileges

--- a/root/admin/EmailSearch.js
+++ b/root/admin/EmailSearch.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import PaginatedResults from '../components/PaginatedResults.js';
 import Layout from '../layout/index.js';
 import expand2react from '../static/scripts/common/i18n/expand2react.js';
 import FormRowText from '../static/scripts/edit/components/FormRowText.js';
@@ -18,11 +19,13 @@ type Props = {
   +form: FormT<{
     +email: ReadOnlyFieldT<string>,
   }>,
+  +pager?: PagerT,
   +results?: $ReadOnlyArray<UnsanitizedEditorT>,
 };
 
 const EmailSearch = ({
   form,
+  pager,
   results,
 }: Props): React$Element<typeof Layout> => (
   <Layout fullWidth title={l('Search users by email')}>
@@ -76,8 +79,10 @@ const EmailSearch = ({
         </div>
 
         {results ? (
-          results.length ? (
-            <UserList users={results} />
+          results.length && pager ? (
+            <PaginatedResults pager={pager}>
+              <UserList users={results} />
+            </PaginatedResults>
           ) : (
             <p>{l('No results found.')}</p>
           )

--- a/root/admin/IpLookup.js
+++ b/root/admin/IpLookup.js
@@ -7,17 +7,20 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import PaginatedResults from '../components/PaginatedResults.js';
 import Layout from '../layout/index.js';
 
 import UserList from './components/UserList.js';
 
 type Props = {
   +ipHash: string,
+  +pager: PagerT,
   +users: $ReadOnlyArray<UnsanitizedEditorT>,
 };
 
 const IpLookup = ({
   ipHash,
+  pager,
   users,
 }: Props): React$Element<typeof Layout> => (
   <Layout fullWidth title={l('IP lookup')}>
@@ -27,7 +30,9 @@ const IpLookup = ({
         {l('IP hash:') + ' ' + ipHash}
       </p>
       {users.length ? (
-        <UserList users={users} />
+        <PaginatedResults pager={pager}>
+          <UserList users={users} />
+        </PaginatedResults>
       ) : (
         <p>
           {l('No results')}

--- a/t/lib/t/MusicBrainz/Server/Data/Editor.pm
+++ b/t/lib/t/MusicBrainz/Server/Data/Editor.pm
@@ -487,49 +487,47 @@ test 'Searching editor by email (for admin only)' => sub {
 
     my $editor_data = MusicBrainz::Server::Data::Editor->new(c => $test->c);
 
-    my @editors;
-
     diag('Bounded search with trimmed user info and escaped host name (recommended)');
-    @editors = $editor_data->search_by_email('^abc@f\.g\.h$');
-    is(@editors => 2, 'found 2 editors');
-    is($editors[0]->id => 1, 'is editor #1');
-    is($editors[1]->id => 2, 'is editor #2');
+    my ($editors, $hits) = $editor_data->search_by_email('^abc@f\.g\.h$');
+    is($hits => 2, 'found 2 editors');
+    is(@$editors[0]->id => 1, 'is editor #1');
+    is(@$editors[1]->id => 2, 'is editor #2');
 
     diag('Bounded search with trimmed user info and escaped host name (ALL CAPS)');
-    @editors = $editor_data->search_by_email('^ABC@F\.G\.H$');
-    is(@editors => 2, 'found 2 editors');
-    is($editors[0]->id => 1, 'is editor #1');
-    is($editors[1]->id => 2, 'is editor #2');
+    my ($editors, $hits) = $editor_data->search_by_email('^ABC@F\.G\.H$');
+    is($hits => 2, 'found 2 editors');
+    is(@$editors[0]->id => 1, 'is editor #1');
+    is(@$editors[1]->id => 2, 'is editor #2');
 
     diag('Search with trimmed user info suffix and escaped host name prefix');
-    @editors = $editor_data->search_by_email('bc@f\.g');
-    is(@editors => 2, 'found 2 editors');
-    is($editors[0]->id => 1, 'is editor #1');
-    is($editors[1]->id => 2, 'is editor #2');
+    ($editors, $hits) = $editor_data->search_by_email('bc@f\.g');
+    is($hits => 2, 'found 2 editors');
+    is(@$editors[0]->id => 1, 'is editor #1');
+    is(@$editors[1]->id => 2, 'is editor #2');
 
     diag('Search with trimmed user info and unescaped host name');
-    @editors = $editor_data->search_by_email('abc@f.g.h');
-    is(@editors => 3, 'found 3 editors');
-    is($editors[0]->id => 1, 'is editor #1');
-    is($editors[1]->id => 2, 'is editor #2');
+    ($editors, $hits) = $editor_data->search_by_email('abc@f.g.h');
+    is($hits => 3, 'found 3 editors');
+    is(@$editors[0]->id => 1, 'is editor #1');
+    is(@$editors[1]->id => 2, 'is editor #2');
     # Special character '.' matches '-'
-    is($editors[2]->id => 3, 'is editor #3');
+    is(@$editors[2]->id => 3, 'is editor #3');
 
     diag('Search with trimmed user info only');
-    @editors = $editor_data->search_by_email('abc@');
-    is(@editors => 4, 'found 4 editors');
-    is($editors[0]->id => 1, 'is editor #1');
-    is($editors[1]->id => 2, 'is editor #2');
-    is($editors[2]->id => 3, 'is editor #3');
-    is($editors[3]->id => 5, 'is editor #5');
+    ($editors, $hits) = $editor_data->search_by_email('abc@');
+    is($hits => 4, 'found 4 editors');
+    is(@$editors[0]->id => 1, 'is editor #1');
+    is(@$editors[1]->id => 2, 'is editor #2');
+    is(@$editors[2]->id => 3, 'is editor #3');
+    is(@$editors[3]->id => 5, 'is editor #5');
 
     diag('Search with untrimmed unescaped user info only');
-    @editors = $editor_data->search_by_email('a.b.c+d.e@');
-    is(@editors => 0, 'found 0 editor');
+    ($editors, $hits) = $editor_data->search_by_email('a.b.c+d.e@');
+    is($hits => 0, 'found 0 editors');
 
     diag('Search with untrimmed escaped user info only');
-    @editors = $editor_data->search_by_email('a\.b\.c\+d\.e@');
-    is(@editors => 0, 'found 0 editor');
+    ($editors, $hits) = $editor_data->search_by_email('a\.b\.c\+d\.e@');
+    is($hits => 0, 'found 0 editors');
 };
 
 1;


### PR DESCRIPTION
### Implement MBS-12902

# Problem
In some cases, there's over 100 accounts using a dodgy IP or the same email pattern. In those cases, we want admins to be able to see (and possibly ban) them all, but the searches are currently limited to 100 results.

# Solution
This adds pagination to both email and IP lookup. The IP pagination is fairly trivial. The email one is more complicated, since the email address is posted when submitting the form. We need to store it somewhere (I put it in `$c->session` at the suggestion of @mwiencek) and use it when navigating through the pages, since otherwise the results will be lost as soon as we navigate to page 2.

# Testing
Email search tested manually with a specific user email (one result shows correctly, no pagination UI is shown) and with a wider search (`mailbox\.org`) with 10 pages of results (pagination works fine and the form contains the searched regex at all times).

IP lookup not tested because I don't have any IP data locally AFAICT.