### PR TITLE
MBS-11565: Use less hopeful image not available message

### DIFF
--- a/root/components/Artwork.js
+++ b/root/components/Artwork.js
@@ -47,7 +47,7 @@ export const ArtworkImage = ({
       data-large-thumbnail={artwork.large_ia_thumbnail}
       data-message={nonEmpty(message)
         ? message
-        : l('Image not available yet, please try again in a few minutes.')}
+        : l('Image not available, please try again later.')}
       data-small-thumbnail={artwork.small_ia_thumbnail}
       data-title={nonEmpty(hover) ? hover : artworkHover(artwork)}
     />

--- a/root/components/common-macros.tt
+++ b/root/components/common-macros.tt
@@ -67,7 +67,7 @@ END; -%]
         data-small-thumbnail="[% artwork.small_ia_thumbnail %]"
         data-large-thumbnail="[% artwork.large_ia_thumbnail %]"
         data-title="[% artwork_hover(artwork) %]"
-        data-message="[% message ? message : l('Image not available yet, please try again in a few minutes.') | html %]"
+        data-message="[% message ? message : l('Image not available, please try again later.') | html %]"
     ></span>
 [% END %]
 


### PR DESCRIPTION
### Implement MBS-11565

# Problem
Our current fallback message if a CAA image fails to load is "_Image not available yet, please try again in a few minutes._"

A lot of the times, the image is not actually going to appear in a few minutes, but having that in the text makes people think the longer delay is uncommon and needs reporting. Sadly, it isn't.

# Solution
This changes the "in a few minutes" wording to the more realistic "later". This will hopefully limit user's optimism and thus limit the amount of reports we have to answer with "shrug, it's the IA".

Since this message is also shown when images have been processed, but the IA is down, this also removes the "yet", which is weird when shown for an image that already worked before.

# Testing
None, since it's a string change.
