### PR TITLE
MBS-12955: Display beginner flag in vote tally 

### DIFF
--- a/root/edit/EditIndex.js
+++ b/root/edit/EditIndex.js
@@ -24,6 +24,7 @@ import formatUserDate from '../utility/formatUserDate.js';
 
 import EditHeader from './components/EditHeader.js';
 import EditNotes from './components/EditNotes.js';
+import EditorTypeInfo from './components/EditorTypeInfo.js';
 import EditSidebar from './components/EditSidebar.js';
 import Vote from './components/Vote.js';
 import VoteTally from './components/VoteTally.js';
@@ -97,7 +98,11 @@ const EditIndex = ({
                           : ''}
                       key={index}
                     >
-                      <th><EditorLink editor={voter} /></th>
+                      <th>
+                        <EditorLink editor={voter} />
+                        {' '}
+                        <EditorTypeInfo editor={voter} />
+                      </th>
                       <td className="vote">
                         {lp(getVoteName(vote.vote), 'vote')}
                         <span className="date">

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -18,7 +18,6 @@ import EditLink from '../../static/scripts/common/components/EditLink.js';
 import EditorLink from '../../static/scripts/common/components/EditorLink.js';
 import linkedEntities from '../../static/scripts/common/linkedEntities.mjs';
 import bracketed from '../../static/scripts/common/utility/bracketed.js';
-import {isBot} from '../../static/scripts/common/utility/privileges.js';
 import getVoteName from '../../static/scripts/edit/utility/getVoteName.js';
 import {
   editorMayApprove,
@@ -29,6 +28,7 @@ import {
 import formatUserDate from '../../utility/formatUserDate.js';
 import {returnToCurrentPage} from '../../utility/returnUri.js';
 
+import EditorTypeInfo from './EditorTypeInfo.js';
 import VoteTally from './VoteTally.js';
 
 type Props = {
@@ -36,29 +36,6 @@ type Props = {
   +isSummary?: boolean,
   +voter?: UnsanitizedEditorT,
 };
-
-const EditorTypeInfo = ({editor}: {editor: EditorT}) => (
-  editor.is_limited ? (
-    <span className="editor-class">
-      {bracketed(
-        <span
-          className="tooltip"
-          title={l('This user is new to MusicBrainz.')}
-        >
-          {l('beginner')}
-        </span>,
-      )}
-    </span>
-  ) : isBot(editor) ? (
-    <span className="editor-class">
-      {bracketed(
-        <span className="tooltip" title={l('This user is automated.')}>
-          {l('bot')}
-        </span>,
-      )}
-    </span>
-  ) : null
-);
 
 const EditHeader = ({
   edit,

--- a/root/static/styles/edit.less
+++ b/root/static/styles/edit.less
@@ -13,6 +13,11 @@
     font-weight: bold;
 }
 
+.editor-class {
+    font-weight: normal;
+    color: @dark-text;
+}
+
 dl.edit-status {
     margin: 0;
 }
@@ -124,11 +129,6 @@ table.vote-tally {
         &.owner {
             font-weight: bold;
         }
-    }
-
-    .edit-note .editor-class {
-        font-weight: normal;
-        color: @dark-text;
     }
 
     .edit-note .date {


### PR DESCRIPTION
### Implement MBS-12955

# Problem
Since beginner users can now vote, it seems worth showing their beginner status also by their vote listing(s),in the same way we show them by their edit note(s). This makes it easier to understand a bad vote might be due to the user's inexperience. Also, a suspicious amount of beginner votes on an edit can be a mark of sockpuppetry.

# Solution
This just reuses the existing `EditorTypeInfo` component. This will also show if the voter is a bot (which is not allowed, so also worth knowing).

# Testing
Manually, with `/edit/97436260` in floyd data (which has a beginner editor and edit note author, making sure that nothing broke there, plus three beginner voters and at least one non-beginner one).