### PR TITLE
MBS-12959: Only hide My vote in header for non-voting editors

### DIFF
--- a/lib/MusicBrainz/Server/Data/Vote.pm
+++ b/lib/MusicBrainz/Server/Data/Vote.pm
@@ -60,7 +60,7 @@ sub enter_votes
             confess 'Unauthorized editor ' . $editor->id . ' tried to approve edit #' . $_->{edit_id};
         }
         @votes = grep {
-            $_->{vote} == $VOTE_APPROVE || $edits->{ $_->{edit_id} }->editor_may_vote($editor)
+            $_->{vote} == $VOTE_APPROVE || $edits->{ $_->{edit_id} }->editor_may_vote_on_edit($editor)
         } @votes;
 
         return unless @votes;

--- a/lib/MusicBrainz/Server/Edit.pm
+++ b/lib/MusicBrainz/Server/Edit.pm
@@ -140,16 +140,14 @@ sub is_open
     return shift->status == $STATUS_OPEN;
 }
 
-sub editor_may_vote {
+sub editor_may_vote_on_edit {
     my ($self, $editor) = @_;
 
     return (
         $self->is_open &&
         defined $editor &&
-        $editor->email_confirmation_date &&
-        $editor->id != $self->editor_id &&
-        !$editor->is_bot &&
-        !$editor->is_editing_disabled
+        $editor->may_vote &&
+        $editor->id != $self->editor_id
     );
 }
 

--- a/lib/MusicBrainz/Server/Entity/Editor.pm
+++ b/lib/MusicBrainz/Server/Entity/Editor.pm
@@ -104,6 +104,14 @@ sub is_editing_enabled {
     (shift->privileges & $EDITING_DISABLED_FLAG) == 0;
 }
 
+sub may_vote {
+    my $self = shift;
+
+    return $self->has_confirmed_email_address &&
+           !$self->is_bot &&
+           $self->is_editing_enabled;
+}
+
 sub is_adding_notes_disabled {
     (shift->privileges & $ADDING_NOTES_DISABLED_FLAG) > 0;
 }

--- a/root/edit/EditIndex.js
+++ b/root/edit/EditIndex.js
@@ -18,7 +18,7 @@ import DBDefs from '../static/scripts/common/DBDefs.mjs';
 import linkedEntities from '../static/scripts/common/linkedEntities.mjs';
 import FormSubmit from '../static/scripts/edit/components/FormSubmit.js';
 import getVoteName from '../static/scripts/edit/utility/getVoteName.js';
-import {editorMayAddNote, editorMayVote}
+import {editorMayAddNote, editorMayVoteOnEdit}
   from '../utility/edit.js';
 import formatUserDate from '../utility/formatUserDate.js';
 
@@ -41,7 +41,7 @@ const EditIndex = ({
   const $c = React.useContext(CatalystContext);
   const canAddNote = Boolean($c.user && editorMayAddNote(edit, $c.user));
   const isOwnEdit = Boolean($c.user && $c.user.id === edit.editor_id);
-  const canVote = Boolean($c.user && editorMayVote(edit, $c.user));
+  const canVoteHere = Boolean($c.user && editorMayVoteOnEdit(edit, $c.user));
   const detailsElement = getEditDetailsElement(edit);
 
   return (
@@ -77,7 +77,7 @@ const EditIndex = ({
             </tr>
             {$c.user ? (
               <>
-                {canVote ? (
+                {canVoteHere ? (
                   <tr className="noborder">
                     <th>{l('My vote:')}</th>
                     <td className="vote">
@@ -111,7 +111,7 @@ const EditIndex = ({
             ) : null}
           </table>
 
-          {edit.is_open && $c.user && !canVote && !isOwnEdit ? (
+          {edit.is_open && $c.user && !canVoteHere && !isOwnEdit ? (
             <p>
               {exp.l(
                 `You are not currently able
@@ -155,7 +155,7 @@ const EditIndex = ({
           {$c.user ? (
             <>
               <EditNotes edit={edit} index={0} isOnEditPage />
-              {canVote ? (
+              {canVoteHere ? (
                 <FormSubmit label={l('Submit vote and note')} />
               ) : canAddNote ? (
                 <FormSubmit label={l('Submit note')} />

--- a/root/edit/components/EditHeader.js
+++ b/root/edit/components/EditHeader.js
@@ -70,7 +70,7 @@ const EditHeader = ({
   const user = $c.user;
   const mayApprove = editorMayApprove(edit, user);
   const mayCancel = editorMayCancel(edit, user);
-  const mayVote = editorMayVote(edit, user);
+  const mayVote = editorMayVote(user);
   const editTitle = texp.l(
     'Edit #{id} - {name}',
     {id: edit.id, name: l(edit.edit_name)},

--- a/root/edit/components/Vote.js
+++ b/root/edit/components/Vote.js
@@ -19,7 +19,7 @@ import {CatalystContext} from '../../context.mjs';
 import DBDefs from '../../static/scripts/common/DBDefs.mjs';
 import FormSubmit from '../../static/scripts/edit/components/FormSubmit.js';
 import {
-  editorMayVote,
+  editorMayVoteOnEdit,
   getLatestVoteForEditor,
 } from '../../utility/edit.js';
 
@@ -71,7 +71,7 @@ const Vote = ({
 }: VoteProps): React.Element<'div'> | null => {
   const $c = React.useContext(CatalystContext);
   const user = $c.user;
-  if (DBDefs.DB_READ_ONLY || !user || !editorMayVote(edit, user)) {
+  if (DBDefs.DB_READ_ONLY || !user || !editorMayVoteOnEdit(edit, user)) {
     return null;
   }
   const props = {

--- a/root/utility/edit.js
+++ b/root/utility/edit.js
@@ -183,16 +183,25 @@ export function editorMayCancel(
 }
 
 export function editorMayVote(
-  edit: GenericEditWithIdT,
   editor: ?UnsanitizedEditorT,
 ): boolean {
   return (
     !!editor &&
     nonEmpty(editor.email_confirmation_date) &&
-    edit.status === EDIT_STATUS_OPEN &&
-    editor.id !== edit.editor_id &&
     !isBot(editor) &&
     isEditingEnabled(editor)
+  );
+}
+
+export function editorMayVoteOnEdit(
+  edit: GenericEditWithIdT,
+  editor: ?UnsanitizedEditorT,
+): boolean {
+  return (
+    !!editor &&
+    editorMayVote(editor) &&
+    edit.status === EDIT_STATUS_OPEN &&
+    editor.id !== edit.editor_id
   );
 }
 


### PR DESCRIPTION
### Fix MBS-12959

# Problem
It seems sensible to hide the "My vote" header from users who are not verified and cannot participate in the voting system, but my previous implementation accidentally hid the vote info also from verified editors checking closed edits, since they unsurprisingly cannot vote on them either. Whoops.

# Solution
This makes it do the thing I actually intended: hide this for editors who don't have the right to vote, but still show it for others.

I separated "Cannot vote" and "Cannot vote on this specific edit" as per @mwiencek's suggestion below, since sometimes (like here) we want to hide stuff from all non-voters, but sometimes (like when showing voting buttons) we care specifically about whether they can vote *here*.


# Testing
Manually, by checking my own old votes and seeing it shows the right thing now.