### PR TITLE
MBS-9063: Don't try to submit dates for reltypes without them

### DIFF
--- a/root/static/scripts/relationship-editor/constants.js
+++ b/root/static/scripts/relationship-editor/constants.js
@@ -9,6 +9,11 @@
 
 import {createContext} from 'react';
 
+import {
+  createCompoundField,
+  createField,
+} from '../edit/utility/createField.js';
+
 import type {
   RelationshipSourceGroupsContextT,
 } from './types.js';
@@ -35,6 +40,47 @@ export const EMPTY_DIALOG_DATE_PERIOD = Object.freeze({
   error: '',
   pendingError: '',
 });
+
+export const EMPTY_DIALOG_DATE_PERIOD_FIELD = Object.freeze(
+  createCompoundField('period', {
+    begin_date: createCompoundField(
+      'period.begin_date',
+      {
+        day: createField(
+          'period.begin_date.day',
+          (null),
+        ),
+        month: createField(
+          'period.begin_date.month',
+          (null),
+        ),
+        year: createField(
+          'period.begin_date.year',
+          (null),
+        ),
+      },
+    ),
+    end_date: createCompoundField(
+      'period.end_date',
+      {
+        day: createField(
+          'period.end_date.day',
+          (null),
+        ),
+        month: createField(
+          'period.end_date.month',
+          (null),
+        ),
+        year: createField(
+          'period.end_date.year',
+          (null),
+        ),
+      },
+    ),
+    ended: createField('period.ended', false),
+  }),
+);
+
 
 export const RelationshipSourceGroupsContext:
   React$Context<RelationshipSourceGroupsContextT> =


### PR DESCRIPTION
### Fix MBS-9063

# Problem
We keep having issues where people will hit an ISE after changing from a relationship type with dates (such as member) to one without (such as founder), because the dates are still stored and submitted with the relationship even though it doesn't make sense.

It's even more confusing with the new editor because the relationship preview will still show the dates, even though the type does not support them, and even though the user has no way to actually change them anymore.

# Solution
Since we do not want to lose the dates in a situation where the user ends up selecting a second type that does support them, this stashes and blanks the dates if a type without dates is selected, and restores the dates from the stashed ones if a type with dates is selected again.

# Checklist for author
* [ ] If the implementation makes sense, look into flow types

# Testing
Tested manually by changing from a performer relationship with dates to a founder one (if submitted, the edit is sent without dates), and  by changing from a performer relationship with dates to a founder one and then to conductor (the dates are shown again once conductor is selected and are correctly kept when submitting).