### PR TITLE
MBS-12962: Don't ISE on undef track_offset

### DIFF
--- a/lib/MusicBrainz/Server/Entity/CDTOC.pm
+++ b/lib/MusicBrainz/Server/Entity/CDTOC.pm
@@ -139,7 +139,7 @@ around TO_JSON => sub {
         length          => 0 + $self->length,
         track_count     => 0 + $self->track_count,
         track_details   => $self->track_details,
-        track_offset    => [map { 0 + $_ } @{ $self->track_offset }],
+        track_offset    => [map { 0 + $_ } @{ $self->track_offset // [] }],
     };
 
     return $data;


### PR DESCRIPTION
### Fix MBS-12962

# Problem
Some historic edits (such as the Move Disc ID edit `/edit/12446292`) don't have any other info for the `CDTOC` than the `discid` string itself. Trying to calculate the `track_offset` (which is unneeded there anyway) was causing an ISE.

# Solution
It seems fine to have it return an empty array when missing, just like `track_details` already did, so I just made it do `@{ $self->track_offset // [] }`.

# Testing
Manually in the given edit.