### PR TITLE
MBS-12970: Negate nameVariation for release country diffs

### DIFF
--- a/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
+++ b/root/static/scripts/edit/components/edit/ReleaseEventsDiff.js
@@ -49,6 +49,8 @@ const changeSide = (
           : <span className={CLASS_MAP[type]}>{sideACountry.name}</span>
       }
       entity={sideACountry}
+      // The text content is the area name, so not really nameVariation
+      nameVariation={false}
     />
   ) : null;
 


### PR DESCRIPTION
### Fix MBS-12970

# Problem
When we need to set a diff class on the country in the `ReleaseEventsDiff` component, we pass a `span` (rather than the entity name alone) to `EntityLink`. This was being compared with a string to calculate `nameVariation` even when passing a `span`, hitting the `invariant` error we added for this situation. 

# Solution
We're expected to set `nameVariation` manually in these cases. Normally we might set `nameVariation` to `true` since we're not passing the name, but in this case we pass either the area name or a span containing the area name, so it probably makes sense for neither of those to be consider an actual `nameVariation`, since I understand the point of that is to help find cases where a different name is printed.

# Testing
Manually, by just loading the same edit on a dev env and making sure it no longer errors.