### PR TITLE
MBS-12848: Reject inc=various-artists without inc=releases

### DIFF
--- a/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
+++ b/lib/MusicBrainz/Server/Controller/WS/2/Artist.pm
@@ -23,7 +23,7 @@ my $ws_defs = Data::OptList::mkopt([
                          action   => '/ws/2/artist/lookup',
                          method   => 'GET',
                          inc      => [ qw(recordings releases release-groups works
-                                          aliases various-artists annotation
+                                          aliases annotation
                                           _relations tags user-tags genres user-genres ratings user-ratings) ],
                          optional => [ qw(fmt) ],
      },

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -53,7 +53,10 @@ our %relation_types = (
 our %extra_inc = (
     'recordings' => [ qw( artist-credits puids isrcs ) ],
     'recording-rels' => [ qw( artist-credits ) ],
-    'releases' => [ qw( artist-credits discids media type status ) ],
+    'releases' => [ qw(
+        artist-credits discids media
+        status type various-artists
+    ) ],
     'release-rels' => [ qw( artist-credits ) ],
     'release-groups' => [ qw( artist-credits type ) ],
     'release-group-rels' => [ qw( artist-credits ) ],

--- a/lib/MusicBrainz/Server/WebService/Validator.pm
+++ b/lib/MusicBrainz/Server/WebService/Validator.pm
@@ -51,16 +51,28 @@ our %relation_types = (
 # request for a recording or a request with inc=recordings.  This hash
 # helps validate the second case (inc=recordings).
 our %extra_inc = (
-    'recordings' => [ qw( artist-credits puids isrcs ) ],
-    'recording-rels' => [ qw( artist-credits ) ],
-    'releases' => [ qw(
-        artist-credits discids media
-        status type various-artists
-    ) ],
-    'release-rels' => [ qw( artist-credits ) ],
-    'release-groups' => [ qw( artist-credits type ) ],
-    'release-group-rels' => [ qw( artist-credits ) ],
-    'works' => [ qw( artist-credits ) ],
+    'recordings' => {
+        generic => [ qw( artist-credits puids isrcs ) ],
+    },
+    'recording-rels' => {
+        generic => [ qw( artist-credits ) ],
+    },
+    'releases' => {
+        artist => [ qw ( various-artists ) ],
+        generic => [ qw( artist-credits discids media status type ) ],
+    },
+    'release-rels' => {
+        generic => [ qw( artist-credits ) ],
+    },
+    'release-groups' => {
+        generic => [ qw( artist-credits type ) ],
+    },
+    'release-group-rels' => {
+        generic => [ qw( artist-credits ) ],
+    },
+    'works' => {
+        generic => [ qw( artist-credits ) ],
+    },
 );
 
 
@@ -207,7 +219,15 @@ sub validate_inc
     my %extra;
     for my $i (@inc)
     {
-        map { $extra{$_} = 1 } @{ $extra_inc{$i} } if (defined $extra_inc{$i});
+        if (defined $extra_inc{$i}) {
+            my @available_extra_incs = (
+                @{ $extra_inc{$i}{generic} // [] },
+                @{ $extra_inc{$i}{$resource} // [] },
+            );
+            for my $extra_inc (@available_extra_incs) {
+                $extra{$extra_inc} = 1;
+            }
+        }
     }
 
     for my $i (@inc)
@@ -224,8 +244,10 @@ sub validate_inc
         if (!exists $acc{$i} && !exists $extra{$i})
         {
             my @possible = grep {
-                my %all = map { $_ => 1 } @{ $extra_inc{$_} };
-                exists $all{$i}
+                my %all = map { $_ => 1 } @{ $extra_inc{$_}{generic} // [] };
+                my %per_resource =
+                    map { $_ => 1 } @{ $extra_inc{$_}{$resource} // [] };
+                exists $all{$i} || exists $per_resource{$i}
             } keys %extra_inc;
 
             if (@possible) {


### PR DESCRIPTION
### Fix MBS-12848

# Problem
The `various-artists` include is used to request only releases where the artist is in the tracks but not the release (so, generally VA or featured releases). As such, it only makes sense if releases are being requested to begin with. Currently, `various-artists` was being accepted as an include even without the accompanying `releases` include, but was then silently ignored, which is not good UX.

# Solution
This treats `various-artists` as an `extra-inc` for `releases`, meaning we only accept passing it if it will actually do something (i.e., if `releases` is also passed), and we reject it with some more info otherwise.

# Testing
Locally by calling the API with/without `releases`, plus made sure the `LookupArtist` tests using `various-artists` still pass.
