### PR TITLE
MBS-12931: Hide (+) button if no relationship type

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -233,14 +233,10 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
     textPhraseLabel = addColonText(linkPhraseGroup.textPhrase);
     textPhraseClassName = kebabCase(linkPhraseGroup.textPhrase);
   }
-  const textPhraseElement = (
+  const textPhraseElement = nonEmpty(textPhraseLabel) ? (
     <>
       <label>
-        {textPhraseLabel ?? (
-          <span className="no-value">
-            {addColonText(l('no type'))}
-          </span>
-        )}
+        {textPhraseLabel}
       </label>
       {' '}
       <ButtonPopover
@@ -262,6 +258,12 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
         toggle={setAddDialogOpen}
       />
     </>
+  ) : (
+    <label>
+      <span className="no-value">
+        {addColonText(l('no type'))}
+      </span>
+    </label>
   );
   const relationshipListElement = (
     <td className="relationship-list">


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Server.
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
-->

# Problem MBS-12931
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When creating a new work for an artist, the relationships group editor is pre-filled with a relationship to the artist, but the relationship type is not selected. This is up to the user to select it. There is no point to allow adding a relationship of the same type if it isn’t defined yet, as there already is a button to add a new relationship of any type.

This issue has been uncovered by invariant error message in development mode.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Just hide the (+) button as long as no relationship type is selected.

# Testing

Tried to reproduce it with the same steps as in the ticket.
Played with the relationship editor a bit.