### PR TITLE
MBS-12958: Block voting without a confirmed email

### DIFF
--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -146,6 +146,7 @@ sub editor_may_vote {
     return (
         $self->is_open &&
         defined $editor &&
+        $editor->email_confirmation_date &&
         $editor->id != $self->editor_id &&
         !$editor->is_bot &&
         !$editor->is_editing_disabled

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -23,6 +23,7 @@ import getVoteName from '../../static/scripts/edit/utility/getVoteName.js';
 import {
   editorMayApprove,
   editorMayCancel,
+  editorMayVote,
   getEditHeaderClass,
   getLatestVoteForEditor,
 } from '../../utility/edit.js';
@@ -69,6 +70,7 @@ const EditHeader = ({
   const user = $c.user;
   const mayApprove = editorMayApprove(edit, user);
   const mayCancel = editorMayCancel(edit, user);
+  const mayVote = editorMayVote(edit, user);
   const editTitle = texp.l(
     'Edit #{id} - {name}',
     {id: edit.id, name: l(edit.edit_name)},
@@ -130,7 +132,7 @@ const EditHeader = ({
                         ? lp(latestVoteForVoterName, 'vote')
                         : null}
                     </div>
-                  ) : user ? (
+                  ) : mayVote ? (
                     <div className="my-vote">
                       <strong>{l('My vote: ')}</strong>
                       {nonEmpty(latestVoteForEditorName) ? (

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -188,6 +188,7 @@ export function editorMayVote(
 ): boolean {
   return (
     !!editor &&
+    nonEmpty(editor.email_confirmation_date) &&
     edit.status === EDIT_STATUS_OPEN &&
     editor.id !== edit.editor_id &&
     !isBot(editor) &&

--- a/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
+++ b/t/lib/t/MusicBrainz/Server/Controller/Edit/Show.pm
@@ -81,6 +81,33 @@ test 'Check edit page differences for own edit' => sub {
     );
 };
 
+test 'Check edit page differences for editor without confirmed email' => sub {
+    my $test = shift;
+    my $mech = $test->mech;
+    my $edit = prepare($test);
+
+    $mech->get_ok('/login');
+    $mech->submit_form( with_fields => {
+        username => 'editor5',
+        password => 'pass',
+    } );
+
+    $mech->get_ok(
+        '/edit/' . $edit->id,
+        'Fetched edit page as a editor without email (not the edit author)',
+    );
+    html_ok($mech->content);
+
+    $mech->content_contains(
+        'You are not currently able to vote on this edit',
+        'The message about not being able to vote is present',
+    );
+    $mech->content_contains(
+        'You are not currently able to add notes to this edit',
+        'The message about not being able to add notes is present',
+    );
+};
+
 test 'Check edit page differences when logged out' => sub {
     my $test = shift;
     my $mech = $test->mech;

--- a/t/sql/vote.sql
+++ b/t/sql/vote.sql
@@ -8,7 +8,7 @@ INSERT INTO editor (id, name, password, email, ha1, email_confirm_date, member_s
     (2, 'editor2', '{CLEARTEXT}pass', 'editor2@example.com', 'ba025a52cc5ff57d5d10f31874a83de6', now(), '2014-12-01'),
     (3, 'editor3', '{CLEARTEXT}pass', 'editor3@example.com', 'c096994132d53f3e1cde757943b10e7d', now(), '2014-12-02'),
     -- Reminder: Editor #4 is ModBot
-    (5, 'editor5', '{CLEARTEXT}pass', 'editor5@example.com', '01de7bc91330d78a6d0a84033e293f15', now(), '2014-12-03');
+    (5, 'editor5', '{CLEARTEXT}pass', null, '01de7bc91330d78a6d0a84033e293f15', null, '2014-12-03');
 
 -- Dummy edits to allow voting
 INSERT INTO edit (id, editor, type, status, expire_time)


### PR DESCRIPTION
### Fix MBS-12958


# Problem
For some reason, editors without a confirmed email cannot leave notes, but they can vote. I'm pretty sure this was an oversight rather than an intended ability, and it was made visible by us removing the beginner restrictions, which would have blocked most editors without an email from voting since it's hard to get 10 accepted edits when you cannot enter any.

# Solution
This specifically checks for `email_confirmation_date` when checking if a user may vote, both on the Perl level (actually blocking the votes being submitted) and on the JS level (hiding the interface to submit votes).

I'm also blocking the "My vote" info on edit list headers for editors who cannot vote, since it makes no sense for them. This is consistent with the `EditIndex` page, where we already hid it.

# Testing
Manually with a newly created account, plus I'm restoring the edit page test we had for beginners, but making it just for editors without a confirmed email instead.