### PR TITLE
MBS-12939: Report for non-bootleg releases with bootleg label

### DIFF
--- a/lib/MusicBrainz/Server/Report/NonBootlegsOnBootlegLabels.pm
+++ b/lib/MusicBrainz/Server/Report/NonBootlegsOnBootlegLabels.pm
@@ -1,0 +1,37 @@
+package MusicBrainz::Server::Report::NonBootlegsOnBootlegLabels;
+use Moose;
+
+with 'MusicBrainz::Server::Report::ReleaseReport',
+     'MusicBrainz::Server::Report::FilterForEditor::ReleaseID';
+
+sub query {<<~'SQL'}
+    SELECT DISTINCT ON (r.id)
+        r.id AS release_id,
+        row_number() OVER (ORDER BY r.artist_credit, r.name)
+    FROM
+    ( SELECT id, artist_credit, name
+      FROM release
+      WHERE status != 3 -- not a bootleg
+      AND EXISTS (
+        SELECT 1
+        FROM release_label rl
+        JOIN label ON label.id = rl.label
+        WHERE rl.release = release.id
+        AND label.type = 5 -- bootleg production
+      )
+    ) r
+    SQL
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2023 MetaBrainz Foundation
+
+This file is part of MusicBrainz, the open internet music database,
+and is licensed under the GPL version 2, or (at your option) any
+later version: http://www.gnu.org/licenses/gpl-2.0.txt
+
+=cut

--- a/lib/MusicBrainz/Server/ReportFactory.pm
+++ b/lib/MusicBrainz/Server/ReportFactory.pm
@@ -68,6 +68,7 @@ my @all = qw(
     MultipleASINs
     MultipleDiscogsLinks
     NoLanguage
+    NonBootlegsOnBootlegLabels
     NoScript
     PartOfSetRelationships
     PlacesWithoutCoordinates
@@ -165,6 +166,7 @@ use MusicBrainz::Server::Report::MislinkedPseudoReleases;
 use MusicBrainz::Server::Report::MultipleASINs;
 use MusicBrainz::Server::Report::MultipleDiscogsLinks;
 use MusicBrainz::Server::Report::NoLanguage;
+use MusicBrainz::Server::Report::NonBootlegsOnBootlegLabels;
 use MusicBrainz::Server::Report::NoScript;
 use MusicBrainz::Server::Report::PartOfSetRelationships;
 use MusicBrainz::Server::Report::PlacesWithoutCoordinates;

--- a/root/report/NonBootlegsOnBootlegLabels.js
+++ b/root/report/NonBootlegsOnBootlegLabels.js
@@ -1,0 +1,41 @@
+/*
+ * @flow strict
+ * Copyright (C) 2023 MetaBrainz Foundation
+ *
+ * This file is part of MusicBrainz, the open internet music database,
+ * and is licensed under the GPL version 2, or (at your option) any
+ * later version: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+import * as React from 'react';
+
+import ReleaseList from './components/ReleaseList.js';
+import ReportLayout from './components/ReportLayout.js';
+import type {ReportDataT, ReportReleaseT} from './types.js';
+
+const NonBootlegsOnBootlegLabels = ({
+  canBeFiltered,
+  filtered,
+  generated,
+  items,
+  pager,
+}: ReportDataT<ReportReleaseT>): React.Element<typeof ReportLayout> => (
+  <ReportLayout
+    canBeFiltered={canBeFiltered}
+    description={l(
+      `This report shows releases that have at least one “Bootleg Production”
+       label in their labels list, but are not set to status “Bootleg”.
+       These labels pretty much never release non-bootleg releases,
+       so chances are that either the label or the status are wrong.`,
+    )}
+    entityType="release"
+    filtered={filtered}
+    generated={generated}
+    title={l('Releases on bootleg labels not set to bootleg')}
+    totalEntries={pager.total_entries}
+  >
+    <ReleaseList items={items} pager={pager} />
+  </ReportLayout>
+);
+
+export default NonBootlegsOnBootlegLabels;

--- a/root/report/ReportsIndex.js
+++ b/root/report/ReportsIndex.js
@@ -451,6 +451,12 @@ const ReportsIndex = (): React.Element<typeof Layout> => {
             )}
             reportName="ReleasesSameBarcode"
           />
+          <ReportsIndexEntry
+            content={l(
+              'Releases on bootleg labels not set to bootleg',
+            )}
+            reportName="NonBootlegsOnBootlegLabels"
+          />
         </ul>
 
         <h2>{l('Recordings')}</h2>

--- a/root/server/components.mjs
+++ b/root/server/components.mjs
@@ -241,6 +241,7 @@ export default {
   'report/MultipleAsins': (): Promise<mixed> => import('../report/MultipleAsins.js'),
   'report/MultipleDiscogsLinks': (): Promise<mixed> => import('../report/MultipleDiscogsLinks.js'),
   'report/NoLanguage': (): Promise<mixed> => import('../report/NoLanguage.js'),
+  'report/NonBootlegsOnBootlegLabels': (): Promise<mixed> => import('../report/NonBootlegsOnBootlegLabels.js'),
   'report/NoScript': (): Promise<mixed> => import('../report/NoScript.js'),
   'report/PartOfSetRelationships': (): Promise<mixed> => import('../report/PartOfSetRelationships.js'),
   'report/PlacesWithoutCoordinates': (): Promise<mixed> => import('../report/PlacesWithoutCoordinates.js'),


### PR DESCRIPTION
### Implement MBS-12939

# Reasoning
Bootleg labels pretty much only put out bootlegs. As such, this report lets editors find non-bootleg releases which have a bootleg label as a release label, which should almost always be wrong in some way.

# Testing
With sample data, which had a few matches already.