### PR TITLE
Sentry template renderer logging improvements

### DIFF
--- a/root/server/response.mjs
+++ b/root/server/response.mjs
@@ -36,6 +36,8 @@ export async function getResponse(requestBody, context) {
   const user = context.user;
   if (user) {
     Sentry.setUser({id: user.id, username: user.name});
+  } else {
+    Sentry.setUser(null);
   }
 
   /*

--- a/root/server/response.mjs
+++ b/root/server/response.mjs
@@ -40,6 +40,9 @@ export async function getResponse(requestBody, context) {
     Sentry.setUser(null);
   }
 
+  Sentry.setTag('component', requestBody.component);
+  Sentry.setTag('url', context.req.uri);
+
   /*
    * Set the current translations to be used for this request based on the
    * given 'current_language' in the stash.

--- a/root/static/scripts/common/components/EntityLink.js
+++ b/root/static/scripts/common/components/EntityLink.js
@@ -205,7 +205,7 @@ $ReadOnlyArray<Expand2ReactOutput> | Expand2ReactOutput | null => {
     if (__DEV__) {
       invariant(false, errorMessage);
     }
-    Sentry.captureMessage(errorMessage);
+    Sentry.captureException(new Error(errorMessage));
   }
 
   if (showDisambiguation === undefined) {


### PR DESCRIPTION
# Sentry template renderer logging improvements

## Problem

It was reported in IRC that `captureMessage` doesn't include a stack trace.

Additionally, the events logged by Sentry for the template renderer aren't very useful, because they don't include the component or URL being rendered.

## Solution

Change `captureMessage` to `captureException` in `EntityLink`.

Add `component` and `url` tags to Sentry events from the template renderer.

## Testing

I tested that pages across the site still render (whether logged in or logged out), so the Sentry API calls don't cause any issue, though I haven't tested that the additional data is actually logged to Sentry properly. I can put this on test.mb to make sure.