### PR TITLE
MBS-12946: Don't put Tooltip div inside span

### DIFF
--- a/root/static/scripts/edit/components/HelpIcon.js
+++ b/root/static/scripts/edit/components/HelpIcon.js
@@ -27,7 +27,7 @@ const HelpIcon = ({
   <Tooltip
     content={content}
     target={
-      <div
+      <span
         className="img icon help"
         style={ICON_STYLE}
       />

--- a/root/static/scripts/edit/components/Tooltip.js
+++ b/root/static/scripts/edit/components/Tooltip.js
@@ -22,8 +22,8 @@ type TooltipProps = {
 const Tooltip = ({
   content,
   target,
-}: TooltipProps): React.Element<'div'> => {
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
+}: TooltipProps): React.Element<'span'> => {
+  const containerRef = React.useRef<HTMLSpanElement | null>(null);
 
   React.useEffect(() => {
     const container = containerRef.current;
@@ -36,15 +36,15 @@ const Tooltip = ({
   }, []);
 
   return (
-    <div className="tooltip-wrapper">
+    <span className="tooltip-wrapper">
       {target}
       {nonEmpty(content) ? (
-        <div className="tooltip-container" ref={containerRef}>
-          <div className="tooltip-triangle" />
-          <div className="tooltip-content">{content}</div>
-        </div>
+        <span className="tooltip-container" ref={containerRef}>
+          <span className="tooltip-triangle" />
+          <span className="tooltip-content">{content}</span>
+        </span>
       ) : null}
-    </div>
+    </span>
   );
 };
 

--- a/root/static/styles/forms.less
+++ b/root/static/styles/forms.less
@@ -516,7 +516,7 @@ ul.conditions button.remove img {
     }
 }
 
-input.icon, div.icon.img, button.icon {
+input.icon, div.icon.img, span.icon.img, button.icon {
     min-width: @form-icon-size;
     min-height: @form-icon-size;
     border: 0 !important;

--- a/root/static/styles/tooltip.less
+++ b/root/static/styles/tooltip.less
@@ -46,6 +46,7 @@
             background: @text-white;
             border: 1px solid @medium-border;
             box-shadow: 0 2px 5px @medium-border;
+            display: inline-block;
             font-size: @default-text-size;
             font-weight: normal;
             padding: 5px 10px;


### PR DESCRIPTION
### Fix MBS-12946

# Problem
The pending edits tooltip on artist credits was showing twice and weirdly broken. On checking it a bit more, I found out it was a hydration error: `Expected server HTML to contain a matching <div> in <span>`. Apparently, `ArtistCreditLink` was trying to put the `Tooltip` `<div>` inside a `<span>`. This is invalid HTML, and React was not happy.

# Solution
I made `Tooltip` accept a `ContainerElement` prop like `CollapsibleList` does, where we can specify we want `Tooltip` to use `<span>` containers when we are using it in an inline situation.

While `externalLinks` (via `HelpIcon`) and `RelationshipItem` were not currently causing issues, both of them had `Tooltip` inside inline elements (`<label>` and `<span>` respectively) so I also changed it to use `<span>`s there.

The tooltip content needs to `display` as `block` when it's a `<span>` so that it's actually usable and readable, so added that to `tooltip.less`.

# Testing
I tested manually on the example given on the ticket, plus tested that the two other places I changed to use <span> still look fine (the links editor question marks, and the relationship editor pending edits warning signs).