### PR TITLE
MBS-12937: Changing credits should work without modifying the source relationship

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipEditor.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipEditor.js
@@ -435,9 +435,19 @@ export function runReducer(
         sourceEntity,
       } = action;
 
+      const relationshipStateChanged = (
+        oldRelationshipState != null &&
+        !relationshipsAreIdentical(
+          oldRelationshipState,
+          newRelationshipState,
+        )
+      );
+
       if (
         oldRelationshipState == null ||
-        !relationshipsAreIdentical(oldRelationshipState, newRelationshipState)
+        relationshipStateChanged ||
+        creditsToChangeForSource ||
+        creditsToChangeForTarget
       ) {
         const targetEntity = getRelationshipTarget(
           newRelationshipState,
@@ -445,7 +455,10 @@ export function runReducer(
         );
         const updates = [];
 
-        if (oldRelationshipState != null) {
+        if (
+          oldRelationshipState != null &&
+          relationshipStateChanged
+        ) {
           /*
            * The old relationship state must be removed first in a separate
            * `updateRelationships` call, because its presence affects other
@@ -464,11 +477,16 @@ export function runReducer(
           );
         }
 
-        updates.push(...getUpdatesForAcceptedRelationship(
-          writableState,
-          newRelationshipState,
-          sourceEntity,
-        ));
+        if (
+          oldRelationshipState == null ||
+          relationshipStateChanged
+        ) {
+          updates.push(...getUpdatesForAcceptedRelationship(
+            writableState,
+            newRelationshipState,
+            sourceEntity,
+          ));
+        }
 
         /*
          * `updateEntityCredits` only uses `newRelationshipState` to obtain

--- a/root/static/scripts/tests/relationship-editor.js
+++ b/root/static/scripts/tests/relationship-editor.js
@@ -671,6 +671,71 @@ test('splitRelationshipByAttributes', function (t) {
   );
 });
 
+test('MBS-12937: Changing credits for other relationships without modifying the source relationship', function (t) {
+  t.plan(1);
+
+  const relationship1 = {
+    _lineage: [],
+    _original: null,
+    _status: REL_STATUS_ADD,
+    attributes: null,
+    begin_date: null,
+    editsPending: false,
+    end_date: null,
+    ended: false,
+    entity0: artist,
+    entity0_credit: 'SOMECREDIT',
+    entity1: recording,
+    entity1_credit: '',
+    id: -1,
+    linkOrder: 0,
+    linkTypeID: 148,
+  };
+
+  const relationship2 = {
+    ...relationship1,
+    entity0_credit: '',
+    id: -2,
+    linkTypeID: 297,
+  };
+
+  Object.freeze(relationship1);
+  Object.freeze(relationship2);
+
+  let state = addRelationships(
+    initialState,
+    recording,
+    [relationship1, relationship2],
+  );
+
+  state = reducer(
+    state,
+    {
+      batchSelectionCount: 0,
+      creditsToChangeForSource: '',
+      creditsToChangeForTarget: 'all',
+      newRelationshipState: relationship1,
+      oldRelationshipState: relationship1,
+      sourceEntity: recording,
+      type: 'update-relationship-state',
+    },
+  );
+
+  currentRelationshipsEqual(
+    t,
+    state,
+    [
+      relationship1,
+      {
+        ...relationship2,
+        entity0_credit: 'SOMECREDIT',
+      },
+    ],
+    'all entity credits are updated despite not modifying the source ' +
+    'relationship',
+  );
+});
+
 function addRelationships(
   rootState: RelationshipEditorStateT,
   source: CoreEntityT,


### PR DESCRIPTION
# Fix MBS-12937

## Problem

Ticking "Change credits for other ... relationships on the page" and submitting the dialog has no effect unless you make other changes to the relationship.

## Solution

Fixes the check in `update-relationship-state` to proceed with updating entity credits even if the source relationship did not change.

## Testing

Tested manually and added a unit test.