### PR TITLE
Fix invariant violation submitting external links

### DIFF
--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -1772,11 +1772,17 @@ export function createExternalLinksEditorForHtmlForm(
     externalLinksEditorRef,
   } = createExternalLinksEditor();
   $(document).on('submit', '#page form', function () {
-    invariant(externalLinksEditorRef.current);
-    prepareExternalLinksHtmlFormSubmission(
-      formName,
-      externalLinksEditorRef.current,
-    );
+    const externalLinksEditor = externalLinksEditorRef.current;
+    /*
+     * If externalLinksEditor isn't set, then it's likely that the form was
+     * submitted before `withLoadedTypeInfo` finished loading.
+     */
+    if (externalLinksEditor) {
+      prepareExternalLinksHtmlFormSubmission(
+        formName,
+        externalLinksEditor,
+      );
+    }
   });
 }
 


### PR DESCRIPTION
# Fix invariant violation submitting external links

## Problem

https://sentry.metabrainz.org/organizations/metabrainz/issues/1075744/?project=12

88a1a97b0709233f1919a217fc33a7fa381a98dc wrapped the ExternalLinksEditor component in `withLoadedTypeInfo`, which ensured that link_type and link_attribute_type data are loaded asynchronously before the component renders.

If the user happened to submit the form before `withLoadedTypeInfo` completed, then an invariant violation would be triggered due to the component ref being null.

## Solution

Since there's no other case where this ref should be null, and since we know the user didn't intend to submit any link changes (otherwise they would have waited for the component to finish loading), we can just ignore the situation. If there was another error that somehow caused the ExternalLinksEditor to become unmounted, it would already be logged to Sentry (but I didn't find any such error).

## Testing

I was able to reproduce the issue by adding a delay to `withLoadedTypeInfo`:

```diff
diff --git a/root/static/scripts/edit/components/withLoadedTypeInfo.js b/root/static/scripts/edit/components/withLoadedTypeInfo.js
index c65a1a6d6a..9a87c888a1 100644
--- a/root/static/scripts/edit/components/withLoadedTypeInfo.js
+++ b/root/static/scripts/edit/components/withLoadedTypeInfo.js
@@ -40,6 +40,8 @@ export default function withLoadedTypeInfo<-Config, +Instance = mixed>(
     const loadingCanceledRef = React.useRef<boolean>(false);

     const loadTypeInfo = React.useCallback(async function (typeName) {
+      await sleep(9999);
+
       const fetchUrl = '/ws/js/type-info/' + typeName;

       const response = await fetch(fetchUrl);
```

I successfully tested that submitting the form while the external links editor component was still loading no longer triggered the invariant violation.