### PR TITLE
ReleaseEventsDiff: Add missing nameVariation prop

### DIFF
--- a/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
+++ b/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
@@ -49,6 +49,7 @@ const changeSide = (
           : <span className={CLASS_MAP[type]}>{sideACountry.name}</span>
       }
       entity={sideACountry}
+      nameVariation={false}
     />
   ) : null;
 


### PR DESCRIPTION
# ReleaseEventsDiff: Add missing nameVariation prop

## Problem

https://sentry.metabrainz.org/organizations/metabrainz/issues/1078098/?project=12

## Solution

Add the missing `nameVariation` prop to `ReleaseEventsDiff`. It's always `false` because the underlying content is `sideACountry.name` in either case.

I'm not 100% sure if this fixes every event logged to Sentry.

## Testing

Tested by loading /edit/97380335 with my local server connected to floyd.