### PR TITLE
Convert 0 linkTypeIDs to null for the relationship dialog

### DIFF
--- a/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
+++ b/root/static/scripts/relationship-editor/components/RelationshipPhraseGroup.js
@@ -143,7 +143,13 @@ const RelationshipPhraseGroup = (React.memo<PropsT>(({
       [backward ? 'entity1' : 'entity0']: source,
       attributes: newAttributesData,
       linkOrder: maxLinkOrder > 0 ? (maxLinkOrder + 1) : 0,
-      linkTypeID: linkTypeId,
+      /*
+       * The `typeId` on `RelationshipLinkTypeGroupT` stores empty types as
+       * `0` (which isn't a valid relationship type row ID anyway) for easier
+       * sorting. `RelationshipStateT` stores empty types as `null`. Convert
+       * `0` back to `null` here.
+       */
+      linkTypeID: linkTypeId || null,
     };
   }, [
     canBeOrdered,

--- a/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
+++ b/root/static/scripts/relationship-editor/hooks/useRelationshipDialogContent.js
@@ -7,6 +7,7 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
+import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 
 import {createCoreEntityObject} from '../../common/entity2.js';
@@ -74,6 +75,17 @@ export default function useRelationshipDialogContent(
     title,
     user,
   } = options;
+
+  if (relationship.linkTypeID === 0) {
+    /*
+     * Empty link types should be stored as `null` on `RelationshipStateT`.
+     * We store them as `0` on `RelationshipLinkTypeGroupT`, so check to
+     * make sure those don't wind up here. (See MBS-12931.)
+     */
+    Sentry.captureException(
+      new Error('relationship.linkTypeID is 0, but should be null'),
+    );
+  }
 
   return React.useCallback((closeAndReturnFocus) => {
     if (targetTypeOptions != null && !targetTypeOptions.length) {


### PR DESCRIPTION
# Convert 0 linkTypeIDs to null for the relationship dialog

## Problem

See https://github.com/metabrainz/musicbrainz-server/pull/2867#issuecomment-1443779955

## Solution

This fixes the underlying cause of MBS-12931 by converting linkTypeIDs stored as 0 to null before constructing the relationship state sent to the dialog.

It also adds some Sentry logging in case we see a link type of 0 in `useRelationshipDialogContent` again, though I think the previous fix for MBS-12931 (hiding the '+' button when there is no type) makes that very unlikely.

## Testing

I tested this by reverting https://github.com/metabrainz/musicbrainz-server/pull/2867 locally and checking that an exception was not thrown if I added another relationship via clicking "+" next to a "no type" section. It correctly added the new relationship into a different section.