### PR TITLE
Upgrade Flow to 0.197.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,6 +17,7 @@
 
 [lints]
 unnecessary-invariant=error
+unused-promise-in-async-scope=error
 
 [options]
 autoimports=true

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.193.0",
+    "flow-bin": "0.194.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.194.0",
+    "flow-bin": "0.195.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.195.2",
+    "flow-bin": "0.196.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.190.0",
+    "flow-bin": "0.191.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.195.1",
+    "flow-bin": "0.195.2",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.192.0",
+    "flow-bin": "0.193.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.196.2",
+    "flow-bin": "0.196.3",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.196.3",
+    "flow-bin": "0.197.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.196.0",
+    "flow-bin": "0.196.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.191.0",
+    "flow-bin": "0.192.0",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.195.0",
+    "flow-bin": "0.195.1",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "7.20.6",
     "eslint-plugin-react-hooks": "4.1.2",
     "file-url": "2.0.2",
-    "flow-bin": "0.196.1",
+    "flow-bin": "0.196.2",
     "gettext-parser": "3.1.0",
     "http-proxy": "1.18.1",
     "json5": "2.1.3",

--- a/root/components/RelationshipsTable.js
+++ b/root/components/RelationshipsTable.js
@@ -296,7 +296,6 @@ const RelationshipsTable = ({
         ...PagedLinkTypeGroupT,
         +phrase: string,
       }>> = Object.values(targetTypeGroup)
-        // $FlowIgnore[incompatible-call]
         .map((group: PagedLinkTypeGroupT) => ({
           ...group,
           phrase: getLinkPhraseForGroup(group),

--- a/root/components/TagEntitiesList.js
+++ b/root/components/TagEntitiesList.js
@@ -49,7 +49,6 @@ const TagEntitiesList = ({
   const $c = React.useContext(CatalystContext);
 
   const totalCount = Object.values(taggedEntities)
-    // $FlowIssue[incompatible-use]
     .reduce((count, info) => count + info.count, 0);
 
   const tagContent = showLink

--- a/root/edit/details/MergeReleases.js
+++ b/root/edit/details/MergeReleases.js
@@ -202,12 +202,14 @@ function buildRecordingMergeRow(
   );
 }
 
-function getHtmlVars(vars: {+[var: string]: string}) {
+function getHtmlVars(
+  vars: {+[var: string]: string},
+): {+[var: string]: Expand2ReactOutput} {
   if (!vars || Object.keys(vars).length === 0) {
     return vars;
   }
 
-  const htmlArgs = {};
+  const htmlArgs: {[var: string]: Expand2ReactOutput} = {};
 
   for (const key of Object.keys(vars)) {
     htmlArgs[key] = expand2react(vars[key]);

--- a/root/layout/components/Search.js
+++ b/root/layout/components/Search.js
@@ -71,8 +71,7 @@ function compareTypeOptionEntries(
 const SearchOptions = () => (
   <select id="headerid-type" name="type">
     {TYPE_OPTION_GROUPS.map((group) => (
-      // $FlowIssue[incompatible-cast]
-      (Object.entries(group): Array<[string, SearchOptionValueT]>)
+      Object.entries(group)
         .sort(compareTypeOptionEntries)
         .map(([key, option]) => {
           const text = localizedTypeOption(option);

--- a/root/static/scripts/common/components/AcoustIdCell.js
+++ b/root/static/scripts/common/components/AcoustIdCell.js
@@ -77,7 +77,6 @@ function loadAcoustIdData(
       })
       .finally(() => {
         const callbacks: $ReadOnlyArray<AcoustIdRequestCallbackT> =
-          // $FlowIssue[incompatible-type]
           Object.values(batch);
 
         for (const callback of callbacks) {

--- a/root/static/scripts/common/components/PostParameters.js
+++ b/root/static/scripts/common/components/PostParameters.js
@@ -29,7 +29,6 @@ const PostParameters = ({
 
   const sortedParams:
     $ReadOnlyArray<[string, string | $ReadOnlyArray<string>]> =
-    // $FlowIgnore[incompatible-type]
     Object.entries(params).sort(
       (a, b) => compareStrings(a[0], b[0]),
     );

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -272,7 +272,7 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
   }
 
   flushPendingVotes(asap?: boolean) {
-    const actions = {};
+    const actions: {[action: string]: Array<PendingVoteT>} = {};
 
     for (const item of this.pendingVotes.values()) {
       const action =

--- a/root/static/scripts/common/components/TagEditor.js
+++ b/root/static/scripts/common/components/TagEditor.js
@@ -254,9 +254,9 @@ class TagEditor extends React.Component<TagEditorProps, TagEditorState> {
     this.handleSubmitBound = (event) => this.handleSubmit(event);
     this.setTagsInputBound = (input) => this.setTagsInput(input);
 
-    this.genreMap = props.genreMap ?? {};
+    this.genreMap = props.genreMap ?? ({}: {+[genreName: string]: GenreT});
     this.genreOptions =
-      ((Object.values(this.genreMap): any): $ReadOnlyArray<GenreT>)
+      Object.values(this.genreMap)
         .map(genre => {
           return {
             label: formatGenreLabel(genre),

--- a/root/static/scripts/common/constants.js
+++ b/root/static/scripts/common/constants.js
@@ -249,7 +249,6 @@ export const PART_OF_SERIES_LINK_TYPES: {
 };
 
 export const PART_OF_SERIES_LINK_TYPE_GIDS: $ReadOnlyArray<string> =
-  // $FlowIssue (Flow thinks Object.values is Array<mixed>)
   (Object.values(PART_OF_SERIES_LINK_TYPES).filter(Boolean));
 
 export const PART_OF_SERIES_LINK_TYPE_IDS: $ReadOnlyArray<number> = [

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -230,17 +230,7 @@ const htmlAttrValueParsers = [
   parseHtmlAttrValueCondSubst,
 ];
 
-// Keep in sync with the htmlAttrName RegExp above.
-type HtmlAttrs = {
-  className?: string,
-  href?: string,
-  id?: string,
-  key?: string,
-  rel?: string,
-  target?: string,
-  title?: string,
-  ...
-};
+type HtmlAttrs = {[attr: string]: string};
 
 function parseHtmlAttr(args: VarArgsClass<Input>) {
   if (!gotMatch(accept(htmlAttrStart))) {

--- a/root/static/scripts/common/i18n/expand2react.js
+++ b/root/static/scripts/common/i18n/expand2react.js
@@ -296,7 +296,7 @@ function parseHtmlTag(args: VarArgsClass<Input>) {
     // Self-closing tag
     return React.createElement(
       name,
-      Object.assign({}, ...attributes),
+      Object.assign(({}: HtmlAttrs), ...attributes),
     );
   }
 
@@ -312,7 +312,7 @@ function parseHtmlTag(args: VarArgsClass<Input>) {
 
   return React.createElement(
     name,
-    Object.assign({}, ...attributes),
+    Object.assign(({}: HtmlAttrs), ...attributes),
     ...children,
   );
 }

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -144,7 +144,7 @@ export function mergeLinkedEntities(
       if (hasOwnProperty.call(linkedEntities, type)) {
         Object.assign(linkedEntities[type], entities);
       } else if (type in linkedEntities) {
-        // $FlowIgnore[prop-missing]
+        // $FlowIgnore[incompatible-type]
         linkedEntities[type] = entities;
       } else {
         throw new Error(

--- a/root/static/scripts/common/linkedEntities.mjs
+++ b/root/static/scripts/common/linkedEntities.mjs
@@ -95,7 +95,6 @@ export type LinkedEntitiesT = {
   work_type: {
     [workTypeId: string]: WorkTypeT,
   },
-  ...
 };
 
 // $FlowIgnore[method-unbinding]
@@ -144,8 +143,14 @@ export function mergeLinkedEntities(
     for (const [type, entities] of Object.entries(update)) {
       if (hasOwnProperty.call(linkedEntities, type)) {
         Object.assign(linkedEntities[type], entities);
-      } else {
+      } else if (type in linkedEntities) {
+        // $FlowIgnore[prop-missing]
         linkedEntities[type] = entities;
+      } else {
+        throw new Error(
+          JSON.stringify(type) +
+          ' is not a valid type assignable to linkedEntities',
+        );
       }
     }
   }

--- a/root/static/scripts/common/utility/_cookies.js
+++ b/root/static/scripts/common/utility/_cookies.js
@@ -7,4 +7,4 @@
  * later version: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-export default ({}: {...});
+export default ({}: {[cookie: string]: string});

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -5657,9 +5657,13 @@ entitySpecificRules.recording = function (url) {
  * }
  */
 function multiple(...types: $ReadOnlyArray<EntityTypeMap>): EntityTypesMap {
-  const result = {};
+  const result: {[entityType: CoreEntityTypeT]: Array<string>} = {};
   types.forEach(function (type: EntityTypeMap) {
-    for (const [entityType, id] of Object.entries(type)) {
+    for (
+      const [entityType, id] of
+      // $FlowIssue[incompatible-cast]
+      (Object.entries(type): Array<[CoreEntityTypeT, string]>)
+    ) {
       result[entityType] = result[entityType] || [];
       result[entityType].push(id);
     }

--- a/root/static/scripts/edit/URLCleanup.js
+++ b/root/static/scripts/edit/URLCleanup.js
@@ -296,7 +296,6 @@ export const LINK_TYPES: LinkTypeMap = {
 
 // See https://musicbrainz.org/doc/Style/Relationships/URLs#Restricted_relationships
 
-// $FlowIssue[incompatible-type]: Array<mixed>
 export const RESTRICTED_LINK_TYPES: $ReadOnlyArray<string> = [
   LINK_TYPES.allmusic,
   LINK_TYPES.amazon,
@@ -5550,7 +5549,6 @@ function testAll(tests: $ReadOnlyArray<RegExp>, text: string) {
   return false;
 }
 
-// $FlowIssue[incompatible-type]: Array<mixed>
 const CLEANUP_ENTRIES: Array<CleanupEntry> = Object.values(CLEANUPS);
 
 const entitySpecificRules: {
@@ -5659,11 +5657,7 @@ entitySpecificRules.recording = function (url) {
 function multiple(...types: $ReadOnlyArray<EntityTypeMap>): EntityTypesMap {
   const result: {[entityType: CoreEntityTypeT]: Array<string>} = {};
   types.forEach(function (type: EntityTypeMap) {
-    for (
-      const [entityType, id] of
-      // $FlowIssue[incompatible-cast]
-      (Object.entries(type): Array<[CoreEntityTypeT, string]>)
-    ) {
+    for (const [entityType, id] of Object.entries(type)) {
       result[entityType] = result[entityType] || [];
       result[entityType].push(id);
     }

--- a/root/static/scripts/edit/components/EnterEdit.js
+++ b/root/static/scripts/edit/components/EnterEdit.js
@@ -36,7 +36,11 @@ const EnterEdit = ({
   ...otherProps
 }: Props): React.MixedElement => {
   const isMakeVotableChecked = form.field.make_votable.value;
-  const makeVotableProps = {};
+  const makeVotableProps: {
+    checked?: boolean,
+    defaultChecked?: boolean,
+    onChange?: (event: SyntheticEvent<HTMLInputElement>) => void,
+  } = {};
   if (otherProps.controlled) {
     makeVotableProps.checked = isMakeVotableChecked;
     makeVotableProps.onChange = otherProps.onChange;

--- a/root/static/scripts/edit/components/EnterEditNote.js
+++ b/root/static/scripts/edit/components/EnterEditNote.js
@@ -34,7 +34,11 @@ const EnterEditNote = ({
   ...otherProps
 }: Props):
 React.Element<'fieldset'> => {
-  const textAreaProps = {};
+  const textAreaProps: {
+    defaultValue?: string,
+    onChange?: (event: SyntheticEvent<HTMLTextAreaElement>) => void,
+    value?: string,
+  } = {};
   if (otherProps.controlled) {
     textAreaProps.value = field.value;
     textAreaProps.onChange = otherProps.onChange;

--- a/root/static/scripts/edit/components/FormRowCheckbox.js
+++ b/root/static/scripts/edit/components/FormRowCheckbox.js
@@ -39,7 +39,11 @@ const FormRowCheckbox = ({
   onChange,
   uncontrolled,
 }: Props): React.Element<typeof FormRow> => {
-  const extraProps = {};
+  const extraProps: {
+    checked?: boolean,
+    defaultChecked?: boolean,
+    onChange?: (event: SyntheticEvent<HTMLInputElement>) => void,
+  } = {};
   if (uncontrolled) {
     extraProps.defaultChecked = field.value;
   } else {

--- a/root/static/scripts/edit/components/PartialDateInput.js
+++ b/root/static/scripts/edit/components/PartialDateInput.js
@@ -94,14 +94,21 @@ export function runReducer(
   }
 }
 
+type DatePartPropsT = {
+  defaultValue?: StrOrNum | null,
+  onBlur?: () => void,
+  onChange?: (SyntheticEvent<HTMLInputElement>) => void,
+  value?: StrOrNum,
+};
+
 const PartialDateInput = (props: Props): React.Element<'span'> => {
   const disabled = props.disabled ?? false;
   const field = props.field;
   const yearInputRef = props.yearInputRef;
 
-  const yearProps = {};
-  const monthProps = {};
-  const dayProps = {};
+  const yearProps: DatePartPropsT = {};
+  const monthProps: DatePartPropsT = {};
+  const dayProps: DatePartPropsT = {};
 
   if (props.uncontrolled) {
     yearProps.defaultValue = field.field.year.value;

--- a/root/static/scripts/edit/components/edit/RelationshipDiff.js
+++ b/root/static/scripts/edit/components/edit/RelationshipDiff.js
@@ -67,12 +67,8 @@ const RelationshipDiff = (React.memo(({
   oldRelationship,
   makeEntityLink = makeDescriptiveLink,
 }: Props): React.Element<typeof React.Fragment> => {
-  const oldAttrs = oldRelationship.attributes
-    ? keyBy(oldRelationship.attributes, getTypeId)
-    : {};
-  const newAttrs = newRelationship.attributes
-    ? keyBy(newRelationship.attributes, getTypeId)
-    : {};
+  const oldAttrs = keyBy(oldRelationship.attributes, getTypeId);
+  const newAttrs = keyBy(newRelationship.attributes, getTypeId);
 
   const i18nConfig: LinkPhraseI18n<Expand2ReactOutput> = {
     commaList,

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -168,7 +168,7 @@ class _ExternalLinksEditor
             '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)',
           'g',
         );
-        const urls = {};
+        const urls: {[index: string]: {[key: string]: string}} = {};
         let match;
 
         while ((match = seededLinkRegex.exec(window.location.search))) {
@@ -667,7 +667,7 @@ class _ExternalLinksEditor
     let error: ErrorT | null = null;
 
     const linkType = link.type
-      ? linkedEntities.link_type[link.type] : {};
+      ? linkedEntities.link_type[link.type] : null;
     // Use existing checker if possible, otherwise create a new one
     checker = checker ||
       new URLCleanup.Checker(link.url, this.sourceType);
@@ -738,7 +738,9 @@ class _ExternalLinksEditor
         target: URLCleanup.ERROR_TARGETS.RELATIONSHIP,
       };
     } else if (
-      linkType.deprecated && (isNewLink || linkTypeChanged)
+      linkType &&
+      linkType.deprecated &&
+      (isNewLink || linkTypeChanged)
     ) {
       error = {
         message: l(`This relationship type is deprecated 
@@ -754,7 +756,7 @@ class _ExternalLinksEditor
         message: l('This relationship already exists.'),
         target: URLCleanup.ERROR_TARGETS.RELATIONSHIP,
       };
-    } else if (isNewOrChangedLink) {
+    } else if (linkType && isNewOrChangedLink) {
       const check = checker.checkRelationship(linkType.gid);
       if (!check.result) {
         error = ({
@@ -925,13 +927,15 @@ class _ExternalLinksEditor
               url, this.sourceType,
             );
             const possibleTypes = checker.getPossibleTypes();
-            const selectedTypes = [];
+            const selectedTypes: Array<string> = [];
             const typeOptions = this.filterTypeOptions(possibleTypes);
             links.forEach(link => {
               linkIndexes.push(link.index);
               const linkType = link.type
-                ? linkedEntities.link_type[link.type] : {};
-              selectedTypes.push(linkType.gid);
+                ? linkedEntities.link_type[link.type] : null;
+              if (linkType) {
+                selectedTypes.push(linkType.gid);
+              }
 
               /*
                * FIXME: Why are links validated on every render, rather than
@@ -1568,7 +1572,7 @@ function withOneEmptyLink(
 ) {
   let emptyCount = 0;
   let canRemoveCount = 0;
-  const canRemove = {};
+  const canRemove: {[index: number]: boolean} = {};
 
   links.forEach(function (link, index) {
     if (isEmpty(link)) {

--- a/root/static/scripts/edit/externalLinks.js
+++ b/root/static/scripts/edit/externalLinks.js
@@ -168,18 +168,21 @@ class _ExternalLinksEditor
             '\\.url\\.([0-9]+)\\.(text|link_type_id)=([^&]+)',
           'g',
         );
-        const urls: {[index: string]: {[key: string]: string}} = {};
+        const urls: {[index: string]: SeededUrlShape} = {};
         let match;
 
         while ((match = seededLinkRegex.exec(window.location.search))) {
           const [/* unused */, index, key, value] = match;
-          (urls[index] = urls[index] || {})[key] = decodeURIComponent(value);
+          switch (key) {
+            case 'link_type_id':
+            case 'text':
+              (urls[index] = urls[index] || {})[key] =
+                decodeURIComponent(value);
+              break;
+          }
         }
 
-        for (
-          const data of
-          ((Object.values(urls): any): $ReadOnlyArray<SeededUrlShape>)
-        ) {
+        for (const data of Object.values(urls)) {
           initialLinks.push(newLinkState({
             rawUrl: data.text || '',
             relationship: uniqueId('new-'),
@@ -1738,8 +1741,8 @@ type InitialOptionsT = {
 };
 
 type SeededUrlShape = {
-  +link_type_id?: string,
-  +text?: string,
+  link_type_id?: string,
+  text?: string,
 };
 
 export function createExternalLinksEditor(

--- a/root/static/scripts/release/components/WorkLanguageMultiselect.js
+++ b/root/static/scripts/release/components/WorkLanguageMultiselect.js
@@ -36,7 +36,6 @@ export function createInitialState(
   initialLanguages?: $ReadOnlyArray<LanguageT>,
 ): MultiselectLanguageStateT {
   const languages: Array<LanguageT> =
-    // $FlowIgnore[incompatible-type]
     Object.values(linkedEntities.language);
 
   languages.sort((a, b) => (

--- a/root/static/scripts/release/components/WorkTypeSelect.js
+++ b/root/static/scripts/release/components/WorkTypeSelect.js
@@ -39,7 +39,6 @@ const WorkTypeSelect: React.AbstractComponent<
 }: WorkTypeSelectPropsT) => {
   const workTypeOptions: OptionListT = React.useMemo(() => {
     const workTypes: $ReadOnlyArray<WorkTypeT> =
-      // $FlowIgnore[incompatible-type]
       Object.values(linkedEntities.work_type);
 
     return buildOptionList(workTypes, l_languages);

--- a/root/utility/compactEntityJson.js
+++ b/root/utility/compactEntityJson.js
@@ -67,7 +67,7 @@ function _indexValue(
             typeof prototype.constructor === 'function' &&
             functionToString.call(prototype.constructor) === objectCtorString
           ) {
-            compactValue = {};
+            compactValue = ({}: {[compactObjectKey: number]: number});
             for (const objectKey in value) {
               if (hasOwnProp(value, objectKey)) {
                 const compactObjectKey = _indexValue(
@@ -137,7 +137,7 @@ export function decompactEntityJson(
         }
         return result;
       }
-      const result = {};
+      const result: {[objectKey: string]: mixed} = {};
       resolved[index] = result;
       for (const objectKeyIndex in value) {
         if (hasOwnProp(value, objectKeyIndex)) {

--- a/script/generate_edit_data_flow_type.mjs
+++ b/script/generate_edit_data_flow_type.mjs
@@ -99,5 +99,5 @@ yargs
   }));
 
   await pgClient.query('ROLLBACK');
-  pgClient.end();
+  await pgClient.end();
 }());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.191.0:
-  version "0.191.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.191.0.tgz#9324c9498584b60575fd8d77a2897ee4f384443b"
-  integrity sha512-IhaDGoOtRDdGUJLjm7KQlHK8BAzOVJmpx+CIR6bCju4pF7zon2v7WNrds5706WZqDE3rD2c8cM4GdhDnIFYXtg==
+flow-bin@0.192.0:
+  version "0.192.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.192.0.tgz#a1d75fb955b3980b23cff43577044c52f5d95d33"
+  integrity sha512-RlHhXn9m1IRTB5yKhnLGgLWq9z4qJ76slum/DXvmTlrAUPaVcmU/IsTHiY4JpjqK7nFz4oyrnU/YES8xDVBoZg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.196.1:
-  version "0.196.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.1.tgz#404f2a192543aefda9a0398853f5c81ebeb5acc1"
-  integrity sha512-DKSqZnidb9gth4jUNqgX0k6JjVRHFsUbIWF4+PMRvLPfutcBLo7BSEEUCNEGnpgLogjijuz6e2bXOTeC/SRCog==
+flow-bin@0.196.2:
+  version "0.196.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.2.tgz#d9aa9a6a5efba5770c8d89322bc6df25f4ee4188"
+  integrity sha512-daO2twJUi7reuC7DBpCLfj1gn7htalc5kDhvnTA6zDOPMa17jB+spjSMi3dFcnF5GCRufvQThVRmMMdseoZh5w==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.195.0:
-  version "0.195.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.0.tgz#67075596cc4ef2560ec001d5c781b07777f05f81"
-  integrity sha512-VGIwDVxcZRLbc2k8dsMcdHHjrPDzr1frqGvpRdYpdnpK/qi4heHFGDU747NElcsNiqyzs+G8gaZmhxZiBvwyUg==
+flow-bin@0.195.1:
+  version "0.195.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.1.tgz#5a1c18f12541b61301f12725b8d219cb6247b465"
+  integrity sha512-vWF6E5NoYyZbPq9Nw/pscBu9BDp65VOnTj54LuwV7aqlcrS+Pg1c3cndmN52P5rsp86lPUg0FGODUQ6FoQNkUw==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.195.2:
-  version "0.195.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.2.tgz#373b3e0a8bc3a8e5df510365419fd7d3904e6a5a"
-  integrity sha512-GKwUBzIjpiJEspa0xPMlqz+8z25qg9Xx2SJFHwYrvMlR7JhSHTMoP4zEpwnY8qmBEH8NE+sw5rA/jRLJoEJeCg==
+flow-bin@0.196.0:
+  version "0.196.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.0.tgz#171952a2f30c48e45f4e9b6ac4a51968594c222d"
+  integrity sha512-FnLpDvRV8ELcpxSeYBo4SPADUk0OMReX8zV/1dOF63PesO8tHVBJX/CI1JOdx2emzXRs3Lv8/UMz9+x2OpYsSg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.196.0:
-  version "0.196.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.0.tgz#171952a2f30c48e45f4e9b6ac4a51968594c222d"
-  integrity sha512-FnLpDvRV8ELcpxSeYBo4SPADUk0OMReX8zV/1dOF63PesO8tHVBJX/CI1JOdx2emzXRs3Lv8/UMz9+x2OpYsSg==
+flow-bin@0.196.1:
+  version "0.196.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.1.tgz#404f2a192543aefda9a0398853f5c81ebeb5acc1"
+  integrity sha512-DKSqZnidb9gth4jUNqgX0k6JjVRHFsUbIWF4+PMRvLPfutcBLo7BSEEUCNEGnpgLogjijuz6e2bXOTeC/SRCog==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.190.0:
-  version "0.190.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.190.0.tgz#cfc50e1474facf8150232a6c498fe66a6bb75969"
-  integrity sha512-Qo3bvN3cmGFXsq63ZxcHFZXQDvgx84fCuq8cXuKk5xbvuebBGwMqS+ku/rH+gEkciRrcTYrXqoSzb9b6ShcoJg==
+flow-bin@0.191.0:
+  version "0.191.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.191.0.tgz#9324c9498584b60575fd8d77a2897ee4f384443b"
+  integrity sha512-IhaDGoOtRDdGUJLjm7KQlHK8BAzOVJmpx+CIR6bCju4pF7zon2v7WNrds5706WZqDE3rD2c8cM4GdhDnIFYXtg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.192.0:
-  version "0.192.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.192.0.tgz#a1d75fb955b3980b23cff43577044c52f5d95d33"
-  integrity sha512-RlHhXn9m1IRTB5yKhnLGgLWq9z4qJ76slum/DXvmTlrAUPaVcmU/IsTHiY4JpjqK7nFz4oyrnU/YES8xDVBoZg==
+flow-bin@0.193.0:
+  version "0.193.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.193.0.tgz#250df37ec2d209dbf6dbec654e06d9e48da72ccb"
+  integrity sha512-DREsJfNcU94P3rfh8TrydflQTKI5u8INzqCzi/R7iG2fBo+QKiEdNiv9NRlt4cRmOEsVvQ+5ed2U+u/68M8a6Q==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.193.0:
-  version "0.193.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.193.0.tgz#250df37ec2d209dbf6dbec654e06d9e48da72ccb"
-  integrity sha512-DREsJfNcU94P3rfh8TrydflQTKI5u8INzqCzi/R7iG2fBo+QKiEdNiv9NRlt4cRmOEsVvQ+5ed2U+u/68M8a6Q==
+flow-bin@0.194.0:
+  version "0.194.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.194.0.tgz#5c55d8fb4c10b3a434100a88e986109743afcbb8"
+  integrity sha512-gJ54JmNXkl9ga3vt2Lx9tFQCuIid1+161dWGdr0bJ/CKW8tVCWxApE/j/1eZo31uVAUNVCY5UTs2gnnAm1hVkQ==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.194.0:
-  version "0.194.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.194.0.tgz#5c55d8fb4c10b3a434100a88e986109743afcbb8"
-  integrity sha512-gJ54JmNXkl9ga3vt2Lx9tFQCuIid1+161dWGdr0bJ/CKW8tVCWxApE/j/1eZo31uVAUNVCY5UTs2gnnAm1hVkQ==
+flow-bin@0.195.0:
+  version "0.195.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.0.tgz#67075596cc4ef2560ec001d5c781b07777f05f81"
+  integrity sha512-VGIwDVxcZRLbc2k8dsMcdHHjrPDzr1frqGvpRdYpdnpK/qi4heHFGDU747NElcsNiqyzs+G8gaZmhxZiBvwyUg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.195.1:
-  version "0.195.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.1.tgz#5a1c18f12541b61301f12725b8d219cb6247b465"
-  integrity sha512-vWF6E5NoYyZbPq9Nw/pscBu9BDp65VOnTj54LuwV7aqlcrS+Pg1c3cndmN52P5rsp86lPUg0FGODUQ6FoQNkUw==
+flow-bin@0.195.2:
+  version "0.195.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.2.tgz#373b3e0a8bc3a8e5df510365419fd7d3904e6a5a"
+  integrity sha512-GKwUBzIjpiJEspa0xPMlqz+8z25qg9Xx2SJFHwYrvMlR7JhSHTMoP4zEpwnY8qmBEH8NE+sw5rA/jRLJoEJeCg==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.196.2:
-  version "0.196.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.2.tgz#d9aa9a6a5efba5770c8d89322bc6df25f4ee4188"
-  integrity sha512-daO2twJUi7reuC7DBpCLfj1gn7htalc5kDhvnTA6zDOPMa17jB+spjSMi3dFcnF5GCRufvQThVRmMMdseoZh5w==
+flow-bin@0.196.3:
+  version "0.196.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.3.tgz#b6df48986a2629f2c6a26fb79d73fc07c8056af0"
+  integrity sha512-pmvjlksi1CvkSnDHpcfhDFj/KC3hwSgE2OpzvugW57dfgqfHzqX1UfZIcScGWM5AmP/IeOsQCW383k3zIbEnrA==
 
 follow-redirects@^1.0.0:
   version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.196.3:
-  version "0.196.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.3.tgz#b6df48986a2629f2c6a26fb79d73fc07c8056af0"
-  integrity sha512-pmvjlksi1CvkSnDHpcfhDFj/KC3hwSgE2OpzvugW57dfgqfHzqX1UfZIcScGWM5AmP/IeOsQCW383k3zIbEnrA==
+flow-bin@0.197.0:
+  version "0.197.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.197.0.tgz#a26ec0e495678676031acb414c1211d59f1d8fff"
+  integrity sha512-6g0c4Hj+JeS9nRayORAC3qUUzecX1RAjYap086yXivjfN2hlaqMYEi4ZDNPhtUOM8IqB4IE8HXPHt17uLsi0zw==
 
 follow-redirects@^1.0.0:
   version "1.15.2"


### PR DESCRIPTION
First step to getting Flow up-to-date.

0.197.0 is the first version where `inference_mode=lti` is available in a non-experimental form, but I haven't enabled it in this PR because it'll require a lot more changes.